### PR TITLE
fix(dashboards): Register agents_traces_table display type in backend

### DIFF
--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -179,6 +179,7 @@ class DashboardWidgetDisplayTypes(TypesClass):
     RAGE_AND_DEAD_CLICKS = 11
     SERVER_TREE = 12
     TEXT = 13
+    AGENTS_TRACES_TABLE = 14
     TYPES = [
         (LINE_CHART, "line"),
         (AREA_CHART, "area"),
@@ -193,6 +194,7 @@ class DashboardWidgetDisplayTypes(TypesClass):
         (RAGE_AND_DEAD_CLICKS, "rage_and_dead_clicks"),
         (SERVER_TREE, "server_tree"),
         (TEXT, "text"),
+        (AGENTS_TRACES_TABLE, "agents_traces_table"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
 


### PR DESCRIPTION
The frontend defines `DisplayType.AGENTS_TRACES_TABLE = 'agents_traces_table'` but the backend `DashboardWidgetDisplayTypes` does not include this value. The DRF serializer uses `ChoiceField(choices=DashboardWidgetDisplayTypes.as_text_choices())`, so it rejects `"agents_traces_table"` as an invalid choice when saving the AI Agents Overview dashboard.

Adds `AGENTS_TRACES_TABLE = 14` to `DashboardWidgetDisplayTypes` and its corresponding entry in the `TYPES` list. No migration needed since `display_type` is a `BoundedPositiveIntegerField` — the choices are only used for validation, not the DB schema.

Refs DAIN-1301