### PR TITLE
ref(nav): Standardize primary nav footer button sizes

### DIFF
--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -44,6 +44,7 @@ interface SidebarItemDropdownProps {
   disableTooltip?: boolean;
   icon?: React.ReactNode;
   onOpen?: MouseEventHandler<HTMLButtonElement>;
+  size?: ButtonProps['size'];
   triggerWrap?: React.ComponentType<{children: React.ReactNode}>;
 }
 
@@ -116,6 +117,7 @@ export function SidebarMenu({
   onOpen,
   disableTooltip,
   icon,
+  size,
   triggerWrap: TriggerWrap = Fragment,
 }: SidebarItemDropdownProps) {
   // This component can be rendered without an organization in some cases
@@ -153,6 +155,7 @@ export function SidebarMenu({
                 {...triggerProps}
                 isMobile={layout === NavLayout.MOBILE}
                 aria-label={showLabel ? undefined : label}
+                size={size}
                 onClick={event => {
                   if (organization) {
                     recordPrimaryItemClick(analyticsKey, organization, analyticsParams);

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -55,6 +55,7 @@ export function PrimaryNavigationHelp() {
   return (
     <SidebarMenu
       triggerWrap={StackedNavigationTourReminder}
+      size="sm"
       items={[
         {
           key: 'search',

--- a/static/app/views/nav/primary/serviceIncidents.tsx
+++ b/static/app/views/nav/primary/serviceIncidents.tsx
@@ -34,6 +34,7 @@ function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) 
         buttonProps={{
           ...overlayTriggerProps,
           icon: <IconFire />,
+          size: 'sm',
         }}
       >
         <SidebarItemUnreadIndicator

--- a/static/app/views/nav/primary/whatsNew/whatsNew.tsx
+++ b/static/app/views/nav/primary/whatsNew/whatsNew.tsx
@@ -138,6 +138,7 @@ export function PrimaryNavigationWhatsNew() {
         buttonProps={{
           ...overlayTriggerProps,
           icon: <IconBroadcast />,
+          size: 'sm',
         }}
       >
         {unseenPostIds.length > 0 && (


### PR DESCRIPTION
I noticed that one of the buttons had a 2px larger border radius, which then turned into me realizing that the button size prop had not been set 😅 