### PR TITLE
fix(detectors): Make mobile build threshold validation require at least one

### DIFF
--- a/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
@@ -98,7 +98,7 @@ function ThresholdSection({
   return (
     <section>
       <DefineThresholdParagraph>
-        <Text bold>{t('Define threshold & set priority (at least one required)')}</Text>
+        <Text bold>{t('Define threshold & set priority')}</Text>
         <Text variant="muted">
           {t('Issues will be created when the query value passes the set threshold.')}
         </Text>
@@ -165,7 +165,11 @@ function PriorityRow({
           hideLabel
           inline
           required={false}
-          validate={validateAtLeastOneThreshold}
+          validate={
+            priority === DetectorPriorityLevel.HIGH
+              ? validateAtLeastOneThreshold
+              : undefined
+          }
           preserveOnUnmount
         />
         <ThresholdSuffix>{isPercentage ? '%' : 'MB'}</ThresholdSuffix>

--- a/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
@@ -98,7 +98,7 @@ function ThresholdSection({
   return (
     <section>
       <DefineThresholdParagraph>
-        <Text bold>{t('Define threshold & set priority')}</Text>
+        <Text bold>{t('Define threshold & set priority (at least one required)')}</Text>
         <Text variant="muted">
           {t('Issues will be created when the query value passes the set threshold.')}
         </Text>
@@ -116,6 +116,22 @@ type SupportedPriorityLevel = Extract<
   DetectorPriorityLevel.HIGH | DetectorPriorityLevel.LOW
 >;
 
+function validateAtLeastOneThreshold({
+  id,
+  form,
+}: {
+  form: Record<string, any>;
+  id: string;
+}): Array<[string, string]> {
+  const high = form[PREPROD_DETECTOR_FORM_FIELDS.highThreshold];
+  const low = form[PREPROD_DETECTOR_FORM_FIELDS.lowThreshold];
+
+  if (!high && !low) {
+    return [[id, t('At least one threshold is required')]];
+  }
+  return [];
+}
+
 function PriorityRow({
   priority,
   isPercentage,
@@ -123,19 +139,16 @@ function PriorityRow({
   isPercentage: boolean;
   priority: SupportedPriorityLevel;
 }) {
-  let required: boolean;
   let priorityLabel: string;
   let thresholdFieldName: string;
   switch (priority) {
     case DetectorPriorityLevel.HIGH:
       priorityLabel = t('High priority');
       thresholdFieldName = PREPROD_DETECTOR_FORM_FIELDS.highThreshold;
-      required = true;
       break;
     case DetectorPriorityLevel.LOW:
       priorityLabel = t('Low priority');
       thresholdFieldName = PREPROD_DETECTOR_FORM_FIELDS.lowThreshold;
-      required = false;
       break;
     default:
       return null;
@@ -144,17 +157,15 @@ function PriorityRow({
   return (
     <Flex align="center" gap="md">
       <PriorityDot priority={DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL[priority]} />
-      <PriorityLabel>
-        {priorityLabel}
-        {required && <RequiredAsterisk>*</RequiredAsterisk>}
-      </PriorityLabel>
+      <PriorityLabel>{priorityLabel}</PriorityLabel>
       <Flex align="center" gap="md">
         <ThresholdField
           name={thresholdFieldName}
           placeholder="-"
           hideLabel
           inline
-          required={required}
+          required={false}
+          validate={validateAtLeastOneThreshold}
           preserveOnUnmount
         />
         <ThresholdSuffix>{isPercentage ? '%' : 'MB'}</ThresholdSuffix>
@@ -198,11 +209,6 @@ const DefineThresholdParagraph = styled('div')`
 const PriorityLabel = styled('span')`
   min-width: 120px;
   font-weight: ${p => p.theme.font.weight.sans.regular};
-`;
-
-const RequiredAsterisk = styled('span')`
-  color: ${p => p.theme.tokens.content.danger};
-  margin-left: ${p => p.theme.space['2xs']};
 `;
 
 const ThresholdField = styled(NumberField)`


### PR DESCRIPTION
Make high or low priority threshold required (not just high) on mobile build monitor creation.

Previously the high priority threshold was unconditionally `required`, blocking users who only wanted to set a low priority threshold. The backend (`createPreprodConditions()`) already handles missing thresholds gracefully, so only the frontend validation needed to change.

- Replace per-field `required` with a cross-field `validate` function that checks if at least one threshold (high or low) is filled
- Show the validation error only on the high priority field to avoid duplicate tooltips
- Remove the required asterisk since neither field is individually required

Refs EME-927