### PR TITLE
fix(dif): Allow reuploading DIFs with different Debug ID

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -2,12 +2,12 @@ import logging
 import posixpath
 import re
 import uuid
-from collections.abc import Sequence
+from collections.abc import Iterable, Mapping, Sequence
 
 import jsonschema
 import orjson
 from django.db import IntegrityError, router
-from django.db.models import Exists, Q
+from django.db.models import Case, Exists, IntegerField, Q, Value, When
 from django.http import Http404, HttpResponse, StreamingHttpResponse
 from rest_framework import status
 from rest_framework.request import Request
@@ -29,10 +29,14 @@ from sentry.auth.system import is_system_auth
 from sentry.constants import DEBUG_FILES_ROLE_DEFAULT, KNOWN_DIF_FORMATS
 from sentry.debug_files.debug_files import maybe_renew_debug_files
 from sentry.debug_files.upload import find_missing_chunks
+from sentry.lang.native.sources import record_last_upload
 from sentry.models.debugfile import (
+    BadDif,
     ProguardArtifactRelease,
     ProjectDebugFile,
+    create_dif_from_existing_file,
     create_files_from_dif_zip,
+    get_debug_id_from_dif_request,
 )
 from sentry.models.files.file import File
 from sentry.models.organizationmember import OrganizationMember
@@ -444,7 +448,15 @@ def batch_assemble(project, files):
         # `ProjectDebugFile` will be created, and we need to prevent a race
         # condition.
         state, detail = get_assemble_status(AssembleTask.DIF, project.id, checksum)
-        if state == ChunkFileState.OK:
+        requested_debug_id = _get_requested_debug_id(files, checksum)
+        cached_debug_id = detail["uuid"] if isinstance(detail, Mapping) else None
+
+        # If the request asks for a different debug id than the cached dif result,
+        # we should fall to step 2 below, as we may need to duplicate the `ProjectDebugFile`
+        # row.
+        if state == ChunkFileState.OK and (
+            requested_debug_id is None or requested_debug_id == cached_debug_id
+        ):
             file_response[checksum] = {
                 "state": state,
                 "detail": None,
@@ -452,29 +464,67 @@ def batch_assemble(project, files):
                 "dif": detail,
             }
             checksums_with_status.add(checksum)
-        elif state is not None:
+        elif state is not None and state != ChunkFileState.OK:
             file_response[checksum] = {"state": state, "detail": detail, "missingChunks": []}
             checksums_with_status.add(checksum)
 
     checksums_to_check -= checksums_with_status
 
-    # 2. Check if this project already owns the `ProjectDebugFile` for each file.
-    debug_files = ProjectDebugFile.objects.filter(
-        project_id=project.id,
-        checksum__in=checksums_to_check,
-    ).select_related("file")
+    # 2. Reuse this project's existing `ProjectDebugFile` rows for each checksum.
+    requested_debug_ids_by_checksum = {
+        checksum: _get_requested_debug_id(files, checksum) for checksum in checksums_to_check
+    }
+    existing_project_debug_files = (
+        ProjectDebugFile.objects.filter(project_id=project.id, checksum__in=checksums_to_check)
+        .annotate(
+            requested_debug_id_match=_build_requested_debug_id_match_annotation(
+                requested_debug_ids_by_checksum.items()
+            )
+        )
+        .select_related("file")
+        .order_by("checksum", "-requested_debug_id_match", "-id")
+        .distinct("checksum")
+    )
 
-    checksums_with_debug_files = set()
-    for debug_file in debug_files:
+    for debug_file in existing_project_debug_files:
+        checksums_to_check.discard(debug_file.checksum)
+        requested_debug_id = requested_debug_ids_by_checksum[debug_file.checksum]
+        if requested_debug_id is None or requested_debug_id == debug_file.debug_id:
+            file_response[debug_file.checksum] = {
+                "state": ChunkFileState.OK,
+                "detail": None,
+                "missingChunks": [],
+                "dif": serialize(debug_file),
+            }
+            continue
+
+        name, debug_id, _ = get_file_info(files, debug_file.checksum)
+        try:
+            dif, created = create_dif_from_existing_file(
+                project,
+                debug_file.file,
+                name=name,
+                debug_id=debug_id,
+            )
+        except BadDif as e:
+            # We expect to hit this path if the UUID is inconsistent with the Debug File.
+            # Not all debug file types support user-provided UUIDs.
+            file_response[debug_file.checksum] = {
+                "state": ChunkFileState.ERROR,
+                "detail": e.args[0],
+                "missingChunks": [],
+            }
+            continue
+
+        if created:
+            record_last_upload(project)
+
         file_response[debug_file.checksum] = {
             "state": ChunkFileState.OK,
             "detail": None,
             "missingChunks": [],
-            "dif": serialize(debug_file),
+            "dif": serialize(dif),
         }
