### PR TITLE
test(symbolicator): Run Sentry tests tagged with symbolicator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,11 +216,7 @@ test-tools:
 # Running Locally: Run `devservices up` before starting these tests
 test-symbolicator:
 	@echo "--> Running symbolicator tests"
-	python3 -b -m pytest tests/symbolicator --reuse-db -vv --junit-xml=.artifacts/symbolicator.junit.xml -o junit_suite_name=symbolicator
-	python3 -b -m pytest tests/relay_integration/lang/javascript/ --reuse-db -vv -m symbolicator
-	python3 -b -m pytest tests/relay_integration/lang/java/ --reuse-db -vv -m symbolicator
-	# All Sentry tests tagged with Symbolicator
-	python3 -b -m pytest tests/sentry/ --reuse-db -vv -m symbolicator
+	python3 -b -m pytest tests/symbolicator tests/relay_integration/lang/javascript/ tests/relay_integration/lang/java/ tests/sentry/ -m symbolicator --reuse-db -vv --junit-xml=.artifacts/symbolicator.junit.xml -o junit_suite_name=symbolicator
 	@echo ""
 
 test-acceptance:

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,8 @@ test-symbolicator:
 	python3 -b -m pytest tests/symbolicator --reuse-db -vv --junit-xml=.artifacts/symbolicator.junit.xml -o junit_suite_name=symbolicator
 	python3 -b -m pytest tests/relay_integration/lang/javascript/ --reuse-db -vv -m symbolicator
 	python3 -b -m pytest tests/relay_integration/lang/java/ --reuse-db -vv -m symbolicator
+	# All Sentry tests tagged with Symbolicator
+	python3 -b -m pytest tests/sentry/ --reuse-db -vv -m symbolicator
 	@echo ""
 
 test-acceptance:

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -107,6 +107,7 @@ def pytest_configure(config: pytest.Config) -> None:
     )
 
     config.addinivalue_line("markers", "migrations: requires --migrations")
+    config.addinivalue_line("markers", "symbolicator: test requires access to symbolicator")
 
     if sys.platform == "darwin" and shutil.which("colima"):
         # This is the only way other than pytest --basetemp to change
