### PR TITLE
feat(tracemetrics): Add metric detail side panel to dropdown

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -196,6 +196,47 @@ describe('MetricSelector', () => {
       );
     });
 
+    it('clamps focusedIndex when displayed options shrink', async () => {
+      const onChange = jest.fn();
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('option', {name: SORTED_METRIC_NAMES[0]!});
+
+      // Move focus near the end of the list
+      for (let i = 0; i < 5; i++) {
+        await userEvent.keyboard('{ArrowDown}');
+      }
+
+      // Simulate search that narrows the list by re-mocking with fewer results
+      MockApiClient.clearMockResponses();
+      setupEventsMock(
+        createTraceMetricFixtures(organization, project, new Date()).baseFixtures.slice(
+          0,
+          2
+        ),
+        [
+          MockApiClient.matchQuery({
+            dataset: 'tracemetrics',
+            referrer: 'api.explore.metric-options',
+          }),
+        ]
+      );
+
+      const searchInput = screen.getByPlaceholderText('Search metrics\u2026');
+      await userEvent.type(searchInput, 'b');
+
+      // After list shrinks, a single ArrowUp then Enter should select a valid option
+      await waitFor(() => {
+        expect(screen.getAllByRole('option').length).toBeLessThanOrEqual(2);
+      });
+      await userEvent.keyboard('{ArrowUp}');
+      await userEvent.keyboard('{Enter}');
+      expect(onChange).toHaveBeenCalled();
+    });
+
     it('ArrowUp does not go below index 0', async () => {
       const onChange = jest.fn();
       render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -1,0 +1,370 @@
+import {
+  createTraceMetricFixtures,
+  initializeTraceMetricsTest,
+} from 'sentry-fixture/tracemetrics';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
+
+const SORTED_METRIC_NAMES = [
+  'bar',
+  'error_rate',
+  'foo',
+  'memory_usage',
+  'request_count',
+  'response_size',
+];
+
+const DEFAULT_TRACE_METRIC = {name: 'bar', type: 'distribution'};
+
+describe('MetricSelector', () => {
+  const {organization, project, setupPageFilters, setupEventsMock} =
+    initializeTraceMetricsTest();
+
+  beforeEach(() => {
+    // Suppress react-popper async flushSync/act warnings (known library compat issue)
+    jest.spyOn(console, 'error').mockImplementation();
+
+    setupPageFilters();
+    const {baseFixtures} = createTraceMetricFixtures(organization, project, new Date());
+
+    setupEventsMock(baseFixtures, [
+      MockApiClient.matchQuery({
+        dataset: 'tracemetrics',
+        referrer: 'api.explore.metric-options',
+      }),
+    ]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    MockApiClient.clearMockResponses();
+  });
+
+  describe('dropdown functionality', () => {
+    it('renders trigger button showing metric name', () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+      expect(screen.getByRole('button', {name: 'bar'})).toBeInTheDocument();
+    });
+
+    it('renders trigger button with None when traceMetric has no name', () => {
+      render(<MetricSelector traceMetric={{name: '', type: ''}} onChange={jest.fn()} />, {
+        organization,
+      });
+      expect(screen.getByRole('button', {name: 'None'})).toBeInTheDocument();
+    });
+
+    it('opens dropdown on click', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('closes on Escape', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('listbox');
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+    });
+
+    it('closes after selecting an option and calls onChange', async () => {
+      const onChange = jest.fn();
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
+        organization,
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'foo'}));
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({name: 'foo'}));
+    });
+
+    describe('empty state', () => {
+      beforeEach(() => {
+        setupEventsMock(
+          [],
+          [
+            MockApiClient.matchQuery({
+              dataset: 'tracemetrics',
+              referrer: 'api.explore.metric-options',
+            }),
+          ]
+        );
+      });
+
+      afterEach(() => {
+        MockApiClient.clearMockResponses();
+      });
+
+      it('shows empty state when API returns no metrics', async () => {
+        render(
+          <MetricSelector traceMetric={{name: '', type: ''}} onChange={jest.fn()} />,
+          {organization}
+        );
+
+        await userEvent.click(screen.getByRole('button', {name: 'None'}));
+
+        expect(await screen.findByText('No metrics found')).toBeInTheDocument();
+      });
+    });
+
+    it('shows search input in open dropdown', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+
+      expect(
+        await screen.findByPlaceholderText('Search metrics\u2026')
+      ).toBeInTheDocument();
+    });
+
+    it('search input accepts typed text', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      const searchInput = await screen.findByPlaceholderText('Search metrics\u2026');
+      await userEvent.type(searchInput, 'foo');
+
+      expect(searchInput).toHaveValue('foo');
+    });
+
+    it('clears search on close and reopens with empty search', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      const trigger = screen.getByRole('button', {name: 'bar'});
+      await userEvent.click(trigger);
+
+      const searchInput = await screen.findByPlaceholderText('Search metrics\u2026');
+      await userEvent.type(searchInput, 'foo');
+
+      expect(searchInput).toHaveValue('foo');
+
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+
+      await userEvent.click(trigger);
+      expect(await screen.findByPlaceholderText('Search metrics\u2026')).toHaveValue('');
+    });
+
+    it('ArrowDown followed by Enter selects an option', async () => {
+      const onChange = jest.fn();
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('option', {name: 'bar'});
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('{Enter}');
+
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('ArrowDown twice selects second option with Enter', async () => {
+      const onChange = jest.fn();
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('option', {name: SORTED_METRIC_NAMES[0]!});
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('{Enter}');
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({name: SORTED_METRIC_NAMES[1]})
+      );
+    });
+
+    it('ArrowUp does not go below index 0', async () => {
+      const onChange = jest.fn();
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('option', {name: SORTED_METRIC_NAMES[0]!});
+      await userEvent.keyboard('{ArrowUp}');
+      await userEvent.keyboard('{Enter}');
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({name: SORTED_METRIC_NAMES[0]})
+      );
+    });
+  });
+
+  describe('metric-specific behavior', () => {
+    it('renders list of metrics from API', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      for (const name of SORTED_METRIC_NAMES) {
+        expect(await screen.findByRole('option', {name})).toBeInTheDocument();
+      }
+    });
+
+    it('shows MetricTypeBadge for each option', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('listbox');
+
+      expect((await screen.findAllByText('distribution')).length).toBeGreaterThan(0);
+      expect(await screen.findByText('gauge')).toBeInTheDocument();
+    });
+
+    it('shows currently selected metric as aria-selected="true"', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+
+      expect(await screen.findByRole('option', {name: 'bar'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('shows unselected metrics as aria-selected="false"', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+
+      expect(await screen.findByRole('option', {name: 'foo'})).toHaveAttribute(
+        'aria-selected',
+        'false'
+      );
+    });
+
+    it('auto-selects first metric when traceMetric has no name', async () => {
+      const onChange = jest.fn();
+
+      render(<MetricSelector traceMetric={{name: '', type: ''}} onChange={onChange} />, {
+        organization,
+      });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.objectContaining({name: SORTED_METRIC_NAMES[0]})
+        );
+      });
+    });
+
+    it('does not show unit badges without tracemetrics-units-ui feature', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('option', {name: 'bar'});
+
+      expect(screen.queryByText('millisecond')).not.toBeInTheDocument();
+      expect(screen.queryByText('megabyte')).not.toBeInTheDocument();
+    });
+
+    it('shows unit badges when tracemetrics-units-ui feature is enabled', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization: {
+          ...organization,
+          features: [...organization.features, 'tracemetrics-units-ui'],
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('listbox');
+
+      expect((await screen.findAllByText('millisecond')).length).toBeGreaterThan(0);
+    });
+
+    it('does not show side panel without tracemetrics-attributes-dropdown-side-panel feature', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('option', {name: 'bar'});
+
+      expect(screen.queryByText('Type:')).not.toBeInTheDocument();
+    });
+
+    it('renders side panel with tracemetrics-attributes-dropdown-side-panel feature', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization: {
+          ...organization,
+          features: [
+            ...organization.features,
+            'tracemetrics-attributes-dropdown-side-panel',
+          ],
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+
+      expect(await screen.findByText('Type:')).toBeInTheDocument();
+    });
+
+    it('side panel defaults to current metric when no option is hovered', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization: {
+          ...organization,
+          features: [
+            ...organization.features,
+            'tracemetrics-attributes-dropdown-side-panel',
+          ],
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('listbox');
+
+      expect(await screen.findByText('Type:')).toBeInTheDocument();
+      expect((await screen.findAllByText('bar')).length).toBeGreaterThan(0);
+    });
+
+    it('side panel updates when hovering over a different metric option', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization: {
+          ...organization,
+          features: [
+            ...organization.features,
+            'tracemetrics-attributes-dropdown-side-panel',
+          ],
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await userEvent.hover(await screen.findByRole('option', {name: 'foo'}));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('foo').length).toBeGreaterThanOrEqual(2);
+      });
+    });
+  });
+});

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -57,6 +57,40 @@ describe('MetricSelector', () => {
       expect(screen.getByRole('button', {name: 'None'})).toBeInTheDocument();
     });
 
