### PR TITLE
feat(workflow_engine): Add a cache for ActionFilters

### DIFF
--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -1,0 +1,107 @@
+from collections.abc import Collection
+from typing import NamedTuple
+
+from django.db.models import F
+
+from sentry.workflow_engine.caches.mapping import CacheMapping
+from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+from sentry.workflow_engine.models.workflow import Workflow
+from sentry.workflow_engine.utils import scopedstats
+from sentry.workflow_engine.utils.metrics import metrics_incr
+
+ACTION_FILTER_CACHE_NAME = "action_filters_by_workflow"
+METRIC_PREFIX = f"workflow_engine.cache.processing_workflow.{ACTION_FILTER_CACHE_NAME}"
+ActionFiltersByWorkflow = dict[int, list[DataConditionGroup]]
+
+
+class _ActionFilterCacheKey(NamedTuple):
+    workflow_id: int
+
+
+class _CacheResults(NamedTuple):
+    cached: ActionFiltersByWorkflow
+    missed_ids: list[int]
+
+
+_action_filters_cache = CacheMapping[_ActionFilterCacheKey, list[DataConditionGroup]](
+    lambda key: f"{key.workflow_id}",
+    namespace=f"workflow:{ACTION_FILTER_CACHE_NAME}",
+)
+
+
+def _check_cache_by_workflows(workflows: Collection[Workflow]) -> _CacheResults:
+    results: ActionFiltersByWorkflow = {}
+    missed_ids: list[int] = []
+
+    keys = [_ActionFilterCacheKey(w.id) for w in workflows]
+    cache_results = _action_filters_cache.get_many(inputs=keys)
+
+    for key, cached in cache_results.items():
+        if cached is not None:
+            results[key.workflow_id] = cached
+            metrics_incr(f"{METRIC_PREFIX}.hit")
+        else:
+            missed_ids.append(key.workflow_id)
+            metrics_incr(f"{METRIC_PREFIX}.miss")
+
+    return _CacheResults(
+        cached=results,
+        missed_ids=missed_ids,
+    )
+
+
+def _get_action_filters_by_workflows(workflow_ids: list[int]) -> ActionFiltersByWorkflow:
+    decorated_action_filters = list(
+        DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow_id__in=workflow_ids)
+        .prefetch_related("conditions")
+        .annotate(workflow_id=F("workflowdataconditiongroup__workflow_id"))
+    )
+
+    action_filters_by_workflow: ActionFiltersByWorkflow = {wid: [] for wid in workflow_ids}
+
+    for action_filter in decorated_action_filters:
+        action_filters_by_workflow[action_filter.workflow_id].append(action_filter)
+
+    return action_filters_by_workflow
+
+
+def _populate_cache(action_filters_by_workflow: ActionFiltersByWorkflow) -> None:
+    cache_items: dict[_ActionFilterCacheKey, list[DataConditionGroup]] = {
+        _ActionFilterCacheKey(workflow_id): action_filters
+        for workflow_id, action_filters in action_filters_by_workflow.items()
+    }
+
+    _action_filters_cache.set_many(cache_items)
+
+
+@scopedstats.timer()
+def get_action_filters_by_workflows(
+    workflows: Collection[Workflow],
+) -> ActionFiltersByWorkflow:
+    """
+    Get the action filters for a collection of Workflows from a cache or fall through to query
+
+    Each workflow has an individual cache of conditions that we check, and collate to the results.
+    If the cache is empty for a specific workflow, it will query the DB and add the result to the cache.
+
+    Args:
+        workflows: Collection[Workflow] a collection of the workflows to get the filters for
+
+    Returns:
+        dict[int, list[DataConditionGroup]] mapping workflow IDs to their action filters.
+            Each list contains the DataConditionGroups with prefetched conditions.
+    """
+    if not workflows:
+        return {}
+
+    cache_results = _check_cache_by_workflows(workflows)
+    action_filters_by_workflow = cache_results.cached
+
+    if cache_results.missed_ids:
+        query_results = _get_action_filters_by_workflows(cache_results.missed_ids)
+        _populate_cache(query_results)
+
+        for workflow_id, action_filters in query_results.items():
+            action_filters_by_workflow[workflow_id] = action_filters
+
+    return action_filters_by_workflow

