### PR TITLE
ref(code_review): remove legacy endpoint

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -711,12 +711,6 @@ register(
 
 # Coding Workflows
 register(
-    "coding_workflows.code_review.seer.use_new_endpoints",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "seer.code-review.excluded-pr-author-logins",
     type=Sequence,
     default=[],

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -11,7 +11,7 @@ import orjson
 from django.conf import settings
 from urllib3.exceptions import HTTPError
 
-from sentry import features, options
+from sentry import features
 from sentry.integrations.github.client import GitHubReaction
 from sentry.integrations.github.utils import is_github_rate_limit_sensitive
 from sentry.integrations.github.webhook_types import GithubWebhookType
@@ -71,27 +71,21 @@ def convert_enum_keys_to_strings(obj: Any) -> Any:
 
 # These values need to match the value defined in the Seer API.
 class SeerEndpoint(StrEnum):
-    # Legacy; used when coding_workflows.code_review.seer.use_new_endpoints is False
-    OVERWATCH_REQUEST = "/v1/automation/overwatch-request"
     # https://github.com/getsentry/seer/blob/main/src/seer/routes/codegen.py
     PR_REVIEW_RERUN = "/v1/code_review/check/rerun"
-    # New dedicated endpoints (used when use_new_endpoints is True)
     CODE_REVIEW_REVIEW_REQUEST = "/v1/code_review/review-request"
     CODE_REVIEW_PR_CLOSED = "/v1/code_review/pr-closed"
 
 
 def get_seer_path_for_request(github_event: str, payload: Mapping[str, Any]) -> str:
     """
-    Get the Seer API path for a webhook request based on event type and option.
+    Get the Seer API path for a webhook request based on event type and payload.
 
-    When coding_workflows.code_review.seer.use_new_endpoints is False, PR/issue_comment
-    events use the legacy overwatch-request endpoint. When True, they use the dedicated
-    review-request or pr-closed endpoints. CHECK_RUN always uses the rerun endpoint.
+    CHECK_RUN events use the rerun endpoint. PR and issue_comment events use the
+    dedicated review-request or pr-closed endpoint based on request_type.
     """
     if github_event == GithubWebhookType.CHECK_RUN.value:
         return SeerEndpoint.PR_REVIEW_RERUN.value
-    if not options.get("coding_workflows.code_review.seer.use_new_endpoints"):
-        return SeerEndpoint.OVERWATCH_REQUEST.value
     if payload.get("request_type") == "pr-closed":
         return SeerEndpoint.CODE_REVIEW_PR_CLOSED.value
     return SeerEndpoint.CODE_REVIEW_REVIEW_REQUEST.value
@@ -273,7 +267,7 @@ def _common_codegen_request_payload(
         data["experiment_enabled"] = is_org_enabled_for_code_review_experiments(organization)
 
     return {
-        # In Seer,src/seer/routes/automation_request.py:overwatch_request_endpoint
+        # Payload shape consumed by Seer code_review routes (review-request, pr-closed).
         "request_type": request_type.value,
         "external_owner_id": repo.external_id,
         "data": data,

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -22,7 +22,6 @@ from sentry.seer.code_review.webhooks.task import (
     process_github_webhook_event,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 
 
 class ProcessGitHubWebhookEventTest(TestCase):
@@ -90,6 +89,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         # Verify metric is incremented exactly once (not double-counted)
@@ -116,6 +116,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         # Verify metric is incremented exactly once (not double-counted)
@@ -142,6 +143,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         # Verify metric is incremented exactly once (not double-counted)
@@ -166,6 +168,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         # Client error tracked in metrics with appropriate status label, not retried
@@ -195,6 +198,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         # Verify metric is incremented exactly once (not double-counted)
@@ -223,6 +227,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         # Verify metric is incremented exactly once (not double-counted)
@@ -251,6 +256,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         # Verify metric is incremented exactly once (not double-counted)
@@ -279,6 +285,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         # Verify metric is incremented exactly once (not double-counted)
@@ -307,6 +314,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         # Verify metric is incremented exactly once (not double-counted)
@@ -336,6 +344,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                 github_event=GithubWebhookType.CHECK_RUN,
                 event_payload={"original_run_id": self.original_run_id},
                 enqueued_at_str=self.enqueued_at_str,
+                tags={},
             )
 
         mock_metrics.incr.assert_called()
@@ -361,6 +370,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
             github_event=GithubWebhookType.CHECK_RUN,
             event_payload={"original_run_id": self.original_run_id},
             enqueued_at_str=self.enqueued_at_str,
+            tags={},
         )
 
         mock_metrics.timing.assert_called_once()
@@ -398,6 +408,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
                     github_event=GithubWebhookType.CHECK_RUN,
                     event_payload={"original_run_id": self.original_run_id},
                     enqueued_at_str=enqueued_at_str,
+                    tags={},
                 )
                 assert False, "Expected MaxRetryError to be raised"
             except MaxRetryError:
@@ -421,13 +432,14 @@ class ProcessGitHubWebhookEventTest(TestCase):
 
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     def test_check_run_and_pr_events_processed_separately(self, mock_request: MagicMock) -> None:
-        """Test that CHECK_RUN uses rerun endpoint; PR events use overwatch-request when option off."""
+        """Test that CHECK_RUN uses rerun endpoint; PR events use review-request endpoint."""
         mock_request.return_value = self._mock_response(200, b"{}")
 
         process_github_webhook_event._func(
             github_event=GithubWebhookType.CHECK_RUN,
             event_payload={"original_run_id": self.original_run_id},
             enqueued_at_str=self.enqueued_at_str,
+            tags={},
         )
 
         assert mock_request.call_count == 1
@@ -470,15 +482,18 @@ class ProcessGitHubWebhookEventTest(TestCase):
             github_event=GithubWebhookType.PULL_REQUEST,
             event_payload=event_payload,
             enqueued_at_str=self.enqueued_at_str,
+            tags={},
         )
 
         assert mock_request.call_count == 1
         pr_call = mock_request.call_args
-        assert pr_call[1]["path"] == "/v1/automation/overwatch-request"
+        assert pr_call[1]["path"] == "/v1/code_review/review-request"
 
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
-    def test_pr_event_uses_new_endpoints_when_option_enabled(self, mock_request: MagicMock) -> None:
-        """Test that with use_new_endpoints option, PR review uses review-request and pr-closed uses pr-closed."""
+    def test_pr_event_uses_review_request_and_pr_closed_endpoints(
+        self, mock_request: MagicMock
+    ) -> None:
+        """Test that PR review uses review-request and pr-closed uses pr-closed endpoint."""
         mock_request.return_value = self._mock_response(200, b"{}")
 
         pr_review_payload = {
@@ -507,12 +522,12 @@ class ProcessGitHubWebhookEventTest(TestCase):
             },
         }
 
