### PR TITLE
ref(grouping): Convert message parameterizer to singleton

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -317,3 +317,7 @@ class Parameterizer:
             metrics.incr("grouping.value_parameterized", amount=value, tags={"key": key})
 
         return parameterized
+
+
+parameterizer = Parameterizer(use_experimental_regexes=False)
+experimental_parameterizer = Parameterizer(use_experimental_regexes=True)

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -269,7 +269,6 @@ class Parameterizer:
         self._parameterization_regex = self._make_regex_from_patterns(
             regex_pattern_keys or DEFAULT_PARAMETERIZATION_REGEXES_MAP.keys()
         )
-        self.matches_counter: defaultdict[str, int] = defaultdict(int)
 
     def _make_regex_from_patterns(self, pattern_keys: Iterable[str]) -> re.Pattern[str]:
         """
@@ -299,19 +298,21 @@ class Parameterizer:
         For example, turn "Error with order #1231" into "Error with order #<int>".
         """
 
+        matches_counter: defaultdict[str, int] = defaultdict(int)
+
         def _handle_regex_match(match: re.Match[str]) -> str:
             # Find the first (should be only) non-None match entry, and sub in the placeholder. For
             # example, given the groupdict item `('hex', '0x40000015')`, this returns '<hex>' as a
             # replacement for the original value in the string.
             for key, value in match.groupdict().items():
                 if value is not None:
-                    self.matches_counter[key] += 1
+                    matches_counter[key] += 1
                     return f"<{key}>"
             return ""
 
         parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
 
-        for key, value in self.matches_counter.items():
+        for key, value in matches_counter.items():
             # Track the kinds of replacements being made
             metrics.incr("grouping.value_parameterized", amount=value, tags={"key": key})
 

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -3,6 +3,8 @@ import re
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
 
+from sentry.utils import metrics
+
 
 @dataclasses.dataclass
 class ParameterizationRegex:
@@ -307,4 +309,10 @@ class Parameterizer:
                     return f"<{key}>"
             return ""
 
