### PR TITLE
fix(migrations): Getsentry clean migration 

### DIFF
--- a/src/sentry/migrations/1040_drop_fk_projecttemplate.py
+++ b/src/sentry/migrations/1040_drop_fk_projecttemplate.py
@@ -26,7 +26,6 @@ class Migration(CheckedMigration):
 
     dependencies = [
         ("sentry", "1039_widget_description_to_textfield"),
-        ("monitors", "0008_fix_processing_error_keys"),
     ]
 
     operations = [

--- a/src/sentry/monitors/migrations/0008_fix_processing_error_keys.py
+++ b/src/sentry/monitors/migrations/0008_fix_processing_error_keys.py
@@ -213,7 +213,7 @@ class Migration(CheckedMigration):
 
     dependencies = [
         ("monitors", "0007_monitors_json_field"),
-        ("sentry", "0964_add_commitcomparison_table"),
+        ("sentry", "1040_drop_fk_projecttemplate"),
     ]
 
     operations = [


### PR DESCRIPTION
With the deletion of project templates, clean installation of getsentry from scratch will error out

This job sets up getsentry dev env from scratch.
https://github.com/getsentry/devinfra-coder-infra/actions/runs/22923463253/job/66527712795

Follow up to https://github.com/getsentry/sentry/pull/110214