### PR TITLE
fix(preprod): Update existing PR comment instead of posting a new one

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -105,8 +105,15 @@ def create_preprod_pr_comment_task(
             .order_by("id")
         )
 
-        # Fresh read of the current row from the locked set
-        cc = next(c for c in all_for_pr if c.id == commit_comparison.id)
+        # Re-read our row from the locked set. The row could theoretically
+        # be deleted between the initial fetch and the lock acquisition, but
+        # CommitComparison rows are never deleted in practice today.
+        try:
+            cc = next(c for c in all_for_pr if c.id == commit_comparison.id)
+        except StopIteration:
+            raise CommitComparison.DoesNotExist(
+                f"CommitComparison {commit_comparison.id} was deleted before lock acquisition"
+            )
 
         siblings = artifact.get_sibling_artifacts_for_commit()
         installable_siblings = [s for s in siblings if is_installable_artifact(s)]

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from enum import StrEnum
 from typing import Any
 
@@ -87,21 +88,32 @@ def create_preprod_pr_comment_task(
         )
         return
 
-    # Use select_for_update on the commit_comparison row to serialize
-    # concurrent tasks for the same commit.  This prevents duplicate
-    # comments when multiple builds finish at the same time and also
-    # guarantees a fresh read of extras (where the comment_id lives).
+    # Lock ALL CommitComparison rows for this PR, ordered by id to prevent
+    # deadlocks.  This serializes tasks across different commits on the same
+    # PR, preventing duplicate comments when a new commit is pushed before
+    # the previous task finishes.
     api_error: Exception | None = None
 
     with transaction.atomic(router.db_for_write(CommitComparison)):
-        cc = CommitComparison.objects.select_for_update().get(id=commit_comparison.id)
+        all_for_pr = list(
+            CommitComparison.objects.select_for_update()
+            .filter(
+                organization_id=commit_comparison.organization_id,
+                head_repo_name=commit_comparison.head_repo_name,
+                pr_number=commit_comparison.pr_number,
+            )
+            .order_by("id")
+        )
+
+        # Fresh read of the current row from the locked set
+        cc = next(c for c in all_for_pr if c.id == commit_comparison.id)
 
         siblings = artifact.get_sibling_artifacts_for_commit()
         installable_siblings = [s for s in siblings if is_installable_artifact(s)]
         if not installable_siblings:
             return
 
-        existing_comment_id = _find_existing_comment_id(cc)
+        existing_comment_id = _find_existing_comment_id(all_for_pr)
         comment_body = format_pr_comment(installable_siblings)
 
         try:
@@ -146,12 +158,14 @@ def create_preprod_pr_comment_task(
         raise api_error
 
 
-def _find_existing_comment_id(commit_comparison: CommitComparison) -> str | None:
-    extras = commit_comparison.extras or {}
-    build_dist = extras.get("pr_comments", {}).get("build_distribution", {})
-    comment_id = build_dist.get("comment_id")
-    if comment_id:
-        return str(comment_id)
+def _find_existing_comment_id(
+    comparisons: Sequence[CommitComparison],
+) -> str | None:
+    for cc in comparisons:
+        extras = cc.extras or {}
+        comment_id = extras.get("pr_comments", {}).get("build_distribution", {}).get("comment_id")
+        if comment_id:
+            return str(comment_id)
     return None
 
 

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -380,6 +380,120 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         )
         mock_client.create_comment.assert_not_called()
 
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
+    def test_updates_comment_from_previous_commit(self, mock_format, mock_get_client):
+        """When a previous commit on the same PR already has a comment_id,
+        a new commit should update that comment instead of creating a new one."""
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "updated body"
+
+        # Commit A already posted a comment
+        cc_a = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+            pr_number=42,
+            extras={
+                "pr_comments": {
+                    "build_distribution": {"success": True, "comment_id": "prev_commit_123"}
+                }
+            },
+        )
+
+        # Commit B on the same PR — no comment_id yet
+        cc_b = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="c" * 40,
+            base_sha="d" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+            pr_number=42,
+        )
+
+        artifact = self._create_artifact(commit_comparison=cc_b)
+
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
+            create_preprod_pr_comment_task(artifact.id)
+
+        mock_client.update_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            comment_id="prev_commit_123",
+            data={"body": "updated body"},
+        )
+        mock_client.create_comment.assert_not_called()
+
+        # comment_id stored on cc_b as well
+        cc_b.refresh_from_db()
+        build_dist = cc_b.extras["pr_comments"]["build_distribution"]
+        assert build_dist["comment_id"] == "prev_commit_123"
+
+        # cc_a unchanged
+        cc_a.refresh_from_db()
+        assert cc_a.extras["pr_comments"]["build_distribution"]["comment_id"] == "prev_commit_123"
+
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
+    def test_creates_comment_when_no_sibling_has_comment_id(self, mock_format, mock_get_client):
+        """When multiple commits exist on the same PR but none has a
+        comment_id, a new comment should be created."""
+        mock_client = Mock()
+        mock_client.create_comment.return_value = {"id": 55555}
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "new body"
+
+        # Two commits on the same PR, neither with a comment_id
+        CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+            pr_number=42,
+        )
+
+        cc_b = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="c" * 40,
+            base_sha="d" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+            pr_number=42,
+        )
+
+        artifact = self._create_artifact(commit_comparison=cc_b)
+
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
+            create_preprod_pr_comment_task(artifact.id)
+
+        mock_client.create_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            data={"body": "new body"},
+        )
+        mock_client.update_comment.assert_not_called()
+
+        cc_b.refresh_from_db()
+        build_dist = cc_b.extras["pr_comments"]["build_distribution"]
+        assert build_dist["success"] is True
+        assert build_dist["comment_id"] == "55555"
+
     def test_skips_xcarchive_without_valid_code_signature(self):
         artifact = self._create_artifact(extras={"is_code_signature_valid": False})
 


### PR DESCRIPTION
Each new commit pushed to a PR creates a new `CommitComparison` row. The previous code only locked and searched the current commit's row for an existing `comment_id`, so new commits always created a duplicate GitHub comment.

This changes the lock scope from a single `CommitComparison` row to all rows matching the PR (`organization_id` + `head_repo_name` + `pr_number`), ordered by `id` to prevent deadlocks. `_find_existing_comment_id` now searches across all locked rows, so a `comment_id` stored by a previous commit is found and reused.

Refs EME-937