### PR TITLE
fix(dashboards): Filter out equation aggregates from create alert menu

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -285,7 +285,11 @@ export function getMenuOptions(
       .map((series, index) => {
         const transformed = transformWidgetSeriesToTimeSeries(series, widget);
 
-        if (!transformed || transformed.timeSeries.meta.isOther) {
+        if (
+          !transformed ||
+          transformed.timeSeries.meta.isOther ||
+          isEquation(transformed.timeSeries.yAxis)
+        ) {
           return null;
         }
 


### PR DESCRIPTION
Equation-prefixed aggregates (e.g. `equation|count_if(...)`) are not valid alert aggregates. When a dashboard widget uses equation series, the "Create Alert" context menu option would pass the raw `equation|...` string as the aggregate to the alert creation page, producing a broken alert configuration.

This filters out series with equation yAxis values from the create alert submenu. If all series are equations, the "Create Alert" option won't appear at all.

Fixes BROWSE-426