-        checksums_with_debug_files.add(debug_file.checksum)
-
-    checksums_to_check -= checksums_with_debug_files
 
     # 3. Compute all the chunks that have to be checked for existence.
     chunks_to_check = {}
@@ -542,6 +592,27 @@ def batch_assemble(project, files):
         file_response[checksum] = {"state": ChunkFileState.CREATED, "missingChunks": []}
 
     return file_response
+
+
+def _get_requested_debug_id(files, checksum: str) -> str | None:
+    """Returns the effective requested debug ID for a checksum payload."""
+    file = files[checksum]
+    return get_debug_id_from_dif_request(name=file.get("name"), debug_id=file.get("debug_id"))
+
+
+def _build_requested_debug_id_match_annotation(
+    requested_debug_ids: Iterable[tuple[str, str | None]],
+) -> Case:
+    """Ranks same-project DIFs so exact debug ID matches sort before fallback rows."""
+    return Case(
+        *[
+            When(checksum=checksum, debug_id=debug_id, then=Value(1))
+            for checksum, debug_id in requested_debug_ids
+            if debug_id is not None
+        ],
+        default=Value(0),
+        output_field=IntegerField(),
+    )
 
 
 @cell_silo_endpoint

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -266,6 +266,25 @@ def create_dif_from_file(
     return create_dif_from_id(project, result[0], file=file)
 
 
+def create_dif_from_existing_file(
+    project: Project,
+    file: File,
+    name: str | None = None,
+    debug_id: str | None = None,
+) -> tuple[ProjectDebugFile, bool]:
+    """Validates an existing stored DIF file and ensures its ProjectDebugFile exists.
+
+    DIF validation currently operates on a filesystem path, while stored ``File``
+    objects expose a readable file object. This helper materializes the stored
+    contents into a temporary file and then reuses ``create_dif_from_file`` so
+    reused-file validation follows the same path-based logic as assembled files.
+    """
+    with file.getfile() as source_file, tempfile.NamedTemporaryFile() as temp_file:
+        shutil.copyfileobj(source_file, temp_file)
+        temp_file.flush()
+        return create_dif_from_file(project, file, temp_file.name, name=name, debug_id=debug_id)
+
+
 def create_dif_from_id(
     project: Project,
     meta: DifMeta,
@@ -384,6 +403,20 @@ def _analyze_progard_filename(filename: str | None) -> str | None:
         return str(uuid.UUID(ident))
     except Exception:
         return None
+
+
+def get_debug_id_from_dif_request(name: str | None, debug_id: str | None) -> str | None:
+    """Returns the effective debug ID from assemble request metadata.
+
+    Most DIF uploads provide an explicit ``debug_id``. ProGuard mappings instead
+    encode it in the request ``name`` such as ``/proguard/mapping-<uuid>.txt``.
+    """
+    try:
+        normalized_id = normalize_debug_id(debug_id)
+    except SymbolicError:
+        normalized_id = None
+
+    return normalized_id or _analyze_progard_filename(name)
 
 
 @cell_silo_model

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -251,3 +251,129 @@ class DifAssembleEndpoint(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data[total_checksum]["state"] == ChunkFileState.ERROR
         assert "unsupported object file format" in response.data[total_checksum]["detail"]
+
+    def test_reuses_existing_proguard_file_with_new_debug_id(self) -> None:
+        file_contents = b"proguard mapping"
+        checksum = sha1(file_contents).hexdigest()
+        blob = FileBlob.from_file_with_organization(ContentFile(file_contents), self.organization)
+        chunks = [blob.checksum]
+
+        assemble_dif(
+            project_id=self.project.id,
+            name="/proguard/mapping-00000000-0000-0000-0000-000000000000.txt",
+            checksum=checksum,
+            chunks=chunks,
+        )
+
+        first_dif = ProjectDebugFile.objects.get(
+            project_id=self.project.id,
+            debug_id="00000000-0000-0000-0000-000000000000",
+        )
+
+        second_response = self.client.post(
+            self.url,
+            data={
+                checksum: {
+                    "name": "/proguard/mapping-11111111-1111-1111-1111-111111111111.txt",
+                    "chunks": chunks,
+                }
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        assert second_response.status_code == 200, second_response.content
+        assert second_response.data[checksum]["state"] == ChunkFileState.OK
+
+        # The second request should create the new logical DIF association.
+        assert (
+            second_response.data[checksum]["dif"]["uuid"] == "11111111-1111-1111-1111-111111111111"
+        )
+
+        new_dif = ProjectDebugFile.objects.get(
+            project_id=self.project.id,
+            debug_id="11111111-1111-1111-1111-111111111111",
+        )
+
+        # Both debug IDs should reuse the same stored file bytes.
+        assert first_dif.file_id == new_dif.file_id
+
+        # Reuse should not create a duplicate File row for the checksum.
+        assert File.objects.filter(type="project.dif", checksum=checksum).count() == 1
+
+    def test_reupload_proguard_with_same_debug_id_is_idempotent(self) -> None:
+        file_contents = b"proguard mapping"
+        checksum = sha1(file_contents).hexdigest()
+        blob = FileBlob.from_file_with_organization(ContentFile(file_contents), self.organization)
+        chunks = [blob.checksum]
+
+        assemble_dif(
+            project_id=self.project.id,
+            name="/proguard/mapping-00000000-0000-0000-0000-000000000000.txt",
+            checksum=checksum,
+            chunks=chunks,
+        )
+
+        second_response = self.client.post(
+            self.url,
+            data={
+                checksum: {
+                    "name": "/proguard/mapping-00000000-0000-0000-0000-000000000000.txt",
+                    "chunks": chunks,
+                }
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        assert second_response.status_code == 200, second_response.content
+        assert second_response.data[checksum]["state"] == ChunkFileState.OK
+
+        # Repeating the same request should not create a duplicate DIF row.
+        assert (
+            ProjectDebugFile.objects.filter(
+                project_id=self.project.id,
+                debug_id="00000000-0000-0000-0000-000000000000",
+            ).count()
+            == 1
+        )
+
+        # Repeating the same request should not create a duplicate File row.
+        assert File.objects.filter(type="project.dif", checksum=checksum).count() == 1
+
+    def test_native_dif_ignores_inconsistent_supplied_debug_id_on_reupload(self) -> None:
+        """Native DIFs ignore inconsistent supplied debug IDs and reuse the embedded one."""
+        file_contents = self.load_fixture("crash.sym")
+        checksum = sha1(file_contents).hexdigest()
+        blob = FileBlob.from_file_with_organization(ContentFile(file_contents), self.organization)
+        chunks = [blob.checksum]
+
+        assemble_dif(
+            project_id=self.project.id,
+            name="crash.sym",
+            checksum=checksum,
+            chunks=chunks,
+        )
+
+        # Simulate re-upload with inconsistent Deub ID
+        response = self.client.post(
+            self.url,
+            data={
+                checksum: {
+                    "name": "crash.sym",
+                    "debug_id": "00000000-0000-0000-0000-000000000000",
+                    "chunks": chunks,
+                }
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data[checksum]["state"] == ChunkFileState.OK
+
+        # Native DIF parsing should preserve the embedded debug ID from the file.
+        assert response.data[checksum]["dif"]["uuid"] == "67e9247c-814e-392b-a027-dbde6748fcbf"
+
+        # Reusing the same file should not create an additional DIF row.
+        assert (
+            ProjectDebugFile.objects.filter(project_id=self.project.id, checksum=checksum).count()
+            == 1
+        )

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -17,6 +17,7 @@ from sentry.models.debugfile import (
     ProjectDebugFile,
     create_dif_from_id,
     detect_dif_from_path,
+    get_debug_id_from_dif_request,
 )
 from sentry.models.files.file import File
 from sentry.testutils.cases import APITestCase, TestCase
@@ -479,6 +480,30 @@ def test_proguard_file_not_detected(path: str, name: str | None) -> None:
         # Note that if the path or name does exist as a file on the filesystem,
         # this test will fail.
         detect_dif_from_path(path, name)
+
+
+def test_get_debug_id_from_dif_request_normalizes_debug_id() -> None:
+    assert (
+        get_debug_id_from_dif_request(
+            name=None,
+            debug_id="67E9247C814E392BA027DBDE6748FCBF",
+        )
+        == "67e9247c-814e-392b-a027-dbde6748fcbf"
+    )
+
+
+def test_get_debug_id_from_dif_request_invalid_debug_id_returns_none() -> None:
+    assert get_debug_id_from_dif_request(name=None, debug_id="not-a-debug-id") is None
+
+
+def test_get_debug_id_from_dif_request_reads_proguard_name() -> None:
+    assert (
+        get_debug_id_from_dif_request(
+            name="/proguard/mapping-00000000-0000-0000-0000-000000000000.txt",
+            debug_id=None,
+        )
+        == "00000000-0000-0000-0000-000000000000"
+    )
 
 
 def test_dartsymbolmap_file_detected() -> None:


### PR DESCRIPTION
For debug file types which allow users to manually specify a Debug ID (such as ProGuard mappings), allow the DIF to be reuploaded with a different UUID.

### What's changed?

Prior to this change, it was not possible to reupload a debug file with a different UUID, since we would detect that a `ProjectDebugFile` with the given checksum already exists, and would just use that on assemble, without even checking the user-specified UUID.

Now, when there is a user-specified UUID, we only reuse the `ProjectDebugFile` when the debug ID matches the user-supplied one (or, if there is no user-supplied debug ID). When there is a user-supplied debug ID which does not match the existing one, we validate the user-supplied debug ID against the debug file, to ensure that the debug ID is consistent with that file type, then we create a duplicate `ProjectDebugFile` row, pointing at the same underlying `File`, but with the new debug ID. This allows us to have multiple debug IDs for the same file, without requiring the file to be reuploaded or stored as a duplicate.

### Limitations of the approach

One limitation of this approach, which I noticed during testing, is that the "Created" date for the reuploaded files is the same as the creation date for the original upload, even if these reuploads occur later. It seems, this happens because the creation date comes from the `File` object, which is shared.

If we want the creation date to match the time when the `ProjectDebugFile` was created, we probably need to add a column to that table with the creation date.

<details>

<summary><strong>Technical description of the limitation, from the clanker 🤖 </strong></summary>

#### Relevant code

The debug-file serializer returns `dateCreated` from `obj.file.timestamp` in [`src/sentry/api/serializers/models/debug_file.py`](https://github.com/getsentry/sentry/blob/706dd09f8f8ab8ab89f69f4605e8a9735f2a828b/src/sentry/api/serializers/models/debug_file.py#L7-L20).

`ProjectDebugFile` stores the association to `File` in [`src/sentry/models/debugfile.py`](https://github.com/getsentry/sentry/blob/706dd09f8f8ab8ab89f69f4605e8a9735f2a828b/src/sentry/models/debugfile.py#L100-L131). The model does not have a creation timestamp field for the association row.

The aliasing path in [`src/sentry/api/endpoints/debug_files.py`](https://github.com/getsentry/sentry/blob/706dd09f8f8ab8ab89f69f4605e8a9735f2a828b/src/sentry/api/endpoints/debug_files.py) reuses the same `File` when it creates a new `ProjectDebugFile` for a different debug ID on the same project.

#### Observed behavior

If a later upload reuses an existing `File` and creates a new `ProjectDebugFile`, the API still returns the original file timestamp as `dateCreated`. The UI appears to render that API field directly in both the general debug-files view and the ProGuard view via [`static/app/views/settings/projectDebugFiles/debugFileRow.tsx`](https://github.com/getsentry/sentry/blob/706dd09f8f8ab8ab89f69f4605e8a9735f2a828b/static/app/views/settings/projectDebugFiles/debugFileRow.tsx#L43-L57) and [`static/app/views/settings/projectProguard/projectProguardRow.tsx`](https://github.com/getsentry/sentry/blob/706dd09f8f8ab8ab89f69f4605e8a9735f2a828b/static/app/views/settings/projectProguard/projectProguardRow.tsx#L29-L41). The shared frontend type also includes `dateCreated` on `DebugFile` in [`static/app/types/debugFiles.tsx`](https://github.com/getsentry/sentry/blob/706dd09f8f8ab8ab89f69f4605e8a9735f2a828b/static/app/types/debugFiles.tsx#L23-L35).

#### Implication

The current API semantics for `dateCreated` are effectively "when these stored bytes were created," not "when this project/debug ID association was created."

#### If behavior needs to change

Changing the displayed date for aliased DIFs would require one of the following:

- changing serializer semantics to use a different timestamp source, or
- adding a real creation timestamp to `ProjectDebugFile` and serializing that value.

</details>

### Issues

Closes #106947
Closes [INGEST-710](https://linear.app/getsentry/issue/INGEST-710/debug-files-with-identical-content-but-different-debug-ids-rejected-on)