### PR TITLE
fix(ai-agents): remove platform filters

### DIFF
--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -35,10 +35,7 @@ import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {SetupTitle} from 'sentry/components/updatedEmptyState';
-import {
-  agentMonitoringPlatforms,
-  javascriptMetaFrameworks,
-} from 'sentry/data/platformCategories';
+import {agentMonitoringPlatforms} from 'sentry/data/platformCategories';
 import platforms, {otherPlatform} from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -75,7 +72,6 @@ import {
   AgentIntegration,
   NODE_AGENT_INTEGRATIONS,
   PYTHON_AGENT_INTEGRATIONS,
-  SERVER_SIDE_NODE_INTEGRATIONS,
 } from './utils/agentIntegrations';
 
 function useAiSpanWaiter(project: Project) {
@@ -246,35 +242,21 @@ export function Onboarding() {
 
   // Local integration options for Agent Monitoring only
   const isPythonPlatform = (project?.platform ?? '').startsWith('python');
-  const isNodePlatform = (project?.platform ?? '').startsWith('node');
-  const isFullStackJsPlatform = javascriptMetaFrameworks.includes(
-    project?.platform ?? 'other'
-  );
-  const hasServerSideNode = isNodePlatform || isFullStackJsPlatform;
+
+  const integrations = isPythonPlatform
+    ? PYTHON_AGENT_INTEGRATIONS
+    : NODE_AGENT_INTEGRATIONS;
 
   const integrationOptions = {
     integration: {
       label: t('Integration'),
-      items: isPythonPlatform
-        ? PYTHON_AGENT_INTEGRATIONS.map(integration => ({
-            label: AGENT_INTEGRATION_LABELS[integration],
-            value: integration,
-            leadingItems: (
-              <PlatformIcon platform={AGENT_INTEGRATION_ICONS[integration]} size={16} />
-            ),
-          }))
-        : (hasServerSideNode
-            ? NODE_AGENT_INTEGRATIONS
-            : NODE_AGENT_INTEGRATIONS.filter(
-                integration => !SERVER_SIDE_NODE_INTEGRATIONS.has(integration)
-              )
-          ).map(integration => ({
-            label: AGENT_INTEGRATION_LABELS[integration],
-            value: integration,
-            leadingItems: (
-              <PlatformIcon platform={AGENT_INTEGRATION_ICONS[integration]} size={16} />
-            ),
-          })),
+      items: integrations.map(integration => ({
+        label: AGENT_INTEGRATION_LABELS[integration],
+        value: integration,
+        leadingItems: (
+          <PlatformIcon platform={AGENT_INTEGRATION_ICONS[integration]} size={16} />
+        ),
+      })),
     },
   };
 

--- a/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
+++ b/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
@@ -52,11 +52,6 @@ export const PYTHON_AGENT_INTEGRATIONS = [
   AgentIntegration.MANUAL,
 ];
 
-export const SERVER_SIDE_NODE_INTEGRATIONS = new Set([
-  AgentIntegration.VERCEL_AI,
-  AgentIntegration.MASTRA,
-]);
-
 export const NODE_AGENT_INTEGRATIONS = [
   AgentIntegration.VERCEL_AI,
   AgentIntegration.ANTHROPIC,

--- a/static/app/views/insights/pages/conversations/onboarding.tsx
+++ b/static/app/views/insights/pages/conversations/onboarding.tsx
@@ -36,10 +36,7 @@ import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import {SetupTitle} from 'sentry/components/updatedEmptyState';
-import {
-  agentMonitoringPlatforms,
-  javascriptMetaFrameworks,
-} from 'sentry/data/platformCategories';
+import {agentMonitoringPlatforms} from 'sentry/data/platformCategories';
 import platforms, {otherPlatform} from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -58,7 +55,6 @@ import {
   AgentIntegration,
   NODE_AGENT_INTEGRATIONS,
   PYTHON_AGENT_INTEGRATIONS,
-  SERVER_SIDE_NODE_INTEGRATIONS,
 } from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {
@@ -278,35 +274,21 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
   });
 
   const isPythonPlatform = (project?.platform ?? '').startsWith('python');
-  const isNodePlatform = (project?.platform ?? '').startsWith('node');
-  const isFullStackJsPlatform = javascriptMetaFrameworks.includes(
-    project?.platform ?? 'other'
-  );
-  const hasServerSideNode = isNodePlatform || isFullStackJsPlatform;
+
+  const integrations = isPythonPlatform
+    ? PYTHON_AGENT_INTEGRATIONS
+    : NODE_AGENT_INTEGRATIONS;
 
   const integrationOptions = {
     integration: {
       label: t('Integration'),
-      items: isPythonPlatform
-        ? PYTHON_AGENT_INTEGRATIONS.map(integration => ({
-            label: AGENT_INTEGRATION_LABELS[integration],
-            value: integration,
-            leadingItems: (
-              <PlatformIcon platform={AGENT_INTEGRATION_ICONS[integration]} size={16} />
-            ),
-          }))
-        : (hasServerSideNode
-            ? NODE_AGENT_INTEGRATIONS
-            : NODE_AGENT_INTEGRATIONS.filter(
-                integration => !SERVER_SIDE_NODE_INTEGRATIONS.has(integration)
-              )
-          ).map(integration => ({
-            label: AGENT_INTEGRATION_LABELS[integration],
-            value: integration,
-            leadingItems: (
-              <PlatformIcon platform={AGENT_INTEGRATION_ICONS[integration]} size={16} />
-            ),
-          })),
+      items: integrations.map(integration => ({
+        label: AGENT_INTEGRATION_LABELS[integration],
+        value: integration,
+        leadingItems: (
+          <PlatformIcon platform={AGENT_INTEGRATION_ICONS[integration]} size={16} />
+        ),
+      })),
     },
   };
 


### PR DESCRIPTION
closes [TET-2060: Do not filter AI Integrations based on platform (only language)](https://linear.app/getsentry/issue/TET-2060/do-not-filter-ai-integrations-based-on-platform-only-language)