### PR TITLE
fix(preprod): Skip snapshot artifacts in expiry detection

### DIFF
--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -852,6 +852,7 @@ def detect_expired_preprod_artifacts() -> None:
     expired_artifacts = PreprodArtifact.objects.filter(
         state__in=[PreprodArtifact.ArtifactState.UPLOADING, PreprodArtifact.ArtifactState.UPLOADED],
         date_updated__lte=timeout_threshold,
+        preprodsnapshotmetrics__isnull=True,
     )
 
     expired_artifacts_count = 0

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -1336,3 +1336,30 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
             just_under_30_artifact.state == PreprodArtifact.ArtifactState.UPLOADED
         )  # Still processing
         assert just_over_30_artifact.state == PreprodArtifact.ArtifactState.FAILED
+
+    def test_detect_expired_preprod_artifacts_skips_snapshot_artifacts(self):
+        from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+
+        current_time = timezone.now()
+        old_time = current_time - timedelta(minutes=35)
+
+        snapshot_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADED,
+        )
+        PreprodArtifact.objects.filter(id=snapshot_artifact.id).update(date_updated=old_time)
+        PreprodSnapshotMetrics.objects.create(preprod_artifact=snapshot_artifact)
+
+        regular_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADED,
+        )
+        PreprodArtifact.objects.filter(id=regular_artifact.id).update(date_updated=old_time)
+
+        detect_expired_preprod_artifacts()
+
+        snapshot_artifact.refresh_from_db()
+        regular_artifact.refresh_from_db()
+
+        assert snapshot_artifact.state == PreprodArtifact.ArtifactState.UPLOADED
+        assert regular_artifact.state == PreprodArtifact.ArtifactState.FAILED


### PR DESCRIPTION
Artifacts with an associated `PreprodSnapshotMetrics` row should not be
marked as timed out by the `detect_expired_preprod_artifacts` task.
Snapshot artifacts have a different processing lifecycle and should be
excluded from the 30-minute expiry check.

Adds a `preprodsnapshotmetrics__isnull=True` filter to the expired
artifacts query, which translates to an efficient `LEFT JOIN ... IS NULL`
using the existing foreign key index.