--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -6,22 +6,23 @@ from django.db.models import F
 from sentry.workflow_engine.caches.mapping import CacheMapping
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
 from sentry.workflow_engine.models.workflow import Workflow
+from sentry.workflow_engine.types import WorkflowId
 from sentry.workflow_engine.utils import scopedstats
 from sentry.workflow_engine.utils.metrics import metrics_incr
 
 CACHE_TTL = 300  # 5 minutes
 ACTION_FILTER_CACHE_NAME = "action_filters_by_workflow"
 METRIC_PREFIX = f"workflow_engine.cache.processing_workflow.{ACTION_FILTER_CACHE_NAME}"
-ActionFiltersByWorkflow = dict[int, list[DataConditionGroup]]
+ActionFiltersByWorkflow = dict[WorkflowId, list[DataConditionGroup]]
 
 
 class _ActionFilterCacheKey(NamedTuple):
-    workflow_id: int
+    workflow_id: WorkflowId
 
 
 class _CacheResults(NamedTuple):
     cached: ActionFiltersByWorkflow
-    missed_ids: list[int]
+    missed_ids: list[WorkflowId]
 
 
 _action_filters_cache = CacheMapping[_ActionFilterCacheKey, list[DataConditionGroup]](
@@ -32,7 +33,7 @@ _action_filters_cache = CacheMapping[_ActionFilterCacheKey, list[DataConditionGr
 
 def _check_cache_by_workflows(workflows: Collection[Workflow]) -> _CacheResults:
     results: ActionFiltersByWorkflow = {}
-    missed_ids: list[int] = []
+    missed_ids: list[WorkflowId] = []
 
     keys = [_ActionFilterCacheKey(w.id) for w in workflows]
     cache_results = _action_filters_cache.get_many(inputs=keys)
@@ -51,7 +52,7 @@ def _check_cache_by_workflows(workflows: Collection[Workflow]) -> _CacheResults:
     )
 
 
-def _get_action_filters_by_workflows(workflow_ids: list[int]) -> ActionFiltersByWorkflow:
+def _query_action_filters_by_workflows(workflow_ids: list[WorkflowId]) -> ActionFiltersByWorkflow:
     decorated_action_filters = list(
         DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow_id__in=workflow_ids)
         .prefetch_related("conditions")
@@ -72,6 +73,7 @@ def _populate_cache(action_filters_by_workflow: ActionFiltersByWorkflow) -> None
         for workflow_id, action_filters in action_filters_by_workflow.items()
     }
 
+    # TODO -- Add cache invalidation
     _action_filters_cache.set_many(cache_items, CACHE_TTL)
 
 
@@ -89,9 +91,10 @@ def get_action_filters_by_workflows(
         workflows: Collection[Workflow] a collection of the workflows to get the filters for
 
     Returns:
-        dict[int, list[DataConditionGroup]] mapping workflow IDs to their action filters.
+        dict[WorkflowId, list[DataConditionGroup]] mapping workflow IDs to their action filters.
             Each list contains the DataConditionGroups with prefetched conditions.
     """
+    # TODO - use this hook in `processors/workflow.py`'s evaluate_workflows_action_filters
     if not workflows:
         return {}
 
@@ -99,7 +102,7 @@ def get_action_filters_by_workflows(
     action_filters_by_workflow = cache_results.cached
 
     if cache_results.missed_ids:
-        query_results = _get_action_filters_by_workflows(cache_results.missed_ids)
+        query_results = _query_action_filters_by_workflows(cache_results.missed_ids)
         _populate_cache(query_results)
 
         for workflow_id, action_filters in query_results.items():

--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -9,6 +9,7 @@ from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils import scopedstats
 from sentry.workflow_engine.utils.metrics import metrics_incr
 
+CACHE_TTL = 300  # 5 minutes
 ACTION_FILTER_CACHE_NAME = "action_filters_by_workflow"
 METRIC_PREFIX = f"workflow_engine.cache.processing_workflow.{ACTION_FILTER_CACHE_NAME}"
 ActionFiltersByWorkflow = dict[int, list[DataConditionGroup]]
@@ -71,7 +72,7 @@ def _populate_cache(action_filters_by_workflow: ActionFiltersByWorkflow) -> None
         for workflow_id, action_filters in action_filters_by_workflow.items()
     }
 
-    _action_filters_cache.set_many(cache_items)
+    _action_filters_cache.set_many(cache_items, CACHE_TTL)
 
 
 @scopedstats.timer()

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from functools import cached_property
-from typing import Any, TypeAlias
+from typing import Any
 
 import sentry_sdk
 from django.utils import timezone
@@ -50,17 +50,19 @@ from sentry.workflow_engine.processors.data_condition_group import (
 )
 from sentry.workflow_engine.processors.log_util import track_batch_performance
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
-from sentry.workflow_engine.types import ConditionError, WorkflowEventData
+from sentry.workflow_engine.types import (
+    ConditionError,
+    DataConditionGroupId,
+    GroupId,
+    WorkflowEventData,
+    WorkflowId,
+)
 from sentry.workflow_engine.utils import log_context
 
 logger = log_context.get_logger("sentry.workflow_engine.processors.delayed_workflow")
 
 EVENT_LIMIT = 100
 COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
-
-GroupId: TypeAlias = int
-DataConditionGroupId: TypeAlias = int
-WorkflowId: TypeAlias = int
 
 
 class EventInstance(BaseModel):

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from logging import Logger
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeAlias, TypedDict, TypeVar
 
 from django.db.models import Q
 from sentry_sdk import logger as sentry_logger
@@ -40,6 +40,10 @@ T = TypeVar("T")
 
 ERROR_DETECTOR_NAME = "Error Monitor"
 ISSUE_STREAM_DETECTOR_NAME = "Issue Stream"
+
+GroupId: TypeAlias = int
+DataConditionGroupId: TypeAlias = int
+WorkflowId: TypeAlias = int
 
 
 class DetectorException(Exception):

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -1,5 +1,6 @@
+from collections.abc import Generator
 from contextlib import contextmanager
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.caches.action_filters import (
@@ -15,7 +16,7 @@ from sentry.workflow_engine.models import (
 
 
 @contextmanager
-def mock_query_action_filters(return_value=None):
+def mock_query_action_filters(return_value: ActionFiltersByWorkflow = None) -> Generator[MagicMock]:
     with patch(
         "sentry.workflow_engine.caches.action_filters._query_action_filters_by_workflows",
         return_value=return_value,
@@ -24,7 +25,7 @@ def mock_query_action_filters(return_value=None):
 
 
 @contextmanager
-def mock_check_action_filters_cache(return_value: _CacheResults = None):
+def mock_check_action_filters_cache(return_value: _CacheResults = None) -> Generator[MagicMock]:
     with patch(
         "sentry.workflow_engine.caches.action_filters._check_cache_by_workflows",
         return_value=return_value,

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -171,3 +171,16 @@ class TestActionFilterCache(TestCase):
             mock_query.assert_not_called()
 
         assert result[workflow.id] == []
+
+    def test_prefetched_conditions_survive_cache(self) -> None:
+        workflow, _ = self.create_workflow_with_filters(num_conditions=2)
+
+        # First call populates cache
+        get_action_filters_by_workflows([workflow])
+
+        # Second call retrieves from cache
+        with self.assertNumQueries(0):  # No DB queries
+            cached_results = get_action_filters_by_workflows([workflow])
+
+            for dcg in cached_results[workflow.id]:
+                list(dcg.conditions.all())

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -156,6 +156,18 @@ class TestActionFilterCache(TestCase):
         self.assert_cache_result(results, workflow, action_filters)
         self.assert_cache_result(results, workflow_two, action_filters_two)
 
-    def test_cache_metrics(self) -> None:
-        # TODO -- test these
-        pass
+    def test_workflow_with_no_filters_is_cached(self) -> None:
+        workflow = self.create_workflow()
+
+        # First call - cache miss, queries DB
+        result = get_action_filters_by_workflows([workflow])
+        assert result[workflow.id] == []
+
+        # Second call - should be cache hit, no DB query
+        with patch(
+            "sentry.workflow_engine.caches.action_filters._get_action_filters_by_workflows"
+        ) as mock_query:
+            result = get_action_filters_by_workflows([workflow])
+            mock_query.assert_not_called()
+
+        assert result[workflow.id] == []

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from sentry.testutils.cases import TestCase
@@ -11,6 +12,24 @@ from sentry.workflow_engine.models import (
     DataConditionGroup,
     Workflow,
 )
+
+
+@contextmanager
+def mock_query_action_filters(return_value=None):
+    with patch(
+        "sentry.workflow_engine.caches.action_filters._query_action_filters_by_workflows",
+        return_value=return_value,
+    ) as mock_query:
+        yield mock_query
+
+
+@contextmanager
+def mock_check_action_filters_cache(return_value: _CacheResults = None):
+    with patch(
+        "sentry.workflow_engine.caches.action_filters._check_cache_by_workflows",
+        return_value=return_value,
+    ) as mock_cache:
+        yield mock_cache
 
 
 class TestActionFilterCache(TestCase):
@@ -46,17 +65,20 @@ class TestActionFilterCache(TestCase):
         expected_action_filters: list[DataConditionGroup],
     ) -> None:
         result_filters = results[workflow.id]
-        assert len(result_filters) == len(expected_action_filters)
 
-        for i in range(len(expected_action_filters)):
-            assert result_filters[i].id == expected_action_filters[i].id
+        for result_filter, expected_filter in zip(
+            result_filters, expected_action_filters, strict=True
+        ):
+            assert result_filter.id == expected_filter.id
 
             # check each condition is the same
-            result_conditions = result_filters[i].conditions.all()
-            expected_conditions = expected_action_filters[i].conditions.all()
+            result_conditions = result_filter.conditions.all()
+            expected_conditions = expected_filter.conditions.all()
 
-            for j in range(len(expected_conditions)):
-                assert result_conditions[j].id == expected_conditions[j].id
+            for result_cond, expected_cond in zip(
+                result_conditions, expected_conditions, strict=True
+            ):
+                assert result_cond.id == expected_cond.id
 
     def test_no_workflows_passed(self) -> None:
         result = get_action_filters_by_workflows([])
@@ -66,10 +88,7 @@ class TestActionFilterCache(TestCase):
         num_conditions = 2
         workflow, action_filters = self.create_workflow_with_filters(num_conditions=num_conditions)
 
-        with patch(
-            "sentry.workflow_engine.caches.action_filters._check_cache_by_workflows",
-            return_value=_CacheResults(cached={}, missed_ids=[workflow.id]),
-        ):
+        with mock_check_action_filters_cache(_CacheResults(cached={}, missed_ids=[workflow.id])):
             results = get_action_filters_by_workflows([workflow])
 
         self.assert_cache_result(results, workflow, action_filters)
@@ -80,9 +99,7 @@ class TestActionFilterCache(TestCase):
 
         _populate_cache({workflow.id: action_filters})
 
-        with patch(
-            "sentry.workflow_engine.caches.action_filters._get_action_filters_by_workflows"
-        ) as mock_query:
+        with mock_query_action_filters() as mock_query:
             results = get_action_filters_by_workflows([workflow])
             mock_query.assert_not_called()
 
@@ -92,9 +109,8 @@ class TestActionFilterCache(TestCase):
         workflow, action_filters = self.create_workflow_with_filters()
         workflow_two, action_filters_two = self.create_workflow_with_filters(num_filters=2)
 
-        with patch(
-            "sentry.workflow_engine.caches.action_filters._check_cache_by_workflows",
-            return_value=_CacheResults(cached={}, missed_ids=[workflow.id, workflow_two.id]),
+        with mock_check_action_filters_cache(
+            _CacheResults(cached={}, missed_ids=[workflow.id, workflow_two.id])
         ):
             results = get_action_filters_by_workflows([workflow, workflow_two])
 
@@ -112,9 +128,7 @@ class TestActionFilterCache(TestCase):
             }
         )
 
-        with patch(
-            "sentry.workflow_engine.caches.action_filters._get_action_filters_by_workflows"
-        ) as mock_query:
+        with mock_query_action_filters() as mock_query:
             results = get_action_filters_by_workflows([workflow, workflow_two])
             mock_query.assert_not_called()
 
@@ -146,10 +160,7 @@ class TestActionFilterCache(TestCase):
             }
         )
 
-        with patch(
-            "sentry.workflow_engine.caches.action_filters._get_action_filters_by_workflows",
-            return_value={workflow.id: action_filters},
-        ) as mock_query:
+        with mock_query_action_filters(return_value={workflow.id: action_filters}) as mock_query:
             results = get_action_filters_by_workflows([workflow, workflow_two])
             mock_query.assert_called_once_with([workflow.id])
 
@@ -164,9 +175,7 @@ class TestActionFilterCache(TestCase):
         assert result[workflow.id] == []
 
         # Second call - should be cache hit, no DB query
-        with patch(
-            "sentry.workflow_engine.caches.action_filters._get_action_filters_by_workflows"
-        ) as mock_query:
+        with mock_query_action_filters() as mock_query:
             result = get_action_filters_by_workflows([workflow])
             mock_query.assert_not_called()
 

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -1,0 +1,161 @@
+from unittest.mock import patch
+
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.caches.action_filters import (
+    ActionFiltersByWorkflow,
+    _CacheResults,
+    _populate_cache,
+    get_action_filters_by_workflows,
+)
+from sentry.workflow_engine.models import (
+    DataConditionGroup,
+    Workflow,
+)
+
+
+class TestActionFilterCache(TestCase):
+    def create_workflow_with_filters(
+        self, num_filters=1, num_conditions=1
+    ) -> tuple[
+        Workflow,
+        list[DataConditionGroup],
+    ]:
+        workflow = self.create_workflow()
+        action_filters: list[DataConditionGroup] = [
+            self.create_data_condition_group() for _ in range(num_filters)
+        ]
+
+        for action_filter in action_filters:
+            self.create_workflow_data_condition_group(
+                workflow=workflow, condition_group=action_filter
+            )
+
+            action_filter.conditions.set(
+                [
+                    self.create_data_condition(condition_group=action_filter)
+                    for _ in range(num_conditions)
+                ]
+            )
+
+        return workflow, action_filters
+
+    def assert_cache_result(
+        self,
+        results: ActionFiltersByWorkflow,
+        workflow: Workflow,
+        expected_action_filters: list[DataConditionGroup],
+    ) -> None:
+        result_filters = results[workflow.id]
+        assert len(result_filters) == len(expected_action_filters)
+
+        for i in range(len(expected_action_filters)):
+            assert result_filters[i].id == expected_action_filters[i].id
+
+            # check each condition is the same
+            result_conditions = result_filters[i].conditions.all()
+            expected_conditions = expected_action_filters[i].conditions.all()
+
+            for j in range(len(expected_conditions)):
+                assert result_conditions[j].id == expected_conditions[j].id
+
+    def test_no_workflows_passed(self) -> None:
+        result = get_action_filters_by_workflows([])
+        assert result == {}
+
+    def test_all_cache_miss__one_workflow(self) -> None:
+        num_conditions = 2
+        workflow, action_filters = self.create_workflow_with_filters(num_conditions=num_conditions)
+
+        with patch(
+            "sentry.workflow_engine.caches.action_filters._check_cache_by_workflows",
+            return_value=_CacheResults(cached={}, missed_ids=[workflow.id]),
+        ):
+            results = get_action_filters_by_workflows([workflow])
+
+        self.assert_cache_result(results, workflow, action_filters)
+
+    def test_all_cache_hits__one_workflow(self) -> None:
+        num_conditions = 2
+        workflow, action_filters = self.create_workflow_with_filters(num_conditions=num_conditions)
+
+        _populate_cache({workflow.id: action_filters})
+
+        with patch(
+            "sentry.workflow_engine.caches.action_filters._get_action_filters_by_workflows"
+        ) as mock_query:
+            results = get_action_filters_by_workflows([workflow])
+            mock_query.assert_not_called()
+
+        self.assert_cache_result(results, workflow, action_filters)
+
+    def test_all_cache_miss__many_workflows(self) -> None:
+        workflow, action_filters = self.create_workflow_with_filters()
+        workflow_two, action_filters_two = self.create_workflow_with_filters(num_filters=2)
+
+        with patch(
+            "sentry.workflow_engine.caches.action_filters._check_cache_by_workflows",
+            return_value=_CacheResults(cached={}, missed_ids=[workflow.id, workflow_two.id]),
+        ):
+            results = get_action_filters_by_workflows([workflow, workflow_two])
+
+        self.assert_cache_result(results, workflow, action_filters)
+        self.assert_cache_result(results, workflow_two, action_filters_two)
+
+    def test_all_cache_hits__many_workflows(self) -> None:
+        workflow, action_filters = self.create_workflow_with_filters()
+        workflow_two, action_filters_two = self.create_workflow_with_filters(num_filters=2)
+
+        _populate_cache(
+            {
+                workflow.id: action_filters,
+                workflow_two.id: action_filters_two,
+            }
+        )
+
+        with patch(
+            "sentry.workflow_engine.caches.action_filters._get_action_filters_by_workflows"
+        ) as mock_query:
+            results = get_action_filters_by_workflows([workflow, workflow_two])
+            mock_query.assert_not_called()
+
+        self.assert_cache_result(results, workflow, action_filters)
+        self.assert_cache_result(results, workflow_two, action_filters_two)
+
+    def test_mixed_cache_hits(self) -> None:
+        workflow, action_filters = self.create_workflow_with_filters()
+        workflow_two, action_filters_two = self.create_workflow_with_filters(num_filters=2)
+
+        _populate_cache(
+            {
+                workflow_two.id: action_filters_two,
+            }
+        )
+
+        results = get_action_filters_by_workflows([workflow, workflow_two])
+
+        self.assert_cache_result(results, workflow, action_filters)
+        self.assert_cache_result(results, workflow_two, action_filters_two)
+
+    def test_mixed_cache_hits__filters_query(self) -> None:
+        workflow, action_filters = self.create_workflow_with_filters()
+        workflow_two, action_filters_two = self.create_workflow_with_filters(num_filters=2)
+
+        _populate_cache(
+            {
+                workflow_two.id: action_filters_two,
+            }
+        )
+
+        with patch(
+            "sentry.workflow_engine.caches.action_filters._get_action_filters_by_workflows",
+            return_value={workflow.id: action_filters},
+        ) as mock_query:
+            results = get_action_filters_by_workflows([workflow, workflow_two])
+            mock_query.assert_called_once_with([workflow.id])
+
+        self.assert_cache_result(results, workflow, action_filters)
+        self.assert_cache_result(results, workflow_two, action_filters_two)
+
+    def test_cache_metrics(self) -> None:
+        # TODO -- test these
+        pass

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -16,7 +16,9 @@ from sentry.workflow_engine.models import (
 
 
 @contextmanager
-def mock_query_action_filters(return_value: ActionFiltersByWorkflow = None) -> Generator[MagicMock]:
+def mock_query_action_filters(
+    return_value: ActionFiltersByWorkflow | None = None,
+) -> Generator[MagicMock]:
     with patch(
         "sentry.workflow_engine.caches.action_filters._query_action_filters_by_workflows",
         return_value=return_value,
@@ -25,7 +27,9 @@ def mock_query_action_filters(return_value: ActionFiltersByWorkflow = None) -> G
 
 
 @contextmanager
-def mock_check_action_filters_cache(return_value: _CacheResults = None) -> Generator[MagicMock]:
+def mock_check_action_filters_cache(
+    return_value: _CacheResults | None = None,
+) -> Generator[MagicMock]:
     with patch(
         "sentry.workflow_engine.caches.action_filters._check_cache_by_workflows",
         return_value=return_value,

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -15,7 +15,7 @@ from sentry.workflow_engine.models import (
 
 class TestActionFilterCache(TestCase):
     def create_workflow_with_filters(
-        self, num_filters=1, num_conditions=1
+        self, num_filters: int = 1, num_conditions: int = 1
     ) -> tuple[
         Workflow,
         list[DataConditionGroup],


### PR DESCRIPTION
# Description
Creates the base cache we can use for the action filters. We'll eventually use this in `evaluate_workflow_action_filters` in `processors/workflow.py`

[Query Impact](https://app.datadoghq.com/databases/queries?query=query_signature%3Af038f4781293cc65&dbPanels=[{%22t%22%3A%22dbQueryPanel%22%2C%22qs%22%3A%22f038f4781293cc65%22%2C%22dbType%22%3A%22PostgreSQL%22}]&dbType=PostgreSQL&fromUser=false&start=1772694406753&end=1773299206753&paused=false)

The cache TTL is 5 minutes, this should help account for delayed condition processing as well as higher volume fast conditions.

The cache invalidation code will be added separately, as it will need to invalidate on a number of different models in an number of different ways, and isolating those changes seemed like a way to make these easier to review. (same with adding the usage / rollout flags)