### PR TITLE
feat(traces): add 'Open in Logs' link to Logs view

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -3,13 +3,12 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import Panel from 'sentry/components/panels/panel';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import useOrganization from 'sentry/utils/useOrganization';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
@@ -74,7 +73,7 @@ function LogsSectionContent({
 
   return (
     <Fragment>
-      <Container display="flex" style={{gap: space(1.5)}}>
+      <Flex gap="lg">
         <SearchQueryBuilder
           placeholder={t('Search logs for this event')}
           filterKeys={{}}
@@ -84,7 +83,7 @@ function LogsSectionContent({
           onSearch={query => setLogsQuery(query)}
         />
         <LinkButton to={logsUrl}>{t('Open in Logs')}</LinkButton>
-      </Container>
+      </Flex>
       <TableContainer>
         <LogsInfiniteTable embedded scrollContainer={scrollContainer} />
       </TableContainer>

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -2,13 +2,21 @@ import type React from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {LinkButton} from '@sentry/scraps/button';
+import {Container} from '@sentry/scraps/layout';
+
+import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import Panel from 'sentry/components/panels/panel';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import useOrganization from 'sentry/utils/useOrganization';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
+import {useLogsFrozenTraceIds} from 'sentry/views/explore/logs/logsFrozenContext';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
+import {adjustLogTraceID, getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {
   useQueryParamsSearch,
   useSetQueryParamsQuery,
@@ -51,19 +59,32 @@ function LogsSectionContent({
 }: {
   scrollContainer: React.RefObject<HTMLDivElement | null>;
 }) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const traceIds = useLogsFrozenTraceIds();
   const setLogsQuery = useSetQueryParamsQuery();
   const logsSearch = useQueryParamsSearch();
 
+  const traceId = traceIds?.[0] && adjustLogTraceID(traceIds[0]);
+  const logsUrl = getLogsUrl({
+    organization,
+    selection,
+    query: traceId ? `trace:${traceId}` : undefined,
+  });
+
   return (
     <Fragment>
-      <SearchQueryBuilder
-        placeholder={t('Search logs for this event')}
-        filterKeys={{}}
-        getTagValues={() => new Promise<string[]>(() => [])}
-        initialQuery={logsSearch.formatString()}
-        searchSource="ourlogs"
-        onSearch={query => setLogsQuery(query)}
-      />
+      <Container display="flex" style={{gap: space(1.5)}}>
+        <SearchQueryBuilder
+          placeholder={t('Search logs for this event')}
+          filterKeys={{}}
+          getTagValues={() => new Promise<string[]>(() => [])}
+          initialQuery={logsSearch.formatString()}
+          searchSource="ourlogs"
+          onSearch={query => setLogsQuery(query)}
+        />
+        <LinkButton to={logsUrl}>{t('Open in Logs')}</LinkButton>
+      </Container>
       <TableContainer>
         <LogsInfiniteTable embedded scrollContainer={scrollContainer} />
       </TableContainer>


### PR DESCRIPTION
Adds a link button to the top-right of Explore > Traces > (trace) > Logs that links to the equivalent query in Explore > Logs.

<img width="922" height="332" alt="Screenshot of a table of logs for a trace, with a 'View in Logs' link in the top-right" src="https://github.com/user-attachments/assets/8fabf82c-3840-4608-b7a4-f568a58eb214" />

Fixes LOGS-132