### PR TITLE
perf(seer): Trim whitespace from ASCII snapshot to reduce token usage

### DIFF
--- a/static/app/views/seerExplorer/hooks/useAsciiSnapshot.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useAsciiSnapshot.spec.tsx
@@ -1,0 +1,50 @@
+import {buildResult, createGridHelpers} from './useAsciiSnapshot';
+
+describe('buildResult whitespace trimming', () => {
+  it('trims trailing spaces, strips common leading indent, and collapses blank rows', () => {
+    // 10 cols x 8 rows — mostly empty space with a few text cells placed
+    // to simulate a sparse page snapshot.
+    const grid = createGridHelpers(8, 10);
+
+    // Place text at column 3 on rows 1 and 5, leaving rows 0, 2-4, 6-7 blank
+    // and columns 0-2 as a shared leading indent.
+    grid.writeOverlay(1, 3, 'Hello');
+    grid.writeOverlay(5, 3, 'World');
+
+    // Build the naive (untrimmed) version for comparison: every row is 10
+    // chars wide, all 8 rows present.
+    const naiveResult = grid.grid.map(row => row.join('')).join('\n');
+
+    const result = buildResult(grid, [], []);
+
+    // --- Step 1: trailing spaces are removed ---
+    const lines = result.split('\n');
+    // Skip line 0 (the URL). Every content line should have no trailing spaces.
+    for (const line of lines.slice(1)) {
+      if (line.length > 0) {
+        expect(line).toBe(line.trimEnd());
+      }
+    }
+
+    // --- Step 2: common leading indent is stripped ---
+    // Original text was at column 3, so after stripping the 3-char shared
+    // indent the text should start at column 0.
+    const contentLines = lines.slice(1).filter(l => l.length > 0);
+    expect(contentLines.some(l => l.startsWith('Hello'))).toBe(true);
+    expect(contentLines.some(l => l.startsWith('World'))).toBe(true);
+
+    // --- Step 3: consecutive blank rows are collapsed ---
+    // Between "Hello" (row 1) and "World" (row 5) there were 3 blank rows;
+    // after collapsing they become 1. Verify no two consecutive blank lines.
+    for (let i = 1; i < lines.length - 1; i++) {
+      const bothBlank = lines[i]!.length === 0 && lines[i + 1]!.length === 0;
+      expect(bothBlank).toBe(false);
+    }
+
+    // --- Overall size reduction ---
+    // The naive grid is 8 rows * 10 chars + 7 newlines = 87 chars.
+    // The trimmed result should be meaningfully smaller.
+    const trimmedBody = lines.slice(1).join('\n');
+    expect(trimmedBody.length).toBeLessThan(naiveResult.length);
+  });
+});