-        with override_options({"coding_workflows.code_review.seer.use_new_endpoints": True}):
-            process_github_webhook_event._func(
-                github_event=GithubWebhookType.PULL_REQUEST,
-                event_payload=pr_review_payload,
-                enqueued_at_str=self.enqueued_at_str,
-            )
+        process_github_webhook_event._func(
+            github_event=GithubWebhookType.PULL_REQUEST,
+            event_payload=pr_review_payload,
+            enqueued_at_str=self.enqueued_at_str,
+            tags={},
+        )
 
         assert mock_request.call_count == 1
         assert mock_request.call_args[1]["path"] == "/v1/code_review/review-request"
@@ -520,12 +535,12 @@ class ProcessGitHubWebhookEventTest(TestCase):
         mock_request.reset_mock()
         pr_closed_payload = {**pr_review_payload, "request_type": "pr-closed"}
 
-        with override_options({"coding_workflows.code_review.seer.use_new_endpoints": True}):
-            process_github_webhook_event._func(
-                github_event=GithubWebhookType.PULL_REQUEST,
-                event_payload=pr_closed_payload,
-                enqueued_at_str=self.enqueued_at_str,
-            )
+        process_github_webhook_event._func(
+            github_event=GithubWebhookType.PULL_REQUEST,
+            event_payload=pr_closed_payload,
+            enqueued_at_str=self.enqueued_at_str,
+            tags={"github_event_action": "closed"},
+        )
 
         assert mock_request.call_count == 1
         assert mock_request.call_args[1]["path"] == "/v1/code_review/pr-closed"
