### PR TITLE
feat(preprod): Add explicit /snapshots/compare path

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2401,7 +2401,11 @@ function buildRoutes(): RouteObject[] {
       ],
     },
     {
-      path: 'snapshots/:snapshotId/',
+      path: 'snapshots/:preprodArtifactId/',
+      component: make(() => import('sentry/views/preprod/snapshots/snapshots')),
+    },
+    {
+      path: 'snapshots/compare/:preprodArtifactId/',
       component: make(() => import('sentry/views/preprod/snapshots/snapshots')),
     },
     // TODO(EME-735): Remove old routes after backend deployment

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2401,11 +2401,7 @@ function buildRoutes(): RouteObject[] {
       ],
     },
     {
-      path: 'snapshots/:preprodArtifactId/',
-      component: make(() => import('sentry/views/preprod/snapshots/snapshots')),
-    },
-    {
-      path: 'snapshots/compare/:preprodArtifactId/',
+      path: 'snapshots/:artifactId/',
       component: make(() => import('sentry/views/preprod/snapshots/snapshots')),
     },
     // TODO(EME-735): Remove old routes after backend deployment

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -54,7 +54,6 @@ type ParamKeys =
   | 'searchId'
   | 'sentryAppSlug'
   | 'shareId'
-  | 'preprodArtifactId'
   | 'snapshotId'
   | 'spanSlug'
   | 'step'

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -54,6 +54,7 @@ type ParamKeys =
   | 'searchId'
   | 'sentryAppSlug'
   | 'shareId'
+  | 'preprodArtifactId'
   | 'snapshotId'
   | 'spanSlug'
   | 'step'

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -31,8 +31,8 @@ import {SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
 export default function SnapshotsPage() {
   const organization = useOrganization();
   const theme = useTheme();
-  const {snapshotId} = useParams<{
-    snapshotId: string;
+  const {preprodArtifactId} = useParams<{
+    preprodArtifactId: string;
   }>();
 
   const {data, isPending, isError, refetch} = useApiQuery<SnapshotDetailsApiResponse>(
@@ -42,14 +42,14 @@ export default function SnapshotsPage() {
         {
           path: {
             organizationIdOrSlug: organization.slug,
-            snapshotId,
+            snapshotId: preprodArtifactId,
           },
         }
       ),
     ],
     {
       staleTime: 0,
-      enabled: !!snapshotId,
+      enabled: !!preprodArtifactId,
     }
   );
 
@@ -182,7 +182,7 @@ export default function SnapshotsPage() {
           <Layout.HeaderActions>
             <SnapshotDevTools
               organizationSlug={organization.slug}
-              snapshotId={snapshotId}
+              snapshotId={preprodArtifactId}
               comparisonRunInfo={comparisonRunInfo}
               hasBaseArtifact={data.base_artifact_id !== null}
               refetch={refetch}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -31,8 +31,8 @@ import {SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
 export default function SnapshotsPage() {
   const organization = useOrganization();
   const theme = useTheme();
-  const {preprodArtifactId} = useParams<{
-    preprodArtifactId: string;
+  const {artifactId} = useParams<{
+    artifactId: string;
   }>();
 
   const {data, isPending, isError, refetch} = useApiQuery<SnapshotDetailsApiResponse>(
@@ -42,14 +42,14 @@ export default function SnapshotsPage() {
         {
           path: {
             organizationIdOrSlug: organization.slug,
-            snapshotId: preprodArtifactId,
+            snapshotId: artifactId,
           },
         }
       ),
     ],
     {
       staleTime: 0,
-      enabled: !!preprodArtifactId,
+      enabled: !!artifactId,
     }
   );
 
@@ -182,7 +182,7 @@ export default function SnapshotsPage() {
           <Layout.HeaderActions>
             <SnapshotDevTools
               organizationSlug={organization.slug}
-              snapshotId={preprodArtifactId}
+              snapshotId={artifactId}
               comparisonRunInfo={comparisonRunInfo}
               hasBaseArtifact={data.base_artifact_id !== null}
               refetch={refetch}


### PR DESCRIPTION
Updates snapshot comparisons to use the `snapshots/compare/artifact_id` slug and solo snapshots to use `/snapshots/artifact_id`. Under the hood, both will use the same `SnapshotsPage` component, which we can force each side to only show solo/compare as a follow up (https://linear.app/getsentry/issue/EME-935/have-comparesolo-snapshot-routes-use-explicit-solocompare-views)