@@ -425,6 +426,15 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     This enables selective testing while maintaining proper conftest loading order by
     invoking pytest with the tests/ directory instead of specific file paths.
     """
+
+    # Auto-add the `symbolicator` marker to any test using the _requires_symbolicator
+    # fixture so that `-m symbolicator` selects all symbolicator-dependent tests.
+    symbolicator_mark = pytest.mark.symbolicator
+    for item in items:
+        for marker in item.iter_markers("usefixtures"):
+            if "_requires_symbolicator" in marker.args:
+                item.add_marker(symbolicator_mark)
+                break
 
     keep, discard = [], []
 

--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -50,6 +50,6 @@ def _requires_objectstore() -> None:
 
 
 requires_snuba = pytest.mark.usefixtures("_requires_snuba")
-requires_symbolicator = pytest.mark.usefixtures("_requires_symbolicator")
+requires_symbolicator = pytest.mark.symbolicator(pytest.mark.usefixtures("_requires_symbolicator"))
 requires_kafka = pytest.mark.usefixtures("_requires_kafka")
 requires_objectstore = pytest.mark.usefixtures("_requires_objectstore")

--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -50,6 +50,6 @@ def _requires_objectstore() -> None:
 
 
 requires_snuba = pytest.mark.usefixtures("_requires_snuba")
-requires_symbolicator = pytest.mark.symbolicator(pytest.mark.usefixtures("_requires_symbolicator"))
+requires_symbolicator = pytest.mark.usefixtures("_requires_symbolicator")
 requires_kafka = pytest.mark.usefixtures("_requires_kafka")
 requires_objectstore = pytest.mark.usefixtures("_requires_objectstore")

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -451,7 +451,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert len(response.json()) == 1
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_basic_resolving(self) -> None:
         self.upload_proguard_mapping(PROGUARD_UUID, PROGUARD_SOURCE)
 
@@ -513,7 +512,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         )
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_value_only_class_names_are_deobfuscated(self) -> None:
         self.upload_proguard_mapping(PROGUARD_UUID, PROGUARD_SOURCE)
 
@@ -542,7 +540,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert "org.a.b.g$a" not in exc.value
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_value_only_multiple_exceptions_are_all_deobfuscated(self) -> None:
         self.upload_proguard_mapping(PROGUARD_UUID, PROGUARD_SOURCE)
 
@@ -576,7 +573,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         )
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_resolving_does_not_fail_when_no_value(self) -> None:
         self.upload_proguard_mapping(PROGUARD_UUID, PROGUARD_SOURCE)
 
@@ -621,7 +617,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert not metrics.get("flag.processing.error")
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_resolving_does_not_fail_when_no_module_or_function(self) -> None:
         self.upload_proguard_mapping(PROGUARD_UUID, PROGUARD_SOURCE)
 
@@ -678,7 +673,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert not metrics.get("flag.processing.error")
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_removes_frames_not_found_in_mapping_but_preserves_native_frames(self) -> None:
         """Test that outline frames are removed while native frames are preserved."""
         self.upload_proguard_mapping(PROGUARD_OUTLINE_UUID, PROGUARD_OUTLINE_SOURCE)
@@ -759,7 +753,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert frames[2].instruction_addr == "0x79571a8000"
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_sets_inapp_after_resolving(self) -> None:
         self.upload_proguard_mapping(PROGUARD_UUID, PROGUARD_SOURCE)
 
@@ -843,7 +836,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert frames[4].in_app is True
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_resolving_inline(self) -> None:
         self.upload_proguard_mapping(PROGUARD_INLINE_UUID, PROGUARD_INLINE_SOURCE)
 
@@ -906,7 +898,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert frames[3].module == "io.sentry.sample.MainActivity"
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_resolving_inline_with_native_frames(self) -> None:
         self.upload_proguard_mapping(PROGUARD_INLINE_UUID, PROGUARD_INLINE_SOURCE)
 
@@ -994,7 +985,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert frames[5].package == "/apex/com.android.art/lib64/libart.so"
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_error_on_resolving(self) -> None:
         url = reverse(
             "sentry-api-0-dsym-files",
@@ -1099,7 +1089,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         )
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_basic_source_lookup(self) -> None:
         debug_id = str(uuid4())
         self.upload_jvm_bundle(debug_id, {"io/sentry/samples/MainActivity.jvm": JVM_SOURCE})
@@ -1290,7 +1279,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
 
     @pytest.mark.skip(reason="flaky: #93951")
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_source_lookup_with_proguard(self) -> None:
         self.upload_proguard_mapping(PROGUARD_SOURCE_LOOKUP_UUID, PROGUARD_SOURCE_LOOKUP_SOURCE)
         debug_id1 = str(uuid4())
@@ -1586,7 +1574,6 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
 
     @pytest.mark.skip(reason="flaky: #93949")
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_invalid_exception(self) -> None:
         event_data = {
             "user": {"ip_address": "31.172.207.97"},

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -47,7 +47,6 @@ class TestExample(RelayStoreHelper):
             yield
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_sourcemap_expansion(self) -> None:
         release = Release.objects.create(
             organization_id=self.project.organization_id, version="abc"

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -77,7 +77,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
             yield
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_adds_contexts_without_device(self) -> None:
         data = {
             "timestamp": self.min_ago,
@@ -106,7 +105,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert contexts.get("device") is None
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_adds_contexts_with_device(self) -> None:
         data = {
             "timestamp": self.min_ago,
@@ -159,7 +157,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         }
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_adds_contexts_with_ps4_device(self) -> None:
         data = {
             "timestamp": self.min_ago,
@@ -189,7 +186,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         }
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_error_message_translations(self) -> None:
         data = {
             "timestamp": self.min_ago,
@@ -227,7 +223,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         )
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_nonhandled_frames_inapp_normalization(self) -> None:
         data = {
             "timestamp": self.min_ago,
@@ -297,7 +292,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
             )
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_sourcemap_source_expansion(self) -> None:
         self.project.update_option("sentry:scrape_javascript", False)
         release = Release.objects.create(
@@ -399,7 +393,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert raw_frame_list[2] == frame_list[2]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_sourcemap_webpack(self) -> None:
         self.project.update_option("sentry:scrape_javascript", False)
         release = Release.objects.create(
@@ -503,7 +496,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
     @pytest.mark.skip(reason="flaky: #94543")
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_sourcemap_embedded_source_expansion(self) -> None:
         self.project.update_option("sentry:scrape_javascript", False)
         release = Release.objects.create(
@@ -590,7 +582,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert frame.post_context == ["}"]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_sourcemap_nofiles_source_expansion(self) -> None:
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
@@ -664,7 +655,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert frame.post_context == ["}"]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_indexed_sourcemap_source_expansion(self) -> None:
         self.project.update_option("sentry:scrape_javascript", False)
         release = Release.objects.create(
@@ -779,7 +769,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert raw_frame.lineno == 2
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_via_debug(self) -> None:
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
@@ -928,7 +917,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         ]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_via_distribution_release_artifacts(self) -> None:
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
@@ -1193,17 +1181,14 @@ class TestJavascriptIntegration(RelayStoreHelper):
         ]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_via_release_archive(self) -> None:
         self._test_expansion_via_release_archive(link_sourcemaps=True)
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_via_release_archive_no_sourcemap_link(self) -> None:
         self._test_expansion_via_release_archive(link_sourcemaps=False)
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_node_processing(self) -> None:
         project = self.project
         release = Release.objects.create(
@@ -1462,7 +1447,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert "errors" not in event.data
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_with_debug_id(self) -> None:
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
@@ -1642,7 +1626,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert frame.post_context == ["}"]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_with_debug_id_and_sourcemap_without_sources_content(self) -> None:
         debug_id = "c941d872-af1f-4f0c-a7ff-ad3d295fe153"
 
@@ -1796,7 +1779,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         ]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_with_debug_id_and_malformed_sourcemap(self) -> None:
         debug_id = "c941d872-af1f-4f0c-a7ff-ad3d295fe153"
 
@@ -1934,7 +1916,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         }
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_with_debug_id_not_found(self) -> None:
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
@@ -2054,7 +2035,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert frame.post_context == ["}"]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_with_release_dist_pair_x(self) -> None:
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
@@ -2213,7 +2193,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert frame.post_context == ["}"]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_with_release_dist_pair_and_sourcemap_without_sources_content(self) -> None:
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
@@ -2354,7 +2333,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         ]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_expansion_with_release_and_malformed_sourcemap(self) -> None:
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
@@ -2494,7 +2472,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         }
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_symbolicated_in_app_after_symbolication(self) -> None:
         self.project.update_option("sentry:scrape_javascript", False)
         release = Release.objects.create(
@@ -2538,7 +2515,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert event.data["symbolicated_in_app"] is True
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_symbolicated_in_app_false_with_unsymbolicated_frame(self) -> None:
         self.project.update_option("sentry:scrape_javascript", False)
         release = Release.objects.create(
@@ -2598,7 +2574,6 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert event.data["symbolicated_in_app"] is False
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_symbolicated_in_app_none_with_no_in_app_frames(self) -> None:
         self.project.update_option("sentry:scrape_javascript", False)
         release = Release.objects.create(

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -335,7 +335,6 @@ def test_with_attachments(default_project, task_runner, missing_chunks, django_c
 
 @django_db_all
 @requires_symbolicator
-@pytest.mark.symbolicator
 @thread_leak_allowlist(reason="django dev server", issue=97036)
 def test_deobfuscate_view_hierarchy(default_project, task_runner, live_server) -> None:
     with override_options({"system.url-prefix": live_server.url}):
@@ -345,7 +344,6 @@ def test_deobfuscate_view_hierarchy(default_project, task_runner, live_server) -
 @django_db_all
 @requires_objectstore
 @requires_symbolicator
-@pytest.mark.symbolicator
 @thread_leak_allowlist(reason="django dev server", issue=97036)
 def test_deobfuscate_view_hierarchy_objectstore(default_project, task_runner, live_server) -> None:
     with override_options({"system.url-prefix": live_server.url}):
@@ -443,7 +441,6 @@ def do_process_view_hierarchy(project, task_runner, use_objectstore=False):
 @django_db_all
 @requires_objectstore
 @requires_symbolicator
-@pytest.mark.symbolicator
 @thread_leak_allowlist(reason="django dev server", issue=97036)
 def test_process_stored_attachment(
     default_project, task_runner, set_sentry_option, live_server

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -589,7 +589,6 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
 
     @pytest.mark.skip(reason="Temporarily skipped due to symbolicator regression")
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_basic_resolving(self) -> None:
         self.upload_proguard_mapping(PROGUARD_UUID, PROGUARD_SOURCE)
         android_profile = load_profile("valid_android_profile.json")
@@ -646,7 +645,6 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
 
     @pytest.mark.skip(reason="Temporarily skipped due to symbolicator regression")
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_inline_resolving(self) -> None:
         self.upload_proguard_mapping(PROGUARD_INLINE_UUID, PROGUARD_INLINE_SOURCE)
         android_profile = load_profile("valid_android_profile.json")
@@ -738,7 +736,6 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
         ]
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_error_on_resolving(self) -> None:
         self.upload_proguard_mapping(PROGUARD_BUG_UUID, PROGUARD_BUG_SOURCE)
         android_profile = load_profile("valid_android_profile.json")
@@ -774,7 +771,6 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
         assert android_profile["profile"]["methods"] == obfuscated_frames
 
     @requires_symbolicator
-    @pytest.mark.symbolicator
     def test_js_symbolication_set_symbolicated_field(self) -> None:
         release = Release.objects.create(
             organization_id=self.project.organization_id, version="nodeprof123"


### PR DESCRIPTION
Changes to proguard processing broke CI recently: https://github.com/getsentry/sentry/actions/runs/22902803288/job/66453716070#step:6:1335

There are symbolicator tests in Sentry itself, we can also run them in the Symbolicator CI.