### PR TITLE
fix(tracemetrics): Include conditions for unit:none explicitly

### DIFF
--- a/src/sentry/search/eap/trace_metrics/types.py
+++ b/src/sentry/search/eap/trace_metrics/types.py
@@ -7,6 +7,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     ComparisonFilter,
     ExistsFilter,
     NotFilter,
+    OrFilter,
     TraceItemFilter,
 )
 
@@ -45,12 +46,34 @@ class TraceMetric:
 
         if self.metric_unit == NONE_UNIT:
             unit_key = AttributeKey(name="sentry.metric_unit", type=AttributeKey.Type.TYPE_STRING)
-            filters.append(
-                TraceItemFilter(
-                    not_filter=NotFilter(
-                        filters=[TraceItemFilter(exists_filter=ExistsFilter(key=unit_key))]
+
+            # In the case of NONE_UNIT, we want to select all items that do not have a unit, or
+            # have a unit explicitly set to "none"
+            filters.extend(
+                [
+                    TraceItemFilter(
+                        or_filter=OrFilter(
+                            filters=[
+                                TraceItemFilter(
+                                    not_filter=NotFilter(
+                                        filters=[
+                                            TraceItemFilter(
+                                                exists_filter=ExistsFilter(key=unit_key)
+                                            )
+                                        ]
+                                    )
+                                ),
+                                TraceItemFilter(
+                                    comparison_filter=ComparisonFilter(
+                                        key=unit_key,
+                                        op=ComparisonFilter.OP_EQUALS,
+                                        value=AttributeValue(val_str=self.metric_unit),
+                                    )
+                                ),
+                            ]
+                        )
                     )
-                )
+                ]
             )
         elif self.metric_unit is not None and self.metric_unit != ANY_UNIT:
             filters.append(

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -726,3 +726,26 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
 
         assert len(data) == 1
         assert data[0]["count(value,request_duration,distribution,none)"] == 1
+
+    def test_aggregation_with_none_includes_items_with_none_explicitly_set(self):
+        trace_metrics = [
+            self.create_trace_metric(
+                "request_duration", 100.0, "distribution", metric_unit="millisecond"
+            ),
+            self.create_trace_metric("request_duration", 200.0, "distribution", metric_unit="none"),
+        ]
+        self.store_trace_metrics(trace_metrics)
+
+        response = self.do_request(
+            {
+                "field": ["count(value,request_duration,distribution,none)"],
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+
+        assert len(data) == 1
+        assert data[0]["count(value,request_duration,distribution,none)"] == 1


### PR DESCRIPTION
Additionally adds the "none" filter because `none` could mean that there legitimately isn't any unit set, which is handled by the `!has:metric.unit` filter, but we also need to OR that with a `metric.unit:none` filter since it seems like that can be stored