### PR TITLE
feat(dashboards): Release pre-starred prebuilt dashboards to EA

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -422,23 +422,18 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 sentry_sdk.capture_exception(err)
 
             # Favorite pre-favorited prebuilt dashboards for the user
-            # TODO - remove this flag check once we confirm the sync is proper, this should be done for all users
-            if features.has(
-                "organizations:dashboards-sync-all-registered-prebuilt-dashboards",
-                organization,
-            ):
-                try:
-                    favorite_lock = locks.get(
-                        f"dashboards:sync_prebuilt_dashboards_favorited:{organization.id}:{request.user.id}",
-                        duration=10,
-                        name="sync_prebuilt_dashboards_favorited",
-                    )
-                    with favorite_lock.acquire():
-                        sync_prebuilt_dashboards_favorited(organization, request.user.id)
-                except UnableToAcquireLock:
-                    pass
-                except Exception as err:
-                    sentry_sdk.capture_exception(err)
+            try:
+                favorite_lock = locks.get(
+                    f"dashboards:sync_prebuilt_dashboards_favorited:{organization.id}:{request.user.id}",
+                    duration=10,
+                    name="sync_prebuilt_dashboards_favorited",
+                )
+                with favorite_lock.acquire():
+                    sync_prebuilt_dashboards_favorited(organization, request.user.id)
+            except UnableToAcquireLock:
+                pass
+            except Exception as err:
+                sentry_sdk.capture_exception(err)
 
         filters = request.query_params.getlist("filter")
 


### PR DESCRIPTION
Remove the feature flag check (`dashboards-sync-all-registered-prebuilt-dashboards`) gating the sync of pre-favorited prebuilt dashboards. There is still a flag check above for `dashboards-prebuilt-insights-dashboards`, which means this PR effectively releases pre-starred dashboards to EA.

Previously, syncing pre-starred prebuilt dashboards was behind a feature flag for validation. The sync logic has been confirmed to work correctly, so the flag guard is no longer needed.

DAIN-1306