### PR TITLE
feat(dashboards): Adds Create Dashboard with Seer frontend modal and preview page

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -2,6 +2,7 @@ import type {ModalTypes} from 'sentry/components/globalModal';
 import type {CreateReleaseIntegrationModalOptions} from 'sentry/components/modals/createReleaseIntegrationModal';
 import type {DashboardWidgetQuerySelectorModalOptions} from 'sentry/components/modals/dashboardWidgetQuerySelectorModal';
 import type {SaveQueryModalProps} from 'sentry/components/modals/explore/saveQueryModal';
+import type {GenerateDashboardFromSeerModalProps} from 'sentry/components/modals/generateDashboardFromSeerModal';
 import type {ImportDashboardFromFileModalProps} from 'sentry/components/modals/importDashboardFromFileModal';
 import type {InsightChartModalOptions} from 'sentry/components/modals/insightChartModal';
 import type {InviteRow} from 'sentry/components/modals/inviteMembersModal/types';
@@ -270,6 +271,17 @@ export async function openImportDashboardFromFileModal(
   openModal(deps => <Modal {...deps} {...options} />, {
     closeEvents: 'escape-key',
     modalCss,
+  });
+}
+
+export async function openGenerateDashboardFromSeerModal(
+  options: GenerateDashboardFromSeerModalProps
+) {
+  const {default: Modal} =
+    await import('sentry/components/modals/generateDashboardFromSeerModal');
+
+  openModal(deps => <Modal {...deps} {...options} />, {
+    closeEvents: 'escape-key',
   });
 }
 

--- a/static/app/components/modals/generateDashboardFromSeerModal.tsx
+++ b/static/app/components/modals/generateDashboardFromSeerModal.tsx
@@ -7,7 +7,6 @@ import {TextArea} from '@sentry/scraps/textarea';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import type {Client} from 'sentry/api';
 import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
