### PR TITLE
ref(stores): Remove dead stats code from `ProjectsStore`

### DIFF
--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -13,8 +13,6 @@ type State = {
   projects: Project[];
 };
 
-type StatsData = Record<string, Project['stats']>;
-
 /**
  * Attributes that need typing but aren't part of the external interface,
  */
@@ -35,7 +33,6 @@ interface ProjectsStoreDefinition
   onDeleteProject(projectSlug: string): void;
   onDeleteTeam(slug: string): void;
   onRemoveTeam(teamSlug: string, projectSlug: string): void;
-  onStatsLoadSuccess(data: StatsData): void;
   onUpdateSuccess(data: Partial<Project>): void;
   reset(): void;
 }
@@ -115,18 +112,6 @@ const storeConfig: ProjectsStoreDefinition = {
 
     this.trigger(new Set([data.id]));
     clearQueryCache();
-  },
-
-  onStatsLoadSuccess(data) {
-    const statsData = data || {};
-
-    // Assign stats into projects
-    const newProjects = this.state.projects.map(project =>
-      statsData[project.id] ? {...project, stats: data[project.id]} : project
-    );
-    this.state = {...this.state, projects: newProjects};
-
-    this.trigger(new Set(Object.keys(data)));
   },
 
   onDeleteProject(projectSlug: string) {


### PR DESCRIPTION
Follow up of https://github.com/getsentry/sentry/pull/110394. This doesn't have any callers, so should be safe to remove.