### PR TITLE
fix(dashboards): Open Explore in aggregate mode for widgets with aggregates

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -266,7 +266,7 @@ export function getMenuOptions(
         dashboardFilters,
         selection,
         organization,
-        Mode.SAMPLES,
+        widget.queries.some(q => q.aggregates.length > 0) ? Mode.AGGREGATE : Mode.SAMPLES,
         getReferrer(widget.displayType)
       ),
     });


### PR DESCRIPTION
The 'Open in Explore' context menu option on dashboard widgets was always opening in samples mode, even for widgets that use aggregates (like counts, averages, etc.). This meant users had to manually switch to the aggregate tab every time.

Now the link checks if any widget query has aggregates defined and opens Explore in aggregate mode when they do, falling back to samples mode only when no aggregates are present.

Refs LINEAR-BROWSE-417