### PR TITLE
chore(tasks) Integration TaskbrokerClient into testutils

### DIFF
--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -6,6 +6,7 @@ from typing import Any, ContextManager, Self
 from unittest import mock
 
 from django.conf import settings
+from taskbroker_client.task import Task as TaskbrokerClientTask
 
 from sentry.taskworker.task import Task as TaskworkerTask
 
@@ -14,7 +15,10 @@ __all__ = ("BurstTaskRunner", "TaskRunner")
 
 @contextlib.contextmanager
 def TaskRunner() -> Generator[None]:
-    with mock.patch.object(settings, "TASKWORKER_ALWAYS_EAGER", True):
+    with (
+        mock.patch.object(settings, "TASKWORKER_ALWAYS_EAGER", True),
+        mock.patch("taskbroker_client.task.ALWAYS_EAGER", True),
+    ):
         yield
 
 
@@ -30,6 +34,7 @@ class _BurstState:
     def __init__(self) -> None:
         self._active = False
         self._orig_signal_send = TaskworkerTask._signal_send
+        self._orig_tb_signal_send = TaskbrokerClientTask._signal_send
         self.queue: list[tuple[TaskworkerTask[Any, Any], tuple[Any, ...], dict[str, Any]]] = []
 
     def _signal_send(
@@ -47,7 +52,10 @@ class _BurstState:
         if self._active:
             raise AssertionError("nested BurstTaskRunner!")
 
-        with mock.patch.object(TaskworkerTask, "_signal_send", self._signal_send):
+        with (
+            mock.patch.object(TaskworkerTask, "_signal_send", self._signal_send),
+            mock.patch.object(TaskbrokerClientTask, "_signal_send", self._signal_send),
+        ):
             self._active = True
             try:
                 yield self
@@ -59,7 +67,10 @@ class _BurstState:
         if not self._active:
             raise AssertionError("cannot disable burst when not active")
 
-        with mock.patch.object(TaskworkerTask, "_signal_send", self._orig_signal_send):
+        with (
+            mock.patch.object(TaskworkerTask, "_signal_send", self._orig_signal_send),
+            mock.patch.object(TaskbrokerClientTask, "_signal_send", self._orig_tb_signal_send),
+        ):
             self._active = False
             try:
                 yield

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -339,23 +339,33 @@ def register_extensions() -> None:
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
+    from taskbroker_client.registry import TaskNamespace as TaskbrokerClientNamespace
+
     from sentry.taskworker.registry import TaskNamespace
 
     # Store original send_task so tests that need it can restore it
     TaskNamespace._original_send_task = TaskNamespace.send_task  # type: ignore[attr-defined]
+    TaskbrokerClientNamespace._original_send_task = TaskbrokerClientNamespace.send_task  # type: ignore[attr-defined]
 
     # Prevent tests from producing real Kafka messages via the taskworker pipeline.
     # Tests use TaskRunner (TASKWORKER_ALWAYS_EAGER=True) or BurstTaskRunner
     # (_signal_send hook) which both operate before send_task in the call chain.
     TaskNamespace.send_task = lambda self, *args, **kwargs: None  # type: ignore[method-assign]
+    TaskbrokerClientNamespace.send_task = lambda self, *args, **kwargs: None  # type: ignore[method-assign]
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    from taskbroker_client.registry import TaskNamespace as TaskbrokerClientNamespace
+
     from sentry.taskworker.registry import TaskNamespace
 
     if hasattr(TaskNamespace, "_original_send_task"):
         TaskNamespace.send_task = TaskNamespace._original_send_task  # type: ignore[method-assign]
         del TaskNamespace._original_send_task
+
+    if hasattr(TaskbrokerClientNamespace, "_original_send_task"):
+        TaskbrokerClientNamespace.send_task = TaskbrokerClientNamespace._original_send_task  # type: ignore[method-assign]
+        del TaskbrokerClientNamespace._original_send_task
 
 
 def pytest_runtest_setup(item: pytest.Item) -> None:

--- a/src/sentry/testutils/pytest/stale_database_reads.py
+++ b/src/sentry/testutils/pytest/stale_database_reads.py
@@ -89,6 +89,8 @@ Or like this in pytest-based tests:
 
 @pytest.fixture(autouse=True)
 def stale_database_reads():
+    from taskbroker_client.task import Task as TaskbrokerClientTask
+
     from sentry.taskworker.task import Task
 
     _state = local()
@@ -134,6 +136,7 @@ def stale_database_reads():
     reports = StaleDatabaseReads(model_signal_handlers=[], transaction_blocks=[])
 
     old_signal_send = Task._signal_send
+    old_tb_signal_send = TaskbrokerClientTask._signal_send
 
     def signal_send(self, task, args=(), kwargs=(), **options):
         in_commit_hook = getattr(_state, "in_on_commit", None) or getattr(
@@ -148,6 +151,19 @@ def stale_database_reads():
 
         return old_signal_send(self, task, args, kwargs, **options)
 
+    def tb_signal_send(self, task, args=(), kwargs=(), **options):
+        in_commit_hook = getattr(_state, "in_on_commit", None) or getattr(
+            _state, "in_run_and_clear_commit_hooks", None
+        )
+
+        if getattr(_state, "in_signal_sender", None) and not in_commit_hook:
+            reports.model_signal_handlers.append((_state.in_signal_sender, self))
+
+        elif getattr(_state, "in_atomic", None) and not in_commit_hook:
+            reports.transaction_blocks.append(self)
+
+        return old_tb_signal_send(self, task, args, kwargs, **options)
+
     with (
         mock.patch.object(ModelSignal, "send", send),
         mock.patch.object(transaction, "on_commit", on_commit),
@@ -156,6 +172,7 @@ def stale_database_reads():
             BaseDatabaseWrapper, "run_and_clear_commit_hooks", run_and_clear_commit_hooks
         ),
         mock.patch.object(Task, "_signal_send", signal_send),
+        mock.patch.object(TaskbrokerClientTask, "_signal_send", tb_signal_send),
     ):
         yield reports
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -142,7 +142,10 @@ def test_debounce(
         assert not args
         tasks.append(kwargs)
 
-    with mock.patch("sentry.taskworker.task.Task._signal_send", signal_send):
+    with (
+        mock.patch("sentry.taskworker.task.Task._signal_send", signal_send),
+        mock.patch("taskbroker_client.task.Task._signal_send", signal_send),
+    ):
         schedule_build_project_config(public_key=default_projectkey.public_key)
         schedule_build_project_config(public_key=default_projectkey.public_key)
 


### PR DESCRIPTION
We monkeypatch task methods in a few different places. Add taskbroker-client integrations in each scenario so that removing sentry.taskworker is simpler.

Refs STREAM-610