### PR TITLE
feat(autofix): Redesigned empty state for autofix section

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
@@ -5,7 +5,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DiffFileType} from 'sentry/components/events/autofix/types';
 import {EntryType} from 'sentry/types/event';
@@ -103,24 +103,6 @@ describe('AutofixSection', () => {
     );
 
     expect(container).toBeEmptyDOMElement();
-  });
-
-  it('renders group summary when no autofix artifacts exist', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
-      body: {autofix: null},
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/summarize/`,
-      method: 'POST',
-      body: {whatsWrong: 'Test what happened', possibleCause: 'Test cause'},
-    });
-
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
-      organization,
-    });
-
-    expect(await screen.findByText('Test cause')).toBeInTheDocument();
   });
 
   it('renders root cause artifact when autofix returns root cause', async () => {
@@ -306,6 +288,61 @@ describe('AutofixSection', () => {
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
   });
 
+  it('shows loading place holder while event is pending', () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+      body: {
+        autofix: {
+          run_id: 1,
+          status: 'completed',
+          updated_at: new Date().toISOString(),
+          blocks: [
+            {
+              id: 'block-1',
+              message: {content: 'Created PR', role: 'assistant'},
+              timestamp: new Date().toISOString(),
+              merged_file_patches: [
+                {
+                  repo_name: 'org/repo',
+                  patch: {
+                    path: 'src/app.py',
+                    added: 1,
+                    removed: 0,
+                    hunks: [],
+                    source_file: 'src/app.py',
+                    target_file: 'src/app.py',
+                    type: DiffFileType.MODIFIED,
+                  },
+                },
+              ],
+            },
+          ],
+          repo_pr_states: {
+            'org/repo': {
+              repo_name: 'org/repo',
+              pr_number: 42,
+              pr_url: 'https://github.com/org/repo/pull/42',
+              branch_name: 'fix/issue',
+              commit_sha: 'abc123',
+              pr_creation_error: null,
+              pr_creation_status: 'completed',
+              pr_id: 1,
+              title: 'Fix null pointer',
+            },
+          },
+        },
+      },
+    });
+
+    render(<AutofixSection event={undefined} group={mockGroup} project={mockProject} />, {
+      organization,
+    });
+
+    // The Seer title should still render
+    expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+  });
+
   it('shows loading placeholder while autofix data is pending', () => {
     // Don't add autofix mock response so the query stays pending
     MockApiClient.addMockResponse({
@@ -320,6 +357,7 @@ describe('AutofixSection', () => {
 
     // The Seer title should still render
     expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
   });
 
   it('renders multiple artifact types in order', async () => {
@@ -383,34 +421,36 @@ describe('AutofixSection', () => {
     expect(screen.getByText('Code Changes')).toBeInTheDocument();
   });
 
-  it('renders resources when no summary and no autofix artifacts', async () => {
-    const performanceGroup: Group = {
-      ...mockGroup,
-      issueCategory: IssueCategory.PERFORMANCE,
-      title: 'ChunkLoadError',
-      platform: 'javascript',
-    };
-
-    const javascriptProject: Project = {...mockProject, platform: 'javascript'};
-
+  it('shows empty state when there are no artifacts', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
-      body: {autofix: null},
+      body: {
+        autofix: {
+          run_id: 1,
+          status: 'completed',
+          updated_at: new Date().toISOString(),
+          blocks: [
+            {
+              id: 'block-1',
+              message: {content: 'Analysis complete', role: 'assistant'},
+              timestamp: new Date().toISOString(),
+              artifacts: [],
+            },
+          ],
+        },
+      },
     });
 
-    render(
-      <AutofixSection
-        event={mockEvent}
-        group={performanceGroup}
-        project={javascriptProject}
-      />,
-      {organization}
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', {name: 'How to fix ChunkLoadErrors'})
-      ).toBeInTheDocument();
+    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+      organization,
     });
+
+    expect(await screen.findByText('Have Seer...')).toBeInTheDocument();
+    expect(
+      screen.getByText('Determine the root cause of your issue')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Outline a plan')).toBeInTheDocument();
+    expect(screen.getByText('Create a code fix')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Fix the Issue'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -160,10 +160,13 @@ function AutofixEmptyState({autofix, group, event, project}: AutofixEmptyStatePr
     event,
   });
 
+  // extract startStep first here so we can depend on it directly as `autofix` itself is unstable.
+  const startStep = autofix.startStep;
+
   const handleStartRootCause = useCallback(() => {
-    autofix.startStep('root_cause');
+    startStep('root_cause');
     openSeerDrawer();
-  }, [autofix, openSeerDrawer]);
+  }, [startStep, openSeerDrawer]);
 
   return (
     <Flex direction="column" gap="xl">

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -1,6 +1,11 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo, type CSSProperties} from 'react';
+import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import seerConfigConnectImg from 'sentry-images/spot/seer-config-connect-2.svg';
+
+import {Button} from '@sentry/scraps/button';
+import {Image} from '@sentry/scraps/image';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
@@ -15,8 +20,8 @@ import {
   RootCausePreview,
   SolutionPreview,
 } from 'sentry/components/events/autofix/v3/autofixPreviews';
-import {GroupSummary} from 'sentry/components/group/groupSummary';
 import Placeholder from 'sentry/components/placeholder';
+import {IconBug} from 'sentry/icons';
 import {IconSeer} from 'sentry/icons/iconSeer';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -24,11 +29,11 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {isArrayOf} from 'sentry/types/utils';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import type {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {SidebarFoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 import Resources from 'sentry/views/issueDetails/streamline/sidebar/resources';
+import {useOpenSeerDrawer} from 'sentry/views/issueDetails/streamline/sidebar/seerDrawer';
 import {isExplorerFilePatch, isRepoPRState} from 'sentry/views/seerExplorer/types';
 
 interface AutofixSectionProps {
@@ -81,83 +86,128 @@ export function AutofixSection({group, project, event}: AutofixSectionProps) {
       sectionKey={SectionKey.SEER}
       preventCollapse={false}
     >
-      <AutofixContent
-        aiConfig={aiConfig}
-        issueTypeConfig={issueTypeConfig}
-        group={group}
-        project={project}
-        event={event}
-      />
+      <AutofixContent group={group} project={project} event={event} />
     </SidebarFoldSection>
   );
 }
 
 interface AutofixContentProps {
-  aiConfig: ReturnType<typeof useAiConfig>;
   group: Group;
-  issueTypeConfig: IssueTypeConfig;
   project: Project;
   event?: Event;
 }
 
-function AutofixContent({
-  aiConfig,
-  group,
-  issueTypeConfig,
-  project,
-  event,
-}: AutofixContentProps) {
+function AutofixContent({group, project, event}: AutofixContentProps) {
   const autofix = useExplorerAutofix(group.id);
   const artifacts = useMemo(
     () => getOrderedAutofixArtifacts(autofix.runState),
     [autofix.runState]
   );
 
-  if (autofix.isLoading) {
+  if (autofix.isLoading || !event) {
     return <Placeholder height="160px" />;
   }
 
-  if (artifacts.length) {
+  if (!artifacts.length) {
     return (
-      <Flex direction="column" gap="xl">
-        {artifacts.map(artifact => {
-          // there should only be 1 artifact of each type
-          if (isRootCauseArtifact(artifact)) {
-            return <RootCausePreview key="root-cause" artifact={artifact} />;
-          }
-
-          if (isSolutionArtifact(artifact)) {
-            return <SolutionPreview key="solution" artifact={artifact} />;
-          }
-
-          if (isArrayOf(artifact, isExplorerFilePatch) && artifact.length) {
-            return <CodeChangesPreview key="code-changes" artifact={artifact} />;
-          }
-
-          if (isArrayOf(artifact, isRepoPRState) && artifact.length) {
-            return <PullRequestsPreview key="pull-requests" artifact={artifact} />;
-          }
-
-          // TODO: maybe send a log?
-          return null;
-        })}
-      </Flex>
-    );
-  }
-
-  if (aiConfig.hasSummary) {
-    return <GroupSummary group={group} event={event} project={project} preview />;
-  }
-
-  if (issueTypeConfig.resources) {
-    return (
-      <Resources
-        configResources={issueTypeConfig.resources}
-        eventPlatform={event?.platform}
+      <AutofixEmptyState
+        autofix={autofix}
+        event={event}
         group={group}
+        project={project}
       />
     );
   }
 
-  return null;
+  return (
+    <Flex direction="column" gap="xl">
+      {artifacts.map(artifact => {
+        // there should only be 1 artifact of each type
+        if (isRootCauseArtifact(artifact)) {
+          return <RootCausePreview key="root-cause" artifact={artifact} />;
+        }
+
+        if (isSolutionArtifact(artifact)) {
+          return <SolutionPreview key="solution" artifact={artifact} />;
+        }
+
+        if (isArrayOf(artifact, isExplorerFilePatch) && artifact.length) {
+          return <CodeChangesPreview key="code-changes" artifact={artifact} />;
+        }
+
+        if (isArrayOf(artifact, isRepoPRState) && artifact.length) {
+          return <PullRequestsPreview key="pull-requests" artifact={artifact} />;
+        }
+
+        // TODO: maybe send a log?
+        return null;
+      })}
+    </Flex>
+  );
 }
+
+interface AutofixEmptyStateProps {
+  autofix: ReturnType<typeof useExplorerAutofix>;
+  event: Event;
+  group: Group;
+  project: Project;
+}
+
+function AutofixEmptyState({autofix, group, event, project}: AutofixEmptyStateProps) {
+  const {openSeerDrawer} = useOpenSeerDrawer({
+    group,
+    project,
+    event,
+  });
+
+  const handleStartRootCause = useCallback(() => {
+    autofix.startStep('root_cause');
+    openSeerDrawer();
+  }, [autofix, openSeerDrawer]);
+
+  return (
+    <Flex direction="column" gap="xl">
+      <Flex
+        border="muted"
+        radius="md"
+        padding="lg"
+        gap="lg"
+        align="center"
+        justify="between"
+      >
+        <Container>
+          <Text>{t('Have Seer...')}</Text>
+          <Container as="ol" margin="0">
+            <li>{t('Determine the root cause of your issue')}</li>
+            <li>{t('Outline a plan')}</li>
+            <li>{t('Create a code fix')}</li>
+          </Container>
+        </Container>
+        <ImageContainer
+          justify="end"
+          align="center"
+          aspectRatio="9 / 16"
+          height={{'2xs': '78px', lg: '98px'}}
+        >
+          <Image src={seerConfigConnectImg} alt="" width="auto" height="100%" />
+        </ImageContainer>
+      </Flex>
+      <Button
+        size="md"
+        icon={<IconBug />}
+        aria-label={t('Fix the Issue')}
+        tooltipProps={{title: t('Fix the Issue')}}
+        priority="primary"
+        onClick={handleStartRootCause}
+      >
+        {t('Fix the Issue')}
+      </Button>
+    </Flex>
+  );
+}
+
+const ImageContainer = styled(Flex)<{
+  aspectRatio?: CSSProperties['aspectRatio'];
+}>`
+  ${p => p.aspectRatio && `aspect-ratio: ${p.aspectRatio}`};
+`;


### PR DESCRIPTION
This replaces the empty state from the group summary to a CTA to start RCA.