### PR TITLE
fix(alerts): Prevent stripping 0 values from request body

### DIFF
--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -38,7 +38,7 @@ class RuleNodeField(serializers.Field):
             raise ValidationError("Missing attribute 'id'")
 
         for key, value in list(data.items()):
-            if not value:
+            if value is None or value == "":
                 del data[key]
 
         cls = rules.get(data["id"], self.type_name)

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -1010,6 +1010,28 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         call_args = mock_find_channel_id_for_alert_rule.call_args[1]["kwargs"]
         assert call_args == kwargs
 
+    def test_condition_with_zero_value(self) -> None:
+        condition = {
+            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+            "interval": "1h",
+            "value": 0,
+        }
+        actions: list[dict[str, object]] = [
+            {"id": "sentry.rules.actions.notify_event.NotifyEventAction", "uuid": str(uuid4())}
+        ]
+        self.run_test(
+            actions=actions,
+            conditions=[condition],
+            expected_conditions=[
+                {
+                    "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+                    "interval": "1h",
+                    "value": 0,
+                    "comparisonType": "count",
+                }
+            ],
+        )
+
     def test_comparison_condition(self) -> None:
         condition = {
             "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/110426

This check was originally added to remove empty strings, but is unintentionally catching empty arrays and 0 values.