### PR TITLE
feat(ACI): Make rule stats and group history endpoints backwards compatible

### DIFF
--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -60,7 +60,51 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
             notification_uuid=notification_uuid,
         )
 
-    def fetch_rule_groups_paginated(
+    def fetch_workflow_groups(
+        self,
+        workflow: Workflow,
+        start: datetime,
+        end: datetime,
+        cursor: Cursor | None = None,
+        per_page: int = 25,
+    ) -> CursorResult[RuleGroupHistory]:
+        # Performs the raw SQL query with pagination
+        def data_fn(offset: int, limit: int) -> list[_Result]:
+            query = """
+                WITH workflow_data AS (
+                    SELECT group_id, date_added, event_id
+                    FROM workflow_engine_workflowfirehistory
+                    WHERE workflow_id = %s
+                    AND date_added >= %s AND date_added < %s
+                )
+                SELECT
+                    group_id as group,
+                    COUNT(*) as count,
+                    MAX(date_added) as last_triggered,
+                    (ARRAY_AGG(event_id ORDER BY date_added DESC))[1] as event_id
+                FROM workflow_data
+                GROUP BY group_id
+                ORDER BY count DESC, last_triggered DESC
+                LIMIT %s OFFSET %s
+            """
+
+            with connection.cursor() as cursor:
+                cursor.execute(query, [workflow.id, start, end, limit, offset])
+                return [
+                    _Result(
+                        group=row[0],
+                        count=row[1],
+                        last_triggered=row[2],
+                        event_id=row[3],
+                    )
+                    for row in cursor.fetchall()
+                ]
+
+        result = GenericOffsetPaginator(data_fn=data_fn).get_result(per_page, cursor)
+        result.results = convert_results(result.results)
+        return result
+
+    def fetch_rule_groups(
         self,
         target: Rule | Workflow,
         start: datetime,
@@ -68,50 +112,11 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         cursor: Cursor | None = None,
         per_page: int = 25,
     ) -> CursorResult[RuleGroupHistory]:
-        if isinstance(target, Workflow):
-            # Performs the raw SQL query with pagination
-            def data_fn(offset: int, limit: int) -> list[_Result]:
-                query = """
-                    WITH workflow_data AS (
-                        SELECT group_id, date_added, event_id
-                        FROM workflow_engine_workflowfirehistory
-                        WHERE workflow_id = %s
-                        AND date_added >= %s AND date_added < %s
-                    )
-                    SELECT
-                        group_id as group,
-                        COUNT(*) as count,
-                        MAX(date_added) as last_triggered,
-                        (ARRAY_AGG(event_id ORDER BY date_added DESC))[1] as event_id
-                    FROM workflow_data
-                    GROUP BY group_id
-                    ORDER BY count DESC, last_triggered DESC
-                    LIMIT %s OFFSET %s
-                """
-
-                with connection.cursor() as cursor:
-                    cursor.execute(query, [target.id, start, end, limit, offset])
-                    return [
-                        _Result(
-                            group=row[0],
-                            count=row[1],
-                            last_triggered=row[2],
-                            event_id=row[3],
-                        )
-                        for row in cursor.fetchall()
-                    ]
-
-            result = GenericOffsetPaginator(data_fn=data_fn).get_result(per_page, cursor)
-            result.results = convert_results(result.results)
-
-            return result
-
         rule_filtered_history = RuleFireHistory.objects.filter(
             rule=target,
             date_added__gte=start,
             date_added__lt=end,
         )
-
         # subquery that retrieves row with the largest date in a group for RuleFireHistory
         rule_group_max_dates = rule_filtered_history.filter(group=OuterRef("group")).order_by(
             "-date_added"
@@ -128,6 +133,65 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
             qs, order_by=("-count", "-last_triggered"), on_results=convert_results
         ).get_result(per_page, cursor)
 
+    def fetch_rule_groups_paginated(
+        self,
+        target: Rule | Workflow,
+        start: datetime,
+        end: datetime,
+        cursor: Cursor | None = None,
+        per_page: int = 25,
+    ) -> CursorResult[RuleGroupHistory]:
+        if isinstance(target, Workflow):
+            return self.fetch_workflow_groups(target, start, end, cursor, per_page)
+
+        return self.fetch_rule_groups(target, start, end, cursor, per_page)
+
+    def fetch_workflow_stats(
+        self, target: Workflow, start: datetime, end: datetime
+    ) -> Sequence[TimeSeriesValue]:
+        # Use raw SQL to combine data from both tables
+        with connection.cursor() as db_cursor:
+            db_cursor.execute(
+                """
+                SELECT
+                    DATE_TRUNC('hour', date_added) as bucket,
+                    COUNT(*) as count
+                FROM (
+                    SELECT date_added
+                    FROM workflow_engine_workflowfirehistory
+                    WHERE workflow_id = %s
+                        AND date_added >= %s
+                        AND date_added < %s
+                ) combined_data
+                GROUP BY DATE_TRUNC('hour', date_added)
+                ORDER BY bucket
+                """,
+                [target.id, start, end],
+            )
+
+            results = db_cursor.fetchall()
+
+        # Convert raw SQL results to the expected format
+        existing_data = {row[0]: TimeSeriesValue(row[0], row[1]) for row in results}
+        return existing_data
+
+    def fetch_rule_stats(
+        self, target: Rule, start: datetime, end: datetime
+    ) -> Sequence[TimeSeriesValue]:
+        qs = (
+            RuleFireHistory.objects.filter(
+                rule=target,
+                date_added__gte=start,
+                date_added__lt=end,
+            )
+            .annotate(bucket=TruncHour("date_added"))
+            .order_by("bucket")
+            .values("bucket")
+            .annotate(count=Count("id"))
+        )
+        existing_data = {row["bucket"]: TimeSeriesValue(row["bucket"], row["count"]) for row in qs}
+        return existing_data
+
     def fetch_rule_hourly_stats(
         self, target: Rule | Workflow, start: datetime, end: datetime
     ) -> Sequence[TimeSeriesValue]:
@@ -137,47 +201,9 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         existing_data: dict[datetime, TimeSeriesValue] = {}
 
         if isinstance(target, Workflow):
-            # Use raw SQL to combine data from both tables
-            with connection.cursor() as db_cursor:
-                db_cursor.execute(
-                    """
-                    SELECT
-                        DATE_TRUNC('hour', date_added) as bucket,
-                        COUNT(*) as count
-                    FROM (
-                        SELECT date_added
-                        FROM workflow_engine_workflowfirehistory
-                        WHERE workflow_id = %s
-                            AND date_added >= %s
-                            AND date_added < %s
-                    ) combined_data
-                    GROUP BY DATE_TRUNC('hour', date_added)
-                    ORDER BY bucket
-                    """,
-                    [target.id, start, end],
-                )
-
-                results = db_cursor.fetchall()
-
-            # Convert raw SQL results to the expected format
-            existing_data = {row[0]: TimeSeriesValue(row[0], row[1]) for row in results}
-
+            existing_data = self.fetch_workflow_stats(target, start, end)
         else:
-            # fall back to previous behavior
-            qs = (
-                RuleFireHistory.objects.filter(
-                    rule=target,
-                    date_added__gte=start,
-                    date_added__lt=end,
-                )
-                .annotate(bucket=TruncHour("date_added"))
-                .order_by("bucket")
-                .values("bucket")
-                .annotate(count=Count("id"))
-            )
-            existing_data = {
-                row["bucket"]: TimeSeriesValue(row["bucket"], row["count"]) for row in qs
-            }
+            existing_data = self.fetch_rule_stats(target, start, end)
 
         # Fill in gaps with zero values for missing hours
         results = []

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -14,7 +14,7 @@ from sentry.models.group import Group
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.history.base import RuleGroupHistory, RuleHistoryBackend, TimeSeriesValue
 from sentry.utils.cursors import Cursor, CursorResult
-from sentry.workflow_engine.models import AlertRuleWorkflow
+from sentry.workflow_engine.models.workflow import Workflow
 
 if TYPE_CHECKING:
     from sentry.models.rule import Rule
@@ -62,24 +62,17 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
     def fetch_rule_groups_paginated(
         self,
-        rule: Rule,
+        target: Rule | Workflow,
         start: datetime,
         end: datetime,
         cursor: Cursor | None = None,
         per_page: int = 25,
     ) -> CursorResult[RuleGroupHistory]:
-        try:
-            alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id)
-            workflow = alert_rule_workflow.workflow
-
+        if isinstance(target, Workflow):
             # Performs the raw SQL query with pagination
             def data_fn(offset: int, limit: int) -> list[_Result]:
                 query = """
-                    WITH combined_data AS (
-                        SELECT group_id, date_added, event_id
-                        FROM sentry_rulefirehistory
-                        WHERE rule_id = %s AND date_added >= %s AND date_added < %s
-                        UNION ALL
+                    WITH workflow_data AS (
                         SELECT group_id, date_added, event_id
                         FROM workflow_engine_workflowfirehistory
                         WHERE workflow_id = %s
@@ -90,16 +83,14 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                         COUNT(*) as count,
                         MAX(date_added) as last_triggered,
                         (ARRAY_AGG(event_id ORDER BY date_added DESC))[1] as event_id
-                    FROM combined_data
+                    FROM workflow_data
                     GROUP BY group_id
                     ORDER BY count DESC, last_triggered DESC
                     LIMIT %s OFFSET %s
                 """
 
                 with connection.cursor() as cursor:
