### PR TITLE
fix(insights): Hide platform selector when platformized insights is active

### DIFF
--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
@@ -132,7 +132,9 @@ function ScreenDetailsPage() {
               module={moduleName}
               hideDefaultTabs
               tabs={{tabList, value: selectedTabKey, onTabChange: handleTabChange}}
-              headerActions={isProjectCrossPlatform && <PlatformSelector />}
+              headerActions={
+                isProjectCrossPlatform && !hasPlatformizedInsights && <PlatformSelector />
+              }
               headerTitle={transactionName}
               breadcrumbs={[
                 {

--- a/static/app/views/insights/pages/mobile/layout.tsx
+++ b/static/app/views/insights/pages/mobile/layout.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import {Outlet, useMatches} from 'react-router-dom';
 
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import useHasPlatformizedInsights from 'sentry/views/insights/common/utils/useHasPlatformizedInsights';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/components/platformSelector';
 import {
@@ -14,6 +15,7 @@ import {ModuleName} from 'sentry/views/insights/types';
 
 function MobileVitalsHeader() {
   const {isProjectCrossPlatform} = useCrossPlatformProject();
+  const hasPlatformizedInsights = useHasPlatformizedInsights();
 
   return (
     <MobileHeader
@@ -26,7 +28,9 @@ function MobileVitalsHeader() {
           />
         </Fragment>
       }
-      headerActions={isProjectCrossPlatform && <PlatformSelector />}
+      headerActions={
+        isProjectCrossPlatform && !hasPlatformizedInsights && <PlatformSelector />
+      }
       module={ModuleName.MOBILE_VITALS}
     />
   );


### PR DESCRIPTION
Hide the Android/iOS platform selector on Mobile Insights pages when the
`insights-prebuilt-dashboards` feature flag is active. The new platformized
dashboard views already have their own global platform filter, making the
selector redundant.

Applies to both the Mobile Vitals overview header and the Screen Details page.

Refs LINEAR-DAIN-1303