### PR TITLE
feat(ACI): Make ProjectRuleDetailsEndpoint PUT method backwards compatible

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -205,13 +205,15 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
             workflow = rule
             organization = project.organization
 
-            if not request.data.get("filterMatch"):
+            data = request.data.copy()
+
+            if not data.get("filterMatch"):
                 # if filterMatch is not passed, don't overwrite it with default value, use the saved dcg type
                 wdcg = WorkflowDataConditionGroup.objects.filter(workflow=workflow).first()
                 if wdcg:
-                    request.data["filterMatch"] = wdcg.condition_group.logic_type
+                    data["filterMatch"] = wdcg.condition_group.logic_type
 
-            request_data = format_request_data(cast(ProjectRulePostData, request.data))
+            request_data = format_request_data(cast(ProjectRulePostData, data))
             if not request_data.get("config", {}).get("frequency"):
                 request_data["config"] = workflow.config
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import cast
 import sentry_sdk
 from django.db import router, transaction
 from drf_spectacular.utils import extend_schema
@@ -12,7 +13,11 @@ from sentry.analytics.events.rule_reenable import RuleReenableEdit
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.rule import WorkflowEngineRuleEndpoint
-from sentry.api.endpoints.project_rules import find_duplicate_rule
+from sentry.api.endpoints.project_rules import (
+    ProjectRulePostData,
+    find_duplicate_rule,
+    format_request_data,
+)
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRuleSerializer
@@ -39,6 +44,7 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
+from sentry.workflow_engine.endpoints.validators.base.workflow import WorkflowValidator
 from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
@@ -193,13 +199,36 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
         if isinstance(rule, Workflow):
