### PR TITLE
feat(occurrences on eap): Implement double-read performance issues query for summaries task

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -272,7 +272,7 @@ def project_key_performance_issues(ctx: OrganizationReportContext, project: Proj
             referrer=referrer,
             group_ids=list(group_id_to_group.keys()),
         )
-        chosen_rows = snuba_rows
+        query_result = snuba_rows
 
         callsite = "tasks.summaries.project_key_performance_issues"
         if EAPOccurrencesComparator.should_check_experiment(callsite):
@@ -282,7 +282,7 @@ def project_key_performance_issues(ctx: OrganizationReportContext, project: Proj
                 referrer=referrer,
                 group_ids=list(group_id_to_group.keys()),
             )
-            chosen_rows = EAPOccurrencesComparator.check_and_choose(
+            query_result = EAPOccurrencesComparator.check_and_choose(
                 snuba_rows,
                 eap_rows,
                 callsite,
@@ -296,16 +296,15 @@ def project_key_performance_issues(ctx: OrganizationReportContext, project: Proj
                     "organization_id": ctx.organization.id,
                     "project_id": project.id,
                     "candidate_group_ids_count": len(group_id_to_group),
-                    "referrer": referrer,
                     "start": ctx.start.isoformat(),
                     "end": (ctx.end + timedelta(days=1)).isoformat(),
                 },
             )
 
         key_performance_issues = []
-        for result in chosen_rows:
-            count = int(result["count()"])
-            group_id = int(result["group_id"])
+        for result in query_result:
+            count = result["count()"]
+            group_id = result["group_id"]
             group = group_id_to_group.get(group_id)
             if group:
                 key_performance_issues.append((group, count))
@@ -382,7 +381,6 @@ def _project_key_performance_issues_eap(
                 "organization_id": ctx.organization.id,
                 "project_id": project.id,
                 "group_ids_count": len(group_ids),
-                "referrer": referrer,
             },
         )
         return []

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 from typing import Any, cast
 
@@ -20,7 +21,12 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.models.team import TeamStatus
+from sentry.search.eap.occurrences.query_utils import keyed_counts_subset_match
+from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.types import SnubaParams
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 from sentry.snuba.referrer import Referrer
 from sentry.types.group import GroupSubStatus
 from sentry.utils.dates import to_datetime
@@ -29,6 +35,7 @@ from sentry.utils.snuba import raw_snql_query
 
 ONE_DAY = int(timedelta(days=1).total_seconds())
 COMPARISON_PERIOD = 14
+logger = logging.getLogger(__name__)
 
 
 class OrganizationReportContext:
