### PR TITLE
chore(tests): Reverse ids when returning values from store_eap_items

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1246,6 +1246,11 @@ class SnubaTestCase(BaseTestCase):
             files=files,
         )
         assert response.status_code == 200
+        # Reverse the ids since these are stored in little endian in
+        # ClickHouse and end up reversed. This helps if we want to compare
+        # these inserted items to results returned from EAP.
+        for item in items:
+            item.item_id = item.item_id[::-1]
 
     def store_issues(self, issues):
         assert (

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -3197,7 +3197,7 @@ class TestMetricsTraceQuery(APITransactionTestCase, SnubaTestCase, TraceMetricsT
 
     @staticmethod
     def get_id_str(item: TraceItem) -> str:
-        return item.item_id[::-1].hex()
+        return item.item_id.hex()
 
     def test_get_metric_attributes_for_trace_basic(self) -> None:
         result = get_metric_attributes_for_trace(

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -523,7 +523,7 @@ class ProjectTraceItemDetailsEndpointTest(
         attachment = self.create_trace_attachment(trace_id=self.trace_uuid, attributes={"foo": 2})
         self.store_eap_items([attachment])
 
-        item_id = uuid.UUID(bytes=bytes(reversed(attachment.item_id))).hex
+        item_id = uuid.UUID(bytes=attachment.item_id).hex
         response = self.do_request("attachments", item_id)
         assert response.status_code == 200, response.data
         assert response.data == {


### PR DESCRIPTION
We're consolidating how we create eap items in tests. This reverses ids of the returned results so that we can compare the created items with the results that we get back from eap when we query. We have to do this because ids we send over are stored little-endian and are reversed from the api.