### PR TITLE
ref(cells): update caller of update_region_user rpc method

### DIFF
--- a/src/sentry/users/models/user.py
+++ b/src/sentry/users/models/user.py
@@ -621,7 +621,7 @@ class User(Model, AbstractBaseUser):
                 is_active=self.is_active,
                 email=self.email,
             ),
-            region_name=region_name,
+            cell_name=region_name,
         )
 
 


### PR DESCRIPTION
callers now use cell_name instead of region_name

note there is only 1 caller of this rpc method, and the `cell_name` param can be deprecated after this
