### PR TITLE
ref(grouping): Move `GroupingContext` to new module

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -10,6 +10,7 @@ import sentry_sdk
 from sentry import options
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.grouping.component import ContributingComponent, RootGroupingComponent
+from sentry.grouping.context import GroupingContext
 from sentry.grouping.enhancer import (
     DEFAULT_ENHANCEMENTS_BASE,
     EnhancementsConfig,
@@ -23,7 +24,6 @@ from sentry.grouping.fingerprinting.utils import (
     is_default_fingerprint_var,
     resolve_fingerprint_values,
 )
-from sentry.grouping.strategies.base import GroupingContext
 from sentry.grouping.strategies.configurations import GROUPING_CONFIG_CLASSES
 from sentry.grouping.utils import hash_from_values
 from sentry.grouping.variants import (

--- a/src/sentry/grouping/context.py
+++ b/src/sentry/grouping/context.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Self
+
+if TYPE_CHECKING:
+    from sentry.grouping.strategies.base import StrategyConfiguration
+    from sentry.services.eventstore.models import Event
+
+
+# XXX: Want to make ContextDict typeddict but also want to type/overload dict
+# API on GroupingContext
+ContextValue = Any
+ContextDict = dict[str, ContextValue]
+
+
+class GroupingContext:
+    """
+    A key-value store used for passing state between strategy functions and other helpers used
+    during grouping.
+
+    Has a dictionary-like interface, along with a context manager which allows values to be
+    temporarily overwritten:
+
+        context = GroupingContext(...)
+        context["some_key"] = "original_value"
+
+        value_at_some_key = context["some_key"] # will be "original_value"
+        value_at_some_key = context.get("some_key") # will be "original_value"
+
+        value_at_another_key = context["another_key"] # will raise a KeyError
+        value_at_another_key = context.get("another_key") # will be None
+        value_at_another_key = context.get("another_key", "some_default") # will be "some_default"
+
+        with context:
+            context["some_key"] = "some_other_value"
+            value_at_some_key = context["some_key"] # will be "some_other_value"
+
+        value_at_some_key = context["some_key"] # will be "original_value"
+    """
+
+    def __init__(self, strategy_config: StrategyConfiguration, event: Event):
+        # The initial context is essentially the grouping config options
+        self._stack = [strategy_config.initial_context]
+        self.config = strategy_config
+        self.event = event
+        self._push_context_layer()
+
+    def __setitem__(self, key: str, value: ContextValue) -> None:
+        # Add the key-value pair to the context layer at the top of the stack
+        self._stack[-1][key] = value
+
+    def __getitem__(self, key: str) -> ContextValue:
+        # Walk down the stack from the top and return the first instance of `key` found
+        for d in reversed(self._stack):
+            if key in d:
+                return d[key]
+        raise KeyError(key)
+
+    def get(self, key: str, default: ContextValue | None = None) -> ContextValue | None:
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __enter__(self) -> Self:
+        self._push_context_layer()
+        return self
+
+    def __exit__(self, exc_type: type[Exception], exc_value: Exception, tb: Any) -> None:
+        self._pop_context_layer()
+
+    def _push_context_layer(self) -> None:
+        self._stack.append({})
+
+    def _pop_context_layer(self) -> None:
+        self._stack.pop()

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -163,38 +163,6 @@ class GroupingContext:
         """
         return _get_grouping_components_for_interface(interface, event, self, **kwargs)
 
-    @overload
-    def get_single_grouping_component(
-        self, interface: Frame, *, event: Event, **kwargs: Any
-    ) -> FrameGroupingComponent: ...
-
-    @overload
-    def get_single_grouping_component(
-        self, interface: SingleException, *, event: Event, **kwargs: Any
-    ) -> ExceptionGroupingComponent: ...
-
-    @overload
-    def get_single_grouping_component(
-        self, interface: Stacktrace, *, event: Event, **kwargs: Any
-    ) -> StacktraceGroupingComponent: ...
-
-    def get_single_grouping_component(
-        self, interface: Interface, *, event: Event, **kwargs: Any
-    ) -> FrameGroupingComponent | ExceptionGroupingComponent | StacktraceGroupingComponent:
-        """
-        Invoke the delegate grouping strategy corresponding to the given interface, returning the
-        grouping component for the variant set on the context.
-        """
-        variant_name = self["variant_name"]
-        assert variant_name is not None
-
-        components_by_variant = _get_grouping_components_for_interface(
-            interface, event, self, **kwargs
-        )
-
-        assert len(components_by_variant) == 1
-        return components_by_variant[variant_name]
-
 
 def lookup_strategy(strategy_id: str) -> Strategy[Any]:
     """Looks up a strategy by id."""
@@ -512,3 +480,39 @@ def _get_grouping_components_for_interface(
     assert isinstance(components_by_variant, dict)
 
     return components_by_variant
+
+
+@overload
+def get_single_grouping_component(
+    interface: Frame, event: Event, context: GroupingContext, **kwargs: Any
+) -> FrameGroupingComponent: ...
+
+
+@overload
+def get_single_grouping_component(
+    interface: SingleException, event: Event, context: GroupingContext, **kwargs: Any
+) -> ExceptionGroupingComponent: ...
+
+
+@overload
+def get_single_grouping_component(
+    interface: Stacktrace, event: Event, context: GroupingContext, **kwargs: Any
+) -> StacktraceGroupingComponent: ...
+
+
+def get_single_grouping_component(
+    interface: Interface, event: Event, context: GroupingContext, **kwargs: Any
+) -> FrameGroupingComponent | ExceptionGroupingComponent | StacktraceGroupingComponent:
+    """
+    Invoke the delegate grouping strategy corresponding to the given interface, returning the
+    grouping component for the variant set on the context.
+    """
+    variant_name = context["variant_name"]
+    assert variant_name is not None
+
+    components_by_variant = _get_grouping_components_for_interface(
+        interface, event, context, **kwargs
+    )
+
+    assert len(components_by_variant) == 1
+    return components_by_variant[variant_name]

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -152,17 +152,6 @@ class GroupingContext:
     def _pop_context_layer(self) -> None:
         self._stack.pop()
 
-    def get_grouping_components_by_variant(
-        self, interface: Interface, *, event: Event, **kwargs: Any
-    ) -> ComponentsByVariant:
-        """
-        Called by a strategy to invoke delegates on its child interfaces.
-
-        For example, the chained exception strategy calls this on the exceptions in the chain, and
-        the exception strategy calls this on each exception's stacktrace.
-        """
-        return _get_grouping_components_for_interface(interface, event, self, **kwargs)
-
 
 def lookup_strategy(strategy_id: str) -> Strategy[Any]:
     """Looks up a strategy by id."""
@@ -516,3 +505,15 @@ def get_single_grouping_component(
 
     assert len(components_by_variant) == 1
     return components_by_variant[variant_name]
+
+
+def get_grouping_components_by_variant(
+    interface: Interface, event: Event, context: GroupingContext, **kwargs: Any
+) -> ComponentsByVariant:
+    """
+    Called by a strategy to invoke delegates on its child interfaces.
+
+    For example, the chained exception strategy calls this on the exceptions in the chain, and
+    the exception strategy calls this on each exception's stacktrace.
+    """
+    return _get_grouping_components_for_interface(interface, event, context, **kwargs)

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -161,7 +161,7 @@ class GroupingContext:
         For example, the chained exception strategy calls this on the exceptions in the chain, and
         the exception strategy calls this on each exception's stacktrace.
         """
-        return self._get_grouping_components_for_interface(interface, event=event, **kwargs)
+        return _get_grouping_components_for_interface(interface, event, self, **kwargs)
 
     @overload
     def get_single_grouping_component(
@@ -188,33 +188,12 @@ class GroupingContext:
         variant_name = self["variant_name"]
         assert variant_name is not None
 
-        components_by_variant = self._get_grouping_components_for_interface(
-            interface, event=event, **kwargs
+        components_by_variant = _get_grouping_components_for_interface(
+            interface, event, self, **kwargs
         )
 
         assert len(components_by_variant) == 1
         return components_by_variant[variant_name]
-
-    def _get_grouping_components_for_interface(
-        self, interface: Interface, *, event: Event, **kwargs: Any
-    ) -> ComponentsByVariant:
-        """
-        Apply a delegate strategy to the given interface to get a dictionary of grouping components
-        keyed by variant name.
-        """
-        interface_id = interface.path
-        strategy = self.config.delegates.get(interface_id)
-
-        if strategy is None:
-            raise RuntimeError(f"No delegate strategy found for interface {interface_id}")
-
-        kwargs["context"] = self
-        kwargs["event"] = event
-
-        components_by_variant = strategy(interface, **kwargs)
-        assert isinstance(components_by_variant, dict)
-
-        return components_by_variant
 
 
 def lookup_strategy(strategy_id: str) -> Strategy[Any]:
@@ -509,5 +488,27 @@ def call_with_variants(
             component = components_by_stripped_variant[stripped_variant_name]
 
         components_by_variant[variant_name] = component
+
+    return components_by_variant
+
+
+def _get_grouping_components_for_interface(
+    interface: Interface, event: Event, context: GroupingContext, **kwargs: Any
+) -> ComponentsByVariant:
+    """
+    Apply a delegate strategy to the given interface to get a dictionary of grouping components
+    keyed by variant name.
+    """
+    interface_id = interface.path
+    strategy = context.config.delegates.get(interface_id)
+
+    if strategy is None:
+        raise RuntimeError(f"No delegate strategy found for interface {interface_id}")
+
+    kwargs["context"] = context
+    kwargs["event"] = event
+
+    components_by_variant = strategy(interface, **kwargs)
+    assert isinstance(components_by_variant, dict)
 
     return components_by_variant

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Sequence
-from typing import TYPE_CHECKING, Any, Generic, Protocol, Self, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, overload
 
 from sentry.grouping.component import (
     BaseGroupingComponent,
@@ -21,6 +21,7 @@ from sentry.interfaces.exception import SingleException
 from sentry.interfaces.stacktrace import Frame, Stacktrace
 
 if TYPE_CHECKING:
+    from sentry.grouping.context import GroupingContext
     from sentry.services.eventstore.models import Event
 
 
@@ -88,69 +89,6 @@ def strategy(
         return strategy_class
 
     return decorator
-
-
-class GroupingContext:
-    """
-    A key-value store used for passing state between strategy functions and other helpers used
-    during grouping.
-
-    Has a dictionary-like interface, along with a context manager which allows values to be
-    temporarily overwritten:
-
-        context = GroupingContext()
-        context["some_key"] = "original_value"
-
-        value_at_some_key = context["some_key"] # will be "original_value"
-        value_at_some_key = context.get("some_key") # will be "original_value"
-
-        value_at_another_key = context["another_key"] # will raise a KeyError
-        value_at_another_key = context.get("another_key") # will be None
-        value_at_another_key = context.get("another_key", "some_default") # will be "some_default"
-
-        with context:
-            context["some_key"] = "some_other_value"
-            value_at_some_key = context["some_key"] # will be "some_other_value"
-
-        value_at_some_key = context["some_key"] # will be "original_value"
-    """
-
-    def __init__(self, strategy_config: StrategyConfiguration, event: Event):
-        # The initial context is essentially the grouping config options
-        self._stack = [strategy_config.initial_context]
-        self.config = strategy_config
-        self.event = event
-        self._push_context_layer()
-
-    def __setitem__(self, key: str, value: ContextValue) -> None:
-        # Add the key-value pair to the context layer at the top of the stack
-        self._stack[-1][key] = value
-
-    def __getitem__(self, key: str) -> ContextValue:
-        # Walk down the stack from the top and return the first instance of `key` found
-        for d in reversed(self._stack):
-            if key in d:
-                return d[key]
-        raise KeyError(key)
-
-    def get(self, key: str, default: ContextValue | None = None) -> ContextValue | None:
-        try:
-            return self[key]
-        except KeyError:
-            return default
-
-    def __enter__(self) -> Self:
-        self._push_context_layer()
-        return self
-
-    def __exit__(self, exc_type: type[Exception], exc_value: Exception, tb: Any) -> None:
-        self._pop_context_layer()
-
-    def _push_context_layer(self) -> None:
-        self._stack.append({})
-
-    def _pop_context_layer(self) -> None:
-        self._stack.pop()
 
 
 def lookup_strategy(strategy_id: str) -> Strategy[Any]:

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 from sentry.grouping.component import MessageGroupingComponent
 from sentry.grouping.strategies.base import (
     ComponentsByVariant,
-    GroupingContext,
     produces_variants,
     strategy,
 )
@@ -13,6 +12,7 @@ from sentry.grouping.utils import normalize_message_for_grouping
 from sentry.interfaces.message import Message
 
 if TYPE_CHECKING:
+    from sentry.grouping.context import GroupingContext
     from sentry.services.eventstore.models import Event
 
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -26,7 +26,6 @@ from sentry.grouping.component import (
 )
 from sentry.grouping.strategies.base import (
     ComponentsByVariant,
-    GroupingContext,
     call_with_variants,
     get_grouping_components_by_variant,
     get_single_grouping_component,
@@ -42,6 +41,7 @@ from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.utils.safe import get_path
 
 if TYPE_CHECKING:
+    from sentry.grouping.context import GroupingContext
     from sentry.services.eventstore.models import Event
 
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -28,6 +28,7 @@ from sentry.grouping.strategies.base import (
     ComponentsByVariant,
     GroupingContext,
     call_with_variants,
+    get_single_grouping_component,
     strategy,
 )
 from sentry.grouping.strategies.utils import has_url_origin, remove_non_stacktrace_variants
@@ -490,7 +491,7 @@ def _single_stacktrace_variant(
     raw_frames = []
 
     for frame in frames:
-        frame_component = context.get_single_grouping_component(frame, event=event, **kwargs)
+        frame_component = get_single_grouping_component(frame, event, context, **kwargs)
         if _is_recursive_frame(frame, prev_frame):
             frame_component.update(contributes=False, hint="ignored due to recursion")
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -28,6 +28,7 @@ from sentry.grouping.strategies.base import (
     ComponentsByVariant,
     GroupingContext,
     call_with_variants,
+    get_grouping_components_by_variant,
     get_single_grouping_component,
     strategy,
 )
@@ -581,9 +582,7 @@ def single_exception(
         with context:
             context["exception_data"] = exception.to_json()
             stacktrace_components_by_variant: dict[str, StacktraceGroupingComponent] = (
-                context.get_grouping_components_by_variant(
-                    exception.stacktrace, event=event, **kwargs
-                )
+                get_grouping_components_by_variant(exception.stacktrace, event, context, **kwargs)
             )
     else:
         stacktrace_components_by_variant = {
@@ -651,7 +650,7 @@ def chained_exception(
 
     # For each exception, create a dictionary of grouping components by variant name
     exception_components_by_exception = {
-        id(exception): context.get_grouping_components_by_variant(exception, event=event, **kwargs)
+        id(exception): get_grouping_components_by_variant(exception, event, context, **kwargs)
         for exception in all_exceptions
     }
 
@@ -916,8 +915,8 @@ def _get_thread_components(
 
     thread_components_by_variant = {}
 
-    for variant_name, stacktrace_component in context.get_grouping_components_by_variant(
-        stacktrace, event=event, **kwargs
+    for variant_name, stacktrace_component in get_grouping_components_by_variant(
+        stacktrace, event, context, **kwargs
     ).items():
         thread_components_by_variant[variant_name] = ThreadsGroupingComponent(
             values=[stacktrace_component], frame_counts=stacktrace_component.frame_counts

--- a/src/sentry/grouping/strategies/security.py
+++ b/src/sentry/grouping/strategies/security.py
@@ -14,13 +14,13 @@ from sentry.grouping.component import (
 )
 from sentry.grouping.strategies.base import (
     ComponentsByVariant,
-    GroupingContext,
     produces_variants,
     strategy,
 )
 from sentry.interfaces.security import Csp, ExpectCT, ExpectStaple, Hpkp
 
 if TYPE_CHECKING:
+    from sentry.grouping.context import GroupingContext
     from sentry.services.eventstore.models import Event
 
 

--- a/src/sentry/grouping/strategies/template.py
+++ b/src/sentry/grouping/strategies/template.py
@@ -9,13 +9,13 @@ from sentry.grouping.component import (
 )
 from sentry.grouping.strategies.base import (
     ComponentsByVariant,
-    GroupingContext,
     produces_variants,
     strategy,
 )
 from sentry.interfaces.template import Template
 
 if TYPE_CHECKING:
+    from sentry.grouping.context import GroupingContext
     from sentry.services.eventstore.models import Event
 
 

--- a/tests/sentry/grouping/test_strategies.py
+++ b/tests/sentry/grouping/test_strategies.py
@@ -3,7 +3,8 @@ from typing import Any
 import pytest
 
 from sentry.grouping.component import StacktraceGroupingComponent
-from sentry.grouping.strategies.base import GroupingContext, create_strategy_configuration_class
+from sentry.grouping.context import GroupingContext
+from sentry.grouping.strategies.base import create_strategy_configuration_class
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event


### PR DESCRIPTION
This moves the `GroupingContext` class into a separate `context` module, in order to prevent a circular dependency in an upcoming PR. 

As part of this move, a few of its methods (those having to do with getting grouping components) have been switched to functions which take `context` as an argument rather than relying on `self`. This allowed them to stay in the `strategies.base` module (where they really belong) even as the `GroupingContext` class got a new home. Also, the `ContextValue` and `ContextDict` aliases for `Any` and `dict[str, Any]` have been removed, since they added complexity without adding any real value.