### PR TITLE
fix(coding integrations): setting branding + loading bug

### DIFF
--- a/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
@@ -6,8 +6,8 @@ import {
 } from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
 import type {Project} from 'sentry/types/project';
-import apiFetch from 'sentry/utils/api/apiFetch';
 import {
+  fetchDataQuery,
   fetchMutation,
   getApiQueryData,
   setApiQueryData,
@@ -32,12 +32,12 @@ export function useFetchProjectSeerPreferences({project}: {project: Project}) {
   const queryKey = makeProjectSeerPreferencesQueryKey(organization.slug, project.slug);
 
   return useCallback(async () => {
-    const response = await queryClient.fetchQuery({
+    const [data] = await queryClient.fetchQuery({
       queryKey,
-      queryFn: apiFetch<SeerPreferencesResponse>,
+      queryFn: fetchDataQuery<SeerPreferencesResponse>,
       staleTime: 0,
     });
-    return response.json.preference;
+    return data?.preference;
   }, [queryClient, queryKey]);
 }
 

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -94,7 +94,7 @@ export default function AutofixAgent({canWrite, preference, project}: Props) {
               name="autofixAgent"
               label={t('Autofix Handoff')}
               help={tct(
-                'Seer will orchestrate the autofix process, and automatically hand off issue data coding agent for processing. You can choose to automatically process Issues, and which agent to use here. You can also manually trigger autofix with different agents from the Issue Details page. [docsLink:Read the docs] to learn more.',
+                'Seer will orchestrate the autofix process, and automatically hand off issue data to the coding agent for processing. You can choose to automatically process Issues, and which agent to use here. You can also manually trigger autofix with different agents from the Issue Details page. [docsLink:Read the docs] to learn more.',
                 {
                   docsLink: (
                     <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/" />

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -77,7 +77,7 @@ export default function AutofixAgent({canWrite, preference, project}: Props) {
 
   return (
     <PanelNoMargin>
-      <PanelHeader>{t('Autofix Agent')}</PanelHeader>
+      <PanelHeader>{t('Autofix Handoff')}</PanelHeader>
       <PanelBody>
         {isPending ? (
           <Flex justify="center" align="center" padding="xl">
@@ -92,7 +92,7 @@ export default function AutofixAgent({canWrite, preference, project}: Props) {
               disabled={Boolean(disabledReason)}
               disabledReason={disabledReason}
               name="autofixAgent"
-              label={t('Autofix Agent')}
+              label={t('Autofix Handoff')}
               help={tct(
                 'Seer will orchestrate the autofix process, and automatically hand off issue data coding agent for processing. You can choose to automatically process Issues, and which agent to use here. You can also manually trigger autofix with different agents from the Issue Details page. [docsLink:Read the docs] to learn more.',
                 {

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -37,7 +37,7 @@ const COLUMNS = [
         {t('PR Creation')}
         <InfoTip
           title={t(
-            'This setting only applies when an Autofix Agent is configured to run automatically.'
+            'This setting only applies when an Autofix Handoff is configured to run automatically.'
           )}
         />
       </Flex>

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -30,7 +30,7 @@ interface Props {
 
 const COLUMNS = [
   {title: t('Project'), key: 'project', sortKey: 'project'},
-  {title: t('Autofix Agent'), key: 'fixes'},
+  {title: t('Autofix Handoff'), key: 'fixes'},
   {
     title: (
       <Flex gap="sm" align="center">

--- a/static/gsApp/views/seerAutomation/components/seerAgentHooks.spec.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerAgentHooks.spec.tsx
@@ -51,7 +51,7 @@ describe('seerAgentHooks', () => {
       expect(options[0]).toEqual({value: 'seer', label: expect.any(String)});
       expect(options[1]).toMatchObject({
         value: {id: '42', name: 'Cursor', provider: 'cursor'},
-        label: 'Cursor (42)',
+        label: 'Cursor',
       });
       expect(options[2]).toEqual({value: 'none', label: expect.any(String)});
     });

--- a/static/gsApp/views/seerAutomation/components/seerAgentHooks.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerAgentHooks.tsx
@@ -30,7 +30,7 @@ export function useAgentOptions({
         .filter(integration => integration.id)
         .map(integration => ({
           value: integration,
-          label: `${integration.name} (${integration.id})`,
+          label: integration.name,
         })),
       {value: 'none' as const, label: t('Manual Agent Selection')},
     ];


### PR DESCRIPTION
1. Changed integration setting headers from "Autofix Agent" to "Autofix Handoff" to match claude branding guidelines
2. Removed integration ids from dropdown options as we will no longer allow multiple integrations per type going forward
3. Fixed loading bug which allowed for "connect repositories" popup to show on settings change