### PR TITLE
ref(grouping): Change custom fingerprint helper to return entire description

### DIFF
--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -206,14 +206,26 @@ def get_fingerprint_type(
     )
 
 
-def get_custom_fingerprint_type(
-    fingerprint_info: FingerprintInfo,
-) -> Literal["built-in", "custom client", "custom server"]:
+def get_custom_fingerprint_description(
+    fingerprint_info: FingerprintInfo, pretty: bool = False
+) -> str:
+    """
+    Get a string describing the type of custom fingerprint as either built-in, from the client, or
+    from the server.
+
+    If `pretty` is true, format the result as separate words (useful for titles, etc.). Otherwise,
+    use underscores so it can be used programmatically, for things like dict keys.
+    """
     matched_server_rule = fingerprint_info.get("matched_rule")
+
     if matched_server_rule:
-        return "built-in" if matched_server_rule.get("is_builtin") else "custom server"
+        fingerprint_type = "built-in" if matched_server_rule.get("is_builtin") else "custom server"
     else:
-        return "custom client"
+        fingerprint_type = "custom client"
+
+    description = f"{fingerprint_type} fingerprint"
+
+    return description if pretty else description.replace("-", "_").replace(" ", "_")
 
 
 def resolve_fingerprint_variable(

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from sentry.grouping.fingerprinting.utils import get_custom_fingerprint_type
+from sentry.grouping.fingerprinting.utils import get_custom_fingerprint_description
 from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.grouping.variants import BaseVariant, ComponentVariant, SaltedComponentVariant
 from sentry.models.project import Project
@@ -113,8 +113,10 @@ def _get_new_description(variant: BaseVariant) -> str:
         description_parts.append(stacktrace_descriptor)
 
     if isinstance(variant, SaltedComponentVariant):
-        custom_fingerprint_type = get_custom_fingerprint_type(variant.fingerprint_info)
-        description_parts.append(f"and {custom_fingerprint_type} fingerprint")
+        fingerprint_description = get_custom_fingerprint_description(
+            variant.fingerprint_info, pretty=True
+        )
+        description_parts.append(f"and {fingerprint_description}")
 
     return " ".join(description_parts)
 

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -8,7 +8,7 @@ from sentry.grouping.component import ContributingComponent, RootGroupingCompone
 from sentry.grouping.fingerprinting.rules import FingerprintRule
 from sentry.grouping.fingerprinting.types import FingerprintInfo
 from sentry.grouping.fingerprinting.utils import (
-    get_custom_fingerprint_type,
+    get_custom_fingerprint_description,
     is_default_fingerprint_var,
 )
 from sentry.grouping.utils import hash_from_values
@@ -204,10 +204,7 @@ class CustomFingerprintVariant(BaseVariant):
 
     @property
     def key(self) -> str:
-        fingerprint_type = get_custom_fingerprint_type(self.fingerprint_info)
-        prefix = fingerprint_type.replace(" ", "_").replace("-", "_")
-
-        return f"{prefix}_fingerprint"
+        return get_custom_fingerprint_description(self.fingerprint_info)
 
     def get_hash(self) -> str | None:
         return hash_from_values(self.values)


### PR DESCRIPTION
In our grouping code, we have a helper called `get_custom_fingerprint_type`, which we use in two places to determine what adjective to put before the word "fingerprint." They're done separately because each requires slightly different formatting (Python-friendly underscores for one, and human-friendly hyphens and spaces for the other). 

Those two spots are about to become three spots, however, so to keep the code dry, this pulls the "add on the word 'fingerprint'" part into the helper function, with a new `pretty` switch to determine which kind of formatting to use. It also renames the function (from `get_custom_fingerprint_type` to `get_custom_fingerprint_description`) to reflect its new behavior.