### PR TITLE
fix(preprod): Strip trailing slash from objectstore base URL

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
@@ -43,7 +43,9 @@ class ProjectPreprodUploadOptionsEndpoint(ProjectEndpoint):
                 "path": "",
             },
         )
-        url = absolute_uri(path, generate_locality_url())
+        # Strip trailing slash so the objectstore client can append subpaths
+        # without producing a double slash (e.g. /objectstore//v1/...).
+        url = absolute_uri(path, generate_locality_url()).rstrip("/")
 
         options = ObjectstoreUploadOptions(
             url=url,

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
@@ -23,7 +23,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
         assert response.status_code == 200
         data = response.data["objectstore"]
 
-        assert f"/api/0/organizations/{self.org.id}/objectstore/" in data["url"]
+        assert data["url"].endswith(f"/api/0/organizations/{self.org.id}/objectstore")
 
         assert data["scopes"] == [("org", str(self.org.id)), ("project", str(self.project.id))]
 
@@ -40,7 +40,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
         url = response.data["objectstore"]["url"]
         region = settings.SENTRY_REGION
         assert url.startswith(f"https://{region}.testserver/")
-        assert f"/api/0/organizations/{self.org.id}/objectstore/" in url
+        assert url.endswith(f"/api/0/organizations/{self.org.id}/objectstore")
 
     def test_without_feature_flag(self):
         response = self.client.get(self.url)


### PR DESCRIPTION
The upload options endpoint returned a base URL ending with a trailing slash.
When the objectstore client appended its subpath, this produced a double slash
in the final URL (e.g. `/objectstore//v1/objects:batch/...`), causing batch
upload requests to fail.

Strips the trailing slash from the generated URL so clients can cleanly
append subpaths.