### PR TITLE
impr(detectors api): Add new endpoint with project in path for detector creation

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_project_detector_index.py
@@ -1,0 +1,107 @@
+from django.db import router, transaction
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
+from sentry.incidents.grouptype import MetricIssue
+from sentry.models.project import Project
+from sentry.workflow_engine.endpoints.organization_detector_index import get_detector_validator
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import DetectorSerializer
+from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
+from sentry.workflow_engine.endpoints.validators.detector_workflow import (
+    BulkDetectorWorkflowsValidator,
+)
+from sentry.workflow_engine.models import Detector
+
+
+class ProjectDetectorPermission(ProjectPermission):
+    scope_map = {
+        "GET": ["project:read", "project:write", "project:admin", "alerts:read"],
+        "POST": ["project:write", "project:admin", "alerts:write"],
+    }
+
+
+@region_silo_endpoint
+@extend_schema(tags=["Monitors"])
+class OrganizationProjectDetectorIndexEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.PUBLIC,
+    }
+    owner = ApiOwner.ISSUES
+    permission_classes = (ProjectDetectorPermission,)
+
+    @extend_schema(
+        operation_id="Create a Monitor for a Project",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+        ],
+        request=BaseDetectorTypeValidator,
+        responses={
+            201: DetectorSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def post(self, request: Request, project: Project) -> Response:
+        """
+        ⚠️ This endpoint is currently in **beta** and may be subject to change. It is supported by [New Monitors and Alerts](/product/new-monitors-and-alerts/) and may not be viewable in the UI today.
+
+        Create a Monitor for a project
+        """
+        organization = project.organization
+
+        detector_type = request.data.get("type")
+        if not detector_type:
+            raise ValidationError({"type": ["This field is required."]})
+
+        # Restrict creating metric issue detectors by plan type
+        if detector_type == MetricIssue.slug and not features.has(
+            "organizations:incidents", organization, actor=request.user
+        ):
+            raise ResourceDoesNotExist
+
+        validator = get_detector_validator(request, project, detector_type)
+        if not validator.is_valid():
+            return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic(router.db_for_write(Detector)):
+            detector = validator.save()
+
+            # Handle workflow connections in bulk
+            workflow_ids = request.data.get("workflowIds", [])
+            if workflow_ids:
+                bulk_validator = BulkDetectorWorkflowsValidator(
+                    data={
+                        "detector_id": detector.id,
+                        "workflow_ids": workflow_ids,
+                    },
+                    context={
+                        "organization": organization,
+                        "request": request,
+                    },
+                )
+                if not bulk_validator.is_valid():
+                    raise ValidationError({"workflowIds": bulk_validator.errors})
+
+                bulk_validator.save()
+
+        return Response(serialize(detector, request.user), status=status.HTTP_201_CREATED)

--- a/src/sentry/workflow_engine/endpoints/organization_project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_project_detector_index.py
@@ -30,9 +30,8 @@ from sentry.workflow_engine.endpoints.validators.detector_workflow import (
 from sentry.workflow_engine.models import Detector
 
 
-class ProjectDetectorPermission(ProjectPermission):
+class OrganizationProjectDetectorPermission(ProjectPermission):
     scope_map = {
-        "GET": ["project:read", "project:write", "project:admin", "alerts:read"],
         "POST": ["project:write", "project:admin", "alerts:write"],
     }
 
@@ -41,10 +40,10 @@ class ProjectDetectorPermission(ProjectPermission):
 @extend_schema(tags=["Monitors"])
 class OrganizationProjectDetectorIndexEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
-    owner = ApiOwner.ISSUES
-    permission_classes = (ProjectDetectorPermission,)
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
+    permission_classes = (OrganizationProjectDetectorPermission,)
 
     @extend_schema(
         operation_id="Create a Monitor for a Project",

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -17,6 +17,7 @@ from .organization_incident_groupopenperiod_index import (
     OrganizationIncidentGroupOpenPeriodIndexEndpoint,
 )
 from .organization_open_periods import OrganizationOpenPeriodsEndpoint
+from .organization_project_detector_index import OrganizationProjectDetectorIndexEndpoint
 from .organization_test_fire_action import OrganizationTestFireActionsEndpoint
 from .organization_workflow_details import OrganizationWorkflowDetailsEndpoint
 from .organization_workflow_group_history import OrganizationWorkflowGroupHistoryEndpoint
@@ -43,6 +44,11 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/detectors/$",
         OrganizationDetectorIndexEndpoint.as_view(),
         name="sentry-api-0-organization-detector-index",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/projects/(?P<project_id_or_slug>[^/]+)/detectors/$",
+        OrganizationProjectDetectorIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-project-detector-index",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/detectors/count/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -502,6 +502,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/project-transaction-threshold-override/'
   | '/organizations/$organizationIdOrSlug/projects-count/'
   | '/organizations/$organizationIdOrSlug/projects/'
+  | '/organizations/$organizationIdOrSlug/projects/$projectIdOrSlug/detectors/'
   | '/organizations/$organizationIdOrSlug/prompts-activity/'
   | '/organizations/$organizationIdOrSlug/pull-requests/size-analysis/$artifactId/'
   | '/organizations/$organizationIdOrSlug/pullrequest-details/$repoName/$prNumber/'

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1027,19 +1027,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.data == {"name": ["This field is required."]}
 
-    def test_missing_data_sources(self) -> None:
-        data = {
-            "name": "Test Cron Monitor",
-            "type": MonitorIncidentType.slug,
-            "projectId": self.project.id,
-        }
-        response = self.get_error_response(
-            self.organization.slug,
-            **data,
-            status_code=400,
-        )
-        assert "dataSources" in response.data
-
     def test_empty_query_string(self) -> None:
         data = {**self.valid_data}
         data["dataSources"][0]["query"] = ""

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1027,6 +1027,19 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.data == {"name": ["This field is required."]}
 
+    def test_missing_data_sources(self) -> None:
+        data = {
+            "name": "Test Cron Monitor",
+            "type": MonitorIncidentType.slug,
+            "projectId": self.project.id,
+        }
+        response = self.get_error_response(
+            self.organization.slug,
+            **data,
+            status_code=400,
+        )
+        assert "dataSources" in response.data
+
     def test_empty_query_string(self) -> None:
         data = {**self.valid_data}
         data["dataSources"][0]["query"] = ""
@@ -1045,6 +1058,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         assert query_sub.snuba_query.query == ""
 
     def test_valid_creation_with_owner(self) -> None:
+        # Test data with owner field
         data_with_owner = {
             **self.valid_data,
             "owner": self.user.get_actor_identifier(),
@@ -1059,11 +1073,13 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
 
         detector = Detector.objects.get(id=response.data["id"])
 
+        # Verify owner is set correctly
         assert detector.owner_user_id == self.user.id
         assert detector.owner_team_id is None
         assert detector.owner is not None
         assert detector.owner.identifier == self.user.get_actor_identifier()
 
+        # Verify serialized response includes owner
         assert response.data["owner"] == {
             "email": self.user.email,
             "id": str(self.user.id),
@@ -1072,8 +1088,10 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         }
 
     def test_valid_creation_with_team_owner(self) -> None:
+        # Create a team for testing
         team = self.create_team(organization=self.organization)
 
+        # Test data with team owner
         data_with_team_owner = {
             **self.valid_data,
             "owner": f"team:{team.id}",
@@ -1088,11 +1106,13 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
 
         detector = Detector.objects.get(id=response.data["id"])
 
+        # Verify team owner is set correctly
         assert detector.owner_user_id is None
         assert detector.owner_team_id == team.id
         assert detector.owner is not None
         assert detector.owner.identifier == f"team:{team.id}"
 
+        # Verify serialized response includes team owner
         assert response.data["owner"] == {
             "id": str(team.id),
             "name": team.slug,
@@ -1100,6 +1120,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         }
 
     def test_invalid_owner(self) -> None:
+        # Test with invalid owner format
         data_with_invalid_owner = {
             **self.valid_data,
             "owner": "invalid:owner:format",
@@ -1113,10 +1134,12 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         assert "owner" in response.data
 
     def test_owner_not_in_organization(self) -> None:
+        # Create a user in another organization
         other_org = self.create_organization()
         other_user = self.create_user()
         self.create_member(organization=other_org, user=other_user)
 
+        # Test with owner not in current organization
         data_with_invalid_owner = {
             **self.valid_data,
             "owner": other_user.get_actor_identifier(),
@@ -1132,8 +1155,10 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
     @with_feature("organizations:workflow-engine-metric-detector-limit")
     @mock.patch("sentry.quotas.backend.get_metric_detector_limit")
     def test_metric_detector_limit(self, mock_get_limit: mock.MagicMock) -> None:
+        # Set limit to 2 detectors
         mock_get_limit.return_value = 2
 
+        # Create 2 metric detectors (1 active, 1 to be deleted)
         self.create_detector(
             project=self.project,
             name="Existing Detector 1",
@@ -1147,6 +1172,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             status=ObjectStatus.PENDING_DELETION,
         )
 
+        # Create another metric detector, it should succeed
         with self.tasks():
             response = self.get_success_response(
                 self.organization.slug,
@@ -1156,6 +1182,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         detector = Detector.objects.get(id=response.data["id"])
         assert detector.name == "Test Detector"
 
+        # Create another metric detector, it should fail
         response = self.get_error_response(
             self.organization.slug,
             **self.valid_data,
@@ -1166,8 +1193,10 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
     @with_feature("organizations:workflow-engine-metric-detector-limit")
     @mock.patch("sentry.quotas.backend.get_metric_detector_limit")
     def test_metric_detector_limit_unlimited_plan(self, mock_get_limit: mock.MagicMock) -> None:
+        # Set limit to -1 (unlimited)
         mock_get_limit.return_value = -1
 
+        # Create many metric detectors
         for i in range(5):
             self.create_detector(
                 project=self.project,
@@ -1176,6 +1205,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
                 status=ObjectStatus.ACTIVE,
             )
 
+        # Create another detector, it should succeed
         with self.tasks():
             response = self.get_success_response(
                 self.organization.slug,
@@ -1191,10 +1221,13 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
     def test_metric_detector_limit_only_applies_to_metric_detectors(
         self, mock_get_limit: mock.MagicMock
     ) -> None:
+        # Set limit to 1 metric detector
         mock_get_limit.return_value = 1
 
+        # Create a not-metric detector
         self.create_uptime_detector()
 
+        # Create 1 metric detector, it should succeed
         response = self.get_success_response(
             self.organization.slug,
             **self.valid_data,
@@ -1203,6 +1236,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         detector = Detector.objects.get(id=response.data["id"])
         assert detector.name == "Test Detector"
 
+        # Create another metric detector, it should fail
         response = self.get_error_response(
             self.organization.slug,
             **self.valid_data,
@@ -1210,6 +1244,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.status_code == 400
 
+        # Create another not-metric detector, it should succeed
         data = {
             "name": "Test Uptime Monitor",
             "type": UptimeDomainCheckFailure.slug,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1045,7 +1045,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         assert query_sub.snuba_query.query == ""
 
     def test_valid_creation_with_owner(self) -> None:
-        # Test data with owner field
         data_with_owner = {
             **self.valid_data,
             "owner": self.user.get_actor_identifier(),
@@ -1060,13 +1059,11 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
 
         detector = Detector.objects.get(id=response.data["id"])
 
-        # Verify owner is set correctly
         assert detector.owner_user_id == self.user.id
         assert detector.owner_team_id is None
         assert detector.owner is not None
         assert detector.owner.identifier == self.user.get_actor_identifier()
 
-        # Verify serialized response includes owner
         assert response.data["owner"] == {
             "email": self.user.email,
             "id": str(self.user.id),
@@ -1075,10 +1072,8 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         }
 
     def test_valid_creation_with_team_owner(self) -> None:
-        # Create a team for testing
         team = self.create_team(organization=self.organization)
 
-        # Test data with team owner
         data_with_team_owner = {
             **self.valid_data,
             "owner": f"team:{team.id}",
@@ -1093,13 +1088,11 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
 
         detector = Detector.objects.get(id=response.data["id"])
 
-        # Verify team owner is set correctly
         assert detector.owner_user_id is None
         assert detector.owner_team_id == team.id
         assert detector.owner is not None
         assert detector.owner.identifier == f"team:{team.id}"
 
-        # Verify serialized response includes team owner
         assert response.data["owner"] == {
             "id": str(team.id),
             "name": team.slug,
@@ -1107,7 +1100,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         }
 
     def test_invalid_owner(self) -> None:
-        # Test with invalid owner format
         data_with_invalid_owner = {
             **self.valid_data,
             "owner": "invalid:owner:format",
@@ -1121,12 +1113,10 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         assert "owner" in response.data
 
     def test_owner_not_in_organization(self) -> None:
-        # Create a user in another organization
         other_org = self.create_organization()
         other_user = self.create_user()
         self.create_member(organization=other_org, user=other_user)
 
-        # Test with owner not in current organization
         data_with_invalid_owner = {
             **self.valid_data,
             "owner": other_user.get_actor_identifier(),
@@ -1142,10 +1132,8 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
     @with_feature("organizations:workflow-engine-metric-detector-limit")
     @mock.patch("sentry.quotas.backend.get_metric_detector_limit")
     def test_metric_detector_limit(self, mock_get_limit: mock.MagicMock) -> None:
-        # Set limit to 2 detectors
         mock_get_limit.return_value = 2
 
-        # Create 2 metric detectors (1 active, 1 to be deleted)
         self.create_detector(
             project=self.project,
             name="Existing Detector 1",
@@ -1159,7 +1147,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             status=ObjectStatus.PENDING_DELETION,
         )
 
-        # Create another metric detector, it should succeed
         with self.tasks():
             response = self.get_success_response(
                 self.organization.slug,
@@ -1169,7 +1156,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         detector = Detector.objects.get(id=response.data["id"])
         assert detector.name == "Test Detector"
 
-        # Create another metric detector, it should fail
         response = self.get_error_response(
             self.organization.slug,
             **self.valid_data,
@@ -1180,10 +1166,8 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
     @with_feature("organizations:workflow-engine-metric-detector-limit")
     @mock.patch("sentry.quotas.backend.get_metric_detector_limit")
     def test_metric_detector_limit_unlimited_plan(self, mock_get_limit: mock.MagicMock) -> None:
-        # Set limit to -1 (unlimited)
         mock_get_limit.return_value = -1
 
-        # Create many metric detectors
         for i in range(5):
             self.create_detector(
                 project=self.project,
@@ -1192,7 +1176,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
                 status=ObjectStatus.ACTIVE,
             )
 
-        # Create another detector, it should succeed
         with self.tasks():
             response = self.get_success_response(
                 self.organization.slug,
@@ -1208,13 +1191,10 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
     def test_metric_detector_limit_only_applies_to_metric_detectors(
         self, mock_get_limit: mock.MagicMock
     ) -> None:
-        # Set limit to 1 metric detector
         mock_get_limit.return_value = 1
 
-        # Create a not-metric detector
         self.create_uptime_detector()
 
-        # Create 1 metric detector, it should succeed
         response = self.get_success_response(
             self.organization.slug,
             **self.valid_data,
@@ -1223,7 +1203,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         detector = Detector.objects.get(id=response.data["id"])
         assert detector.name == "Test Detector"
 
-        # Create another metric detector, it should fail
         response = self.get_error_response(
             self.organization.slug,
             **self.valid_data,
@@ -1231,7 +1210,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.status_code == 400
 
-        # Create another not-metric detector, it should succeed
         data = {
             "name": "Test Uptime Monitor",
             "type": UptimeDomainCheckFailure.slug,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
@@ -1,0 +1,310 @@
+from unittest import mock
+
+from rest_framework.exceptions import ErrorDetail
+
+from sentry.api.serializers import serialize
+from sentry.incidents.grouptype import MetricIssue
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType
+from sentry.models.environment import Environment
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import (
+    QuerySubscription,
+    QuerySubscriptionDataSourceHandler,
+    SnubaQuery,
+    SnubaQueryEventType,
+)
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import region_silo_test
+from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detector_type_error
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup, DataSource, Detector
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
+from sentry.workflow_engine.registry import data_source_type_registry
+from sentry.workflow_engine.types import DetectorPriorityLevel
+
+
+class ProjectDetectorIndexBaseTest(APITestCase):
+    endpoint = "sentry-api-0-organization-project-detector-index"
+    method = "POST"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        # Access self.project eagerly to avoid lazy creation inside mock contexts
+        _ = self.project
+        self.environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+        self.data_condition_group = self.create_data_condition_group(
+            organization_id=self.organization.id,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+        self.connected_workflow = self.create_workflow(
+            organization_id=self.organization.id,
+        )
+        self.valid_data = {
+            "name": "Test Detector",
+            "type": MetricIssue.slug,
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.ERROR.value,
+                    "dataset": Dataset.Events.name.lower(),
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
+                }
+            ],
+            "conditionGroup": {
+                "id": self.data_condition_group.id,
+                "organizationId": self.organization.id,
+                "logicType": self.data_condition_group.logic_type,
+                "conditions": [
+                    {
+                        "type": Condition.GREATER,
+                        "comparison": 100,
+                        "conditionResult": DetectorPriorityLevel.HIGH,
+                        "conditionGroupId": self.data_condition_group.id,
+                    },
+                    {
+                        "type": Condition.LESS_OR_EQUAL,
+                        "comparison": 100,
+                        "conditionResult": DetectorPriorityLevel.OK,
+                        "conditionGroupId": self.data_condition_group.id,
+                    },
+                ],
+            },
+            "config": {
+                "thresholdPeriod": 1,
+                "detectionType": AlertRuleDetectionType.STATIC.value,
+            },
+            "workflowIds": [self.connected_workflow.id],
+        }
+
+
+@region_silo_test
+@with_feature("organizations:incidents")
+class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
+    def test_missing_group_type(self) -> None:
+        data = {**self.valid_data}
+        del data["type"]
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert response.data == {"type": ["This field is required."]}
+
+    def test_invalid_group_type(self) -> None:
+        data = {**self.valid_data, "type": "invalid_type"}
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert response.data == {
+            "type": [get_unknown_detector_type_error("invalid_type", self.organization)]
+        }
+
+    def test_incompatible_group_type(self) -> None:
+        with mock.patch.object(MetricIssue, "detector_settings", None):
+            data = {**self.valid_data, "type": MetricIssue.slug}
+            response = self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                **data,
+                status_code=400,
+            )
+            assert response.data == {"type": ["Detector type not compatible with detectors"]}
+
+    def test_without_feature_flag(self) -> None:
+        with self.feature({"organizations:incidents": False}):
+            response = self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                **self.valid_data,
+                status_code=404,
+            )
+        assert response.data == {
+            "detail": ErrorDetail(string="The requested resource does not exist", code="error")
+        }
+
+    def test_project_not_found(self) -> None:
+        self.get_error_response(
+            self.organization.slug,
+            "nonexistent-project-slug",
+            **self.valid_data,
+            status_code=404,
+        )
+
+    def test_project_belongs_to_different_org(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        self.get_error_response(
+            self.organization.slug,
+            other_project.slug,
+            **self.valid_data,
+            status_code=404,
+        )
+
+    def test_project_by_id(self) -> None:
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.id,
+                **self.valid_data,
+                status_code=201,
+            )
+        assert response.data["projectId"] == str(self.project.id)
+
+    def test_project_by_slug(self) -> None:
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                **self.valid_data,
+                status_code=201,
+            )
+        assert response.data["projectId"] == str(self.project.id)
+
+    @mock.patch("sentry.incidents.metric_issue_detector.schedule_update_project_config")
+    @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
+    def test_valid_creation(
+        self,
+        mock_audit: mock.MagicMock,
+        mock_schedule_update_project_config: mock.MagicMock,
+    ) -> None:
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                **self.valid_data,
+                status_code=201,
+            )
+
+        detector = Detector.objects.get(id=response.data["id"])
+        assert response.data == serialize([detector])[0]
+        assert detector.name == "Test Detector"
+        assert detector.type == MetricIssue.slug
+        assert detector.project_id == self.project.id
+        assert detector.description is None
+
+        # Verify data source
+        data_source = DataSource.objects.get(detector=detector)
+        assert data_source.type == data_source_type_registry.get_key(
+            QuerySubscriptionDataSourceHandler
+        )
+        assert data_source.organization_id == self.organization.id
+
+        # Verify query subscription
+        query_sub = QuerySubscription.objects.get(id=int(data_source.source_id))
+        assert query_sub.project == self.project
+        assert query_sub.snuba_query.type == SnubaQuery.Type.ERROR.value
+        assert query_sub.snuba_query.dataset == Dataset.Events.value
+        assert query_sub.snuba_query.query == "test query"
+        assert query_sub.snuba_query.aggregate == "count()"
+        assert query_sub.snuba_query.time_window == 3600
+        assert query_sub.snuba_query.environment == self.environment
+        assert query_sub.snuba_query.event_types == [SnubaQueryEventType.EventType.ERROR]
+
+        # Verify condition group and conditions
+        condition_group = detector.workflow_condition_group
+        assert condition_group
+        assert condition_group.logic_type == DataConditionGroup.Type.ANY
+        assert condition_group.organization_id == self.organization.id
+
+        conditions = list(DataCondition.objects.filter(condition_group=condition_group))
+        assert len(conditions) == 2
+        condition = conditions[0]
+        assert condition.type == Condition.GREATER
+        assert condition.comparison == 100
+        assert condition.condition_result == DetectorPriorityLevel.HIGH
+
+        # Verify connected workflows
+        detector_workflow = DetectorWorkflow.objects.get(
+            detector=detector, workflow=self.connected_workflow
+        )
+        assert detector_workflow.detector == detector
+        assert detector_workflow.workflow == self.connected_workflow
+
+        # Verify audit log
+        mock_audit.assert_called_once_with(
+            request=mock.ANY,
+            organization=self.organization,
+            target_object=detector.id,
+            event=mock.ANY,
+            data=detector.get_audit_log_data(),
+        )
+        mock_schedule_update_project_config.assert_called_once_with(detector)
+
+    def test_creation_with_description(self) -> None:
+        data = {**self.valid_data, "description": "This is a test metric detector"}
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                **data,
+                status_code=201,
+            )
+
+        detector = Detector.objects.get(id=response.data["id"])
+        assert detector.description == "This is a test metric detector"
+
+    def test_invalid_workflow_ids(self) -> None:
+        data = {**self.valid_data, "workflowIds": [999999]}
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert "Some workflows do not exist" in str(response.data)
+
+        other_org = self.create_organization()
+        other_workflow = self.create_workflow(organization_id=other_org.id)
+        data = {**self.valid_data, "workflowIds": [other_workflow.id]}
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert "Some workflows do not exist" in str(response.data)
+
+    def test_transaction_rollback_on_workflow_validation_failure(self) -> None:
+        initial_detector_count = Detector.objects.filter(project=self.project).count()
+
+        data = {**self.valid_data, "workflowIds": [999999]}
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+
+        final_detector_count = Detector.objects.filter(project=self.project).count()
+        assert final_detector_count == initial_detector_count
+        assert "Some workflows do not exist" in str(response.data)
+
+    def test_missing_required_field(self) -> None:
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=400,
+        )
+        assert response.data == {"type": ["This field is required."]}
+
+    def test_missing_name(self) -> None:
+        data = {**self.valid_data}
+        del data["name"]
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert response.data == {"name": ["This field is required."]}

--- a/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
@@ -24,7 +24,7 @@ from sentry.workflow_engine.registry import data_source_type_registry
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
-class ProjectDetectorIndexBaseTest(APITestCase):
+class OrganizationProjectDetectorIndexBaseTest(APITestCase):
     endpoint = "sentry-api-0-organization-project-detector-index"
     method = "POST"
 
@@ -86,7 +86,7 @@ class ProjectDetectorIndexBaseTest(APITestCase):
 
 @region_silo_test
 @with_feature("organizations:incidents")
-class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
+class OrganizationProjectDetectorIndexPostTest(OrganizationProjectDetectorIndexBaseTest):
     def test_missing_group_type(self) -> None:
         data = {**self.valid_data}
         del data["type"]


### PR DESCRIPTION
We want to support taking in the project id & slug for detector creation. We can't blanket change the current `OrganizationDetectorIndex` endpoint to be project qualified as the PUT, DELETE & GET endpoints take in many projects via query parameters. This PR introduces a new endpoint w/ project_id or slug in the path params for detector creation specific to a project.

- Bulk operations will continue to use the previous `OrganizationDetectorIndex` endpoint.
- The deprecation will be, New endpoint (this PR) -> Update calling code/frontend -> Delete old endpoint