### PR TITLE
feat(dashboards): Add analytics events to onboarding CTAs on Project Details

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -169,16 +169,12 @@ export type TeamInsightsEventParameters = {
     project_id: string;
     rule_ids: string[];
   };
-  'project_detail.alerts_create_alert_clicked': Record<string, unknown>;
-  'project_detail.alerts_learn_more_clicked': Record<string, unknown>;
   'project_detail.change_chart': {chart_index: number; metric: string};
   'project_detail.open_anr_issues': Record<string, unknown>;
   'project_detail.open_discover': Record<string, unknown>;
   'project_detail.open_issues': Record<string, unknown>;
-  'project_detail.performance_setup_clicked': Record<string, unknown>;
   'project_detail.performance_tour.advance': BaseTour;
   'project_detail.performance_tour.close': BaseTour;
-  'project_detail.releases_setup_clicked': Record<string, unknown>;
   'project_detail.releases_tour.advance': ReleasesTour;
   'project_detail.releases_tour.close': ReleasesTour;
   'release_detail.pagination': {direction: string};
@@ -255,14 +251,8 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'project_detail.open_discover': 'Project Detail: Open discover from project detail',
   'project_detail.open_anr_issues': 'Project Detail: Open issues from ANR rate scorecard',
   'project_detail.change_chart': 'Project Detail: Change Chart',
-  'project_detail.alerts_create_alert_clicked':
-    'Project Detail: Alerts Create Alert Clicked',
-  'project_detail.alerts_learn_more_clicked': 'Project Detail: Alerts Learn More Clicked',
-  'project_detail.performance_setup_clicked':
-    'Project Detail: Performance Start Setup Clicked',
   'project_detail.performance_tour.advance': 'Project Detail: Performance Tour Advance',
   'project_detail.performance_tour.close': 'Project Detail: Performance Tour Close',
-  'project_detail.releases_setup_clicked': 'Project Detail: Releases Start Setup Clicked',
   'project_detail.releases_tour.advance': 'Project Detail: Releases Tour Advance',
   'project_detail.releases_tour.close': 'Project Detail: Releases Tour Close',
   'release_detail.pagination': 'Release Detail: Pagination',

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -169,12 +169,16 @@ export type TeamInsightsEventParameters = {
     project_id: string;
     rule_ids: string[];
   };
+  'project_detail.alerts_create_alert_clicked': Record<string, unknown>;
+  'project_detail.alerts_learn_more_clicked': Record<string, unknown>;
   'project_detail.change_chart': {chart_index: number; metric: string};
   'project_detail.open_anr_issues': Record<string, unknown>;
   'project_detail.open_discover': Record<string, unknown>;
   'project_detail.open_issues': Record<string, unknown>;
+  'project_detail.performance_setup_clicked': Record<string, unknown>;
   'project_detail.performance_tour.advance': BaseTour;
   'project_detail.performance_tour.close': BaseTour;
+  'project_detail.releases_setup_clicked': Record<string, unknown>;
   'project_detail.releases_tour.advance': ReleasesTour;
   'project_detail.releases_tour.close': ReleasesTour;
   'release_detail.pagination': {direction: string};
@@ -251,8 +255,14 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'project_detail.open_discover': 'Project Detail: Open discover from project detail',
   'project_detail.open_anr_issues': 'Project Detail: Open issues from ANR rate scorecard',
   'project_detail.change_chart': 'Project Detail: Change Chart',
+  'project_detail.alerts_create_alert_clicked':
+    'Project Detail: Alerts Create Alert Clicked',
+  'project_detail.alerts_learn_more_clicked': 'Project Detail: Alerts Learn More Clicked',
+  'project_detail.performance_setup_clicked':
+    'Project Detail: Performance Start Setup Clicked',
   'project_detail.performance_tour.advance': 'Project Detail: Performance Tour Advance',
   'project_detail.performance_tour.close': 'Project Detail: Performance Tour Close',