--- a/static/app/views/seerExplorer/hooks/useAsciiSnapshot.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useAsciiSnapshot.spec.tsx
@@ -33,13 +33,9 @@ describe('buildResult whitespace trimming', () => {
     expect(contentLines.some(l => l.startsWith('Hello'))).toBe(true);
     expect(contentLines.some(l => l.startsWith('World'))).toBe(true);
 
-    // --- Step 3: consecutive blank rows are collapsed ---
-    // Between "Hello" (row 1) and "World" (row 5) there were 3 blank rows;
-    // after collapsing they become 1. Verify no two consecutive blank lines.
-    for (let i = 1; i < lines.length - 1; i++) {
-      const bothBlank = lines[i]!.length === 0 && lines[i + 1]!.length === 0;
-      expect(bothBlank).toBe(false);
-    }
+    // --- Step 3: blank rows are removed entirely ---
+    const blankLines = lines.slice(1).filter(l => l.length === 0);
+    expect(blankLines).toHaveLength(0);
 
     // --- Overall size reduction ---
     // The naive grid is 8 rows * 10 chars + 7 newlines = 87 chars.

--- a/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
+++ b/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
@@ -47,7 +47,7 @@ type ChartProcessingContext = {
 /**
  * Creates grid helpers for ASCII rendering
  */
-function createGridHelpers(rows: number, cols: number): GridHelpers {
+export function createGridHelpers(rows: number, cols: number): GridHelpers {
   const grid = Array.from({length: rows}, () => Array.from({length: cols}, () => ' '));
 
   const setCell = (r: number, c: number, ch: string) => {
@@ -832,13 +832,44 @@ function renderTextNodes(
 /**
  * Builds the final result string with footnotes
  */
-function buildResult(
+export function buildResult(
   gridHelpers: GridHelpers,
   chartTables: string[],
   projectSlugs: string[]
 ): string {
   const url = window.location.href;
-  let result = url + '\n' + gridHelpers.grid.map(row => row.join('')).join('\n');
+
+  // Step 1: Strip trailing spaces from each row. The grid is initialized as
+  // all-space cells so rows are always full-width;
+  let lines = gridHelpers.grid.map(row => row.join('').trimEnd());
+
+  // Step 2: Remove the common leading whitespace shared by every non-empty
+  // row. After the nav-bar left-shift, all content starts at the same offset
+  // which produces a useless left margin of spaces.
+  const minIndent = lines
+    .filter(l => l.length > 0)
+    .reduce((min, l) => Math.min(min, l.length - l.trimStart().length), Infinity);
+  if (minIndent > 0 && Number.isFinite(minIndent)) {
+    lines = lines.map(l => (l.length > 0 ? l.slice(minIndent) : l));
+  }
+
+  // Step 3: Collapse consecutive blank rows into a single blank line.
+  // Large empty vertical gaps carry no information but cost tokens.
+  const collapsed: string[] = [];
+  let lastWasBlank = false;
+  for (const line of lines) {
+    if (line.length === 0) {
+      if (!lastWasBlank) {
+        collapsed.push('');
+      }
+      lastWasBlank = true;
+    } else {
+      collapsed.push(line);
+      lastWasBlank = false;
+    }
+  }
+
+  let result = url + '\n' + collapsed.join('\n');
 
   if (chartTables.length > 0 || projectSlugs.length > 0) {
     result += '\n\n=== FOOTNOTES ===\n\n';

--- a/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
+++ b/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
@@ -853,23 +853,10 @@ export function buildResult(
     lines = lines.map(l => (l.length > 0 ? l.slice(minIndent) : l));
   }
 
-  // Step 3: Collapse consecutive blank rows into a single blank line.
-  // Large empty vertical gaps carry no information but cost tokens.
-  const collapsed: string[] = [];
-  let lastWasBlank = false;
-  for (const line of lines) {
-    if (line.length === 0) {
-      if (!lastWasBlank) {
-        collapsed.push('');
-      }
-      lastWasBlank = true;
-    } else {
-      collapsed.push(line);
-      lastWasBlank = false;
-    }
-  }
+  // Step 3: Drop all blank rows
+  const nonBlank = lines.filter(l => l.length > 0);
 
-  let result = url + '\n' + collapsed.join('\n');
+  let result = url + '\n' + nonBlank.join('\n');
 
   if (chartTables.length > 0 || projectSlugs.length > 0) {
     result += '\n\n=== FOOTNOTES ===\n\n';


### PR DESCRIPTION
+ The ASCII grid sent as on_page_context to Seer was emitting every row at full viewport width and preserving all blank rows, wasting lots of characters on spaces (depends on what page it's on). Blank spaces waste tokens (and therefore cost/latency) without carrying any information, reducing the useful context budget available for the LLM to reason about. These changes still preserve the structure of the page. 
+ Mitigating this by striping trailing spaces, removing the common leading indent from the nav-bar shift, and removing blank rows. 
+ [Sample conversation with lots of blank space](https://sentry.sentry.io/explore/conversations/?agent=Explorer+Main+Step&conversationSpan=a1e5527ea57b1c41&project=6178942&query=user.email:%EF%80%8DContains%EF%80%8D[mihir.mavalankar@sentry.io,shruthilaya.jaganathan@sentry.io]&statsPeriod=7d&conversation=11418248&conversationStart=1773069518945&conversationEnd=1773069545470)