### PR TITLE
chore(eslint): enforce dynamic type-loader imports

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -383,6 +383,11 @@ export default typescript.config([
             'JSXExpressionContainer > CallExpression[callee.type="ArrowFunctionExpression"], JSXExpressionContainer > CallExpression[callee.type="FunctionExpression"], JSXSpreadAttribute > CallExpression[callee.type="ArrowFunctionExpression"], JSXSpreadAttribute > CallExpression[callee.type="FunctionExpression"]',
           message: 'Do not use IIFEs inside JSX.',
         },
+        {
+          selector: 'ImportDeclaration[source.value=/^!!type-loader!/]',
+          message:
+            "Use dynamic import for type-loader imports (for example: `import('!!type-loader!@sentry/scraps/alert')`), not `import ... from '!!type-loader!...'`.",
+        },
         // Forbid absolute URLs in Link's to=. Use ExternalLink instead.
         {
           selector:


### PR DESCRIPTION
Require type-loader imports to use dynamic import so type docs are lazy loaded instead of resolved at module load time.

enforces that we don't regress from after enabling lazy loaded types in #110332
