### PR TITLE
feat(broadcasts): Add status and limit query params to org broadcasts endpoint

### DIFF
--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -118,15 +118,23 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
                 queryset = queryset.exclude(broadcastseen__user_id=request.user.id)
             elif status == "seen":
                 queryset = queryset.filter(broadcastseen__user_id=request.user.id)
+            elif status is not None:
+                return self.respond(
+                    {"detail": "Invalid status. Valid values are 'seen' and 'unseen'."},
+                    status=400,
+                )
 
             data = self._secondary_filtering(request, organization, queryset)
 
             limit_param = request.GET.get("limit")
             if limit_param is not None:
                 try:
-                    data = data[: int(limit_param)]
+                    limit = int(limit_param)
                 except ValueError:
-                    pass
+                    return self.respond({"detail": "limit must be an integer."}, status=400)
+                if limit <= 0:
+                    return self.respond({"detail": "limit must be a positive integer."}, status=400)
+                data = data[:limit]
 
             return self.respond(self._serialize_objects(data, request))
 

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -114,28 +114,19 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
 
         if organization:
             status = request.GET.get("status")
-            if status == "unseen" and request.user.is_authenticated:
-                seen_ids = set(
-                    BroadcastSeen.objects.filter(user_id=request.user.id).values_list(
-                        "broadcast_id", flat=True
-                    )
-                )
-                queryset = queryset.exclude(id__in=seen_ids)
-            elif status == "seen" and request.user.is_authenticated:
-                seen_ids = set(
-                    BroadcastSeen.objects.filter(user_id=request.user.id).values_list(
-                        "broadcast_id", flat=True
-                    )
-                )
-                queryset = queryset.filter(id__in=seen_ids)
+            if status == "unseen":
+                queryset = queryset.exclude(broadcastseen__user_id=request.user.id)
+            elif status == "seen":
+                queryset = queryset.filter(broadcastseen__user_id=request.user.id)
 
             data = self._secondary_filtering(request, organization, queryset)
 
-            try:
-                limit = int(request.GET["limit"])
-                data = data[:limit]
-            except (KeyError, ValueError, TypeError):
-                pass
+            limit_param = request.GET.get("limit")
+            if limit_param is not None:
+                try:
+                    data = data[: int(limit_param)]
+                except ValueError:
+                    pass
 
             return self.respond(self._serialize_objects(data, request))
 

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -5,7 +5,7 @@ from functools import reduce
 from operator import or_
 
 from django.db import IntegrityError, router, transaction
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Q
 from django.utils import timezone
 
 from sentry.api.api_owners import ApiOwner
@@ -123,17 +123,6 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
                     {"detail": "Invalid status. Valid values are 'seen' and 'unseen'."},
                     status=400,
                 )
-            else:
-                # No status filter: annotate so unseen results sort before seen ones,
-                # ensuring they are prioritised when a limit is applied.
-                queryset = queryset.annotate(
-                    has_seen=Exists(
-                        BroadcastSeen.objects.filter(
-                            broadcast_id=OuterRef("pk"),
-                            user_id=request.user.id,
-                        )
-                    )
-                ).order_by("has_seen", "-date_added")
 
             data = self._secondary_filtering(request, organization, queryset)
 

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -113,7 +113,42 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
                     queryset = queryset.none()
 
         if organization:
+            status = request.GET.get("status", "all")
+            if status == "unseen" and request.user.is_authenticated:
+                seen_ids = set(
+                    BroadcastSeen.objects.filter(user_id=request.user.id).values_list(
+                        "broadcast_id", flat=True
+                    )
+                )
+                queryset = queryset.exclude(id__in=seen_ids)
+            elif status == "seen" and request.user.is_authenticated:
+                seen_ids = set(
+                    BroadcastSeen.objects.filter(user_id=request.user.id).values_list(
+                        "broadcast_id", flat=True
+                    )
+                )
+                queryset = queryset.filter(id__in=seen_ids)
+
             data = self._secondary_filtering(request, organization, queryset)