-            return Response(
-                {
-                    "rule": [
-                        "Passing a workflow through this endpoint is not yet supported",
-                    ]
+            workflow = rule
+            organization = project.organization
+            request_data = format_request_data(cast(ProjectRulePostData, request.data))
+            if not request_data.get("config", {}).get("frequency"):
+                request_data["config"] = workflow.config
+
+            validator = WorkflowValidator(
+                data=request_data,
+                context={
+                    "organization": organization,
+                    "request": request,
+                    "workflow": workflow,
                 },
-                status=status.HTTP_400_BAD_REQUEST,
+            )
+            validator.is_valid(raise_exception=True)
+
+            with transaction.atomic(router.db_for_write(Workflow)):
+                validator.update(workflow, validator.validated_data)
+                self.create_audit_entry(
+                    request=request,
+                    organization=organization,
+                    target_object=workflow.id,
+                    event=audit_log.get_event_id("WORKFLOW_EDIT"),
+                    data=workflow.get_audit_log_data(),
+                )
+
+            workflow.refresh_from_db()
+            return Response(
+                serialize(workflow, request.user, WorkflowEngineRuleSerializer()),
+                status=200,
             )
 
         rule_data_before = dict(rule.data)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import cast
+
 import sentry_sdk
 from django.db import router, transaction
 from drf_spectacular.utils import extend_schema
@@ -47,6 +48,7 @@ from sentry.types.actor import Actor
 from sentry.workflow_engine.endpoints.validators.base.workflow import WorkflowValidator
 from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
+from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
@@ -201,6 +203,13 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         if isinstance(rule, Workflow):
             workflow = rule
             organization = project.organization
+
+            if not request.data.get("filterMatch"):
+                # if filterMatch is not passed, don't overwrite it with default value, use the saved dcg type
+                wdcg = WorkflowDataConditionGroup.objects.filter(workflow=workflow).first()
+                if wdcg:
+                    request.data["filterMatch"] = wdcg.condition_group.logic_type
+
             request_data = format_request_data(cast(ProjectRulePostData, request.data))
             if not request_data.get("config", {}).get("frequency"):
                 request_data["config"] = workflow.config

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -139,12 +139,13 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
         if isinstance(rule, Workflow):
+            workflow = rule
             workflow_engine_rule_serializer = WorkflowEngineRuleSerializer(
                 expand=request.GET.getlist("expand", []),
                 prepare_component_fields=True,
                 project_slug=project.slug,
             )
-            serialized_rule = serialize(rule, request.user, workflow_engine_rule_serializer)
+            serialized_rule = serialize(workflow, request.user, workflow_engine_rule_serializer)
         else:
             # Serialize Rule object
             rule_serializer = RuleSerializer(

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -213,7 +213,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
                 if wdcg:
                     data["filterMatch"] = wdcg.condition_group.logic_type
 
-            request_data = format_request_data(cast(ProjectRulePostData, data), project)
+            request_data = format_request_data(cast(ProjectRulePostData, data))
             if not request_data.get("config", {}).get("frequency"):
                 request_data["config"] = workflow.config
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -213,7 +213,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
                 if wdcg:
                     data["filterMatch"] = wdcg.condition_group.logic_type
 
-            request_data = format_request_data(cast(ProjectRulePostData, data))
+            request_data = format_request_data(cast(ProjectRulePostData, data), project)
             if not request_data.get("config", {}).get("frequency"):
                 request_data["config"] = workflow.config
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -42,7 +42,6 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.processing.processor import is_condition_slow
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_created
-from sentry.types.actor import parse_and_validate_actor
 from sentry.workflow_engine.endpoints.validators.base.workflow import WorkflowValidator
 from sentry.workflow_engine.endpoints.validators.detector_workflow import (
     BulkWorkflowDetectorsValidator,
@@ -747,15 +746,6 @@ def format_request_data(
         "environment": data.get("environment"),
         "config": {"frequency": data.get("frequency")},
     }
-    owner = data.get("owner")
-    if owner:
-        actor = parse_and_validate_actor(str(owner), project.organization_id)
-
-        if actor and actor.is_team:
-            workflow_payload["owner_team_id"] = actor.id
-        elif actor:
-            workflow_payload["owner_user_id"] = actor.id
-
     triggers: dict[str, Any] = {"logicType": "any-short", "conditions": []}
     translated_filter_list = []
     fake_dcg = DataConditionGroup()

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -748,13 +748,16 @@ def format_request_data(
 
     if data.get("owner"):
         owner = data["owner"]
-        split_owner = owner.split(":")
-        identifier, owner_id = split_owner[0], split_owner[1]
-
-        if identifier == "team":
-            workflow_payload["owner_team_id"] = owner_id
+        if isinstance(owner, int):
+            workflow_payload["owner_user_id"] = owner
         else:
-            workflow_payload["owner_user_id"] = owner_id
+            split_owner = owner.split(":")
+            identifier, owner_id = split_owner[0], split_owner[1]
+
+            if identifier == "team":
+                workflow_payload["owner_team_id"] = owner_id
+            else:
+                workflow_payload["owner_user_id"] = owner_id
 
     triggers: dict[str, Any] = {"logicType": "any-short", "conditions": []}
     translated_filter_list = []

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -738,7 +738,6 @@ class ProjectRulePostData(TypedDict):
 
 def format_request_data(
     data: ProjectRulePostData,
-    project: Project,
 ) -> dict[str, Any]:
     workflow_payload = {
         "name": data.get("name"),
@@ -894,7 +893,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
-            request_data = format_request_data(cast(ProjectRulePostData, request.data), project)
+            request_data = format_request_data(cast(ProjectRulePostData, request.data))
             validator = WorkflowValidator(
                 data=request_data,
                 context={"organization": project.organization, "request": request},

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -749,7 +749,7 @@ def format_request_data(
     }
     owner = data.get("owner")
     if owner:
-        actor = parse_and_validate_actor(owner, project.organization_id)
+        actor = parse_and_validate_actor(str(owner), project.organization_id)
 
         if actor and actor.is_team:
             workflow_payload["owner_team_id"] = actor.id

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -8,6 +8,7 @@ from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -752,14 +753,26 @@ def format_request_data(
     # we pass in a dummy DCG and then pop it off since we just need the formatted data
 
     for condition in data.get("conditions", []):
-        translated_conditions = asdict(translate_to_data_condition_data(condition, fake_dcg))
+        try:
+            translated_conditions = asdict(translate_to_data_condition_data(condition, fake_dcg))
+        except KeyError:
+            raise ValidationError("Ensure all required fields are filled in.")
+        except ValueError as e:
+            raise ValidationError(str(e))
+
         translated_conditions.pop("condition_group")
         triggers["conditions"].append(translated_conditions)
 
     workflow_payload["triggers"] = triggers
 
     for filter_data in data.get("filters", []):
-        translated_filters = asdict(translate_to_data_condition_data(filter_data, fake_dcg))
+        try:
+            translated_filters = asdict(translate_to_data_condition_data(filter_data, fake_dcg))
+        except KeyError:
+            raise ValidationError("Ensure all required fields are filled in.")
+        except ValueError as e:
+            raise ValidationError(str(e))
+
         translated_filters.pop("condition_group")
         translated_filter_list.append(translated_filters)
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -42,6 +42,7 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.processing.processor import is_condition_slow
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_created
+from sentry.types.actor import parse_and_validate_actor
 from sentry.workflow_engine.endpoints.validators.base.workflow import WorkflowValidator
 from sentry.workflow_engine.endpoints.validators.detector_workflow import (
     BulkWorkflowDetectorsValidator,
@@ -738,6 +739,7 @@ class ProjectRulePostData(TypedDict):
 
 def format_request_data(
     data: ProjectRulePostData,
+    project: Project,
 ) -> dict[str, Any]:
     workflow_payload = {
         "name": data.get("name"),
@@ -745,18 +747,14 @@ def format_request_data(
         "environment": data.get("environment"),
         "config": {"frequency": data.get("frequency")},
     }
-
     owner = data.get("owner")
-    if isinstance(owner, int):
-        workflow_payload["owner_user_id"] = owner
-    elif isinstance(owner, str):
-        split_owner = owner.split(":")
-        identifier, owner_id = split_owner[0], split_owner[1]
+    if owner:
+        actor = parse_and_validate_actor(owner, project.organization_id)
 
-        if identifier == "team":
-            workflow_payload["owner_team_id"] = owner_id
-        else:
-            workflow_payload["owner_user_id"] = owner_id
+        if actor and actor.is_team:
+            workflow_payload["owner_team_id"] = actor.id
+        elif actor:
+            workflow_payload["owner_user_id"] = actor.id
 
     triggers: dict[str, Any] = {"logicType": "any-short", "conditions": []}
     translated_filter_list = []
@@ -906,7 +904,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
-            request_data = format_request_data(cast(ProjectRulePostData, request.data))
+            request_data = format_request_data(cast(ProjectRulePostData, request.data), project)
             validator = WorkflowValidator(
                 data=request_data,
                 context={"organization": project.organization, "request": request},

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -757,8 +757,8 @@ def format_request_data(
             translated_conditions = asdict(translate_to_data_condition_data(condition, fake_dcg))
         except KeyError:
             raise ValidationError("Ensure all required fields are filled in.")
-        except ValueError as e:
-            raise ValidationError(str(e))
+        except ValueError:
+            raise ValidationError("Invalid condition data")
 
         translated_conditions.pop("condition_group")
         triggers["conditions"].append(translated_conditions)
@@ -770,8 +770,8 @@ def format_request_data(
             translated_filters = asdict(translate_to_data_condition_data(filter_data, fake_dcg))
         except KeyError:
             raise ValidationError("Ensure all required fields are filled in.")
-        except ValueError as e:
-            raise ValidationError(str(e))
+        except ValueError:
+            raise ValidationError("Invalid filter data")
 
         translated_filters.pop("condition_group")
         translated_filter_list.append(translated_filters)

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -728,7 +728,7 @@ class ProjectRulePostData(TypedDict):
     conditions: list[ConditionsData]
     actions: list[dict[str, Any]]
     environment: NotRequired[str | None]
-    owner: NotRequired[str | None]
+    owner: NotRequired[str | int | None]
     filterMatch: NotRequired[Literal["all", "any", "none"]]
     filters: NotRequired[list[FiltersData]]
     status: NotRequired[str]
@@ -746,18 +746,17 @@ def format_request_data(
         "config": {"frequency": data.get("frequency")},
     }
 
-    if data.get("owner"):
-        owner = data["owner"]
-        if isinstance(owner, int):
-            workflow_payload["owner_user_id"] = owner
-        else:
-            split_owner = owner.split(":")
-            identifier, owner_id = split_owner[0], split_owner[1]
+    owner = data.get("owner")
+    if isinstance(owner, int):
+        workflow_payload["owner_user_id"] = owner
+    elif isinstance(owner, str):
+        split_owner = owner.split(":")
+        identifier, owner_id = split_owner[0], split_owner[1]
 
-            if identifier == "team":
-                workflow_payload["owner_team_id"] = owner_id
-            else:
-                workflow_payload["owner_user_id"] = owner_id
+        if identifier == "team":
+            workflow_payload["owner_team_id"] = owner_id
+        else:
+            workflow_payload["owner_user_id"] = owner_id
 
     triggers: dict[str, Any] = {"logicType": "any-short", "conditions": []}
     translated_filter_list = []

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -746,6 +746,16 @@ def format_request_data(
         "config": {"frequency": data.get("frequency")},
     }
 
+    if data.get("owner"):
+        owner = data["owner"]
+        split_owner = owner.split(":")
+        identifier, owner_id = split_owner[0], split_owner[1]
+
+        if identifier == "team":
+            workflow_payload["owner_team_id"] = owner_id
+        else:
+            workflow_payload["owner_user_id"] = owner_id
+
     triggers: dict[str, Any] = {"logicType": "any-short", "conditions": []}
     translated_filter_list = []
     fake_dcg = DataConditionGroup()

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -647,7 +647,10 @@ class WorkflowEngineRuleSerializer(Serializer):
             )
             for f in filters:
                 if f.get("value"):
-                    f["value"] = int(f["value"])
+                    try:
+                        f["value"] = int(f["value"])
+                    except (ValueError, AttributeError):
+                        continue
 
             result[workflow]["conditions"] = conditions
             result[workflow]["filters"] = filters

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -635,6 +635,10 @@ class WorkflowEngineRuleSerializer(Serializer):
                 if action.data.get("notes") == "":
                     action_data.pop("notes", None)
 
+                # XXX: workspace needs to be returned as a string
+                if action_data.get("workspace"):
+                    action_data["workspace"] = str(action_data["workspace"])
+
                 serialized_actions.append(action_data)
 
             # Generate conditions and filters

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -653,7 +653,7 @@ class WorkflowEngineRuleSerializer(Serializer):
                 ):
                     try:
                         f["value"] = int(f["value"])
-                    except TypeError:
+                    except (ValueError, TypeError):
                         continue
 
             result[workflow]["conditions"] = conditions

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -653,7 +653,7 @@ class WorkflowEngineRuleSerializer(Serializer):
                 ):
                     try:
                         f["value"] = int(f["value"])
-                    except (ValueError, AttributeError):
+                    except TypeError:
                         continue
 
             result[workflow]["conditions"] = conditions

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -646,7 +646,11 @@ class WorkflowEngineRuleSerializer(Serializer):
                 workflow, result[workflow]["projects"][0], workflow_dcg
             )
             for f in filters:
-                if f.get("value"):
+                # IssueCategoryFilter stores numeric string choices and must stay as str
+                if (
+                    f.get("value")
+                    and f.get("id") != "sentry.rules.filters.issue_category.IssueCategoryFilter"
+                ):
                     try:
                         f["value"] = int(f["value"])
                     except (ValueError, AttributeError):

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -645,6 +645,10 @@ class WorkflowEngineRuleSerializer(Serializer):
             conditions, filters = self._generate_rule_conditions_filters(
                 workflow, result[workflow]["projects"][0], workflow_dcg
             )
+            for f in filters:
+                if f.get("value"):
+                    f["value"] = int(f["value"])
+
             result[workflow]["conditions"] = conditions
             result[workflow]["filters"] = filters
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -26,16 +26,9 @@ from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
-from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
-    translate_to_data_condition_data,
-)
-from sentry.workflow_engine.migration_helpers.rule_action import (
-    translate_rule_data_actions_to_notification_actions,
-)
 from sentry.workflow_engine.models import Action, AlertRuleWorkflow
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
-from sentry.workflow_engine.models.data_condition_group_action import DataConditionGroupAction
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
@@ -98,66 +91,38 @@ def assert_rule_from_payload(rule: Rule, payload: Mapping[str, Any]) -> None:
     assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.UPDATED.value).exists()
 
 
-def assert_workflow_from_payload(workflow: Workflow, payload: Mapping[str, Any]) -> None:
-    """
-    Helper function to assert every field on a Workflow was modified correctly from the incoming payload
-    """
-    workflow.refresh_from_db()
-    assert workflow.name == payload.get("name")
-
-    environment = payload.get("environment")
-    if environment:
-        assert workflow.environment is not None
-        assert workflow.environment.name == environment
-    else:
-        assert workflow.environment is None
-
-    frequency = payload.get("frequency")
-    if frequency is not None:
-        assert workflow.config["frequency"] == frequency
-
-    # Check trigger conditions in the when_condition_group
-    fake_dcg = DataConditionGroup()
-    when_dcg = workflow.when_condition_group
-    if when_dcg is not None:
-        actual_conditions = list(
-            DataCondition.objects.filter(condition_group=when_dcg).values("type", "comparison")
-        )
-        for payload_condition in payload.get("conditions", []):
-            translated = translate_to_data_condition_data(payload_condition, fake_dcg)
-            assert any(
-                translated.type == ac["type"] and translated.comparison == ac["comparison"]
-                for ac in actual_conditions
-            )
-
-    # Check action filter (filterMatch, filters, and actions)
-    action_filter_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
-    action_filter_dcg.refresh_from_db()
-
-    filter_match = payload.get("filterMatch", "any")
-    if filter_match == "any":
-        filter_match = DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
-    assert action_filter_dcg.logic_type == filter_match
-
-    actual_filter_conditions = list(
-        DataCondition.objects.filter(condition_group=action_filter_dcg).values("type", "comparison")
+def assert_serializer_results_match(
+    rule_response: dict[str, Any], workflow_response: dict[str, Any]
+) -> None:
+    rule_conditions = sorted(rule_response.get("conditions", []), key=lambda t: t.get("id", ""))
+    workflow_conditions = sorted(
+        workflow_response.get("conditions", []), key=lambda t: t.get("id", "")
     )
-    for payload_filter in payload.get("filters", []):
-        translated = translate_to_data_condition_data(payload_filter, fake_dcg)
-        assert any(
-            translated.type == afc["type"] and translated.comparison == afc["comparison"]
-            for afc in actual_filter_conditions
-        )
 
-    action_ids = DataConditionGroupAction.objects.filter(
-        condition_group=action_filter_dcg
-    ).values_list("action_id", flat=True)
-    actual_actions = list(Action.objects.filter(id__in=action_ids).values("type"))
-    translated_actions = translate_rule_data_actions_to_notification_actions(
-        payload.get("actions", []), False
-    )
-    for translated_action in translated_actions:
-        assert any(translated_action["type"] == aa["type"] for aa in actual_actions)
+    for rule_condition_data, workflow_condition_data in zip(rule_conditions, workflow_conditions):
+        assert rule_condition_data == workflow_condition_data
+
+    rule_filters = sorted(rule_response.get("filters", []), key=lambda t: t.get("id", ""))
+    workflow_filters = sorted(workflow_response.get("filters", []), key=lambda t: t.get("id", ""))
+
+    for rule_filter_data, workflow_filter_data in zip(rule_filters, workflow_filters):
+        assert rule_filter_data == workflow_filter_data
+
+    rule_actions = sorted(rule_response.get("actions", []), key=lambda t: t.get("id", ""))
+    workflow_actions = sorted(workflow_response.get("actions", []), key=lambda t: t.get("id", ""))
+
+    for rule_action_data, workflow_action_data in zip(rule_actions, workflow_actions):
+        del rule_action_data["uuid"]
+        assert rule_action_data == workflow_action_data
+
+    assert rule_response.get("actionMatch") == workflow_response.get("actionMatch")
+    assert rule_response.get("filterMatch") == workflow_response.get("filterMatch")
+    assert rule_response.get("frequency") == workflow_response.get("frequency")
+    assert rule_response.get("name") == workflow_response.get("name")
+    assert rule_response.get("environment") == workflow_response.get("environment")
+    assert rule_response.get("projects") == workflow_response.get("projects")
+    assert rule_response.get("status") == workflow_response.get("status")
+    assert rule_response.get("snooze") == workflow_response.get("snooze")
 
 
 class ProjectRuleDetailsBaseTestCase(APITestCase, BaseWorkflowTest):
@@ -208,7 +173,7 @@ class ProjectRuleDetailsBaseTestCase(APITestCase, BaseWorkflowTest):
         self.workflow = self.create_workflow(
             when_condition_group=self.workflow_triggers,
             organization=self.detector.project.organization,
-            config={"frequency": 1440},
+            config={"frequency": 30},
         )
         self.detector_workflow = self.create_detector_workflow(
             detector=self.detector, workflow=self.workflow
@@ -685,9 +650,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         conditions = [
             {
                 "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-                "key": "foo",
-                "match": "eq",
-                "value": "bar",
+                # "key": "foo",
+                # "match": "eq",
+                # "value": "bar",
             }
         ]
         payload = {
@@ -705,16 +670,20 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert_rule_from_payload(self.rule, payload)
         assert send_robust.called
 
+        # test with a workflow
+        arw = AlertRuleWorkflow.objects.get(rule_id=self.rule.id)
+        workflow = arw.workflow
+        fake_workflow_id = get_fake_id_from_object_id(workflow.id)
+
         with self.feature("organizations:workflow-engine-rule-serializers"):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_workflow_id,
+                fake_workflow_id,
                 status_code=200,
                 **payload,
             )
-        assert workflow_response.data["id"] == str(self.fake_workflow_id)
-        assert_workflow_from_payload(self.workflow, payload)
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_no_owner(self) -> None:
         conditions = [

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1003,11 +1003,15 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         )
         assert_rule_from_payload(rule, payload)
 
+        arw = AlertRuleWorkflow.objects.get(rule_id=rule.id)
+        dual_written_workflow = arw.workflow
+        fake_dual_written_workflow_id = get_fake_id_from_object_id(dual_written_workflow.id)
+
         with self.feature("organizations:workflow-engine-rule-serializers"):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                fake_dual_written_workflow_id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )
@@ -1253,11 +1257,15 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 organization_id=self.organization.id,
             ),
         )
+
+        arw = AlertRuleWorkflow.objects.get(rule_id=rule.id)
+        dual_written_workflow = arw.workflow
+        fake_dual_written_workflow_id = get_fake_id_from_object_id(dual_written_workflow.id)
         with self.feature("organizations:workflow-engine-rule-serializers"):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                fake_dual_written_workflow_id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -104,12 +104,14 @@ def assert_serializer_results_match(
 
     rule_filters = sorted(rule_response.get("filters", []), key=lambda t: t.get("id", ""))
     workflow_filters = sorted(workflow_response.get("filters", []), key=lambda t: t.get("id", ""))
+    assert len(rule_filters) == len(workflow_filters)
 
     for rule_filter_data, workflow_filter_data in zip(rule_filters, workflow_filters):
         assert rule_filter_data == workflow_filter_data
 
     rule_actions = sorted(rule_response.get("actions", []), key=lambda t: t.get("id", ""))
     workflow_actions = sorted(workflow_response.get("actions", []), key=lambda t: t.get("id", ""))
+    assert len(rule_actions) == len(workflow_actions)
 
     # this is not read by the front end
     for rule_action in rule_actions:

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -134,6 +134,7 @@ def assert_serializer_results_match(
     assert rule_response.get("projects") == workflow_response.get("projects")
     assert rule_response.get("status") == workflow_response.get("status")
     assert rule_response.get("snooze") == workflow_response.get("snooze")
+    assert rule_response.get("owner") == workflow_response.get("owner")
 
 
 class ProjectRuleDetailsBaseTestCase(APITestCase, BaseWorkflowTest):

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -113,9 +113,13 @@ def assert_serializer_results_match(
 
     for rule_action_data, workflow_action_data in zip(rule_actions, workflow_actions):
         del rule_action_data["uuid"]
+        del rule_action_data["legacy_rule_id"]
+        del rule_action_data["workflow_id"]
         assert rule_action_data == workflow_action_data
 
-    assert rule_response.get("actionMatch") == workflow_response.get("actionMatch")
+    # XXX: actionMatch is always coerced to 'any-short' for a Workflow as it is the only acceptable value
+    # which is then translated to 'any' in the serializer as 'any-short' can't be rendered in the old UI
+    # this may cause confusion if the old rule is changed to be 'all' but it can't be helped
     assert rule_response.get("filterMatch") == workflow_response.get("filterMatch")
     assert rule_response.get("frequency") == workflow_response.get("frequency")
     assert rule_response.get("name") == workflow_response.get("name")
@@ -829,7 +833,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 self.organization.slug,
                 self.project.slug,
                 self.fake_dual_written_workflow_id,
-                status_code=200,
+                status_code=status.HTTP_200_OK,
                 **payload,
             )
         assert_serializer_results_match(response.data, workflow_response.data)
@@ -869,6 +873,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["owner"] == f"team:{target_team.id}"
         rule = Rule.objects.get(id=response.data["id"])
         assert rule.owner_team_id == target_team.id
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=status.HTTP_200_OK,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_cannot_reassign_owner_from_other_team(self) -> None:
         """Test that a user cannot reassign rule ownership from a team they don't belong to"""
@@ -946,6 +960,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         )
         assert_rule_from_payload(self.rule, payload)
 
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=status.HTTP_200_OK,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
+
     def test_remove_conditions(self) -> None:
         """Test that you can edit an alert rule to have no conditions (aka fire on every event)"""
         rule = self.create_project_rule(
@@ -964,10 +988,20 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "actions": self.notify_issue_owners_action,
         }
 
-        self.get_success_response(
+        response = self.get_success_response(
             self.organization.slug, self.project.slug, rule.id, status_code=200, **payload
         )
         assert_rule_from_payload(rule, payload)
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=status.HTTP_200_OK,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_update_duplicate_rule(self) -> None:
         """Test that if you edit a rule such that it's now the exact duplicate of another rule in the same project
@@ -1194,7 +1228,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "actions": self.notify_issue_owners_action,
             "conditions": self.first_seen_condition,
         }
-        self.get_success_response(
+        response = self.get_success_response(
             self.organization.slug, self.project.slug, rule.id, status_code=200, **payload
         )
         # re-fetch rule after update
@@ -1209,6 +1243,15 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 organization_id=self.organization.id,
             ),
         )
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=status.HTTP_200_OK,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_with_environment(self) -> None:
         payload = {
@@ -1227,6 +1270,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["id"] == str(self.rule.id)
         assert response.data["environment"] == self.environment.name
         assert_rule_from_payload(self.rule, payload)
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=status.HTTP_200_OK,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_with_null_environment(self) -> None:
         self.rule.update(environment_id=self.environment.id)
@@ -1248,6 +1301,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["id"] == str(self.rule.id)
         assert response.data["environment"] is None
         assert_rule_from_payload(self.rule, payload)
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=status.HTTP_200_OK,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_update_channel_slack_workspace_fail_sdk(self) -> None:
         conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
@@ -1287,6 +1350,14 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                     status_code=400,
                     **payload,
                 )
+                with self.feature("organizations:workflow-engine-rule-serializers"):
+                    self.get_error_response(
+                        self.organization.slug,
+                        self.project.slug,
+                        self.fake_dual_written_workflow_id,
+                        status_code=400,
+                        **payload,
+                    )
 
     def test_slack_channel_id_saved_sdk(self) -> None:
         channel_id = "CSVK0921"
@@ -1316,6 +1387,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             )
             assert response.data["id"] == str(self.rule.id)
             assert response.data["actions"][0]["channel_id"] == channel_id
+
+            with self.feature("organizations:workflow-engine-rule-serializers"):
+                workflow_response = self.get_success_response(
+                    self.organization.slug,
+                    self.project.slug,
+                    self.fake_dual_written_workflow_id,
+                    status_code=status.HTTP_200_OK,
+                    **payload,
+                )
+            assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_invalid_rule_node_type(self) -> None:
         payload = {
@@ -1352,6 +1433,14 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         self.get_error_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=400, **payload
         )
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=500,
+                **payload,
+            )
 
     def test_rule_form_owner_perms(self) -> None:
         new_user = self.create_user()

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -26,9 +26,16 @@ from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
+from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
+    translate_to_data_condition_data,
+)
+from sentry.workflow_engine.migration_helpers.rule_action import (
+    translate_rule_data_actions_to_notification_actions,
+)
 from sentry.workflow_engine.models import Action, AlertRuleWorkflow
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+from sentry.workflow_engine.models.data_condition_group_action import DataConditionGroupAction
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
@@ -89,6 +96,68 @@ def assert_rule_from_payload(rule: Rule, payload: Mapping[str, Any]) -> None:
             for rule_condition in rule.data["conditions"]
         )
     assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.UPDATED.value).exists()
+
+
+def assert_workflow_from_payload(workflow: Workflow, payload: Mapping[str, Any]) -> None:
+    """
+    Helper function to assert every field on a Workflow was modified correctly from the incoming payload
+    """
+    workflow.refresh_from_db()
+    assert workflow.name == payload.get("name")
+
+    environment = payload.get("environment")
+    if environment:
+        assert workflow.environment is not None
+        assert workflow.environment.name == environment
+    else:
+        assert workflow.environment is None
+
+    frequency = payload.get("frequency")
+    if frequency is not None:
+        assert workflow.config["frequency"] == frequency
+
+    # Check trigger conditions in the when_condition_group
+    fake_dcg = DataConditionGroup()
+    when_dcg = workflow.when_condition_group
+    if when_dcg is not None:
+        actual_conditions = list(
+            DataCondition.objects.filter(condition_group=when_dcg).values("type", "comparison")
+        )
+        for payload_condition in payload.get("conditions", []):
+            translated = translate_to_data_condition_data(payload_condition, fake_dcg)
+            assert any(
+                translated.type == ac["type"] and translated.comparison == ac["comparison"]
+                for ac in actual_conditions
+            )
+
+    # Check action filter (filterMatch, filters, and actions)
+    action_filter_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+    action_filter_dcg.refresh_from_db()
+
+    filter_match = payload.get("filterMatch", "any")
+    if filter_match == "any":
+        filter_match = DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
+    assert action_filter_dcg.logic_type == filter_match
+
+    actual_filter_conditions = list(
+        DataCondition.objects.filter(condition_group=action_filter_dcg).values("type", "comparison")
+    )
+    for payload_filter in payload.get("filters", []):
+        translated = translate_to_data_condition_data(payload_filter, fake_dcg)
+        assert any(
+            translated.type == afc["type"] and translated.comparison == afc["comparison"]
+            for afc in actual_filter_conditions
+        )
+
+    action_ids = DataConditionGroupAction.objects.filter(
+        condition_group=action_filter_dcg
+    ).values_list("action_id", flat=True)
+    actual_actions = list(Action.objects.filter(id__in=action_ids).values("type"))
+    translated_actions = translate_rule_data_actions_to_notification_actions(
+        payload.get("actions", []), False
+    )
+    for translated_action in translated_actions:
+        assert any(translated_action["type"] == aa["type"] for aa in actual_actions)
 
 
 class ProjectRuleDetailsBaseTestCase(APITestCase, BaseWorkflowTest):
@@ -636,31 +705,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert_rule_from_payload(self.rule, payload)
         assert send_robust.called
 
-    @with_feature("organizations:workflow-engine-rule-serializers")
-    def test_workflow_passed(self) -> None:
-        conditions = [
-            {
-                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-                "key": "foo",
-                "match": "eq",
-                "value": "bar",
-            }
-        ]
-        payload = {
-            "name": "hello world",
-            "owner": self.user.id,
-            "actionMatch": "any",
-            "filterMatch": "any",
-            "actions": [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}],
-            "conditions": conditions,
-        }
-        self.get_success_response(
-            self.organization.slug,
-            self.project.slug,
-            self.fake_workflow_id,
-            status_code=200,
-            **payload,
-        )
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_workflow_id,
+                status_code=200,
+                **payload,
+            )
+        assert workflow_response.data["id"] == str(self.fake_workflow_id)
+        assert_workflow_from_payload(self.workflow, payload)
 
     def test_no_owner(self) -> None:
         conditions = [

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -113,8 +113,10 @@ def assert_serializer_results_match(
 
     for rule_action_data, workflow_action_data in zip(rule_actions, workflow_actions):
         del rule_action_data["uuid"]
-        del rule_action_data["legacy_rule_id"]
-        del rule_action_data["workflow_id"]
+        if rule_action_data.get("legacy_rule_id"):
+            del rule_action_data["legacy_rule_id"]
+        if rule_action_data.get("workflow_id"):
+            del rule_action_data["workflow_id"]
         assert rule_action_data == workflow_action_data
 
     # XXX: actionMatch is always coerced to 'any-short' for a Workflow as it is the only acceptable value
@@ -1493,6 +1495,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["id"] == str(self.rule.id)
 
         assert_rule_from_payload(self.rule, payload)
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=status.HTTP_200_OK,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     @responses.activate
     def test_update_sentry_app_action_success(self) -> None:

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -139,6 +139,7 @@ class ProjectRuleDetailsBaseTestCase(APITestCase, BaseWorkflowTest):
         self.workflow = self.create_workflow(
             when_condition_group=self.workflow_triggers,
             organization=self.detector.project.organization,
+            config={"frequency": 1440},
         )
         self.detector_workflow = self.create_detector_workflow(
             detector=self.detector, workflow=self.workflow
@@ -637,8 +638,28 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     def test_workflow_passed(self) -> None:
-        self.get_error_response(
-            self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=400
+        conditions = [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                "key": "foo",
+                "match": "eq",
+                "value": "bar",
+            }
+        ]
+        payload = {
+            "name": "hello world",
+            "owner": self.user.id,
+            "actionMatch": "any",
+            "filterMatch": "any",
+            "actions": [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}],
+            "conditions": conditions,
+        }
+        self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.fake_workflow_id,
+            status_code=200,
+            **payload,
         )
 
     def test_no_owner(self) -> None:

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -197,6 +197,13 @@ class ProjectRuleDetailsBaseTestCase(APITestCase, BaseWorkflowTest):
         self.action_group, self.action = self.create_workflow_action(self.workflow)
         self.fake_workflow_id = get_fake_id_from_object_id(self.workflow.id)
 
+        # fetch dual written workflow
+        arw = AlertRuleWorkflow.objects.get(rule_id=self.rule.id)
+        self.dual_written_workflow = arw.workflow
+        self.fake_dual_written_workflow_id = get_fake_id_from_object_id(
+            self.dual_written_workflow.id
+        )
+
 
 class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
     def test_simple(self) -> None:
@@ -647,14 +654,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
 
     @patch("sentry.signals.alert_rule_edited.send_robust")
     def test_simple(self, send_robust: MagicMock) -> None:
-        conditions = [
-            {
-                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-                # "key": "foo",
-                # "match": "eq",
-                # "value": "bar",
-            }
-        ]
+        conditions = [{"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"}]
         payload = {
             "name": "hello world",
             "owner": self.user.id,
@@ -670,30 +670,18 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert_rule_from_payload(self.rule, payload)
         assert send_robust.called
 
-        # test with a workflow
-        arw = AlertRuleWorkflow.objects.get(rule_id=self.rule.id)
-        workflow = arw.workflow
-        fake_workflow_id = get_fake_id_from_object_id(workflow.id)
-
         with self.feature("organizations:workflow-engine-rule-serializers"):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                fake_workflow_id,
+                self.fake_dual_written_workflow_id,
                 status_code=200,
                 **payload,
             )
         assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_no_owner(self) -> None:
-        conditions = [
-            {
-                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-                "key": "foo",
-                "match": "eq",
-                "value": "bar",
-            }
-        ]
+        conditions = [{"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"}]
         payload = {
             "name": "hello world",
             "owner": None,
@@ -707,6 +695,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         )
         assert response.data["id"] == str(self.rule.id)
         assert_rule_from_payload(self.rule, payload)
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=200,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_update_owner_type(self) -> None:
         team = self.create_team(organization=self.organization, members=[self.user])
@@ -727,6 +725,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert rule.owner_team_id == team.id
         assert rule.owner_user_id is None
 
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=200,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
+
         payload = {
             "name": "hello world 2",
             "owner": f"user:{self.user.id}",
@@ -742,6 +750,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         rule = Rule.objects.get(id=response.data["id"])
         assert rule.owner_team_id is None
         assert rule.owner_user_id == self.user.id
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=200,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_team_owner_not_member(self) -> None:
         self.organization.flags.allow_joinleave = False
@@ -805,6 +823,16 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         rule = Rule.objects.get(id=response.data["id"])
         assert rule.owner_team_id == team.id
         assert rule.owner_user_id is None
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=200,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_reassign_owner_from_own_team_to_any_team(self) -> None:
         """Test that a user can reassign rule ownership from their team to any other team"""

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -111,6 +111,11 @@ def assert_serializer_results_match(
     rule_actions = sorted(rule_response.get("actions", []), key=lambda t: t.get("id", ""))
     workflow_actions = sorted(workflow_response.get("actions", []), key=lambda t: t.get("id", ""))
 
+    # this is not read by the front end
+    for rule_action in rule_actions:
+        if rule_action.get("hasSchemaFormConfig"):
+            del rule_action["hasSchemaFormConfig"]
+
     for rule_action_data, workflow_action_data in zip(rule_actions, workflow_actions):
         del rule_action_data["uuid"]
         if rule_action_data.get("legacy_rule_id"):
@@ -1411,6 +1416,14 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         self.get_error_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=400, **payload
         )
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=400,
+                **payload,
+            )
 
     def test_invalid_rule_node(self) -> None:
         payload = {
@@ -1423,6 +1436,14 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         self.get_error_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=400, **payload
         )
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=400,
+                **payload,
+            )
 
     def test_rule_form_not_valid(self) -> None:
         payload = {
@@ -1440,7 +1461,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 self.organization.slug,
                 self.project.slug,
                 self.fake_dual_written_workflow_id,
-                status_code=500,
+                status_code=400,
                 **payload,
             )
 
@@ -1530,11 +1551,21 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "conditions": [],
             "filters": [],
         }
-        self.get_success_response(
+        response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
         )
         assert_rule_from_payload(self.rule, payload)
         assert len(responses.calls) == 1
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=status.HTTP_200_OK,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     @responses.activate
     def test_update_sentry_app_action_failure(self) -> None:
@@ -1566,6 +1597,15 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         )
         assert len(responses.calls) == 1
         assert error_message in response.json().get("actions")[0]
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=400,
+                **payload,
+            )
 
     @patch("sentry.sentry_apps.services.app.app_service.trigger_sentry_app_action_creators")
     def test_update_sentry_app_action_failure_with_public_context(self, result: MagicMock) -> None:
@@ -1599,6 +1639,15 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         )
         assert error_message in response.json().get("actions")[0]
         assert response.json().get("context") == {"bruh": "bruhhhh"}
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=400,
+                **payload,
+            )
 
     @patch("sentry.sentry_apps.services.app.app_service.trigger_sentry_app_action_creators")
     def test_update_sentry_app_action_failure_sentry_error(self, result: MagicMock) -> None:
@@ -1639,6 +1688,15 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert response.json().get("context") == {"bruh": "bro!"}
         assert list(response.json().keys()) == ["context", "actions"]
 
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=400,
+                **payload,
+            )
+
     @patch("sentry.sentry_apps.services.app.app_service.trigger_sentry_app_action_creators")
     def test_update_sentry_app_action_failure_missing_error_type(self, result: MagicMock) -> None:
         error_message = "Something is totally broken :'("
@@ -1675,6 +1733,15 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         )
         assert list(response.json().keys()) == ["actions"]
 
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=400,
+                **payload,
+            )
+
     def test_edit_condition_metric(self) -> None:
         payload = {
             "name": "name",
@@ -1684,9 +1751,18 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "actions": [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}],
             "conditions": self.first_seen_condition,
         }
-        self.get_success_response(
+        response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
         )
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.fake_dual_written_workflow_id,
+                status_code=200,
+                **payload,
+            )
+        assert_serializer_results_match(response.data, workflow_response.data)
 
     def test_edit_non_condition_metric(self) -> None:
         payload = {

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -1406,7 +1406,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             ],
             "actionMatch": "any",
             "filterMatch": "all",
-            "owner": "team:74234",
+            "owner": f"team:{self.team.id}",
             "projects": [self.project.slug],
         }
         responses.add(

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -403,7 +403,7 @@ class WorkflowRuleSerializerTest(TestCase):
             },
             {
                 "id": IssueOccurrencesFilter.id,
-                "value": "10",
+                "value": 10,
             },
             {
                 "id": IssueTypeFilter.id,

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -626,7 +626,7 @@ class WorkflowRuleSerializerTest(TestCase):
                 metadata={"access_token": "xoxb-access-token"},
             )
         action_data = {
-            "workspace": self.integration.id,
+            "workspace": str(self.integration.id),
             "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
             "channel_id": "C0123456789",
             "tags": "hellboy, meow",


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/109926 to transform an issue alert PUT payload into a workflow PUT payload and serialize it as if it were an issue alert rule. 

I intentionally skipped a few tests as we do not appear to fail on the same things in workflow engine. We may want to go back and block these things from occurring but that is outside of the scope of this PR. Those tests are:
* `test_cannot_reassign_owner_from_other_team`
* `test_team_owner_not_member`
* `test_rule_form_owner_perms` - note that for workflow engine, it first fails on the malformed condition earlier than it fails on the owner being in a different org. to verify I passed match, key, and value and it ran successfully
* `test_rule_form_missing_action` see above, condition is malformed but when fixed we return successfully. maybe it's ok for workflow engine if there is no action 
* `test_edit_non_condition_metric` - skipped because it uses the every event condition which is not valid in workflow engine