### PR TITLE
fix(tracemetrics): Hide explicit none types in UI

### DIFF
--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -125,11 +125,13 @@ export default function EAPMetricsField({
         trailingItems: (
           <Fragment>
             <MetricTypeBadge metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]} />
-            {hasMetricUnitsUI && option[TraceMetricKnownFieldKey.METRIC_UNIT] && (
-              <Tag variant="promotion">
-                {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
-              </Tag>
-            )}
+            {hasMetricUnitsUI &&
+              option[TraceMetricKnownFieldKey.METRIC_UNIT] &&
+              option[TraceMetricKnownFieldKey.METRIC_UNIT] !== NONE_UNIT && (
+                <Tag variant="promotion">
+                  {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
+                </Tag>
+              )}
           </Fragment>
         ),
       })) ?? []),

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -129,11 +129,13 @@ export function MetricsVisualize() {
         trailingItems: (
           <Fragment>
             <MetricTypeBadge metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]} />
-            {hasMetricUnitsUI && option[TraceMetricKnownFieldKey.METRIC_UNIT] && (
-              <Tag variant="promotion">
-                {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
-              </Tag>
-            )}
+            {hasMetricUnitsUI &&
+              option[TraceMetricKnownFieldKey.METRIC_UNIT] &&
+              option[TraceMetricKnownFieldKey.METRIC_UNIT] !== NONE_UNIT && (
+                <Tag variant="promotion">
+                  {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
+                </Tag>
+              )}
           </Fragment>
         ),
       })) ?? []),

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -107,7 +107,11 @@ function useMetricsQueryKey({
             traceMetric.unit
           );
         } else if (traceMetric.unit === NONE_UNIT) {
+          newSearch.addOp('(');
           newSearch.addFilterValue('!has', TraceMetricKnownFieldKey.METRIC_UNIT);
+          newSearch.addOp('OR');
+          newSearch.addFilterValue(TraceMetricKnownFieldKey.METRIC_UNIT, NONE_UNIT);
+          newSearch.addOp(')');
         }
       }
     }

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -76,7 +76,7 @@ export function MetricSelector({
             name: option[TraceMetricKnownFieldKey.METRIC_NAME],
             type: option[TraceMetricKnownFieldKey.METRIC_TYPE],
             unit: hasMetricUnitsUI
-              ? option[TraceMetricKnownFieldKey.METRIC_UNIT]
+              ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
               : undefined,
           }) === makeMetricSelectValue(traceMetric)
       );

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -76,7 +76,7 @@ export function MetricSelector({
             name: option[TraceMetricKnownFieldKey.METRIC_NAME],
             type: option[TraceMetricKnownFieldKey.METRIC_TYPE],
             unit: hasMetricUnitsUI
-              ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
+              ? option[TraceMetricKnownFieldKey.METRIC_UNIT]
               : undefined,
           }) === makeMetricSelectValue(traceMetric)
       );
@@ -99,11 +99,13 @@ export function MetricSelector({
         trailingItems: () => (
           <Fragment>
             <MetricTypeBadge metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]} />
-            {hasMetricUnitsUI && option[TraceMetricKnownFieldKey.METRIC_UNIT] && (
-              <Tag variant="promotion">
-                {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
-              </Tag>
-            )}
+            {hasMetricUnitsUI &&
+              option[TraceMetricKnownFieldKey.METRIC_UNIT] &&
+              option[TraceMetricKnownFieldKey.METRIC_UNIT] !== NONE_UNIT && (
+                <Tag variant="promotion">
+                  {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
+                </Tag>
+              )}
           </Fragment>
         ),
       })) ?? []),


### PR DESCRIPTION
We expected `none` to only apply to metrics that _do not_ have unit set on them, but it turns out we can also store the "none" string as a unit. For now we're going to treat them the same way, so this PR adjusts the events request to additionally had `metric.unit:none` to the existing `!has:metric.unit` check, as well as updates the select rows to _not_ show `none` even though it is explicitly defined.

We will regroup and figure out if we should keep this behaviour or separate them.