### PR TITLE
feat(spans): add per-trace segment flush limit

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3223,6 +3223,15 @@ register(
     default=500,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Maximum number of segments a single trace can flush per cycle. Prevents a
+# single trace from monopolizing a flush cycle and concentrating SSCAN load
+# on one Redis node. 0 means no limit.
+register(
+    "spans.buffer.max-flush-segments-per-trace",
+    type=Int,
+    default=0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Maximum memory percentage for the span buffer in Redis before rejecting messages.
 register(
     "spans.buffer.max-memory-percentage",

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -516,7 +516,7 @@ class SpansBuffer:
             for segment_key in keys:
                 segment_keys.append((shard, queue_key, segment_key))
 
-        segment_keys = self._apply_per_trace_limit(segment_keys, max_flush_segments_per_trace)
+        segment_keys = self._apply_per_trace_limit(segment_keys, max_flush_segments_per_trace, now)
 
         data_start = time.monotonic()
         with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
@@ -612,30 +612,41 @@ class SpansBuffer:
         self,
         segment_keys: list[tuple[int, QueueKey, SegmentKey]],
         max_per_trace: int,
+        now: int,
     ) -> list[tuple[int, QueueKey, SegmentKey]]:
         """
         Limits how many segments a single trace can be flushed in one cycle.
         Prevents a trace from monopolizing the cycle and concentrating all
         operations on one Redis node.
+
+        Deferred segments have their score set to ``now`` so they no longer
+        sit at the front of the sorted set.  This avoids head-of-line
+        blocking where a hot trace's overdue segments are re-fetched and
+        re-discarded every cycle.
         """
         if max_per_trace <= 0:
             return segment_keys
         trace_counts: dict[bytes, int] = {}
-        filtered: list[tuple[int, QueueKey, SegmentKey]] = []
-        num_deferred = 0
+        accepted: list[tuple[int, QueueKey, SegmentKey]] = []
+        deferred: list[tuple[int, QueueKey, SegmentKey]] = []
         for shard, queue_key, segment_key in segment_keys:
             _, trace_id, _ = parse_segment_key(segment_key)
             count = trace_counts.get(trace_id, 0)
             if count < max_per_trace:
-                filtered.append((shard, queue_key, segment_key))
+                accepted.append((shard, queue_key, segment_key))
                 trace_counts[trace_id] = count + 1
             else:
-                num_deferred += 1
+                deferred.append((shard, queue_key, segment_key))
 
-        if num_deferred:
+        if deferred:
+            num_deferred = len(deferred)
             metrics.incr("spans.buffer.flush_segments.deferred", amount=num_deferred)
+            with self.client.pipeline(transaction=False) as p:
+                for shard, queue_key, segment_key in deferred:
+                    p.zadd(queue_key, {segment_key: now})
+                p.execute()
 
-        return filtered
+        return accepted
 
     def _load_segment_data(self, segment_keys: list[SegmentKey]) -> dict[SegmentKey, list[bytes]]:
         """

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -496,6 +496,7 @@ class SpansBuffer:
         queue_keys = []
         shard_factor = max(1, len(self.assigned_shards))
         max_flush_segments = options.get("spans.buffer.max-flush-segments")
+        max_flush_segments_per_trace = options.get("spans.buffer.max-flush-segments-per-trace")
         flusher_logger_enabled = options.get("spans.buffer.flusher-cumulative-logger-enabled")
         max_segments_per_shard = math.ceil(max_flush_segments / shard_factor)
 
@@ -514,6 +515,8 @@ class SpansBuffer:
         for shard, queue_key, keys in zip(self.assigned_shards, queue_keys, result):
             for segment_key in keys:
                 segment_keys.append((shard, queue_key, segment_key))
+
+        segment_keys = self._apply_per_trace_limit(segment_keys, max_flush_segments_per_trace)
 
         data_start = time.monotonic()
         with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
@@ -604,6 +607,35 @@ class SpansBuffer:
 
         self.any_shard_at_limit = any_shard_at_limit
         return return_segments
+
+    def _apply_per_trace_limit(
+        self,
+        segment_keys: list[tuple[int, QueueKey, SegmentKey]],
+        max_per_trace: int,
+    ) -> list[tuple[int, QueueKey, SegmentKey]]:
+        """
+        Limits how many segments a single trace can be flushed in one cycle.
+        Prevents a trace from monopolizing the cycle and concentrating all
+        operations on one Redis node.
+        """
+        if max_per_trace <= 0:
+            return segment_keys
+        trace_counts: dict[bytes, int] = {}
+        filtered: list[tuple[int, QueueKey, SegmentKey]] = []
+        num_deferred = 0
+        for shard, queue_key, segment_key in segment_keys:
+            _, trace_id, _ = parse_segment_key(segment_key)
+            count = trace_counts.get(trace_id, 0)
+            if count < max_per_trace:
+                filtered.append((shard, queue_key, segment_key))
+                trace_counts[trace_id] = count + 1
+            else:
+                num_deferred += 1
+
+        if num_deferred:
+            metrics.incr("spans.buffer.flush_segments.deferred", amount=num_deferred)
+
+        return filtered
 
     def _load_segment_data(self, segment_keys: list[SegmentKey]) -> dict[SegmentKey, list[bytes]]:
         """

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -9,7 +9,7 @@ import pytest
 from sentry_redis_tools.clients import StrictRedis
 
 from sentry.spans.buffer import FlushedSegment, OutputSpan, Span, SpansBuffer
-from sentry.spans.segment_key import SegmentKey
+from sentry.spans.segment_key import SegmentKey, parse_segment_key
 from sentry.testutils.helpers.options import override_options
 
 DEFAULT_OPTIONS = {
@@ -31,6 +31,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.debug-traces": [],
     "spans.buffer.evalsha-cumulative-logger-enabled": True,
     "spans.buffer.zero-copy-dest-threshold-bytes": 0,
+    "spans.buffer.max-flush-segments-per-trace": 0,
 }
 
 
@@ -1262,3 +1263,90 @@ def test_partition_routing_stable_across_rebalance() -> None:
 
         buf.done_flush_segments(rv)
         assert_clean(buf.client)
+
+
+def test_per_trace_flush_limit_throttles(buffer: SpansBuffer) -> None:
+    """A trace exceeding the per-trace limit is capped; other traces flush normally."""
+    spans_a = [
+        Span(
+            payload=_payload(f"a{i:015d}"),
+            trace_id="a" * 32,
+            span_id=f"a{i:015d}",
+            parent_span_id=None,
+            segment_id=None,
+            is_segment_span=True,
+            project_id=1,
+            end_timestamp=1700000000.0,
+        )
+        for i in range(3)
+    ]
+    spans_b = [
+        Span(
+            payload=_payload("b" * 16),
+            trace_id="b" * 32,
+            span_id="b" * 16,
+            parent_span_id=None,
+            segment_id=None,
+            is_segment_span=True,
+            project_id=2,
+            end_timestamp=1700000000.0,
+        )
+    ]
+
+    process_spans(spans_a + spans_b, buffer, now=0)
+
+    with override_options({"spans.buffer.max-flush-segments-per-trace": 1}):
+        rv = buffer.flush_segments(now=11)
+        trace_a_key = ("a" * 32).encode()
+        trace_b_key = ("b" * 32).encode()
+        traces_flushed = set()
+        for seg_key in rv:
+            _, trace_id, _ = parse_segment_key(seg_key)
+            traces_flushed.add(trace_id)
+        assert trace_a_key in traces_flushed
+        assert trace_b_key in traces_flushed
+        assert len(rv) == 2
+        buffer.done_flush_segments(rv)
+
+        rv = buffer.flush_segments(now=12)
+        assert len(rv) == 1
+        buffer.done_flush_segments(rv)
+
+        rv = buffer.flush_segments(now=13)
+        assert len(rv) == 1
+        buffer.done_flush_segments(rv)
+
+
+def test_per_trace_flush_limit_disabled(buffer: SpansBuffer) -> None:
+    """With default option (0), all segments flush in one cycle."""
+    spans_a = [
+        Span(
+            payload=_payload(f"a{i:015d}"),
+            trace_id="a" * 32,
+            span_id=f"a{i:015d}",
+            parent_span_id=None,
+            segment_id=None,
+            is_segment_span=True,
+            project_id=1,
+            end_timestamp=1700000000.0,
+        )
+        for i in range(3)
+    ]
+    spans_b = [
+        Span(
+            payload=_payload("b" * 16),
+            trace_id="b" * 32,
+            span_id="b" * 16,
+            parent_span_id=None,
+            segment_id=None,
+            is_segment_span=True,
+            project_id=2,
+            end_timestamp=1700000000.0,
+        )
+    ]
+
+    process_spans(spans_a + spans_b, buffer, now=0)
+
+    rv = buffer.flush_segments(now=11)
+    buffer.done_flush_segments(rv)
+    assert len(rv) == 4


### PR DESCRIPTION
Adds a new option `spans.buffer.max-flush-segments-per-trace` (default 0 = disabled) that caps how many segments a single trace can flush per flush cycle. This prevents a single large trace from monopolizing a flush cycle and concentrating Redis load on one node.