### PR TITLE
fix(AutoSaveField): type inference for mutationOptions

### DIFF
--- a/static/app/components/core/form/field/autoSaveField.spec.tsx
+++ b/static/app/components/core/form/field/autoSaveField.spec.tsx
@@ -1,0 +1,48 @@
+import {expectTypeOf} from 'expect-type';
+import {z} from 'zod';
+
+import {AutoSaveField} from '@sentry/scraps/form';
+
+const testSchema = z.object({
+  testField: z.string(),
+});
+
+describe('AutoSaveField', () => {
+  describe('types', () => {
+    it('should have data type flow towards callbacks', () => {
+      function TypeTestField() {
+        return (
+          <AutoSaveField
+            name="testField"
+            schema={testSchema}
+            initialValue=""
+            mutationOptions={{
+              onMutate: variables => {
+                expectTypeOf(variables).toEqualTypeOf<{testField: string}>();
+                return {
+                  context: true,
+                };
+              },
+              mutationFn: data => Promise.resolve(data.testField),
+              onSuccess: data => {
+                expectTypeOf(data).toEqualTypeOf<string>();
+              },
+              onError: (error, variables, context) => {
+                expectTypeOf(error).toEqualTypeOf<Error>();
+                expectTypeOf(variables).toEqualTypeOf<{testField: string}>();
+                expectTypeOf(context).toEqualTypeOf<{context: boolean} | undefined>();
+              },
+            }}
+          >
+            {field => (
+              <field.Layout.Row label="Username">
+                <field.Input value={field.state.value} onChange={field.handleChange} />
+              </field.Layout.Row>
+            )}
+          </AutoSaveField>
+        );
+      }
+      void TypeTestField;
+    });
+  });
+});

--- a/static/app/components/core/form/field/autoSaveField.tsx
+++ b/static/app/components/core/form/field/autoSaveField.tsx
@@ -102,6 +102,8 @@ type AutoSaveFieldRenderArg<
  */
 
 interface AutoSaveFieldProps<
+  TData,
+  TContext,
   TSchema extends z.ZodObject<z.ZodRawShape>,
   TFieldName extends Extract<keyof z.infer<TSchema>, string>,
 > {
@@ -119,10 +121,10 @@ interface AutoSaveFieldProps<
    * TanStack Query mutation options - mutationFn receives single-field data
    */
   mutationOptions: UseMutationOptions<
-    any, // it doesn't matter here what the mutation returns
+    TData,
     Error,
     NoInfer<Record<TFieldName, z.infer<TSchema>[TFieldName]>>,
-    any // context type from onMutate - allow any shape
+    TContext
   >;
 
   /**
@@ -155,9 +157,11 @@ interface AutoSaveFieldProps<
 }
 
 export function AutoSaveField<
+  TData,
+  TContext,
   TSchema extends z.ZodObject<z.ZodRawShape>,
   TFieldName extends Extract<keyof z.infer<TSchema>, string>,
->(props: AutoSaveFieldProps<TSchema, TFieldName>) {
+>(props: AutoSaveFieldProps<TData, TContext, TSchema, TFieldName>) {
   const {name, schema, initialValue, mutationOptions, confirm, children} = props;
   const id = useId();
   const mutation = useMutation(mutationOptions);


### PR DESCRIPTION
while we initially thought we don’t need those type parameters, if `mutationOptions` uses callbacks like `onMutate`, `onSuccess`, `onError` or `onSettled`, the type information gets lost, e.g. when `onMutate` returns a `context`. 