### PR TITLE
fix(gsAdmin): handle missing abuse reason in customer stats

### DIFF
--- a/static/gsAdmin/components/customers/customerStats.tsx
+++ b/static/gsAdmin/components/customers/customerStats.tsx
@@ -207,7 +207,10 @@ export function populateChartData(
         return;
       }
 
-      if (point.by.outcome === 'abuse' && point.by.reason === 'none') {
+      if (
+        point.by.outcome === 'abuse' &&
+        (!point.by.reason || point.by.reason === 'none')
+      ) {
         if (droppedData.abuse === undefined) {
           droppedData.abuse = {
             seriesName: 'Abuse',

--- a/static/gsAdmin/components/customers/customerStats.tsx
+++ b/static/gsAdmin/components/customers/customerStats.tsx
@@ -218,7 +218,11 @@ export function populateChartData(
           };
         }
 
-        droppedData.abuse.data.push(dataObject);
+        if (dateIndex >= droppedData.abuse.data.length) {
+          droppedData.abuse.data.push(dataObject);
+        } else {
+          droppedData.abuse.data[dateIndex]!.value += dataObject.value;
+        }
 
         if (dateIndex >= totalDropped!.data.length) {
           totalDropped!.data.push({...dataObject, value: 0});


### PR DESCRIPTION
The customer stats chart filters abuse data points by checking `point.by.reason === 'none'`, but the API can also return abuse entries where `reason` is `undefined` or an empty string. These entries were silently dropped from the abuse bucket in the chart, leading to underreported abuse volumes.

This adds a falsy check (`!point.by.reason`) alongside the existing `'none'` comparison, so all abuse entries without a specific reason are correctly aggregated into the "Abuse" series on the stats chart.