### PR TITLE
test(relay): Update project config snapshot for health-check glob

### DIFF
--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -159,6 +159,7 @@ config:
       isEnabled: true
       patterns:
       - '*healthcheck*'
+      - '*health-check*'
       - '*heartbeat*'
       - '*/health{/,}'
       - '*/healthy{/,}'


### PR DESCRIPTION
The `HEALTH_CHECK_GLOBS` constant in `src/sentry/constants.py` gained a new `*health-check*` pattern (https://github.com/getsentry/sentry/pull/110402), but the relay project config snapshot was not regenerated at that time, causing `test_get_project_config` to fail.

Regenerated the snapshot using `SENTRY_SNAPSHOTS_WRITEBACK=1`.