### PR TITLE
ref(dashboards): Remove pre-favorited prebuilt dashboards feature

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -96,7 +96,6 @@ class PrebuiltDashboardId(IntEnum):
 class PrebuiltDashboard(TypedDict, total=False):
     prebuilt_id: Required[PrebuiltDashboardId]
     title: Required[str]
-    pre_favorited: bool
 
 
 # Prebuilt dashboards store minimal fields in the database. The actual dashboard and widget settings are
@@ -132,7 +131,6 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.WEB_VITALS,
         "title": "Web Vitals",
-        "pre_favorited": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.WEB_VITALS_SUMMARY,
@@ -141,7 +139,6 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.MOBILE_VITALS,
         "title": "Mobile Vitals",
-        "pre_favorited": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MOBILE_VITALS_APP_STARTS,
@@ -158,7 +155,6 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_OVERVIEW,
         "title": "Backend Overview",
-        "pre_favorited": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MOBILE_SESSION_HEALTH,
@@ -195,12 +191,10 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.AI_AGENTS_OVERVIEW,
         "title": "AI Agents Overview",
-        "pre_favorited": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MCP_OVERVIEW,
         "title": "MCP Overview",
-        "pre_favorited": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.LARAVEL_OVERVIEW,
@@ -297,41 +291,6 @@ def sync_prebuilt_dashboards(organization: Organization) -> None:
         ).exclude(prebuilt_id__in=prebuilt_ids).delete()
 
 
-def sync_prebuilt_dashboards_favorited(organization: Organization, user_id: int) -> None:
-    """
-    Checks if pre-favorited prebuilt dashboards have a DashboardFavoriteUser record for the
-    user, and creates them if they don't. This ensures that certain prebuilt dashboards are
-    favorited by default for all users.
-    """
-    enabled_prebuilt_dashboards = get_enabled_prebuilt_dashboards(organization)
-    pre_favorited_ids = [
-        d["prebuilt_id"] for d in enabled_prebuilt_dashboards if d.get("pre_favorited")
-    ]
-    if not pre_favorited_ids:
-        return
-
-    with transaction.atomic(router.db_for_write(DashboardFavoriteUser)):
-        prebuilt_dashboards_without_favorite = (
-            Dashboard.objects.filter(
-                organization=organization,
-                prebuilt_id__in=pre_favorited_ids,
-            )
-            .exclude(
-                id__in=DashboardFavoriteUser.objects.filter(
-                    organization=organization,
-                    user_id=user_id,
-                ).values_list("dashboard_id", flat=True)
-            )
-            .order_by("prebuilt_id")
-        )
-        for dashboard in prebuilt_dashboards_without_favorite:
-            DashboardFavoriteUser.objects.insert_favorite_dashboard(
-                organization=organization,
-                user_id=user_id,
-                dashboard=dashboard,
-            )
-
-
 class OrganizationDashboardsPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
@@ -416,20 +375,6 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 )
                 with lock.acquire():
                     sync_prebuilt_dashboards(organization)
-            except UnableToAcquireLock:
-                pass
-            except Exception as err:
-                sentry_sdk.capture_exception(err)
-
-            # Favorite pre-favorited prebuilt dashboards for the user
-            try:
-                favorite_lock = locks.get(
-                    f"dashboards:sync_prebuilt_dashboards_favorited:{organization.id}:{request.user.id}",
-                    duration=10,
-                    name="sync_prebuilt_dashboards_favorited",
-                )
-                with favorite_lock.acquire():
-                    sync_prebuilt_dashboards_favorited(organization, request.user.id)
             except UnableToAcquireLock:
                 pass
             except Exception as err:

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2269,37 +2269,6 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 assert response.status_code == 200
                 assert len(response.data) == total_count - prebuilt_dashboards_count
 
-    def test_endpoint_creates_favorites_for_pre_favorited_prebuilt_dashboards(self) -> None:
-        assert (
-            DashboardFavoriteUser.objects.filter(
-                organization=self.organization, user_id=self.user.id
-            ).count()
-            == 0
-        )
-
-        pre_favorited_prebuilt_ids = {
-            d["prebuilt_id"] for d in PREBUILT_DASHBOARDS if d.get("pre_favorited")
-        }
-
-        with self.feature(
-            [
-                "organizations:dashboards-prebuilt-insights-dashboards",
-                "organizations:dashboards-sync-all-registered-prebuilt-dashboards",
-            ]
-        ):
-            response = self.do_request("get", self.url)
-        assert response.status_code == 200
-
-        favorites = DashboardFavoriteUser.objects.filter(
-            organization=self.organization, user_id=self.user.id
-        )
-        favorited_prebuilt_ids = set(
-            Dashboard.objects.filter(
-                id__in=favorites.values_list("dashboard_id", flat=True)
-            ).values_list("prebuilt_id", flat=True)
-        )
-        assert favorited_prebuilt_ids == pre_favorited_prebuilt_ids
-
     def test_post_with_text_widget(self) -> None:
         with self.feature("organizations:dashboards-text-widgets"):
             data = {


### PR DESCRIPTION
Remove the `sync_prebuilt_dashboards_favorited` function and all related code that automatically favorited certain prebuilt dashboards for users on the GET dashboards endpoint.

This removes:
- The `pre_favorited` field from the `PrebuiltDashboard` TypedDict
- All `"pre_favorited": True` entries from the `PREBUILT_DASHBOARDS` list
- The `sync_prebuilt_dashboards_favorited()` function
- The lock-and-call block in `OrganizationDashboardsEndpoint.get()` that invoked it
- The associated test

Refs DAIN-1312