### PR TITLE
perf(logs): Prevent search query builder rerenders on auto-refresh

### DIFF
--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -18,7 +18,6 @@ import {
 } from 'sentry/components/searchQueryBuilder/context';
 import {IconChevron, IconEdit, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {TagCollection} from 'sentry/types/group';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
@@ -104,21 +103,6 @@ interface LogsSearchBarProps {
   tracesItemSearchQueryBuilderProps: Parameters<typeof TraceItemSearchQueryBuilder>[0];
 }
 
-interface LogsSearchSectionProps {
-  areAiFeaturesAllowed: boolean;
-  booleanAttributes: TagCollection;
-  booleanSecondaryAliases: TagCollection;
-  datePageFilterProps: DatePageFilterProps;
-  numberAttributes: TagCollection;
-  numberSecondaryAliases: TagCollection;
-  stringAttributes: TagCollection;
-  stringSecondaryAliases: TagCollection;
-  booleanAttributesLoading?: boolean;
-  numberAttributesLoading?: boolean;
-  searchBarWidthOffset?: number;
-  stringAttributesLoading?: boolean;
-}
-
 function LogsSearchBar({tracesItemSearchQueryBuilderProps}: LogsSearchBarProps) {
   const {displayAskSeer} = useSearchQueryBuilder();
 
@@ -129,20 +113,16 @@ function LogsSearchBar({tracesItemSearchQueryBuilderProps}: LogsSearchBarProps) 
   return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;
 }
 
+interface LogsSearchSectionProps {
+  datePageFilterProps: DatePageFilterProps;
+  searchBarWidthOffset?: number;
+}
+
 const LogsSearchSection = memo(function LogsSearchSection({
-  areAiFeaturesAllowed,
-  booleanAttributes,
-  booleanSecondaryAliases,
-  booleanAttributesLoading,
   datePageFilterProps,
-  numberAttributes,
-  numberSecondaryAliases,
-  numberAttributesLoading,
   searchBarWidthOffset,
-  stringAttributes,
-  stringSecondaryAliases,
-  stringAttributesLoading,
 }: LogsSearchSectionProps) {
+  const organization = useOrganization();
   const logsSearch = useQueryParamsSearch();
   const logsSearchQuery = logsSearch.formatString();
   const groupBys = useQueryParamsGroupBys();
@@ -150,6 +130,12 @@ const LogsSearchSection = memo(function LogsSearchSection({
   const [interval] = useChartInterval();
   const visualizes = useQueryParamsVisualizes();
   const aggregateSortBys = useQueryParamsAggregateSortBys();
+
+  // AI search is gated behind the gen-ai-search-agent-translate feature flag
+  const areAiFeaturesAllowed =
+    !organization?.hideAiFeatures &&
+    organization.features.includes('gen-ai-features') &&
+    organization.features.includes('gen-ai-search-agent-translate');
 
   const saveAsItems = useSaveAsItems({
     visualizes,
@@ -159,6 +145,22 @@ const LogsSearchSection = memo(function LogsSearchSection({
     search: logsSearch,
     sortBys: aggregateSortBys,
   });
+
+  const {
+    attributes: stringAttributes,
+    isLoading: stringAttributesLoading,
+    secondaryAliases: stringSecondaryAliases,
+  } = useLogItemAttributes({}, 'string', HiddenLogSearchFields);
+  const {
+    attributes: numberAttributes,
+    isLoading: numberAttributesLoading,
+    secondaryAliases: numberSecondaryAliases,
+  } = useLogItemAttributes({}, 'number', HiddenLogSearchFields);
+  const {
+    attributes: booleanAttributes,
+    isLoading: booleanAttributesLoading,
+    secondaryAliases: booleanSecondaryAliases,
+  } = useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
 
   const {tracesItemSearchQueryBuilderProps, searchQueryBuilderProviderProps} =
     useLogsSearchQueryBuilderProps({
@@ -238,7 +240,6 @@ const LogsSearchSection = memo(function LogsSearchSection({
 });
 
 export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
-  const organization = useOrganization();
   const pageFilters = usePageFilters();
   const fields = useQueryParamsFields();
   const mode = useQueryParamsMode();
@@ -251,11 +252,6 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
   const tableData = useLogsPageDataQueryResult();
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
 
-  // AI search is gated behind the gen-ai-search-agent-translate feature flag
-  const areAiFeaturesAllowed =
-    !organization?.hideAiFeatures &&
-    organization.features.includes('gen-ai-features') &&
-    organization.features.includes('gen-ai-search-agent-translate');
   const [timeseriesIngestDelay, setTimeseriesIngestDelay] = useState<bigint>(
     getMaxIngestDelayTimestamp()
   );
@@ -292,21 +288,21 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
     limit: 50,
   });
 
-  const {
-    attributes: stringAttributes,
-    isLoading: stringAttributesLoading,
-    secondaryAliases: stringSecondaryAliases,
-  } = useLogItemAttributes({}, 'string', HiddenLogSearchFields);
-  const {
-    attributes: numberAttributes,
-    isLoading: numberAttributesLoading,
-    secondaryAliases: numberSecondaryAliases,
-  } = useLogItemAttributes({}, 'number', HiddenLogSearchFields);
-  const {
-    attributes: booleanAttributes,
-    isLoading: booleanAttributesLoading,
-    secondaryAliases: booleanSecondaryAliases,
-  } = useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
+  const {attributes: stringAttributes} = useLogItemAttributes(
+    {},
+    'string',
+    HiddenLogSearchFields
+  );
+  const {attributes: numberAttributes} = useLogItemAttributes(
+    {},
+    'number',
+    HiddenLogSearchFields
+  );
+  const {attributes: booleanAttributes} = useLogItemAttributes(
+    {},
+    'boolean',
+    HiddenLogSearchFields
+  );
 
   const averageLogsPerSecond = calculateAverageLogsPerSecond(timeseriesResult);
 
@@ -432,17 +428,7 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
   return (
     <Fragment>
       <LogsSearchSection
-        areAiFeaturesAllowed={areAiFeaturesAllowed}
         datePageFilterProps={datePageFilterProps}
-        booleanAttributes={booleanAttributes}
-        booleanSecondaryAliases={booleanSecondaryAliases}
-        numberAttributes={numberAttributes}
-        numberSecondaryAliases={numberSecondaryAliases}
-        stringAttributes={stringAttributes}
-        stringSecondaryAliases={stringSecondaryAliases}
-        booleanAttributesLoading={booleanAttributesLoading}
-        numberAttributesLoading={numberAttributesLoading}
-        stringAttributesLoading={stringAttributesLoading}
         searchBarWidthOffset={columnEditorButtonRef.current?.clientWidth}
       />
       <ExploreBodyContent>

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
@@ -18,9 +18,11 @@ import {
 } from 'sentry/components/searchQueryBuilder/context';
 import {IconChevron, IconEdit, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
+import type {AggregationKey} from 'sentry/utils/fields';
 import {HOUR} from 'sentry/utils/formatters';
 import {useQueryClient, type InfiniteData} from 'sentry/utils/queryClient';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
@@ -102,6 +104,21 @@ interface LogsSearchBarProps {
   tracesItemSearchQueryBuilderProps: Parameters<typeof TraceItemSearchQueryBuilder>[0];
 }
 
+interface LogsSearchSectionProps {
+  areAiFeaturesAllowed: boolean;
+  booleanAttributes: TagCollection;
+  booleanSecondaryAliases: TagCollection;
+  datePageFilterProps: DatePageFilterProps;
+  numberAttributes: TagCollection;
+  numberSecondaryAliases: TagCollection;
+  stringAttributes: TagCollection;
+  stringSecondaryAliases: TagCollection;
+  booleanAttributesLoading?: boolean;
+  numberAttributesLoading?: boolean;
+  searchBarWidthOffset?: number;
+  stringAttributesLoading?: boolean;
+}
+
 function LogsSearchBar({tracesItemSearchQueryBuilderProps}: LogsSearchBarProps) {
   const {displayAskSeer} = useSearchQueryBuilder();
 
@@ -112,12 +129,118 @@ function LogsSearchBar({tracesItemSearchQueryBuilderProps}: LogsSearchBarProps) 
   return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;
 }
 
+const LogsSearchSection = memo(function LogsSearchSection({
+  areAiFeaturesAllowed,
+  booleanAttributes,
+  booleanSecondaryAliases,
+  booleanAttributesLoading,
+  datePageFilterProps,
+  numberAttributes,
+  numberSecondaryAliases,
+  numberAttributesLoading,
+  searchBarWidthOffset,
+  stringAttributes,
+  stringSecondaryAliases,
+  stringAttributesLoading,
+}: LogsSearchSectionProps) {
+  const logsSearch = useQueryParamsSearch();
+  const logsSearchQuery = logsSearch.formatString();
+  const groupBys = useQueryParamsGroupBys();
+  const mode = useQueryParamsMode();
+  const [interval] = useChartInterval();
+  const visualizes = useQueryParamsVisualizes();
+  const aggregateSortBys = useQueryParamsAggregateSortBys();
+
+  const saveAsItems = useSaveAsItems({
+    visualizes,
+    groupBys,
+    interval,
+    mode,
+    search: logsSearch,
+    sortBys: aggregateSortBys,
+  });
+
+  const {tracesItemSearchQueryBuilderProps, searchQueryBuilderProviderProps} =
+    useLogsSearchQueryBuilderProps({
+      booleanAttributes,
+      numberAttributes,
+      stringAttributes,
+      booleanSecondaryAliases,
+      numberSecondaryAliases,
+      stringSecondaryAliases,
+    });
+
+  const supportedAggregates = useMemo<AggregationKey[]>(() => {
+    return [];
+  }, []);
+
+  return (
+    <SearchQueryBuilderProvider
+      enableAISearch={areAiFeaturesAllowed}
+      aiSearchBadgeType="alpha"
+      {...searchQueryBuilderProviderProps}
+    >
+      <ExploreBodySearch>
+        <Layout.Main width="full">
+          <LogsFilterSection>
+            <StyledPageFilterBar condensed>
+              <ProjectPageFilter />
+              <EnvironmentPageFilter />
+              <DatePageFilter
+                {...datePageFilterProps}
+                searchPlaceholder={t('Custom range: 2h, 4d, 3w')}
+              />
+            </StyledPageFilterBar>
+            <LogsSearchBar
+              tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}
+            />
+            {saveAsItems.length > 0 && (
+              <DropdownMenu
+                items={saveAsItems}
+                trigger={triggerProps => (
+                  <Button
+                    {...triggerProps}
+                    priority="default"
+                    aria-label={t('Save as')}
+                    onClick={e => {
+                      e.stopPropagation();
+                      e.preventDefault();
+
+                      triggerProps.onClick?.(e);
+                    }}
+                  >
+                    {t('Save as')}
+                  </Button>
+                )}
+              />
+            )}
+          </LogsFilterSection>
+          <ExploreSchemaHintsSection>
+            <SchemaHintsList
+              supportedAggregates={supportedAggregates}
+              booleanTags={booleanAttributes}
+              numberTags={numberAttributes}
+              stringTags={stringAttributes}
+              isLoading={
+                numberAttributesLoading ||
+                stringAttributesLoading ||
+                booleanAttributesLoading
+              }
+              exploreQuery={logsSearchQuery}
+              source={SchemaHintsSources.LOGS}
+              searchBarWidthOffset={searchBarWidthOffset}
+            />
+          </ExploreSchemaHintsSection>
+        </Layout.Main>
+      </ExploreBodySearch>
+    </SearchQueryBuilderProvider>
+  );
+});
+
 export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
-  const logsSearch = useQueryParamsSearch();
   const fields = useQueryParamsFields();
-  const groupBys = useQueryParamsGroupBys();
   const mode = useQueryParamsMode();
   const topEventsLimit = useQueryParamsTopEventsLimit();
   const queryClient = useQueryClient();
@@ -200,20 +323,6 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
     aggregateSortBys,
   });
 
-  const {tracesItemSearchQueryBuilderProps, searchQueryBuilderProviderProps} =
-    useLogsSearchQueryBuilderProps({
-      booleanAttributes,
-      numberAttributes,
-      stringAttributes,
-      booleanSecondaryAliases,
-      numberSecondaryAliases,
-      stringSecondaryAliases,
-    });
-
-  const supportedAggregates = useMemo(() => {
-    return [];
-  }, []);
-
   const refreshTable = useCallback(async () => {
     setTimeseriesIngestDelay(getMaxIngestDelayTimestamp());
     queryClient.setQueryData(
@@ -277,15 +386,6 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
     [setSidebarOpen, setMode]
   );
 
-  const saveAsItems = useSaveAsItems({
-    visualizes,
-    groupBys,
-    interval,
-    mode,
-    search: logsSearch,
-    sortBys: aggregateSortBys,
-  });
-
   /**
    * Manual refresh doesn't work for longer relative periods as it hits cacheing. Only allow manual refresh if the relative period or absolute time range is less than 1 hour.
    */
@@ -330,65 +430,21 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
   const {infiniteLogsQueryResult} = useLogsPageData();
 
   return (
-    <SearchQueryBuilderProvider
-      enableAISearch={areAiFeaturesAllowed}
-      aiSearchBadgeType="alpha"
-      {...searchQueryBuilderProviderProps}
-    >
-      <ExploreBodySearch>
-        <Layout.Main width="full">
-          <LogsFilterSection>
-            <StyledPageFilterBar condensed>
-              <ProjectPageFilter />
-              <EnvironmentPageFilter />
-              <DatePageFilter
-                {...datePageFilterProps}
-                searchPlaceholder={t('Custom range: 2h, 4d, 3w')}
-              />
-            </StyledPageFilterBar>
-            <LogsSearchBar
-              tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}
-            />
-            {saveAsItems.length > 0 && (
-              <DropdownMenu
-                items={saveAsItems}
-                trigger={triggerProps => (
-                  <Button
-                    {...triggerProps}
-                    priority="default"
-                    aria-label={t('Save as')}
-                    onClick={e => {
-                      e.stopPropagation();
-                      e.preventDefault();
-
-                      triggerProps.onClick?.(e);
-                    }}
-                  >
-                    {t('Save as')}
-                  </Button>
-                )}
-              />
-            )}
-          </LogsFilterSection>
-          <ExploreSchemaHintsSection>
-            <SchemaHintsList
-              supportedAggregates={supportedAggregates}
-              booleanTags={booleanAttributes}
-              numberTags={numberAttributes}
-              stringTags={stringAttributes}
-              isLoading={
-                numberAttributesLoading ||
-                stringAttributesLoading ||
-                booleanAttributesLoading
-              }
-              exploreQuery={logsSearch.formatString()}
-              source={SchemaHintsSources.LOGS}
-              searchBarWidthOffset={columnEditorButtonRef.current?.clientWidth}
-            />
-          </ExploreSchemaHintsSection>
-        </Layout.Main>
-      </ExploreBodySearch>
-
+    <Fragment>
+      <LogsSearchSection
+        areAiFeaturesAllowed={areAiFeaturesAllowed}
+        datePageFilterProps={datePageFilterProps}
+        booleanAttributes={booleanAttributes}
+        booleanSecondaryAliases={booleanSecondaryAliases}
+        numberAttributes={numberAttributes}
+        numberSecondaryAliases={numberSecondaryAliases}
+        stringAttributes={stringAttributes}
+        stringSecondaryAliases={stringSecondaryAliases}
+        booleanAttributesLoading={booleanAttributesLoading}
+        numberAttributesLoading={numberAttributesLoading}
+        stringAttributesLoading={stringAttributesLoading}
+        searchBarWidthOffset={columnEditorButtonRef.current?.clientWidth}
+      />
       <ExploreBodyContent>
         <ExploreControlSection expanded={sidebarOpen}>
           {sidebarOpen ? <LogsToolbar /> : null}
@@ -482,6 +538,6 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
           </LogsItemContainer>
         </ExploreContentSection>
       </ExploreBodyContent>
-    </SearchQueryBuilderProvider>
+    </Fragment>
   );
 }

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import type {TagCollection} from 'sentry/types/group';
@@ -69,22 +69,38 @@ export function useLogsSearchQueryBuilderProps({
     ]
   );
 
-  const tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps = {
-    initialQuery: logsSearch.formatString(),
-    searchSource: 'ourlogs',
-    onSearch,
-    booleanAttributes,
-    numberAttributes,
-    stringAttributes,
-    itemType: TraceItemDataset.LOGS as TraceItemDataset.LOGS,
-    booleanSecondaryAliases,
-    numberSecondaryAliases,
-    stringSecondaryAliases,
-    caseInsensitive,
-    onCaseInsensitiveClick: setCaseInsensitive,
-    replaceRawSearchKeys: hasRawSearchReplacement ? ['message'] : undefined,
-    matchKeySuggestions: [{key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/}],
-  };
+  const initialQuery = logsSearch.formatString();
+  const tracesItemSearchQueryBuilderProps = useMemo<TraceItemSearchQueryBuilderProps>(
+    () => ({
+      initialQuery,
+      searchSource: 'ourlogs',
+      onSearch,
+      booleanAttributes,
+      numberAttributes,
+      stringAttributes,
+      itemType: TraceItemDataset.LOGS as TraceItemDataset.LOGS,
+      booleanSecondaryAliases,
+      numberSecondaryAliases,
+      stringSecondaryAliases,
+      caseInsensitive,
+      onCaseInsensitiveClick: setCaseInsensitive,
+      replaceRawSearchKeys: hasRawSearchReplacement ? ['message'] : undefined,
+      matchKeySuggestions: [{key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/}],
+    }),
+    [
+      booleanAttributes,
+      booleanSecondaryAliases,
+      caseInsensitive,
+      hasRawSearchReplacement,
+      initialQuery,
+      numberAttributes,
+      numberSecondaryAliases,
+      onSearch,
+      setCaseInsensitive,
+      stringAttributes,
+      stringSecondaryAliases,
+    ]
+  );
 
   const searchQueryBuilderProviderProps = useTraceItemSearchQueryBuilderProps(
     tracesItemSearchQueryBuilderProps


### PR DESCRIPTION
## Summary
- Extract the logs search/filter area into a memoized `LogsSearchSection` so table refreshes and layout updates do not force the query builder subtree to rerender.
- Memoize `tracesItemSearchQueryBuilderProps` in `useLogsSearchQueryBuilderProps` so provider props remain referentially stable between auto-refresh cycles.
- Preserve existing logs search behavior while reducing unnecessary renders that were causing avoidable UI churn.

Refs LOGS-603

Made with [Cursor](https://cursor.com)