### PR TITLE
fix(dashboards): Enable fullscreen widget view in prebuilt dashboard renderer

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import type {LegendComponentOption} from 'echarts';
 import type {Location} from 'history';
 
+import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
 import {DateTime} from 'sentry/components/dateTime';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -234,7 +235,10 @@ function WidgetCard(props: Props) {
   }, [timeoutRef]);
 
   const onFullScreenViewClick = () => {
-    if (!isWidgetViewerPath(location.pathname)) {
+    if (isWidgetViewerPath(location.pathname)) {
+      return;
+    }
+    if (currentDashboardId) {
       navigate(
         normalizeUrl({
           pathname: `/organizations/${organization.slug}/dashboard/${currentDashboardId}/widget/${props.index}/`,
@@ -248,6 +252,14 @@ function WidgetCard(props: Props) {
         }),
         {preventScrollReset: true}
       );
+    } else {
+      openWidgetViewerModal({
+        organization,
+        widget,
+        widgetLegendState,
+        dashboardFilters,
+        widgetInterval,
+      });
     }
   };
 
@@ -320,13 +332,7 @@ function WidgetCard(props: Props) {
             actionsMessage={actionsMessage}
             actions={actions}
             noVisualizationPadding={canUseTimeseriesVisualization}
-            onFullScreenViewClick={
-              disableFullscreen
-                ? undefined
-                : currentDashboardId
-                  ? onFullScreenViewClick
-                  : undefined
-            }
+            onFullScreenViewClick={disableFullscreen ? undefined : onFullScreenViewClick}
             borderless={props.borderless}
             revealTooltip={props.forceDescriptionTooltip ? 'always' : undefined}
           >

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -264,7 +264,7 @@ function WidgetCard(props: Props) {
         dashboardFilters,
         widgetInterval,
         onClose: () => {
-          // Strip widget viewer query params so they don't linger on the host page
+          // Filter out Widget Viewer Modal query params when exiting the Modal
           const query = omit(location.query, Object.values(WidgetViewerQueryField));
           navigate(
             {pathname: location.pathname, query},

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -266,7 +266,10 @@ function WidgetCard(props: Props) {
         onClose: () => {
           // Strip widget viewer query params so they don't linger on the host page
           const query = omit(location.query, Object.values(WidgetViewerQueryField));
-          navigate({pathname: location.pathname, query}, {preventScrollReset: true});
+          navigate(
+            {pathname: location.pathname, query},
+            {preventScrollReset: true, replace: true}
+          );
         },
       });
     }

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -375,13 +375,7 @@ function WidgetCard(props: Props) {
           error={widgetQueryError}
           actionsMessage={actionsMessage}
           actions={actions}
-          onFullScreenViewClick={
-            disableFullscreen
-              ? undefined
-              : currentDashboardId
-                ? onFullScreenViewClick
-                : undefined
-          }
+          onFullScreenViewClick={disableFullscreen ? undefined : onFullScreenViewClick}
           borderless={props.borderless}
           revealTooltip={props.forceDescriptionTooltip ? 'always' : undefined}
           noVisualizationPadding

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -2,12 +2,16 @@ import {useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import type {LegendComponentOption} from 'echarts';
 import type {Location} from 'history';
+import omit from 'lodash/omit';
 
 import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
 import {DateTime} from 'sentry/components/dateTime';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {isWidgetViewerPath} from 'sentry/components/modals/widgetViewerModal/utils';
+import {
+  isWidgetViewerPath,
+  WidgetViewerQueryField,
+} from 'sentry/components/modals/widgetViewerModal/utils';
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import PanelAlert from 'sentry/components/panels/panelAlert';
 import Placeholder from 'sentry/components/placeholder';
@@ -259,6 +263,11 @@ function WidgetCard(props: Props) {
         widgetLegendState,
         dashboardFilters,
         widgetInterval,
+        onClose: () => {
+          // Strip widget viewer query params so they don't linger on the host page
+          const query = omit(location.query, Object.values(WidgetViewerQueryField));
+          navigate({pathname: location.pathname, query}, {preventScrollReset: true});
+        },
       });
     }
   };


### PR DESCRIPTION
The fullscreen (expand) button on widgets was not appearing when dashboards
were rendered via the `PrebuiltDashboardRenderer` used in insights pages.

The widget card's fullscreen handler relied on `useParams()` to get
`dashboardId` from the route, but insights pages don't have a `:dashboardId`
route param. When it was undefined, the fullscreen button was hidden entirely.

Now when there's no route-level dashboard ID (embedded/prebuilt context), the
widget viewer modal is opened directly via `openWidgetViewerModal()` instead
of navigating to a dashboard URL. The fullscreen button is shown in all
non-disabled contexts.

Refs LINEAR-BROWSE-245