+
+            try:
+                limit = int(request.GET.get("limit", 0))
+            except (ValueError, TypeError):
+                limit = 0
+
+            if limit > 0 and len(data) < limit:
+                existing_ids = {b.id for b in data}
+                backfill = list(
+                    Broadcast.objects.filter(is_active=True)
+                    .exclude(id__in=existing_ids)
+                    .order_by("-date_added")[: limit - len(data)]
+                )
+                data = sorted(
+                    list(data) + backfill,
+                    key=lambda b: b.date_added,
+                    reverse=True,
+                )
+
             return self.respond(self._serialize_objects(data, request))
 
         sort_by = request.GET.get("sortBy")

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -114,13 +114,9 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
 
         status = request.GET.get("status")
         if status == "unseen":
-            if request.user.is_authenticated:
-                queryset = queryset.exclude(broadcastseen__user_id=request.user.id)
+            queryset = queryset.exclude(broadcastseen__user_id=request.user.id)
         elif status == "seen":
-            if request.user.is_authenticated:
-                queryset = queryset.filter(broadcastseen__user_id=request.user.id)
-            else:
-                queryset = queryset.none()
+            queryset = queryset.filter(broadcastseen__user_id=request.user.id)
         elif status is not None and status != "all":
             return self.respond(
                 {"detail": "Invalid status. Valid values are 'seen', 'unseen', and 'all'."},

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -112,24 +112,22 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
                 else:
                     queryset = queryset.none()
 
-        if organization:
-            status = request.GET.get("status")
-            if status == "unseen":
-                if request.user.is_authenticated:
-                    queryset = queryset.exclude(broadcastseen__user_id=request.user.id)
-            elif status == "seen":
-                if request.user.is_authenticated:
-                    queryset = queryset.filter(broadcastseen__user_id=request.user.id)
-                else:
-                    queryset = queryset.none()
-            elif status == "all":
-                pass
-            elif status is not None:
-                return self.respond(
-                    {"detail": "Invalid status. Valid values are 'all', 'seen', and 'unseen'."},
-                    status=400,
-                )
+        status = request.GET.get("status")
+        if status == "unseen":
+            if request.user.is_authenticated:
+                queryset = queryset.exclude(broadcastseen__user_id=request.user.id)
+        elif status == "seen":
+            if request.user.is_authenticated:
+                queryset = queryset.filter(broadcastseen__user_id=request.user.id)
+            else:
+                queryset = queryset.none()
+        elif status is not None and status != "all":
+            return self.respond(
+                {"detail": "Invalid status. Valid values are 'seen', 'unseen', and 'all'."},
+                status=400,
+            )
 
+        if organization:
             data = self._secondary_filtering(request, organization, queryset)
 
             limit_param = request.GET.get("limit")

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -113,7 +113,7 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
                     queryset = queryset.none()
 
         if organization:
-            status = request.GET.get("status", "all")
+            status = request.GET.get("status")
             if status == "unseen" and request.user.is_authenticated:
                 seen_ids = set(
                     BroadcastSeen.objects.filter(user_id=request.user.id).values_list(
@@ -132,22 +132,10 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
             data = self._secondary_filtering(request, organization, queryset)
 
             try:
-                limit = int(request.GET.get("limit", 0))
-            except (ValueError, TypeError):
-                limit = 0
-
-            if limit > 0 and len(data) < limit:
-                existing_ids = {b.id for b in data}
-                backfill = list(
-                    Broadcast.objects.filter(is_active=True)
-                    .exclude(id__in=existing_ids)
-                    .order_by("-date_added")[: limit - len(data)]
-                )
-                data = sorted(
-                    list(data) + backfill,
-                    key=lambda b: b.date_added,
-                    reverse=True,
-                )
+                limit = int(request.GET["limit"])
+                data = data[:limit]
+            except (KeyError, ValueError, TypeError):
+                pass
 
             return self.respond(self._serialize_objects(data, request))
 

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -5,7 +5,7 @@ from functools import reduce
 from operator import or_
 
 from django.db import IntegrityError, router, transaction
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 
 from sentry.api.api_owners import ApiOwner
@@ -123,6 +123,17 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
                     {"detail": "Invalid status. Valid values are 'seen' and 'unseen'."},
                     status=400,
                 )
+            else:
+                # No status filter: annotate so unseen results sort before seen ones,
+                # ensuring they are prioritised when a limit is applied.
+                queryset = queryset.annotate(
+                    has_seen=Exists(
+                        BroadcastSeen.objects.filter(
+                            broadcast_id=OuterRef("pk"),
+                            user_id=request.user.id,
+                        )
+                    )
+                ).order_by("has_seen", "-date_added")
 
             data = self._secondary_filtering(request, organization, queryset)
 

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -122,9 +122,11 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
                     queryset = queryset.filter(broadcastseen__user_id=request.user.id)
                 else:
                     queryset = queryset.none()
+            elif status == "all":
+                pass
             elif status is not None:
                 return self.respond(
-                    {"detail": "Invalid status. Valid values are 'seen' and 'unseen'."},
+                    {"detail": "Invalid status. Valid values are 'all', 'seen', and 'unseen'."},
                     status=400,
                 )
 

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -115,9 +115,13 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
         if organization:
             status = request.GET.get("status")
             if status == "unseen":
-                queryset = queryset.exclude(broadcastseen__user_id=request.user.id)
+                if request.user.is_authenticated:
+                    queryset = queryset.exclude(broadcastseen__user_id=request.user.id)
             elif status == "seen":
-                queryset = queryset.filter(broadcastseen__user_id=request.user.id)
+                if request.user.is_authenticated:
+                    queryset = queryset.filter(broadcastseen__user_id=request.user.id)
+                else:
+                    queryset = queryset.none()
             elif status is not None:
                 return self.respond(
                     {"detail": "Invalid status. Valid values are 'seen' and 'unseen'."},

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -119,21 +119,6 @@ class BroadcastListTest(APITestCase):
         assert str(broadcast1.id) in ids
         assert str(broadcast2.id) in ids
 
-    def test_organization_unseen_prioritised_when_no_status_filter(self) -> None:
-        seen_broadcast = Broadcast.objects.create(message="seen", is_active=True)
-        unseen_broadcast = Broadcast.objects.create(message="unseen", is_active=True)
-        BroadcastSeen.objects.create(broadcast=seen_broadcast, user=self.user)
-
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
-
-        # limit=1 should return the unseen broadcast even though seen_broadcast
-        # was created first (and would win a purely date-based sort).
-        response = self.client.get(url, {"limit": "1"})
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(unseen_broadcast.id)
-
     def test_organization_limit_slices_results(self) -> None:
         for i in range(5):
             Broadcast.objects.create(message=f"broadcast {i}", is_active=True)

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -159,6 +159,21 @@ class BroadcastListTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 2
 
+    def test_organization_status_all_explicit(self) -> None:
+        broadcast1 = Broadcast.objects.create(message="unseen", is_active=True)
+        broadcast2 = Broadcast.objects.create(message="seen", is_active=True)
+        BroadcastSeen.objects.create(broadcast=broadcast2, user=self.user)
+
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        response = self.client.get(url, {"status": "all"})
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        ids = [b["id"] for b in response.data]
+        assert str(broadcast1.id) in ids
+        assert str(broadcast2.id) in ids
+
     def test_organization_invalid_status_returns_400(self) -> None:
         self.login_as(user=self.user)
         url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -119,47 +119,42 @@ class BroadcastListTest(APITestCase):
         assert str(broadcast1.id) in ids
         assert str(broadcast2.id) in ids
 
-    def test_organization_limit_backfills_when_below_minimum(self) -> None:
+    def test_organization_limit_slices_results(self) -> None:
         for i in range(5):
             Broadcast.objects.create(message=f"broadcast {i}", is_active=True)
 
         self.login_as(user=self.user)
         url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
 
-        # Mark all as seen so status=unseen returns 0, then limit=3 should backfill
-        for broadcast in Broadcast.objects.filter(is_active=True):
-            BroadcastSeen.objects.create(broadcast=broadcast, user=self.user)
-
-        response = self.client.get(url, {"status": "unseen", "limit": "3"})
+        response = self.client.get(url, {"limit": "3"})
         assert response.status_code == 200
         assert len(response.data) == 3
 
-    def test_organization_limit_does_not_exceed_available_broadcasts(self) -> None:
-        Broadcast.objects.create(message="only one", is_active=True)
+    def test_organization_limit_respects_status_filter(self) -> None:
+        for i in range(5):
+            broadcast = Broadcast.objects.create(message=f"broadcast {i}", is_active=True)
+            if i < 2:
+                BroadcastSeen.objects.create(broadcast=broadcast, user=self.user)
 
         self.login_as(user=self.user)
         url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
 
-        response = self.client.get(url, {"status": "unseen", "limit": "3"})
+        # 3 unseen broadcasts exist; limit=2 should return only 2 of them
+        response = self.client.get(url, {"status": "unseen", "limit": "2"})
         assert response.status_code == 200
-        assert len(response.data) == 1
+        assert len(response.data) == 2
 
-    def test_organization_limit_backfill_excludes_inactive_broadcasts(self) -> None:
-        Broadcast.objects.create(message="active", is_active=True)
-        Broadcast.objects.create(message="inactive 1", is_active=False)
-        Broadcast.objects.create(message="inactive 2", is_active=False)
+    def test_organization_limit_without_params_is_backwards_compatible(self) -> None:
+        for i in range(5):
+            Broadcast.objects.create(message=f"broadcast {i}", is_active=True)
 
         self.login_as(user=self.user)
         url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
 
-        # Mark active as seen so unseen returns 0, limit=3 should only backfill active
-        for broadcast in Broadcast.objects.filter(is_active=True):
-            BroadcastSeen.objects.create(broadcast=broadcast, user=self.user)
-
-        response = self.client.get(url, {"status": "unseen", "limit": "3"})
+        # No params — returns all results, same as before
+        response = self.client.get(url)
         assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["message"] == "active"
+        assert len(response.data) == 5
 
 
 @control_silo_test

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -119,6 +119,21 @@ class BroadcastListTest(APITestCase):
         assert str(broadcast1.id) in ids
         assert str(broadcast2.id) in ids
 
+    def test_organization_status_all_explicit(self) -> None:
+        broadcast1 = Broadcast.objects.create(message="unseen", is_active=True)
+        broadcast2 = Broadcast.objects.create(message="seen", is_active=True)
+        BroadcastSeen.objects.create(broadcast=broadcast2, user=self.user)
+
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        response = self.client.get(url, {"status": "all"})
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        ids = [b["id"] for b in response.data]
+        assert str(broadcast1.id) in ids
+        assert str(broadcast2.id) in ids
+
     def test_organization_limit_slices_results(self) -> None:
         for i in range(5):
             Broadcast.objects.create(message=f"broadcast {i}", is_active=True)
@@ -150,6 +165,9 @@ class BroadcastListTest(APITestCase):
 
         response = self.client.get(url, {"status": "invalid"})
         assert response.status_code == 400
+        assert "all" in response.data["detail"]
+        assert "seen" in response.data["detail"]
+        assert "unseen" in response.data["detail"]
 
     def test_organization_invalid_limit_returns_400(self) -> None:
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -159,21 +159,6 @@ class BroadcastListTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 2
 
-    def test_organization_status_all_explicit(self) -> None:
-        broadcast1 = Broadcast.objects.create(message="unseen", is_active=True)
-        broadcast2 = Broadcast.objects.create(message="seen", is_active=True)
-        BroadcastSeen.objects.create(broadcast=broadcast2, user=self.user)
-
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
-
-        response = self.client.get(url, {"status": "all"})
-        assert response.status_code == 200
-        assert len(response.data) == 2
-        ids = [b["id"] for b in response.data]
-        assert str(broadcast1.id) in ids
-        assert str(broadcast2.id) in ids
-
     def test_organization_invalid_status_returns_400(self) -> None:
         self.login_as(user=self.user)
         url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -144,6 +144,27 @@ class BroadcastListTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 2
 
+    def test_organization_invalid_status_returns_400(self) -> None:
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        response = self.client.get(url, {"status": "invalid"})
+        assert response.status_code == 400
+
+    def test_organization_invalid_limit_returns_400(self) -> None:
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        response = self.client.get(url, {"limit": "notanumber"})
+        assert response.status_code == 400
+
+    def test_organization_negative_limit_returns_400(self) -> None:
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        response = self.client.get(url, {"limit": "-1"})
+        assert response.status_code == 400
+
     def test_organization_limit_without_params_is_backwards_compatible(self) -> None:
         for i in range(5):
             Broadcast.objects.create(message=f"broadcast {i}", is_active=True)

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -119,6 +119,21 @@ class BroadcastListTest(APITestCase):
         assert str(broadcast1.id) in ids
         assert str(broadcast2.id) in ids
 
+    def test_organization_unseen_prioritised_when_no_status_filter(self) -> None:
+        seen_broadcast = Broadcast.objects.create(message="seen", is_active=True)
+        unseen_broadcast = Broadcast.objects.create(message="unseen", is_active=True)
+        BroadcastSeen.objects.create(broadcast=seen_broadcast, user=self.user)
+
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        # limit=1 should return the unseen broadcast even though seen_broadcast
+        # was created first (and would win a purely date-based sort).
+        response = self.client.get(url, {"limit": "1"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(unseen_broadcast.id)
+
     def test_organization_limit_slices_results(self) -> None:
         for i in range(5):
             Broadcast.objects.create(message=f"broadcast {i}", is_active=True)

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -78,6 +78,89 @@ class BroadcastListTest(APITestCase):
         assert str(broadcast1.id) in [str(broadcast["id"]) for broadcast in response.data]
         assert str(broadcast2.id) in [str(broadcast["id"]) for broadcast in response.data]
 
+    def test_organization_status_unseen(self) -> None:
+        broadcast1 = Broadcast.objects.create(message="unseen", is_active=True)
+        broadcast2 = Broadcast.objects.create(message="seen", is_active=True)
+        BroadcastSeen.objects.create(broadcast=broadcast2, user=self.user)
+
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        response = self.client.get(url, {"status": "unseen"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(broadcast1.id)
+
+    def test_organization_status_seen(self) -> None:
+        Broadcast.objects.create(message="unseen", is_active=True)
+        broadcast2 = Broadcast.objects.create(message="seen", is_active=True)
+        BroadcastSeen.objects.create(broadcast=broadcast2, user=self.user)
+
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        response = self.client.get(url, {"status": "seen"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(broadcast2.id)
+
+    def test_organization_status_all_is_default(self) -> None:
+        broadcast1 = Broadcast.objects.create(message="unseen", is_active=True)
+        broadcast2 = Broadcast.objects.create(message="seen", is_active=True)
+        BroadcastSeen.objects.create(broadcast=broadcast2, user=self.user)
+
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        ids = [b["id"] for b in response.data]
+        assert str(broadcast1.id) in ids
+        assert str(broadcast2.id) in ids
+
+    def test_organization_limit_backfills_when_below_minimum(self) -> None:
+        for i in range(5):
+            Broadcast.objects.create(message=f"broadcast {i}", is_active=True)
+
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        # Mark all as seen so status=unseen returns 0, then limit=3 should backfill
+        for broadcast in Broadcast.objects.filter(is_active=True):
+            BroadcastSeen.objects.create(broadcast=broadcast, user=self.user)
+
+        response = self.client.get(url, {"status": "unseen", "limit": "3"})
+        assert response.status_code == 200
+        assert len(response.data) == 3
+
+    def test_organization_limit_does_not_exceed_available_broadcasts(self) -> None:
+        Broadcast.objects.create(message="only one", is_active=True)
+
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        response = self.client.get(url, {"status": "unseen", "limit": "3"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+
+    def test_organization_limit_backfill_excludes_inactive_broadcasts(self) -> None:
+        Broadcast.objects.create(message="active", is_active=True)
+        Broadcast.objects.create(message="inactive 1", is_active=False)
+        Broadcast.objects.create(message="inactive 2", is_active=False)
+
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-broadcasts", args=[self.organization.slug])
+
+        # Mark active as seen so unseen returns 0, limit=3 should only backfill active
+        for broadcast in Broadcast.objects.filter(is_active=True):
+            BroadcastSeen.objects.create(broadcast=broadcast, user=self.user)
+
+        response = self.client.get(url, {"status": "unseen", "limit": "3"})
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["message"] == "active"
+
 
 @control_silo_test
 class BroadcastCreateTest(APITestCase):


### PR DESCRIPTION
Add two optional query parameters to the organization broadcasts endpoint:

- `status=all|seen|unseen` — filters broadcasts by the requesting user's seen state. Defaults to `all`.
- `limit=n` — limits the number of broadcasts returned, sorted by `date_added` descending.