### PR TITLE
feat(autofix): Add next steps button in autofix drawer

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -135,7 +135,7 @@ export interface TriageArtifact {
  * State returned from the Explorer autofix endpoint.
  * This extends the SeerExplorer types with autofix-specific data.
  */
-interface ExplorerAutofixState {
+export interface ExplorerAutofixState {
   blocks: Block[];
   run_id: number;
   status: 'processing' | 'completed' | 'error' | 'awaiting_user_input';

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -135,7 +135,7 @@ export interface TriageArtifact {
  * State returned from the Explorer autofix endpoint.
  * This extends the SeerExplorer types with autofix-specific data.
  */
-export interface ExplorerAutofixState {
+interface ExplorerAutofixState {
   blocks: Block[];
   run_id: number;
   status: 'processing' | 'completed' | 'error' | 'awaiting_user_input';

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 
@@ -15,6 +15,7 @@ import {
   RootCauseCard,
   SolutionCard,
 } from 'sentry/components/events/autofix/v3/autofixCards';
+import {SeerDrawerNextStep} from 'sentry/components/events/autofix/v3/nextStep';
 import Placeholder from 'sentry/components/placeholder';
 import {isArrayOf} from 'sentry/types/utils';
 import type {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
@@ -31,14 +32,27 @@ export function SeerDrawerContent({aiConfig, autofix}: SeerDrawerContentProps) {
     [autofix.runState]
   );
 
-  return autofix.isLoading ? (
-    <Flex direction="column" gap="xl">
-      <Placeholder height="10rem" />
-      <Placeholder height="15rem" />
+  if (autofix.isLoading) {
+    return (
+      <Flex direction="column" gap="xl">
+        <Placeholder height="10rem" />
+        <Placeholder height="15rem" />
+      </Flex>
+    );
+  }
+
+  if (!autofix.runState && aiConfig.hasAutofix) {
+    return null; // TODO: should this have an empty state?
+  }
+
+  return (
+    <Flex direction="column" gap="lg">
+      <SeerDrawerArtifacts artifacts={artifacts} />
+      {autofix.runState?.status === 'completed' && (
+        <SeerDrawerNextStep autofix={autofix} artifacts={artifacts} />
+      )}
     </Flex>
-  ) : !autofix.runState && aiConfig.hasAutofix ? null : artifacts.length ? (
-    <SeerDrawerArtifacts artifacts={artifacts} />
-  ) : null;
+  );
 }
 
 interface SeerDrawerArtifactsProps {
@@ -47,7 +61,7 @@ interface SeerDrawerArtifactsProps {
 
 function SeerDrawerArtifacts({artifacts}: SeerDrawerArtifactsProps) {
   return (
-    <Flex direction="column" gap="lg">
+    <Fragment>
       {artifacts.map(artifact => {
         // there should only be 1 artifact of each type
         if (isRootCauseArtifact(artifact)) {
@@ -69,6 +83,6 @@ function SeerDrawerArtifacts({artifacts}: SeerDrawerArtifactsProps) {
         // TODO: maybe send a log?
         return null;
       })}
-    </Flex>
+    </Fragment>
   );
 }

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -1,0 +1,180 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {
+  RootCauseArtifact,
+  SolutionArtifact,
+  useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import type {Artifact, ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
+
+import {SeerDrawerNextStep} from './nextStep';
+
+function makeAutofix(
+  overrides: Partial<ReturnType<typeof useExplorerAutofix>> = {}
+): ReturnType<typeof useExplorerAutofix> {
+  return {
+    runState: {run_id: 1} as any,
+    startStep: jest.fn(),
+    createPR: jest.fn(),
+    sendMessage: jest.fn(),
+    reset: jest.fn(),
+    isLoading: false,
+    isReady: true,
+    isStreaming: false,
+    ...overrides,
+  } as ReturnType<typeof useExplorerAutofix>;
+}
+
+function makeRootCauseArtifact(): Artifact<RootCauseArtifact> {
+  return {
+    key: 'root-cause',
+    reason: 'Found root cause',
+    data: {
+      one_line_description: 'Null pointer dereference',
+      five_whys: ['Why 1', 'Why 2'],
+    },
+  };
+}
+
+function makeSolutionArtifact(): Artifact<SolutionArtifact> {
+  return {
+    key: 'solution',
+    reason: 'Found solution',
+    data: {
+      one_line_summary: 'Add null check',
+      steps: [{title: 'Step 1', description: 'Add guard clause'}],
+    },
+  };
+}
+
+function makePatch(): ExplorerFilePatch {
+  return {
+    repo_name: 'org/repo',
+    diff: 'diff content',
+    patch: {
+      path: 'src/file.py',
+      added: 1,
+      removed: 0,
+      hunks: [],
+      source_file: 'src/file.py',
+      target_file: 'src/file.py',
+      type: 'M',
+    },
+  } as ExplorerFilePatch;
+}
+
+describe('SeerDrawerNextStep', () => {
+  it('returns null when no runId', () => {
+    const autofix = makeAutofix({runState: null});
+    const {container} = render(<SeerDrawerNextStep artifacts={[]} autofix={autofix} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when artifact type does not match any case', () => {
+    const autofix = makeAutofix();
+    const {container} = render(<SeerDrawerNextStep artifacts={[]} autofix={autofix} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('RootCauseNextStep', () => {
+    it('renders prompt and yes button', () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep artifacts={[makeRootCauseArtifact()]} autofix={autofix} />
+      );
+      expect(screen.getByText('Are you happy with this root cause?')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'No'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Yes, make an implementation plan'})
+      ).toBeInTheDocument();
+    });
+
+    it('calls startStep with solution on yes click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep artifacts={[makeRootCauseArtifact()]} autofix={autofix} />
+      );
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Yes, make an implementation plan'})
+      );
+      expect(autofix.startStep).toHaveBeenCalledWith('solution', 1);
+    });
+
+    it('calls startStep with root_cause on no click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep artifacts={[makeRootCauseArtifact()]} autofix={autofix} />
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      expect(autofix.startStep).toHaveBeenCalledWith('root_cause', 1);
+    });
+  });
+
+  describe('SolutionNextStep', () => {
+    it('renders prompt and yes button', () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep artifacts={[makeSolutionArtifact()]} autofix={autofix} />
+      );
+      expect(
+        screen.getByText('Are you happy with this implementation plan?')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'No'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Yes, write a code fix'})
+      ).toBeInTheDocument();
+    });
+
+    it('calls startStep with code_changes on yes click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep artifacts={[makeSolutionArtifact()]} autofix={autofix} />
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'Yes, write a code fix'}));
+      expect(autofix.startStep).toHaveBeenCalledWith('code_changes', 1);
+    });
+
+    it('calls startStep with solution on no click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep artifacts={[makeSolutionArtifact()]} autofix={autofix} />
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      expect(autofix.startStep).toHaveBeenCalledWith('solution', 1);
+    });
+  });
+
+  describe('CodeChangesNextStep', () => {
+    it('renders prompt and yes button', () => {
+      const autofix = makeAutofix();
+      render(<SeerDrawerNextStep artifacts={[[makePatch()]]} autofix={autofix} />);
+      expect(
+        screen.getByText('Are you happy with these code changes?')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'No'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Yes, draft a PR'})).toBeInTheDocument();
+    });
+
+    it('calls createPR on yes click', async () => {
+      const autofix = makeAutofix();
+      render(<SeerDrawerNextStep artifacts={[[makePatch()]]} autofix={autofix} />);
+      await userEvent.click(screen.getByRole('button', {name: 'Yes, draft a PR'}));
+      expect(autofix.createPR).toHaveBeenCalledWith(1);
+    });
+
+    it('calls startStep with code_changes on no click', async () => {
+      const autofix = makeAutofix();
+      render(<SeerDrawerNextStep artifacts={[[makePatch()]]} autofix={autofix} />);
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      expect(autofix.startStep).toHaveBeenCalledWith('code_changes', 1);
+    });
+
+    it('returns null for empty file patches array', () => {
+      const autofix = makeAutofix();
+      const {container} = render(
+        <SeerDrawerNextStep artifacts={[[]]} autofix={autofix} />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -1,0 +1,144 @@
+import {useCallback, type ReactNode} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {
+  isRootCauseArtifact,
+  isSolutionArtifact,
+  type AutofixArtifact,
+  type useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {t} from 'sentry/locale';
+import {isArrayOf} from 'sentry/types/utils';
+import {isExplorerFilePatch} from 'sentry/views/seerExplorer/types';
+
+interface SeerDrawerNextStepProps {
+  artifacts: AutofixArtifact[];
+  autofix: ReturnType<typeof useExplorerAutofix>;
+}
+
+export function SeerDrawerNextStep({artifacts, autofix}: SeerDrawerNextStepProps) {
+  const runId = autofix.runState?.run_id;
+  if (!runId) {
+    return null;
+  }
+
+  const lastArtifact = artifacts[artifacts.length - 1];
+
+  if (isRootCauseArtifact(lastArtifact)) {
+    return <RootCauseNextStep autofix={autofix} runId={runId} />;
+  }
+
+  if (isSolutionArtifact(lastArtifact)) {
+    return <SolutionNextStep autofix={autofix} runId={runId} />;
+  }
+
+  if (isArrayOf(lastArtifact, isExplorerFilePatch) && lastArtifact.length) {
+    return <CodeChangesNextStep autofix={autofix} runId={runId} />;
+  }
+
+  return null;
+}
+
+interface NextStepProps {
+  autofix: ReturnType<typeof useExplorerAutofix>;
+  runId: number;
+}
+
+function RootCauseNextStep({autofix, runId}: NextStepProps) {
+  const {startStep} = autofix;
+
+  const handleYesClick = useCallback(() => {
+    startStep('solution', runId);
+  }, [startStep, runId]);
+
+  const handleNoClick = useCallback(() => {
+    // for now, just re run the current step
+    startStep('root_cause', runId);
+  }, [startStep, runId]);
+
+  return (
+    <NextStep
+      prompt={t('Are you happy with this root cause?')}
+      labelYes={t('Yes, make an implementation plan')}
+      onClickYes={handleYesClick}
+      labelNo={t('No')}
+      onClickNo={handleNoClick}
+    />
+  );
+}
+
+function SolutionNextStep({autofix, runId}: NextStepProps) {
+  const {startStep} = autofix;
+
+  const handleYesClick = useCallback(() => {
+    startStep('code_changes', runId);
+  }, [startStep, runId]);
+
+  const handleNoClick = useCallback(() => {
+    // for now, just re run the current step
+    startStep('solution', runId);
+  }, [startStep, runId]);
+
+  return (
+    <NextStep
+      prompt={t('Are you happy with this implementation plan?')}
+      labelYes={t('Yes, write a code fix')}
+      onClickYes={handleYesClick}
+      labelNo={t('No')}
+      onClickNo={handleNoClick}
+    />
+  );
+}
+
+function CodeChangesNextStep({autofix, runId}: NextStepProps) {
+  const {createPR, startStep} = autofix;
+
+  const handleYesClick = useCallback(() => {
+    createPR(runId);
+  }, [createPR, runId]);
+
+  const handleNoClick = useCallback(() => {
+    startStep('code_changes', runId);
+  }, [startStep, runId]);
+
+  return (
+    <NextStep
+      prompt={t('Are you happy with these code changes?')}
+      labelYes={t('Yes, draft a PR')}
+      onClickYes={handleYesClick}
+      labelNo={t('No')}
+      onClickNo={handleNoClick}
+    />
+  );
+}
+
+interface NextStepTemplateProps {
+  labelNo: ReactNode;
+  labelYes: ReactNode;
+  onClickNo: () => void;
+  onClickYes: () => void;
+  prompt: ReactNode;
+}
+
+function NextStep({
+  prompt,
+  labelYes,
+  onClickYes,
+  labelNo,
+  onClickNo,
+}: NextStepTemplateProps) {
+  return (
+    <Flex direction="column" gap="lg">
+      <Text>{prompt}</Text>
+      <Flex gap="md">
+        <Button onClick={onClickNo}>{labelNo}</Button>
+        <Button priority="primary" onClick={onClickYes}>
+          {labelYes}
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}


### PR DESCRIPTION
This implements the next steps button after each artifact. This only implements the yes path for now and the no path does not yet work.

# Screenshots

| Root Cause | Implementation Plan | Code Changes |
| ----------- | --------------------- | --------------- |
| <img width="992" height="976" alt="image" src="https://github.com/user-attachments/assets/3c25607c-66d3-4b63-a4cb-09b64051c42a" /> | <img width="992" height="738" alt="image" src="https://github.com/user-attachments/assets/ee2293d3-3ede-46fb-ae8b-fe46427d1dca" /> | <img width="992" height="986" alt="image" src="https://github.com/user-attachments/assets/08864832-925e-4ac5-ba24-8435d35156aa" /> |