### PR TITLE
feat(monitors): Add Mobile Builds to monitors sidebar

### DIFF
--- a/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
@@ -60,6 +60,14 @@ export function MonitorsSecondaryNavigation() {
               {t('Uptime')}
             </SecondaryNavigation.Item>
           </Feature>
+          <Feature features={['organizations:preprod-size-monitors-frontend']}>
+            <SecondaryNavigation.Item
+              to={`${baseUrl}/mobile-builds/`}
+              analyticsItemName="monitors_mobile_builds"
+            >
+              {t('Mobile Builds')}
+            </SecondaryNavigation.Item>
+          </Feature>
         </SecondaryNavigation.Section>
 
         <SecondaryNavigation.Section id="monitors-automations">


### PR DESCRIPTION
Add a "Mobile Builds" entry to the monitors sidebar's "By Data Type" section, gated behind the `organizations:preprod-size-monitors-frontend` feature flag.

Follows the same `<Feature>` wrapper pattern used for the Uptime entry.

Refs EME-929