### PR TITLE
fix(preprod): Mark App Store signed builds as not installable (EME-917)

### DIFF
--- a/src/sentry/preprod/build_distribution_utils.py
+++ b/src/sentry/preprod/build_distribution_utils.py
@@ -84,6 +84,8 @@ def is_installable_artifact(artifact: PreprodArtifact) -> bool:
         extras = artifact.extras or {}
         if extras.get("is_code_signature_valid") is not True:
             return False
+        if extras.get("codesigning_type") == "app-store":
+            return False
     return True
 
 

--- a/tests/sentry/preprod/test_build_distribution_utils.py
+++ b/tests/sentry/preprod/test_build_distribution_utils.py
@@ -1,0 +1,65 @@
+from sentry.preprod.build_distribution_utils import is_installable_artifact
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
+    PreprodBuildConfiguration,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class IsInstallableArtifactTest(TestCase):
+    def _create_artifact(
+        self,
+        artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        installable_app_file_id=1,
+        build_number="456",
+        extras=None,
+    ) -> PreprodArtifact:
+        build_config = PreprodBuildConfiguration.objects.create(
+            project=self.project, name="Release"
+        )
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=artifact_type,
+            app_id="com.example.app",
+            build_configuration=build_config,
+            installable_app_file_id=installable_app_file_id,
+            extras=extras,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
+            app_name="TestApp",
+            build_version="1.0.0",
+            build_number=build_number,
+        )
+        return PreprodArtifact.objects.select_related("mobile_app_info").get(id=artifact.id)
+
+    def test_xcarchive_with_valid_signature_is_installable(self):
+        artifact = self._create_artifact(extras={"is_code_signature_valid": True})
+        assert is_installable_artifact(artifact) is True
+
+    def test_xcarchive_without_valid_signature_is_not_installable(self):
+        artifact = self._create_artifact(extras={"is_code_signature_valid": False})
+        assert is_installable_artifact(artifact) is False
+
+    def test_xcarchive_with_app_store_codesigning_is_not_installable(self):
+        artifact = self._create_artifact(
+            extras={"is_code_signature_valid": True, "codesigning_type": "app-store"}
+        )
+        assert is_installable_artifact(artifact) is False
+
+    def test_xcarchive_without_installable_app_file_is_not_installable(self):
+        artifact = self._create_artifact(
+            installable_app_file_id=None, extras={"is_code_signature_valid": True}
+        )
+        assert is_installable_artifact(artifact) is False
+
+    def test_aab_is_installable(self):
+        artifact = self._create_artifact(
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+            extras=None,
+        )
+        assert is_installable_artifact(artifact) is True

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -536,3 +536,17 @@ class CreatePreprodPrCommentTaskTest(TestCase):
             create_preprod_pr_comment_task(artifact.id)
 
         # No comment posted — task returns early because artifact is not installable
+
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
+    def test_skips_xcarchive_with_app_store_codesigning(self, mock_get_client):
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        artifact = self._create_artifact(
+            extras={"is_code_signature_valid": True, "codesigning_type": "app-store"}
+        )
+
+        with self.feature(self._pr_comment_feature):
+            create_preprod_pr_comment_task(artifact.id)
+
+        mock_client.create_comment.assert_not_called()
+        mock_client.update_comment.assert_not_called()


### PR DESCRIPTION
App Store code signatures can only be installed by Apple (via TestFlight/App Store). When a build has an `app-store` codesigning type, we should treat it as not installable so it doesn't appear in PR comments, install pages, or update checks with a broken install link.

`is_installable_artifact()` is the single source of truth for installability — all downstream consumers (`get_artifact_install_info()`, PR comments task, `find_latest_installable_artifact()`, etc.) already use this function, so the one-line check propagates everywhere.

Refs EME-917