### PR TITLE
ref(cells): Update all org provisioning rpc methods with cell terminology

### DIFF
--- a/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
@@ -127,12 +127,19 @@ class DatabaseBackedControlOrganizationProvisioningService(
         )
 
     def provision_organization(
-        self, *, region_name: str, org_provision_args: OrganizationProvisioningOptions
+        self,
+        *,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
+        org_provision_args: OrganizationProvisioningOptions,
     ) -> RpcOrganizationSlugReservation:
+        resolved_cell_name = cell_name or region_name
+        assert resolved_cell_name is not None, "cell_name or region_name must be provided"
+
         # Generate a new non-conflicting slug and org ID
-        org_id = self._generate_org_snowflake_id(region_name=region_name)
+        org_id = self._generate_org_snowflake_id(region_name=resolved_cell_name)
         slug = self._generate_org_slug(
-            region_name=region_name, slug=org_provision_args.provision_options.slug
+            region_name=resolved_cell_name, slug=org_provision_args.provision_options.slug
         )
 
         # Generate a provisioning outbox for the region and drain
@@ -151,13 +158,13 @@ class DatabaseBackedControlOrganizationProvisioningService(
                 slug=slug,
                 organization_id=org_id,
                 user_id=org_provision_args.provision_options.owning_user_id,
-                cell_name=region_name,
+                cell_name=resolved_cell_name,
             )
 
             org_slug_res.save(unsafe_write=True)
             create_organization_provisioning_outbox(
                 organization_id=org_id,
-                region_name=region_name,
+                region_name=resolved_cell_name,
                 org_provision_payload=provision_payload,
             ).save()
 
