### PR TITLE
ref(avatarButton): Halve padding for padded avatar container

### DIFF
--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -82,7 +82,7 @@ const AvatarContainer = styled('div')<{
         : p.size === 'xs'
           ? p.theme.radius.sm
           : p.theme.radius.xs};
-  padding: ${p => (p.padded ? p.theme.space.xs : '0')};
+  padding: ${p => (p.padded ? p.theme.space['2xs'] : '0')};
   background: ${p => (p.padded ? p.theme.tokens.background.primary : 'transparent')};
   position: relative;
 `;


### PR DESCRIPTION
Reduces the padding on the `AvatarContainer` when in padded mode from `space.xs` (4px) to `space['2xs']` (2px) which results in a 4px increase in image sizes inside avatarButton

Before
<img width="896" height="198" alt="CleanShot 2026-03-11 at 08 53 18@2x" src="https://github.com/user-attachments/assets/4d0901f2-f781-4b82-9281-c4166b92bfc7" />

After
<img width="928" height="194" alt="CleanShot 2026-03-11 at 08 53 35@2x" src="https://github.com/user-attachments/assets/1fcf88ce-67fc-46c8-8e02-a89f688b07a7" />
