### PR TITLE
fix(preprod): Include display param in builds API on initial load

### DIFF
--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -45,8 +45,8 @@ export function MobileBuilds({organization, selectedProjectIds}: Props) {
   const buildsQueryParams = useMemo(() => {
     const query: Record<string, any> = {
       per_page: 25,
-      display: activeDisplay,
       ...normalizeDateTimeParams(location.query),
+      display: activeDisplay,
     };
 
     if (cursor) {

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -45,6 +45,7 @@ export function MobileBuilds({organization, selectedProjectIds}: Props) {
   const buildsQueryParams = useMemo(() => {
     const query: Record<string, any> = {
       per_page: 25,
+      display: activeDisplay,
       ...normalizeDateTimeParams(location.query),
     };
 


### PR DESCRIPTION
On the Releases Mobile Builds tab, the `display` query parameter (defaulting to `size`) was missing from the initial API request to `/organizations/{org}/builds/`. It only appeared after the user toggled the display selector, which added `display` to the URL — at which point `normalizeDateTimeParams` would pass it through via its `...otherParams` spread.

Explicitly include `activeDisplay` in the query object so the backend always receives the current display value, including on first load.