### PR TITLE
ref: Add S015 flake8 rule for make_signed_seer_api_request viewer_con…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,7 @@ sentry =
 # All other linting (E, W, F, B, LOG, I) is handled by ruff.
 # See [tool.ruff] in pyproject.toml for the main linting configuration.
 select = S
+ignore = S015
 per-file-ignores =
     # these scripts must have minimal dependencies so opt out of the usual sentry rules
     .github/*: S

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -240,3 +240,41 @@ def test(monkeypatch) -> None: pass
 """
     expected = ["t.py:1:9: S014 Use `unittest.mock` instead"]
     assert _run(src) == expected
+
+
+def test_S015() -> None:
+    # bad: no viewer_context keyword
+    src = """\
+make_signed_seer_api_request(pool, "/path", b"body")
+"""
+    expected = [
+        "t.py:1:0: S015 Pass `viewer_context=` explicitly (use None if no user/org context is available)"
+    ]
+    assert _run(src) == expected
+
+    # bad: attribute-style call without viewer_context
+    src = """\
+signed_seer_api.make_signed_seer_api_request(pool, "/path", b"body")
+"""
+    expected = [
+        "t.py:1:0: S015 Pass `viewer_context=` explicitly (use None if no user/org context is available)"
+    ]
+    assert _run(src) == expected
+
+    # ok: viewer_context passed as keyword with a value
+    src = """\
+make_signed_seer_api_request(pool, "/path", b"body", viewer_context=ctx)
+"""
+    assert _run(src) == []
+
+    # ok: viewer_context explicitly set to None
+    src = """\
+make_signed_seer_api_request(pool, "/path", b"body", viewer_context=None)
+"""
+    assert _run(src) == []
+
+    # ok: unrelated function call
+    src = """\
+make_other_request(pool, "/path", b"body")
+"""
+    assert _run(src) == []

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -40,6 +40,8 @@ S013_msg = "S013 Use `django.contrib.postgres.fields.array.ArrayField` instead"
 
 S014_msg = "S014 Use `unittest.mock` instead"
 
+S015_msg = "S015 Pass `viewer_context=` explicitly (use None if no user/org context is available)"
+
 
 class SentryVisitor(ast.NodeVisitor):
     def __init__(self, filename: str) -> None:
@@ -157,6 +159,14 @@ class SentryVisitor(ast.NodeVisitor):
             for keyword in node.keywords:
                 if keyword.arg == "SENTRY_OPTIONS":
                     self.errors.append((keyword.lineno, keyword.col_offset, S011_msg))
+
+        # S015: make_signed_seer_api_request must pass viewer_context explicitly
+        if (isinstance(node.func, ast.Name) and node.func.id == "make_signed_seer_api_request") or (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "make_signed_seer_api_request"
+        ):
+            if not any(kw.arg == "viewer_context" for kw in node.keywords):
+                self.errors.append((node.lineno, node.col_offset, S015_msg))
 
         self.generic_visit(node)
 


### PR DESCRIPTION
…text

Require `viewer_context=` to be passed explicitly in all calls to `make_signed_seer_api_request`. This ensures user_id and organization_id are threaded through every call site, either as an actual value or explicitly None.

The rule is added as disabled (ignored in setup.cfg) so it does not block CI until all existing call sites are fixed.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
