### PR TITLE
feat(notifications): improve deploy email subjects

### DIFF
--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -95,13 +95,13 @@ class ReleaseActivityNotification(ActivityNotification):
             "version_parsed": self.version_parsed,
         }
 
-    def get_projects(self, recipient: Actor) -> list[Project]:
+    def get_projects(self, recipient: Actor) -> set[Project]:
         if not self.release:
-            return []
+            return set()
 
         if recipient.is_user:
             if self.organization.flags.allow_joinleave:
-                return sorted(self.projects, key=lambda project: project.slug)
+                return self.projects
             team_ids = self.get_users_by_teams()[recipient.id]
         else:
             team_ids = [recipient.id]
@@ -109,7 +109,7 @@ class ReleaseActivityNotification(ActivityNotification):
         projects = Project.objects.get_for_team_ids(team_ids).filter(
             id__in={p.id for p in self.projects}
         )
-        return sorted(projects, key=lambda project: project.slug)
+        return set(projects)
 
     def get_subject_project_text(self, project_slugs: Sequence[str]) -> str:
         visible_project_slugs = list(project_slugs[: self.max_subject_projects])
@@ -122,7 +122,7 @@ class ReleaseActivityNotification(ActivityNotification):
     def get_recipient_context(
         self, recipient: Actor, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
-        projects = self.get_projects(recipient)
+        projects = sorted(self.get_projects(recipient), key=lambda project: project.slug)
         release_links = [
             self.organization.absolute_url(
                 f"/organizations/{self.organization.slug}/releases/{self.version}/?project={p.id}",

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -145,7 +145,7 @@ class ReleaseActivityNotification(ActivityNotification):
         project_slugs = context.get("subject_project_slugs", []) if context else []
         if project_slugs:
             projects_text = self.get_subject_project_text(project_slugs)
-            return f"Deployed {projects_text} {self.version_parsed} to {self.environment}"
+            return f"Deployed {projects_text} to version {self.version_parsed} to {self.environment}"
         return f"Deployed {self.version_parsed} to {self.environment}"
 
     @property

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -146,7 +146,7 @@ class ReleaseActivityNotification(ActivityNotification):
         if project_slugs:
             projects_text = self.get_subject_project_text(project_slugs)
             return (
-                f"Deployed {projects_text} to version {self.version_parsed} to {self.environment}"
+                f"Deployed {projects_text} version {self.version_parsed} to {self.environment}"
             )
         return f"Deployed {self.version_parsed} to {self.environment}"
 

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -145,9 +145,7 @@ class ReleaseActivityNotification(ActivityNotification):
         project_slugs = context.get("subject_project_slugs", []) if context else []
         if project_slugs:
             projects_text = self.get_subject_project_text(project_slugs)
-            return (
-                f"Deployed {projects_text} version {self.version_parsed} to {self.environment}"
-            )
+            return f"Deployed {projects_text} version {self.version_parsed} to {self.environment}"
         return f"Deployed {self.version_parsed} to {self.environment}"
 
     @property

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -33,6 +33,7 @@ class ReleaseActivityNotification(ActivityNotification):
     metrics_key = "release_activity"
     notification_setting_type_enum = NotificationSettingEnum.DEPLOY
     template_path = "sentry/emails/activity/release"
+    max_subject_projects = 2
 
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
@@ -94,13 +95,13 @@ class ReleaseActivityNotification(ActivityNotification):
             "version_parsed": self.version_parsed,
         }
 
-    def get_projects(self, recipient: Actor) -> set[Project]:
+    def get_projects(self, recipient: Actor) -> list[Project]:
         if not self.release:
-            return set()
+            return []
 
         if recipient.is_user:
             if self.organization.flags.allow_joinleave:
-                return self.projects
+                return sorted(self.projects, key=lambda project: project.slug)
             team_ids = self.get_users_by_teams()[recipient.id]
         else:
             team_ids = [recipient.id]
@@ -108,7 +109,15 @@ class ReleaseActivityNotification(ActivityNotification):
         projects = Project.objects.get_for_team_ids(team_ids).filter(
             id__in={p.id for p in self.projects}
         )
-        return set(projects)
+        return sorted(projects, key=lambda project: project.slug)
+
+    def get_subject_project_text(self, project_slugs: Sequence[str]) -> str:
+        visible_project_slugs = list(project_slugs[: self.max_subject_projects])
+        remaining_projects = len(project_slugs) - len(visible_project_slugs)
+        projects_text = ", ".join(visible_project_slugs)
+        if remaining_projects > 0:
+            projects_text = f"{projects_text} +{remaining_projects} more"
+        return projects_text
 
     def get_recipient_context(
         self, recipient: Actor, extra_context: Mapping[str, Any]
@@ -129,10 +138,15 @@ class ReleaseActivityNotification(ActivityNotification):
             **super().get_recipient_context(recipient, extra_context),
             "projects": list(zip(projects, release_links, resolved_issue_counts)),
             "project_count": len(projects),
+            "subject_project_slugs": [project.slug for project in projects],
         }
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
-        return f"Deployed version {self.version_parsed} to {self.environment}"
+        project_slugs = context.get("subject_project_slugs", []) if context else []
+        if project_slugs:
+            projects_text = self.get_subject_project_text(project_slugs)
+            return f"Deployed {projects_text} {self.version_parsed} to {self.environment}"
+        return f"Deployed {self.version_parsed} to {self.environment}"
 
     @property
     def title(self) -> str:

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -145,7 +145,9 @@ class ReleaseActivityNotification(ActivityNotification):
         project_slugs = context.get("subject_project_slugs", []) if context else []
         if project_slugs:
             projects_text = self.get_subject_project_text(project_slugs)
-            return f"Deployed {projects_text} to version {self.version_parsed} to {self.environment}"
+            return (
+                f"Deployed {projects_text} to version {self.version_parsed} to {self.environment}"
+            )
         return f"Deployed {self.version_parsed} to {self.environment}"
 
     @property

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -146,7 +146,7 @@ class ReleaseActivityNotification(ActivityNotification):
         if project_slugs:
             projects_text = self.get_subject_project_text(project_slugs)
             return f"Deployed {projects_text} version {self.version_parsed} to {self.environment}"
-        return f"Deployed {self.version_parsed} to {self.environment}"
+        return f"Deployed version {self.version_parsed} to {self.environment}"
 
     @property
     def title(self) -> str:

--- a/src/sentry/utils/email/message_builder.py
+++ b/src/sentry/utils/email/message_builder.py
@@ -190,7 +190,8 @@ class MessageBuilder:
         reference = self.reference
         if isinstance(reference, Activity):
             reference = reference.group
-            subject = f"Re: {subject}"
+            if reference is not None:
+                subject = f"Re: {subject}"
 
         if isinstance(reference, Group):
             thread, created = GroupEmailThread.objects.get_or_create(

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -1,6 +1,7 @@
 from django.core import mail
 
 from sentry.integrations.types import ExternalProviderEnum, ExternalProviders
+from sentry.mail.notifications import build_subject_prefix
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.release import Release
@@ -23,6 +24,9 @@ from sentry.users.services.user.service import user_service
 
 
 class ReleaseTestCase(ActivityTestCase):
+    def get_prefixed_subject(self, subject: str) -> str:
+        return f"{build_subject_prefix(self.project).rstrip()} {subject}"
+
     def setUp(self) -> None:
         super().setUp()
 
@@ -165,6 +169,11 @@ class ReleaseTestCase(ActivityTestCase):
             self.user3.email,
             self.user5.email,
         }
+        expected_subject = self.get_prefixed_subject(
+            f"Deployed {self.project.slug} {email.version_parsed} to {self.environment.name}"
+        )
+        assert {msg.subject for msg in mail.outbox} == {expected_subject}
+        assert all(not msg.subject.startswith("Re:") for msg in mail.outbox)
 
     def test_prevent_duplicate_projects(self) -> None:
         email = ReleaseActivityNotification(
@@ -184,6 +193,76 @@ class ReleaseTestCase(ActivityTestCase):
         # the same project twice
         assert len(user_context["projects"]) == 1
         assert user_context["projects"][0][0] == self.project
+
+    def test_subject_uses_recipient_visible_projects(self) -> None:
+        mail.outbox.clear()
+        self.create_team_membership(user=self.user1, team=self.team2)
+
+        email = ReleaseActivityNotification(
+            Activity(
+                project=self.project,
+                user_id=self.user1.id,
+                type=ActivityType.RELEASE.value,
+                data={"version": self.release.version, "deploy_id": self.deploy.id},
+            )
+        )
+
+        user_context = email.get_recipient_context(Actor.from_orm_user(self.user1), {})
+        expected_project_slugs = sorted([self.project.slug, self.project2.slug])
+
+        assert [
+            project.slug for project, _, _ in user_context["projects"]
+        ] == expected_project_slugs
+        assert user_context["subject_project_slugs"] == expected_project_slugs
+
+        with self.tasks():
+            email.send()
+
+        subjects_by_recipient = {message.to[0]: message.subject for message in mail.outbox}
+
+        assert subjects_by_recipient[self.user1.email] == self.get_prefixed_subject(
+            f"Deployed {', '.join(expected_project_slugs)} {email.version_parsed} to {self.environment.name}"
+        )
+        assert subjects_by_recipient[self.user3.email] == self.get_prefixed_subject(
+            f"Deployed {self.project.slug} {email.version_parsed} to {self.environment.name}"
+        )
+        assert all(not subject.startswith("Re:") for subject in subjects_by_recipient.values())
+
+    def test_subject_caps_projects_at_two(self) -> None:
+        mail.outbox.clear()
+        team3 = self.create_team(organization=self.org)
+        project3 = self.create_project(
+            organization=self.org,
+            teams=[team3],
+            name="AAA Third",
+            slug="aaa-third",
+        )
+        self.release.add_project(project3)
+        self.create_team_membership(user=self.user1, team=self.team2)
+        self.create_team_membership(user=self.user1, team=team3)
+
+        email = ReleaseActivityNotification(
+            Activity(
+                project=self.project,
+                user_id=self.user1.id,
+                type=ActivityType.RELEASE.value,
+                data={"version": self.release.version, "deploy_id": self.deploy.id},
+            )
+        )
+
+        expected_project_slugs = sorted([self.project.slug, self.project2.slug, project3.slug])
+        user_context = email.get_recipient_context(Actor.from_orm_user(self.user1), {})
+
+        assert user_context["subject_project_slugs"] == expected_project_slugs
+
+        with self.tasks():
+            email.send()
+
+        subjects_by_recipient = {message.to[0]: message.subject for message in mail.outbox}
+
+        assert subjects_by_recipient[self.user1.email] == self.get_prefixed_subject(
+            f"Deployed {expected_project_slugs[0]}, {expected_project_slugs[1]} +1 more {email.version_parsed} to {self.environment.name}"
+        )
 
     def test_does_not_generate_on_no_release(self) -> None:
         email = ReleaseActivityNotification(

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -170,7 +170,7 @@ class ReleaseTestCase(ActivityTestCase):
             self.user5.email,
         }
         expected_subject = self.get_prefixed_subject(
-            f"Deployed {self.project.slug} {email.version_parsed} to {self.environment.name}"
+            f"Deployed {self.project.slug} version {email.version_parsed} to {self.environment.name}"
         )
         assert {msg.subject for msg in mail.outbox} == {expected_subject}
         assert all(not msg.subject.startswith("Re:") for msg in mail.outbox)
@@ -221,10 +221,10 @@ class ReleaseTestCase(ActivityTestCase):
         subjects_by_recipient = {message.to[0]: message.subject for message in mail.outbox}
 
         assert subjects_by_recipient[self.user1.email] == self.get_prefixed_subject(
-            f"Deployed {', '.join(expected_project_slugs)} {email.version_parsed} to {self.environment.name}"
+            f"Deployed {', '.join(expected_project_slugs)} version {email.version_parsed} to {self.environment.name}"
         )
         assert subjects_by_recipient[self.user3.email] == self.get_prefixed_subject(
-            f"Deployed {self.project.slug} {email.version_parsed} to {self.environment.name}"
+            f"Deployed {self.project.slug} version {email.version_parsed} to {self.environment.name}"
         )
         assert all(not subject.startswith("Re:") for subject in subjects_by_recipient.values())
 
@@ -261,7 +261,7 @@ class ReleaseTestCase(ActivityTestCase):
         subjects_by_recipient = {message.to[0]: message.subject for message in mail.outbox}
 
         assert subjects_by_recipient[self.user1.email] == self.get_prefixed_subject(
-            f"Deployed {expected_project_slugs[0]}, {expected_project_slugs[1]} +1 more {email.version_parsed} to {self.environment.name}"
+            f"Deployed {expected_project_slugs[0]}, {expected_project_slugs[1]} +1 more version {email.version_parsed} to {self.environment.name}"
         )
 
     def test_does_not_generate_on_no_release(self) -> None:

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -156,6 +156,7 @@ class ReleaseTestCase(ActivityTestCase):
         # make sure this only includes projects user has access to
         assert len(user_context["projects"]) == 1
         assert user_context["projects"][0][0] == self.project
+        assert email.title == f"Deployed version {email.version_parsed} to {self.environment.name}"
 
         with self.tasks():
             email.send()

--- a/tests/sentry/utils/email/test_message_builder.py
+++ b/tests/sentry/utils/email/test_message_builder.py
@@ -5,6 +5,7 @@ from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 
 from sentry import options
+from sentry.models.activity import Activity
 from sentry.models.groupemailthread import GroupEmailThread
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
@@ -257,6 +258,31 @@ class MessageBuilderTest(TestCase):
         assert GroupEmailThread.objects.order_by("id")[0].msgid == "abc123", (
             "msgid should not have changed"
         )
+
+    @patch("sentry.utils.email.message_builder.make_msgid")
+    def test_group_less_activity_reference_does_not_prefix_subject(
+        self, make_msgid: MagicMock
+    ) -> None:
+        make_msgid.return_value = "abc123"
+
+        msg = MessageBuilder(
+            subject="Test",
+            body="hello world",
+            html_body="<b>hello world</b>",
+            reference=Activity(project=self.project),
+        )
+        msg.send(["foo@example.com"])
+
+        assert len(mail.outbox) == 1
+
+        out = mail.outbox[0]
+        assert isinstance(out, EmailMultiAlternatives)
+        assert out.to == ["foo@example.com"]
+        assert out.subject == "Test"
+        assert out.extra_headers["Message-Id"] == "abc123"
+        assert "In-Reply-To" not in out.extra_headers
+        assert "References" not in out.extra_headers
+        assert GroupEmailThread.objects.count() == 0
 
     def test_get_built_messages(self) -> None:
         msg = MessageBuilder(


### PR DESCRIPTION
Improve deploy email subjects so they no longer use a reply-style `Re:` prefix and instead include the projects visible to the recipient.

These deploy emails were not actually threading against anything useful, and the old subject omitted the project context people use to scan notifications. This change builds the subject from the same recipient-filtered project list shown in the email body, sorts that list alphabetically, and caps longer lists with `+N more` to keep the subject readable.

The change is intentionally limited to the deploy email path. It also adds regression coverage for recipient-scoped deploy subjects and for group-less activity emails so future subject/threading changes do not reintroduce this behavior.