@@ -174,18 +181,25 @@ class DatabaseBackedControlOrganizationProvisioningService(
         return serialize_slug_reservation(org_slug_res)
 
     def idempotent_provision_organization(
-        self, *, region_name: str, org_provision_args: OrganizationProvisioningOptions
+        self,
+        *,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
+        org_provision_args: OrganizationProvisioningOptions,
     ) -> RpcOrganizationSlugReservation | None:
         raise NotImplementedError()
 
     def update_organization_slug(
         self,
         *,
-        region_name: str,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
         organization_id: int,
         desired_slug: str,
         require_exact: bool = True,
     ) -> RpcOrganizationSlugReservation:
+        resolved_cell_name = cell_name or region_name
+        assert resolved_cell_name is not None, "cell_name or region_name must be provided"
         existing_slug_reservations = list(
             OrganizationSlugReservation.objects.filter(organization_id=organization_id)
         )
@@ -206,12 +220,12 @@ class DatabaseBackedControlOrganizationProvisioningService(
         # If there's already a matching primary slug reservation for the org,
         # just replicate it to the region to kick off the organization sync process
         if existing_primary_alias and existing_primary_alias.slug == desired_slug:
-            existing_primary_alias.handle_async_replication(region_name, organization_id)
+            existing_primary_alias.handle_async_replication(resolved_cell_name, organization_id)
             return serialize_slug_reservation(existing_primary_alias)
 
         slug_base = desired_slug
         if not require_exact:
-            slug_base = self._generate_org_slug(region_name=region_name, slug=slug_base)
+            slug_base = self._generate_org_slug(region_name=resolved_cell_name, slug=slug_base)
 
         try:
             with outbox_context(
@@ -221,7 +235,7 @@ class DatabaseBackedControlOrganizationProvisioningService(
                     slug=slug_base,
                     organization_id=organization_id,
                     user_id=-1,
-                    cell_name=region_name,
+                    cell_name=resolved_cell_name,
                     reservation_type=OrganizationSlugReservationType.TEMPORARY_RENAME_ALIAS.value,
                 ).save(unsafe_write=True)
 
@@ -290,19 +304,23 @@ class DatabaseBackedControlOrganizationProvisioningService(
     def bulk_create_organization_slug_reservations(
         self,
         *,
-        region_name: str,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
         slug_mapping: dict[int, str],
     ) -> None:
+        resolved_cell_name = cell_name or region_name
+        assert resolved_cell_name is not None, "cell_name or region_name must be provided"
+
         slug_reservations_to_create: list[OrganizationSlugReservation] = []
 
         with outbox_context(transaction.atomic(router.db_for_write(OrganizationSlugReservation))):
             for org_id, slug in slug_mapping.items():
                 slug_reservation = OrganizationSlugReservation(
-                    slug=self._generate_org_slug(slug=slug, region_name=region_name),
+                    slug=self._generate_org_slug(slug=slug, region_name=resolved_cell_name),
                     organization_id=org_id,
                     reservation_type=OrganizationSlugReservationType.TEMPORARY_RENAME_ALIAS.value,
                     user_id=-1,
-                    cell_name=region_name,
+                    cell_name=resolved_cell_name,
                 )
                 slug_reservation.save(unsafe_write=True)
 

--- a/src/sentry/hybridcloud/services/control_organization_provisioning/service.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/service.py
@@ -19,13 +19,17 @@ class ControlOrganizationProvisioningRpcService(RpcService):
     @abstractmethod
     @rpc_method
     def provision_organization(
-        self, *, region_name: str, org_provision_args: OrganizationProvisioningOptions
+        self,
+        *,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
+        org_provision_args: OrganizationProvisioningOptions,
     ) -> RpcOrganizationSlugReservation:
         """
         Provisions an organization, an organization member, and team based on the provisioning args passed.
 
         In the event of a slug conflict, a new slug will be generated using the provided slug as a seed.
-        :param region_name: The region to provision the organization in.
+        :param cell_name: The cell to provision the organization in.
         :param org_provision_args: Provisioning and post-provisioning options for the organization.
         :return: RpcOrganizationSlugReservation containing the organization ID and slug.
         """
@@ -33,7 +37,11 @@ class ControlOrganizationProvisioningRpcService(RpcService):
     @abstractmethod
     @rpc_method
     def idempotent_provision_organization(
-        self, *, region_name: str, org_provision_args: OrganizationProvisioningOptions
+        self,
+        *,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
+        org_provision_args: OrganizationProvisioningOptions,
     ) -> RpcOrganizationSlugReservation | None:
         """
         Provisions an organization, an organization member, and team based on the provisioning args passed.
@@ -43,7 +51,7 @@ class ControlOrganizationProvisioningRpcService(RpcService):
 
         Note: This is not intended to be used for normal organization provisioning; but rather, for use-cases
         such as integrations which require strong idempotency.
-        :param region_name: The region to provision the organization in.
+        :param cell_name: The cell to provision the organization in.
         :param org_provision_args: Provisioning and post-provisioning options for the organization.
         :return: RpcOrganization the organization ID and slug.
         """
@@ -53,7 +61,8 @@ class ControlOrganizationProvisioningRpcService(RpcService):
     def update_organization_slug(
         self,
         *,
-        region_name: str,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
         organization_id: int,
         desired_slug: str,
         require_exact: bool = True,
@@ -66,7 +75,7 @@ class ControlOrganizationProvisioningRpcService(RpcService):
         outbox to the desired region in order to ensure that a slug change in control _will eventually_
         result in a slug change on the region side.
 
-        :param region_name: The region where the organization exists
+        :param cell_name: The cell where the organization exists
         :param organization_id: the ID of the organization whose slug to change
         :param desired_slug: The slug to update the organization with
         :param require_exact: Determines whether the slug can be modified with a unique suffix in the
@@ -79,17 +88,16 @@ class ControlOrganizationProvisioningRpcService(RpcService):
     def bulk_create_organization_slug_reservations(
         self,
         *,
-        region_name: str,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
         slug_mapping: dict[int, str],
     ) -> None:
         """
         Only really intended for bulk organization import usage. Creates unique organization slug
         reservations for the given list of IDs and slug bases for organizations already provisioned
-        in the provided region.
+        in the provided cell.
 
-        :param region_name: The region where the imported organization exist
-        :param organization_ids_and_slugs: A set of ID and base slug tuples to reserve slugs for.
-            This parameter is deprecated. Use slug_mapping instead.
+        :param cell_name: The cell where the imported organizations exist
         :param slug_mapping: A map of organization id -> slug to reserve.
         :return:
         """

--- a/src/sentry/hybridcloud/services/region_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/region_organization_provisioning/impl.py
@@ -166,9 +166,24 @@ class DatabaseBackedRegionOrganizationProvisioningRpcService(
 
         return True
 
+    def create_organization_in_cell(
+        self,
+        *,
+        cell_name: str,
+        organization_id: int,
+        provision_payload: OrganizationProvisioningOptions,
+    ) -> bool:
+        return self.create_organization_in_region(
+            region_name=cell_name,
+            organization_id=organization_id,
+            provision_payload=provision_payload,
+        )
+
     def update_organization_slug_from_reservation(
         self,
-        region_name: str,
+        *,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
         org_slug_temporary_alias_res: RpcOrganizationSlugReservation,
     ) -> bool:
         # Skip any non-primary organization slug updates

--- a/src/sentry/hybridcloud/services/region_organization_provisioning/service.py
+++ b/src/sentry/hybridcloud/services/region_organization_provisioning/service.py
@@ -29,12 +29,25 @@ class RegionOrganizationProvisioningRpcService(RpcService):
         provision_payload: OrganizationProvisioningOptions,
     ) -> bool:
         """
+        TODO(cells): Deprecated, remove method when all callers are updated to use cell_name create_organization_in_cell
+        """
+
+    @regional_rpc_method(resolve=ByCellName())
+    @abstractmethod
+    def create_organization_in_cell(
+        self,
+        *,
+        cell_name: str,
+        organization_id: int,
+        provision_payload: OrganizationProvisioningOptions,
+    ) -> bool:
+        """
         CAUTION: THIS IS ONLY INTENDED TO BE USED BY THE `organization_provisioning` RPC SERVICE.
         DO NOT USE FOR LOCAL ORGANIZATION PROVISIONING.
 
-        An RPC method for creating an organization in the desired region.
+        An RPC method for creating an organization in the desired cell.
 
-        :param region_name: The region to create an organization in.
+        :param cell_name: The cell to create an organization in.
         :param organization_id: The desired organization's ID, which must be a snowflake ID.
         :param provision_payload: The provisioning options for the organization.
         """
@@ -43,7 +56,9 @@ class RegionOrganizationProvisioningRpcService(RpcService):
     @abstractmethod
     def update_organization_slug_from_reservation(
         self,
-        region_name: str,
+        *,
+        cell_name: str | None = None,  # TODO(cells): make required when all callers are updated
+        region_name: str | None = None,  # TODO(cells): remove when all callers are updated
         org_slug_temporary_alias_res: RpcOrganizationSlugReservation,
     ) -> bool:
         """
@@ -53,7 +68,7 @@ class RegionOrganizationProvisioningRpcService(RpcService):
         An RPC method for processing a slug change on the region, after it has been reserved
         as a temporary alias in the control silo.
 
-        :param region_name: The region name where the organization resides.
+        :param cell_name: The cell where the organization resides.
         :param org_slug_temporary_alias_res: OrganizationSlugReservation for the new temporary alias.
         :return: True if provisioning succeeded, False if a conflict occurred
         """

--- a/src/sentry/hybridcloud/services/region_organization_provisioning/service.py
+++ b/src/sentry/hybridcloud/services/region_organization_provisioning/service.py
@@ -29,7 +29,7 @@ class RegionOrganizationProvisioningRpcService(RpcService):
         provision_payload: OrganizationProvisioningOptions,
     ) -> bool:
         """
-        TODO(cells): Deprecated, remove method when all callers are updated to use cell_name create_organization_in_cell
+        TODO(cells): Deprecated, remove method when all callers are updated to use create_organization_in_cell
         """
 
     @regional_rpc_method(resolve=ByCellName())

--- a/tests/sentry/hybridcloud/services/test_region_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/services/test_region_organization_provisioning.py
@@ -69,8 +69,8 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
         user = self.create_user()
         provision_options = self.get_provisioning_args(user)
         organization_id = 42
-        result = region_organization_provisioning_rpc_service.create_organization_in_region(
-            organization_id=organization_id, provision_payload=provision_options, region_name="us"
+        result = region_organization_provisioning_rpc_service.create_organization_in_cell(
+            organization_id=organization_id, provision_payload=provision_options, cell_name="us"
         )
 
         assert result
@@ -83,8 +83,8 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
         user = self.create_user()
         provision_options = self.get_provisioning_args(user, create_default_team=False)
         organization_id = 42
-        result = region_organization_provisioning_rpc_service.create_organization_in_region(
-            organization_id=organization_id, provision_payload=provision_options, region_name="us"
+        result = region_organization_provisioning_rpc_service.create_organization_in_cell(
+            organization_id=organization_id, provision_payload=provision_options, cell_name="us"
         )
 
         assert result
@@ -104,8 +104,8 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
         assert existing_org.id == organization_id
 
         provision_options = self.get_provisioning_args(user, create_default_team=False)
-        result = region_organization_provisioning_rpc_service.create_organization_in_region(
-            organization_id=organization_id, provision_payload=provision_options, region_name="us"
+        result = region_organization_provisioning_rpc_service.create_organization_in_cell(
+            organization_id=organization_id, provision_payload=provision_options, cell_name="us"
         )
 
         assert result
@@ -125,8 +125,8 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
 
         provisioning_user = self.create_user()
         provision_options = self.get_provisioning_args(provisioning_user, create_default_team=False)
-        result = region_organization_provisioning_rpc_service.create_organization_in_region(
-            organization_id=organization_id, provision_payload=provision_options, region_name="us"
+        result = region_organization_provisioning_rpc_service.create_organization_in_cell(
+            organization_id=organization_id, provision_payload=provision_options, cell_name="us"
         )
 
         assert not result
@@ -142,8 +142,8 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
         user = self.create_user()
         provision_options = self.get_provisioning_args(user)
         provision_options.provision_options.name = "a" * 128
-        result = region_organization_provisioning_rpc_service.create_organization_in_region(
-            organization_id=42, provision_payload=provision_options, region_name="us"
+        result = region_organization_provisioning_rpc_service.create_organization_in_cell(
+            organization_id=42, provision_payload=provision_options, cell_name="us"
         )
 
         assert result is True
@@ -161,8 +161,8 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
 
         provisioning_user = self.create_user()
         provision_options = self.get_provisioning_args(provisioning_user)
-        result = region_organization_provisioning_rpc_service.create_organization_in_region(
-            organization_id=organization_id, provision_payload=provision_options, region_name="us"
+        result = region_organization_provisioning_rpc_service.create_organization_in_cell(
+            organization_id=organization_id, provision_payload=provision_options, cell_name="us"
         )
 
         assert not result
@@ -183,8 +183,8 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
         )
 
         provision_options = self.get_provisioning_args(user)
-        result = region_organization_provisioning_rpc_service.create_organization_in_region(
-            organization_id=organization_id, provision_payload=provision_options, region_name="us"
+        result = region_organization_provisioning_rpc_service.create_organization_in_cell(
+            organization_id=organization_id, provision_payload=provision_options, cell_name="us"
         )
 
         assert not result
@@ -201,8 +201,8 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
         self.create_organization(slug="santry", name="Santry", owner=user)
 
         provision_options = self.get_provisioning_args(user)
-        result = region_organization_provisioning_rpc_service.create_organization_in_region(
-            organization_id=organization_id, provision_payload=provision_options, region_name="us"
+        result = region_organization_provisioning_rpc_service.create_organization_in_cell(
+            organization_id=organization_id, provision_payload=provision_options, cell_name="us"
         )
 
         assert not result
@@ -217,10 +217,10 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
         user = self.create_user()
         provision_options = self.get_provisioning_args(user)
         organization_id = 42
-        region_organization_provisioning_rpc_service.create_organization_in_region(
+        region_organization_provisioning_rpc_service.create_organization_in_cell(
             organization_id=organization_id,
             provision_payload=provision_options,
-            region_name="us",
+            cell_name="us",
         )
         with assume_test_silo_mode(SiloMode.REGION):
             org: Organization = Organization.objects.get(id=organization_id)


### PR DESCRIPTION
- `create_organization_in_cell` is created as a replacement to `create_organization_in_region`
- 4 other methods (provision_organization, idempotent_provision_organization, update_organization_slug, bulk_create_organization_slug_reservations) now accepted `cell_name` as well as `region_name`
- none of callers are updated yet, we will wait for new method signatures to be updated on all pods first