+  'project_detail.releases_setup_clicked': 'Project Detail: Releases Start Setup Clicked',
   'project_detail.releases_tour.advance': 'Project Detail: Releases Tour Advance',
   'project_detail.releases_tour.close': 'Project Detail: Releases Tour Close',
   'release_detail.pagination': 'Release Detail: Pagination',

--- a/static/app/views/projectDetail/missingFeatureButtons/missingAlertsButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingAlertsButtons.tsx
@@ -23,10 +23,18 @@ function MissingAlertsButtons({organization, projectSlug}: Props) {
         referrer="project_detail"
         projectSlug={projectSlug}
         hideIcon
+        analyticsEventKey="project_detail.alerts_create_alert_clicked"
+        analyticsEventName="Project Detail: Alerts Create Alert Clicked"
       >
         {t('Create Alert')}
       </CreateAlertButton>
-      <LinkButton size="sm" external href={DOCS_URL}>
+      <LinkButton
+        size="sm"
+        external
+        href={DOCS_URL}
+        analyticsEventKey="project_detail.alerts_learn_more_clicked"
+        analyticsEventName="Project Detail: Alerts Learn More Clicked"
+      >
         {t('Learn More')}
       </LinkButton>
     </Grid>

--- a/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
@@ -77,7 +77,12 @@ function MissingPerformanceButtons({organization}: Props) {
           doneUrl={DOCS_URL}
         >
           {({showModal}) => (
-            <Button size="sm" onClick={showModal}>
+            <Button
+              size="sm"
+              onClick={showModal}
+              analyticsEventKey="project_detail.performance_tour_clicked"
+              analyticsEventName="Project Detail: Performance Get Tour Clicked"
+            >
               {t('Get Tour')}
             </Button>
           )}

--- a/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
@@ -56,9 +56,10 @@ function MissingPerformanceButtons({organization}: Props) {
         <Button
           size="sm"
           priority="primary"
+          analyticsEventKey="project_detail.performance_setup_clicked"
+          analyticsEventName="Project Detail: Performance Start Setup Clicked"
           onClick={event => {
             event.preventDefault();
-            // TODO: add analytics here for this specific action.
             navigateTo(
               `${getPerformanceBaseUrl(organization.slug, domainView)}/?project=:project#performance-sidequest`,
               router

--- a/static/app/views/projectDetail/missingFeatureButtons/missingReleasesButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingReleasesButtons.tsx
@@ -55,6 +55,8 @@ function MissingReleasesButtons({organization, health, projectId, platform}: Pro
         href={health ? DOCS_HEALTH_URL : DOCS_URL}
         disabled={setupDisabled}
         tooltipProps={{title: setupDisabled ? setupDisabledTooltip : undefined}}
+        analyticsEventKey="project_detail.releases_setup_clicked"
+        analyticsEventName="Project Detail: Releases Start Setup Clicked"
       >
         {t('Start Setup')}
       </LinkButton>

--- a/static/app/views/projectDetail/missingFeatureButtons/missingReleasesButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingReleasesButtons.tsx
@@ -69,7 +69,12 @@ function MissingReleasesButtons({organization, health, projectId, platform}: Pro
           doneUrl={health ? DOCS_HEALTH_URL : DOCS_URL}
         >
           {({showModal}) => (
-            <Button size="sm" onClick={showModal}>
+            <Button
+              size="sm"
+              onClick={showModal}
+              analyticsEventKey="project_detail.releases_tour_clicked"
+              analyticsEventName="Project Detail: Releases Get Tour Clicked"
+            >
               {t('Get Tour')}
             </Button>
           )}


### PR DESCRIPTION
Add analytics tracking to the performance, releases, and alerts onboarding CTA buttons on the Project Details page. This will help us understand how often these CTAs are clicked, informing decisions about whether to keep or remove this page.

Refs DAIN-1310