### PR TITLE
ref(settings): Remove dead loadStats call from org teams page

### DIFF
--- a/static/app/actionCreators/projects.tsx
+++ b/static/app/actionCreators/projects.tsx
@@ -47,16 +47,6 @@ export function update(api: Client, params: UpdateParams) {
     );
 }
 
-type StatsParams = Pick<UpdateParams, 'orgId' | 'data' | 'query'>;
-
-export function loadStats(api: Client, params: StatsParams) {
-  const endpoint = `/organizations/${params.orgId}/stats/`;
-  api.request(endpoint, {
-    query: params.query,
-    success: data => ProjectsStore.onStatsLoadSuccess(data),
-  });
-}
-
 // This is going to queue up a list of project ids we need to fetch stats for
 // Will be cleared when debounced function fires
 export const _projectStatsToFetch = new Set<string>();

--- a/static/app/views/settings/organizationTeams/index.tsx
+++ b/static/app/views/settings/organizationTeams/index.tsx
@@ -1,6 +1,5 @@
-import {useCallback, useEffect, useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
-import {loadStats} from 'sentry/actionCreators/projects';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -8,13 +7,11 @@ import TeamStore from 'sentry/stores/teamStore';
 import type {AccessRequest} from 'sentry/types/organization';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
-import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import OrganizationTeams from './organizationTeams';
 
 export default function OrganizationTeamsContainer() {
-  const api = useApi();
   const organization = useOrganization({allowNull: true});
   const queryClient = useQueryClient();
 
@@ -37,20 +34,6 @@ export default function OrganizationTeamsContainer() {
     retry: false,
     enabled: !!organization?.slug,
   });
-
-  useEffect(() => {
-    if (!organization?.slug) {
-      return;
-    }
-    loadStats(api, {
-      orgId: organization?.slug,
-      query: {
-        since: (Date.now() / 1000 - 3600 * 24).toString(),
-        stat: 'generated',
-        group: 'project',
-      },
-    });
-  }, [organization?.slug, api]);
 
   const handleRemoveAccessRequest = useCallback(
     (id: string, isApproved: boolean) => {


### PR DESCRIPTION
The organizationTeams page has called loadStats() since at least 2018, but the 2020 TS refactor (#22064) dropped the ProjectsStore listener and stopped passing projectList to child components. The stats data has been fetched but never rendered since then. Remove the vestigial loadStats() function and its call site.