### PR TITLE
fix(preprod): Allow user tokens for ProjectPreprodBuildDistributionLatestEndpoint

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -90,6 +90,15 @@ class ProjectDistributionPermission(ProjectPermission):
     }
 
 
+class ProjectDistributionOrProjectPermission(ProjectPermission):
+    scope_map = {
+        "GET": ["project:distribution", "project:read", "project:write", "project:admin"],
+        "POST": ["project:write", "project:admin"],
+        "PUT": ["project:write", "project:admin"],
+        "DELETE": ["project:admin"],
+    }
+
+
 class ProjectEventPermission(ProjectPermission):
     scope_map = {
         "GET": ["event:read", "event:write", "event:admin"],

--- a/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
@@ -9,7 +9,10 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.project import ProjectDistributionPermission, ProjectEndpoint
+from sentry.api.bases.project import (
+    ProjectDistributionOrProjectPermission,
+    ProjectEndpoint,
+)
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -35,7 +38,7 @@ class ProjectPreprodBuildDistributionLatestEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    permission_classes = (ProjectDistributionPermission,)
+    permission_classes = (ProjectDistributionOrProjectPermission,)
     rate_limits = RateLimitConfig(
         limit_overrides={
             "GET": {


### PR DESCRIPTION
fix(preprod): Allow user tokens for ProjectPreprodBuildDistributionLatestEndpoint

Previously only distribution scoped tokens where allowed. These are
hard to mint (only via custom integrations). Since Sentry doesn't use
the composable permissions of django-rest-framework just make a new
permission which is the union of the ones we want:
ProjectDistributionOrProjectPermission

