### PR TITLE
fix(preprod): Expose PR comments feature flag to frontend API

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -242,7 +242,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable writing preprod build distribution data to EAP for querying
     manager.add("organizations:preprod-build-distribution-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod PR comments for build distribution
-    manager.add("organizations:preprod-build-distribution-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:preprod-build-distribution-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod app size dashboard widget
     manager.add("organizations:preprod-app-size-dashboard", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)


### PR DESCRIPTION
Set `api_expose=True` for the `organizations:preprod-build-distribution-pr-comments`
feature flag so the frontend `<Feature>` component can check it.

Without this, the flag is never included in the organization features response,
causing the PR comments toggle to never render on the settings page.

Related to this PR: https://github.com/getsentry/sentry/pull/110051

And EME-796