### PR TITLE
feat(preprod): Add app name, app ID, and install columns to PR comment table

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -13,7 +13,8 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
 
     for artifact in artifacts:
         mobile_app_info = artifact.get_mobile_app_info()
-        app_name = mobile_app_info.app_name if mobile_app_info else "--"
+        app_name_value = mobile_app_info.app_name if mobile_app_info else None
+        app_name = app_name_value or "--"
         app_id = artifact.app_id or "--"
         version_string = mobile_app_info.format_version_string() if mobile_app_info else "--"
         config = artifact.build_configuration.name if artifact.build_configuration else "--"

--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -13,15 +13,15 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
 
     for artifact in artifacts:
         mobile_app_info = artifact.get_mobile_app_info()
-        app_name = mobile_app_info.app_name if mobile_app_info else None
-        app_id = artifact.app_id or "Unknown"
+        app_name = mobile_app_info.app_name if mobile_app_info else "--"
+        app_id = artifact.app_id or "--"
         version_string = mobile_app_info.format_version_string() if mobile_app_info else "--"
         config = artifact.build_configuration.name if artifact.build_configuration else "--"
         artifact_url = get_preprod_artifact_url(artifact, view_type="install")
 
-        name_cell = f"[{app_name or app_id}]({artifact_url})"
+        install_cell = f"[Install Build]({artifact_url})"
 
-        row = f"| {name_cell} | {version_string} | {config} |"
+        row = f"| {app_name} | {app_id} | {version_string} | {config} | {install_cell} |"
 
         if artifact.is_android():
             android_rows.append(row)
@@ -30,8 +30,8 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
 
     sections: list[str] = ["## Sentry Build Distribution"]
 
-    header = "| App | Version | Configuration |"
-    separator = "|-----|---------|---------------|"
+    header = "| App Name | App ID | Version | Configuration | Install Page |"
+    separator = "|----------|--------|---------|---------------|--------------|"
 
     if ios_rows:
         if android_rows:

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -59,9 +59,12 @@ class FormatPrCommentTest(TestCase):
         result = format_pr_comment([artifact])
 
         assert "## Sentry Build Distribution" in result
+        assert "| App Name | App ID | Version | Configuration | Install Page |" in result
         assert "MyApp" in result
+        assert "com.example.app" in result
         assert "1.2.3 (456)" in result
         assert "Release" in result
+        assert "[Install Build](" in result
         # Single platform — no subheader
         assert "### iOS" not in result
 


### PR DESCRIPTION
Expand the build distribution PR comment table to more closely match the Emerge version.

Previously the table had: App (name linked to install page), Version, Configuration. Now it has: App Name, App ID, Version, Configuration, Install Page (separate clickable "Install Build" link).

This makes it easier to identify builds at a glance, especially when multiple apps share similar names or when the app name isn't available.