### PR TITLE
feat(dashboards): Separate prebuilt dashboards in starred sidebar

### DIFF
--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 import * as Sentry from '@sentry/react';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -24,8 +24,13 @@ export function DashboardsSecondaryNav() {
 
   const {data: starredDashboards = []} = useGetStarredDashboards();
 
-  const prebuiltDashboards = starredDashboards.filter(d => defined(d.prebuiltId));
-  const customDashboards = starredDashboards.filter(d => !defined(d.prebuiltId));
+  const {prebuiltDashboards, customDashboards} = useMemo(
+    () => ({
+      prebuiltDashboards: starredDashboards.filter(d => defined(d.prebuiltId)),
+      customDashboards: starredDashboards.filter(d => !defined(d.prebuiltId)),
+    }),
+    [starredDashboards]
+  );
 
   return (
     <Fragment>

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -87,7 +87,7 @@ export function DashboardsSecondaryNav() {
         {prebuiltDashboards.length > 0 ? (
           <SecondaryNav.Section
             id="dashboards-starred-sentry"
-            title={t('Starred Sentry Built Dashboards')}
+            title={t('Starred Sentry Built')}
           >
             <ErrorBoundary mini>
               {prebuiltDashboards.map(dashboard => {

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -22,6 +22,9 @@ export function DashboardsSecondaryNav() {
 
   const {data: starredDashboards = []} = useGetStarredDashboards();
 
+  const prebuiltDashboards = starredDashboards.filter(d => defined(d.prebuiltId));
+  const customDashboards = starredDashboards.filter(d => !defined(d.prebuiltId));
+
   return (
     <Fragment>
       <SecondaryNav.Header>
@@ -33,13 +36,13 @@ export function DashboardsSecondaryNav() {
             {t('All Dashboards')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
-        {starredDashboards.length > 0 ? (
+        {customDashboards.length > 0 ? (
           <SecondaryNav.Section id="dashboards-starred" title={t('Starred Dashboards')}>
             <ErrorBoundary mini>
               {organization.features.includes('dashboards-starred-reordering') ? (
-                <DashboardsNavItems initialDashboards={starredDashboards} />
+                <DashboardsNavItems initialDashboards={customDashboards} />
               ) : (
-                starredDashboards.map(dashboard => {
+                customDashboards.map(dashboard => {
                   const dashboardProjects = new Set(
                     (dashboard?.projects ?? []).map(String)
                   );
@@ -78,6 +81,52 @@ export function DashboardsSecondaryNav() {
                   );
                 })
               )}
+            </ErrorBoundary>
+          </SecondaryNav.Section>
+        ) : null}
+        {prebuiltDashboards.length > 0 ? (
+          <SecondaryNav.Section
+            id="dashboards-starred-sentry"
+            title={t('Starred Sentry Built Dashboards')}
+          >
+            <ErrorBoundary mini>
+              {prebuiltDashboards.map(dashboard => {
+                const dashboardProjects = new Set(
+                  (dashboard?.projects ?? []).map(String)
+                );
+                if (!defined(dashboard?.projects)) {
+                  Sentry.setTag('organization', organization.id);
+                  Sentry.setTag('dashboard.id', dashboard.id);
+                  Sentry.setTag('user.id', user.id);
+                  Sentry.captureMessage(
+                    'dashboard.projects is undefined in starred sidebar',
+                    {
+                      level: 'warning',
+                    }
+                  );
+                }
+                const dashboardProjectPlatforms = projects
+                  .filter(p => dashboardProjects.has(p.id))
+                  .map(p => p.platform)
+                  .filter(defined);
+                return (
+                  <SecondaryNav.Item
+                    key={dashboard.id}
+                    to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
+                    analyticsItemName="dashboard_starred_item"
+                    leadingItems={
+                      <ProjectIcon
+                        projectPlatforms={dashboardProjectPlatforms}
+                        allProjects={
+                          dashboard.projects.length === 1 && dashboard.projects[0] === -1
+                        }
+                      />
+                    }
+                  >
+                    {dashboard.title}
+                  </SecondaryNav.Item>
+                );
+              })}
             </ErrorBoundary>
           </SecondaryNav.Section>
         ) : null}

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -3,11 +3,13 @@ import * as Sentry from '@sentry/react';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
 import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import ProjectIcon from 'sentry/views/nav/projectIcon';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
@@ -42,44 +44,13 @@ export function DashboardsSecondaryNav() {
               {organization.features.includes('dashboards-starred-reordering') ? (
                 <DashboardsNavItems initialDashboards={customDashboards} />
               ) : (
-                customDashboards.map(dashboard => {
-                  const dashboardProjects = new Set(
-                    (dashboard?.projects ?? []).map(String)
-                  );
-                  if (!defined(dashboard?.projects)) {
-                    Sentry.setTag('organization', organization.id);
-                    Sentry.setTag('dashboard.id', dashboard.id);
-                    Sentry.setTag('user.id', user.id);
-                    Sentry.captureMessage(
-                      'dashboard.projects is undefined in starred sidebar',
-                      {
-                        level: 'warning',
-                      }
-                    );
-                  }
-                  const dashboardProjectPlatforms = projects
-                    .filter(p => dashboardProjects.has(p.id))
-                    .map(p => p.platform)
-                    .filter(defined);
-                  return (
-                    <SecondaryNav.Item
-                      key={dashboard.id}
-                      to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
-                      analyticsItemName="dashboard_starred_item"
-                      leadingItems={
-                        <ProjectIcon
-                          projectPlatforms={dashboardProjectPlatforms}
-                          allProjects={
-                            dashboard.projects.length === 1 &&
-                            dashboard.projects[0] === -1
-                          }
-                        />
-                      }
-                    >
-                      {dashboard.title}
-                    </SecondaryNav.Item>
-                  );
-                })
+                <StarredDashboardItems
+                  dashboards={customDashboards}
+                  projects={projects}
+                  organizationSlug={organization.slug}
+                  organizationId={organization.id}
+                  userId={user.id}
+                />
               )}
             </ErrorBoundary>
           </SecondaryNav.Section>
@@ -90,47 +61,62 @@ export function DashboardsSecondaryNav() {
             title={t('Starred Sentry Built')}
           >
             <ErrorBoundary mini>
-              {prebuiltDashboards.map(dashboard => {
-                const dashboardProjects = new Set(
-                  (dashboard?.projects ?? []).map(String)
-                );
-                if (!defined(dashboard?.projects)) {
-                  Sentry.setTag('organization', organization.id);
-                  Sentry.setTag('dashboard.id', dashboard.id);
-                  Sentry.setTag('user.id', user.id);
-                  Sentry.captureMessage(
-                    'dashboard.projects is undefined in starred sidebar',
-                    {
-                      level: 'warning',
-                    }
-                  );
-                }
-                const dashboardProjectPlatforms = projects
-                  .filter(p => dashboardProjects.has(p.id))
-                  .map(p => p.platform)
-                  .filter(defined);
-                return (
-                  <SecondaryNav.Item
-                    key={dashboard.id}
-                    to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
-                    analyticsItemName="dashboard_starred_item"
-                    leadingItems={
-                      <ProjectIcon
-                        projectPlatforms={dashboardProjectPlatforms}
-                        allProjects={
-                          dashboard.projects.length === 1 && dashboard.projects[0] === -1
-                        }
-                      />
-                    }
-                  >
-                    {dashboard.title}
-                  </SecondaryNav.Item>
-                );
-              })}
+              <StarredDashboardItems
+                dashboards={prebuiltDashboards}
+                projects={projects}
+                organizationSlug={organization.slug}
+                organizationId={organization.id}
+                userId={user.id}
+              />
             </ErrorBoundary>
           </SecondaryNav.Section>
         ) : null}
       </SecondaryNav.Body>
     </Fragment>
   );
+}
+
+function StarredDashboardItems({
+  dashboards,
+  projects,
+  organizationSlug,
+  organizationId,
+  userId,
+}: {
+  dashboards: DashboardListItem[];
+  organizationId: string;
+  organizationSlug: string;
+  projects: Project[];
+  userId: string;
+}) {
+  return dashboards.map(dashboard => {
+    const dashboardProjects = new Set((dashboard?.projects ?? []).map(String));
+    if (!defined(dashboard?.projects)) {
+      Sentry.setTag('organization', organizationId);
+      Sentry.setTag('dashboard.id', dashboard.id);
+      Sentry.setTag('user.id', userId);
+      Sentry.captureMessage('dashboard.projects is undefined in starred sidebar', {
+        level: 'warning',
+      });
+    }
+    const dashboardProjectPlatforms = projects
+      .filter(p => dashboardProjects.has(p.id))
+      .map(p => p.platform)
+      .filter(defined);
+    return (
+      <SecondaryNav.Item
+        key={dashboard.id}
+        to={`/organizations/${organizationSlug}/dashboard/${dashboard.id}/`}
+        analyticsItemName="dashboard_starred_item"
+        leadingItems={
+          <ProjectIcon
+            projectPlatforms={dashboardProjectPlatforms}
+            allProjects={dashboard.projects?.length === 1 && dashboard.projects[0] === -1}
+          />
+        }
+      >
+        {dashboard.title}
+      </SecondaryNav.Item>
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- Splits the starred dashboards sidebar into two sections: custom dashboards ("Starred Dashboards") and Sentry-built dashboards ("Starred Sentry Built Dashboards")
<img width="213" height="430" alt="image" src="https://github.com/user-attachments/assets/3c4e700b-759a-416d-a4f2-99cb5aeeb247" />

- Prebuilt dashboards are identified by having a `prebuiltId` and are shown in a separate section below custom starred dashboards
- Custom dashboards continue to support the `dashboards-starred-reordering` feature flag

## Test plan
- [ ] Star a custom dashboard and verify it appears in "Starred Dashboards"
- [ ] Star a Sentry-built dashboard and verify it appears in "Starred Sentry Built Dashboards"
- [ ] Verify sections only appear when they have items
- [ ] Verify the reordering feature flag still works for custom dashboards