### PR TITLE
feat(dashboards): Add Sentry Built nav item and remove prebuilt toggle

### DIFF
--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -601,7 +601,7 @@ function ManageDashboards() {
                         title={
                           isOnlyPrebuilt
                             ? t(
-                                'Pre-configured dashboards built by Sentry to help you monitor key metrics out of the box.'
+                                'Dashboards built by Sentry to help you monitor key metrics out of the box.'
                               )
                             : t(
                                 "A broad overview of your application's health where you can navigate through error and performance data across multiple projects."

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -605,7 +605,7 @@ function ManageDashboards() {
                         title={
                           isOnlyPrebuilt
                             ? t(
-                                'Dashboards built by Sentry to help monitor key metrics out of the box.'
+                                'Dashboards built by Sentry to help monitor your application out of the box.'
                               )
                             : t(
                                 "A broad overview of your application's health where you can navigate through error and performance data across multiple projects."

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -605,7 +605,7 @@ function ManageDashboards() {
                         title={
                           isOnlyPrebuilt
                             ? t(
-                                'Dashboards built by Sentry to help you monitor key metrics out of the box.'
+                                'Dashboards built by Sentry to help monitor key metrics out of the box.'
                               )
                             : t(
                                 "A broad overview of your application's health where you can navigate through error and performance data across multiple projects."

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -51,7 +51,11 @@ import OwnedDashboardsTable, {
   OWNED_CURSOR_KEY,
 } from 'sentry/views/dashboards/manage/tableView/ownedDashboardsTable';
 import type {DashboardsLayout} from 'sentry/views/dashboards/manage/types';
-import type {DashboardDetails, DashboardListItem} from 'sentry/views/dashboards/types';
+import type {
+  DashboardDetails,
+  DashboardFilterType,
+  DashboardListItem,
+} from 'sentry/views/dashboards/types';
 import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import RouteError from 'sentry/views/routeError';
 
@@ -153,8 +157,10 @@ function ManageDashboards() {
   const hasPrebuiltDashboards = organization.features.includes(
     'dashboards-prebuilt-insights-dashboards'
   );
-  const isOnlyPrebuilt =
-    hasPrebuiltDashboards && decodeScalar(location.query.filter) === 'onlyPrebuilt';
+  const urlFilter = decodeScalar(location.query.filter) as
+    | DashboardFilterType
+    | undefined;
+  const isOnlyPrebuilt = hasPrebuiltDashboards && urlFilter === 'onlyPrebuilt';
 
   const [showTemplates, setShowTemplatesLocal] = useLocalStorageState(
     SHOW_TEMPLATES_KEY,
@@ -194,7 +200,9 @@ function ManageDashboards() {
           pin: 'favorites',
           per_page:
             dashboardsLayout === GRID ? rowCount * columnCount : DASHBOARD_TABLE_NUM_ROWS,
-          ...(isOnlyPrebuilt ? {filter: 'onlyPrebuilt'} : {}),
+          ...(isOnlyPrebuilt
+            ? {filter: 'onlyPrebuilt' satisfies DashboardFilterType}
+            : {}),
         },
       },
     ],

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -67,7 +67,6 @@ import {
 import TemplateCard from './templateCard';
 
 const SHOW_TEMPLATES_KEY = 'dashboards-show-templates';
-const SHOW_PREBUILT_KEY = 'dashboards-show-prebuilt';
 export const LAYOUT_KEY = 'dashboards-overview-layout';
 
 const GRID = 'grid';
@@ -75,11 +74,6 @@ const TABLE = 'table';
 
 function shouldShowTemplates(): boolean {
   const shouldShow = localStorage.getItem(SHOW_TEMPLATES_KEY);
-  return shouldShow === 'true' || shouldShow === null;
-}
-
-function shouldShowPrebuilt(): boolean {
-  const shouldShow = localStorage.getItem(SHOW_PREBUILT_KEY);
   return shouldShow === 'true' || shouldShow === null;
 }
 
@@ -100,25 +94,37 @@ function getDashboardsOverviewLayout(): DashboardsLayout {
 function getSortOptions({
   organization,
   dashboardsLayout,
+  isOnlyPrebuilt,
 }: {
   dashboardsLayout: DashboardsLayout;
+  isOnlyPrebuilt: boolean;
   organization: Organization;
 }) {
-  return [
-    ...(!organization.features.includes('dashboards-starred-reordering') ||
-    dashboardsLayout === GRID
-      ? [{label: t('My Dashboards'), value: 'mydashboards'}]
-      : []),
+  const options = [];
+
+  if (
+    !isOnlyPrebuilt &&
+    (!organization.features.includes('dashboards-starred-reordering') ||
+      dashboardsLayout === GRID)
+  ) {
+    options.push({label: t('My Dashboards'), value: 'mydashboards'});
+  }
+
+  options.push(
     {label: t('Dashboard Name (A-Z)'), value: 'title'},
     {label: t('Dashboard Name (Z-A)'), value: '-title'},
     {label: t('Date Created (Newest)'), value: '-dateCreated'},
     {label: t('Date Created (Oldest)'), value: 'dateCreated'},
-    {label: t('Most Popular'), value: 'mostPopular'},
-    ...(organization.features.includes('dashboards-starred-reordering')
-      ? [{label: t('Most Starred'), value: 'mostFavorited'}]
-      : []),
-    {label: t('Recently Viewed'), value: 'recentlyViewed'},
-  ];
+    {label: t('Most Popular'), value: 'mostPopular'}
+  );
+
+  if (organization.features.includes('dashboards-starred-reordering')) {
+    options.push({label: t('Most Starred'), value: 'mostFavorited'});
+  }
+
+  options.push({label: t('Recently Viewed'), value: 'recentlyViewed'});
+
+  return options;
 }
 
 function getDefaultSort({
@@ -147,14 +153,12 @@ function ManageDashboards() {
   const hasPrebuiltDashboards = organization.features.includes(
     'dashboards-prebuilt-insights-dashboards'
   );
+  const isOnlyPrebuilt =
+    hasPrebuiltDashboards && decodeScalar(location.query.filter) === 'onlyPrebuilt';
 
   const [showTemplates, setShowTemplatesLocal] = useLocalStorageState(
     SHOW_TEMPLATES_KEY,
     shouldShowTemplates()
-  );
-  const [showPrebuilt, setShowPrebuiltLocal] = useLocalStorageState(
-    SHOW_PREBUILT_KEY,
-    shouldShowPrebuilt()
   );
   const [dashboardsLayout, setDashboardsLayout] = useLocalStorageState(
     LAYOUT_KEY,
@@ -168,6 +172,7 @@ function ManageDashboards() {
   const sortOptions = getSortOptions({
     organization,
     dashboardsLayout,
+    isOnlyPrebuilt,
   });
 
   const {
@@ -189,7 +194,7 @@ function ManageDashboards() {
           pin: 'favorites',
           per_page:
             dashboardsLayout === GRID ? rowCount * columnCount : DASHBOARD_TABLE_NUM_ROWS,
-          ...(hasPrebuiltDashboards && !showPrebuilt ? {filter: 'excludePrebuilt'} : {}),
+          ...(isOnlyPrebuilt ? {filter: 'onlyPrebuilt'} : {}),
         },
       },
     ],
@@ -367,14 +372,6 @@ function ManageDashboards() {
       show_templates: !showTemplates,
     });
     setShowTemplatesLocal(!showTemplates);
-  };
-
-  const togglePrebuilt = () => {
-    setShowPrebuiltLocal(!showPrebuilt);
-    navigate({
-      pathname: location.pathname,
-      query: {...location.query, cursor: undefined, [OWNED_CURSOR_KEY]: undefined},
-    });
   };
 
   function getQuery() {
@@ -575,7 +572,10 @@ function ManageDashboards() {
       features="dashboards-edit"
       renderDisabled={renderNoAccess}
     >
-      <SentryDocumentTitle title={t('All Dashboards')} orgSlug={organization.slug}>
+      <SentryDocumentTitle
+        title={isOnlyPrebuilt ? t('Sentry Built') : t('All Dashboards')}
+        orgSlug={organization.slug}
+      >
         <ErrorBoundary>
           {isError ? (
             <Layout.Page withPadding>
@@ -587,27 +587,24 @@ function ManageDashboards() {
                 <Layout.Header unified>
                   <Layout.HeaderContent unified>
                     <Layout.Title>
-                      {t('All Dashboards')}
+                      {isOnlyPrebuilt ? t('Sentry Built') : t('All Dashboards')}
                       <PageHeadingQuestionTooltip
                         docsUrl="https://docs.sentry.io/product/dashboards/"
-                        title={t(
-                          'A broad overview of your application’s health where you can navigate through error and performance data across multiple projects.'
-                        )}
+                        title={
+                          isOnlyPrebuilt
+                            ? t(
+                                'Pre-configured dashboards built by Sentry to help you monitor key metrics out of the box.'
+                              )
+                            : t(
+                                "A broad overview of your application's health where you can navigate through error and performance data across multiple projects."
+                              )
+                        }
                       />
                     </Layout.Title>
                   </Layout.HeaderContent>
                   <Layout.HeaderActions>
                     <Grid flow="column" align="center" gap="lg">
-                      {hasPrebuiltDashboards ? (
-                        <TemplateSwitch>
-                          {t('Show Sentry Built Dashboards')}
-                          <Switch
-                            checked={showPrebuilt}
-                            size="lg"
-                            onChange={togglePrebuilt}
-                          />
-                        </TemplateSwitch>
-                      ) : (
+                      {!hasPrebuiltDashboards && (
                         <TemplateSwitch>
                           {t('Show Templates')}
                           <Switch

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -51,11 +51,8 @@ import OwnedDashboardsTable, {
   OWNED_CURSOR_KEY,
 } from 'sentry/views/dashboards/manage/tableView/ownedDashboardsTable';
 import type {DashboardsLayout} from 'sentry/views/dashboards/manage/types';
-import type {
-  DashboardDetails,
-  DashboardFilterType,
-  DashboardListItem,
-} from 'sentry/views/dashboards/types';
+import {DashboardFilter} from 'sentry/views/dashboards/types';
+import type {DashboardDetails, DashboardListItem} from 'sentry/views/dashboards/types';
 import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import RouteError from 'sentry/views/routeError';
 
@@ -66,6 +63,7 @@ import {
   DASHBOARD_GRID_DEFAULT_NUM_COLUMNS,
   DASHBOARD_GRID_DEFAULT_NUM_ROWS,
   DASHBOARD_TABLE_NUM_ROWS,
+  DEFAULT_PREBUILT_SORT,
   MINIMUM_DASHBOARD_CARD_WIDTH,
 } from './settings';
 import TemplateCard from './templateCard';
@@ -141,7 +139,7 @@ function getDefaultSort({
   organization: Organization;
 }) {
   if (isOnlyPrebuilt) {
-    return 'mostPopular';
+    return DEFAULT_PREBUILT_SORT;
   }
 
   if (
@@ -163,10 +161,9 @@ function ManageDashboards() {
   const hasPrebuiltDashboards = organization.features.includes(
     'dashboards-prebuilt-insights-dashboards'
   );
-  const urlFilter = decodeScalar(location.query.filter) as
-    | DashboardFilterType
-    | undefined;
-  const isOnlyPrebuilt = hasPrebuiltDashboards && urlFilter === 'onlyPrebuilt';
+  const urlFilter = decodeScalar(location.query.filter) as DashboardFilter | undefined;
+  const isOnlyPrebuilt =
+    hasPrebuiltDashboards && urlFilter === DashboardFilter.ONLY_PREBUILT;
 
   const [showTemplates, setShowTemplatesLocal] = useLocalStorageState(
     SHOW_TEMPLATES_KEY,
@@ -206,9 +203,7 @@ function ManageDashboards() {
           pin: 'favorites',
           per_page:
             dashboardsLayout === GRID ? rowCount * columnCount : DASHBOARD_TABLE_NUM_ROWS,
-          ...(isOnlyPrebuilt
-            ? {filter: 'onlyPrebuilt' satisfies DashboardFilterType}
-            : {}),
+          ...(isOnlyPrebuilt ? {filter: DashboardFilter.ONLY_PREBUILT} : {}),
         },
       },
     ],

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -134,10 +134,16 @@ function getSortOptions({
 function getDefaultSort({
   organization,
   dashboardsLayout,
+  isOnlyPrebuilt,
 }: {
   dashboardsLayout: DashboardsLayout;
+  isOnlyPrebuilt: boolean;
   organization: Organization;
 }) {
+  if (isOnlyPrebuilt) {
+    return 'mostPopular';
+  }
+
   if (
     organization.features.includes('dashboards-starred-reordering') &&
     dashboardsLayout === TABLE
@@ -311,6 +317,7 @@ function ManageDashboards() {
     const defaultSort = getDefaultSort({
       organization,
       dashboardsLayout,
+      isOnlyPrebuilt,
     });
     if (urlSort && !sortOptions.some(option => option.value === urlSort)) {
       // The sort option is not valid, so we need to set the default sort
@@ -322,6 +329,7 @@ function ManageDashboards() {
     }
   }, [
     dashboardsLayout,
+    isOnlyPrebuilt,
     location.pathname,
     location.query,
     navigate,
@@ -333,6 +341,7 @@ function ManageDashboards() {
     const defaultSort = getDefaultSort({
       organization,
       dashboardsLayout,
+      isOnlyPrebuilt,
     });
     const urlSort = decodeScalar(location.query.sort, defaultSort);
 

--- a/static/app/views/dashboards/manage/settings.tsx
+++ b/static/app/views/dashboards/manage/settings.tsx
@@ -7,3 +7,5 @@ export const DASHBOARD_GRID_DEFAULT_NUM_COLUMNS = 3;
 export const DASHBOARD_GRID_DEFAULT_NUM_CARDS = 8;
 
 export const DASHBOARD_TABLE_NUM_ROWS = 25;
+
+export const DEFAULT_PREBUILT_SORT = 'mostPopular';

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -10,13 +10,14 @@ import type {TimeSeriesMeta} from 'sentry/views/dashboards/widgets/common/types'
 
 import type {ThresholdsConfig} from './widgetBuilder/buildSteps/thresholdsStep/thresholds';
 
-export type DashboardFilterType =
-  | 'onlyFavorites'
-  | 'excludeFavorites'
-  | 'owned'
-  | 'shared'
-  | 'excludePrebuilt'
-  | 'onlyPrebuilt';
+export enum DashboardFilter {
+  ONLY_FAVORITES = 'onlyFavorites',
+  EXCLUDE_FAVORITES = 'excludeFavorites',
+  OWNED = 'owned',
+  SHARED = 'shared',
+  EXCLUDE_PREBUILT = 'excludePrebuilt',
+  ONLY_PREBUILT = 'onlyPrebuilt',
+}
 
 export type LegendType = 'default' | 'breakdown';
 

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -10,6 +10,14 @@ import type {TimeSeriesMeta} from 'sentry/views/dashboards/widgets/common/types'
 
 import type {ThresholdsConfig} from './widgetBuilder/buildSteps/thresholdsStep/thresholds';
 
+export type DashboardFilterType =
+  | 'onlyFavorites'
+  | 'excludeFavorites'
+  | 'owned'
+  | 'shared'
+  | 'excludePrebuilt'
+  | 'onlyPrebuilt';
+
 export type LegendType = 'default' | 'breakdown';
 
 // Max widgets per dashboard we are currently willing

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
@@ -22,6 +22,9 @@ export function DashboardsSecondaryNavigation() {
   const user = useUser();
 
   const {data: starredDashboards = []} = useGetStarredDashboards();
+  const hasPrebuiltDashboards = organization.features.includes(
+    'dashboards-prebuilt-insights-dashboards'
+  );
 
   return (
     <Fragment>
@@ -37,6 +40,14 @@ export function DashboardsSecondaryNavigation() {
           >
             {t('All Dashboards')}
           </SecondaryNavigation.Item>
+          {hasPrebuiltDashboards ? (
+            <SecondaryNavigation.Item
+              to={`${baseUrl}/?filter=onlyPrebuilt`}
+              analyticsItemName="dashboards_sentry_built"
+            >
+              {t('Sentry Built')}
+            </SecondaryNavigation.Item>
+          ) : null}
         </SecondaryNavigation.Section>
         {starredDashboards.length > 0 ? (
           <SecondaryNavigation.Section

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
@@ -5,11 +5,13 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
 import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
-import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import type {DashboardFilterType, DashboardListItem} from 'sentry/views/dashboards/types';
 import {PRIMARY_NAVIGATION_GROUP_CONFIG} from 'sentry/views/navigation/primary/config';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/secondary';
 import {DashboardsNavigationItems} from 'sentry/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems';
@@ -21,10 +23,15 @@ export function DashboardsSecondaryNavigation() {
   const {projects} = useProjects();
   const user = useUser();
 
+  const location = useLocation();
   const {data: starredDashboards = []} = useGetStarredDashboards();
   const hasPrebuiltDashboards = organization.features.includes(
     'dashboards-prebuilt-insights-dashboards'
   );
+  const urlFilter = decodeScalar(location.query.filter) as
+    | DashboardFilterType
+    | undefined;
+  const isOnlyPrebuilt = urlFilter === 'onlyPrebuilt';
 
   return (
     <Fragment>
@@ -36,6 +43,7 @@ export function DashboardsSecondaryNavigation() {
           <SecondaryNavigation.Item
             to={`${baseUrl}/`}
             end
+            isActive={hasPrebuiltDashboards ? !isOnlyPrebuilt : undefined}
             analyticsItemName="dashboards_all"
           >
             {t('All Dashboards')}
@@ -43,6 +51,7 @@ export function DashboardsSecondaryNavigation() {
           {hasPrebuiltDashboards ? (
             <SecondaryNavigation.Item
               to={`${baseUrl}/?filter=onlyPrebuilt`}
+              isActive={isOnlyPrebuilt}
               analyticsItemName="dashboards_sentry_built"
             >
               {t('Sentry Built')}

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
@@ -11,7 +11,9 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
 import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
-import type {DashboardFilterType, DashboardListItem} from 'sentry/views/dashboards/types';
+import {DEFAULT_PREBUILT_SORT} from 'sentry/views/dashboards/manage/settings';
+import {DashboardFilter} from 'sentry/views/dashboards/types';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {PRIMARY_NAVIGATION_GROUP_CONFIG} from 'sentry/views/navigation/primary/config';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/secondary';
 import {DashboardsNavigationItems} from 'sentry/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems';
@@ -28,10 +30,8 @@ export function DashboardsSecondaryNavigation() {
   const hasPrebuiltDashboards = organization.features.includes(
     'dashboards-prebuilt-insights-dashboards'
   );
-  const urlFilter = decodeScalar(location.query.filter) as
-    | DashboardFilterType
-    | undefined;
-  const isOnlyPrebuilt = urlFilter === 'onlyPrebuilt';
+  const urlFilter = decodeScalar(location.query.filter) as DashboardFilter | undefined;
+  const isOnlyPrebuilt = urlFilter === DashboardFilter.ONLY_PREBUILT;
 
   return (
     <Fragment>
@@ -50,7 +50,7 @@ export function DashboardsSecondaryNavigation() {
           </SecondaryNavigation.Item>
           {hasPrebuiltDashboards ? (
             <SecondaryNavigation.Item
-              to={`${baseUrl}/?filter=onlyPrebuilt`}
+              to={`${baseUrl}/?filter=${DashboardFilter.ONLY_PREBUILT}&sort=${DEFAULT_PREBUILT_SORT}`}
               isActive={isOnlyPrebuilt}
               analyticsItemName="dashboards_sentry_built"
             >

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
@@ -14,6 +14,7 @@ import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarr
 import {DEFAULT_PREBUILT_SORT} from 'sentry/views/dashboards/manage/settings';
 import {DashboardFilter} from 'sentry/views/dashboards/types';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import {isSidebarLinkActive} from 'sentry/views/navigation/primary/components';
 import {PRIMARY_NAVIGATION_GROUP_CONFIG} from 'sentry/views/navigation/primary/config';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/secondary';
 import {DashboardsNavigationItems} from 'sentry/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems';
@@ -32,6 +33,9 @@ export function DashboardsSecondaryNavigation() {
   );
   const urlFilter = decodeScalar(location.query.filter) as DashboardFilter | undefined;
   const isOnlyPrebuilt = urlFilter === DashboardFilter.ONLY_PREBUILT;
+  const isOnDashboardsList = isSidebarLinkActive(`${baseUrl}/`, location.pathname, {
+    end: true,
+  });
 
   return (
     <Fragment>
@@ -43,7 +47,9 @@ export function DashboardsSecondaryNavigation() {
           <SecondaryNavigation.Item
             to={`${baseUrl}/`}
             end
-            isActive={hasPrebuiltDashboards ? !isOnlyPrebuilt : undefined}
+            isActive={
+              hasPrebuiltDashboards ? isOnDashboardsList && !isOnlyPrebuilt : undefined
+            }
             analyticsItemName="dashboards_all"
           >
             {t('All Dashboards')}
@@ -51,7 +57,7 @@ export function DashboardsSecondaryNavigation() {
           {hasPrebuiltDashboards ? (
             <SecondaryNavigation.Item
               to={`${baseUrl}/?filter=${DashboardFilter.ONLY_PREBUILT}&sort=${DEFAULT_PREBUILT_SORT}`}
-              isActive={isOnlyPrebuilt}
+              isActive={isOnDashboardsList && isOnlyPrebuilt}
               analyticsItemName="dashboards_sentry_built"
             >
               {t('Sentry Built')}


### PR DESCRIPTION
Adds a "Sentry Built" item to the dashboards secondary navigation sidebar, gated behind the `dashboards-prebuilt-insights-dashboards` feature flag. Clicking it navigates to the dashboards manage page with `?filter=onlyPrebuilt`, which filters the API response to only prebuilt dashboards.

Removes the "Show Sentry Built Dashboards" toggle from the manage page header since the dedicated sidebar nav item replaces this functionality.

When viewing "Sentry Built":
- Page title and document title update to "Sentry Built"
- Tooltip describes prebuilt dashboards
- "My Dashboards" sort option is hidden (prebuilt dashboards are not user-owned)

<img width="1316" height="189" alt="image" src="https://github.com/user-attachments/assets/90511339-42dc-41ac-b27f-36b11938c549" />


Depends on #110465 for the backend `onlyPrebuilt` filter.

Refs BROWSE-429