@@ -17,7 +16,6 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 
 export interface GenerateDashboardFromSeerModalProps {
-  api: Client;
   location: Location;
   navigate: ReactRouter3Navigate;
   organization: Organization;
@@ -57,6 +55,8 @@ function GenerateDashboardFromSeerModal({
       const runId = response.run_id;
       if (!runId) {
         addErrorMessage(t('Failed to start dashboard generation'));
+        setIsGenerating(false);
+        return;
       }
 
       closeModal();

--- a/static/app/components/modals/generateDashboardFromSeerModal.tsx
+++ b/static/app/components/modals/generateDashboardFromSeerModal.tsx
@@ -1,0 +1,113 @@
+import {Fragment, useCallback, useState} from 'react';
+import type {Location} from 'history';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {TextArea} from '@sentry/scraps/textarea';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import type {Client} from 'sentry/api';
+import {IconSeer} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+
+export interface GenerateDashboardFromSeerModalProps {
+  api: Client;
+  location: Location;
+  navigate: ReactRouter3Navigate;
+  organization: Organization;
+}
+
+function GenerateDashboardFromSeerModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  organization,
+  location,
+  navigate,
+}: ModalRenderProps & GenerateDashboardFromSeerModalProps) {
+  const [prompt, setPrompt] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const handleGenerate = useCallback(async () => {
+    if (!prompt.trim()) {
+      return;
+    }
+
+    setIsGenerating(true);
+
+    try {
+      const url = getApiUrl('/organizations/$organizationIdOrSlug/dashboards/generate/', {
+        path: {
+          organizationIdOrSlug: organization.slug,
+        },
+      });
+      const response = await fetchMutation<{run_id: string}>({
+        url,
+        method: 'POST',
+        data: {prompt: prompt.trim()},
+      });
+
+      const runId = response.run_id;
+      if (!runId) {
+        addErrorMessage(t('Failed to start dashboard generation'));
+      }
+
+      closeModal();
+
+      navigate(
+        normalizeUrl({
+          pathname: `/organizations/${organization.slug}/dashboards/new/from-seer/`,
+          query: {...location.query, seerRunId: String(runId)},
+        })
+      );
+    } catch (error) {
+      setIsGenerating(false);
+      addErrorMessage(t('Failed to start dashboard generation'));
+    }
+  }, [prompt, organization.slug, location.query, closeModal, navigate]);
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h4>{t('Generate Dashboard with Seer')}</h4>
+      </Header>
+      <Body>
+        <p>{t('Describe the dashboard you would like Seer to generate for you.')}</p>
+        <TextArea
+          value={prompt}
+          onChange={(e: {target: HTMLTextAreaElement}) => setPrompt(e.target.value)}
+          placeholder={t(
+            'e.g. Show me error rates by project with a breakdown of error types'
+          )}
+          rows={4}
+          autoFocus
+          disabled={isGenerating}
+        />
+      </Body>
+      <Footer>
+        <Flex justify="end">
+          <Button onClick={closeModal} disabled={isGenerating}>
+            {t('Cancel')}
+          </Button>
+          <Button
+            priority="primary"
+            onClick={handleGenerate}
+            disabled={!prompt.trim() || isGenerating}
+            icon={<IconSeer />}
+          >
+            {isGenerating ? t('Generating...') : t('Generate')}
+          </Button>
+        </Flex>
+      </Footer>
+    </Fragment>
+  );
+}
+
+export default GenerateDashboardFromSeerModal;

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1369,6 +1369,11 @@ function buildRoutes(): RouteObject[] {
       ],
     },
     {
+      path: '/dashboards/new/from-seer/',
+      component: make(() => import('sentry/views/dashboards/createFromSeer')),
+      withOrgPath: true,
+    },
+    {
       path: '/dashboards/new/',
       component: make(() => import('sentry/views/dashboards/create')),
       withOrgPath: true,

--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -26,13 +26,28 @@ import {cloneDashboard} from './utils';
 
 const POLL_INTERVAL_MS = 500;
 
-// Camel case widget properties
-function normalizeWidget(raw: any): Widget {
+type DashboardArtifact = {
+  title: string;
+  widgets: WidgetArtifact[];
+};
+
+type WidgetArtifact = {
+  display_type: Widget['displayType'];
+  layout: {h: number; min_h: number; w: number; x: number; y: number};
+  queries: Widget['queries'];
+  title: string;
+  widget_type: Widget['widgetType'];
+  description?: string;
+  limit?: number;
+};
+
+function normalizeWidget(raw: WidgetArtifact): Widget {
   const {display_type, widget_type, ...rest} = raw;
   return {
     ...rest,
-    displayType: display_type ?? raw.displayType,
-    widgetType: widget_type ?? raw.widgetType,
+    interval: '',
+    displayType: display_type,
+    widgetType: widget_type,
     layout: raw.layout
       ? {
           x: raw.layout.x,
@@ -54,7 +69,7 @@ function extractDashboardFromSession(
   for (const block of session.blocks) {
     for (const artifact of block.artifacts ?? []) {
       if (artifact.key === 'dashboard' && artifact.data) {
-        const data = artifact.data as {title: string; widgets: any[]};
+        const data = artifact.data as DashboardArtifact;
         return {
           title: data.title,
           widgets: assignDefaultLayout(

--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -1,0 +1,194 @@
+import {useEffect, useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Flex} from '@sentry/scraps/layout';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import Feature from 'sentry/components/acl/feature';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import {MarkedText} from 'sentry/utils/marked/markedText';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
+import {makeSeerExplorerQueryKey} from 'sentry/views/seerExplorer/utils';
+
+import {EMPTY_DASHBOARD} from './data';
+import DashboardDetail from './detail';
+import {assignDefaultLayout, assignTempId, getInitialColumnDepths} from './layoutUtils';
+import type {DashboardDetails, Widget} from './types';
+import {DashboardState} from './types';
+import {cloneDashboard} from './utils';
+
+const POLL_INTERVAL_MS = 500;
+
+// Camel case widget properties
+function normalizeWidget(raw: any): Widget {
+  const {display_type, widget_type, ...rest} = raw;
+  return {
+    ...rest,
+    displayType: display_type ?? raw.displayType,
+    widgetType: widget_type ?? raw.widgetType,
+    layout: raw.layout
+      ? {
+          x: raw.layout.x,
+          y: raw.layout.y,
+          w: raw.layout.w,
+          h: raw.layout.h,
+          minH: raw.layout.min_h,
+        }
+      : undefined,
+  };
+}
+
+function extractDashboardFromSession(
+  session: NonNullable<SeerExplorerResponse['session']>
+): {
+  title: string;
+  widgets: Widget[];
+} | null {
+  for (const block of session.blocks) {
+    for (const artifact of block.artifacts ?? []) {
+      if (artifact.key === 'dashboard' && artifact.data) {
+        const data = artifact.data as {title: string; widgets: any[]};
+        return {
+          title: data.title,
+          widgets: assignDefaultLayout(
+            data.widgets.map(normalizeWidget).map(assignTempId),
+            getInitialColumnDepths()
+          ),
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function extractMessages(
+  session: NonNullable<SeerExplorerResponse['session']>
+): string[] {
+  const messages: string[] = [];
+  for (const block of session.blocks ?? []) {
+    if (block.message?.content) {
+      messages.push(block.message.content);
+    }
+  }
+  return messages;
+}
+
+export default function CreateFromSeer() {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  const seerRunId = location.query?.seerRunId ? Number(location.query.seerRunId) : null;
+
+  const {data, isError} = useApiQuery<SeerExplorerResponse>(
+    makeSeerExplorerQueryKey(organization.slug, seerRunId),
+    {
+      staleTime: 0,
+      retry: false,
+      enabled: !!seerRunId,
+      refetchInterval: query => {
+        const status = query.state.data?.[0]?.session?.status;
+        if (status === 'completed' || status === 'error') {
+          return false;
+        }
+        return POLL_INTERVAL_MS;
+      },
+    }
+  );
+
+  const session = data?.session ?? null;
+  const sessionStatus = session?.status ?? null;
+
+  const blockMessages = useMemo(
+    () => (session ? extractMessages(session) : []),
+    [session]
+  );
+
+  const dashboard = useMemo<DashboardDetails>(() => {
+    const baseDashboard = cloneDashboard(EMPTY_DASHBOARD);
+    if (sessionStatus !== 'completed' || !session) {
+      return baseDashboard;
+    }
+    const dashboardData = extractDashboardFromSession(session);
+    if (!dashboardData) {
+      return baseDashboard;
+    }
+    return {
+      ...baseDashboard,
+      title: dashboardData.title,
+      widgets: dashboardData.widgets,
+    };
+  }, [session, sessionStatus]);
+
+  const isLoading =
+    !!seerRunId && sessionStatus !== 'completed' && sessionStatus !== 'error' && !isError;
+
+  useEffect(() => {
+    if (sessionStatus === 'error' || isError) {
+      addErrorMessage(t('Failed to generate dashboard'));
+    }
+  }, [sessionStatus, isError]);
+
+  function renderDisabled() {
+    return (
+      <Layout.Page withPadding>
+        <Alert.Container>
+          <Alert variant="warning" showIcon={false}>
+            {t("You don't have access to this feature")}
+          </Alert>
+        </Alert.Container>
+      </Layout.Page>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Layout.Page withPadding>
+        <Flex direction="column" gap="lg" align="center">
+          <LoadingIndicator>{t('Generating dashboard...')}</LoadingIndicator>
+          {blockMessages.length > 0 && (
+            <Flex direction="column" gap="sm" maxWidth="600px">
+              {blockMessages.map((message, index) => (
+                <MessageBlock key={index} text={message} />
+              ))}
+            </Flex>
+          )}
+        </Flex>
+      </Layout.Page>
+    );
+  }
+
+  return (
+    <Feature
+      features={['dashboards-edit', 'dashboards-ai-generate']}
+      organization={organization}
+      renderDisabled={renderDisabled}
+    >
+      <ErrorBoundary>
+        <DashboardDetail
+          initialState={DashboardState.PREVIEW}
+          dashboard={dashboard}
+          dashboards={[]}
+        />
+      </ErrorBoundary>
+    </Feature>
+  );
+}
+
+const MessageBlock = styled(MarkedText)`
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+  background: ${p => p.theme.tokens.background.secondary};
+  border-radius: ${p => p.theme.radius.md};
+  font-size: ${p => p.theme.font.size.sm};
+  color: ${p => p.theme.tokens.content.secondary};
+
+  p {
+    margin-bottom: 0;
+  }
+`;

--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -5,7 +5,6 @@ import {Alert} from '@sentry/scraps/alert';
 import {Flex} from '@sentry/scraps/layout';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import Feature from 'sentry/components/acl/feature';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -100,13 +99,16 @@ export default function CreateFromSeer() {
   const location = useLocation();
 
   const seerRunId = location.query?.seerRunId ? Number(location.query.seerRunId) : null;
+  const hasFeature =
+    organization.features.includes('dashboards-edit') &&
+    organization.features.includes('dashboards-ai-generate');
 
   const {data, isError} = useApiQuery<SeerExplorerResponse>(
     makeSeerExplorerQueryKey(organization.slug, seerRunId),
     {
       staleTime: 0,
       retry: false,
-      enabled: !!seerRunId,
+      enabled: !!seerRunId && hasFeature,
       refetchInterval: query => {
         const status = query.state.data?.[0]?.session?.status;
         if (status === 'completed' || status === 'error') {
@@ -150,7 +152,7 @@ export default function CreateFromSeer() {
     }
   }, [sessionStatus, isError]);
 
-  function renderDisabled() {
+  if (!hasFeature) {
     return (
       <Layout.Page withPadding>
         <Alert.Container>
@@ -180,19 +182,13 @@ export default function CreateFromSeer() {
   }
 
   return (
-    <Feature
-      features={['dashboards-edit', 'dashboards-ai-generate']}
-      organization={organization}
-      renderDisabled={renderDisabled}
-    >
-      <ErrorBoundary>
-        <DashboardDetail
-          initialState={DashboardState.PREVIEW}
-          dashboard={dashboard}
-          dashboards={[]}
-        />
-      </ErrorBoundary>
-    </Feature>
+    <ErrorBoundary>
+      <DashboardDetail
+        initialState={DashboardState.PREVIEW}
+        dashboard={dashboard}
+        dashboards={[]}
+      />
+    </ErrorBoundary>
   );
 }
 

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -14,7 +14,10 @@ import {Switch} from '@sentry/scraps/switch';
 
 import {createDashboard} from 'sentry/actionCreators/dashboards';
 import {addLoadingMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {openImportDashboardFromFileModal} from 'sentry/actionCreators/modal';
+import {
+  openGenerateDashboardFromSeerModal,
+  openImportDashboardFromFileModal,
+} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
@@ -24,7 +27,7 @@ import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionT
 import Pagination from 'sentry/components/pagination';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {IconAdd, IconGrid, IconList} from 'sentry/icons';
+import {IconAdd, IconGrid, IconList, IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -646,6 +649,24 @@ function ManageDashboards() {
                           </Button>
                         )}
                       </DashboardCreateLimitWrapper>
+                      <Feature features="dashboards-ai-generate">
+                        <Button
+                          data-test-id="dashboard-generate-seer"
+                          onClick={() => {
+                            openGenerateDashboardFromSeerModal({
+                              organization,
+                              api,
+                              location,
+                              navigate,
+                            });
+                          }}
+                          size="sm"
+                          priority="primary"
+                          icon={<IconSeer />}
+                        >
+                          {t('Create Dashboard with Seer')}
+                        </Button>
+                      </Feature>
                       <Feature features="dashboards-import">
                         <Button
                           onClick={() => {

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -655,7 +655,6 @@ function ManageDashboards() {
                           onClick={() => {
                             openGenerateDashboardFromSeerModal({
                               organization,
-                              api,
                               location,
                               navigate,
                             });


### PR DESCRIPTION
Adds a new `Create Dashboard with Seer` button:
- Opens a `GenerateDashboardFromSeerModal` modal which accepts a prompt text field from the user
   - Clicking generate starts a seer run via the `orgslug/dashboards/generate/` endpoint and navigates user to the `CreateFromSeer` preview page with the `run_id`
- `CreateFromSeer` preview page polls the seer `run_id` and renders a dashboard preview using the artifact response when complete
<img width="439" height="160" alt="image" src="https://github.com/user-attachments/assets/2d13dd36-7f58-48a6-a283-39c2311ace86" />