-        return self._parameterization_regex.sub(_handle_regex_match, input_str)
+        parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
+
+        for key, value in self.matches_counter.items():
+            # Track the kinds of replacements being made
+            metrics.incr("grouping.value_parameterized", amount=value, tags={"key": key})
+
+        return parameterized

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -72,13 +72,16 @@ def normalize_message_for_grouping(
         # If there are multiple lines, grab the first two non-empty ones
         trimmed = _trim_extra_lines(message)
         normalized = parameterizer.parameterize(trimmed)
+        message_parameterized = normalized != trimmed
     else:
         normalized = parameterizer.parameterize(message)
+        message_parameterized = normalized != message
+
+    if message_parameterized:
+        metrics.incr("grouping.message_parameterized", tags={"source": reason})
 
     parameterization_counts = parameterizer.matches_counter.items()
     if parameterization_counts:
-        metrics.incr("grouping.message_parameterized", tags={"source": reason})
-
         for key, value in parameterization_counts:
             # `key` can only be one of the keys from `_parameterization_regex`, thus, not a large
             # cardinality. Tracking the key helps distinguish what kinds of replacements are happening.

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -8,7 +8,8 @@ from uuid import UUID
 
 from django.utils.encoding import force_bytes
 
-from sentry.grouping.parameterization import Parameterizer
+from sentry.grouping.parameterization import experimental_parameterizer
+from sentry.grouping.parameterization import parameterizer as default_parameterizer
 from sentry.options.rollout import in_rollout_group
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
@@ -62,10 +63,10 @@ def normalize_message_for_grouping(
     Replace values from a event's message with placeholders (in order to improve grouping). If
     `trim_message` is True, trim the message to at most 2 lines.
     """
-    parameterizer = Parameterizer(
-        use_experimental_regexes=in_rollout_group(
-            "grouping.experimental_parameterization", event.project_id
-        ),
+    parameterizer = (
+        experimental_parameterizer
+        if in_rollout_group("grouping.experimental_parameterization", event.project_id)
+        else default_parameterizer
     )
 
     if trim_message:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -80,13 +80,6 @@ def normalize_message_for_grouping(
     if message_parameterized:
         metrics.incr("grouping.message_parameterized", tags={"source": reason})
 
-    parameterization_counts = parameterizer.matches_counter.items()
-    if parameterization_counts:
-        for key, value in parameterization_counts:
-            # `key` can only be one of the keys from `_parameterization_regex`, thus, not a large
-            # cardinality. Tracking the key helps distinguish what kinds of replacements are happening.
-            metrics.incr("grouping.value_trimmed_from_message", amount=value, tags={"key": key})
-
     return normalized
 
 

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -3,19 +3,9 @@ import pytest
 from sentry.grouping.parameterization import (
     DEFAULT_PARAMETERIZATION_REGEXES_MAP,
     EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP,
-    Parameterizer,
+    experimental_parameterizer,
+    parameterizer,
 )
-
-
-@pytest.fixture
-def parameterizer() -> Parameterizer:
-    return Parameterizer(use_experimental_regexes=False)
-
-
-@pytest.fixture
-def experimental_parameterizer() -> Parameterizer:
-    return Parameterizer(use_experimental_regexes=True)
-
 
 standard_cases = [
     ("email", "test@email.com", "<email>"),
@@ -169,9 +159,7 @@ experimental_cases: list[tuple[str, str, str]] = [
 
 
 @pytest.mark.parametrize(("name", "input", "expected"), standard_cases)
-def test_default_parameterization(
-    name: str, input: str, expected: str, parameterizer: Parameterizer
-) -> None:
+def test_default_parameterization(name: str, input: str, expected: str) -> None:
     assert parameterizer.parameterize(input) == expected
     assert parameterizer.parameterize(f"prefix {input}") == f"prefix {expected}"
     assert parameterizer.parameterize(f"{input} suffix") == f"{expected} suffix"
@@ -180,7 +168,7 @@ def test_default_parameterization(
 
 @pytest.mark.parametrize(("name", "input", "expected"), experimental_cases)
 def test_default_parameterizer_misses_experimental_cases(
-    name: str, input: str, expected: str, parameterizer: Parameterizer
+    name: str, input: str, expected: str
 ) -> None:
     assert parameterizer.parameterize(input) != expected
     assert parameterizer.parameterize(f"prefix {input}") != f"prefix {expected}"
@@ -193,9 +181,7 @@ def test_default_parameterizer_misses_experimental_cases(
     reason="no experimental regexes to test",
 )
 @pytest.mark.parametrize(("name", "input", "expected"), standard_cases + experimental_cases)
-def test_experimental_parameterization(
-    name: str, input: str, expected: str, experimental_parameterizer: Parameterizer
-) -> None:
+def test_experimental_parameterization(name: str, input: str, expected: str) -> None:
     assert experimental_parameterizer.parameterize(input) == expected
     assert experimental_parameterizer.parameterize(f"prefix {input}") == f"prefix {expected}"
     assert experimental_parameterizer.parameterize(f"{input} suffix") == f"{expected} suffix"
@@ -255,8 +241,6 @@ incorrect_cases = [
 
 
 @pytest.mark.parametrize(("name", "input", "desired", "actual"), incorrect_cases)
-def test_incorrect_parameterization(
-    name: str, input: str, desired: str, actual: str, parameterizer: Parameterizer
-) -> None:
+def test_incorrect_parameterization(name: str, input: str, desired: str, actual: str) -> None:
     assert parameterizer.parameterize(input) != desired
     assert parameterizer.parameterize(input) == actual


### PR DESCRIPTION
Right now, whenever we want to parameterize a message, we create a new instance of the `Parameterizer` class, which then means that we end up re-compiling the combined regex we use for parameterization over and over again - at least once per event, and sometimes more. This is obviously not ideal, but the reason we do it is because the class is currently stateful, because it keeps a count of all the matches it makes, organized by match type. This then lets the calling function (in this case `normalize_message_for_grouping`) read that data and use it to power a metric.

However, there's no reason the parameterizer itself couldn't emit the metric (and by rights it actually should be the one to do so). This PR therefore moves the metric into the parameterizer, which then obviates the need for the counter to be stored on the `Parameterizer` instance, since it no longer needs to be accessible from the outside. This in turn means the class is no longer stateful, allowing us to only initialize it once, rather than millions of times a day. 

The parameterization module now includes two singletons, `parameterizer` (which uses the default collection of regexes) and `experimental_parameterizer` (which uses the experimental ones, if any), and all call sites have been switched to use them.