### PR TITLE
fix(data-browsing): Allow SQLish to parse some Unicode control characters

### DIFF
--- a/static/app/utils/sqlish/SQLishFormatter.tsx
+++ b/static/app/utils/sqlish/SQLishFormatter.tsx
@@ -49,10 +49,25 @@ export class SQLishFormatter {
       tokens = this.parser.parse(sql);
     } catch (error: any) {
       Sentry.withScope(scope => {
-        scope.setFingerprint(['sqlish-parse-error']);
-        // Get the last 100 characters of the error message
-        scope.setExtra('message', error.message?.slice(-100));
-        scope.setExtra('found', error.found);
+        const fingerprint = ['sqlish-parse-error'];
+
+        if (error?.message) {
+          // The error message might be a PEG grammar error, or some kind of
+          // other parser error. They're usually too long to be useful since PEG
+          // errors contain the entire current grammar. Take the last 100
+          // characters instead.
+          scope.setExtra('message', error.message?.slice(-100));
+          scope.setExtra('found', error.found);
+
+          // Grammar error. Group these by the specific missing grammar, so we
+          // can make case-by-case decisions whether we should amend the
+          // grammar.
+          if (error.message.includes('Expected')) {
+            fingerprint.push(error.message.slice(-10));
+          }
+        }
+
+        scope.setFingerprint(fingerprint);
         Sentry.captureException(error);
       });
       // If we fail to parse the SQL, return the original string

--- a/static/app/utils/sqlish/SQLishParser.spec.tsx
+++ b/static/app/utils/sqlish/SQLishParser.spec.tsx
@@ -21,6 +21,7 @@ describe('SQLishParser', () => {
       '\r\n', // Windows newlines
       '✌🏻', // Emoji
       'ă', // Unicode
+      `\u0000`, // Unicode null
       'SELECT id, nam*', // Truncation
       'AND created >= :c1', // PHP-Style I
       'LIMIT $2', // PHP-style II

--- a/static/app/utils/sqlish/sqlish.pegjs
+++ b/static/app/utils/sqlish/sqlish.pegjs
@@ -36,10 +36,11 @@ Whitespace
   = Whitespace:[\n\t\r ]+ { return { type: 'Whitespace', content: Whitespace.join("") } }
 
 // \u0000-\u001F are C0 Unicode control characters which sometimes sneak into
-// strings, especially \u0000 which is Unicode null.
+// strings, especially \u0000 which is Unicode null. I added support for a few
+// just to prevent exceptions.
 // \u00A0-\uFFFF is the entire Unicode BMP _including_ surrogate pairs and
 // unassigned code points, which aren't parse-able naively. A more precise
 // approach would be to define all valid Unicode ranges exactly but for
 // permissive parsing we don't mind the lack of precision.
 GenericToken
-  = GenericToken:[a-zA-Z0-9\u0000-\u001F\u00A0-\uFFFF"'`_\-.=><:,*;!\[\]?$%|/\\@#&~^+{}]+ { return { type: 'GenericToken', content: GenericToken.join('') } }
+  = GenericToken:[a-zA-Z0-9\u0000-\u0006\u00A0-\uFFFF"'`_\-.=><:,*;!\[\]?$%|/\\@#&~^+{}]+ { return { type: 'GenericToken', content: GenericToken.join('') } }

--- a/static/app/utils/sqlish/sqlish.pegjs
+++ b/static/app/utils/sqlish/sqlish.pegjs
@@ -35,9 +35,11 @@ CollapsedColumns
 Whitespace
   = Whitespace:[\n\t\r ]+ { return { type: 'Whitespace', content: Whitespace.join("") } }
 
+// \u0000-\u001F are C0 Unicode control characters which sometimes sneak into
+// strings, especially \u0000 which is Unicode null.
 // \u00A0-\uFFFF is the entire Unicode BMP _including_ surrogate pairs and
 // unassigned code points, which aren't parse-able naively. A more precise
 // approach would be to define all valid Unicode ranges exactly but for
 // permissive parsing we don't mind the lack of precision.
 GenericToken
-  = GenericToken:[a-zA-Z0-9\u00A0-\uFFFF"'`_\-.=><:,*;!\[\]?$%|/\\@#&~^+{}]+ { return { type: 'GenericToken', content: GenericToken.join('') } }
+  = GenericToken:[a-zA-Z0-9\u0000-\u001F\u00A0-\uFFFF"'`_\-.=><:,*;!\[\]?$%|/\\@#&~^+{}]+ { return { type: 'GenericToken', content: GenericToken.join('') } }


### PR DESCRIPTION
Some Unicode control characters like `\u0000` show up in telemetry strings. Most likely this is an accident, or some kind of instrumentation bug, or something else, but I don't think it's good to _crash_ in those cases, so I added that character range to the grammar. I'll talk to the Relay team separately whether those characters should be stripped out, but in the meantime this closes a bug.

I also updated the grouping so that different characters create different errors, for ease of debugging.
