### PR TITLE
fix(agents): Add error boundary around ModelsTable

### DIFF
--- a/static/app/views/insights/agentModels/views/modelsLandingPage.tsx
+++ b/static/app/views/insights/agentModels/views/modelsLandingPage.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 
+import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
@@ -103,7 +104,9 @@ function AgentModelsLandingPage({datePageFilterProps}: AgentModelsLandingPagePro
                         <TokenTypesWidget />
                       </WidgetGrid.Position3>
                     </WidgetGrid>
-                    <ModelsTable />
+                    <ErrorBoundary mini>
+                      <ModelsTable />
+                    </ErrorBoundary>
                   </Fragment>
                 )}
               </ModuleLayout.Full>


### PR DESCRIPTION
Wrap `ModelsTable` with `<ErrorBoundary mini>` on the agent models landing page so that rendering errors (e.g. null `modelId` hitting `.toLowerCase()`) are contained within the table instead of crashing the entire page.

This follows the existing pattern of wrapping table consumers at the call site. The widget footer error boundary was added in #110506 but `ModelsTable` (a standalone `GridEditable` table) was unprotected.

Refs #110505