### PR TITLE
fix(pageFilters): Expand sentinel selection before unchecking a project

### DIFF
--- a/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
@@ -532,6 +532,52 @@ describe('ProjectPageFilter', () => {
     });
   });
 
+  it('shows selection limit warning when clicking All Projects then unchecking a single project', async () => {
+    // 51 members + 1 non-member = 52 total so the "All Projects" sentinel appears
+    const manyProjects = [
+      ...Array.from({length: 51}, (_, index) =>
+        ProjectFixture({
+          id: String(index + 1),
+          slug: `project-${index + 1}`,
+          isMember: true,
+        })
+      ),
+      ProjectFixture({id: '52', slug: 'project-52', isMember: false}),
+    ];
+    ProjectsStore.loadInitialData(manyProjects);
+
+    // Start with a single project selected
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1],
+      environments: [],
+      datetime: {start: null, end: null, period: '14d', utc: null},
+    });
+
+    render(<ProjectPageFilter />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/issues/',
+          query: {project: '1'},
+        },
+      },
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'project-1'}));
+
+    // Click "All Projects" to stage all 52 projects
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Select All Projects'}));
+
+    // Uncheck project-1 — should be unchecked and leave 51 selections, exceeding the limit
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Select project-1'}));
+
+    expect(screen.getByRole('checkbox', {name: 'Select project-1'})).not.toBeChecked();
+    expect(
+      screen.getByText(/only up to 50 can be selected at a time/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Apply'})).toBeDisabled();
+  });
+
   it.each([
     {
       label: 'My Projects',

--- a/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
@@ -532,6 +532,73 @@ describe('ProjectPageFilter', () => {
     });
   });
 
+  it.each([
+    {
+      label: 'My Projects',
+      // 52 members + 1 non-member so the "My Projects" sentinel appears
+      // (requires memberProjectList.length < projects.length)
+      memberCount: 52,
+      nonMemberCount: 1,
+      urlProjects: [] as number[],
+      urlQuery: {} as Record<string, string>,
+      triggerName: 'My Projects',
+    },
+    {
+      label: 'All Projects',
+      // 51 members + 1 non-member so the "All Projects" sentinel appears
+      // (requires nonMemberProjectList.length > 0)
+      memberCount: 51,
+      nonMemberCount: 1,
+      urlProjects: [-1],
+      urlQuery: {project: '-1'},
+      triggerName: 'All Projects',
+    },
+  ])(
+    'shows selection limit warning when $label is active and a single project is unchecked',
+    async ({memberCount, nonMemberCount, urlProjects, urlQuery, triggerName}) => {
+      const manyProjects = [
+        ...Array.from({length: memberCount}, (_, index) =>
+          ProjectFixture({
+            id: String(index + 1),
+            slug: `project-${index + 1}`,
+            isMember: true,
+          })
+        ),
+        ...Array.from({length: nonMemberCount}, (_, index) =>
+          ProjectFixture({
+            id: String(memberCount + index + 1),
+            slug: `project-${memberCount + index + 1}`,
+            isMember: false,
+          })
+        ),
+      ];
+      ProjectsStore.loadInitialData(manyProjects);
+
+      PageFiltersStore.onInitializeUrlState({
+        projects: urlProjects,
+        environments: [],
+        datetime: {start: null, end: null, period: '14d', utc: null},
+      });
+
+      render(<ProjectPageFilter />, {
+        organization,
+        initialRouterConfig: {
+          location: {pathname: '/organizations/org-slug/issues/', query: urlQuery},
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: triggerName}));
+
+      // Unchecking one project leaves memberCount explicit selections, which exceeds the limit of 50
+      await userEvent.click(screen.getByRole('checkbox', {name: 'Select project-1'}));
+
+      expect(
+        screen.getByText(/only up to 50 can be selected at a time/i)
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Apply'})).toBeDisabled();
+    }
+  );
+
   it('shows selection limit warning after editing All Projects sentinel selection', async () => {
     const manyProjects = Array.from({length: 52}, (_, index) =>
       ProjectFixture({

--- a/static/app/components/pageFilters/project/projectPageFilter.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.tsx
@@ -128,7 +128,26 @@ export function ProjectPageFilter({
                 ? true
                 : isSelected
             }
-            onChange={() => toggleOptionRef.current?.(parseInt(project.id, 10))}
+            onChange={() => {
+              const projectId = parseInt(project.id, 10);
+              // When a sentinel is staged, the checkbox appears checked via the
+              // `checked` override above — but toggleOption would just add the
+              // ID alongside the sentinel (e.g. [-1, 1]), keeping kind='all'.
+              // Instead, expand to explicit IDs first, then remove this project.
+              if (optionSelectionIntent.kind === 'all') {
+                dispatchRef.current?.({
+                  type: 'set staged',
+                  value: allProjectIds(projects).filter(id => id !== projectId),
+                });
+              } else if (optionSelectionIntent.kind === 'my' && project.isMember) {
+                dispatchRef.current?.({
+                  type: 'set staged',
+                  value: memberProjectIds(projects).filter(id => id !== projectId),
+                });
+              } else {
+                toggleOptionRef.current?.(projectId);
+              }
+            }}
             aria-label={t('Select %s', project.slug)}
             tabIndex={-1}
           />


### PR DESCRIPTION
When All Projects or My Projects was staged (not yet committed) and the
user clicked an individual project checkbox to uncheck it, the toggle
logic would add the project ID alongside the sentinel value (e.g. `[-1,
1]`). Because `-1` was still present, the selection still resolved to
`kind='all'`, leaving the checkbox visually checked and suppressing the
selection limit warning.

The fix expands the sentinel to explicit IDs before removing the clicked
project:
- `kind='all'` → expand to all project IDs, then remove the clicked one
- `kind='my'` → expand to member project IDs, then remove the clicked one
- anything else → existing `toggleOption` path unchanged

Also adds three new tests covering the selection limit warning for the
flows that exposed this bug: clicking All Projects then unchecking a
project, and the parametrized My/All Projects active + uncheck cases.