+    describe('loading state', () => {
+      beforeEach(() => {
+        // Replace mock with one that never resolves to keep loading state
+        MockApiClient.clearMockResponses();
+        MockApiClient.addMockResponse({
+          url: `/organizations/${organization.slug}/events/`,
+          method: 'GET',
+          body: new Promise(() => {}),
+          match: [
+            MockApiClient.matchQuery({
+              dataset: 'tracemetrics',
+              referrer: 'api.explore.metric-options',
+            }),
+          ],
+        });
+      });
+
+      it('disables trigger button while loading when no metric is selected', () => {
+        render(
+          <MetricSelector traceMetric={{name: '', type: ''}} onChange={jest.fn()} />,
+          {organization}
+        );
+        expect(screen.getByRole('button', {name: 'None'})).toBeDisabled();
+      });
+
+      it('does not disable trigger button while loading when a metric is already selected', () => {
+        render(
+          <MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />,
+          {organization}
+        );
+        expect(screen.getByRole('button', {name: 'bar'})).toBeEnabled();
+      });
+    });
+
     it('opens dropdown on click', async () => {
       render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
         organization,
@@ -117,6 +151,17 @@ describe('MetricSelector', () => {
 
         expect(await screen.findByText('No metrics found')).toBeInTheDocument();
       });
+    });
+
+    it('focuses search input when dropdown opens', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      const searchInput = await screen.findByPlaceholderText('Search metrics\u2026');
+
+      expect(searchInput).toHaveFocus();
     });
 
     it('shows search input in open dropdown', async () => {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -3,7 +3,13 @@ import {
   initializeTraceMetricsTest,
 } from 'sentry-fixture/tracemetrics';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
 
@@ -387,6 +393,23 @@ describe('MetricSelector', () => {
       await screen.findByRole('listbox');
 
       expect((await screen.findAllByText('millisecond')).length).toBeGreaterThan(0);
+    });
+
+    it('does not show a unit badge when the metric unit is none', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization: {
+          ...organization,
+          features: [...organization.features, 'tracemetrics-units-ui'],
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+
+      const requestCountOption = await screen.findByRole('option', {
+        name: 'request_count',
+      });
+
+      expect(within(requestCountOption).queryByText('none')).not.toBeInTheDocument();
     });
 
     it('does not show side panel without tracemetrics-attributes-dropdown-side-panel feature', async () => {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -1,12 +1,11 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {useTheme} from '@emotion/react';
 import {FocusScope} from '@react-aria/focus';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Tag} from '@sentry/scraps/badge';
 import {LeadWrap} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {MenuListItem} from '@sentry/scraps/menuListItem';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
@@ -252,8 +251,7 @@ export function MetricSelector({
           <Overlay style={{display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
             <FocusScope contain restoreFocus>
               <Flex direction={{xs: 'column', sm: 'row'}}>
-                <Flex
-                  direction="column"
+                <Stack
                   minWidth="300px"
                   minHeight="0"
                   borderRight={{sm: 'primary'}}
@@ -335,19 +333,17 @@ export function MetricSelector({
                         </Text>
                       </Flex>
                     ) : (
-                      <div
-                        style={{
-                          height: virtualizer.getTotalSize(),
-                          width: '100%',
-                          position: 'relative',
-                        }}
+                      <Container
+                        width="100%"
+                        position="relative"
+                        style={{height: virtualizer.getTotalSize()}}
                       >
-                        <div
+                        <Container
+                          width="100%"
+                          position="absolute"
+                          top={0}
+                          left={0}
                           style={{
-                            position: 'absolute',
-                            top: 0,
-                            left: 0,
-                            width: '100%',
                             transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
                           }}
                         >
@@ -374,11 +370,9 @@ export function MetricSelector({
                                   isSelected={isSelected}
                                   priority={isSelected ? 'primary' : 'default'}
                                   leadingItems={
-                                    <Fragment>
-                                      <LeadWrap aria-hidden="true">
-                                        {isSelected && <IconCheckmark size="sm" />}
-                                      </LeadWrap>
-                                    </Fragment>
+                                    <LeadWrap aria-hidden="true">
+                                      {isSelected && <IconCheckmark size="sm" />}
+                                    </LeadWrap>
                                   }
                                   trailingItems={
                                     <Flex gap="xs" align="center" flexShrink={0}>
@@ -397,11 +391,11 @@ export function MetricSelector({
                               </div>
                             );
                           })}
-                        </div>
-                      </div>
+                        </Container>
+                      </Container>
                     )}
                   </Container>
-                </Flex>
+                </Stack>
                 <Container width={{sm: '280px'}} padding="lg" minHeight={{sm: '200px'}}>
                   <MetricDetailPanel
                     metric={highlightedOption ?? optionFromTraceMetric}
@@ -433,7 +427,7 @@ function MetricDetailPanel({
   }
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Text bold>{metric.metricName}</Text>
       <Flex gap="xs" align="center">
         <Text variant="muted" size="sm">
@@ -452,7 +446,7 @@ function MetricDetailPanel({
             <Tag variant="promotion">{metric.metricUnit}</Tag>
           </Flex>
         )}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -212,22 +212,20 @@ export function MetricSelector({
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       switch (e.key) {
-        case 'ArrowDown':
+        case 'ArrowDown': {
           e.preventDefault();
-          setFocusedIndex(prev => {
-            const next = Math.min(prev + 1, displayedOptions.length - 1);
-            virtualizer.scrollToIndex(next);
-            return next;
-          });
+          const next = Math.min(focusedIndex + 1, displayedOptions.length - 1);
+          setFocusedIndex(next);
+          virtualizer.scrollToIndex(next);
           break;
-        case 'ArrowUp':
+        }
+        case 'ArrowUp': {
           e.preventDefault();
-          setFocusedIndex(prev => {
-            const next = Math.max(prev - 1, 0);
-            virtualizer.scrollToIndex(next);
-            return next;
-          });
+          const next = Math.max(focusedIndex - 1, 0);
+          setFocusedIndex(next);
+          virtualizer.scrollToIndex(next);
           break;
+        }
         case 'Enter':
           e.preventDefault();
           if (focusedIndex >= 0 && displayedOptions[focusedIndex]) {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -1,13 +1,12 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import isPropValid from '@emotion/is-prop-valid';
-import styled from '@emotion/styled';
+import {useTheme} from '@emotion/react';
 import {FocusScope} from '@react-aria/focus';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Tag} from '@sentry/scraps/badge';
 import {LeadWrap} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {MenuListItem} from '@sentry/scraps/menuListItem';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
@@ -64,7 +63,7 @@ export function MetricSelector({
   } = useOverlay({
     type: 'listbox',
     position: 'bottom-start',
-    offset: 4,
+    offset: 6,
     isDismissable: true,
     shouldApplyMinWidth: true,
     onOpenChange: open => {
@@ -237,21 +236,37 @@ export function MetricSelector({
   const virtualItems = virtualizer.getVirtualItems();
 
   return (
-    <div style={{width: '100%', position: 'relative'}}>
-      <TriggerButton {...triggerProps}>
-        <TriggerLabel>{traceMetric.name || t('Select a metric')}</TriggerLabel>
-      </TriggerButton>
-      <StyledPositionWrapper zIndex={1001} visible={isOpen} {...overlayProps}>
+    <Container width="100%" position="relative">
+      <OverlayTrigger.Button
+        style={{width: '100%', fontWeight: 'bold'}}
+        {...triggerProps}
+      >
+        <Text ellipsis>{traceMetric.name || t('Select a metric')}</Text>
+      </OverlayTrigger.Button>
+      <PositionWrapper
+        zIndex={1001}
+        {...overlayProps}
+        style={{...overlayProps.style, display: isOpen ? 'block' : 'none'}}
+      >
         {isOpen && (
-          <StyledOverlay>
+          <Overlay style={{display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
             <FocusScope contain restoreFocus>
-              <PanelLayout>
-                <OptionsPanel onKeyDown={onKeyDown}>
-                  <MenuHeader>
-                    <MenuTitle>{t('Metrics')}</MenuTitle>
-                    {isFetching && <StyledLoadingIndicator size={12} />}
-                  </MenuHeader>
-                  <SearchWrap>
+              <Flex direction={{xs: 'column', sm: 'row'}}>
+                <Flex
+                  direction="column"
+                  minWidth="300px"
+                  minHeight="0"
+                  borderRight={{sm: 'primary'}}
+                  borderBottom={{xs: 'primary', sm: undefined}}
+                  onKeyDown={onKeyDown}
+                >
+                  <Flex align="center" justify="between" padding="sm lg">
+                    <Text size="sm" bold wrap="nowrap">
+                      {t('Metrics')}
+                    </Text>
+                    {isFetching && <LoadingIndicator size={12} style={{margin: 0}} />}
+                  </Flex>
+                  <Container padding="0 xs">
                     <InputGroup>
                       <InputGroup.LeadingItems disablePointerEvents>
                         <Flex
@@ -263,7 +278,7 @@ export function MetricSelector({
                           <IconSearch size="xs" variant="muted" />
                         </Flex>
                       </InputGroup.LeadingItems>
-                      <SearchInput
+                      <InputGroup.Input
                         ref={searchRef}
                         placeholder={t('Search metrics\u2026')}
                         value={searchInputValue}
@@ -271,10 +286,21 @@ export function MetricSelector({
                         size="xs"
                       />
                     </InputGroup>
-                  </SearchWrap>
-                  <OptionsList ref={scrollElementRef} role="listbox">
+                  </Container>
+                  <Container
+                    ref={scrollElementRef}
+                    role="listbox"
+                    overflowY="auto"
+                    flex="1"
+                    minHeight="0"
+                    maxHeight="400px"
+                    padding="xs 0"
+                  >
                     {longestOption && (
-                      <WidthSizer aria-hidden>
+                      <div
+                        aria-hidden
+                        style={{visibility: 'hidden', height: 0, overflow: 'hidden'}}
+                      >
                         <MenuListItem
                           as="div"
                           size="md"
@@ -300,14 +326,14 @@ export function MetricSelector({
                             </Flex>
                           }
                         />
-                      </WidthSizer>
+                      </div>
                     )}
                     {displayedOptions.length === 0 ? (
-                      <EmptyMessage>
+                      <Flex align="center" justify="center" padding="xl">
                         <Text variant="muted" size="sm">
                           {t('No metrics found')}
                         </Text>
-                      </EmptyMessage>
+                      </Flex>
                     ) : (
                       <div
                         style={{
@@ -374,20 +400,20 @@ export function MetricSelector({
                         </div>
                       </div>
                     )}
-                  </OptionsList>
-                </OptionsPanel>
-                <DetailPanel>
+                  </Container>
+                </Flex>
+                <Container width={{sm: '280px'}} padding="lg" minHeight={{sm: '200px'}}>
                   <MetricDetailPanel
                     metric={highlightedOption ?? optionFromTraceMetric}
                     hasMetricUnitsUI={hasMetricUnitsUI}
                   />
-                </DetailPanel>
-              </PanelLayout>
+                </Container>
+              </Flex>
             </FocusScope>
-          </StyledOverlay>
+          </Overlay>
         )}
-      </StyledPositionWrapper>
-    </div>
+      </PositionWrapper>
+    </Container>
   );
 }
 
@@ -433,115 +459,3 @@ function MetricDetailPanel({
 function makeMetricSelectValue(metric: TraceMetric): string {
   return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
 }
-
-const StyledPositionWrapper = styled(PositionWrapper, {
-  shouldForwardProp: prop => isPropValid(prop),
-})<{visible?: boolean; zIndex?: number}>`
-  display: ${p => (p.visible ? 'block' : 'none')};
-  z-index: ${p => p?.zIndex};
-`;
-
-const TriggerButton = styled(OverlayTrigger.Button)`
-  width: 100%;
-  font-weight: bold;
-`;
-
-const TriggerLabel = styled('span')`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-`;
-
-const StyledOverlay = styled(Overlay)`
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-`;
-
-const NARROW_BREAKPOINT = '700px';
-
-const PanelLayout = styled('div')`
-  display: flex;
-  flex-direction: row;
-
-  @media (max-width: ${NARROW_BREAKPOINT}) {
-    flex-direction: column;
-  }
-`;
-
-const OptionsPanel = styled('div')`
-  display: flex;
-  flex-direction: column;
-  min-width: 300px;
-  min-height: 0;
-  border-right: 1px solid ${p => p.theme.tokens.border.primary};
-
-  @media (max-width: ${NARROW_BREAKPOINT}) {
-    border-right: none;
-    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-  }
-`;
-
-const MenuHeader = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: ${p => p.theme.space.sm} ${p => p.theme.space.lg};
-`;
-
-const MenuTitle = styled('span')`
-  font-size: ${p => p.theme.font.size.sm};
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-  white-space: nowrap;
-`;
-
-const StyledLoadingIndicator = styled(LoadingIndicator)`
-  display: flex;
-  align-items: center;
-  && {
-    margin: 0;
-  }
-`;
-
-const SearchWrap = styled('div')`
-  padding: 0 ${p => p.theme.space.xs};
-`;
-
-const SearchInput = styled(InputGroup.Input)`
-  appearance: none;
-  width: calc(100% - ${p => p.theme.space.xs} * 2);
-  margin: ${p => p.theme.space.xs};
-`;
-
-const OptionsList = styled('div')`
-  overflow-y: auto;
-  flex: 1;
-  min-height: 0;
-  max-height: 400px;
-  padding: ${p => p.theme.space.xs} 0;
-`;
-
-const WidthSizer = styled('div')`
-  visibility: hidden;
-  height: 0;
-  overflow: hidden;
-`;
-
-const EmptyMessage = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: ${p => p.theme.space.xl};
-`;
-
-const DetailPanel = styled('div')`
-  width: 280px;
-  padding: ${p => p.theme.space.lg};
-  min-height: 200px;
-
-  @media (max-width: ${NARROW_BREAKPOINT}) {
-    width: auto;
-    min-height: auto;
-  }
-`;

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -396,7 +396,7 @@ export function MetricSelector({
                       <Container
                         width="100%"
                         position="relative"
-                        style={{height: virtualizer.getTotalSize()}}
+                        style={{height: `${virtualizer.getTotalSize()}px`}}
                       >
                         <Container
                           width="100%"

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -54,7 +54,6 @@ export function MetricSelector({
     search: debouncedSearch,
   });
   const hasMetricUnitsUI = useHasMetricUnitsUI();
-  const searchRef = useRef<HTMLInputElement>(null);
   const scrollElementRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -69,12 +68,7 @@ export function MetricSelector({
     isDismissable: true,
     shouldApplyMinWidth: true,
     onOpenChange: open => {
-      if (open) {
-        // Focus the search input when the overlay opens
-        requestAnimationFrame(() => {
-          searchRef.current?.focus();
-        });
-      } else {
+      if (!open) {
         setSearchInputValue('');
         setFocusedIndex(-1);
       }
@@ -277,7 +271,7 @@ export function MetricSelector({
       >
         {isOpen && (
           <Overlay style={{display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
-            <FocusScope contain restoreFocus>
+            <FocusScope contain restoreFocus autoFocus>
               <Flex direction={{xs: 'column', sm: 'row'}}>
                 <Stack
                   minWidth="300px"
@@ -305,7 +299,6 @@ export function MetricSelector({
                         </Flex>
                       </InputGroup.LeadingItems>
                       <InputGroup.Input
-                        ref={searchRef}
                         placeholder={t('Search metrics\u2026')}
                         value={searchInputValue}
                         onChange={onSearchChange}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -165,6 +165,18 @@ export function MetricSelector({
     [isFetching, previousOptions, metricOptions]
   );
 
+  useEffect(() => {
+    if (displayedOptions.length === 0) {
+      return;
+    }
+
+    if (focusedIndex < displayedOptions.length) {
+      return;
+    }
+
+    setFocusedIndex(Math.max(displayedOptions.length - 1, -1));
+  }, [displayedOptions.length, focusedIndex]);
+
   const longestOption = useMemo(
     () =>
       displayedOptions.reduce<MetricSelectOption | null>(

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -236,6 +236,19 @@ export function MetricSelector({
   );
 
   const virtualItems = virtualizer.getVirtualItems();
+  // Fall back to rendering all items when the virtualizer can't measure the scroll
+  // container (e.g. in test environments where DOM has no layout dimensions).
+  const itemsToRender =
+    virtualItems.length > 0 || displayedOptions.length === 0
+      ? virtualItems
+      : displayedOptions.map((_, index) => ({
+          index,
+          key: index,
+          start: 0,
+          end: 0,
+          size: 42,
+          lane: 0,
+        }));
 
   return (
     <Container width="100%" position="relative">
@@ -243,7 +256,7 @@ export function MetricSelector({
         style={{width: '100%', fontWeight: 'bold'}}
         {...triggerProps}
       >
-        <Text ellipsis>{traceMetric.name || t('Select a metric')}</Text>
+        <Text ellipsis>{traceMetric.name || t('None')}</Text>
       </OverlayTrigger.Button>
       <PositionWrapper
         zIndex={1001}
@@ -347,10 +360,10 @@ export function MetricSelector({
                           top={0}
                           left={0}
                           style={{
-                            transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
+                            transform: `translateY(${itemsToRender[0]?.start ?? 0}px)`,
                           }}
                         >
-                          {virtualItems.map(virtualRow => {
+                          {itemsToRender.map(virtualRow => {
                             const option = displayedOptions[virtualRow.index];
                             if (!option) {
                               return null;
@@ -362,6 +375,9 @@ export function MetricSelector({
                                 key={option.value}
                                 ref={virtualizer.measureElement}
                                 data-index={virtualRow.index}
+                                role="option"
+                                aria-label={option.label}
+                                aria-selected={isSelected}
                                 onClick={() => handleSelect(option)}
                                 onMouseEnter={() => setFocusedIndex(virtualRow.index)}
                               >

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -31,6 +31,26 @@ import {
 
 export const NONE_UNIT = 'none';
 
+function MetricOptionTrailingItems({
+  metricType,
+  metricUnit,
+  hasMetricUnitsUI,
+}: {
+  hasMetricUnitsUI: boolean;
+  metricType: TraceMetricTypeValue;
+  metricUnit?: string;
+}) {
+  return (
+    <Fragment>
+      <MetricTypeBadge metricType={metricType} />
+      {hasMetricUnitsUI &&
+        metricUnit &&
+        metricUnit !== '-' &&
+        metricUnit !== NONE_UNIT && <Tag variant="promotion">{metricUnit}</Tag>}
+    </Fragment>
+  );
+}
+
 interface MetricSelectOption {
   label: string;
   metricName: string;
@@ -86,6 +106,13 @@ export function MetricSelector({
       metricType: traceMetric.type as TraceMetricTypeValue,
       metricUnit: hasMetricUnitsUI ? (traceMetric.unit ?? '-') : undefined,
       metricName: traceMetric.name,
+      trailingItems: () => (
+        <MetricOptionTrailingItems
+          metricType={traceMetric.type as TraceMetricTypeValue}
+          metricUnit={traceMetric.unit ?? '-'}
+          hasMetricUnitsUI={hasMetricUnitsUI}
+        />
+      ),
     }),
     [
       metricSelectValue,
@@ -126,16 +153,11 @@ export function MetricSelector({
           ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
           : undefined,
         trailingItems: () => (
-          <Fragment>
-            <MetricTypeBadge metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]} />
-            {hasMetricUnitsUI &&
-              option[TraceMetricKnownFieldKey.METRIC_UNIT] &&
-              option[TraceMetricKnownFieldKey.METRIC_UNIT] !== NONE_UNIT && (
-                <Tag variant="promotion">
-                  {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
-                </Tag>
-              )}
-          </Fragment>
+          <MetricOptionTrailingItems
+            hasMetricUnitsUI={hasMetricUnitsUI}
+            metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]}
+            metricUnit={option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT}
+          />
         ),
       })) ?? []),
     ];
@@ -337,19 +359,7 @@ export function MetricSelector({
                               </LeadWrap>
                             </Fragment>
                           }
-                          trailingItems={
-                            <Flex gap="xs" align="center" flexShrink={0}>
-                              <MetricTypeBadge metricType={longestOption.metricType} />
-                              {hasMetricUnitsUI &&
-                                longestOption.metricUnit &&
-                                longestOption.metricUnit !== '-' &&
-                                longestOption.metricUnit !== NONE_UNIT && (
-                                  <Tag variant="promotion">
-                                    {longestOption.metricUnit}
-                                  </Tag>
-                                )}
-                            </Flex>
-                          }
+                          trailingItems={longestOption.trailingItems}
                         />
                       </div>
                     )}
@@ -376,11 +386,11 @@ export function MetricSelector({
                         >
                           {itemsToRender.map(virtualRow => {
                             const option = displayedOptions[virtualRow.index];
-                            if (!option) {
-                              return null;
-                            }
+                            if (!option) return null;
+
                             const isSelected = option.value === traceMetricSelectValue;
                             const isFocused = virtualRow.index === focusedIndex;
+
                             return (
                               <div
                                 key={option.value}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -44,9 +44,11 @@ function MetricOptionTrailingItems({
     <Fragment>
       <MetricTypeBadge metricType={metricType} />
       {hasMetricUnitsUI &&
-        metricUnit &&
-        metricUnit !== '-' &&
-        metricUnit !== NONE_UNIT && <Tag variant="promotion">{metricUnit}</Tag>}
+      metricUnit &&
+      metricUnit !== '-' &&
+      metricUnit !== NONE_UNIT ? (
+        <Tag variant="promotion">{metricUnit}</Tag>
+      ) : null}
     </Fragment>
   );
 }
@@ -300,7 +302,7 @@ export function MetricSelector({
         {...overlayProps}
         style={{...overlayProps.style, display: isOpen ? 'block' : 'none'}}
       >
-        {isOpen && (
+        {isOpen ? (
           <Overlay style={{display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
             <FocusScope contain restoreFocus autoFocus>
               <Flex direction={{xs: 'column', sm: 'row'}}>
@@ -315,7 +317,9 @@ export function MetricSelector({
                     <Text size="sm" bold wrap="nowrap">
                       {t('Metrics')}
                     </Text>
-                    {isFetching && <LoadingIndicator size={12} style={{margin: 0}} />}
+                    {isFetching ? (
+                      <LoadingIndicator size={12} style={{margin: 0}} />
+                    ) : null}
                   </Flex>
                   <Container padding="0 xs">
                     <InputGroup>
@@ -347,7 +351,7 @@ export function MetricSelector({
                     padding="xs 0"
                   >
                     {/* Hidden element that reserves width based on the longest option label */}
-                    {longestOption && (
+                    {longestOption ? (
                       <Container
                         aria-hidden
                         visibility="hidden"
@@ -368,7 +372,7 @@ export function MetricSelector({
                           trailingItems={longestOption.trailingItems}
                         />
                       </Container>
-                    )}
+                    ) : null}
                     {displayedOptions.length === 0 ? (
                       <Flex align="center" justify="center" padding="xl">
                         <Text variant="muted" size="sm">
@@ -417,7 +421,7 @@ export function MetricSelector({
                                   priority={isSelected ? 'primary' : 'default'}
                                   leadingItems={
                                     <LeadWrap aria-hidden="true">
-                                      {isSelected && <IconCheckmark size="sm" />}
+                                      {isSelected ? <IconCheckmark size="sm" /> : null}
                                     </LeadWrap>
                                   }
                                   trailingItems={option.trailingItems}
@@ -441,7 +445,7 @@ export function MetricSelector({
               </Flex>
             </FocusScope>
           </Overlay>
-        )}
+        ) : null}
       </PositionWrapper>
     </Container>
   );
@@ -472,16 +476,16 @@ function MetricDetailPanel({
         <MetricTypeBadge metricType={metric.metricType} />
       </Flex>
       {hasMetricUnitsUI &&
-        metric.metricUnit &&
-        metric.metricUnit !== '-' &&
-        metric.metricUnit !== NONE_UNIT && (
-          <Flex gap="xs" align="center">
-            <Text variant="muted" size="sm">
-              {t('Unit:')}
-            </Text>
-            <Tag variant="promotion">{metric.metricUnit}</Tag>
-          </Flex>
-        )}
+      metric.metricUnit &&
+      metric.metricUnit !== '-' &&
+      metric.metricUnit !== NONE_UNIT ? (
+        <Flex gap="xs" align="center">
+          <Text variant="muted" size="sm">
+            {t('Unit:')}
+          </Text>
+          <Tag variant="promotion">{metric.metricUnit}</Tag>
+        </Flex>
+      ) : null}
     </Stack>
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -90,6 +90,8 @@ export function MetricSelector({
     offset: 6,
     isDismissable: true,
     shouldApplyMinWidth: true,
+    // Reset search and keyboard focus when the overlay closes so it
+    // starts fresh the next time the user opens it.
     onOpenChange: open => {
       if (!open) {
         setSearchInputValue('');
@@ -101,6 +103,10 @@ export function MetricSelector({
   const metricSelectValue = makeMetricSelectValue(
     hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
   );
+
+  // Build an option object from the currently selected trace metric so it
+  // can be shown in the list even if the API response hasn't loaded yet or
+  // doesn't include it (e.g. it was filtered out by search).
   const optionFromTraceMetric: MetricSelectOption = useMemo(
     () => ({
       label: traceMetric.name,
@@ -125,6 +131,9 @@ export function MetricSelector({
     ]
   );
 
+  // Merge API results with the currently selected metric. If the selected
+  // metric isn't present in the API response (e.g. filtered by search),
+  // prepend it so the user always sees their current selection.
   const metricOptions = useMemo((): MetricSelectOption[] => {
     const shouldIncludeOptionFromTraceMetric =
       traceMetric.name &&
@@ -138,6 +147,7 @@ export function MetricSelector({
               : undefined,
           }) === makeMetricSelectValue(traceMetric)
       );
+
     return [
       ...(shouldIncludeOptionFromTraceMetric ? [optionFromTraceMetric] : []),
       ...(metricOptionsData?.data?.map(option => ({
@@ -165,6 +175,8 @@ export function MetricSelector({
     ];
   }, [metricOptionsData, optionFromTraceMetric, traceMetric, hasMetricUnitsUI]);
 
+  // Auto-select the first metric when no metric is currently selected.
+  // This handles the initial load case where the URL has no metric param.
   useEffect(() => {
     if (metricOptions.length && metricOptions[0] && !traceMetric.name) {
       onChange({
@@ -178,21 +190,21 @@ export function MetricSelector({
   const traceMetricSelectValue = makeMetricSelectValue(
     hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
   );
+
+  // Show the previous options while a new search is loading so the list
+  // doesn't flash empty during debounced re-fetches.
   const previousOptions = usePrevious(metricOptions ?? []);
   const displayedOptions = useMemo(
     () => (isFetching ? previousOptions : (metricOptions ?? [])),
     [isFetching, previousOptions, metricOptions]
   );
 
+  // Clamp the focused index when the list shrinks (e.g. after a search
+  // filters out options) so it doesn't point past the end of the list.
   useEffect(() => {
-    if (displayedOptions.length === 0) {
+    if (displayedOptions.length === 0 || focusedIndex < displayedOptions.length) {
       return;
     }
-
-    if (focusedIndex < displayedOptions.length) {
-      return;
-    }
-
     setFocusedIndex(Math.max(displayedOptions.length - 1, -1));
   }, [displayedOptions.length, focusedIndex]);
 
@@ -274,8 +286,9 @@ export function MetricSelector({
   );
 
   const virtualItems = virtualizer.getVirtualItems();
-  // Fall back to rendering all items when the virtualizer can't measure the scroll
-  // container (e.g. in test environments where DOM has no layout dimensions).
+
+  // Fall back to rendering all items when the virtualizer can't measure
+  // the scroll container (e.g. in tests where the DOM has no layout).
   const itemsToRender =
     virtualItems.length > 0 || displayedOptions.length === 0
       ? virtualItems

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -31,6 +31,15 @@ import {
 
 export const NONE_UNIT = 'none';
 
+function hasDisplayMetricUnit(
+  hasMetricUnitsUI: boolean,
+  metricUnit?: string
+): metricUnit is string {
+  return (
+    hasMetricUnitsUI && !!metricUnit && metricUnit !== '-' && metricUnit !== NONE_UNIT
+  );
+}
+
 function MetricOptionTrailingItems({
   metricType,
   metricUnit,
@@ -43,10 +52,7 @@ function MetricOptionTrailingItems({
   return (
     <Fragment>
       <MetricTypeBadge metricType={metricType} />
-      {hasMetricUnitsUI &&
-      metricUnit &&
-      metricUnit !== '-' &&
-      metricUnit !== NONE_UNIT ? (
+      {hasDisplayMetricUnit(hasMetricUnitsUI, metricUnit) ? (
         <Tag variant="promotion">{metricUnit}</Tag>
       ) : null}
     </Fragment>
@@ -488,10 +494,7 @@ function MetricDetailPanel({
         </Text>
         <MetricTypeBadge metricType={metric.metricType} />
       </Flex>
-      {hasMetricUnitsUI &&
-      metric.metricUnit &&
-      metric.metricUnit !== '-' &&
-      metric.metricUnit !== NONE_UNIT ? (
+      {hasDisplayMetricUnit(hasMetricUnitsUI, metric.metricUnit) ? (
         <Flex gap="xs" align="center">
           <Text variant="muted" size="sm">
             {t('Unit:')}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -214,6 +214,9 @@ export function MetricSelector({
       switch (e.key) {
         case 'ArrowDown': {
           e.preventDefault();
+          if (displayedOptions.length === 0) {
+            break;
+          }
           const next = Math.min(focusedIndex + 1, displayedOptions.length - 1);
           setFocusedIndex(next);
           virtualizer.scrollToIndex(next);
@@ -221,6 +224,9 @@ export function MetricSelector({
         }
         case 'ArrowUp': {
           e.preventDefault();
+          if (displayedOptions.length === 0) {
+            break;
+          }
           const next = Math.max(focusedIndex - 1, 0);
           setFocusedIndex(next);
           virtualizer.scrollToIndex(next);

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -194,6 +194,9 @@ export function MetricSelector({
     setFocusedIndex(Math.max(displayedOptions.length - 1, -1));
   }, [displayedOptions.length, focusedIndex]);
 
+  // Find the option with the longest label to render as a hidden element.
+  // This reserves enough width for the overlay so it doesn't resize as
+  // the user scrolls through the virtualized list.
   const longestOption = useMemo(
     () =>
       displayedOptions.reduce<MetricSelectOption | null>(
@@ -343,10 +346,13 @@ export function MetricSelector({
                     maxHeight="400px"
                     padding="xs 0"
                   >
+                    {/* Hidden element that reserves width based on the longest option label */}
                     {longestOption && (
-                      <div
+                      <Container
                         aria-hidden
-                        style={{visibility: 'hidden', height: 0, overflow: 'hidden'}}
+                        visibility="hidden"
+                        height={0}
+                        overflow="hidden"
                       >
                         <MenuListItem
                           as="div"
@@ -361,7 +367,7 @@ export function MetricSelector({
                           }
                           trailingItems={longestOption.trailingItems}
                         />
-                      </div>
+                      </Container>
                     )}
                     {displayedOptions.length === 0 ? (
                       <Flex align="center" justify="center" padding="xl">

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -16,11 +16,13 @@ import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconCheckmark, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useOverlay} from 'sentry/utils/useOverlay';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {canUseMetricsSidePanelUI} from 'sentry/views/explore/metrics/metricsFlags';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
 import {
   TraceMetricKnownFieldKey,
@@ -44,6 +46,7 @@ export function MetricSelector({
   onChange: (traceMetric: TraceMetric) => void;
   traceMetric: TraceMetric;
 }) {
+  const organization = useOrganization();
   const [searchInputValue, setSearchInputValue] = useState('');
   const debouncedSearch = useDebouncedValue(searchInputValue, DEFAULT_DEBOUNCE_DURATION);
   const [focusedIndex, setFocusedIndex] = useState(-1);
@@ -396,12 +399,14 @@ export function MetricSelector({
                     )}
                   </Container>
                 </Stack>
-                <Container width={{sm: '280px'}} padding="lg" minHeight={{sm: '200px'}}>
-                  <MetricDetailPanel
-                    metric={highlightedOption ?? optionFromTraceMetric}
-                    hasMetricUnitsUI={hasMetricUnitsUI}
-                  />
-                </Container>
+                {canUseMetricsSidePanelUI(organization) ? (
+                  <Container width={{sm: '280px'}} padding="lg" minHeight={{sm: '200px'}}>
+                    <MetricDetailPanel
+                      metric={highlightedOption ?? optionFromTraceMetric}
+                      hasMetricUnitsUI={hasMetricUnitsUI}
+                    />
+                  </Container>
+                ) : null}
               </Flex>
             </FocusScope>
           </Overlay>

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -259,8 +259,9 @@ export function MetricSelector({
   return (
     <Container width="100%" position="relative">
       <OverlayTrigger.Button
-        style={{width: '100%', fontWeight: 'bold'}}
         {...triggerProps}
+        style={{width: '100%', fontWeight: 'bold', textAlign: 'left'}}
+        disabled={isFetching && !traceMetric.name}
       >
         <Text ellipsis>{traceMetric.name || t('None')}</Text>
       </OverlayTrigger.Button>

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -179,7 +179,7 @@ export function MetricSelector({
     count: displayedOptions.length,
     getScrollElement: () => scrollElementRef.current,
     estimateSize: () => 42,
-    overscan: 5,
+    overscan: 20,
   });
 
   const highlightedOption =

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -10,7 +10,7 @@ import {MenuListItem, type MenuListItemProps} from '@sentry/scraps/menuListItem'
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
-import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconCheckmark, IconSearch} from 'sentry/icons';

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -1,12 +1,24 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
-import debounce from 'lodash/debounce';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
+import styled from '@emotion/styled';
+import {FocusScope} from '@react-aria/focus';
+import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Tag} from '@sentry/scraps/badge';
-import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
+import {LeadWrap} from '@sentry/scraps/compactSelect';
+import {InputGroup} from '@sentry/scraps/input';
+import {Flex} from '@sentry/scraps/layout';
+import {MenuListItem} from '@sentry/scraps/menuListItem';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Text} from '@sentry/scraps/text';
 
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
+import {IconCheckmark, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useOverlay} from 'sentry/utils/useOverlay';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
@@ -19,9 +31,11 @@ import {
 
 export const NONE_UNIT = 'none';
 
-interface MetricSelectOption extends SelectOption<string> {
+interface MetricSelectOption {
+  label: string;
   metricName: string;
   metricType: TraceMetricTypeValue;
+  value: string;
   metricUnit?: string;
 }
 
@@ -32,9 +46,39 @@ export function MetricSelector({
   onChange: (traceMetric: TraceMetric) => void;
   traceMetric: TraceMetric;
 }) {
-  const [search, setSearch] = useState('');
-  const {data: metricOptionsData, isFetching} = useMetricOptions({search});
+  const [searchInputValue, setSearchInputValue] = useState('');
+  const debouncedSearch = useDebouncedValue(searchInputValue, DEFAULT_DEBOUNCE_DURATION);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const {data: metricOptionsData, isFetching} = useMetricOptions({
+    search: debouncedSearch,
+  });
   const hasMetricUnitsUI = useHasMetricUnitsUI();
+  const searchRef = useRef<HTMLInputElement>(null);
+  const scrollElementRef = useRef<HTMLDivElement>(null);
+
+  const {
+    isOpen,
+    state: overlayState,
+    triggerProps,
+    overlayProps,
+  } = useOverlay({
+    type: 'listbox',
+    position: 'bottom-start',
+    offset: 4,
+    isDismissable: true,
+    shouldApplyMinWidth: true,
+    onOpenChange: open => {
+      if (open) {
+        // Focus the search input when the overlay opens
+        requestAnimationFrame(() => {
+          searchRef.current?.focus();
+        });
+      } else {
+        setSearchInputValue('');
+        setFocusedIndex(-1);
+      }
+    },
+  });
 
   const metricSelectValue = makeMetricSelectValue(
     hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
@@ -46,17 +90,6 @@ export function MetricSelector({
       metricType: traceMetric.type as TraceMetricTypeValue,
       metricUnit: hasMetricUnitsUI ? (traceMetric.unit ?? '-') : undefined,
       metricName: traceMetric.name,
-      trailingItems: () => (
-        <Fragment>
-          <MetricTypeBadge metricType={traceMetric.type as TraceMetricTypeValue} />
-          {hasMetricUnitsUI &&
-            traceMetric.unit &&
-            traceMetric.unit !== '-' &&
-            traceMetric.unit !== NONE_UNIT && (
-              <Tag variant="promotion">{traceMetric.unit}</Tag>
-            )}
-        </Fragment>
-      ),
     }),
     [
       metricSelectValue,
@@ -122,48 +155,393 @@ export function MetricSelector({
     }
   }, [metricOptions, onChange, traceMetric.name, hasMetricUnitsUI]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedSetSearch = useCallback(
-    debounce(newSearch => {
-      setSearch(newSearch);
-    }, DEFAULT_DEBOUNCE_DURATION),
-    [setSearch]
-  );
-
   const traceMetricSelectValue = makeMetricSelectValue(
     hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
   );
   const previousOptions = usePrevious(metricOptions ?? []);
+  const displayedOptions = useMemo(
+    () => (isFetching ? previousOptions : (metricOptions ?? [])),
+    [isFetching, previousOptions, metricOptions]
+  );
+
+  const longestOption = useMemo(
+    () =>
+      displayedOptions.reduce<MetricSelectOption | null>(
+        (longest, option) =>
+          !longest || option.label.length > longest.label.length ? option : longest,
+        null
+      ),
+    [displayedOptions]
+  );
+
+  const virtualizer = useVirtualizer({
+    count: displayedOptions.length,
+    getScrollElement: () => scrollElementRef.current,
+    estimateSize: () => 42,
+    overscan: 5,
+  });
+
+  const highlightedOption =
+    focusedIndex >= 0 && focusedIndex < displayedOptions.length
+      ? displayedOptions[focusedIndex]
+      : null;
+
+  const handleSelect = useCallback(
+    (option: MetricSelectOption) => {
+      onChange({
+        name: option.metricName,
+        type: option.metricType,
+        unit: hasMetricUnitsUI ? option.metricUnit : undefined,
+      });
+      overlayState.close();
+    },
+    [onChange, hasMetricUnitsUI, overlayState]
+  );
+
+  const onSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchInputValue(e.target.value);
+  }, []);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setFocusedIndex(prev => {
+            const next = Math.min(prev + 1, displayedOptions.length - 1);
+            virtualizer.scrollToIndex(next);
+            return next;
+          });
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setFocusedIndex(prev => {
+            const next = Math.max(prev - 1, 0);
+            virtualizer.scrollToIndex(next);
+            return next;
+          });
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (focusedIndex >= 0 && displayedOptions[focusedIndex]) {
+            handleSelect(displayedOptions[focusedIndex]);
+          }
+          break;
+        default:
+          break;
+      }
+    },
+    [displayedOptions, focusedIndex, handleSelect, virtualizer]
+  );
+
+  const virtualItems = virtualizer.getVirtualItems();
 
   return (
-    <CompactSelect
-      virtualizeThreshold={100}
-      search={{onChange: debouncedSetSearch}}
-      options={isFetching ? previousOptions : (metricOptions ?? [])}
-      value={traceMetricSelectValue}
-      loading={isFetching}
-      menuTitle={t('Metrics')}
-      onChange={option => {
-        if ('metricType' in option) {
-          const typedOption = option as MetricSelectOption;
-          onChange({
-            name: typedOption.metricName,
-            type: typedOption.metricType,
-            unit: hasMetricUnitsUI ? typedOption.metricUnit : undefined,
-          });
-        }
-      }}
-      style={{width: '100%'}}
-      trigger={triggerProps => (
-        <OverlayTrigger.Button
-          {...triggerProps}
-          style={{width: '100%', fontWeight: 'bold'}}
-        />
-      )}
-    />
+    <div style={{width: '100%', position: 'relative'}}>
+      <TriggerButton {...triggerProps}>
+        <TriggerLabel>{traceMetric.name || t('Select a metric')}</TriggerLabel>
+      </TriggerButton>
+      <StyledPositionWrapper zIndex={1001} visible={isOpen} {...overlayProps}>
+        {isOpen && (
+          <StyledOverlay>
+            <FocusScope contain restoreFocus>
+              <PanelLayout>
+                <OptionsPanel onKeyDown={onKeyDown}>
+                  <MenuHeader>
+                    <MenuTitle>{t('Metrics')}</MenuTitle>
+                    {isFetching && <StyledLoadingIndicator size={12} />}
+                  </MenuHeader>
+                  <SearchWrap>
+                    <InputGroup>
+                      <InputGroup.LeadingItems disablePointerEvents>
+                        <Flex
+                          paddingLeft="2xs"
+                          align="center"
+                          justify="center"
+                          style={{transform: 'translateY(1px) translateX(1px)'}}
+                        >
+                          <IconSearch size="xs" variant="muted" />
+                        </Flex>
+                      </InputGroup.LeadingItems>
+                      <SearchInput
+                        ref={searchRef}
+                        placeholder={t('Search metrics\u2026')}
+                        value={searchInputValue}
+                        onChange={onSearchChange}
+                        size="xs"
+                      />
+                    </InputGroup>
+                  </SearchWrap>
+                  <OptionsList ref={scrollElementRef} role="listbox">
+                    {longestOption && (
+                      <WidthSizer aria-hidden>
+                        <MenuListItem
+                          as="div"
+                          size="md"
+                          label={longestOption.label}
+                          leadingItems={
+                            <Fragment>
+                              <LeadWrap>
+                                <IconCheckmark size="sm" />
+                              </LeadWrap>
+                            </Fragment>
+                          }
+                          trailingItems={
+                            <Flex gap="xs" align="center" flexShrink={0}>
+                              <MetricTypeBadge metricType={longestOption.metricType} />
+                              {hasMetricUnitsUI &&
+                                longestOption.metricUnit &&
+                                longestOption.metricUnit !== '-' &&
+                                longestOption.metricUnit !== NONE_UNIT && (
+                                  <Tag variant="promotion">
+                                    {longestOption.metricUnit}
+                                  </Tag>
+                                )}
+                            </Flex>
+                          }
+                        />
+                      </WidthSizer>
+                    )}
+                    {displayedOptions.length === 0 ? (
+                      <EmptyMessage>
+                        <Text variant="muted" size="sm">
+                          {t('No metrics found')}
+                        </Text>
+                      </EmptyMessage>
+                    ) : (
+                      <div
+                        style={{
+                          height: virtualizer.getTotalSize(),
+                          width: '100%',
+                          position: 'relative',
+                        }}
+                      >
+                        <div
+                          style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            width: '100%',
+                            transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
+                          }}
+                        >
+                          {virtualItems.map(virtualRow => {
+                            const option = displayedOptions[virtualRow.index];
+                            if (!option) {
+                              return null;
+                            }
+                            const isSelected = option.value === traceMetricSelectValue;
+                            const isFocused = virtualRow.index === focusedIndex;
+                            return (
+                              <div
+                                key={option.value}
+                                ref={virtualizer.measureElement}
+                                data-index={virtualRow.index}
+                                onClick={() => handleSelect(option)}
+                                onMouseEnter={() => setFocusedIndex(virtualRow.index)}
+                              >
+                                <MenuListItem
+                                  as="div"
+                                  size="md"
+                                  label={option.label}
+                                  isFocused={isFocused}
+                                  isSelected={isSelected}
+                                  priority={isSelected ? 'primary' : 'default'}
+                                  leadingItems={
+                                    <Fragment>
+                                      <LeadWrap aria-hidden="true">
+                                        {isSelected && <IconCheckmark size="sm" />}
+                                      </LeadWrap>
+                                    </Fragment>
+                                  }
+                                  trailingItems={
+                                    <Flex gap="xs" align="center" flexShrink={0}>
+                                      <MetricTypeBadge metricType={option.metricType} />
+                                      {hasMetricUnitsUI &&
+                                        option.metricUnit &&
+                                        option.metricUnit !== '-' &&
+                                        option.metricUnit !== NONE_UNIT && (
+                                          <Tag variant="promotion">
+                                            {option.metricUnit}
+                                          </Tag>
+                                        )}
+                                    </Flex>
+                                  }
+                                />
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </OptionsList>
+                </OptionsPanel>
+                <DetailPanel>
+                  <MetricDetailPanel
+                    metric={highlightedOption ?? optionFromTraceMetric}
+                    hasMetricUnitsUI={hasMetricUnitsUI}
+                  />
+                </DetailPanel>
+              </PanelLayout>
+            </FocusScope>
+          </StyledOverlay>
+        )}
+      </StyledPositionWrapper>
+    </div>
+  );
+}
+
+function MetricDetailPanel({
+  metric,
+  hasMetricUnitsUI,
+}: {
+  hasMetricUnitsUI: boolean;
+  metric: MetricSelectOption | null;
+}) {
+  if (!metric) {
+    return (
+      <Flex align="center" justify="center" flex="1">
+        <Text variant="muted">{t('Select a metric to see details')}</Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="md">
+      <Text bold>{metric.metricName}</Text>
+      <Flex gap="xs" align="center">
+        <Text variant="muted" size="sm">
+          {t('Type:')}
+        </Text>
+        <MetricTypeBadge metricType={metric.metricType} />
+      </Flex>
+      {hasMetricUnitsUI &&
+        metric.metricUnit &&
+        metric.metricUnit !== '-' &&
+        metric.metricUnit !== NONE_UNIT && (
+          <Flex gap="xs" align="center">
+            <Text variant="muted" size="sm">
+              {t('Unit:')}
+            </Text>
+            <Tag variant="promotion">{metric.metricUnit}</Tag>
+          </Flex>
+        )}
+    </Flex>
   );
 }
 
 function makeMetricSelectValue(metric: TraceMetric): string {
   return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
 }
+
+const StyledPositionWrapper = styled(PositionWrapper, {
+  shouldForwardProp: prop => isPropValid(prop),
+})<{visible?: boolean; zIndex?: number}>`
+  display: ${p => (p.visible ? 'block' : 'none')};
+  z-index: ${p => p?.zIndex};
+`;
+
+const TriggerButton = styled(OverlayTrigger.Button)`
+  width: 100%;
+  font-weight: bold;
+`;
+
+const TriggerLabel = styled('span')`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+`;
+
+const StyledOverlay = styled(Overlay)`
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+const NARROW_BREAKPOINT = '700px';
+
+const PanelLayout = styled('div')`
+  display: flex;
+  flex-direction: row;
+
+  @media (max-width: ${NARROW_BREAKPOINT}) {
+    flex-direction: column;
+  }
+`;
+
+const OptionsPanel = styled('div')`
+  display: flex;
+  flex-direction: column;
+  min-width: 300px;
+  min-height: 0;
+  border-right: 1px solid ${p => p.theme.tokens.border.primary};
+
+  @media (max-width: ${NARROW_BREAKPOINT}) {
+    border-right: none;
+    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+`;
+
+const MenuHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${p => p.theme.space.sm} ${p => p.theme.space.lg};
+`;
+
+const MenuTitle = styled('span')`
+  font-size: ${p => p.theme.font.size.sm};
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  white-space: nowrap;
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  display: flex;
+  align-items: center;
+  && {
+    margin: 0;
+  }
+`;
+
+const SearchWrap = styled('div')`
+  padding: 0 ${p => p.theme.space.xs};
+`;
+
+const SearchInput = styled(InputGroup.Input)`
+  appearance: none;
+  width: calc(100% - ${p => p.theme.space.xs} * 2);
+  margin: ${p => p.theme.space.xs};
+`;
+
+const OptionsList = styled('div')`
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+  max-height: 400px;
+  padding: ${p => p.theme.space.xs} 0;
+`;
+
+const WidthSizer = styled('div')`
+  visibility: hidden;
+  height: 0;
+  overflow: hidden;
+`;
+
+const EmptyMessage = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${p => p.theme.space.xl};
+`;
+
+const DetailPanel = styled('div')`
+  width: 280px;
+  padding: ${p => p.theme.space.lg};
+  min-height: 200px;
+
+  @media (max-width: ${NARROW_BREAKPOINT}) {
+    width: auto;
+    min-height: auto;
+  }
+`;

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -6,7 +6,7 @@ import {Tag} from '@sentry/scraps/badge';
 import {LeadWrap} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {MenuListItem} from '@sentry/scraps/menuListItem';
+import {MenuListItem, type MenuListItemProps} from '@sentry/scraps/menuListItem';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
@@ -37,6 +37,7 @@ interface MetricSelectOption {
   metricType: TraceMetricTypeValue;
   value: string;
   metricUnit?: string;
+  trailingItems?: MenuListItemProps['trailingItems'];
 }
 
 export function MetricSelector({
@@ -403,19 +404,7 @@ export function MetricSelector({
                                       {isSelected && <IconCheckmark size="sm" />}
                                     </LeadWrap>
                                   }
-                                  trailingItems={
-                                    <Flex gap="xs" align="center" flexShrink={0}>
-                                      <MetricTypeBadge metricType={option.metricType} />
-                                      {hasMetricUnitsUI &&
-                                        option.metricUnit &&
-                                        option.metricUnit !== '-' &&
-                                        option.metricUnit !== NONE_UNIT && (
-                                          <Tag variant="promotion">
-                                            {option.metricUnit}
-                                          </Tag>
-                                        )}
-                                    </Flex>
-                                  }
+                                  trailingItems={option.trailingItems}
                                 />
                               </div>
                             );

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -27,3 +27,10 @@ export const canUseMetricsMultiAggregateUI = (organization: Organization) => {
     organization.features.includes('tracemetrics-overlay-charts-ui')
   );
 };
+
+export const canUseMetricsSidePanelUI = (organization: Organization) => {
+  return (
+    canUseMetricsUI(organization) &&
+    organization.features.includes('tracemetrics-attributes-dropdown-side-panel')
+  );
+};


### PR DESCRIPTION
Replace the CompactSelect metric picker with a custom overlay that includes a side panel showing metric details (name, type, unit, description). When a metric is selected or focused, the panel displays its metadata.

The new UI is gated behind the `tracemetrics-attributes-dropdown-side-panel` feature flag. Migrated from styled components to design system primitives (Container, Flex, Stack). Increased virtualizer overscan for smoother scrolling.

Refs LOGS-595
| | |
|--|--|
|**Before**|<img width="851" height="167" alt="Screenshot 2026-03-16 at 14 24 23" src="https://github.com/user-attachments/assets/114c72ce-b3c4-413f-8908-0c1988636d73" />|
|**After (Flag on)|**<img width="764" height="265" alt="Screenshot 2026-03-16 at 14 24 05" src="https://github.com/user-attachments/assets/f58f32c0-0dfd-4d3c-9d9e-16c33844c495" />|
|**After (Flag off)**|<img width="521" height="159" alt="Screenshot 2026-03-16 at 14 27 32" src="https://github.com/user-attachments/assets/9056ec17-327c-4a59-95e3-f0f845916f74" />|