@@ -575,6 +590,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
             github_event=GithubWebhookType.PULL_REQUEST,
             event_payload=event_payload,
             enqueued_at_str=self.enqueued_at_str,
+            tags={},
         )
 
         # Verify the request was made
@@ -632,6 +648,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
             github_event=GithubWebhookType.PULL_REQUEST,
             event_payload=event_payload,
             enqueued_at_str=self.enqueued_at_str,
+            tags={},
         )
 
         assert mock_request.call_count == 1
@@ -675,6 +692,7 @@ class ProcessGitHubWebhookEventTest(TestCase):
             github_event=GithubWebhookType.PULL_REQUEST,
             event_payload=event_payload,
             enqueued_at_str=self.enqueued_at_str,
+            tags={"github_event_action": "closed"},
         )
 
         assert mock_request.call_count == 1

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -1,5 +1,4 @@
 from collections.abc import Generator
-from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -142,8 +141,8 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert response.status_code == 204
             self.mock_seer.assert_not_called()
 
-    def test_success_case_uses_legacy_endpoint_by_default(self) -> None:
-        """Test that with option disabled, issue comment uses overwatch-request."""
+    def test_success_case_uses_review_request_endpoint(self) -> None:
+        """Test that issue comment uses review-request endpoint."""
         with self.code_review_setup(), self.tasks():
             event_dict = orjson.loads(
                 self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
@@ -156,38 +155,6 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             self.mock_reaction.assert_called_once_with(
                 "sentry-ecosystem/repo", "123456789", GitHubReaction.EYES
             )
-            self.mock_seer.assert_called_once()
-
-            call_args = self.mock_seer.call_args
-            assert call_args[1]["path"] == "/v1/automation/overwatch-request"
-            payload = call_args[1]["payload"]
-            assert payload["request_type"] == "pr-review"
-            assert payload["data"]["repo"]["base_commit_sha"] == "abc123"
-            assert payload["data"]["config"]["trigger_user"] == "test-user"
-            assert payload["data"]["config"]["trigger_comment_id"] == 123456789
-            assert payload["data"]["config"]["trigger_comment_type"] == "issue_comment"
-            # After Pydantic validation, trigger_at is a datetime object
-            assert payload["data"]["config"]["trigger_at"] == datetime(
-                2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc
-            )
-            # sentry_received_trigger_at is set to current time when transform happens
-            assert isinstance(payload["data"]["config"]["sentry_received_trigger_at"], datetime)
-
-    def test_success_case_uses_new_endpoint_when_option_enabled(self) -> None:
-        """Test that with use_new_endpoints option, issue comment uses review-request."""
-        with (
-            self.code_review_setup(),
-            self.tasks(),
-            self.options({"coding_workflows.code_review.seer.use_new_endpoints": True}),
-        ):
-            event_dict = orjson.loads(
-                self._build_issue_comment_event(f"Please {SENTRY_REVIEW_COMMAND} this PR")
-            )
-            event_dict["comment"]["user"] = {"login": "test-user"}
-            event = orjson.dumps(event_dict)
-
-            response = self._send_issue_comment_event(event)
-            assert response.status_code == 204
             self.mock_seer.assert_called_once()
             call_args = self.mock_seer.call_args
             assert call_args[1]["path"] == "/v1/code_review/review-request"

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -1,5 +1,4 @@
 from collections.abc import Generator
-from datetime import datetime, timezone
 from unittest.mock import patch
 
 import orjson
@@ -60,36 +59,9 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             self.mock_seer = mock_seer
             yield
 
-    def test_pull_request_opened_uses_legacy_endpoint_by_default(self) -> None:
-        """Test that with option disabled, opened action uses overwatch-request."""
+    def test_pull_request_opened_uses_review_request_endpoint(self) -> None:
+        """Test that opened action uses review-request endpoint."""
         with self.code_review_setup(), self.tasks():
-            event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
-            assert event["action"] == "opened"
-
-            self._send_webhook_event(
-                GithubWebhookType.PULL_REQUEST,
-                orjson.dumps(event),
-            )
-
-            self.mock_seer.assert_called_once()
-            call_kwargs = self.mock_seer.call_args[1]
-            assert call_kwargs["path"] == "/v1/automation/overwatch-request"
-            payload = call_kwargs["payload"]
-            assert payload["request_type"] == SeerCodeReviewRequestType.PR_REVIEW.value
-
-            self.mock_reaction.assert_called_once_with(
-                event["repository"]["full_name"],
-                str(event["pull_request"]["number"]),
-                GitHubReaction.EYES,
-            )
-
-    def test_pull_request_opened_uses_new_endpoint_when_option_enabled(self) -> None:
-        """Test that with use_new_endpoints option, opened action uses review-request."""
-        with (
-            self.code_review_setup(),
-            self.tasks(),
-            self.options({"coding_workflows.code_review.seer.use_new_endpoints": True}),
-        ):
             event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
             assert event["action"] == "opened"
 
@@ -263,41 +235,9 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             self.mock_seer.assert_not_called()
             self.mock_reaction.assert_not_called()
 
-    def test_pull_request_closed_uses_legacy_endpoint_by_default(self) -> None:
-        """Test that with option disabled, closed action uses overwatch-request."""
+    def test_pull_request_closed_uses_pr_closed_endpoint(self) -> None:
+        """Test that closed action uses pr-closed endpoint."""
         with self.code_review_setup(), self.tasks():
-            event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
-            event["action"] = "closed"
-
-            self._send_webhook_event(
-                GithubWebhookType.PULL_REQUEST,
-                orjson.dumps(event),
-            )
-
-            self.mock_seer.assert_called_once()
-            call_kwargs = self.mock_seer.call_args[1]
-            assert call_kwargs["path"] == "/v1/automation/overwatch-request"
-            payload = call_kwargs["payload"]
-            assert payload["request_type"] == SeerCodeReviewRequestType.PR_CLOSED.value
-            assert payload["data"]["config"]["trigger"] == SeerCodeReviewTrigger.UNKNOWN.value
-            assert payload["data"]["config"]["trigger_user"] == "baxterthehacker"
-            assert payload["data"]["config"]["trigger_comment_id"] is None
-            assert payload["data"]["config"]["trigger_comment_type"] is None
-            # After Pydantic validation, trigger_at is a datetime object
-            assert payload["data"]["config"]["trigger_at"] == datetime(
-                2015, 5, 5, 23, 40, 27, tzinfo=timezone.utc
-            )
-            # sentry_received_trigger_at is set to current time when transform happens
-            assert isinstance(payload["data"]["config"]["sentry_received_trigger_at"], datetime)
-            self.mock_reaction.assert_not_called()
-
-    def test_pull_request_closed_uses_new_endpoint_when_option_enabled(self) -> None:
-        """Test that with use_new_endpoints option, closed action uses pr-closed endpoint."""
-        with (
-            self.code_review_setup(),
-            self.tasks(),
-            self.options({"coding_workflows.code_review.seer.use_new_endpoints": True}),
-        ):
             event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
             event["action"] = "closed"
 


### PR DESCRIPTION
This commit removes the `coding_workflows.code_review.seer.use_new_endpoints` option, which was previously used to toggle between legacy (`overwatch-request`) and the new Code Review endpoints for GitHub webhook events. All relevant tests have been updated to consistently use the new `review-request` and `pr-closed` endpoints. The code has been adjusted to reflect these changes, ensuring that the new endpoints are utilized for processing pull request and issue comment events.