### PR TITLE
ref(dashboards): Remove prebuilt dashboards section from sidebar nav

### DIFF
--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment} from 'react';
 import * as Sentry from '@sentry/react';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -12,7 +12,6 @@ import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarr
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {PRIMARY_NAVIGATION_GROUP_CONFIG} from 'sentry/views/navigation/primary/config';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/secondary';
-import {DashboardsNavigationItems} from 'sentry/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems';
 import {PrimaryNavigationGroup} from 'sentry/views/navigation/types';
 
 export function DashboardsSecondaryNavigation() {
@@ -22,14 +21,6 @@ export function DashboardsSecondaryNavigation() {
   const user = useUser();
 
   const {data: starredDashboards = []} = useGetStarredDashboards();
-
-  const {prebuiltDashboards, customDashboards} = useMemo(
-    () => ({
-      prebuiltDashboards: starredDashboards.filter(d => defined(d.prebuiltId)),
-      customDashboards: starredDashboards.filter(d => !defined(d.prebuiltId)),
-    }),
-    [starredDashboards]
-  );
 
   return (
     <Fragment>
@@ -46,34 +37,14 @@ export function DashboardsSecondaryNavigation() {
             {t('All Dashboards')}
           </SecondaryNavigation.Item>
         </SecondaryNavigation.Section>
-        {customDashboards.length > 0 ? (
+        {starredDashboards.length > 0 ? (
           <SecondaryNavigation.Section
             id="dashboards-starred"
             title={t('Starred Dashboards')}
           >
             <ErrorBoundary mini>
-              {organization.features.includes('dashboards-starred-reordering') ? (
-                <DashboardsNavigationItems initialDashboards={customDashboards} />
-              ) : (
-                <StarredDashboardItems
-                  dashboards={customDashboards}
-                  projects={projects}
-                  organizationSlug={organization.slug}
-                  organizationId={organization.id}
-                  userId={user.id}
-                />
-              )}
-            </ErrorBoundary>
-          </SecondaryNavigation.Section>
-        ) : null}
-        {prebuiltDashboards.length > 0 ? (
-          <SecondaryNavigation.Section
-            id="dashboards-starred-sentry"
-            title={t('Starred Sentry Built')}
-          >
-            <ErrorBoundary mini>
               <StarredDashboardItems
-                dashboards={prebuiltDashboards}
+                dashboards={starredDashboards}
                 projects={projects}
                 organizationSlug={organization.slug}
                 organizationId={organization.id}

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
@@ -12,6 +12,7 @@ import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarr
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {PRIMARY_NAVIGATION_GROUP_CONFIG} from 'sentry/views/navigation/primary/config';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/secondary';
+import {DashboardsNavigationItems} from 'sentry/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems';
 import {PrimaryNavigationGroup} from 'sentry/views/navigation/types';
 
 export function DashboardsSecondaryNavigation() {
@@ -43,13 +44,17 @@ export function DashboardsSecondaryNavigation() {
             title={t('Starred Dashboards')}
           >
             <ErrorBoundary mini>
-              <StarredDashboardItems
-                dashboards={starredDashboards}
-                projects={projects}
-                organizationSlug={organization.slug}
-                organizationId={organization.id}
-                userId={user.id}
-              />
+              {organization.features.includes('dashboards-starred-reordering') ? (
+                <DashboardsNavigationItems initialDashboards={starredDashboards} />
+              ) : (
+                <StarredDashboardItems
+                  dashboards={starredDashboards}
+                  projects={projects}
+                  organizationSlug={organization.slug}
+                  organizationId={organization.id}
+                  userId={user.id}
+                />
+              )}
             </ErrorBoundary>
           </SecondaryNavigation.Section>
         ) : null}


### PR DESCRIPTION
Consolidate the separate "Starred Dashboards" and "Starred Sentry Built" sections in the dashboards sidebar navigation into a single "Starred Dashboards" list.

Previously, starred dashboards were split by `prebuiltId` into two sections — custom dashboards and prebuilt (Sentry-built) dashboards. This removes that distinction and shows all starred dashboards in one unified section.

Also removes the `DashboardsNavigationItems` import and the `dashboards-starred-reordering` feature flag branch from this component.