### PR TITLE
ref(gen-ai): Remove noisy parse exception captures in AI input

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -118,14 +118,7 @@ function parseAIMessages(messages: string): AIMessage[] | string {
         (message): message is Exclude<typeof message, null> =>
           message !== null && Boolean(message.content)
       );
-  } catch (error) {
-    try {
-      Sentry.captureException(
-        new Error('Error parsing ai.prompt.messages', {cause: error})
-      );
-    } catch {
-      // ignore errors with browsers that don't support `cause`
-    }
+  } catch {
     return messages;
   }
 }
@@ -157,14 +150,7 @@ function transformInputMessages(inputMessages: string): {
       result: JSON.stringify(result),
       fixedInvalidJson,
     };
-  } catch (error) {
-    try {
-      Sentry.captureException(
-        new Error('Error parsing ai.input_messages', {cause: error})
-      );
-    } catch {
-      // ignore errors with browsers that don't support `cause`
-    }
+  } catch {
     return {
       result: undefined,
       fixedInvalidJson: false,
@@ -197,12 +183,7 @@ function transformPrompt(prompt: string): {
       result: JSON.stringify(result),
       fixedInvalidJson,
     };
-  } catch (error) {
-    try {
-      Sentry.captureException(new Error('Error parsing ai.prompt', {cause: error}));
-    } catch {
-      // ignore errors with browsers that don't support `cause`
-    }
+  } catch {
     return {
       result: undefined,
       fixedInvalidJson: false,
@@ -265,14 +246,7 @@ export function transformPartsMessages(messages: string): {
       result: JSON.stringify(transformed),
       fixedInvalidJson,
     };
-  } catch (error) {
-    try {
-      Sentry.captureException(
-        new Error('Error parsing gen_ai messages with parts format', {cause: error})
-      );
-    } catch {
-      // ignore errors with browsers that don't support `cause`
-    }
+  } catch {
     return {
       result: undefined,
       fixedInvalidJson: false,


### PR DESCRIPTION
These exception captures were useful in the past for surfacing edge cases and issues with our parsing functions (like the [OpenRouter input parsing fix](https://github.com/getsentry/sentry/pull/107487)). However, the notifications we now receive are almost entirely due to PII redaction, which is expected behavior. Since our
  parsing functions have been stable and we haven't seen anything unusual in quite some time, we're removing the Sentry exception captures for the following:
  
  
- `Error parsing ai.prompt.messages`
- `Error parsing ai.input_messages`
- `Error parsing ai.prompt`
- `Error parsing gen_ai messages with parts format`