### PR TITLE
fix(safe): Handle None query parameter in safe_urlencode

### DIFF
--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -195,8 +195,11 @@ def safe_urlencode(query, **kwargs):
     """
     django.utils.http.urlencode wrapper that replaces query parameter values
     of None with empty string so that urlencode doesn't raise TypeError
-    "Cannot encode None in a query string".
+    "Cannot encode None in a query string". Returns empty string if query
+    itself is None.
     """
+    if query is None:
+        return ""
     # sequence of 2-element tuples
     if isinstance(query, (list, tuple)):
         query_seq = ((pair[0], "" if pair[1] is None else pair[1]) for pair in query)

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -201,3 +201,6 @@ class SafeUrlencodeTest(unittest.TestCase):
         assert d == [["1", None], ["3", "4"]]
         d = [["1", "2"], ["3", "4"]]
         assert safe_urlencode(d) == "1=2&3=4"
+
+    def test_none(self) -> None:
+        assert safe_urlencode(None) == ""


### PR DESCRIPTION
Fixes SENTRY-40GD

Some code paths end up passing `None` to `safe_urlencode` which raises an error. The point of the function is to be safe, so it makes sense that we'd want to return an empty string here.