### PR TITLE
feat(dashboards): Add onlyPrebuilt filter to dashboards endpoint

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -400,6 +400,8 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 dashboards = dashboards.exclude(created_by_id=request.user.id)
             elif f == "excludePrebuilt":
                 dashboards = dashboards.exclude(prebuilt_id__isnull=False)
+            elif f == "onlyPrebuilt":
+                dashboards = dashboards.filter(prebuilt_id__isnull=False)
 
         query = request.GET.get("query")
         prebuilt_ids = request.GET.getlist("prebuiltId")
@@ -568,7 +570,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             )
             return serialized
 
-        HIDE_PREBUILT_FILTERS = {"onlyFavorites", "owned", "excludePrebuilt"}
+        HIDE_PREBUILT_FILTERS = {"onlyFavorites", "owned", "excludePrebuilt", "onlyPrebuilt"}
         render_pre_built_dashboard = True
         if HIDE_PREBUILT_FILTERS.intersection(filters) or should_filter_by_prebuilt_ids:
             render_pre_built_dashboard = False

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2269,6 +2269,20 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 assert response.status_code == 200
                 assert len(response.data) == total_count - prebuilt_dashboards_count
 
+    def test_get_with_only_prebuilt(self) -> None:
+        with self.feature("organizations:dashboards-prebuilt-insights-dashboards"):
+            with override_options({"dashboards.prebuilt-dashboard-ids": [1, 2, 3]}):
+                response = self.do_request("get", self.url, {"filter": "onlyPrebuilt"})
+
+                prebuilt_dashboards_count = Dashboard.objects.filter(
+                    organization=self.organization, prebuilt_id__isnull=False
+                ).count()
+                assert prebuilt_dashboards_count == 3
+
+                assert response.status_code == 200
+                assert len(response.data) == prebuilt_dashboards_count
+                assert all(d.get("prebuiltId") is not None for d in response.data)
+
     def test_post_with_text_widget(self) -> None:
         with self.feature("organizations:dashboards-text-widgets"):
             data = {


### PR DESCRIPTION
Adds a new `onlyPrebuilt` filter option to the organization dashboards list endpoint (`GET /api/0/organizations/{org}/dashboards/?filter=onlyPrebuilt`). This is the counterpart to the existing `excludePrebuilt` filter and returns only dashboards that have a `prebuilt_id` set.

This will be used by the upcoming "Sentry Built" secondary nav item (BROWSE-429) to show a filtered view of only sentry-built dashboards.

Also adds `onlyPrebuilt` to `HIDE_PREBUILT_FILTERS` so the default General dashboard template isn't injected into the response when this filter is active.

Refs BROWSE-429