### PR TITLE
fix(seer): Reduce the staletime of the SCM tree so it can refresh as integrations change

### DIFF
--- a/static/gsApp/views/seerAutomation/components/scmIntegrationTree/useScmIntegrationTreeData.ts
+++ b/static/gsApp/views/seerAutomation/components/scmIntegrationTree/useScmIntegrationTreeData.ts
@@ -32,7 +32,7 @@ export function useScmIntegrationTreeData(): ScmIntegrationTreeData {
       '/organizations/$organizationIdOrSlug/config/integrations/',
       {
         path: {organizationIdOrSlug: organization.slug},
-        staleTime: 60_000,
+        staleTime: 0,
       }
     )
   );


### PR DESCRIPTION
There's a problem now where the cache seems to be very long and something is clearing it when we navigate to another page. coming back was showing "No source code management integrations found."

Now the cache can refresh when the scm tree is rendered, and all is ok