### PR TITLE
fix(dashboards): Pass translated options to CompactSelect dropdown

### DIFF
--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -4,6 +4,7 @@ import {FieldKind} from 'sentry/utils/fields';
 import type {SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
 import FilterSelector from 'sentry/views/dashboards/globalFilter/filterSelector';
 import {WidgetType, type GlobalFilter} from 'sentry/views/dashboards/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 describe('FilterSelector', () => {
   const mockOnUpdateFilter = jest.fn();
@@ -106,5 +107,42 @@ describe('FilterSelector', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Remove Filter'}));
 
     expect(mockOnRemoveFilter).toHaveBeenCalledWith(mockGlobalFilter);
+  });
+
+  it('translates subregion codes to human-readable names for spans dataset', async () => {
+    const subregionFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {
+        key: SpanFields.USER_GEO_SUBREGION,
+        name: 'User Geo Subregion',
+        kind: FieldKind.FIELD,
+      },
+      value: '',
+    };
+
+    const subregionSearchBarData: SearchBarData = {
+      getFilterKeySections: () => [],
+      getFilterKeys: () => ({}),
+      getTagValues: () => Promise.resolve(['21', '154']),
+    };
+
+    render(
+      <FilterSelector
+        globalFilter={subregionFilter}
+        searchBarData={subregionSearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
+    const button = screen.getByRole('button', {
+      name: SpanFields.USER_GEO_SUBREGION + ' :',
+    });
+    await userEvent.click(button);
+
+    expect(screen.getByRole('row', {name: 'North America'})).toBeInTheDocument();
+    expect(screen.getByRole('row', {name: 'Northern Europe'})).toBeInTheDocument();
+    expect(screen.queryByRole('row', {name: '21'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('row', {name: '154'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -305,7 +305,7 @@ function FilterSelector({
 
   const stagedSelect = useStagedCompactSelect({
     value: activeFilterValues,
-    options,
+    options: translatedOptions,
     onChange: handleChange,
     onStagedValueChange: setStagedFilterValues,
     multiple: true,


### PR DESCRIPTION
Fixes a regression from https://github.com/getsentry/sentry/pull/108217

The global filter for `user.geo.subregion` was displaying raw integer codes (e.g. `21`, `154`) in the dropdown instead of human-readable subregion names (e.g. "North America", "Northern Europe").

The `translateKnownFilterOptions` function was correctly translating the labels, but the untranslated `options` were being passed to `useStagedCompactSelect`, whose `compactSelectProps` are spread into the `CompactSelect` dropdown — bypassing the translated options entirely.

The fix passes `translatedOptions` to `useStagedCompactSelect` so the dropdown renders the human-readable names. Adds a test to verify subregion codes are translated in the dropdown and prevents future regressions.

<img width="287" height="308" alt="image" src="https://github.com/user-attachments/assets/25aebb5e-dee8-4678-8f4d-f964bb2e0140" />


Fixes DAIN-1294