### PR TITLE
fix(components): [SearchQueryBuilder] cap FilterWrapper width to 2xl less than parent

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/components.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/components.tsx
@@ -42,6 +42,8 @@ export function FilterWrapper({children, ...props}: FilterWrapperProps) {
 }
 
 const StyledFilterWrapper = styled(Container)<{state: 'invalid' | 'warning' | 'valid'}>`
+  max-width: calc(100% - ${p => p.theme.space['2xl']});
+
   :focus,
   &[aria-selected='true'] {
     background-color: ${p => p.theme.colors.gray100};


### PR DESCRIPTION
The query editor adds "free text" input areas before, between, and after all filters. When a filter takes up full width of the parent then those free texts have to wrap onto their own lines. This change prevents filters from taking up that last 2xl-token-width of space, so wrapping never happens. There's now always a hefty number of pixels for folks to click and start typing free text.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="329" height="339" alt="Screenshot of a narrow Logs header showing a 'message contains long text ...' filter with extra 100% padding above and below the filter" src="https://github.com/user-attachments/assets/738fa961-8137-48cc-91c4-23f0812d58d4" />
</td>
<td>
<img width="329" height="287" alt="Screenshot of a narrow Logs header showing a 'message contains long text ...' filter with very little padding above and below the filter" src="https://github.com/user-attachments/assets/99c3d9bc-5cff-4f86-a171-8be38054874b" />
</td>
</tr>
</tbody>
</table>

Fixes LOGS-605