### PR TITLE
feat(dashboards): Add default filters for AI Agents and MCP dashboards

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
@@ -157,6 +158,18 @@ export const AI_AGENTS_MODELS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
   title: 'AI Agents Models',
-  filters: {},
+  filters: {
+    globalFilter: [
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: 'gen_ai.request.model',
+          name: 'gen_ai.request.model',
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+    ],
+  },
   widgets: [...FIRST_ROW_WIDGETS, MODELS_TABLE],
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsTools.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsTools.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
@@ -94,6 +95,18 @@ export const AI_AGENTS_TOOLS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
   title: 'AI Agents Tools',
-  filters: {},
+  filters: {
+    globalFilter: [
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: 'gen_ai.tool.name',
+          name: 'gen_ai.tool.name',
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+    ],
+  },
   widgets: [...FIRST_ROW_WIDGETS, TOOLS_TABLE],
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpPrompts.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpPrompts.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
@@ -123,6 +124,18 @@ export const MCP_PROMPTS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
   title: 'MCP Prompts',
-  filters: {},
+  filters: {
+    globalFilter: [
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: 'mcp.prompt.name',
+          name: 'mcp.prompt.name',
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+    ],
+  },
   widgets: [...FIRST_ROW_WIDGETS, PROMPTS_TABLE],
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpResources.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpResources.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
@@ -123,6 +124,18 @@ export const MCP_RESOURCES_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
   title: 'MCP Resources',
-  filters: {},
+  filters: {
+    globalFilter: [
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: 'mcp.resource.uri',
+          name: 'mcp.resource.uri',
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+    ],
+  },
   widgets: [...FIRST_ROW_WIDGETS, RESOURCES_TABLE],
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpTools.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpTools.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
@@ -123,6 +124,18 @@ export const MCP_TOOLS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
   title: 'MCP Tools',
-  filters: {},
+  filters: {
+    globalFilter: [
+      {
+        dataset: WidgetType.SPANS,
+        tag: {
+          key: 'mcp.tool.name',
+          name: 'mcp.tool.name',
+          kind: FieldKind.TAG,
+        },
+        value: '',
+      },
+    ],
+  },
   widgets: [...FIRST_ROW_WIDGETS, TOOLS_TABLE],
 };


### PR DESCRIPTION
Adds tool name, model name, resource uri, etc default filters to Agents and MCP dashboards where appropriate.