### PR TITLE
ref(grouping): Remove `ContextValue` and `ContextDict`

### DIFF
--- a/src/sentry/grouping/context.py
+++ b/src/sentry/grouping/context.py
@@ -7,12 +7,6 @@ if TYPE_CHECKING:
     from sentry.services.eventstore.models import Event
 
 
-# XXX: Want to make ContextDict typeddict but also want to type/overload dict
-# API on GroupingContext
-ContextValue = Any
-ContextDict = dict[str, ContextValue]
-
-
 class GroupingContext:
     """
     A key-value store used for passing state between strategy functions and other helpers used
@@ -45,18 +39,18 @@ class GroupingContext:
         self.event = event
         self._push_context_layer()
 
-    def __setitem__(self, key: str, value: ContextValue) -> None:
+    def __setitem__(self, key: str, value: Any) -> None:
         # Add the key-value pair to the context layer at the top of the stack
         self._stack[-1][key] = value
 
-    def __getitem__(self, key: str) -> ContextValue:
+    def __getitem__(self, key: str) -> Any:
         # Walk down the stack from the top and return the first instance of `key` found
         for d in reversed(self._stack):
             if key in d:
                 return d[key]
         raise KeyError(key)
 
-    def get(self, key: str, default: ContextValue | None = None) -> ContextValue | None:
+    def get(self, key: str, default: Any = None) -> Any | None:
         try:
             return self[key]
         except KeyError:

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -28,12 +28,6 @@ if TYPE_CHECKING:
 STRATEGIES: dict[str, Strategy[Any]] = {}
 
 
-# XXX: Want to make ContextDict typeddict but also want to type/overload dict
-# API on GroupingContext
-ContextValue = Any
-ContextDict = dict[str, ContextValue]
-
-
 # TODO: Hack to make `ComponentsByVariant` covariant. At some point we should probably turn
 # `ComponentsByVariant` into a Mapping (immutable), since in practice it's read-only.
 GroupingComponent = TypeVar("GroupingComponent", bound=BaseGroupingComponent[Any])
@@ -198,7 +192,7 @@ class StrategyConfiguration:
     base: type[StrategyConfiguration] | None = None
     strategies: dict[str, Strategy[Any]] = {}
     delegates: dict[str, Strategy[Any]] = {}
-    initial_context: ContextDict = {}
+    initial_context: dict[str, Any] = {}
     enhancements_base: str | None = DEFAULT_ENHANCEMENTS_BASE
     fingerprinting_bases: Sequence[str] | None = DEFAULT_GROUPING_FINGERPRINTING_BASES
 
@@ -242,7 +236,7 @@ def create_strategy_configuration_class(
     strategies: Sequence[str] | None = None,
     delegates: Sequence[str] | None = None,
     base: type[StrategyConfiguration] | None = None,
-    initial_context: ContextDict | None = None,
+    initial_context: dict[str, Any] | None = None,
     enhancements_base: str | None = None,
     fingerprinting_bases: Sequence[str] | None = None,
 ) -> type[StrategyConfiguration]:


### PR DESCRIPTION
The `ContextValue` and `ContextDict` type aliases for `Any` and `dict[str, Any]`, respectively, were meant to be removed in https://github.com/getsentry/sentry/pull/110373, but I not-so-cleverly forgot to push that last change before I merged it. This makes the change for real this time.