### PR TITLE
fix(logs): allow vertical padding height for 'No logs found' messages

### DIFF
--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -246,21 +246,16 @@ export const GridBodyCellStatic = styled(GridBodyCell)`
 const GridStatusWrapper = styled(GridBodyCell)`
   grid-column: 1 / -1;
   width: 100%;
-  height: ${GRID_STATUS_MESSAGE_HEIGHT}px;
+  min-height: ${GRID_STATUS_MESSAGE_HEIGHT}px;
   background-color: transparent;
 `;
 
 const GridStatusFloat = styled('div')`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
   display: flex;
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: ${GRID_STATUS_MESSAGE_HEIGHT}px;
-  overflow: hidden;
+  min-height: ${GRID_STATUS_MESSAGE_HEIGHT}px;
 `;
 
 export function GridBodyCellStatus(props: any) {


### PR DESCRIPTION
The `EmptyStateWarning` child inside the td already has `padding: 32px 16px` that I'm betting was meant to apply here. But `GridStatusWapper` and `GridStatusFloat` have explicit `height: 168px` and GridStatusFloat has `position: absolute` which set the height to 168px. This removes the absolute positioning and switches to `min-height: 168px`.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="681" height="295" alt="image" src="https://github.com/user-attachments/assets/a1937028-9bd5-4cf0-adbc-9f3a5051137a" />
</td>
<td>
<img width="681" height="348" alt="image" src="https://github.com/user-attachments/assets/5104a587-33fd-4baa-8bca-4eddb4a7bd31" />
</td>
</table>

Fixes LOGS-604.