### PR TITLE
feat(dashboards): Add starred transaction field to widget builder

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -822,9 +822,10 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
     sortField: null,
     renderFunc: data => (
       <StarredSegmentCell
-        projectSlug={data.project}
-        segmentName={data.transaction}
-        isStarred={data.is_starred_transaction}
+        projectSlug={data[SpanFields.PROJECT]}
+        projectId={data[SpanFields.PROJECT_ID]?.toString()}
+        segmentName={data[SpanFields.TRANSACTION]}
+        isStarred={data[SpanFields.IS_STARRED_TRANSACTION]}
       />
     ),
   },

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -327,6 +327,7 @@ function Visualize({error, setError}: VisualizeProps) {
         .filter(
           column =>
             column !== '' &&
+            column !== SpanFields.IS_STARRED_TRANSACTION &&
             !stringSpanTags.hasOwnProperty(column) &&
             !numericSpanTags.hasOwnProperty(column) &&
             !booleanSpanTags.hasOwnProperty(column)

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -67,7 +67,6 @@ import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
-import {SpanFields} from 'sentry/views/insights/types';
 
 export const NONE = 'none';
 
@@ -327,7 +326,6 @@ function Visualize({error, setError}: VisualizeProps) {
         .filter(
           column =>
             column !== '' &&
-            column !== SpanFields.IS_STARRED_TRANSACTION &&
             !stringSpanTags.hasOwnProperty(column) &&
             !numericSpanTags.hasOwnProperty(column) &&
             !booleanSpanTags.hasOwnProperty(column)
@@ -346,16 +344,6 @@ function Visualize({error, setError}: VisualizeProps) {
           trailingItems: () => <TypeBadge kind={FieldKind.BOOLEAN} />,
         };
       }),
-      ...(state.dataset === WidgetType.SPANS &&
-      !booleanSpanTags.hasOwnProperty(SpanFields.IS_STARRED_TRANSACTION)
-        ? [
-            {
-              label: prettifyTagKey(SpanFields.IS_STARRED_TRANSACTION),
-              value: SpanFields.IS_STARRED_TRANSACTION,
-              trailingItems: () => <TypeBadge kind={FieldKind.BOOLEAN} />,
-            },
-          ]
-        : []),
       ...Object.values(stringSpanTags).map(tag => {
         return {
           label: tag.name,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -67,6 +67,7 @@ import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
+import {SpanFields} from 'sentry/views/insights/types';
 
 export const NONE = 'none';
 
@@ -344,6 +345,16 @@ function Visualize({error, setError}: VisualizeProps) {
           trailingItems: () => <TypeBadge kind={FieldKind.BOOLEAN} />,
         };
       }),
+      ...(state.dataset === WidgetType.SPANS &&
+      !booleanSpanTags.hasOwnProperty(SpanFields.IS_STARRED_TRANSACTION)
+        ? [
+            {
+              label: prettifyTagKey(SpanFields.IS_STARRED_TRANSACTION),
+              value: SpanFields.IS_STARRED_TRANSACTION,
+              trailingItems: () => <TypeBadge kind={FieldKind.BOOLEAN} />,
+            },
+          ]
+        : []),
       ...Object.values(stringSpanTags).map(tag => {
         return {
           label: tag.name,

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -72,6 +72,14 @@ export const SENTRY_SPAN_NUMBER_TAGS: string[] = [...SENTRY_SEARCHABLE_SPAN_NUMB
 export const SENTRY_SPAN_BOOLEAN_TAGS: string[] = [
   // duplicating until we've fully rolled out boolean attributes
   SpanFields.IS_TRANSACTION,
+  SpanFields.IS_STARRED_TRANSACTION,
+];
+
+// Span attributes that should only appear in dashboards, not in Explore.
+// is_starred_transaction relies on the dashboard widget query cache for
+// starring mutations and is not supported in Explore.
+export const DASHBOARD_ONLY_SPAN_ATTRIBUTES: string[] = [
+  SpanFields.IS_STARRED_TRANSACTION,
 ];
 
 export const SENTRY_LOG_STRING_TAGS: string[] = [

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -5,6 +5,7 @@ import type {Project} from 'sentry/types/project';
 import {FieldKind} from 'sentry/utils/fields';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
+  DASHBOARD_ONLY_SPAN_ATTRIBUTES,
   SENTRY_LOG_BOOLEAN_TAGS,
   SENTRY_LOG_NUMBER_TAGS,
   SENTRY_LOG_STRING_TAGS,
@@ -251,7 +252,19 @@ export function useSpanItemAttributes(
   type?: TraceItemAttributeType,
   hiddenKeys?: string[]
 ): TraceItemAttributeResult {
-  return useTraceItemDatasetAttributes(TraceItemDataset.SPANS, options, type, hiddenKeys);
+  const mergedHiddenKeys = useMemo(() => {
+    if (!hiddenKeys?.length) {
+      return DASHBOARD_ONLY_SPAN_ATTRIBUTES;
+    }
+    return [...hiddenKeys, ...DASHBOARD_ONLY_SPAN_ATTRIBUTES];
+  }, [hiddenKeys]);
+
+  return useTraceItemDatasetAttributes(
+    TraceItemDataset.SPANS,
+    options,
+    type,
+    mergedHiddenKeys
+  );
 }
 
 export function useLogItemAttributes(

--- a/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
@@ -13,8 +13,9 @@ import type {SpanResponse} from 'sentry/views/insights/types';
 
 interface Props {
   isStarred: boolean;
-  projectSlug: string;
   segmentName: string;
+  projectId?: string;
+  projectSlug?: string;
 }
 
 type TableRow = Simplify<
@@ -26,18 +27,23 @@ type TableResponse = [{confidence: any; meta: EventsMetaType; data?: TableRow[]}
 // The query key used for the starred segments table request, this key is used to reference that query and update the starred segment state
 export const STARRED_SEGMENT_TABLE_QUERY_KEY = ['starred-segment-table'];
 
-export function StarredSegmentCell({segmentName, isStarred, projectSlug}: Props) {
+export function StarredSegmentCell({
+  segmentName,
+  isStarred,
+  projectSlug,
+  projectId,
+}: Props) {
   const queryClient = useQueryClient();
   const {projects} = useProjects();
   const project = projects.find(p => p.slug === projectSlug);
 
   const {setStarredSegment, isPending} = useStarredSegment({
-    projectId: project?.id,
+    projectId: project?.id || projectId,
     segmentName,
     onError: () => updateTableData(!isStarred),
   });
 
-  const disabled = !project || !segmentName || isPending;
+  const disabled = (!project && !projectId) || !segmentName || isPending;
 
   const updateTableData = (newIsStarred: boolean) => {
     queryClient.setQueriesData(


### PR DESCRIPTION
## Summary
- Adds `is_starred_transaction` as a column option in the dashboard widget builder for the Spans dataset
- Scoped to dashboards only (not Explore) since the starring mutation relies on the dashboard widget query cache
- Updates `StarredSegmentCell` to accept an optional `projectId` prop, making `projectSlug` optional, starring is only available when `project` or 'project.id` is selected and `transaction`
- Uses `SpanFields` enum constants in the field renderer for consistency

<img width="762" height="280" alt="image" src="https://github.com/user-attachments/assets/e59c3498-4e9b-472f-9121-1a3d6df9a019" />


Fixes BROWSE-224

## Test plan
- [ ] Open widget builder, select Spans dataset, switch to Table display
- [ ] Verify `is_starred_transaction` appears in the column dropdown
- [ ] Add `is_starred_transaction` column with and without `transaction` column — star button should be disabled when transaction is absent
- [ ] Verify `is_starred_transaction` does NOT appear in Explore column picker