### PR TITLE
ref(settings): move projects sparklines to use /projects/ endpoint

### DIFF
--- a/static/app/views/settings/organizationProjects/index.spec.tsx
+++ b/static/app/views/settings/organizationProjects/index.spec.tsx
@@ -6,7 +6,6 @@ import OrganizationProjectsContainer from 'sentry/views/settings/organizationPro
 
 describe('OrganizationProjects', () => {
   let projectsGetMock: jest.Mock;
-  let statsGetMock: jest.Mock;
   let projectsPutMock: jest.Mock;
   const project = ProjectFixture();
 
@@ -14,11 +13,6 @@ describe('OrganizationProjects', () => {
     projectsGetMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [project],
-    });
-
-    statsGetMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/stats/',
-      body: [[[], 1]],
     });
 
     projectsPutMock = MockApiClient.addMockResponse({
@@ -37,19 +31,6 @@ describe('OrganizationProjects', () => {
     expect(await screen.findByText('project-slug')).toBeInTheDocument();
 
     expect(projectsGetMock).toHaveBeenCalledTimes(1);
-    expect(statsGetMock).toHaveBeenCalledTimes(1);
-    expect(statsGetMock).toHaveBeenCalledWith(
-      '/organizations/org-slug/stats/',
-      expect.objectContaining({
-        query: {
-          group: 'project',
-          projectID: [project.id],
-          // Time is frozen in tests
-          since: 1508121680,
-          stat: 'generated',
-        },
-      })
-    );
     expect(projectsPutMock).toHaveBeenCalledTimes(0);
 
     await userEvent.click(await screen.findByRole('button', {name: 'Bookmark'}));

--- a/static/app/views/settings/organizationProjects/index.tsx
+++ b/static/app/views/settings/organizationProjects/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useRef} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
@@ -10,7 +10,6 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import PanelItem from 'sentry/components/panels/panelItem';
-import Placeholder from 'sentry/components/placeholder';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
@@ -32,8 +31,6 @@ import ProjectStatsGraph from './projectStatsGraph';
 
 const ITEMS_PER_PAGE = 50;
 
-type ProjectStats = Record<string, Required<Project['stats']>>;
-
 function OrganizationProjects() {
   const organization = useOrganization();
 
@@ -41,7 +38,6 @@ function OrganizationProjects() {
   const location = useLocation();
   const query = decodeScalar(location.query.query, '');
 
-  const time = useRef(Date.now());
   const {
     data: projectList,
     getResponseHeader,
@@ -57,30 +53,11 @@ function OrganizationProjects() {
           ...location.query,
           query,
           per_page: ITEMS_PER_PAGE,
+          statsPeriod: '24h',
         },
       },
     ],
     {staleTime: 0}
-  );
-
-  const {data: projectStats, isPending: isLoadingStats} = useApiQuery<ProjectStats>(
-    [
-      getApiUrl(`/organizations/$organizationIdOrSlug/stats/`, {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
-      {
-        query: {
-          projectID: projectList?.map(p => p.id),
-          since: time.current / 1000 - 3600 * 24,
-          stat: 'generated',
-          group: 'project',
-        },
-      },
-    ],
-    {
-      staleTime: 60_000,
-      enabled: !!projectList,
-    }
   );
 
   const projectListPageLinks = getResponseHeader?.('Link');
@@ -126,14 +103,7 @@ function OrganizationProjects() {
                   <ProjectListItem project={project} organization={organization} />
                 </ProjectListItemWrapper>
                 <ProjectStatsGraphWrapper>
-                  {isLoadingStats && <Placeholder height="25px" />}
-                  {projectStats && (
-                    <ProjectStatsGraph
-                      key={project.id}
-                      project={project}
-                      stats={projectStats[project.id]}
-                    />
-                  )}
+                  <ProjectStatsGraph project={project} />
                 </ProjectStatsGraphWrapper>
               </GridPanelItem>
             ))}


### PR DESCRIPTION
The Settings > Projects page made a separate API call to the v1 /organizations/{org}/stats/ endpoint to render per-project event sparklines. The /projects/ endpoint already supports returning stats inline via the statsPeriod query param, and ProjectStatsGraph already has a fallback to project.stats. Switch to using the inline stats from the /projects/ response, eliminating a frontend caller of the v1 stats endpoint.

Prod:
<img width="1223" height="627" alt="Screenshot 2026-03-10 at 5 32 37 PM" src="https://github.com/user-attachments/assets/a20fe34f-dad3-4158-959a-9f779e0f4b45" />

New:
<img width="1210" height="634" alt="Screenshot 2026-03-10 at 5 32 52 PM" src="https://github.com/user-attachments/assets/0c2fe04c-1722-4f5b-986c-318203ee3ee0" />

There are some minor discrepancies between the stats. Spot checking a few of them indicated that the new version is more accurate in terms of event counts. 