### PR TITLE
fix(agents): Handle null modelId in agent monitoring page

### DIFF
--- a/static/app/views/insights/pages/agents/components/modelName.tsx
+++ b/static/app/views/insights/pages/agents/components/modelName.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 import type {SpaceSize} from 'sentry/utils/theme';
 
 interface ModelNameProps {
-  modelId: string;
+  modelId: string | null;
   gap?: SpaceSize;
   provider?: string;
   size?: number;
@@ -21,7 +21,9 @@ export function ModelName({modelId, provider, size = 16, gap = 'md'}: ModelNameP
       <IconWrapper>
         <PlatformIcon platform={platform ?? 'unknown'} size={size} />
       </IconWrapper>
-      <NameWrapper>{modelId === 'null' ? t('(no value)') : modelId}</NameWrapper>
+      <NameWrapper>
+        {!modelId || modelId === 'null' ? t('(no value)') : modelId}
+      </NameWrapper>
     </Flex>
   );
 }
@@ -39,9 +41,13 @@ const NameWrapper = styled('div')`
   min-width: 0;
 `;
 
-export function getModelPlatform(modelId: string, provider?: string) {
+export function getModelPlatform(modelId: string | null, provider?: string) {
   if (provider) {
     return provider;
+  }
+
+  if (!modelId) {
+    return null;
   }
 
   const lowerCaseModelId = modelId.toLowerCase();


### PR DESCRIPTION
Handle null `modelId` in the `ModelName` component and `getModelPlatform` function
on the agent monitoring page.

The code assumed `modelId` was always a string, but span data can contain actual
`null` values. When a null `modelId` reached `getModelPlatform`, calling
`.toLowerCase()` on it threw a `TypeError`, crashing the page via React's
error boundary.

Adds null guards to both the render path and the platform lookup, and updates
the type to `string | null` to reflect reality.