### PR TITLE
ref(cells): Update RegionReplicaService rpc methods to accept cell_name

### DIFF
--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -142,7 +142,13 @@ def handle_replication(
 
 
 class DatabaseBackedRegionReplicaService(RegionReplicaService):
-    def upsert_replicated_api_token(self, *, api_token: RpcApiToken, region_name: str) -> None:
+    def upsert_replicated_api_token(
+        self,
+        *,
+        api_token: RpcApiToken,
+        cell_name: str | None = None,
+        region_name: str | None = None,
+    ) -> None:
         organization: Organization | None = None
         if api_token.organization_id is not None:
             try:
@@ -167,12 +173,20 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
         )
         handle_replication(ApiToken, destination)
 
-    def delete_replicated_api_token(self, *, apitoken_id: int, region_name: str) -> None:
+    def delete_replicated_api_token(
+        self, *, apitoken_id: int, cell_name: str | None = None, region_name: str | None = None
+    ) -> None:
         with enforce_constraints(transaction.atomic(router.db_for_write(ApiTokenReplica))):
             api_token_qs = ApiTokenReplica.objects.filter(apitoken_id=apitoken_id)
             api_token_qs.delete()
 
-    def upsert_replicated_org_auth_token(self, *, token: RpcOrgAuthToken, region_name: str) -> None:
+    def upsert_replicated_org_auth_token(
+        self,
+        *,
+        token: RpcOrgAuthToken,
+        cell_name: str | None = None,
+        region_name: str | None = None,
+    ) -> None:
         try:
             organization = Organization.objects.get(id=token.organization_id)
         except Organization.DoesNotExist:
@@ -190,7 +204,11 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
         handle_replication(OrgAuthToken, destination)
 
     def upsert_replicated_auth_provider(
-        self, *, auth_provider: RpcAuthProvider, region_name: str
+        self,
+        *,
+        auth_provider: RpcAuthProvider,
+        cell_name: str | None = None,
+        region_name: str | None = None,
     ) -> None:
         try:
             organization = Organization.objects.get(id=auth_provider.organization_id)
@@ -211,7 +229,11 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
         handle_replication(AuthProvider, destination)
 
     def upsert_replicated_auth_identity(
-        self, *, auth_identity: RpcAuthIdentity, region_name: str
+        self,
+        *,
+        auth_identity: RpcAuthIdentity,
+        cell_name: str | None = None,
+        region_name: str | None = None,
     ) -> None:
         destination = AuthIdentityReplica(
             auth_identity_id=auth_identity.id,
@@ -224,7 +246,9 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
 
         handle_replication(AuthIdentity, destination)
 
-    def upsert_replicated_api_key(self, *, api_key: RpcApiKey, region_name: str) -> None:
+    def upsert_replicated_api_key(
+        self, *, api_key: RpcApiKey, cell_name: str | None = None, region_name: str | None = None
+    ) -> None:
         try:
             organization = Organization.objects.get(id=api_key.organization_id)
         except Organization.DoesNotExist:
@@ -243,7 +267,11 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
         handle_replication(ApiKey, destination)
 
     def upsert_replicated_org_slug_reservation(
-        self, *, slug_reservation: RpcOrganizationSlugReservation, region_name: str
+        self,
+        *,
+        slug_reservation: RpcOrganizationSlugReservation,
+        cell_name: str | None = None,
+        region_name: str | None = None,
     ) -> None:
         with enforce_constraints(
             transaction.atomic(router.db_for_write(OrganizationSlugReservationReplica))
@@ -268,7 +296,11 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
             )
 
     def delete_replicated_org_slug_reservation(
-        self, *, organization_slug_reservation_id: int, region_name: str
+        self,
+        *,
+        organization_slug_reservation_id: int,
+        cell_name: str | None = None,
+        region_name: str | None = None,
     ) -> None:
         with enforce_constraints(
             transaction.atomic(router.db_for_write(OrganizationSlugReservationReplica))
@@ -278,7 +310,9 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
             )
             org_slug_qs.delete()
 
-    def delete_replicated_auth_provider(self, *, auth_provider_id: int, region_name: str) -> None:
+    def delete_replicated_auth_provider(
+        self, *, auth_provider_id: int, cell_name: str | None = None, region_name: str | None = None
+    ) -> None:
         with enforce_constraints(transaction.atomic(router.db_for_write(AuthProviderReplica))):
             AuthProviderReplica.objects.filter(auth_provider_id=auth_provider_id).delete()
 

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -52,54 +52,88 @@ class RegionReplicaService(RpcService):
     @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def upsert_replicated_auth_provider(
-        self, *, auth_provider: RpcAuthProvider, region_name: str
+        self,
+        *,
+        auth_provider: RpcAuthProvider,
+        cell_name: str | None = None,
+        region_name: str | None = None,
     ) -> None:
         pass
 
     @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def upsert_replicated_auth_identity(
-        self, *, auth_identity: RpcAuthIdentity, region_name: str
+        self,
+        *,
+        auth_identity: RpcAuthIdentity,
+        cell_name: str | None = None,
+        region_name: str | None = None,
     ) -> None:
         pass
 
     @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
-    def upsert_replicated_api_key(self, *, api_key: RpcApiKey, region_name: str) -> None:
+    def upsert_replicated_api_key(
+        self, *, api_key: RpcApiKey, cell_name: str | None = None, region_name: str | None = None
+    ) -> None:
         pass
 
     @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
-    def upsert_replicated_api_token(self, *, api_token: RpcApiToken, region_name: str) -> None:
+    def upsert_replicated_api_token(
+        self,
+        *,
+        api_token: RpcApiToken,
+        cell_name: str | None = None,
+        region_name: str | None = None,
+    ) -> None:
         pass
 
     @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
-    def delete_replicated_api_token(self, *, apitoken_id: int, region_name: str) -> None:
+    def delete_replicated_api_token(
+        self, *, apitoken_id: int, cell_name: str | None = None, region_name: str | None = None
+    ) -> None:
         pass
 
     @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
-    def upsert_replicated_org_auth_token(self, *, token: RpcOrgAuthToken, region_name: str) -> None:
+    def upsert_replicated_org_auth_token(
+        self,
+        *,
+        token: RpcOrgAuthToken,
+        cell_name: str | None = None,
+        region_name: str | None = None,
+    ) -> None:
         pass
 
     @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def upsert_replicated_org_slug_reservation(
-        self, *, slug_reservation: RpcOrganizationSlugReservation, region_name: str
+        self,
+        *,
+        slug_reservation: RpcOrganizationSlugReservation,
+        cell_name: str | None = None,
+        region_name: str | None = None,
     ) -> None:
         pass
 
     @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def delete_replicated_org_slug_reservation(
-        self, *, organization_slug_reservation_id: int, region_name: str
+        self,
+        *,
+        organization_slug_reservation_id: int,
+        cell_name: str | None = None,
+        region_name: str | None = None,
     ) -> None:
         pass
 
     @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
-    def delete_replicated_auth_provider(self, *, auth_provider_id: int, region_name: str) -> None:
+    def delete_replicated_auth_provider(
+        self, *, auth_provider_id: int, cell_name: str | None = None, region_name: str | None = None
+    ) -> None:
         pass
 
     @classmethod


### PR DESCRIPTION
now both `cell_name` and `region_name` are accepted

callers will be updated in a subsequent step, once new method signature is deployed everywhere
