### PR TITLE
feat(autofix): Add open seer button in autofix section

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
@@ -141,6 +141,7 @@ describe('AutofixSection', () => {
 
     expect(await screen.findByText('Root Cause')).toBeInTheDocument();
     expect(screen.getByText('Null pointer in user handler')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
   });
 
   it('renders solution artifact', async () => {
@@ -178,6 +179,7 @@ describe('AutofixSection', () => {
 
     expect(await screen.findByText('Implementation Plan')).toBeInTheDocument();
     expect(screen.getByText('Add null check before accessing user')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
   });
 
   it('renders code changes preview from merged file patches', async () => {
@@ -233,6 +235,7 @@ describe('AutofixSection', () => {
 
     expect(await screen.findByText('Code Changes')).toBeInTheDocument();
     expect(screen.getByText('2 files changed in 1 repo')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
   });
 
   it('renders pull request previews from repo_pr_states', async () => {
@@ -288,6 +291,7 @@ describe('AutofixSection', () => {
     expect(await screen.findByText('Pull Requests')).toBeInTheDocument();
     const link = screen.getByRole('link', {name: 'org/repo#42'});
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
   });
 
   it('shows loading place holder while event is pending', () => {
@@ -422,6 +426,7 @@ describe('AutofixSection', () => {
     expect(await screen.findByText('Root Cause')).toBeInTheDocument();
     expect(screen.getByText('Implementation Plan')).toBeInTheDocument();
     expect(screen.getByText('Code Changes')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
   });
 
   it('shows empty state when there are no artifacts', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -13,7 +13,7 @@ import {
   isRootCauseArtifact,
   isSolutionArtifact,
   useExplorerAutofix,
-  type AutofixArtifacts,
+  type AutofixArtifact,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {
   CodeChangesPreview,
@@ -153,7 +153,7 @@ function AutofixEmptyState({autofix, group, event, project}: AutofixEmptyStatePr
   }, [startStep, openSeerDrawer]);
 
   return (
-    <Flex direction="column" gap="xl">
+    <Flex direction="column" gap="md">
       <Flex
         border="muted"
         radius="md"
@@ -194,7 +194,7 @@ function AutofixEmptyState({autofix, group, event, project}: AutofixEmptyStatePr
 }
 
 interface AutofixPreviewsProps {
-  artifacts: AutofixArtifacts[];
+  artifacts: AutofixArtifact[];
   event: Event;
   group: Group;
   project: Project;

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -13,6 +13,7 @@ import {
   isRootCauseArtifact,
   isSolutionArtifact,
   useExplorerAutofix,
+  type AutofixArtifacts,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {
   CodeChangesPreview,
@@ -120,29 +121,12 @@ function AutofixContent({group, project, event}: AutofixContentProps) {
   }
 
   return (
-    <Flex direction="column" gap="xl">
-      {artifacts.map(artifact => {
-        // there should only be 1 artifact of each type
-        if (isRootCauseArtifact(artifact)) {
-          return <RootCausePreview key="root-cause" artifact={artifact} />;
-        }
-
-        if (isSolutionArtifact(artifact)) {
-          return <SolutionPreview key="solution" artifact={artifact} />;
-        }
-
-        if (isArrayOf(artifact, isExplorerFilePatch) && artifact.length) {
-          return <CodeChangesPreview key="code-changes" artifact={artifact} />;
-        }
-
-        if (isArrayOf(artifact, isRepoPRState) && artifact.length) {
-          return <PullRequestsPreview key="pull-requests" artifact={artifact} />;
-        }
-
-        // TODO: maybe send a log?
-        return null;
-      })}
-    </Flex>
+    <AutofixPreviews
+      artifacts={artifacts}
+      event={event}
+      group={group}
+      project={project}
+    />
   );
 }
 
@@ -204,6 +188,57 @@ function AutofixEmptyState({autofix, group, event, project}: AutofixEmptyStatePr
         onClick={handleStartRootCause}
       >
         {t('Fix the Issue')}
+      </Button>
+    </Flex>
+  );
+}
+
+interface AutofixPreviewsProps {
+  artifacts: AutofixArtifacts[];
+  event: Event;
+  group: Group;
+  project: Project;
+}
+
+function AutofixPreviews({artifacts, event, group, project}: AutofixPreviewsProps) {
+  const {openSeerDrawer} = useOpenSeerDrawer({
+    group,
+    project,
+    event,
+  });
+
+  return (
+    <Flex direction="column" gap="xl">
+      {artifacts.map(artifact => {
+        // there should only be 1 artifact of each type
+        if (isRootCauseArtifact(artifact)) {
+          return <RootCausePreview key="root-cause" artifact={artifact} />;
+        }
+
+        if (isSolutionArtifact(artifact)) {
+          return <SolutionPreview key="solution" artifact={artifact} />;
+        }
+
+        if (isArrayOf(artifact, isExplorerFilePatch) && artifact.length) {
+          return <CodeChangesPreview key="code-changes" artifact={artifact} />;
+        }
+
+        if (isArrayOf(artifact, isRepoPRState) && artifact.length) {
+          return <PullRequestsPreview key="pull-requests" artifact={artifact} />;
+        }
+
+        // TODO: maybe send a log?
+        return null;
+      })}
+      <Button
+        size="md"
+        icon={<IconSeer />}
+        aria-label={t('Open Seer')}
+        tooltipProps={{title: t('Open Seer')}}
+        priority="primary"
+        onClick={openSeerDrawer}
+      >
+        {t('Open Seer')}
       </Button>
     </Flex>
   );


### PR DESCRIPTION
This adds a button to open the seer drawer when there is at least 1 artifact.

# Screenshot

<img width="622" height="370" alt="image" src="https://github.com/user-attachments/assets/e2e0d0ef-4eea-46e6-9c8a-86d908210ee0" />