### PR TITLE
fix(billing): _admin provisioning for legacy Seer

### DIFF
--- a/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
@@ -1534,6 +1534,31 @@ describe('provisionSubscriptionAction', () => {
     );
   }, 15_000);
 
+  it('shows seer budget when both seer reserved CPE fields are set', async () => {
+    const am3Sub = SubscriptionFixture({organization: mockOrg, plan: 'am3_f'});
+    triggerProvisionSubscription({
+      subscription: am3Sub,
+      orgId: am3Sub.slug,
+      onSuccess,
+      billingConfig: mockBillingConfig,
+    });
+
+    await loadModal();
+
+    await selectEvent.select(
+      await screen.findByRole('textbox', {name: 'Plan'}),
+      'Enterprise (Business) (am3)'
+    );
+
+    expect(screen.queryByLabelText('Seer Budget')).not.toBeInTheDocument();
+
+    typeNumForField('Reserved Cost-Per-Event Issue Fixes', '1');
+    expect(screen.queryByLabelText('Seer Budget')).not.toBeInTheDocument();
+
+    typeNumForField('Reserved Cost-Per-Event Issue Scans', '0.5');
+    expect(screen.getByLabelText('Seer Budget')).toBeInTheDocument();
+  });
+
   it('calls api with seer reserved budget args with 0 values', async () => {
     const am3Sub = SubscriptionFixture({organization: mockOrg, plan: 'am3_f'});
     triggerProvisionSubscription({

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -337,10 +337,17 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
   // Same as above, but for Seer budgets
   isSettingSeerBudget = () =>
     Object.entries(this.state.data)
-      .filter(([key, _]) => key.startsWith('reservedCpeSeer'))
+      .filter(
+        ([key, _]) =>
+          key.startsWith('reservedCpeSeerAutofix') ||
+          key.startsWith('reservedCpeSeerScanner')
+      )
       .every(([_, value]) => value !== null && value !== undefined) &&
-    Object.keys(this.state.data).filter(key => key.startsWith('reservedCpeSeer'))
-      .length >= 2;
+    Object.keys(this.state.data).filter(
+      key =>
+        key.startsWith('reservedCpeSeerAutofix') ||
+        key.startsWith('reservedCpeSeerScanner')
+    ).length >= 2;
 
   isSettingReservedBudget = (category: DataCategory) => {
     if (category === DataCategory.SPANS || category === DataCategory.SPANS_INDEXED) {


### PR DESCRIPTION
It wasn't showing the Seer budget field because `reservedCpeSeerUser` is not set. So now we're explicitly checking the legacy Seer categories