-                    cursor.execute(
-                        query, [rule.id, start, end, workflow.id, start, end, limit, offset]
-                    )
+                    cursor.execute(query, [target.id, start, end, limit, offset])
                     return [
                         _Result(
                             group=row[0],
@@ -115,13 +106,8 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
             return result
 
-        except AlertRuleWorkflow.DoesNotExist:
-            # If no workflow is associated with this rule, just use the original behavior
-            logger.exception("No workflow associated with rule", extra={"rule_id": rule.id})
-            pass
-
         rule_filtered_history = RuleFireHistory.objects.filter(
-            rule=rule,
+            rule=target,
             date_added__gte=start,
             date_added__lt=end,
         )
@@ -143,17 +129,14 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         ).get_result(per_page, cursor)
 
     def fetch_rule_hourly_stats(
-        self, rule: Rule, start: datetime, end: datetime
+        self, target: Rule | Workflow, start: datetime, end: datetime
     ) -> Sequence[TimeSeriesValue]:
         start = start.replace(tzinfo=timezone.utc)
         end = end.replace(tzinfo=timezone.utc)
 
         existing_data: dict[datetime, TimeSeriesValue] = {}
 
-        try:
-            alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id)
-            workflow = alert_rule_workflow.workflow
-
+        if isinstance(target, Workflow):
             # Use raw SQL to combine data from both tables
             with connection.cursor() as db_cursor:
                 db_cursor.execute(
@@ -163,14 +146,6 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                         COUNT(*) as count
                     FROM (
                         SELECT date_added
-                        FROM sentry_rulefirehistory
-                        WHERE rule_id = %s
-                            AND date_added >= %s
-                            AND date_added < %s
-
-                        UNION ALL
-
-                        SELECT date_added
                         FROM workflow_engine_workflowfirehistory
                         WHERE workflow_id = %s
                             AND date_added >= %s
@@ -179,7 +154,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                     GROUP BY DATE_TRUNC('hour', date_added)
                     ORDER BY bucket
                     """,
-                    [rule.id, start, end, workflow.id, start, end],
+                    [target.id, start, end],
                 )
 
                 results = db_cursor.fetchall()
@@ -187,15 +162,11 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
             # Convert raw SQL results to the expected format
             existing_data = {row[0]: TimeSeriesValue(row[0], row[1]) for row in results}
 
-        except AlertRuleWorkflow.DoesNotExist:
-            # If no workflow is associated with this rule, just use the original behavior
-            logger.exception("No workflow associated with rule", extra={"rule_id": rule.id})
-            pass
-
-        if not existing_data:
+        else:
+            # fall back to previous behavior
             qs = (
                 RuleFireHistory.objects.filter(
-                    rule=rule,
+                    rule=target,
                     date_added__gte=start,
                     date_added__lt=end,
                 )

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -106,7 +106,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
     def fetch_rule_groups(
         self,
-        target: Rule | Workflow,
+        target: Rule,
         start: datetime,
         end: datetime,
         cursor: Cursor | None = None,
@@ -148,7 +148,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
     def fetch_workflow_stats(
         self, target: Workflow, start: datetime, end: datetime
-    ) -> Sequence[TimeSeriesValue]:
+    ) -> dict[datetime, TimeSeriesValue]:
         # Use raw SQL to combine data from both tables
         with connection.cursor() as db_cursor:
             db_cursor.execute(
@@ -177,7 +177,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
     def fetch_rule_stats(
         self, target: Rule, start: datetime, end: datetime
-    ) -> Sequence[TimeSeriesValue]:
+    ) -> dict[datetime, TimeSeriesValue]:
         qs = (
             RuleFireHistory.objects.filter(
                 rule=target,

--- a/src/sentry/rules/history/base.py
+++ b/src/sentry/rules/history/base.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sentry.utils.services import Service
+from sentry.workflow_engine.models.workflow import Workflow
 
 if TYPE_CHECKING:
     from typing import Any
@@ -49,7 +50,7 @@ class RuleHistoryBackend(Service):
         raise NotImplementedError
 
     def fetch_rule_groups_paginated(
-        self, rule: Rule, start: datetime, end: datetime, cursor: Cursor, per_page: int
+        self, rule: Rule | Workflow, start: datetime, end: datetime, cursor: Cursor, per_page: int
     ) -> CursorResult[RuleGroupHistory]:
         """
         Fetches groups that triggered a rule within a given timeframe, ordered by number of
@@ -58,7 +59,7 @@ class RuleHistoryBackend(Service):
         raise NotImplementedError
 
     def fetch_rule_hourly_stats(
-        self, rule: Rule, start: datetime, end: datetime
+        self, rule: Rule | Workflow, start: datetime, end: datetime
     ) -> Sequence[TimeSeriesValue]:
         """
         Fetches counts of how often a rule has fired withing a given datetime range, bucketed by

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.rule import RuleEndpoint
+from sentry.api.bases.rule import WorkflowEngineRuleEndpoint
 from sentry.api.serializers import Serializer, serialize
 from sentry.api.serializers.models.group import BaseGroupSerializerResponse
 from sentry.api.utils import get_date_range_from_params
@@ -22,6 +22,7 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.rules.history import fetch_rule_groups_paginated
 from sentry.rules.history.base import RuleGroupHistory
+from sentry.workflow_engine.models.workflow import Workflow
 
 
 class RuleGroupHistoryResponse(TypedDict):
@@ -55,7 +56,7 @@ class RuleGroupHistorySerializer(Serializer):
 
 @extend_schema(tags=["issue_alerts"])
 @region_silo_endpoint
-class ProjectRuleGroupHistoryIndexEndpoint(RuleEndpoint):
+class ProjectRuleGroupHistoryIndexEndpoint(WorkflowEngineRuleEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
@@ -74,7 +75,7 @@ class ProjectRuleGroupHistoryIndexEndpoint(RuleEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project: Project, rule: Rule) -> Response:
+    def get(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         per_page = self.get_per_page(request)
         cursor = self.get_cursor_from_request(request)
         try:

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.rule import RuleEndpoint
+from sentry.api.bases.rule import WorkflowEngineRuleEndpoint
 from sentry.api.serializers import Serializer, serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
@@ -19,6 +19,7 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.rules.history import fetch_rule_hourly_stats
 from sentry.rules.history.base import TimeSeriesValue
+from sentry.workflow_engine.models.workflow import Workflow
 
 
 class TimeSeriesValueResponse(TypedDict):
@@ -38,7 +39,7 @@ class TimeSeriesValueSerializer(Serializer):
 
 @extend_schema(tags=["issue_alerts"])
 @region_silo_endpoint
-class ProjectRuleStatsIndexEndpoint(RuleEndpoint):
+class ProjectRuleStatsIndexEndpoint(WorkflowEngineRuleEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
@@ -57,7 +58,7 @@ class ProjectRuleStatsIndexEndpoint(RuleEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project: Project, rule: Rule) -> Response:
+    def get(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """
         Note that results are returned in hourly buckets.
         """

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -4,9 +4,11 @@ from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.history.backends.postgres import PostgresRuleHistoryBackend
 from sentry.rules.history.base import RuleGroupHistory
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.models import AlertRuleWorkflow, Workflow, WorkflowFireHistory
+from sentry.workflow_engine.models import WorkflowFireHistory
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 pytestmark = [requires_snuba]
 
@@ -36,7 +38,7 @@ class RecordTest(BasePostgresRuleHistoryBackendTest):
 
 
 @freeze_time()
-class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
+class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest, BaseWorkflowTest):
     def run_test(self, rule, start, end, expected, cursor=None, per_page=25):
         result = self.backend.fetch_rule_groups_paginated(rule, start, end, cursor, per_page)
         assert result.results == expected, (result.results, expected)
@@ -194,25 +196,14 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             ],
         )
 
-    def test_combined_rule_and_workflow_history(self) -> None:
-        """Test combining RuleFireHistory and WorkflowFireHistory when feature flag is enabled"""
-        rule = self.create_project_rule(project=self.event.project)
-        workflow = Workflow.objects.get(
-            id=AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow_id
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_single_written_workflow_history(self) -> None:
+        """Test using WorkflowFireHistory when feature flag is enabled"""
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
         )
-
-        # Create some RuleFireHistory entries
-        rule_history = []
-        for i in range(2):
-            rule_history.append(
-                RuleFireHistory(
-                    project=rule.project,
-                    rule=rule,
-                    group=self.group,
-                    date_added=before_now(days=i + 1),
-                    event_id=f"rule_event_{i}",
-                )
-            )
 
         # Create some WorkflowFireHistory entries
         for i in range(2):
@@ -224,16 +215,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             )
             wfh.update(date_added=before_now(days=i + 3))
 
-        RuleFireHistory.objects.bulk_create(rule_history)
-
         group_2 = self.create_group()
-        RuleFireHistory.objects.create(
-            project=rule.project,
-            rule=rule,
-            group=group_2,
-            date_added=before_now(days=3),
-            event_id="rule_event_group2",
-        )
         new_workflow_history = WorkflowFireHistory.objects.create(
             workflow=workflow,
             group=group_2,
@@ -243,19 +225,19 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         new_workflow_history.update(date_added=before_now(days=2))
 
         self.run_test(
-            rule,
+            workflow,
             before_now(days=6),
             before_now(days=0),
             [
                 RuleGroupHistory(
                     group=self.group,
-                    count=4,  # 4 from the original data
-                    last_triggered=before_now(days=1),  # Most recent from RuleFireHistory
-                    event_id="rule_event_0",
+                    count=2,
+                    last_triggered=before_now(days=3),
+                    event_id="workflow_event_0",
                 ),
                 RuleGroupHistory(
                     group=group_2,
-                    count=2,  # 2 from both Rule and WorkflowFireHistory
+                    count=1,
                     last_triggered=before_now(days=2),
                     event_id="workflow_event_group2",
                 ),
@@ -264,27 +246,27 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
 
         # Test pagination
         result = self.run_test(
-            rule,
+            workflow,
             before_now(days=6),
             before_now(days=0),
             [
                 RuleGroupHistory(
                     group=self.group,
-                    count=4,
-                    last_triggered=before_now(days=1),
-                    event_id="rule_event_0",
+                    count=2,
+                    last_triggered=before_now(days=3),
+                    event_id="workflow_event_0",
                 ),
             ],
             per_page=1,
         )
         self.run_test(
-            rule,
+            workflow,
             before_now(days=6),
             before_now(days=0),
             [
                 RuleGroupHistory(
                     group=group_2,
-                    count=2,
+                    count=1,
                     last_triggered=before_now(days=2),
                     event_id="workflow_event_group2",
                 ),
@@ -332,32 +314,13 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         assert len(results) == 24
         assert [r.count for r in results[-5:]] == [0, 0, 1, 1, 0]
 
-    def test_combined_rule_and_workflow_history(self) -> None:
-        """Test combining RuleFireHistory and WorkflowFireHistory for hourly stats when feature flag is enabled"""
-        rule = self.create_project_rule(project=self.event.project)
-        workflow = Workflow.objects.get(
-            id=AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow_id
-        )
-
-        rule_history = []
-        # Hour 1: 2 rule fire entries
-        for _ in range(2):
-            rule_history.append(
-                RuleFireHistory(
-                    project=rule.project,
-                    rule=rule,
-                    group=self.group,
-                    date_added=before_now(hours=1),
-                )
-            )
-        # Hour 2: 1 rule fire entry
-        rule_history.append(
-            RuleFireHistory(
-                project=rule.project,
-                rule=rule,
-                group=self.group,
-                date_added=before_now(hours=2),
-            )
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_single_written_workflow_history(self) -> None:
+        """Test using WorkflowFireHistory when feature flag is enabled"""
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
         )
 
         # Hour 1: 1 workflow fire entry
@@ -376,15 +339,13 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             )
             wfh.update(date_added=before_now(hours=3))
 
-        RuleFireHistory.objects.bulk_create(rule_history)
-
-        results = self.backend.fetch_rule_hourly_stats(rule, before_now(hours=24), before_now())
+        results = self.backend.fetch_rule_hourly_stats(workflow, before_now(hours=24), before_now())
         assert len(results) == 24
 
         # Check the last 5 hours (from most recent to oldest)
         # Hour 0: 0 total
-        # Hour 1: 2 (rule) + 1 (workflow) = 3 total
-        # Hour 2: 1 (rule) + 0 (workflow) = 1 total
-        # Hour 3: 0 (rule) + 2 (workflow) = 2 total
+        # Hour 1: 1 (workflow)
+        # Hour 2: 0 (workflow)
+        # Hour 3: 2 (workflow)
         # Hour 4: 0 total
-        assert [r.count for r in results[-5:]] == [0, 2, 1, 3, 0]
+        assert [r.count for r in results[-5:]] == [0, 2, 0, 1, 0]

--- a/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
@@ -1,12 +1,15 @@
 from datetime import datetime
 
 from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.history.base import RuleGroupHistory
 from sentry.rules.history.endpoints.project_rule_group_history import RuleGroupHistorySerializer
 from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.models import WorkflowFireHistory
 
 pytestmark = [requires_snuba]
 
@@ -91,6 +94,78 @@ class ProjectRuleGroupHistoryIndexEndpointTest(APITestCase):
         )
         assert resp.data == serialize(
             [RuleGroupHistory(group_2, 1, base_triggered_date)],
+            self.user,
+            RuleGroupHistorySerializer(),
+        )
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_engine(self) -> None:
+        workflow = self.create_workflow(organization=self.organization)
+        for i in range(3):
+            WorkflowFireHistory.objects.create(
+                workflow=workflow,
+                group=self.group,
+                date_added=before_now(days=i + 1),
+                event_id=f"workflow_event_{i}",
+            )
+
+        wfhs = WorkflowFireHistory.objects.filter(workflow=workflow)
+        assert len(wfhs) == 3
+        for day, wfh in enumerate(wfhs.order_by("id")):
+            wfh.update(date_added=before_now(days=day + 1))
+
+        group_2 = self.create_group()
+        event_id = "workflow_event_99"
+        wfh = WorkflowFireHistory.objects.create(
+            workflow=workflow,
+            group=group_2,
+            date_added=before_now(days=1),
+            event_id=event_id,
+        )
+        wfh.update(date_added=before_now(days=1))
+
+        self.login_as(self.user)
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            get_fake_id_from_object_id(workflow.id),
+            start=before_now(days=6),
+            end=before_now(days=0),
+        )
+        base_triggered_date = before_now(days=1)
+        assert resp.data == serialize(
+            [
+                RuleGroupHistory(self.group, 3, base_triggered_date, "workflow_event_0"),
+                RuleGroupHistory(group_2, 1, base_triggered_date, event_id),
+            ],
+            self.user,
+            RuleGroupHistorySerializer(),
+        )
+
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            get_fake_id_from_object_id(workflow.id),
+            start=before_now(days=6),
+            end=before_now(days=0),
+            per_page=1,
+        )
+        assert resp.data == serialize(
+            [RuleGroupHistory(self.group, 3, base_triggered_date, "workflow_event_0")],
+            self.user,
+            RuleGroupHistorySerializer(),
+        )
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            get_fake_id_from_object_id(workflow.id),
+            start=before_now(days=6),
+            end=before_now(days=0),
+            per_page=1,
+            cursor=self.get_cursor_headers(resp)[1],
+        )
+        assert resp.data == serialize(
+            [RuleGroupHistory(group_2, 1, base_triggered_date, event_id)],
             self.user,
             RuleGroupHistorySerializer(),
         )

--- a/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
@@ -3,13 +3,17 @@ from datetime import datetime, timedelta
 from django.utils import timezone
 
 from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.history.base import TimeSeriesValue
 from sentry.rules.history.endpoints.project_rule_stats import TimeSeriesValueSerializer
 from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.silo import control_silo_test
 from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.models import WorkflowFireHistory
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 pytestmark = [requires_snuba]
 
@@ -28,7 +32,7 @@ class TimeSeriesValueSerializerTest(TestCase):
 
 
 @freeze_time()
-class ProjectRuleStatsIndexEndpointTest(APITestCase):
+class ProjectRuleStatsIndexEndpointTest(APITestCase, BaseWorkflowTest):
     endpoint = "sentry-api-0-project-rule-stats-index"
 
     def test(self) -> None:
@@ -63,6 +67,56 @@ class ProjectRuleStatsIndexEndpointTest(APITestCase):
             self.organization.slug,
             self.project.slug,
             rule.id,
+            start=before_now(days=6),
+            end=before_now(days=0),
+        )
+        assert len(resp.data) == 144
+        now = timezone.now().replace(minute=0, second=0, microsecond=0)
+        assert [r for r in resp.data[-4:]] == [
+            {"date": now - timedelta(hours=3), "count": 3},
+            {"date": now - timedelta(hours=2), "count": 2},
+            {"date": now - timedelta(hours=1), "count": 1},
+            {"date": now, "count": 0},
+        ]
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_engine(self) -> None:
+        workflow = self.create_workflow(organization=self.organization)
+        workflow2 = self.create_workflow(organization=self.organization)
+
+        for i in range(3):
+            for _ in range(i + 1):
+                wfh = WorkflowFireHistory.objects.create(
+                    workflow=workflow,
+                    group=self.group,
+                    date_added=before_now(days=i + 1),
+                    event_id=f"workflow_event_{i}",
+                )
+
+        wfhs = WorkflowFireHistory.objects.filter(workflow=workflow)
+        hours = [1, 2, 2, 3, 3, 3]
+        for hour, wfh in zip(hours, wfhs):
+            wfh.update(date_added=before_now(hours=hour))
+
+        # make a couple in a different workflow to ensure we're not mixing them up
+        for i in range(2):
+            wfh = WorkflowFireHistory(
+                workflow=workflow2,
+                group=self.group,
+                date_added=before_now(hours=i + 1),
+                event_id=f"workflow2_event_{i}",
+            )
+
+        wfhs = WorkflowFireHistory.objects.filter(workflow=workflow2)
+        hours = [1, 2]
+        for hour, wfh in zip(hours, wfhs):
+            wfh.update(date_added=before_now(hours=hour))
+
+        self.login_as(self.user)
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            get_fake_id_from_object_id(workflow.id),
             start=before_now(days=6),
             end=before_now(days=0),
         )

--- a/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
@@ -100,7 +100,7 @@ class ProjectRuleStatsIndexEndpointTest(APITestCase, BaseWorkflowTest):
 
         # make a couple in a different workflow to ensure we're not mixing them up
         for i in range(2):
-            wfh = WorkflowFireHistory(
+            wfh = WorkflowFireHistory.objects.create(
                 workflow=workflow2,
                 group=self.group,
                 date_added=before_now(hours=i + 1),


### PR DESCRIPTION
Update the `ProjectRuleStatsIndexEndpoint` and `ProjectRuleGroupHistoryIndexEndpoint` to accept a workflow ID. Thankfully we already had the functions they call updated to use workflows so this wasn't too large of a change.