### PR TITLE
chore: Add v10 directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+/v10
 .cache/
 .code-workspace
 .coverage*


### PR DESCRIPTION
Add the `v10/` directory to `.gitignore` to keep it out of version control.