@@ -259,40 +266,136 @@ def project_key_performance_issues(ctx: OrganizationReportContext, project: Proj
         if len(group_id_to_group) == 0:
             return
 
-        # Fine grained query for 3 most frequent events happend during last week
-        query = Query(
-            match=Entity("search_issues"),
-            select=[
-                Column("group_id"),
-                Function("count", []),
-            ],
-            where=[
-                Condition(Column("group_id"), Op.IN, list(group_id_to_group.keys())),
-                Condition(Column("timestamp"), Op.GTE, ctx.start),
-                Condition(Column("timestamp"), Op.LT, ctx.end + timedelta(days=1)),
-                Condition(Column("project_id"), Op.EQ, project.id),
-            ],
-            groupby=[Column("group_id")],
-            orderby=[OrderBy(Function("count", []), Direction.DESC)],
-            limit=Limit(3),
+        snuba_rows = _project_key_performance_issues_snuba(
+            ctx=ctx,
+            project=project,
+            referrer=referrer,
+            group_ids=list(group_id_to_group.keys()),
         )
-        request = Request(
-            dataset=Dataset.IssuePlatform.value,
-            app_id="reports",
-            query=query,
-            tenant_ids={"organization_id": ctx.organization.id},
-        )
-        query_result = raw_snql_query(request, referrer=referrer)["data"]
+        chosen_rows = snuba_rows
+
+        callsite = "tasks.summaries.project_key_performance_issues"
+        if EAPOccurrencesComparator.should_check_experiment(callsite):
+            eap_rows = _project_key_performance_issues_eap(
+                ctx=ctx,
+                project=project,
+                referrer=referrer,
+                group_ids=list(group_id_to_group.keys()),
+            )
+            chosen_rows = EAPOccurrencesComparator.check_and_choose(
+                snuba_rows,
+                eap_rows,
+                callsite,
+                is_experimental_data_a_null_result=len(eap_rows) == 0,
+                reasonable_match_comparator=lambda snuba, eap: keyed_counts_subset_match(
+                    snuba,
+                    eap,
+                    key_fn=lambda row: int(row["group_id"]),
+                ),
+                debug_context={
+                    "organization_id": ctx.organization.id,
+                    "project_id": project.id,
+                    "candidate_group_ids_count": len(group_id_to_group),
+                    "referrer": referrer,
+                    "start": ctx.start.isoformat(),
+                    "end": (ctx.end + timedelta(days=1)).isoformat(),
+                },
+            )
 
         key_performance_issues = []
-        for result in query_result:
-            count = result["count()"]
-            group_id = result["group_id"]
+        for result in chosen_rows:
+            count = int(result["count()"])
+            group_id = int(result["group_id"])
             group = group_id_to_group.get(group_id)
             if group:
                 key_performance_issues.append((group, count))
 
         return key_performance_issues
+
+
+def _project_key_performance_issues_snuba(
+    ctx: OrganizationReportContext,
+    project: Project,
+    referrer: str,
+    group_ids: list[int],
+) -> list[dict[str, Any]]:
+    # Fine grained query for 3 most frequent events happened during last week.
+    query = Query(
+        match=Entity("search_issues"),
+        select=[
+            Column("group_id"),
+            Function("count", []),
+        ],
+        where=[
+            Condition(Column("group_id"), Op.IN, group_ids),
+            Condition(Column("timestamp"), Op.GTE, ctx.start),
+            Condition(Column("timestamp"), Op.LT, ctx.end + timedelta(days=1)),
+            Condition(Column("project_id"), Op.EQ, project.id),
+        ],
+        groupby=[Column("group_id")],
+        orderby=[OrderBy(Function("count", []), Direction.DESC)],
+        limit=Limit(3),
+    )
+    request = Request(
+        dataset=Dataset.IssuePlatform.value,
+        app_id="reports",
+        query=query,
+        tenant_ids={"organization_id": ctx.organization.id},
+    )
+    return raw_snql_query(request, referrer=referrer)["data"]
+
+
+def _project_key_performance_issues_eap(
+    ctx: OrganizationReportContext,
+    project: Project,
+    referrer: str,
+    group_ids: list[int],
+) -> list[dict[str, Any]]:
+    if len(group_ids) == 1:
+        query_string = f"group_id:{group_ids[0]}"
+    else:
+        query_string = f"group_id:[{', '.join(str(group_id) for group_id in group_ids)}]"
+
+    snuba_params = SnubaParams(
+        start=ctx.start,
+        end=ctx.end + timedelta(days=1),
+        organization=ctx.organization,
+        projects=[project],
+    )
+
+    try:
+        eap_response = Occurrences.run_table_query(
+            params=snuba_params,
+            query_string=query_string,
+            selected_columns=["group_id", "count()"],
+            orderby=["-count()"],
+            offset=0,
+            limit=3,
+            referrer=referrer,
+            config=SearchResolverConfig(),
+            occurrence_category=OccurrenceCategory.GENERIC,
+        )
+    except Exception:
+        logger.exception(
+            "summaries.key_performance_issues.eap_query_failed",
+            extra={
+                "organization_id": ctx.organization.id,
+                "project_id": project.id,
+                "group_ids_count": len(group_ids),
+                "referrer": referrer,
+            },
+        )
+        return []
+
+    normalized_rows = []
+    for row in eap_response.get("data", []):
+        group_id = row.get("group_id")
+        count = row.get("count()")
+        if group_id is None or count is None:
+            continue
+        normalized_rows.append({"group_id": int(group_id), "count()": int(count)})
+
+    return normalized_rows
 
 
 def project_key_transactions_this_week(ctx, project):

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -27,6 +27,8 @@ from sentry.tasks.summaries.utils import (
     ONE_DAY,
     OrganizationReportContext,
     ProjectContext,
+    _project_key_performance_issues_eap,
+    _project_key_performance_issues_snuba,
     organization_project_issue_substatus_summaries,
     project_key_errors,
     user_project_ownership,
@@ -39,7 +41,12 @@ from sentry.tasks.summaries.weekly_reports import (
     prepare_template_context,
     schedule_organizations,
 )
-from sentry.testutils.cases import OutcomesSnubaTest, PerformanceIssueTestCase, SnubaTestCase
+from sentry.testutils.cases import (
+    OccurrenceTestCase,
+    OutcomesSnubaTest,
+    PerformanceIssueTestCase,
+    SnubaTestCase,
+)
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
@@ -56,7 +63,9 @@ from sentry.utils.outcomes import Outcome
 DISABLED_ORGANIZATIONS_USER_OPTION_KEY = "reports:disabled-organizations"
 
 
-class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCase):
+class WeeklyReportsTest(
+    OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCase, OccurrenceTestCase
+):
     def setUp(self) -> None:
         super().setUp()
         self.now = timezone.now()
@@ -357,6 +366,65 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         user_project_ownership(ctx)
         key_errors = project_key_errors(ctx, self.project, Referrer.REPORTS_KEY_ERRORS.value)
         assert key_errors == [{"events.group_id": event1.group.id, "count()": 1}]
+
+    def test_project_key_performance_issues_eap_matches_snuba(self) -> None:
+        """Snuba and EAP paths return the same top performance issues with the same counts."""
+        self.project.first_event = self.now - timedelta(days=3)
+        self.project.save()
+
+        # Create 3 events for group1 and 1 for group2 in Snuba (via search_issues)
+        fingerprint_1 = f"{PerformanceNPlusOneGroupType.type_id}-group1"
+        fingerprint_2 = f"{PerformanceNPlusOneGroupType.type_id}-group2"
+        perf_event_1a = self.create_performance_issue(fingerprint=fingerprint_1)
+        self.create_performance_issue(fingerprint=fingerprint_1)
+        self.create_performance_issue(fingerprint=fingerprint_1)
+        perf_event_2 = self.create_performance_issue(fingerprint=fingerprint_2)
+
+        assert perf_event_1a.group is not None
+        assert perf_event_2.group is not None
+        perf_group_1 = perf_event_1a.group
+        perf_group_2 = perf_event_2.group
+        perf_group_1.update(last_seen=self.now, times_seen=10)
+        perf_group_2.update(last_seen=self.now, times_seen=5)
+
+        # Store matching EAP occurrences for the same groups with the same counts
+        self.store_eap_items(
+            [
+                self.create_eap_occurrence(
+                    group_id=perf_group_1.id,
+                    project=self.project,
+                    timestamp=self.now - timedelta(minutes=i + 1),
+                    occurrence_type="generic",
+                )
+                for i in range(3)
+            ]
+            + [
+                self.create_eap_occurrence(
+                    group_id=perf_group_2.id,
+                    project=self.project,
+                    timestamp=self.now - timedelta(minutes=1),
+                    occurrence_type="generic",
+                ),
+            ]
+        )
+
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        group_ids = [perf_group_1.id, perf_group_2.id]
+        referrer = Referrer.REPORTS_KEY_PERFORMANCE_ISSUES.value
+
+        snuba_rows = _project_key_performance_issues_snuba(ctx, self.project, referrer, group_ids)
+        eap_rows = _project_key_performance_issues_eap(ctx, self.project, referrer, group_ids)
+
+        assert len(snuba_rows) == 2
+        assert len(eap_rows) == 2
+        for snuba_row, eap_row in zip(snuba_rows, eap_rows):
+            assert int(snuba_row["group_id"]) == int(eap_row["group_id"])
+            assert int(snuba_row["count()"]) == int(eap_row["count()"])
+
+        assert int(snuba_rows[0]["group_id"]) == perf_group_1.id
+        assert int(snuba_rows[0]["count()"]) == 3
+        assert int(snuba_rows[1]["group_id"]) == perf_group_2.id
+        assert int(snuba_rows[1]["count()"]) == 1
 
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -368,7 +368,6 @@ class WeeklyReportsTest(
         assert key_errors == [{"events.group_id": event1.group.id, "count()": 1}]
 
     def test_project_key_performance_issues_eap_matches_snuba(self) -> None:
-        """Snuba and EAP paths return the same top performance issues with the same counts."""
         self.project.first_event = self.now - timedelta(days=3)
         self.project.save()
 


### PR DESCRIPTION
Implements double reads of occurrences from EAP for `project_key_performance_issues` in `src/sentry/tasks/summaries/utils.py`.