### PR TITLE
ref(grouping): Change where message variable is parameterized

### DIFF
--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -299,8 +299,7 @@ def resolve_fingerprint_values(
             return entry
 
         # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
-        # can remove `use_legacy_unknown_variable_handling` and just return the value given by
-        # `resolve_fingerprint_variable`
+        # can remove `use_legacy_unknown_variable_handling`
         resolved_value = resolve_fingerprint_variable(
             variable_key, event, use_legacy_unknown_variable_handling
         )

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -227,17 +227,7 @@ def resolve_fingerprint_variable(
 
     elif variable_key == "message":
         message = get_canonical_message_from_event(event)
-
-        # Fingerprint variables can be used in custom titles, and there we want the original message
-        if not parameterize_message:
-            return message or "<no-message>"
-
-        normalized_message = (
-            normalize_message_for_grouping(message, event, reason="fingerprint", trim_message=False)
-            if message
-            else None
-        )
-        return normalized_message or "<no-message>"
+        return message or "<no-message>"
 
     elif variable_key in ("type", "error.type"):
         exception_type = get_path(event.data, "exception", "values", -1, "type")
@@ -320,6 +310,12 @@ def resolve_fingerprint_values(
         # can remove this
         if resolved_value is None:  # variable wasn't recognized
             return entry
+
+        if variable_key == "message" and resolved_value != "<no-message>":
+            return normalize_message_for_grouping(
+                resolved_value, event, reason="fingerprint", trim_message=False
+            )
+
         return resolved_value
 
     return [_resolve_single_entry(entry) for entry in fingerprint]

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -220,7 +220,6 @@ def resolve_fingerprint_variable(
     variable_key: str,
     event: Event,
     use_legacy_unknown_variable_handling: bool,
-    parameterize_message: bool = True,
 ) -> str | None:
     if variable_key == "transaction":
         return event.data.get("transaction") or "<no-transaction>"
@@ -333,9 +332,6 @@ def expand_title_template(
             variable_key,
             event,
             use_legacy_unknown_variable_handling,
-            # Parameterization is useful for grouping, but we want to show the real error message in
-            # the event/issue title
-            parameterize_message=False,
         )
 
         # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we


### PR DESCRIPTION
This is a small refactor to the code used for variable resolution in custom fingerprints. Recently, we began [parameterizing the `{{ message }}` variable](https://github.com/getsentry/sentry/pull/107808) using `normalize_message_for_grouping` inside of `resolve_fingerprint_variable`, but subsequently realized we needed to prevent parameterization when the variable is used for a custom title. Thus we introduced [a `parameterize_message` parameter](https://github.com/getsentry/sentry/pull/109893) to `resolve_fingerprint_variable`, to control whether or not parameterization runs.

This PR is a different (better) solution to the same problem, done in order to both simplify the code and decrease the blast radius of an upcoming change to `normalize_message_for_grouping`. Instead of having `parameterize_message: True` at one of the two `resolve_fingerprint_variable` call sites and `parameterize_message: False` at the other, it just moves the parameterization to the one place where `parameterize_message` is currently true. This lets us get rid of the new parameter, and prevents the `parameterize_message: False` code from having to compensate for the `normalize_message_for_grouping` changes.