### PR TITLE
Use new compare URL for snapshot status check URLs

### DIFF
--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -25,5 +25,9 @@ def get_preprod_artifact_comparison_url(
     organization: Organization = Organization.objects.get_from_cache(
         id=preprod_artifact.project.organization_id
     )
-    path = f"/organizations/{organization.slug}/preprod/{comparison_type}/compare/{preprod_artifact.id}/{base_artifact.id}"
+    if comparison_type == "snapshots":
+        path = f"/organizations/{organization.slug}/preprod/{comparison_type}/compare/{preprod_artifact.id}"
+    else:
+        path = f"/organizations/{organization.slug}/preprod/{comparison_type}/compare/{preprod_artifact.id}/{base_artifact.id}"
+
     return organization.absolute_url(path)

--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from sentry.models.organization import Organization
 from sentry.preprod.models import PreprodArtifact
 
+ViewType = Literal["size", "snapshots"]
 
-def get_preprod_artifact_url(preprod_artifact: PreprodArtifact, view_type: str = "size") -> str:
+
+def get_preprod_artifact_url(
+    preprod_artifact: PreprodArtifact, view_type: ViewType = "size"
+) -> str:
     """
     Build a region/customer-domain aware absolute URL for the preprod artifact UI.
     """
@@ -17,7 +23,9 @@ def get_preprod_artifact_url(preprod_artifact: PreprodArtifact, view_type: str =
 
 
 def get_preprod_artifact_comparison_url(
-    preprod_artifact: PreprodArtifact, base_artifact: PreprodArtifact, comparison_type: str = "size"
+    preprod_artifact: PreprodArtifact,
+    base_artifact: PreprodArtifact,
+    comparison_type: ViewType = "size",
 ) -> str:
     """
     Build a region/customer-domain aware absolute URL for the preprod artifact comparison UI.
@@ -26,7 +34,7 @@ def get_preprod_artifact_comparison_url(
         id=preprod_artifact.project.organization_id
     )
     if comparison_type == "snapshots":
-        path = f"/organizations/{organization.slug}/preprod/{comparison_type}/compare/{preprod_artifact.id}"
+        path = f"/organizations/{organization.slug}/preprod/{comparison_type}/{preprod_artifact.id}"
     else:
         path = f"/organizations/{organization.slug}/preprod/{comparison_type}/compare/{preprod_artifact.id}/{base_artifact.id}"
 

--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -5,7 +5,7 @@ from typing import Literal
 from sentry.models.organization import Organization
 from sentry.preprod.models import PreprodArtifact
 
-ViewType = Literal["size", "snapshots"]
+ViewType = Literal["size", "snapshots", "install"]
 
 
 def get_preprod_artifact_url(

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -560,7 +560,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             base_artifact_map,
         )
 
-        expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/compare/{head_artifact.id}/{base_artifact.id}"
+        expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/compare/{head_artifact.id}"
         assert expected_url in summary
 
     def test_summary_uses_artifact_url_when_no_base(self):

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -560,7 +560,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             base_artifact_map,
         )
 
-        expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/compare/{head_artifact.id}"
+        expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{head_artifact.id}"
         assert expected_url in summary
 
     def test_summary_uses_artifact_url_when_no_base(self):


### PR DESCRIPTION
Per discussion, compare URLs will now just be `/snapshots/artifact_id`