### PR TITLE
fix(conversations): left-align text content in user message bubbles

### DIFF
--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -92,7 +92,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
               isSelected={isAssistant && isSelected}
               onClick={isAssistant ? () => handleMessageClick(message) : undefined}
             >
-              <MessageHeader justify={message.role === 'user' ? 'end' : 'start'}>
+              <MessageHeader>
                 {message.role === 'user' ? (
                   <Text bold size="sm">
                     {message.userEmail || t('User')}
@@ -116,10 +116,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
                 collapsible
               >
                 <Container padding="md">
-                  <MessageText
-                    size="sm"
-                    align={message.role === 'user' ? 'right' : 'left'}
-                  >
+                  <MessageText size="sm" align="left">
                     <MarkedText
                       as={TraceDrawerComponents.MarkdownContainer}
                       text={message.content}
@@ -143,12 +140,12 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
   );
 }
 
-const MessageHeader = styled('div')<{justify?: 'start' | 'end'}>`
+const MessageHeader = styled('div')`
   display: flex;
   align-items: center;
   gap: ${p => p.theme.space.sm};
   padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
-  justify-content: ${p => (p.justify === 'end' ? 'flex-end' : 'flex-start')};
+  justify-content: flex-start;
 
   &::after {
     content: '';


### PR DESCRIPTION
User message bubbles previously right-aligned both the header (sender name) and body text, making them hard to read. This aligns all message content to the left regardless of role, while keeping bubble positioning (user right, assistant left) unchanged.

| Before | After |
|--------|-------|
| ![Before](https://raw.githubusercontent.com/getsentry/sentry/priscilawebdev/fix/left-align-conversation-messages/.github/before-fix.png) | ![After](https://raw.githubusercontent.com/getsentry/sentry/priscilawebdev/fix/left-align-conversation-messages/.github/after-fix.png) |