### PR TITLE
tests: Skip test_basic_resolving

### DIFF
--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -587,7 +587,7 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
         assert response.status_code == 201, response.content
         assert len(response.json()) == 1
 
-    @pytest.mark.skip(reason="Temporarily skipped")
+    @pytest.mark.skip(reason="Temporarily skipped due to symbolicator regression")
     @requires_symbolicator
     @pytest.mark.symbolicator
     def test_basic_resolving(self) -> None:
@@ -644,6 +644,7 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
             },
         ]
 
+    @pytest.mark.skip(reason="Temporarily skipped due to symbolicator regression")
     @requires_symbolicator
     @pytest.mark.symbolicator
     def test_inline_resolving(self) -> None:

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -587,6 +587,7 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
         assert response.status_code == 201, response.content
         assert len(response.json()) == 1
 
+    @pytest.mark.skip(reason="Temporarily skipped")
     @requires_symbolicator
     @pytest.mark.symbolicator
     def test_basic_resolving(self) -> None:


### PR DESCRIPTION
A couple of the recent symbolicator changes may have caused this regression:
https://github.com/getsentry/symbolicator/commits/master/