### PR TITLE
fix(profiling): correctly classify vendor JS frames as not in-app

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -349,5 +349,9 @@ def is_in_app(frame):
         return not NODE_MODULES_RE.search(filename)
     elif "/node_modules/" in abs_path:
         return False
+    elif filename and NODE_MODULES_RE.search(filename):
+        # Frame was symbolicated and filename reveals it is a node_module,
+        # even if abs_path is an unresolved https:// CDN URL.
+        return False
     else:
         return None

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -28,6 +28,7 @@ from sentry import features, options, quotas
 from sentry.conf.types.kafka_definition import Topic
 from sentry.constants import DataCategory
 from sentry.lang.javascript.processing import _handles_frame as is_valid_javascript_frame
+from sentry.lang.javascript.processing import is_in_app
 from sentry.lang.native.processing import _merge_image
 from sentry.lang.native.symbolicator import (
     FrameOrder,
@@ -793,6 +794,10 @@ def _process_symbolicator_results_for_sample(
             for frame_idx in symbolicated_frames_dict[symbolicated_frame_idx]:
                 f = symbolicated_frames[frame_idx]
                 f["platform"] = platform
+                if platform in JS_PLATFORMS:
+                    in_app = is_in_app(f)
+                    if in_app is not None:
+                        f["in_app"] = in_app
                 new_frames.append(f)
 
             # go to the next symbolicated frame result

--- a/tests/sentry/lang/javascript/test_processing.py
+++ b/tests/sentry/lang/javascript/test_processing.py
@@ -114,13 +114,44 @@ class JavaScriptProcessingTest(TestCase):
 
     def test_node_modules_regex(self) -> None:
         # Test the NODE_MODULES_RE pattern directly
+
         self.assertIsNotNone(NODE_MODULES_RE.search("/node_modules/"))
         self.assertIsNotNone(NODE_MODULES_RE.search("path/node_modules/package"))
         self.assertIsNotNone(NODE_MODULES_RE.search("/path/to/node_modules/react"))
-
         # Should not match without the slashes
         self.assertIsNone(NODE_MODULES_RE.search("node_modules"))
         self.assertIsNone(NODE_MODULES_RE.search("mynode_modules"))
+
+    def test_is_in_app_cdn_url_with_node_modules_in_filename(self) -> None:
+        """
+        Regression test for Revolut EU — "Slowest Functions" widget was
+        polluted with React/vendor functions from node_modules.
+
+        When a JS frame resolves via release-based source maps, the symbolicator
+        updates `filename` to the original source path (e.g. "./node_modules/react-dom/...")
+        but `abs_path` stays as the CDN URL (e.g. "https://.../vendors.HASH.js").
+
+        The old is_in_app() only checked abs_path for node_modules so it returned
+        None for these frames. vroomrs then incorrectly set in_app=True.
+
+        Fix: is_in_app() now also checks filename for node_modules.
+        """
+        self.assertFalse(
+            is_in_app(
+                {
+                    "abs_path": "https://business.revolut.com/assets/vendors.b1d183fd6fb0da242e21.js",
+                    "filename": "./node_modules/react-dom/cjs/react-dom.production.min.js",
+                }
+            )
+        )
+        self.assertFalse(
+            is_in_app(
+                {
+                    "abs_path": "https://cdn.example.com/assets/bundle.abc123.js",
+                    "filename": "./node_modules/styled-components/dist/styled-components.browser.esm.js",
+                }
+            )
+        )
 
     def _get_test_data_and_symbolicator(self, in_app_frames: bool, symbolicated_in_app=True):
         """Helper method to create test data and mock symbolicator

--- a/tests/sentry/profiles/test_js_in_app_classification.py
+++ b/tests/sentry/profiles/test_js_in_app_classification.py
@@ -1,0 +1,163 @@
+"""
+Tests for in_app classification in the JS profiling pipeline.
+"""
+
+from typing import Any
+
+from sentry.profiles.task import _process_symbolicator_results_for_sample
+
+
+def make_js_profile(frames: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "version": "1",
+        "platform": "javascript",
+        "profile": {
+            "frames": frames,
+            "samples": [{"stack_id": 0, "elapsed_since_start_ns": 1, "thread_id": "1"}],
+            "stacks": [list(range(len(frames)))],
+            "thread_metadata": {},
+        },
+    }
+
+
+def run_profiling_pipeline(raw_frames, symbolicated_frames):
+    """Run _process_symbolicator_results_for_sample and return resulting frames."""
+    profile = make_js_profile(raw_frames)
+    frames_sent = set(range(len(raw_frames)))
+    stacktraces = [{"frames": symbolicated_frames}]
+    _process_symbolicator_results_for_sample(
+        profile, stacktraces, frames_sent, platform="javascript"
+    )
+    return profile["profile"]["frames"]
+
+
+class TestProfilingPipelineInAppClassification:
+    """
+    Tests for the _process_symbolicator_results_for_sample() fix.
+    """
+
+    def test_vendor_frame_is_marked_not_in_app(self) -> None:
+        """
+        Vendor frames should be marked in_app=False by the profiling pipeline
+        after symbolication, regardless of whether abs_path resolves to a
+        webpack:// URL or stays as a CDN URL.
+        """
+        raw = [
+            {
+                "function": "uv",
+                "abs_path": "https://business.revolut.com/assets/vendors.b1d183fd6fb0da242e21.js",
+                "lineno": 89,
+                "colno": 94978,
+            }
+        ]
+
+        # Scenario A: fully resolved webpack path
+        symbolicated_a = [
+            {
+                "function": "Lj",
+                "abs_path": "webpack://revolut-biz-frontend/./node_modules/react-dom/cjs/react-dom.production.min.js",
+                "filename": "./node_modules/react-dom/cjs/react-dom.production.min.js",
+                "data": {"resolved_with": "release", "symbolicated": True},
+                "original_index": 0,
+            }
+        ]
+        assert run_profiling_pipeline(raw, symbolicated_a)[0].get("in_app") is False, (
+            "Scenario A: webpack://...node_modules/... frame should be in_app=False"
+        )
+
+        # Scenario B: abs_path stays as CDN URL, filename reveals node_modules
+        symbolicated_b = [
+            {
+                "function": "Lj",
+                "abs_path": "https://business.revolut.com/assets/vendors.b1d183fd6fb0da242e21.js",
+                "filename": "./node_modules/react-dom/cjs/react-dom.production.min.js",
+                "data": {"resolved_with": "release", "symbolicated": True},
+                "original_index": 0,
+            }
+        ]
+        assert run_profiling_pipeline(raw, symbolicated_b)[0].get("in_app") is False, (
+            "Scenario B: CDN URL + node_modules filename should be in_app=False"
+        )
+
+    def test_mixed_vendor_and_app_frames(self) -> None:
+        """
+        End-to-end: a realistic stack with both vendor and app frames.
+        """
+        raw = [
+            {
+                "function": "G",
+                "abs_path": "https://business.revolut.com/assets/vendors.b1d183fd6fb0da242e21.js",
+                "lineno": 168,
+                "colno": 115382,
+            },
+            {
+                "function": "render",
+                "abs_path": "https://business.revolut.com/assets/main.abc.js",
+                "lineno": 1,
+                "colno": 100,
+            },
+            {
+                "function": "dispatchAction",
+                "abs_path": "https://business.revolut.com/assets/vendors.b1d183fd6fb0da242e21.js",
+                "lineno": 89,
+                "colno": 200,
+            },
+            {
+                "function": "handleSubmit",
+                "abs_path": "https://business.revolut.com/assets/main.abc.js",
+                "lineno": 5,
+                "colno": 300,
+            },
+        ]
+        symbolicated = [
+            {  # vendor — resolves to node_modules
+                "function": "Lj",
+                "abs_path": "webpack://revolut-biz-frontend/./node_modules/react-dom/cjs/react-dom.production.min.js",
+                "filename": "./node_modules/react-dom/cjs/react-dom.production.min.js",
+                "data": {"resolved_with": "release", "symbolicated": True},
+                "original_index": 0,
+            },
+            {  # app code
+                "function": "PrivatePage",
+                "abs_path": "webpack://revolut-biz-frontend/./src/pages/Main/PrivatePage.tsx",
+                "filename": "./src/pages/Main/PrivatePage.tsx",
+                "in_app": True,
+                "data": {"resolved_with": "release", "symbolicated": True},
+                "original_index": 1,
+            },
+            {  # vendor — CDN url + node_modules filename (the Revolut case)
+                "function": "dispatchEvent",
+                "abs_path": "https://business.revolut.com/assets/vendors.b1d183fd6fb0da242e21.js",
+                "filename": "./node_modules/styled-components/dist/styled-components.browser.esm.js",
+                "data": {"resolved_with": "release", "symbolicated": True},
+                "original_index": 2,
+            },
+            {  # app code
+                "function": "fetchCurrentPricingPlan",
+                "abs_path": "webpack://revolut-biz-frontend/./src/domains/PricingPlan/api.ts",
+                "filename": "./src/domains/PricingPlan/api.ts",
+                "in_app": True,
+                "data": {"resolved_with": "release", "symbolicated": True},
+                "original_index": 3,
+            },
+        ]
+
+        frames = run_profiling_pipeline(raw, symbolicated)
+
+        assert len(frames) == 4
+
+        # Vendor frames must be False
+        assert frames[0].get("in_app") is False, (
+            f"Frame 0 (react-dom) should be in_app=False, got {frames[0].get('in_app')!r}"
+        )
+        assert frames[2].get("in_app") is False, (
+            f"Frame 2 (styled-components) should be in_app=False, got {frames[2].get('in_app')!r}"
+        )
+
+        # App frames must be True
+        assert frames[1].get("in_app") is True, (
+            f"Frame 1 (PrivatePage) should be in_app=True, got {frames[1].get('in_app')!r}"
+        )
+        assert frames[3].get("in_app") is True, (
+            f"Frame 3 (PricingPlan) should be in_app=True, got {frames[3].get('in_app')!r}"
+        )


### PR DESCRIPTION
Root cause
----------
When the JS profiling pipeline processes a profile:

  1. Raw frames arrive from the SDK with no in_app field set.
     Example:
       ```
       abs_path: "https://business.domain.com/assets/vendors.HASH.js"
       lineno/colno: ...
      ```

  2. The symbolicator resolves frames using release-based source maps.
     For vendor frames that resolve, abs_path becomes:
       `"webpack://.../node_modules/react-dom/..."`
     For vendor frames that fail to resolve, `abs_path` stays as the CDN URL.

  3. `_process_symbolicator_results_for_sample()` in `task.py` writes the
     symbolicated frames back to the profile. Previously it never called
     `is_in_app()` — unlike the error pipeline which does.

  4. `vroomrs.normalize()` then runs is_javascript_application_frame() on
     each frame. This checks abs_path for "node_modules". For resolved frames
     `(abs_path = webpack://.../node_modules/...)` it correctly returns False.
     For unresolved frames (abs_path = https://...vendors.js) it finds no
     node_modules in the CDN URL and incorrectly returns True.

     Additionally, `is_in_app()` itself had a gap: for CDN URLs (https://...)
     it returned None even when filename showed node_modules, because it only
     checked abs_path for node_modules, not filename.

Fixes
-----
1. `src/sentry/lang/javascript/processing.py` (`is_in_app`):
   Added check for filename containing node_modules when abs_path is a CDN URL.

2. `src/sentry/profiles/task.py` (`_process_symbolicator_results_for_sample`):
   Now calls `is_in_app()` after symbolication for JS platforms, same as the
   error pipeline. This `sets in_app=False` for resolved vendor frames before
   vroomrs sees them.

Related
-------
Slack thread: sentry.slack.com/archives/C02MYEFL2Q7/p1769759626402989

  Raw data          `function="uv", abs_path="https://.../vendors.b1d183fd6fb0da242e21.js"`
  Symbolicated: function=
```"Lj",
       abs_path="https://.../vendors.b1d183fd6fb0da242e21.js",
        filename="./node_modules/react-dom/cjs/react-dom.production.min.js"
```
