### PR TITLE
Add project scoping to release_file query in artifact_lookup

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -91,10 +91,12 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
             )
             metrics.incr("sourcemaps.download.artifact_bundle")
         elif ty == "release_file":
-            # NOTE: `ReleaseFile` does have a `project_id`, but that seems to
-            # be always empty, so using the `organization_id` instead.
             file_m = (
-                ReleaseFile.objects.filter(id=ty_id, organization_id=project.organization.id)
+                ReleaseFile.objects.filter(
+                    id=ty_id,
+                    organization_id=project.organization.id,
+                    release__projects=project,
+                )
                 .select_related("file")
                 .first()
             )

--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -29,6 +29,7 @@ from sentry.models.distribution import Distribution
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releasefile import ReleaseFile
+from sentry.models.releases.release_project import ReleaseProject
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.api")
@@ -95,7 +96,9 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
                 ReleaseFile.objects.filter(
                     id=ty_id,
                     organization_id=project.organization.id,
-                    release__projects=project,
+                    release_id__in=ReleaseProject.objects.filter(
+                        project=project,
+                    ).values("release_id"),
                 )
                 .select_related("file")
                 .first()

--- a/tests/sentry/api/endpoints/test_project_artifact_lookup.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_lookup.py
@@ -714,6 +714,56 @@ class ArtifactLookupTest(APITestCase):
         response = self.client.get(f"{url}?download=artifact_bundle/{artifact_bundle.id}")
         assert response.status_code == 404
 
+    def test_cross_project_release_file_download_blocked(self) -> None:
+        """Downloading a ReleaseFile from Project B via Project A's endpoint must return 404."""
+        project_b = self.create_project(organization=self.organization, name="project-b")
+        release_b = self.create_release(project=project_b, version="cross-proj-v1")
+
+        secret_content = b"secret-data-from-project-b"
+        file_b = make_file("secret.js", secret_content, "release.file", {})
+        rf_b = ReleaseFile.objects.create(
+            organization_id=self.organization.id,
+            release_id=release_b.id,
+            file=file_b,
+            name="http://example.com/secret.js",
+        )
+
+        self.login_as(user=self.user)
+
+        url_a = reverse(
+            "sentry-api-0-project-artifact-lookup",
+            kwargs={
+                "organization_id_or_slug": self.project.organization.slug,
+                "project_id_or_slug": self.project.slug,
+            },
+        )
+
+        response = self.client.get(f"{url_a}?download=release_file/{rf_b.id}")
+        assert response.status_code == 404
+
+    def test_same_project_release_file_download_allowed(self) -> None:
+        """Downloading a ReleaseFile through the project that owns the release must succeed."""
+        file_content = b"legitimate-project-a-data"
+        file_a = make_file("app.js", file_content, "release.file", {})
+        rf_a = ReleaseFile.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release.id,
+            file=file_a,
+            name="http://example.com/app.js",
+        )
+
+        self.login_as(user=self.user)
+
+        url = reverse(
+            "sentry-api-0-project-artifact-lookup",
+            kwargs={
+                "organization_id_or_slug": self.project.organization.slug,
+                "project_id_or_slug": self.project.slug,
+            },
+        )
+
+        self.assert_download_matches_file(f"{url}?download=release_file/{rf_a.id}", file_content)
+
     def test_download_invalid_id(self) -> None:
         self.login_as(user=self.user)
 


### PR DESCRIPTION
Added effective project scoping for the release_file query. Prevents the cross-project IDOR.

Can't use ReleaseFile.release_id since it's not a ForeignKey and the ORM gets mad. Need to subquery it for projects instead. 