### PR TITLE
fix(trace): Prefer standalone span indicators over pageload span indicators

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
@@ -135,10 +135,16 @@ export function collectTraceMeasurements(
       score,
     });
 
-    const hasSeenMeasurement = tree.indicators.some(
+    if (!RENDERABLE_MEASUREMENTS[collectableMeasurement]) {
+      continue;
+    }
+
+    const isStandalone = isStandaloneSpanMeasurementNode(node);
+    const existingIndicatorIndex = tree.indicators.findIndex(
       indicator => indicator.type === collectableMeasurement
     );
-    if (!RENDERABLE_MEASUREMENTS[collectableMeasurement] || hasSeenMeasurement) {
+
+    if (existingIndicatorIndex !== -1 && !isStandalone) {
       continue;
     }
 
@@ -146,11 +152,11 @@ export function collectTraceMeasurements(
     // We pass in 0 as the measurement value to prevent applying any unnecessary offset.
     const timestamp = traceMeasurementToTimestamp(
       start_timestamp,
-      isStandaloneSpanMeasurementNode(node) ? 0 : measurement.value,
+      isStandalone ? 0 : measurement.value,
       measurement.unit ?? 'millisecond'
     );
 
-    indicators.push({
+    const indicator: TraceTree.Indicator = {
       start: timestamp,
       duration: 0,
       measurement,
@@ -162,7 +168,13 @@ export function collectTraceMeasurements(
         MEASUREMENT_ACRONYM_MAPPING[collectableMeasurement] ?? collectableMeasurement
       ).toUpperCase(),
       score,
-    });
+    };
+
+    if (existingIndicatorIndex === -1) {
+      indicators.push(indicator);
+    } else {
+      tree.indicators[existingIndicatorIndex] = indicator;
+    }
   }
 
   return indicators;

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
@@ -148,11 +148,11 @@ export function collectTraceMeasurements(
       continue;
     }
 
-    // Standalone span measurements occur at the exact start timestamp of the span.
-    // We pass in 0 as the measurement value to prevent applying any unnecessary offset.
+    // Standalone spans should win over transaction-level measurements, but the
+    // measurement value is still applied relative to the provided timeline origin.
     const timestamp = traceMeasurementToTimestamp(
       start_timestamp,
-      isStandalone ? 0 : measurement.value,
+      measurement.value,
       measurement.unit ?? 'millisecond'
     );
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -833,19 +833,18 @@ describe('TraceTree', () => {
             measurements: {
               'measurements.lcp': 500,
             },
-            children: [
-              makeEAPSpan({
-                event_id: 'standalone-lcp-span',
-                op: 'ui.webvital.lcp',
-                start_timestamp: standaloneStart,
-                end_timestamp: standaloneStart + 0.1,
-                is_transaction: false,
-                measurements: {
-                  'measurements.lcp': 500,
-                },
-                children: [],
-              }),
-            ],
+            children: [],
+          }),
+          makeEAPSpan({
+            event_id: 'standalone-lcp-span',
+            op: 'ui.webvital.lcp',
+            start_timestamp: standaloneStart,
+            end_timestamp: standaloneStart + 0.1,
+            is_transaction: false,
+            measurements: {
+              'measurements.lcp': 500,
+            },
+            children: [],
           }),
         ]),
         {meta: null, replay: null, organization}
@@ -871,19 +870,18 @@ describe('TraceTree', () => {
             measurements: {
               'measurements.lcp': 500,
             },
-            children: [
-              makeEAPSpan({
-                event_id: 'standalone-lcp-span',
-                op: 'ui.webvital.lcp',
-                start_timestamp: start + 1.5,
-                end_timestamp: start + 1.6,
-                is_transaction: false,
-                measurements: {
-                  'measurements.lcp': 1240,
-                },
-                children: [],
-              }),
-            ],
+            children: [],
+          }),
+          makeEAPSpan({
+            event_id: 'standalone-lcp-span',
+            op: 'ui.webvital.lcp',
+            start_timestamp: start + 1.5,
+            end_timestamp: start + 1.6,
+            is_transaction: false,
+            measurements: {
+              'measurements.lcp': 1240,
+            },
+            children: [],
           }),
         ]),
         {meta: null, replay: null, organization}

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -853,7 +853,45 @@ describe('TraceTree', () => {
 
       const lcpIndicators = tree.indicators.filter(i => i.type === 'lcp');
       expect(lcpIndicators).toHaveLength(1);
-      expect(lcpIndicators[0]!.start).toBe(standaloneStart * 1e3);
+      expect(lcpIndicators[0]!.start).toBe(standaloneStart * 1e3 + 500);
+    });
+
+    it('applies standalone LCP measurement offset from trace origin when present', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'pageload-span',
+            op: 'pageload',
+            start_timestamp: start,
+            end_timestamp: start + 2,
+            is_transaction: true,
+            additional_attributes: {
+              'tags[performance.timeOrigin,number]': start,
+            },
+            measurements: {
+              'measurements.lcp': 500,
+            },
+            children: [
+              makeEAPSpan({
+                event_id: 'standalone-lcp-span',
+                op: 'ui.webvital.lcp',
+                start_timestamp: start + 1.5,
+                end_timestamp: start + 1.6,
+                is_transaction: false,
+                measurements: {
+                  'measurements.lcp': 1240,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const lcpIndicators = tree.indicators.filter(i => i.type === 'lcp');
+      expect(lcpIndicators).toHaveLength(1);
+      expect(lcpIndicators[0]!.start).toBe(start * 1e3 + 1240);
     });
 
     it('handles cycles in EAP trace structure without infinite loop', () => {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -820,6 +820,42 @@ describe('TraceTree', () => {
       );
     });
 
+    it('standalone LCP span indicator takes priority over pageload LCP indicator', () => {
+      const standaloneStart = start + 1.5;
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'pageload-span',
+            op: 'pageload',
+            start_timestamp: start,
+            end_timestamp: start + 2,
+            is_transaction: true,
+            measurements: {
+              'measurements.lcp': 500,
+            },
+            children: [
+              makeEAPSpan({
+                event_id: 'standalone-lcp-span',
+                op: 'ui.webvital.lcp',
+                start_timestamp: standaloneStart,
+                end_timestamp: standaloneStart + 0.1,
+                is_transaction: false,
+                measurements: {
+                  'measurements.lcp': 500,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const lcpIndicators = tree.indicators.filter(i => i.type === 'lcp');
+      expect(lcpIndicators).toHaveLength(1);
+      expect(lcpIndicators[0]!.start).toBe(standaloneStart * 1e3);
+    });
+
     it('handles cycles in EAP trace structure without infinite loop', () => {
       const cyclicSpan = makeEAPSpan({
         event_id: 'cyclic-span',


### PR DESCRIPTION
Fix trend line placement for standalone LCP spans in the trace waterfall.

When both a pageload span and a standalone LCP span are present, the trace waterfall should prefer the standalone span's indicator instead of leaving the pageload-derived indicator in place.

This branch now does two things. First, standalone span measurements replace an existing indicator of the same type so the more specific LCP span wins. Second, the indicator timestamp still applies the measurement offset from the provided origin rather than assuming standalone spans always occur exactly at span start. That matters for both the node-start path and the `performance.timeOrigin` path used by EAP trace data.

The updated tests cover standalone indicator priority and the trace-origin case so we don't regress the offset calculation again.

Refs EXP-824