### PR TITLE
fix(dashboards): Prevent empty SQL strings from being passed to SQL formatter

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -529,7 +529,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
   'span.description': {
     sortField: 'span.description',
     renderFunc: data => {
-      const value = data[SpanFields.SPAN_DESCRIPTION];
+      const value = data[SpanFields.SPAN_DESCRIPTION] ?? '';
       const op: string = data[SpanFields.SPAN_OP];
       const projectId =
         typeof data[SpanFields.PROJECT_ID] === 'number'

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -529,7 +529,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
   'span.description': {
     sortField: 'span.description',
     renderFunc: data => {
-      const value = data[SpanFields.SPAN_DESCRIPTION] ?? '';
+      const value = data[SpanFields.SPAN_DESCRIPTION];
       const op: string = data[SpanFields.SPAN_OP];
       const projectId =
         typeof data[SpanFields.PROJECT_ID] === 'number'
@@ -540,7 +540,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       if (op === ModuleName.DB || op === ModuleName.RESOURCE) {
         return (
           <SpanDescriptionCell
-            description={value}
+            description={value ?? ''}
             moduleName={op}
             projectId={projectId}
             group={spanGroup}

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -681,7 +681,8 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
           );
         case PerformanceWidgetSetting.MOST_TIME_SPENT_DB_QUERIES:
         case PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES: {
-          const description = listItem[SpanFields.NORMALIZED_DESCRIPTION] as string;
+          const description = (listItem[SpanFields.NORMALIZED_DESCRIPTION] ??
+            '') as string;
           const group = listItem[SpanFields.SPAN_GROUP] as string;
           const projectID = listItem['project.id'] as number;
           const timeSpentPercentage = listItem[fieldString] as number;


### PR DESCRIPTION
I recently covered a bunch of these in https://github.com/getsentry/sentry/pull/110186 but two places were left! This will prevent `undefined` descriptions from making their way to the SQLish formatter.