### PR TITLE
ref(gen-ai): Remove redundant cost alert capture message

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -51,10 +51,6 @@ describe('getHighlightedSpanAttributes', () => {
     };
 
     expect(Sentry.captureMessage).toHaveBeenCalledWith(
-      'Gen AI span missing cost calculation',
-      expectedContext
-    );
-    expect(Sentry.captureMessage).toHaveBeenCalledWith(
       'Gen AI cost data missing for model: gpt-4',
       expectedContext
     );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -162,10 +162,7 @@ function getAISpanAttributes({
         (inputTokens || outputTokens) &&
         (!totalCosts || Number(totalCosts) === 0)
       ),
-      messages: [
-        'Gen AI span missing cost calculation',
-        `Gen AI cost data missing for model: ${model?.toString()}`,
-      ],
+      messages: [`Gen AI cost data missing for model: ${model?.toString()}`],
     },
     {
       shouldCapture: Boolean(model && totalCosts && Number(totalCosts) < 0),


### PR DESCRIPTION
The `'Gen AI span missing cost calculation'` message was only used for a Sentry alert that has since been deleted. The model-specific message `'Gen AI cost data missing for model: ...'` still powers the dashboard widget and is sufficient on its own.