### PR TITLE
ref(cells): More renames of core region methods

### DIFF
--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -23,7 +23,7 @@ from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.organizations.services.organization import RpcUserInviteContext, organization_service
-from sentry.types.region import RegionResolutionError, get_cell_by_name
+from sentry.types.region import CellResolutionError, get_cell_by_name
 from sentry.utils import auth
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ def handle_empty_organization_id_or_slug(
             if get_cell_by_name(mapping.cell_name).is_historic_monolith_region():
                 member_mapping = member_mappings.get(mapping.organization_id)
                 break
-        except RegionResolutionError:
+        except CellResolutionError:
             pass
 
     if member_mapping is None:

--- a/src/sentry/core/endpoints/organization_region.py
+++ b/src/sentry/core/endpoints/organization_region.py
@@ -11,7 +11,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import SentryPermission
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
-from sentry.types.region import RegionResolutionError, get_global_directory
+from sentry.types.region import CellResolutionError, get_global_directory
 
 
 class OrganizationRegionEndpointPermissions(SentryPermission):
@@ -81,7 +81,7 @@ class OrganizationRegionEndpoint(Endpoint):
     def get(self, request: Request, organization_mapping: OrganizationMapping) -> Response:
         locality = get_global_directory().get_locality_for_cell(organization_mapping.cell_name)
         if locality is None:
-            raise RegionResolutionError(
+            raise CellResolutionError(
                 f"No locality found for cell: {organization_mapping.cell_name!r}"
             )
         return self.respond(locality.api_serialize())

--- a/src/sentry/deletions/defaults/organizationintegration.py
+++ b/src/sentry/deletions/defaults/organizationintegration.py
@@ -4,7 +4,7 @@ from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.repository import repository_service
 from sentry.organizations.services.organization import organization_service
-from sentry.types.region import RegionMappingNotFound
+from sentry.types.region import CellMappingNotFound
 from sentry.workflow_engine.service.action import action_service
 
 
@@ -41,7 +41,7 @@ class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegrat
                     status=ObjectStatus.DISABLED,
                 )
 
-        except RegionMappingNotFound:
+        except CellMappingNotFound:
             # This can happen when an organization has been deleted already.
             pass
         return super().delete_instance(instance)

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -27,7 +27,7 @@ from sentry.silo.util import (
 )
 from sentry.types.region import (
     Cell,
-    RegionResolutionError,
+    CellResolutionError,
     get_cell_by_name,
     get_cell_for_organization,
 )
@@ -81,7 +81,7 @@ def proxy_request(request: HttpRequest, org_id_or_slug: str, url_name: str) -> H
 
     try:
         cell = get_cell_for_organization(org_id_or_slug)
-    except RegionResolutionError as e:
+    except CellResolutionError as e:
         logger.info("region_resolution_error", extra={"org_slug": org_id_or_slug, "error": str(e)})
         return HttpResponse(status=404)
 

--- a/src/sentry/hybridcloud/outbox/base.py
+++ b/src/sentry/hybridcloud/outbox/base.py
@@ -14,7 +14,7 @@ from sentry.db.models.manager.base import BaseManager
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.signals import post_upgrade
 from sentry.silo.base import SiloMode
-from sentry.types.region import find_regions_for_orgs, find_regions_for_user
+from sentry.types.region import find_cells_for_orgs, find_cells_for_user
 from sentry.utils.env import in_test_environment
 from sentry.utils.snowflake import uses_snowflake_id
 
@@ -382,9 +382,9 @@ class ReplicatedControlModel(ControlOutboxProducingModel):
         Subclasses should override this with logic for inferring the regions that need to be contacted for this resource.
         """
         if hasattr(self, "organization_id"):
-            return find_regions_for_orgs([self.organization_id])
+            return find_cells_for_orgs([self.organization_id])
         if hasattr(self, "user_id"):
-            return find_regions_for_user(self.user_id)
+            return find_cells_for_user(self.user_id)
         # Note that a default implementation for user_id is NOT given, because handling the case where a user
         # joins a new organization after the last outbox was processed is a special case that requires special handling.
         raise NotImplementedError

--- a/src/sentry/hybridcloud/rpc/resolvers.py
+++ b/src/sentry/hybridcloud/rpc/resolvers.py
@@ -9,8 +9,8 @@ from django.conf import settings
 from sentry.hybridcloud.rpc import ArgumentDict
 from sentry.types.region import (
     Cell,
-    RegionMappingNotFound,
-    RegionResolutionError,
+    CellMappingNotFound,
+    CellResolutionError,
     get_cell_by_name,
 )
 
@@ -30,7 +30,7 @@ class CellResolutionStrategy(ABC):
         try:
             mapping = OrganizationMapping.objects.get(**query)
         except OrganizationMapping.DoesNotExist as e:
-            raise RegionMappingNotFound from e
+            raise CellMappingNotFound from e
 
         return get_cell_by_name(mapping.cell_name)
 
@@ -98,7 +98,7 @@ class RequireSingleOrganization(CellResolutionStrategy):
         from sentry.models.organizationmapping import OrganizationMapping
 
         if not settings.SENTRY_SINGLE_ORGANIZATION:
-            raise RegionResolutionError("Method is available only in single-org environment")
+            raise CellResolutionError("Method is available only in single-org environment")
 
         all_cell_names = list(
             OrganizationMapping.objects.all().values_list("cell_name", flat=True).distinct()[:2]
@@ -106,7 +106,7 @@ class RequireSingleOrganization(CellResolutionStrategy):
         if len(all_cell_names) == 0:
             return get_cell_by_name(settings.SENTRY_MONOLITH_REGION)
         if len(all_cell_names) != 1:
-            raise RegionResolutionError("Expected single-org environment to have only one cell")
+            raise CellResolutionError("Expected single-org environment to have only one cell")
 
         (single_cell_name,) = all_cell_names
         return get_cell_by_name(single_cell_name)

--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -32,7 +32,7 @@ from sentry import options
 from sentry.hybridcloud.rpc import ArgumentDict, DelegatedBySiloMode, RpcModel
 from sentry.hybridcloud.rpc.sig import SerializableFunctionSignature
 from sentry.silo.base import SiloMode, SingleProcessSiloModeState
-from sentry.types.region import Cell, RegionMappingNotFound
+from sentry.types.region import Cell, CellMappingNotFound
 from sentry.utils import json, metrics
 from sentry.utils.env import in_test_environment
 
@@ -118,7 +118,7 @@ class RpcMethodSignature(SerializableFunctionSignature):
         try:
             region = self._region_resolution.resolve(arguments)
             return _RegionResolutionResult(region)
-        except RegionMappingNotFound:
+        except CellMappingNotFound:
             if getattr(self.base_function, _REGION_RESOLUTION_OPTIONAL_RETURN_ATTR, False):
                 return _RegionResolutionResult(None, is_early_halt=True)
             else:

--- a/src/sentry/integrations/jira/views/sentry_issue_details.py
+++ b/src/sentry/integrations/jira/views/sentry_issue_details.py
@@ -29,7 +29,7 @@ from sentry.issues.services.issue.model import RpcExternalIssueGroupMetadata
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.types.region import find_regions_for_orgs
+from sentry.types.region import find_cells_for_orgs
 from sentry.utils.http import absolute_uri
 from sentry.web.frontend.base import cell_silo_view, control_silo_view
 
@@ -239,7 +239,7 @@ class JiraSentryIssueDetailsControlView(JiraSentryUIBaseView):
                 status=ObjectStatus.ACTIVE,
             ).values_list("organization_id", flat=True)
         )
-        org_regions = find_regions_for_orgs(organization_ids)
+        org_regions = find_cells_for_orgs(organization_ids)
         for region_name in org_regions:
             region_groups = issue_service.get_external_issue_groups(
                 region_name=region_name, external_issue_key=issue_key, integration_id=integration.id

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -31,7 +31,7 @@ from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.ratelimits import backend as ratelimiter
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.silo.client import RegionSiloClient, SiloClientError
-from sentry.types.region import Cell, find_regions_for_orgs, get_cell_by_name
+from sentry.types.region import Cell, find_cells_for_orgs, get_cell_by_name
 from sentry.utils import metrics
 from sentry.utils.options import sample_modulo
 
@@ -374,7 +374,7 @@ class BaseRequestParser(ABC):
         if len(organizations) == 0:
             return []
 
-        region_names = find_regions_for_orgs([org.id for org in organizations])
+        region_names = find_cells_for_orgs([org.id for org in organizations])
         return sorted([get_cell_by_name(name) for name in region_names], key=lambda r: r.name)
 
     def get_default_missing_integration_response(self) -> HttpResponse:

--- a/src/sentry/integrations/models/integration.py
+++ b/src/sentry/integrations/models/integration.py
@@ -20,7 +20,7 @@ from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.signals import integration_added
-from sentry.types.region import find_regions_for_orgs
+from sentry.types.region import find_cells_for_orgs
 
 if TYPE_CHECKING:
     from sentry.integrations.base import (
@@ -100,7 +100,7 @@ class Integration(DefaultFieldsModelExisting):
                 category=OutboxCategory.INTEGRATION_UPDATE,
                 cell_name=region_name,
             )
-            for region_name in find_regions_for_orgs(org_ids)
+            for region_name in find_cells_for_orgs(org_ids)
         ]
 
     def add_organization(

--- a/src/sentry/middleware/integrations/parsers/bitbucket.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket.py
@@ -10,7 +10,7 @@ from sentry.integrations.bitbucket.webhook import BitbucketWebhookEndpoint
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organizationmapping import OrganizationMapping
-from sentry.types.region import RegionResolutionError, get_cell_by_name
+from sentry.types.region import CellResolutionError, get_cell_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class BitbucketRequestParser(BaseRequestParser):
 
         try:
             region = get_cell_by_name(mapping.cell_name)
-        except RegionResolutionError as e:
+        except CellResolutionError as e:
             logging_extra["error"] = str(e)
             logging_extra["mapping_id"] = mapping.id
             logger.info("%s.no_region", self.provider, extra=logging_extra)

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -16,7 +16,7 @@ from sentry.integrations.msteams import parsing
 from sentry.integrations.msteams.webhook import MsTeamsEvents, MsTeamsWebhookEndpoint
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.silo.base import control_silo_function
-from sentry.types.region import Cell, RegionResolutionError
+from sentry.types.region import Cell, CellResolutionError
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ class MsTeamsRequestParser(BaseRequestParser):
                 # Since self.can_infer_integration is True, we should be able to resolve a non-empty set of regions.
                 # If the list of regions is empty, then we need to investigate.
                 sentry_sdk.capture_exception(
-                    RegionResolutionError(
+                    CellResolutionError(
                         f"Regions list is empty for {self.provider}.request_parser."
                     )
                 )

--- a/src/sentry/middleware/integrations/parsers/plugin.py
+++ b/src/sentry/middleware/integrations/parsers/plugin.py
@@ -9,7 +9,7 @@ from django.http.response import HttpResponseBase
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.models.organizationmapping import OrganizationMapping
-from sentry.types.region import RegionResolutionError, get_cell_by_name
+from sentry.types.region import CellResolutionError, get_cell_by_name
 from sentry_plugins.bitbucket.endpoints.webhook import BitbucketPluginWebhookEndpoint
 from sentry_plugins.github.webhooks.non_integration import GithubPluginWebhookEndpoint
 
@@ -47,7 +47,7 @@ class PluginRequestParser(BaseRequestParser):
 
         try:
             region = get_cell_by_name(mapping.cell_name)
-        except RegionResolutionError as e:
+        except CellResolutionError as e:
             logging_extra["error"] = str(e)
             logging_extra["mapping_id"] = mapping.id
             logger.info("%s.no_region", self.provider, extra=logging_extra)

--- a/src/sentry/models/authidentity.py
+++ b/src/sentry/models/authidentity.py
@@ -14,7 +14,7 @@ from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, control_silo_model, sane_repr
 from sentry.hybridcloud.outbox.base import ReplicatedControlModel
 from sentry.hybridcloud.outbox.category import OutboxCategory
-from sentry.types.region import find_regions_for_orgs
+from sentry.types.region import find_cells_for_orgs
 
 logger = logging.getLogger("sentry.auth.identity")
 
@@ -37,7 +37,7 @@ class AuthIdentity(ReplicatedControlModel):
     date_added = models.DateTimeField(default=timezone.now)
 
     def outbox_region_names(self) -> Collection[str]:
-        return find_regions_for_orgs([self.auth_provider.organization_id])
+        return find_cells_for_orgs([self.auth_provider.organization_id])
 
     def handle_async_replication(self, region_name: str, shard_identifier: int) -> None:
         from sentry.auth.services.auth.serial import serialize_auth_identity

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -18,7 +18,7 @@ from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.hybridcloud.models.outbox import ControlOutbox
 from sentry.hybridcloud.outbox.base import ReplicatedControlModel
 from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
-from sentry.types.region import find_regions_for_orgs
+from sentry.types.region import find_cells_for_orgs
 
 logger = logging.getLogger("sentry.authprovider")
 
@@ -162,7 +162,7 @@ class AuthProvider(ReplicatedControlModel):
                 object_identifier=self.organization_id,
                 cell_name=region_name,
             )
-            for region_name in find_regions_for_orgs([self.organization_id])
+            for region_name in find_cells_for_orgs([self.organization_id])
         ]
 
     def disable_scim(self):
@@ -210,7 +210,7 @@ class AuthProvider(ReplicatedControlModel):
                 object_identifier=user_id,
                 cell_name=region_name,
             )
-            for region_name in find_regions_for_orgs([self.organization_id])
+            for region_name in find_cells_for_orgs([self.organization_id])
         ]
 
     @classmethod

--- a/src/sentry/organizations/services/organization/impl.py
+++ b/src/sentry/organizations/services/organization/impl.py
@@ -79,7 +79,7 @@ from sentry.projects.services.project import RpcProjectFlags
 from sentry.sentry_apps.services.app import app_service
 from sentry.silo.safety import unguarded_write
 from sentry.tasks.auth.auth import email_unlink_notifications
-from sentry.types.region import find_regions_for_orgs
+from sentry.types.region import find_cells_for_orgs
 from sentry.users.services.user import RpcUser
 from sentry.utils.audit import create_org_delete_log
 
@@ -824,7 +824,7 @@ class OutboxBackedOrganizationSignalService(OrganizationSignalService):
                 "args": args,
                 "signal": int(RpcOrganizationSignal.from_signal(signal)),
             }
-            for region_name in find_regions_for_orgs([organization_id]):
+            for region_name in find_cells_for_orgs([organization_id]):
                 ControlOutbox(
                     shard_scope=OutboxScope.ORGANIZATION_SCOPE,
                     shard_identifier=organization_id,

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -27,7 +27,7 @@ from sentry.sentry_apps.utils.errors import (
     SentryAppIntegratorError,
     SentryAppSentryError,
 )
-from sentry.types.region import find_all_cell_names, find_regions_for_orgs
+from sentry.types.region import find_all_cell_names, find_cells_for_orgs
 
 if TYPE_CHECKING:
     from sentry.models.project import Project
@@ -149,7 +149,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
             return None
 
     def outbox_region_names(self) -> Collection[str]:
-        return find_regions_for_orgs([self.organization_id])
+        return find_cells_for_orgs([self.organization_id])
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
         # Use 0 in case of bad relations from api_application_id -- the replication ordering for

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -28,7 +28,7 @@ from sentry.silo.util import (
 )
 from sentry.types.region import (
     Cell,
-    RegionResolutionError,
+    CellResolutionError,
     get_cell_by_name,
     get_global_directory,
 )
@@ -61,13 +61,13 @@ def get_region_ip_addresses() -> frozenset[ipaddress.IPv4Address | ipaddress.IPv
                     tags={"region": cell.name},
                 )
                 sentry_sdk.capture_exception(
-                    RegionResolutionError(f"Unable to resolve region host for: {url.host}")
+                    CellResolutionError(f"Unable to resolve region host for: {url.host}")
                 )
                 continue
             region_ip_addresses.add(ipaddress.ip_address(force_str(ip, strings_only=True)))
         else:
             sentry_sdk.capture_exception(
-                RegionResolutionError(f"Unable to parse url to host for: {cell.address}")
+                CellResolutionError(f"Unable to parse url to host for: {cell.address}")
             )
 
     return frozenset(region_ip_addresses)
@@ -80,7 +80,7 @@ def validate_region_ip_address(ip: str) -> bool:
     allowed_region_ip_addresses = get_region_ip_addresses()
     if not allowed_region_ip_addresses:
         sentry_sdk.capture_exception(
-            RegionResolutionError(f"allowed_region_ip_addresses is empty for: {ip}")
+            CellResolutionError(f"allowed_region_ip_addresses is empty for: {ip}")
         )
         return False
 
@@ -89,7 +89,7 @@ def validate_region_ip_address(ip: str) -> bool:
 
     if not result:
         sentry_sdk.capture_exception(
-            RegionResolutionError(f"Disallowed Region Silo IP address: {ip}")
+            CellResolutionError(f"Disallowed Region Silo IP address: {ip}")
         )
     return result
 

--- a/src/sentry/tasks/auth/auth.py
+++ b/src/sentry/tasks/auth/auth.py
@@ -17,7 +17,7 @@ from sentry.silo.safety import unguarded_write
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.namespaces import auth_control_tasks, auth_tasks
 from sentry.taskworker.retry import Retry
-from sentry.types.region import RegionMappingNotFound
+from sentry.types.region import CellMappingNotFound
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.utils.audit import create_audit_entry_from_user
@@ -58,7 +58,7 @@ def _email_missing_links(org_id: int, sending_user_id: int, provider_key: str) -
         organization_service.send_sso_link_emails(
             organization_id=org_id, sending_user_email=user.email, provider_key=provider_key
         )
-    except RegionMappingNotFound:
+    except CellMappingNotFound:
         logger.warning("Could not send SSO link emails: Missing organization")
 
 

--- a/src/sentry/testutils/region.py
+++ b/src/sentry/testutils/region.py
@@ -5,10 +5,10 @@ from contextlib import contextmanager
 
 from django.test import override_settings
 
-from sentry.types.region import Cell, Locality, RegionDirectory, get_global_directory
+from sentry.types.region import Cell, CellDirectory, Locality, get_global_directory
 
 
-class TestEnvRegionDirectory(RegionDirectory):
+class TestEnvRegionDirectory(CellDirectory):
     __test__ = False
 
     def __init__(self, regions: Collection[Cell]) -> None:

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -57,9 +57,8 @@ class Locality:
         return {"name": self.name, "url": self.to_url("")}
 
 
-# TODO(cells): rename to LocalityConfigurationError
-class RegionConfigurationError(Exception):
-    """Indicate that a region was misconfigured or could not be initialized."""
+class CellConfigurationError(Exception):
+    """Indicate that a cell was misconfigured or could not be initialized."""
 
 
 @dataclass(frozen=True, eq=True)
@@ -121,19 +120,19 @@ class Cell:
         return self.name == settings.SENTRY_MONOLITH_REGION
 
 
-class RegionResolutionError(Exception):
-    """Indicate that a region's identity could not be resolved."""
+class CellResolutionError(Exception):
+    """Indicate that a cell's identity could not be resolved."""
 
 
-class RegionMappingNotFound(RegionResolutionError):
-    """Indicate that a mapping to a region could not be found."""
+class CellMappingNotFound(CellResolutionError):
+    """Indicate that a mapping to a cell could not be found."""
 
 
-class RegionContextError(Exception):
-    """Indicate that the server is not in a state to resolve a region."""
+class CellContextError(Exception):
+    """Indicate that the server is not in a state to resolve a cell."""
 
 
-class RegionDirectory:
+class CellDirectory:
     """A set of cells in a Sentry environment.
 
     This is a singleton class. It is immutable in a production environment,
@@ -159,8 +158,8 @@ class RegionDirectory:
     def localities(self) -> frozenset[Locality]:
         return self._localities
 
-    def get_cell_by_name(self, region_name: str) -> Cell | None:
-        return self._by_name.get(region_name)
+    def get_cell_by_name(self, cell_name: str) -> Cell | None:
+        return self._by_name.get(cell_name)
 
     def get_locality_by_name(self, locality_name: str) -> Locality | None:
         return self._localities_by_name.get(locality_name)
@@ -188,8 +187,8 @@ class RegionDirectory:
         return (r for name in loc.cells if (r := self._by_name.get(name)) is not None)
 
     def validate_all(self) -> None:
-        for region in self.cells:
-            region.validate()
+        for cell in self.cells:
+            cell.validate()
 
         # Ensure that a cell cannot be registered to more than one locality
         all_cell_refs = [cell_name for loc in self.localities for cell_name in loc.cells]
@@ -198,21 +197,21 @@ class RegionDirectory:
 
         if len(all_cell_refs) != len(assigned_cells):
             duplicates = {c for c in all_cell_refs if all_cell_refs.count(c) > 1}
-            raise RegionConfigurationError(
+            raise CellConfigurationError(
                 f"Cells assigned to more than one locality: {duplicates!r}"
             )
 
         # Ensure that all cells are assigned to a locality, and that all localities only reference defined cells
         if assigned_cells != defined_cells:
-            raise RegionConfigurationError(
+            raise CellConfigurationError(
                 f"Cells in locality config do not match cell config: "
                 f"locality-only={assigned_cells - defined_cells!r}, "
                 f"cell-only={defined_cells - assigned_cells!r}"
             )
 
 
-def _parse_raw_config(region_config: list[CellConfig]) -> Iterable[Cell]:
-    for config_value in region_config:
+def _parse_raw_config(cell_config: list[CellConfig]) -> Iterable[Cell]:
+    for config_value in cell_config:
         yield Cell(
             name=config_value["name"],
             snowflake_id=config_value["snowflake_id"],
@@ -222,29 +221,27 @@ def _parse_raw_config(region_config: list[CellConfig]) -> Iterable[Cell]:
         )
 
 
-def _generate_monolith_region_if_needed(regions: Collection[Cell]) -> Iterable[Cell]:
-    """Check whether a default monolith region must be generated.
+def _generate_monolith_cell_if_needed(cells: Collection[Cell]) -> Iterable[Cell]:
+    """Check whether a default monolith cell must be generated.
 
-    Check the provided set of regions to see whether a region with the configured
+    Check the provided set of cells to see whether a cell with the configured
     name is present. If so, return an empty iterator. Else, yield the newly generated
-    region.
+    cell.
     """
     if not settings.SENTRY_MONOLITH_REGION:
-        raise RegionConfigurationError(
-            "`SENTRY_MONOLITH_REGION` must provide a default region name"
-        )
-    if not regions:
+        raise CellConfigurationError("`SENTRY_MONOLITH_REGION` must provide a default cell name")
+    if not cells:
         yield Cell(
             name=settings.SENTRY_MONOLITH_REGION,
             snowflake_id=0,
             address=options.get("system.url-prefix"),
             category=RegionCategory.MULTI_TENANT,
         )
-    elif not any(r.name == settings.SENTRY_MONOLITH_REGION for r in regions):
-        raise RegionConfigurationError(
-            "The SENTRY_MONOLITH_REGION setting must point to a region name "
+    elif not any(r.name == settings.SENTRY_MONOLITH_REGION for r in cells):
+        raise CellConfigurationError(
+            "The SENTRY_MONOLITH_REGION setting must point to a cell name "
             f"({settings.SENTRY_MONOLITH_REGION=!r}; "
-            f"region names = {[r.name for r in regions]!r})"
+            f"cell names = {[r.name for r in cells]!r})"
         )
 
 
@@ -263,86 +260,85 @@ def _parse_locality_config(
 def load_from_config(
     region_config: list[CellConfig],
     locality_config: list[LocalityConfig],
-) -> RegionDirectory:
+) -> CellDirectory:
     try:
-        regions = set(_parse_raw_config(region_config))
-        regions |= set(_generate_monolith_region_if_needed(regions))
+        cells = set(_parse_raw_config(region_config))
+        cells |= set(_generate_monolith_cell_if_needed(cells))
         localities = set(_parse_locality_config(locality_config))
 
         if not locality_config:
             # TODO(cells): If no locality config present — create a synthetic 1:1 locality per cell
             # as a temporary fallback. Once SENTRY_LOCALITIES is configured, all cells
             # must be explicitly assigned; missing cells will have no locality mapping.
-            for region in regions:
+            for cell in cells:
                 localities.add(
                     Locality(
-                        name=region.name,
-                        category=region.category,
-                        cells=frozenset([region.name]),
-                        visible=region.visible,
+                        name=cell.name,
+                        category=cell.category,
+                        cells=frozenset([cell.name]),
+                        visible=cell.visible,
                     )
                 )
 
-        return RegionDirectory(regions, localities)
-    except RegionConfigurationError as e:
+        return CellDirectory(cells, localities)
+    except CellConfigurationError as e:
         sentry_sdk.capture_exception(e)
         raise
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise RegionConfigurationError("Unable to parse region_config.") from e
+        raise CellConfigurationError("Unable to parse region_config.") from e
 
 
-_global_regions: RegionDirectory | None = None
+_global_directory: CellDirectory | None = None
 
 
-def set_global_directory(directory: RegionDirectory) -> None:
+def set_global_directory(directory: CellDirectory) -> None:
     if not in_test_environment():
         raise Exception(
-            "The region directory can be set directly only in a test environment. "
+            "The cell directory can be set directly only in a test environment. "
             "Otherwise, it should be automatically loaded from config when "
             "get_global_directory is first called."
         )
-    global _global_regions
-    _global_regions = directory
+    global _global_directory
+    _global_directory = directory
 
 
-def get_global_directory() -> RegionDirectory:
-    global _global_regions
-    if _global_regions is not None:
-        return _global_regions
+def get_global_directory() -> CellDirectory:
+    global _global_directory
+    if _global_directory is not None:
+        return _global_directory
 
     from django.conf import settings
 
-    # For now, assume that all region configs can be taken in through Django
+    # For now, assume that all cell configs can be taken in through Django
     # settings. We may investigate other ways of delivering those configs in
     # production.
-    _global_regions = load_from_config(settings.SENTRY_REGION_CONFIG, settings.SENTRY_LOCALITIES)
-    return _global_regions
+    _global_directory = load_from_config(settings.SENTRY_REGION_CONFIG, settings.SENTRY_LOCALITIES)
+    return _global_directory
 
 
 def get_cell_by_name(name: str) -> Cell:
     """Look up a cell by name."""
-    global_regions = get_global_directory()
-    region = global_regions.get_cell_by_name(name)
-    if region is not None:
-        return region
+    cell_regions = get_global_directory()
+    cell = cell_regions.get_cell_by_name(name)
+    if cell is not None:
+        return cell
     else:
-        region_names = list(global_regions.get_cell_names(RegionCategory.MULTI_TENANT))
-        raise RegionResolutionError(
-            f"No cell with name: {name!r} "
-            f"(expected one of {region_names!r} or a single-tenant name)"
+        cell_names = list(cell_regions.get_cell_names(RegionCategory.MULTI_TENANT))
+        raise CellResolutionError(
+            f"No cell with name: {name!r} (expected one of {cell_names!r} or a single-tenant name)"
         )
 
 
 def get_locality_by_name(name: str) -> Locality:
     """Look up a locality by name."""
-    global_regions = get_global_directory()
-    locality = global_regions.get_locality_by_name(name)
+    global_directory = get_global_directory()
+    locality = global_directory.get_locality_by_name(name)
     if locality is not None:
         return locality
     else:
-        locality_names = [loc.name for loc in global_regions.localities]
-        raise RegionResolutionError(
+        locality_names = [loc.name for loc in global_directory.localities]
+        raise CellResolutionError(
             f"No locality with name: {name!r} (expected one of {locality_names!r})"
         )
 
@@ -377,7 +373,7 @@ def get_cell_for_organization(organization_id_or_slug: str) -> Cell:
         mapping = OrganizationMapping.objects.filter(slug=organization_id_or_slug).first()
 
     if not mapping:
-        raise RegionResolutionError(
+        raise CellResolutionError(
             f"Organization {organization_id_or_slug} has no associated mapping."
         )
 
@@ -393,7 +389,7 @@ def get_local_locality() -> Locality:
     cell = get_local_cell()
     locality = get_global_directory().get_locality_for_cell(cell.name)
     if locality is None:
-        raise RegionResolutionError(f"No locality found for cell {cell.name!r}")
+        raise CellResolutionError(f"No locality found for cell {cell.name!r}")
     return locality
 
 
@@ -403,7 +399,7 @@ def get_locality_name_for_cell(cell_name: str) -> str:
     """
     locality = get_global_directory().get_locality_for_cell(cell_name)
     if locality is None:
-        raise RegionResolutionError(f"No locality found for cell {cell_name!r}")
+        raise CellResolutionError(f"No locality found for cell {cell_name!r}")
 
     return locality.name
 
@@ -412,22 +408,22 @@ def get_local_cell() -> Cell:
     """Get the cell in which this server instance is running.
 
     Return the monolith cell if this server instance is in monolith mode.
-    Otherwise, it must be a region silo; raise RegionContextError otherwise.
+    Otherwise, it must be a cell silo; raise CellContextError otherwise.
     """
 
     if SiloMode.get_current_mode() == SiloMode.MONOLITH:
         return get_cell_by_name(settings.SENTRY_MONOLITH_REGION)
 
     if SiloMode.get_current_mode() != SiloMode.REGION:
-        raise RegionContextError("Not a region silo")
+        raise CellContextError("Not a region silo")
 
     # In our threaded acceptance tests, we need to override the region of the current
     # context when passing through test rpc calls, but we can't rely on settings because
     # django settings are not thread safe :'(
     # We use this thread local instead which is managed by the SiloMode context managers
-    single_process_region = SingleProcessSiloModeState.get_region()
-    if single_process_region is not None:
-        return single_process_region
+    single_process_cell = SingleProcessSiloModeState.get_region()
+    if single_process_cell is not None:
+        return single_process_cell
 
     if not settings.SENTRY_REGION:
         if in_test_environment():
@@ -452,7 +448,7 @@ def _find_orgs_for_user(user_id: int) -> set[int]:
 
 
 @control_silo_function
-def find_regions_for_orgs(org_ids: Iterable[int]) -> set[str]:
+def find_cells_for_orgs(org_ids: Iterable[int]) -> set[str]:
     from sentry.models.organizationmapping import OrganizationMapping
 
     if SiloMode.get_current_mode() == SiloMode.MONOLITH:
@@ -466,12 +462,12 @@ def find_regions_for_orgs(org_ids: Iterable[int]) -> set[str]:
 
 
 @control_silo_function
-def find_regions_for_user(user_id: int) -> set[str]:
+def find_cells_for_user(user_id: int) -> set[str]:
     if SiloMode.get_current_mode() == SiloMode.MONOLITH:
         return {settings.SENTRY_MONOLITH_REGION}
 
     org_ids = _find_orgs_for_user(user_id)
-    return find_regions_for_orgs(org_ids)
+    return find_cells_for_orgs(org_ids)
 
 
 @control_silo_function
@@ -485,24 +481,24 @@ def find_cells_for_sentry_app(sentry_app: SentryApp) -> set[str]:
     organizations_with_installations = SentryAppInstallation.objects.filter(
         sentry_app=sentry_app
     ).values_list("organization_id")
-    regions = (
+    cells = (
         OrganizationMapping.objects.filter(organization_id__in=organizations_with_installations)
         .distinct("cell_name")
         .values_list("cell_name")
     )
-    return {r[0] for r in regions}
+    return {c[0] for c in cells}
 
 
 def find_all_cell_names() -> Iterable[str]:
     return get_global_directory().get_cell_names()
 
 
-def find_all_multitenant_region_names() -> list[str]:
+def find_all_multitenant_cell_names() -> list[str]:
     """
-    Return all visible multi_tenant regions.
+    Return all visible multi_tenant cells.
     """
-    regions = get_global_directory().get_cells(RegionCategory.MULTI_TENANT)
-    return list([r.name for r in regions if r.visible])
+    cells = get_global_directory().get_cells(RegionCategory.MULTI_TENANT)
+    return list([c.name for c in cells if c.visible])
 
 
 def find_all_multitenant_locality_names() -> list[str]:
@@ -514,3 +510,14 @@ def find_all_multitenant_locality_names() -> list[str]:
         for loc in get_global_directory().localities
         if loc.category == RegionCategory.MULTI_TENANT and loc.visible
     ]
+
+
+# TODO(cells): Remove aliases once getsentry import sites are updated
+RegionConfigurationError = CellConfigurationError
+RegionResolutionError = CellResolutionError
+RegionMappingNotFound = CellMappingNotFound
+RegionContextError = CellContextError
+RegionDirectory = CellDirectory
+find_regions_for_orgs = find_cells_for_orgs
+find_regions_for_user = find_cells_for_user
+find_all_multitenant_region_names = find_all_multitenant_cell_names

--- a/src/sentry/users/models/authenticator.py
+++ b/src/sentry/users/models/authenticator.py
@@ -33,7 +33,7 @@ from sentry.db.models.manager.base import BaseManager
 from sentry.hybridcloud.models.outbox import ControlOutboxBase
 from sentry.hybridcloud.outbox.base import ControlOutboxProducingModel
 from sentry.hybridcloud.outbox.category import OutboxCategory
-from sentry.types.region import find_regions_for_user
+from sentry.types.region import find_cells_for_user
 
 if TYPE_CHECKING:
     from sentry.users.models.user import User
@@ -184,7 +184,7 @@ class Authenticator(ControlOutboxProducingModel):
         unique_together = (("user", "type"),)
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = find_regions_for_user(self.user_id)
+        regions = find_cells_for_user(self.user_id)
         return OutboxCategory.USER_UPDATE.as_control_outboxes(
             cell_names=regions,
             shard_identifier=self.user_id,

--- a/src/sentry/users/models/user.py
+++ b/src/sentry/users/models/user.py
@@ -44,7 +44,7 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.organizations.services.organization import RpcRegionUser, organization_service
-from sentry.types.region import find_all_cell_names, find_regions_for_user
+from sentry.types.region import find_all_cell_names, find_cells_for_user
 from sentry.users.models.authenticator import Authenticator
 from sentry.users.models.lostpasswordhash import LostPasswordHash
 from sentry.users.models.user_avatar import UserAvatar
@@ -373,7 +373,7 @@ class User(Model, AbstractBaseUser):
         if is_user_delete:
             user_regions = set(find_all_cell_names())
         else:
-            user_regions = find_regions_for_user(identifier)
+            user_regions = find_cells_for_user(identifier)
 
         return OutboxCategory.USER_UPDATE.as_control_outboxes(
             cell_names=user_regions,

--- a/src/sentry/users/models/user_avatar.py
+++ b/src/sentry/users/models/user_avatar.py
@@ -12,7 +12,7 @@ from sentry.db.models.manager.base import BaseManager
 from sentry.hybridcloud.models.outbox import ControlOutboxBase
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.models.avatars import ControlAvatarBase
-from sentry.types.region import find_regions_for_user
+from sentry.types.region import find_cells_for_user
 
 
 class UserAvatarType(IntEnum):
@@ -55,7 +55,7 @@ class UserAvatar(ControlAvatarBase):
     url_path = "avatar"
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = find_regions_for_user(self.user_id)
+        regions = find_cells_for_user(self.user_id)
         return OutboxCategory.USER_UPDATE.as_control_outboxes(
             cell_names=regions,
             shard_identifier=self.user_id,

--- a/src/sentry/users/models/useremail.py
+++ b/src/sentry/users/models/useremail.py
@@ -25,7 +25,7 @@ from sentry.hybridcloud.models.outbox import ControlOutboxBase
 from sentry.hybridcloud.outbox.base import ControlOutboxProducingModel
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.types.region import find_regions_for_user
+from sentry.types.region import find_cells_for_user
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.security import get_secure_token
 
@@ -78,7 +78,7 @@ class UserEmail(ControlOutboxProducingModel):
     __repr__ = sane_repr("user_id", "email")
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = find_regions_for_user(self.user_id)
+        regions = find_cells_for_user(self.user_id)
         return [
             outbox
             for outbox in OutboxCategory.USER_UPDATE.as_control_outboxes(

--- a/src/sentry/users/models/userpermission.py
+++ b/src/sentry/users/models/userpermission.py
@@ -10,7 +10,7 @@ from sentry.db.models import FlexibleForeignKey, control_silo_model, sane_repr
 from sentry.hybridcloud.models.outbox import ControlOutboxBase
 from sentry.hybridcloud.outbox.base import ControlOutboxProducingModel
 from sentry.hybridcloud.outbox.category import OutboxCategory
-from sentry.types.region import find_regions_for_user
+from sentry.types.region import find_cells_for_user
 
 
 @control_silo_model
@@ -43,7 +43,7 @@ class UserPermission(OverwritableConfigMixin, ControlOutboxProducingModel):
         return frozenset(cls.objects.filter(user=user_id).values_list("permission", flat=True))
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = find_regions_for_user(self.user_id)
+        regions = find_cells_for_user(self.user_id)
         return [
             outbox
             for outbox in OutboxCategory.USER_UPDATE.as_control_outboxes(

--- a/src/sentry/utils/snowflake.py
+++ b/src/sentry/utils/snowflake.py
@@ -13,7 +13,7 @@ from rest_framework.exceptions import APIException
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
 from sentry.db.postgres.transactions import enforce_constraints
-from sentry.types.region import RegionContextError, get_local_cell
+from sentry.types.region import CellContextError, get_local_cell
 from sentry.utils import redis
 
 if TYPE_CHECKING:
@@ -118,7 +118,7 @@ def generate_snowflake_id(redis_key: str) -> int:
 
     try:
         segment_values[REGION_ID] = get_local_cell().snowflake_id
-    except RegionContextError:  # expected if running in monolith mode
+    except CellContextError:  # expected if running in monolith mode
         segment_values[REGION_ID] = NULL_REGION_ID
 
     current_time = datetime.now().timestamp()

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -27,7 +27,7 @@ from sentry.projects.services.project.model import RpcProject
 from sentry.projects.services.project.service import project_service
 from sentry.projects.services.project_key.model import RpcProjectKey
 from sentry.projects.services.project_key.service import project_key_service
-from sentry.types.region import RegionResolutionError, get_locality_name_for_cell
+from sentry.types.region import CellResolutionError, get_locality_name_for_cell
 from sentry.types.token import AuthTokenType
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -271,7 +271,7 @@ def get_org_token(mapping: OrganizationMapping, user: User | RpcUser | Anonymous
         token_str = generate_token(
             mapping.slug, generate_locality_url(get_locality_name_for_cell(mapping.cell_name))
         )
-    except (SystemUrlPrefixMissingException, RegionResolutionError):
+    except (SystemUrlPrefixMissingException, CellResolutionError):
         return None
 
     token_hashed = hash_token(token_str)

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -45,7 +45,7 @@ from sentry.testutils.silo import (
     control_silo_test,
     region_silo_test,
 )
-from sentry.types.region import find_regions_for_user
+from sentry.types.region import find_cells_for_user
 from sentry.users.models.user import User
 
 
@@ -149,7 +149,7 @@ def setup_deletable_objects(
     for i in range(count):
         Factories.create_saved_search(f"s-{i}", owner_id=u_id)
 
-    for region_name in find_regions_for_user(u_id):
+    for region_name in find_cells_for_user(u_id):
         shard = ControlOutbox(
             shard_scope=OutboxScope.USER_SCOPE, shard_identifier=u_id, cell_name=region_name
         )

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -25,7 +25,7 @@ from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
-from sentry.types.region import Cell, RegionCategory, RegionResolutionError
+from sentry.types.region import Cell, CellResolutionError, RegionCategory
 
 region_config = [Cell("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT)]
 
@@ -302,7 +302,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="lolnope",
         )
-        with pytest.raises(RegionResolutionError):
+        with pytest.raises(CellResolutionError):
             drain_mailbox(webhook_one.id)
         assert len(responses.calls) == 0
 
@@ -738,7 +738,7 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="lolnope",
         )
-        with pytest.raises(RegionResolutionError):
+        with pytest.raises(CellResolutionError):
             drain_mailbox_parallel(webhook_one.id)
         assert len(responses.calls) == 0
 

--- a/tests/sentry/hybridcloud/test_region.py
+++ b/tests/sentry/hybridcloud/test_region.py
@@ -13,7 +13,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from sentry.types.region import Cell, RegionCategory, RegionResolutionError
+from sentry.types.region import Cell, CellResolutionError, RegionCategory
 
 _TEST_REGIONS = (
     Cell("north_america", 1, "na.sentry.io", RegionCategory.MULTI_TENANT),
@@ -82,10 +82,10 @@ class RegionResolutionTest(TestCase):
             override_regions([self.target_region]),
             override_settings(SENTRY_SINGLE_ORGANIZATION=False),
         ):
-            with pytest.raises(RegionResolutionError):
+            with pytest.raises(CellResolutionError):
                 region_resolution.resolve({})
 
         with override_regions(_TEST_REGIONS), override_settings(SENTRY_SINGLE_ORGANIZATION=True):
             self.create_organization(region=_TEST_REGIONS[1])
-            with pytest.raises(RegionResolutionError):
+            with pytest.raises(CellResolutionError):
                 region_resolution.resolve({})

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -23,7 +23,7 @@ from sentry.silo.util import PROXY_DIRECT_LOCATION_HEADER, PROXY_SIGNATURE_HEADE
 from sentry.testutils.cases import TestCase
 from sentry.testutils.hybrid_cloud import override_allowed_region_silo_ip_addresses
 from sentry.testutils.region import override_regions
-from sentry.types.region import Cell, RegionCategory, RegionResolutionError
+from sentry.types.region import Cell, CellResolutionError, RegionCategory
 from sentry.utils import json
 
 
@@ -46,7 +46,7 @@ class SiloClientTest(TestCase):
             with raises(SiloClientError):
                 RegionSiloClient("atlantis")  # type: ignore[arg-type]
 
-            with raises(RegionResolutionError):
+            with raises(CellResolutionError):
                 region = Cell("atlantis", 1, self.dummy_address, RegionCategory.MULTI_TENANT)
                 RegionSiloClient(region)
 
@@ -327,7 +327,7 @@ class SiloClientTest(TestCase):
 
         assert mock_capture_exception.call_count == 1
         err = mock_capture_exception.call_args.args[0]
-        assert isinstance(err, RegionResolutionError)
+        assert isinstance(err, CellResolutionError)
         assert err.args == ("Disallowed Region Silo IP address: 172.31.255.255",)
 
         with (
@@ -346,7 +346,7 @@ class SiloClientTest(TestCase):
 
         assert mock_capture_exception.call_count == 1
         err = mock_capture_exception.call_args.args[0]
-        assert isinstance(err, RegionResolutionError)
+        assert isinstance(err, CellResolutionError)
         assert err.args == ("Disallowed Region Silo IP address: 172.31.255.31",)
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
@@ -391,7 +391,7 @@ def test_validate_region_ip_address() -> None:
         assert validate_region_ip_address("172.31.255.255") is False
         assert mock_capture_exception.call_count == 1
         err = mock_capture_exception.call_args.args[0]
-        assert isinstance(err, RegionResolutionError)
+        assert isinstance(err, CellResolutionError)
         assert err.args == ("allowed_region_ip_addresses is empty for: 172.31.255.255",)
 
     with (
@@ -401,7 +401,7 @@ def test_validate_region_ip_address() -> None:
         assert validate_region_ip_address("172.31.255.255") is False
         assert mock_capture_exception.call_count == 1
         err = mock_capture_exception.call_args.args[0]
-        assert isinstance(err, RegionResolutionError)
+        assert isinstance(err, CellResolutionError)
         assert err.args == ("Disallowed Region Silo IP address: 172.31.255.255",)
 
     with (

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -33,11 +33,11 @@ from sentry.types.region import (
 
 
 class CellDirectoryTest(TestCase):
-    """Test region config parsing and setup.
+    """Test cell config parsing and setup.
 
     Note: Because this test case is targeted at the logic of setting up the
     CellDirectory, it uses a lot of `override_settings` in ways that most test
-    cases shouldn't. If you are having difficulty with region setup in other test
+    cases shouldn't. If you are having difficulty with cell setup in other test
     cases, please don't follow this class as an example, but instead use the
     utilities in testutils/silo.py and testutils/region.py.
     """
@@ -75,7 +75,7 @@ class CellDirectoryTest(TestCase):
         with get_test_env_directory().swap_state(tuple(directory.cells)):
             yield
 
-    def test_region_config_parsing_in_monolith(self) -> None:
+    def test_cell_config_parsing_in_monolith(self) -> None:
         with override_settings(SENTRY_MONOLITH_REGION="us"):
             directory = load_from_config(self._INPUTS, [])
         assert directory.cells == frozenset(self._EXPECTED_OUTPUTS)
@@ -87,7 +87,7 @@ class CellDirectoryTest(TestCase):
             with pytest.raises(CellResolutionError):
                 get_cell_by_name("nowhere")
 
-    def test_region_config_parsing_in_control(self) -> None:
+    def test_cell_config_parsing_in_control(self) -> None:
         with (
             override_settings(SILO_MODE=SiloMode.CONTROL),
             override_settings(SENTRY_MONOLITH_REGION="us"),
@@ -102,7 +102,7 @@ class CellDirectoryTest(TestCase):
         with self._in_global_state(directory):
             assert get_local_cell() == self._EXPECTED_OUTPUTS[0]
 
-    def test_get_generated_monolith_region(self) -> None:
+    def test_get_generated_monolith_cell(self) -> None:
         with (
             override_settings(SILO_MODE=SiloMode.MONOLITH, SENTRY_MONOLITH_REGION="defaultland"),
             self._in_global_state(load_from_config([], [])),
@@ -137,9 +137,9 @@ class CellDirectoryTest(TestCase):
                 # OrganizationMapping does not exist
                 get_cell_for_organization(self.organization.slug)
 
-    def test_validate_region(self) -> None:
-        for region in self._EXPECTED_OUTPUTS:
-            region.validate()
+    def test_validate_cell(self) -> None:
+        for cell in self._EXPECTED_OUTPUTS:
+            cell.validate()
 
     def test_locality_to_url(self) -> None:
         locality = Locality("us", frozenset(["us"]), RegionCategory.MULTI_TENANT)
@@ -157,7 +157,7 @@ class CellDirectoryTest(TestCase):
             load_from_config(["invalid"], [])  # type: ignore[list-item]
         assert sentry_sdk_mock.capture_exception.call_count == 1
 
-    def test_invalid_historic_region_setting(self) -> None:
+    def test_invalid_historic_cell_setting(self) -> None:
         with pytest.raises(CellConfigurationError):
             with override_settings(SENTRY_MONOLITH_REGION="nonexistent"):
                 load_from_config(self._INPUTS, [])
@@ -175,8 +175,8 @@ class CellDirectoryTest(TestCase):
                 default_org_role=organization.default_role,
                 user_id=user.id,
             )
-            actual_regions = find_cells_for_user(user_id=user.id)
-            assert actual_regions == {"us"}
+            actual_cells = find_cells_for_user(user_id=user.id)
+            assert actual_cells == {"us"}
 
         with (
             override_settings(SILO_MODE=SiloMode.REGION),
@@ -253,7 +253,7 @@ class CellDirectoryTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_subdomain_is_locality(self) -> None:
-        regions: list[CellConfig] = [
+        cells: list[CellConfig] = [
             {
                 "name": "us",
                 "snowflake_id": 1,
@@ -263,7 +263,7 @@ class CellDirectoryTest(TestCase):
         ]
         rf = RequestFactory()
         with override_settings(SENTRY_MONOLITH_REGION="us"):
-            directory = load_from_config(regions, [])
+            directory = load_from_config(cells, [])
         with self._in_global_state(directory):
             req = rf.get("/")
             setattr(req, "subdomain", "us")

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -15,15 +15,15 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.region import get_test_env_directory
 from sentry.types.region import (
     Cell,
+    CellConfigurationError,
+    CellDirectory,
+    CellResolutionError,
     Locality,
     RegionCategory,
-    RegionConfigurationError,
-    RegionDirectory,
-    RegionResolutionError,
     find_all_cell_names,
-    find_all_multitenant_region_names,
+    find_all_multitenant_cell_names,
     find_cells_for_sentry_app,
-    find_regions_for_user,
+    find_cells_for_user,
     get_cell_by_name,
     get_cell_for_organization,
     get_local_cell,
@@ -32,11 +32,11 @@ from sentry.types.region import (
 )
 
 
-class RegionDirectoryTest(TestCase):
+class CellDirectoryTest(TestCase):
     """Test region config parsing and setup.
 
     Note: Because this test case is targeted at the logic of setting up the
-    RegionDirectory, it uses a lot of `override_settings` in ways that most test
+    CellDirectory, it uses a lot of `override_settings` in ways that most test
     cases shouldn't. If you are having difficulty with region setup in other test
     cases, please don't follow this class as an example, but instead use the
     utilities in testutils/silo.py and testutils/region.py.
@@ -71,7 +71,7 @@ class RegionDirectoryTest(TestCase):
 
     @staticmethod
     @contextmanager
-    def _in_global_state(directory: RegionDirectory) -> Generator[None]:
+    def _in_global_state(directory: CellDirectory) -> Generator[None]:
         with get_test_env_directory().swap_state(tuple(directory.cells)):
             yield
 
@@ -84,7 +84,7 @@ class RegionDirectoryTest(TestCase):
         with self._in_global_state(directory):
             assert get_cell_by_name("eu") == self._EXPECTED_OUTPUTS[1]
 
-            with pytest.raises(RegionResolutionError):
+            with pytest.raises(CellResolutionError):
                 get_cell_by_name("nowhere")
 
     def test_region_config_parsing_in_control(self) -> None:
@@ -120,7 +120,7 @@ class RegionDirectoryTest(TestCase):
             directory = load_from_config(self._INPUTS, [])
         with self._in_global_state(directory):
             mapping.update(cell_name="az")
-            with pytest.raises(RegionResolutionError):
+            with pytest.raises(CellResolutionError):
                 # Cell does not exist
                 get_cell_for_organization(self.organization.slug)
 
@@ -133,7 +133,7 @@ class RegionDirectoryTest(TestCase):
             assert cell == self._EXPECTED_OUTPUTS[1]
 
             mapping.delete()
-            with pytest.raises(RegionResolutionError):
+            with pytest.raises(CellResolutionError):
                 # OrganizationMapping does not exist
                 get_cell_for_organization(self.organization.slug)
 
@@ -153,17 +153,17 @@ class RegionDirectoryTest(TestCase):
     @patch("sentry.types.region.sentry_sdk")
     def test_invalid_config(self, sentry_sdk_mock: MagicMock) -> None:
         assert sentry_sdk_mock.capture_exception.call_count == 0
-        with pytest.raises(RegionConfigurationError):
+        with pytest.raises(CellConfigurationError):
             load_from_config(["invalid"], [])  # type: ignore[list-item]
         assert sentry_sdk_mock.capture_exception.call_count == 1
 
     def test_invalid_historic_region_setting(self) -> None:
-        with pytest.raises(RegionConfigurationError):
+        with pytest.raises(CellConfigurationError):
             with override_settings(SENTRY_MONOLITH_REGION="nonexistent"):
                 load_from_config(self._INPUTS, [])
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    def test_find_regions_for_user(self) -> None:
+    def test_find_cells_for_user(self) -> None:
         with override_settings(SENTRY_MONOLITH_REGION="us"):
             directory = load_from_config(self._INPUTS, [])
         with self._in_global_state(directory):
@@ -175,14 +175,14 @@ class RegionDirectoryTest(TestCase):
                 default_org_role=organization.default_role,
                 user_id=user.id,
             )
-            actual_regions = find_regions_for_user(user_id=user.id)
+            actual_regions = find_cells_for_user(user_id=user.id)
             assert actual_regions == {"us"}
 
         with (
             override_settings(SILO_MODE=SiloMode.REGION),
             pytest.raises(SiloLimit.AvailabilityError),
         ):
-            find_regions_for_user(user_id=user.id)
+            find_cells_for_user(user_id=user.id)
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_find_cells_for_sentry_app(self) -> None:
@@ -226,15 +226,15 @@ class RegionDirectoryTest(TestCase):
             assert set(result) == {"us", "eu", "acme"}
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    def test_find_all_multitenant_region_names(self) -> None:
+    def test_find_all_multitenant_cell_names(self) -> None:
         with override_settings(SENTRY_MONOLITH_REGION="us"):
             directory = load_from_config(self._INPUTS, [])
         with self._in_global_state(directory):
-            result = find_all_multitenant_region_names()
+            result = find_all_multitenant_cell_names()
             assert set(result) == {"us", "eu"}
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    def test_find_all_multitenant_region_names_non_visible(self) -> None:
+    def test_find_all_multitenant_cell_names_non_visible(self) -> None:
         inputs: list[CellConfig] = [
             *self._INPUTS,
             {
@@ -248,7 +248,7 @@ class RegionDirectoryTest(TestCase):
         with override_settings(SENTRY_MONOLITH_REGION="us"):
             directory = load_from_config(inputs, [])
         with self._in_global_state(directory):
-            result = find_all_multitenant_region_names()
+            result = find_all_multitenant_cell_names()
             assert set(result) == {"us", "eu"}
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)

--- a/tests/sentry/users/models/test_user.py
+++ b/tests/sentry/users/models/test_user.py
@@ -40,7 +40,7 @@ from sentry.testutils.helpers.backups import BackupTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
-from sentry.types.region import Cell, RegionCategory, find_regions_for_user
+from sentry.types.region import Cell, RegionCategory, find_cells_for_user
 from sentry.users.models.authenticator import Authenticator
 from sentry.users.models.user import User
 from sentry.users.models.useremail import UserEmail
@@ -140,7 +140,7 @@ class UserHybridCloudDeletionTest(TestCase):
             for member in OrganizationMember.objects.filter(user_id=self.user.id):
                 member.delete()
 
-        assert find_regions_for_user(self.user.id) == set()
+        assert find_cells_for_user(self.user.id) == set()
 
         with outbox_runner():
             self.user.delete()


### PR DESCRIPTION
- RegionConfigurationError -> CellConfigurationError
- RegionResolutionError -> CellResolutionError
- RegionMappingNotFound -> CellMappingNotFound
- RegionContextError -> CellContextError
- RegionDirectory -> CellDirectory
- find_regions_for_orgs -> find_cells_for_orgs
- find_regions_for_user -> find_cells_for_user
- find_all_multitenant_region_names -> find_all_multitenant_cell_names
