### PR TITLE
feat(integrations): Add on-demand source context fetching from SCM integrations

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1114,6 +1114,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 attrs, "sentry:seer_scanner_automation"
             ),
             "debugFilesRole": attrs["options"].get("sentry:debug_files_role"),
+            "scmSourceContextEnabled": self.get_value_with_default(
+                attrs, "sentry:scm_source_context_enabled"
+            ),
         }
 
         if has_tempest_access(obj.organization):

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -964,6 +964,7 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     tempestFetchScreenshots: NotRequired[bool]
     autofixAutomationTuning: NotRequired[str]
     seerScannerAutomation: NotRequired[bool]
+    scmSourceContextEnabled: NotRequired[bool]
     debugFilesRole: NotRequired[str | None]
 
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -334,6 +334,7 @@ from sentry.issues.endpoints import (
     ProjectGroupIndexEndpoint,
     ProjectGroupStatsEndpoint,
     ProjectStacktraceLinkEndpoint,
+    ProjectStacktraceSourceContextEndpoint,
     RelatedIssuesEndpoint,
     SharedGroupDetailsEndpoint,
     ShortIdLookupEndpoint,
@@ -3265,6 +3266,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/stacktrace-link/$",
         ProjectStacktraceLinkEndpoint.as_view(),
         name="sentry-api-0-project-stacktrace-link",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/stacktrace-source-context/$",
+        ProjectStacktraceSourceContextEndpoint.as_view(),
+        name="sentry-api-0-project-stacktrace-source-context",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/repo-path-parsing/$",

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -273,6 +273,7 @@ DETAILED_PROJECT = {
     "highlightTags": [],
     "highlightContext": {},
     "highlightPreset": {"tags": [], "context": {}},
+    "scmSourceContextEnabled": False,
 }
 
 PROJECT_SUMMARY = {

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -257,6 +257,7 @@ E.g. `['release', 'environment']`""",
     targetSampleRate = serializers.FloatField(required=False, min_value=0, max_value=1)
     dynamicSamplingBiases = DynamicSamplingBiasSerializer(required=False, many=True)
     tempestFetchScreenshots = serializers.BooleanField(required=False)
+    scmSourceContextEnabled = serializers.BooleanField(required=False)
 
     # DO NOT ADD MORE TO OPTIONS
     # Each param should be a field in the serializer like above.
@@ -470,6 +471,14 @@ E.g. `['release', 'environment']`""",
         if not has_tempest_access(organization):
             raise serializers.ValidationError(
                 "Organization does not have the tempest feature enabled."
+            )
+        return value
+
+    def validate_scmSourceContextEnabled(self, value):
+        organization = self.context["project"].organization
+        if not features.has("organizations:scm-source-context", organization):
+            raise serializers.ValidationError(
+                "Organization does not have the SCM source context feature enabled."
             )
         return value
 
@@ -760,6 +769,13 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             ):
                 changed_proj_settings["sentry:tempest_fetch_screenshots"] = result[
                     "tempestFetchScreenshots"
+                ]
+        if result.get("scmSourceContextEnabled") is not None:
+            if project.update_option(
+                "sentry:scm_source_context_enabled", result["scmSourceContextEnabled"]
+            ):
+                changed_proj_settings["sentry:scm_source_context_enabled"] = result[
+                    "scmSourceContextEnabled"
                 ]
         if result.get("targetSampleRate") is not None:
             if project.update_option(

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -475,11 +475,12 @@ E.g. `['release', 'environment']`""",
         return value
 
     def validate_scmSourceContextEnabled(self, value):
-        organization = self.context["project"].organization
-        if not features.has("organizations:scm-source-context", organization):
-            raise serializers.ValidationError(
-                "Organization does not have the SCM source context feature enabled."
-            )
+        if value:
+            organization = self.context["project"].organization
+            if not features.has("organizations:scm-source-context", organization):
+                raise serializers.ValidationError(
+                    "Organization does not have the SCM source context feature enabled."
+                )
         return value
 
     def validate_debugFilesRole(self, value):

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -257,7 +257,10 @@ E.g. `['release', 'environment']`""",
     targetSampleRate = serializers.FloatField(required=False, min_value=0, max_value=1)
     dynamicSamplingBiases = DynamicSamplingBiasSerializer(required=False, many=True)
     tempestFetchScreenshots = serializers.BooleanField(required=False)
-    scmSourceContextEnabled = serializers.BooleanField(required=False)
+    scmSourceContextEnabled = serializers.BooleanField(
+        required=False,
+        help_text="Enable on-demand source context fetching from SCM integrations for stack traces.",
+    )
 
     # DO NOT ADD MORE TO OPTIONS
     # Each param should be a field in the serializer like above.

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -137,6 +137,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-github-copilot-agent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-perforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:scm-source-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Project Management Integrations Feature Parity Flags
     manager.add("organizations:integrations-github_enterprise-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-gitlab-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/integrations/utils/source_context.py
+++ b/src/sentry/integrations/utils/source_context.py
@@ -45,7 +45,6 @@ def _format_context(
     context_line: bytes | None,
     post_context: list[bytes] | None,
     lineno: int,
-    context_size: int = LINES_OF_CONTEXT,
 ) -> list[list[int | str]]:
     """Format source context into [[lineNo, content], ...] tuples for the frontend."""
     result: list[list[int | str]] = []
@@ -160,7 +159,7 @@ def _extract_source_lines(
 
     pre_context, context_line, post_context = get_source_context(lines, lineno, context_lines)
 
-    context = _format_context(pre_context, context_line, post_context, lineno, context_lines)
+    context = _format_context(pre_context, context_line, post_context, lineno)
     return context, None
 
 
@@ -217,6 +216,7 @@ def fetch_source_context_from_scm(
         integration, install = resolved
 
         ref = ctx.get("commit_id") or str(config.default_branch or "")
+
         cache_key = _make_cache_key(
             org_integration_id,
             config.repository_id,
@@ -250,7 +250,7 @@ def fetch_source_context_from_scm(
                 config.repository, src_path, str(config.default_branch or ""), ctx.get("commit_id")
             )
             result["source_url"] = source_url
-        except (ApiError, Exception):
+        except ApiError:
             pass
 
         return result

--- a/src/sentry/integrations/utils/source_context.py
+++ b/src/sentry/integrations/utils/source_context.py
@@ -127,6 +127,19 @@ def fetch_source_context_from_scm(
         if file_content is None:
             try:
                 client = install.get_client()
+            except Exception:
+                logger.warning(
+                    "scm_source_context.get_client_error",
+                    extra={
+                        "integration_id": integration.id,
+                        "src_path": src_path,
+                    },
+                    exc_info=True,
+                )
+                result["error"] = "integration_error"
+                continue
+
+            try:
                 file_content = client.get_file(config.repository, src_path, ref)
             except NotImplementedError:
                 result["error"] = "get_file_not_supported"
@@ -154,16 +167,13 @@ def fetch_source_context_from_scm(
             if file_content is not None:
                 cache.set(cache_key, file_content, SOURCE_CONTEXT_CACHE_TTL)
 
-        if file_content is None:
-            result["error"] = "empty_file"
-            continue
-
         lines = [line.encode("utf-8") for line in file_content.splitlines()]
-        pre_context, context_line, post_context = get_source_context(lines, lineno, context_lines)
 
-        if context_line is None:
+        if lineno < 1 or lineno > len(lines):
             result["error"] = "line_out_of_range"
             continue
+
+        pre_context, context_line, post_context = get_source_context(lines, lineno, context_lines)
 
         result["context"] = _format_context(
             pre_context, context_line, post_context, lineno, context_lines

--- a/src/sentry/integrations/utils/source_context.py
+++ b/src/sentry/integrations/utils/source_context.py
@@ -192,14 +192,18 @@ def fetch_source_context_from_scm(
         result["error"] = "invalid_line_number"
         return result
 
+    frame = EventFrame.from_dict(ctx)
+    platform = ctx["platform"]
+    sdk_name = ctx.get("sdk_name")
+
     # Resolve integration and install once per unique org_integration_id
     resolved_integrations: dict[int, tuple[RpcIntegration, RepositoryIntegration] | None] = {}
 
     for config in configs:
         src_path = convert_stacktrace_frame_path_to_source_path(
-            frame=EventFrame.from_dict(ctx),
-            platform=ctx["platform"],
-            sdk_name=ctx.get("sdk_name"),
+            frame=frame,
+            platform=platform,
+            sdk_name=sdk_name,
             code_mapping=config,
         )
         if not src_path:

--- a/src/sentry/integrations/utils/source_context.py
+++ b/src/sentry/integrations/utils/source_context.py
@@ -18,7 +18,10 @@ from sentry.utils.cache import cache
 from sentry.utils.event_frames import EventFrame
 
 if TYPE_CHECKING:
+    from sentry.integrations.base import IntegrationInstallation
+    from sentry.integrations.services.integration.model import RpcIntegration
     from sentry.issues.endpoints.project_stacktrace_link import StacktraceLinkContext
+    from sentry.models.repository import Repository
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +66,104 @@ def _format_context(
     return result
 
 
+def _resolve_integration(
+    config: RepositoryProjectPathConfig,
+) -> tuple[RpcIntegration, RepositoryIntegration] | None:
+    """Resolve the integration and installation for a code mapping config."""
+    integration = integration_service.get_integration(
+        organization_integration_id=config.organization_integration_id,
+        status=ObjectStatus.ACTIVE,
+    )
+    if not integration:
+        return None
+
+    install = integration.get_installation(organization_id=config.project.organization_id)
+    if not isinstance(install, RepositoryIntegration):
+        return None
+
+    return integration, install
+
+
+def _fetch_file_from_scm(
+    install: IntegrationInstallation,
+    integration_id: int,
+    repository: Repository,
+    src_path: str,
+    ref: str,
+    cache_key: str,
+) -> tuple[str | None, str | None]:
+    """
+    Fetch file content from SCM, using cache when available.
+
+    Returns (file_content, error). If error is "rate_limited", the caller
+    should stop iterating entirely.
+    """
+    file_content: str | None = cache.get(cache_key)
+    if file_content is not None:
+        return file_content, None
+
+    try:
+        client = install.get_client()
+    except Exception:
+        logger.warning(
+            "scm_source_context.get_client_error",
+            extra={
+                "integration_id": integration_id,
+                "src_path": src_path,
+            },
+            exc_info=True,
+        )
+        return None, "integration_error"
+
+    try:
+        file_content = client.get_file(repository, src_path, ref)
+    except NotImplementedError:
+        return None, "get_file_not_supported"
+    except ApiRateLimitedError:
+        return None, "rate_limited"
+    except ApiError as e:
+        if e.code == 404:
+            return None, "file_not_found"
+        elif e.code == 403:
+            return None, "integration_forbidden"
+        else:
+            logger.warning(
+                "scm_source_context.fetch_error",
+                extra={
+                    "error": str(e),
+                    "integration_id": integration_id,
+                    "src_path": src_path,
+                },
+            )
+            return None, "integration_error"
+
+    if file_content is not None:
+        cache.set(cache_key, file_content, SOURCE_CONTEXT_CACHE_TTL)
+
+    return file_content, None
+
+
+def _extract_source_lines(
+    file_content: str,
+    lineno: int,
+    context_lines: int,
+) -> tuple[list[list[int | str]], str | None]:
+    """
+    Extract context lines from file content around the given line number.
+
+    Returns (context, error).
+    """
+    lines = [line.encode("utf-8") for line in file_content.splitlines()]
+
+    if lineno < 1 or lineno > len(lines):
+        return [], "line_out_of_range"
+
+    pre_context, context_line, post_context = get_source_context(lines, lineno, context_lines)
+
+    context = _format_context(pre_context, context_line, post_context, lineno, context_lines)
+    return context, None
+
+
 def fetch_source_context_from_scm(
     configs: Sequence[RepositoryProjectPathConfig],
     ctx: StacktraceLinkContext,
@@ -92,6 +193,9 @@ def fetch_source_context_from_scm(
         result["error"] = "invalid_line_number"
         return result
 
+    # Resolve integration and install once per unique org_integration_id
+    resolved_integrations: dict[int, tuple[RpcIntegration, RepositoryIntegration] | None] = {}
+
     for config in configs:
         src_path = convert_stacktrace_frame_path_to_source_path(
             frame=EventFrame.from_dict(ctx),
@@ -102,85 +206,45 @@ def fetch_source_context_from_scm(
         if not src_path:
             continue
 
-        integration = integration_service.get_integration(
-            organization_integration_id=config.organization_integration_id,
-            status=ObjectStatus.ACTIVE,
-        )
-        if not integration:
+        org_integration_id = config.organization_integration_id
+        if org_integration_id not in resolved_integrations:
+            resolved_integrations[org_integration_id] = _resolve_integration(config)
+
+        resolved = resolved_integrations[org_integration_id]
+        if resolved is None:
             continue
 
-        install = integration.get_installation(organization_id=config.project.organization_id)
-        if not isinstance(install, RepositoryIntegration):
-            continue
+        integration, install = resolved
 
         ref = ctx.get("commit_id") or str(config.default_branch or "")
         cache_key = _make_cache_key(
-            config.organization_integration_id,
+            org_integration_id,
             config.repository_id,
             src_path,
             ref,
         )
 
-        # Try cache first
-        file_content: str | None = cache.get(cache_key)
+        file_content, fetch_error = _fetch_file_from_scm(
+            install, integration.id, config.repository, src_path, ref, cache_key
+        )
 
-        if file_content is None:
-            try:
-                client = install.get_client()
-            except Exception:
-                logger.warning(
-                    "scm_source_context.get_client_error",
-                    extra={
-                        "integration_id": integration.id,
-                        "src_path": src_path,
-                    },
-                    exc_info=True,
-                )
-                result["error"] = "integration_error"
-                continue
-
-            try:
-                file_content = client.get_file(config.repository, src_path, ref)
-            except NotImplementedError:
-                result["error"] = "get_file_not_supported"
-                continue
-            except ApiRateLimitedError:
-                result["error"] = "rate_limited"
+        if fetch_error:
+            result["error"] = fetch_error
+            if fetch_error == "rate_limited":
                 return result
-            except ApiError as e:
-                if e.code == 404:
-                    result["error"] = "file_not_found"
-                elif e.code == 403:
-                    result["error"] = "integration_forbidden"
-                else:
-                    result["error"] = "integration_error"
-                    logger.warning(
-                        "scm_source_context.fetch_error",
-                        extra={
-                            "error": str(e),
-                            "integration_id": integration.id,
-                            "src_path": src_path,
-                        },
-                    )
-                continue
-
-            if file_content is not None:
-                cache.set(cache_key, file_content, SOURCE_CONTEXT_CACHE_TTL)
-
-        lines = [line.encode("utf-8") for line in file_content.splitlines()]
-
-        if lineno < 1 or lineno > len(lines):
-            result["error"] = "line_out_of_range"
             continue
 
-        pre_context, context_line, post_context = get_source_context(lines, lineno, context_lines)
+        if file_content is None:
+            continue
 
-        result["context"] = _format_context(
-            pre_context, context_line, post_context, lineno, context_lines
-        )
+        context, extract_error = _extract_source_lines(file_content, lineno, context_lines)
+        if extract_error:
+            result["error"] = extract_error
+            continue
+
+        result["context"] = context
         result["error"] = None
 
-        # Also generate the source URL for convenience
         try:
             source_url = install.get_stacktrace_link(
                 config.repository, src_path, str(config.default_branch or ""), ctx.get("commit_id")

--- a/src/sentry/integrations/utils/source_context.py
+++ b/src/sentry/integrations/utils/source_context.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, TypedDict
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.issues.auto_source_code_config.code_mapping import (
+    convert_stacktrace_frame_path_to_source_path,
+)
+from sentry.lang.javascript.utils import LINES_OF_CONTEXT, get_source_context
+from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+from sentry.utils.cache import cache
+from sentry.utils.event_frames import EventFrame
+
+if TYPE_CHECKING:
+    from sentry.issues.endpoints.project_stacktrace_link import StacktraceLinkContext
+
+logger = logging.getLogger(__name__)
+
+# Cache file contents for 1 hour
+SOURCE_CONTEXT_CACHE_TTL = 3600
+
+
+class SourceContextResult(TypedDict):
+    context: list[list[int | str]]  # [[lineNo, content], ...]
+    error: str | None
+    source_url: str | None
+
+
+def _make_cache_key(org_integration_id: int, repo_id: int, src_path: str, ref: str | None) -> str:
+    path_hash = hashlib.md5(f"{src_path}:{ref or ''}".encode()).hexdigest()
+    return f"scm-src-ctx:{org_integration_id}:{repo_id}:{path_hash}"
+
+
+def _format_context(
+    pre_context: list[bytes] | None,
+    context_line: bytes | None,
+    post_context: list[bytes] | None,
+    lineno: int,
+    context_size: int = LINES_OF_CONTEXT,
+) -> list[list[int | str]]:
+    """Format source context into [[lineNo, content], ...] tuples for the frontend."""
+    result: list[list[int | str]] = []
+
+    start_line = lineno - len(pre_context or [])
+
+    if pre_context:
+        for i, line in enumerate(pre_context):
+            result.append([start_line + i, line.decode("utf-8", errors="replace")])
+
+    if context_line is not None:
+        result.append([lineno, context_line.decode("utf-8", errors="replace")])
+
+    if post_context:
+        for i, line in enumerate(post_context):
+            result.append([lineno + 1 + i, line.decode("utf-8", errors="replace")])
+
+    return result
+
+
+def fetch_source_context_from_scm(
+    configs: Sequence[RepositoryProjectPathConfig],
+    ctx: StacktraceLinkContext,
+    context_lines: int = LINES_OF_CONTEXT,
+) -> SourceContextResult:
+    """
+    Fetch source context lines from an SCM integration for a stack trace frame.
+
+    Iterates code mappings to resolve the frame file path to a repository path,
+    then fetches the file content via the integration client and extracts the
+    surrounding lines. File content is cached for 1 hour.
+    """
+    result: SourceContextResult = {
+        "context": [],
+        "error": None,
+        "source_url": None,
+    }
+
+    line_no_str = ctx.get("line_no")
+    if not line_no_str:
+        result["error"] = "missing_line_number"
+        return result
+
+    try:
+        lineno = int(line_no_str)
+    except (TypeError, ValueError):
+        result["error"] = "invalid_line_number"
+        return result
+
+    for config in configs:
+        src_path = convert_stacktrace_frame_path_to_source_path(
+            frame=EventFrame.from_dict(ctx),
+            platform=ctx["platform"],
+            sdk_name=ctx.get("sdk_name"),
+            code_mapping=config,
+        )
+        if not src_path:
+            continue
+
+        integration = integration_service.get_integration(
+            organization_integration_id=config.organization_integration_id,
+            status=ObjectStatus.ACTIVE,
+        )
+        if not integration:
+            continue
+
+        install = integration.get_installation(organization_id=config.project.organization_id)
+        if not isinstance(install, RepositoryIntegration):
+            continue
+
+        ref = ctx.get("commit_id") or str(config.default_branch or "")
+        cache_key = _make_cache_key(
+            config.organization_integration_id,
+            config.repository_id,
+            src_path,
+            ref,
+        )
+
+        # Try cache first
+        file_content: str | None = cache.get(cache_key)
+
+        if file_content is None:
+            try:
+                client = install.get_client()
+                file_content = client.get_file(config.repository, src_path, ref)
+            except NotImplementedError:
+                result["error"] = "get_file_not_supported"
+                continue
+            except ApiRateLimitedError:
+                result["error"] = "rate_limited"
+                return result
+            except ApiError as e:
+                if e.code == 404:
+                    result["error"] = "file_not_found"
+                elif e.code == 403:
+                    result["error"] = "integration_forbidden"
+                else:
+                    result["error"] = "integration_error"
+                    logger.warning(
+                        "scm_source_context.fetch_error",
+                        extra={
+                            "error": str(e),
+                            "integration_id": integration.id,
+                            "src_path": src_path,
+                        },
+                    )
+                continue
+
+            if file_content is not None:
+                cache.set(cache_key, file_content, SOURCE_CONTEXT_CACHE_TTL)
+
+        if file_content is None:
+            result["error"] = "empty_file"
+            continue
+
+        lines = [line.encode("utf-8") for line in file_content.splitlines()]
+        pre_context, context_line, post_context = get_source_context(lines, lineno, context_lines)
+
+        if context_line is None:
+            result["error"] = "line_out_of_range"
+            continue
+
+        result["context"] = _format_context(
+            pre_context, context_line, post_context, lineno, context_lines
+        )
+        result["error"] = None
+
+        # Also generate the source URL for convenience
+        try:
+            source_url = install.get_stacktrace_link(
+                config.repository, src_path, str(config.default_branch or ""), ctx.get("commit_id")
+            )
+            result["source_url"] = source_url
+        except (ApiError, Exception):
+            pass
+
+        return result
+
+    if not result["error"]:
+        result["error"] = "no_code_mapping_match"
+    return result

--- a/src/sentry/integrations/utils/source_context.py
+++ b/src/sentry/integrations/utils/source_context.py
@@ -12,7 +12,11 @@ from sentry.issues.auto_source_code_config.code_mapping import (
     convert_stacktrace_frame_path_to_source_path,
 )
 from sentry.lang.javascript.utils import LINES_OF_CONTEXT, get_source_context
-from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiRateLimitedError,
+    IntegrationConfigurationError,
+)
 from sentry.utils.event_frames import EventFrame
 
 if TYPE_CHECKING:
@@ -229,7 +233,7 @@ def fetch_source_context_from_scm(
                 config.repository, src_path, str(config.default_branch or ""), ctx.get("commit_id")
             )
             result["source_url"] = source_url
-        except ApiError:
+        except (ApiError, IntegrationConfigurationError):
             pass
 
         return result

--- a/src/sentry/integrations/utils/source_context.py
+++ b/src/sentry/integrations/utils/source_context.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, TypedDict
@@ -14,7 +13,6 @@ from sentry.issues.auto_source_code_config.code_mapping import (
 )
 from sentry.lang.javascript.utils import LINES_OF_CONTEXT, get_source_context
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
-from sentry.utils.cache import cache
 from sentry.utils.event_frames import EventFrame
 
 if TYPE_CHECKING:
@@ -25,19 +23,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Cache file contents for 1 hour
-SOURCE_CONTEXT_CACHE_TTL = 3600
-
 
 class SourceContextResult(TypedDict):
     context: list[list[int | str]]  # [[lineNo, content], ...]
     error: str | None
     source_url: str | None
-
-
-def _make_cache_key(org_integration_id: int, repo_id: int, src_path: str, ref: str | None) -> str:
-    path_hash = hashlib.md5(f"{src_path}:{ref or ''}".encode()).hexdigest()
-    return f"scm-src-ctx:{org_integration_id}:{repo_id}:{path_hash}"
 
 
 def _format_context(
@@ -89,18 +79,13 @@ def _fetch_file_from_scm(
     repository: Repository,
     src_path: str,
     ref: str,
-    cache_key: str,
 ) -> tuple[str | None, str | None]:
     """
-    Fetch file content from SCM, using cache when available.
+    Fetch file content from SCM.
 
     Returns (file_content, error). If error is "rate_limited", the caller
     should stop iterating entirely.
     """
-    file_content: str | None = cache.get(cache_key)
-    if file_content is not None:
-        return file_content, None
-
     try:
         client = install.get_client()
     except Exception:
@@ -136,9 +121,6 @@ def _fetch_file_from_scm(
             )
             return None, "integration_error"
 
-    if file_content is not None:
-        cache.set(cache_key, file_content, SOURCE_CONTEXT_CACHE_TTL)
-
     return file_content, None
 
 
@@ -173,7 +155,7 @@ def fetch_source_context_from_scm(
 
     Iterates code mappings to resolve the frame file path to a repository path,
     then fetches the file content via the integration client and extracts the
-    surrounding lines. File content is cached for 1 hour.
+    surrounding lines.
     """
     result: SourceContextResult = {
         "context": [],
@@ -221,15 +203,8 @@ def fetch_source_context_from_scm(
 
         ref = ctx.get("commit_id") or str(config.default_branch or "")
 
-        cache_key = _make_cache_key(
-            org_integration_id,
-            config.repository_id,
-            src_path,
-            ref,
-        )
-
         file_content, fetch_error = _fetch_file_from_scm(
-            install, integration.id, config.repository, src_path, ref, cache_key
+            install, integration.id, config.repository, src_path, ref
         )
 
         if fetch_error:

--- a/src/sentry/issues/endpoints/__init__.py
+++ b/src/sentry/issues/endpoints/__init__.py
@@ -30,6 +30,7 @@ from .project_events import ProjectEventsEndpoint
 from .project_group_index import ProjectGroupIndexEndpoint
 from .project_group_stats import ProjectGroupStatsEndpoint
 from .project_stacktrace_link import ProjectStacktraceLinkEndpoint
+from .project_stacktrace_source_context import ProjectStacktraceSourceContextEndpoint
 from .related_issues import RelatedIssuesEndpoint
 from .shared_group_details import SharedGroupDetailsEndpoint
 from .source_map_debug import SourceMapDebugEndpoint
@@ -66,6 +67,7 @@ __all__ = (
     "ProjectGroupIndexEndpoint",
     "ProjectGroupStatsEndpoint",
     "ProjectStacktraceLinkEndpoint",
+    "ProjectStacktraceSourceContextEndpoint",
     "RelatedIssuesEndpoint",
     "SharedGroupDetailsEndpoint",
     "ShortIdLookupEndpoint",

--- a/src/sentry/issues/endpoints/project_stacktrace_source_context.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_source_context.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import region_silo_endpoint
+from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.integrations.utils.source_context import fetch_source_context_from_scm
 from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
@@ -18,7 +18,7 @@ from sentry.models.project import Project
 logger = logging.getLogger(__name__)
 
 
-@region_silo_endpoint
+@cell_silo_endpoint
 class ProjectStacktraceSourceContextEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,

--- a/src/sentry/issues/endpoints/project_stacktrace_source_context.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_source_context.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.integrations.utils.source_context import fetch_source_context_from_scm
+from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
+from sentry.issues.endpoints.project_stacktrace_link import generate_context
+from sentry.models.project import Project
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class ProjectStacktraceSourceContextEndpoint(ProjectEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    """
+    Returns source context lines for a stack trace frame by fetching the file
+    from the configured SCM integration (GitHub, GitLab, Perforce, etc.).
+
+    `file`: The file path from the stack trace (required)
+    `lineNo`: The line number to fetch context around (required)
+    `commitId` (optional): The commit_id for the last commit of the release
+    `platform` (optional): The platform of the event
+    `sdkName` (optional): The sdk.name associated with the event
+    `absPath` (optional): The abs_path field value of the relevant stack frame
+    `module`  (optional): The module field value of the relevant stack frame
+    `package` (optional): The package field value of the relevant stack frame
+    """
+
+    owner = ApiOwner.ISSUES
+
+    def get(self, request: Request, project: Project) -> Response:
+        if not features.has(
+            "organizations:scm-source-context",
+            project.organization,
+            actor=request.user,
+        ):
+            return Response(status=404)
+
+        ctx = generate_context(request.GET)
+
+        if not ctx["file"]:
+            return Response({"detail": "Filepath is required"}, status=400)
+
+        if not ctx["line_no"]:
+            return Response({"detail": "lineNo is required"}, status=400)
+
+        configs = get_sorted_code_mapping_configs(project)
+        if not configs:
+            return Response(
+                {
+                    "context": [],
+                    "error": "no_code_mappings_for_project",
+                    "sourceUrl": None,
+                }
+            )
+
+        result = fetch_source_context_from_scm(configs, ctx)
+
+        return Response(
+            {
+                "context": result["context"],
+                "error": result["error"],
+                "sourceUrl": result["source_url"],
+            }
+        )

--- a/src/sentry/issues/endpoints/project_stacktrace_source_context.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_source_context.py
@@ -47,9 +47,12 @@ class ProjectStacktraceSourceContextEndpoint(ProjectEndpoint):
         ):
             return Response(status=404)
 
+        if not project.get_option("sentry:scm_source_context_enabled", False):
+            return Response(status=404)
+
         ctx = generate_context(request.GET)
 
-        if not ctx["file"]:
+        if ctx["file"] == "":
             return Response({"detail": "Filepath is required"}, status=400)
 
         if not ctx["line_no"]:

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -78,6 +78,7 @@ OPTION_KEYS = frozenset(
         "sentry:preprod_snapshot_status_checks_fail_on_added",
         "sentry:preprod_snapshot_status_checks_fail_on_removed",
         "sentry:preprod_distribution_pr_comments_enabled_by_customer",
+        "sentry:scm_source_context_enabled",
         "quotas:spike-protection-disabled",
         "feedback:branding",
         "digests:mail:minimum_delay",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -210,3 +210,6 @@ register(key="sentry:preprod_distribution_enabled_query", default="")
 
 # Boolean to enable/disable build distribution PR comments for this project.
 register(key="sentry:preprod_distribution_pr_comments_enabled_by_customer", default=True)
+
+# Whether to enable on-demand source context fetching from SCM integrations
+register(key="sentry:scm_source_context_enabled", default=False)

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -721,6 +721,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/seer/preferences/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/stacktrace-coverage/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/stacktrace-link/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/stacktrace-source-context/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/statistical-detector/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/stats/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/symbol-sources/'

--- a/tests/sentry/integrations/utils/test_source_context.py
+++ b/tests/sentry/integrations/utils/test_source_context.py
@@ -94,7 +94,9 @@ class FetchSourceContextTest(TestCase):
         assert result["context"] == []
 
     def test_no_code_mapping_match(self) -> None:
-        ctx = self._make_ctx(file="unknown/path.py", filename="unknown/path.py")
+        ctx = self._make_ctx(
+            file="unknown/path.py", filename="unknown/path.py", abs_path="unknown/path.py"
+        )
         result = fetch_source_context_from_scm([self.code_mapping], ctx)
         assert result["error"] == "no_code_mapping_match"
         assert result["context"] == []

--- a/tests/sentry/integrations/utils/test_source_context.py
+++ b/tests/sentry/integrations/utils/test_source_context.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from sentry_sdk import SiloMode
+
+from sentry.integrations.utils.source_context import (
+    _format_context,
+    _make_cache_key,
+    fetch_source_context_from_scm,
+)
+from sentry.issues.endpoints.project_stacktrace_link import StacktraceLinkContext
+from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.silo import assume_test_silo_mode
+
+
+class FormatContextTest(IntegrationTestCase):
+    def test_format_context_basic(self) -> None:
+        pre = [b"line1", b"line2"]
+        ctx_line = b"line3"
+        post = [b"line4", b"line5"]
+        result = _format_context(pre, ctx_line, post, lineno=3)
+        assert result == [
+            [1, "line1"],
+            [2, "line2"],
+            [3, "line3"],
+            [4, "line4"],
+            [5, "line5"],
+        ]
+
+    def test_format_context_no_pre_or_post(self) -> None:
+        result = _format_context(None, b"only_line", None, lineno=1)
+        assert result == [[1, "only_line"]]
+
+    def test_format_context_none_context_line(self) -> None:
+        result = _format_context(None, None, None, lineno=1)
+        assert result == []
+
+    def test_format_context_utf8_decode(self) -> None:
+        result = _format_context(None, "héllo".encode(), None, lineno=1)
+        assert result == [[1, "héllo"]]
+
+
+class FetchSourceContextTest(IntegrationTestCase):
+    provider = "example"
+
+    def setUp(self) -> None:
+        super().setUp()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration, self.oi = self.create_provider_integration_for(
+                self.organization, self.user, provider="example", name="Example"
+            )
+
+        self.repo = self.create_repo(
+            project=self.project,
+            name="getsentry/sentry",
+        )
+        self.repo.integration_id = self.integration.id
+        self.repo.provider = "example"
+        self.repo.save()
+
+        self.code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="src/",
+            source_root="src/",
+        )
+
+    def _make_ctx(self, **overrides: str | None) -> StacktraceLinkContext:
+        defaults: StacktraceLinkContext = {
+            "file": "src/app/main.py",
+            "filename": "src/app/main.py",
+            "platform": "python",
+            "abs_path": "src/app/main.py",
+            "commit_id": None,
+            "group_id": None,
+            "line_no": "10",
+            "module": None,
+            "package": None,
+            "sdk_name": None,
+        }
+        defaults.update(overrides)  # type: ignore[typeddict-item]
+        return defaults
+
+    def test_missing_line_number(self) -> None:
+        ctx = self._make_ctx(line_no=None)
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result["error"] == "missing_line_number"
+        assert result["context"] == []
+
+    def test_invalid_line_number(self) -> None:
+        ctx = self._make_ctx(line_no="abc")
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result["error"] == "invalid_line_number"
+        assert result["context"] == []
+
+    def test_no_code_mapping_match(self) -> None:
+        ctx = self._make_ctx(file="unknown/path.py", filename="unknown/path.py")
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result["error"] == "no_code_mapping_match"
+        assert result["context"] == []
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_integration_not_found(self, mock_service: MagicMock) -> None:
+        mock_service.get_integration.return_value = None
+        ctx = self._make_ctx()
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result["error"] == "no_code_mapping_match"
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_successful_fetch(self, mock_service: MagicMock) -> None:
+        file_content = "\n".join([f"line{i}" for i in range(1, 20)])
+
+        mock_integration = MagicMock()
+        mock_service.get_integration.return_value = mock_integration
+        mock_install = MagicMock()
+        mock_integration.get_installation.return_value = mock_install
+        mock_client = MagicMock()
+        mock_install.get_client.return_value = mock_client
+        mock_client.get_file.return_value = file_content
+        mock_install.get_stacktrace_link.return_value = "https://github.com/example"
+
+        # Make mock pass isinstance check
+        from sentry.integrations.source_code_management.repository import RepositoryIntegration
+
+        mock_install.__class__ = RepositoryIntegration
+
+        ctx = self._make_ctx(line_no="10")
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+
+        assert result["error"] is None
+        assert len(result["context"]) == 11  # 5 pre + 1 context + 5 post
+        assert result["context"][5] == [10, "line10"]
+        assert result["source_url"] == "https://github.com/example"
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_get_file_not_supported(self, mock_service: MagicMock) -> None:
+        mock_integration = MagicMock()
+        mock_service.get_integration.return_value = mock_integration
+        mock_install = MagicMock()
+        mock_integration.get_installation.return_value = mock_install
+        mock_client = MagicMock()
+        mock_install.get_client.return_value = mock_client
+        mock_client.get_file.side_effect = NotImplementedError
+
+        from sentry.integrations.source_code_management.repository import RepositoryIntegration
+
+        mock_install.__class__ = RepositoryIntegration
+
+        ctx = self._make_ctx()
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result["error"] == "get_file_not_supported"
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_rate_limited(self, mock_service: MagicMock) -> None:
+        mock_integration = MagicMock()
+        mock_service.get_integration.return_value = mock_integration
+        mock_install = MagicMock()
+        mock_integration.get_installation.return_value = mock_install
+        mock_client = MagicMock()
+        mock_install.get_client.return_value = mock_client
+        mock_client.get_file.side_effect = ApiRateLimitedError("rate limited")
+
+        from sentry.integrations.source_code_management.repository import RepositoryIntegration
+
+        mock_install.__class__ = RepositoryIntegration
+
+        ctx = self._make_ctx()
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result["error"] == "rate_limited"
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_file_not_found(self, mock_service: MagicMock) -> None:
+        mock_integration = MagicMock()
+        mock_service.get_integration.return_value = mock_integration
+        mock_install = MagicMock()
+        mock_integration.get_installation.return_value = mock_install
+        mock_client = MagicMock()
+        mock_install.get_client.return_value = mock_client
+        mock_client.get_file.side_effect = ApiError("Not Found", code=404)
+
+        from sentry.integrations.source_code_management.repository import RepositoryIntegration
+
+        mock_install.__class__ = RepositoryIntegration
+
+        ctx = self._make_ctx()
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result["error"] == "file_not_found"
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_line_out_of_range(self, mock_service: MagicMock) -> None:
+        file_content = "line1\nline2\nline3"
+
+        mock_integration = MagicMock()
+        mock_service.get_integration.return_value = mock_integration
+        mock_install = MagicMock()
+        mock_integration.get_installation.return_value = mock_install
+        mock_client = MagicMock()
+        mock_install.get_client.return_value = mock_client
+        mock_client.get_file.return_value = file_content
+
+        from sentry.integrations.source_code_management.repository import RepositoryIntegration
+
+        mock_install.__class__ = RepositoryIntegration
+
+        ctx = self._make_ctx(line_no="100")
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result["error"] == "line_out_of_range"
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_caching(self, mock_service: MagicMock) -> None:
+        file_content = "\n".join([f"line{i}" for i in range(1, 20)])
+
+        mock_integration = MagicMock()
+        mock_service.get_integration.return_value = mock_integration
+        mock_install = MagicMock()
+        mock_integration.get_installation.return_value = mock_install
+        mock_client = MagicMock()
+        mock_install.get_client.return_value = mock_client
+        mock_client.get_file.return_value = file_content
+        mock_install.get_stacktrace_link.return_value = None
+
+        from sentry.integrations.source_code_management.repository import RepositoryIntegration
+
+        mock_install.__class__ = RepositoryIntegration
+
+        ctx = self._make_ctx(line_no="5")
+
+        # First call fetches from integration
+        result1 = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result1["error"] is None
+        assert mock_client.get_file.call_count == 1
+
+        # Second call should use cache
+        result2 = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result2["error"] is None
+        # get_file should still only have been called once
+        assert mock_client.get_file.call_count == 1
+
+    def test_cache_key_uniqueness(self) -> None:
+        key1 = _make_cache_key(1, 1, "path/a.py", "main")
+        key2 = _make_cache_key(1, 1, "path/b.py", "main")
+        key3 = _make_cache_key(1, 1, "path/a.py", "dev")
+        assert key1 != key2
+        assert key1 != key3

--- a/tests/sentry/integrations/utils/test_source_context.py
+++ b/tests/sentry/integrations/utils/test_source_context.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from sentry_sdk import SiloMode
-
 from sentry.integrations.utils.source_context import (
     _format_context,
     _make_cache_key,
@@ -11,6 +9,7 @@ from sentry.integrations.utils.source_context import (
 )
 from sentry.issues.endpoints.project_stacktrace_link import StacktraceLinkContext
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode
 
@@ -125,7 +124,7 @@ class FetchSourceContextTest(IntegrationTestCase):
         # Make mock pass isinstance check
         from sentry.integrations.source_code_management.repository import RepositoryIntegration
 
-        mock_install.__class__ = RepositoryIntegration
+        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
 
         ctx = self._make_ctx(line_no="10")
         result = fetch_source_context_from_scm([self.code_mapping], ctx)
@@ -147,7 +146,7 @@ class FetchSourceContextTest(IntegrationTestCase):
 
         from sentry.integrations.source_code_management.repository import RepositoryIntegration
 
-        mock_install.__class__ = RepositoryIntegration
+        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
 
         ctx = self._make_ctx()
         result = fetch_source_context_from_scm([self.code_mapping], ctx)
@@ -165,7 +164,7 @@ class FetchSourceContextTest(IntegrationTestCase):
 
         from sentry.integrations.source_code_management.repository import RepositoryIntegration
 
-        mock_install.__class__ = RepositoryIntegration
+        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
 
         ctx = self._make_ctx()
         result = fetch_source_context_from_scm([self.code_mapping], ctx)
@@ -183,7 +182,7 @@ class FetchSourceContextTest(IntegrationTestCase):
 
         from sentry.integrations.source_code_management.repository import RepositoryIntegration
 
-        mock_install.__class__ = RepositoryIntegration
+        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
 
         ctx = self._make_ctx()
         result = fetch_source_context_from_scm([self.code_mapping], ctx)
@@ -203,7 +202,7 @@ class FetchSourceContextTest(IntegrationTestCase):
 
         from sentry.integrations.source_code_management.repository import RepositoryIntegration
 
-        mock_install.__class__ = RepositoryIntegration
+        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
 
         ctx = self._make_ctx(line_no="100")
         result = fetch_source_context_from_scm([self.code_mapping], ctx)
@@ -224,7 +223,7 @@ class FetchSourceContextTest(IntegrationTestCase):
 
         from sentry.integrations.source_code_management.repository import RepositoryIntegration
 
-        mock_install.__class__ = RepositoryIntegration
+        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
 
         ctx = self._make_ctx(line_no="5")
 
@@ -238,6 +237,22 @@ class FetchSourceContextTest(IntegrationTestCase):
         assert result2["error"] is None
         # get_file should still only have been called once
         assert mock_client.get_file.call_count == 1
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_get_client_exception(self, mock_service: MagicMock) -> None:
+        mock_integration = MagicMock()
+        mock_service.get_integration.return_value = mock_integration
+        mock_install = MagicMock()
+        mock_integration.get_installation.return_value = mock_install
+        mock_install.get_client.side_effect = Exception("identity not found")
+
+        from sentry.integrations.source_code_management.repository import RepositoryIntegration
+
+        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
+
+        ctx = self._make_ctx()
+        result = fetch_source_context_from_scm([self.code_mapping], ctx)
+        assert result["error"] == "integration_error"
 
     def test_cache_key_uniqueness(self) -> None:
         key1 = _make_cache_key(1, 1, "path/a.py", "main")

--- a/tests/sentry/integrations/utils/test_source_context.py
+++ b/tests/sentry/integrations/utils/test_source_context.py
@@ -10,11 +10,11 @@ from sentry.integrations.utils.source_context import (
 from sentry.issues.endpoints.project_stacktrace_link import StacktraceLinkContext
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 
 
-class FormatContextTest(IntegrationTestCase):
+class FormatContextTest(TestCase):
     def test_format_context_basic(self) -> None:
         pre = [b"line1", b"line2"]
         ctx_line = b"line3"
@@ -41,9 +41,7 @@ class FormatContextTest(IntegrationTestCase):
         assert result == [[1, "héllo"]]
 
 
-class FetchSourceContextTest(IntegrationTestCase):
-    provider = "example"
-
+class FetchSourceContextTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/integrations/utils/test_source_context.py
+++ b/tests/sentry/integrations/utils/test_source_context.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 
 from sentry.integrations.utils.source_context import (
     _format_context,
-    _make_cache_key,
     fetch_source_context_from_scm,
 )
 from sentry.issues.endpoints.project_stacktrace_link import StacktraceLinkContext
@@ -209,36 +208,6 @@ class FetchSourceContextTest(TestCase):
         assert result["error"] == "line_out_of_range"
 
     @patch("sentry.integrations.utils.source_context.integration_service")
-    def test_caching(self, mock_service: MagicMock) -> None:
-        file_content = "\n".join([f"line{i}" for i in range(1, 20)])
-
-        mock_integration = MagicMock()
-        mock_service.get_integration.return_value = mock_integration
-        mock_install = MagicMock()
-        mock_integration.get_installation.return_value = mock_install
-        mock_client = MagicMock()
-        mock_install.get_client.return_value = mock_client
-        mock_client.get_file.return_value = file_content
-        mock_install.get_stacktrace_link.return_value = None
-
-        from sentry.integrations.source_code_management.repository import RepositoryIntegration
-
-        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
-
-        ctx = self._make_ctx(line_no="5")
-
-        # First call fetches from integration
-        result1 = fetch_source_context_from_scm([self.code_mapping], ctx)
-        assert result1["error"] is None
-        assert mock_client.get_file.call_count == 1
-
-        # Second call should use cache
-        result2 = fetch_source_context_from_scm([self.code_mapping], ctx)
-        assert result2["error"] is None
-        # get_file should still only have been called once
-        assert mock_client.get_file.call_count == 1
-
-    @patch("sentry.integrations.utils.source_context.integration_service")
     def test_get_client_exception(self, mock_service: MagicMock) -> None:
         mock_integration = MagicMock()
         mock_service.get_integration.return_value = mock_integration
@@ -253,10 +222,3 @@ class FetchSourceContextTest(TestCase):
         ctx = self._make_ctx()
         result = fetch_source_context_from_scm([self.code_mapping], ctx)
         assert result["error"] == "integration_error"
-
-    def test_cache_key_uniqueness(self) -> None:
-        key1 = _make_cache_key(1, 1, "path/a.py", "main")
-        key2 = _make_cache_key(1, 1, "path/b.py", "main")
-        key3 = _make_cache_key(1, 1, "path/a.py", "dev")
-        assert key1 != key2
-        assert key1 != key3

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_source_context.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_source_context.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from sentry_sdk import SiloMode
-
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 
@@ -88,7 +87,7 @@ class ProjectStacktraceSourceContextTest(APITestCase):
 
         from sentry.integrations.source_code_management.repository import RepositoryIntegration
 
-        mock_install.__class__ = RepositoryIntegration
+        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
 
         with self.feature("organizations:scm-source-context"):
             response = self.get_success_response(
@@ -114,7 +113,7 @@ class ProjectStacktraceSourceContextTest(APITestCase):
         mock_service.get_integration.return_value = mock_integration
         mock_install = MagicMock()
         mock_integration.get_installation.return_value = mock_install
-        mock_install.__class__ = RepositoryIntegration
+        mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
         mock_client = MagicMock()
         mock_install.get_client.return_value = mock_client
         mock_client.get_file.side_effect = ApiError("Not Found", code=404)

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_source_context.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_source_context.py
@@ -34,6 +34,7 @@ class ProjectStacktraceSourceContextTest(APITestCase):
         )
 
         self.login_as(self.user)
+        self.project.update_option("sentry:scm_source_context_enabled", True)
 
     def test_feature_flag_required(self) -> None:
         response = self.get_response(
@@ -42,6 +43,16 @@ class ProjectStacktraceSourceContextTest(APITestCase):
             qs_params={"file": "src/main.py", "lineNo": "10", "platform": "python"},
         )
         assert response.status_code == 404
+
+    def test_project_option_required(self) -> None:
+        self.project.update_option("sentry:scm_source_context_enabled", False)
+        with self.feature("organizations:scm-source-context"):
+            response = self.get_response(
+                self.organization.slug,
+                self.project.slug,
+                qs_params={"file": "src/main.py", "lineNo": "10", "platform": "python"},
+            )
+            assert response.status_code == 404
 
     def test_missing_filepath(self) -> None:
         with self.feature("organizations:scm-source-context"):

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_source_context.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_source_context.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from sentry_sdk import SiloMode
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode
+
+
+class ProjectStacktraceSourceContextTest(APITestCase):
+    endpoint = "sentry-api-0-project-stacktrace-source-context"
+
+    def setUp(self) -> None:
+        super().setUp()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration, self.oi = self.create_provider_integration_for(
+                self.organization, self.user, provider="example", name="Example"
+            )
+
+        self.repo = self.create_repo(
+            project=self.project,
+            name="getsentry/sentry",
+        )
+        self.repo.integration_id = self.integration.id
+        self.repo.provider = "example"
+        self.repo.save()
+
+        self.code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="src/",
+            source_root="src/",
+        )
+
+        self.login_as(self.user)
+
+    def test_feature_flag_required(self) -> None:
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={"file": "src/main.py", "lineNo": "10", "platform": "python"},
+        )
+        assert response.status_code == 404
+
+    def test_missing_filepath(self) -> None:
+        with self.feature("organizations:scm-source-context"):
+            response = self.get_response(
+                self.organization.slug,
+                self.project.slug,
+                qs_params={"lineNo": "10", "platform": "python"},
+            )
+            assert response.status_code == 400
+
+    def test_missing_lineno(self) -> None:
+        with self.feature("organizations:scm-source-context"):
+            response = self.get_response(
+                self.organization.slug,
+                self.project.slug,
+                qs_params={"file": "src/main.py", "platform": "python"},
+            )
+            assert response.status_code == 400
+
+    def test_no_code_mappings(self) -> None:
+        self.code_mapping.delete()
+        with self.feature("organizations:scm-source-context"):
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                qs_params={"file": "src/main.py", "lineNo": "10", "platform": "python"},
+            )
+            assert response.data["error"] == "no_code_mappings_for_project"
+            assert response.data["context"] == []
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_successful_fetch(self, mock_service: MagicMock) -> None:
+        file_content = "\n".join([f"line{i}" for i in range(1, 20)])
+
+        mock_integration = MagicMock()
+        mock_service.get_integration.return_value = mock_integration
+        mock_install = MagicMock()
+        mock_integration.get_installation.return_value = mock_install
+        mock_client = MagicMock()
+        mock_install.get_client.return_value = mock_client
+        mock_client.get_file.return_value = file_content
+        mock_install.get_stacktrace_link.return_value = "https://github.com/file"
+
+        from sentry.integrations.source_code_management.repository import RepositoryIntegration
+
+        mock_install.__class__ = RepositoryIntegration
+
+        with self.feature("organizations:scm-source-context"):
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                qs_params={
+                    "file": "src/app/main.py",
+                    "lineNo": "10",
+                    "platform": "python",
+                },
+            )
+            assert response.data["error"] is None
+            assert len(response.data["context"]) == 11
+            assert response.data["context"][5] == [10, "line10"]
+            assert response.data["sourceUrl"] == "https://github.com/file"
+
+    @patch("sentry.integrations.utils.source_context.integration_service")
+    def test_file_not_found(self, mock_service: MagicMock) -> None:
+        from sentry.integrations.source_code_management.repository import RepositoryIntegration
+        from sentry.shared_integrations.exceptions import ApiError
+
+        mock_integration = MagicMock()
+        mock_service.get_integration.return_value = mock_integration
+        mock_install = MagicMock()
+        mock_integration.get_installation.return_value = mock_install
+        mock_install.__class__ = RepositoryIntegration
+        mock_client = MagicMock()
+        mock_install.get_client.return_value = mock_client
+        mock_client.get_file.side_effect = ApiError("Not Found", code=404)
+
+        with self.feature("organizations:scm-source-context"):
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                qs_params={
+                    "file": "src/app/main.py",
+                    "lineNo": "10",
+                    "platform": "python",
+                },
+            )
+            assert response.data["error"] == "file_not_found"
+            assert response.data["context"] == []


### PR DESCRIPTION
When stack trace frames lack inline source context, this feature fetches the file from the configured SCM integration (GitHub, GitLab, Perforce) and returns the surrounding lines via a new API endpoint.

- New endpoint: /projects/{org}/{project}/stacktrace-source-context/
- New utility: fetch_source_context_from_scm() with caching
- Feature-flagged behind organizations:scm-source-context