### PR TITLE
feat(lint): Add S015/S016 rules for Seer viewer_context enforcement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,8 @@ per-file-ignores =
     tools/*: S
     # testing the options manager itself
     src/sentry/testutils/helpers/options.py, tests/sentry/options/test_manager.py: S011
+    # S015/S016 (viewer_context in Seer API calls) are disabled while violations are being fixed
+    src/*: S015, S016
 
 [flake8:local-plugins]
 paths = .

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -240,3 +240,97 @@ def test(monkeypatch) -> None: pass
 """
     expected = ["t.py:1:9: S014 Use `unittest.mock` instead"]
     assert _run(src) == expected
+
+
+def test_S015() -> None:
+    # Bad: missing viewer_context keyword argument
+    src = """\
+make_signed_seer_api_request(pool, "/path", body=b"data")
+"""
+    errors = _run(src, filename="src/sentry/seer/something.py")
+    assert errors == [
+        "t.py:1:0: S015 `make_signed_seer_api_request` must be called with an explicit `viewer_context` keyword argument",
+    ]
+
+    # Good: viewer_context is passed
+    src = """\
+make_signed_seer_api_request(pool, "/path", body=b"data", viewer_context=ctx)
+"""
+    assert _run(src, filename="src/sentry/seer/something.py") == []
+
+    # Good: viewer_context=None is explicit
+    src = """\
+make_signed_seer_api_request(pool, "/path", body=b"data", viewer_context=None)
+"""
+    assert _run(src, filename="src/sentry/seer/something.py") == []
+
+    # No error in test files
+    src = """\
+make_signed_seer_api_request(pool, "/path", body=b"data")
+"""
+    assert _run(src, filename="tests/sentry/seer/test_something.py") == []
+
+    # Bad: attribute-style call without viewer_context
+    src = """\
+seer_api.make_signed_seer_api_request(pool, "/path", body=b"data")
+"""
+    errors = _run(src, filename="src/sentry/seer/something.py")
+    assert errors == [
+        "t.py:1:0: S015 `make_signed_seer_api_request` must be called with an explicit `viewer_context` keyword argument",
+    ]
+
+
+def test_S016() -> None:
+    # Bad: missing both organization_id and user_id
+    src = """\
+SeerViewerContext()
+"""
+    errors = _run(src, filename="src/sentry/seer/something.py")
+    assert errors == [
+        "t.py:1:0: S016 `SeerViewerContext` must include both `organization_id` and `user_id` keyword arguments",
+    ]
+
+    # Bad: missing user_id
+    src = """\
+SeerViewerContext(organization_id=123)
+"""
+    errors = _run(src, filename="src/sentry/seer/something.py")
+    assert errors == [
+        "t.py:1:0: S016 `SeerViewerContext` must include both `organization_id` and `user_id` keyword arguments",
+    ]
+
+    # Bad: missing organization_id
+    src = """\
+SeerViewerContext(user_id=456)
+"""
+    errors = _run(src, filename="src/sentry/seer/something.py")
+    assert errors == [
+        "t.py:1:0: S016 `SeerViewerContext` must include both `organization_id` and `user_id` keyword arguments",
+    ]
+
+    # Good: both present
+    src = """\
+SeerViewerContext(organization_id=123, user_id=456)
+"""
+    assert _run(src, filename="src/sentry/seer/something.py") == []
+
+    # Good: user_id=None is acceptable
+    src = """\
+SeerViewerContext(organization_id=123, user_id=None)
+"""
+    assert _run(src, filename="src/sentry/seer/something.py") == []
+
+    # No error in test files
+    src = """\
+SeerViewerContext(organization_id=123)
+"""
+    assert _run(src, filename="tests/sentry/seer/test_something.py") == []
+
+    # Bad: attribute-style call missing keys
+    src = """\
+signed_seer_api.SeerViewerContext(organization_id=123)
+"""
+    errors = _run(src, filename="src/sentry/seer/something.py")
+    assert errors == [
+        "t.py:1:0: S016 `SeerViewerContext` must include both `organization_id` and `user_id` keyword arguments",
+    ]

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -40,6 +40,12 @@ S013_msg = "S013 Use `django.contrib.postgres.fields.array.ArrayField` instead"
 
 S014_msg = "S014 Use `unittest.mock` instead"
 
+S015_msg = "S015 `make_signed_seer_api_request` must be called with an explicit `viewer_context` keyword argument"
+
+S016_msg = (
+    "S016 `SeerViewerContext` must include both `organization_id` and `user_id` keyword arguments"
+)
+
 
 class SentryVisitor(ast.NodeVisitor):
     def __init__(self, filename: str) -> None:
@@ -157,6 +163,29 @@ class SentryVisitor(ast.NodeVisitor):
             for keyword in node.keywords:
                 if keyword.arg == "SENTRY_OPTIONS":
                     self.errors.append((keyword.lineno, keyword.col_offset, S011_msg))
+
+        # S015: make_signed_seer_api_request must include viewer_context
+        if (
+            "tests/" not in self.filename
+            and (
+                (isinstance(node.func, ast.Name) and node.func.id == "make_signed_seer_api_request")
+                or (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "make_signed_seer_api_request"
+                )
+            )
+            and not any(kw.arg == "viewer_context" for kw in node.keywords)
+        ):
+            self.errors.append((node.lineno, node.col_offset, S015_msg))
+
+        # S016: SeerViewerContext must include both organization_id and user_id
+        if "tests/" not in self.filename and (
+            (isinstance(node.func, ast.Name) and node.func.id == "SeerViewerContext")
+            or (isinstance(node.func, ast.Attribute) and node.func.attr == "SeerViewerContext")
+        ):
+            kw_names = {kw.arg for kw in node.keywords if kw.arg is not None}
+            if "organization_id" not in kw_names or "user_id" not in kw_names:
+                self.errors.append((node.lineno, node.col_offset, S016_msg))
 
         self.generic_visit(node)
 


### PR DESCRIPTION
S015 requires all `make_signed_seer_api_request` calls to pass an explicit `viewer_context` keyword argument. S016 requires all `SeerViewerContext` constructions to include both `organization_id` and `user_id` keywords. Both rules are disabled via per-file-ignores while existing violations are being fixed.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
