### PR TITLE
feat(dashboards): Add prototype Seer-assisted dashboard creation flow

### DIFF
--- a/src/sentry/seer/dashboards/dashboard_validation_tool.py
+++ b/src/sentry/seer/dashboards/dashboard_validation_tool.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, validator
+
+from sentry.models.organization import Organization
+from sentry.seer.explorer.custom_tool_utils import ExplorerTool
+
+GRID_WIDTH = 6
+
+
+class DashboardWidgetQuery(BaseModel):
+    name: str = Field(default="", description="Display name for this query series")
+    aggregates: list[str] = Field(
+        default_factory=list, description="Aggregate functions, e.g. ['count()', 'p95(duration)']"
+    )
+    columns: list[str] = Field(
+        default_factory=list, description="Group-by columns, e.g. ['transaction', 'project']"
+    )
+    conditions: str = Field(
+        default="", description="Filter conditions in Sentry query syntax, e.g. 'is:unresolved'"
+    )
+    orderby: str = Field(default="", description="Order-by field, e.g. '-count()' for descending")
+    fields: list[str] = Field(
+        description="Combined fields list (aggregates + columns), e.g. ['count()', 'transaction']"
+    )
+
+    @validator("fields", always=True)
+    def populate_fields(cls, v: list[str], values: dict) -> list[str]:
+        return [*values.get("columns", []), *values.get("aggregates", [])]
+
+
+class DashboardWidgetLayout(BaseModel):
+    x: int = Field(
+        default=0,
+        description=f"Column position (0-{GRID_WIDTH - 1}). x + w must not exceed {GRID_WIDTH}.",
+    )
+    y: int = Field(default=0, description="Row position (0+).")
+    w: int = Field(
+        default=GRID_WIDTH,
+        description=f"Width in columns (1-{GRID_WIDTH}). x + w must not exceed {GRID_WIDTH}.",
+    )
+    h: int = Field(
+        default=2, description="Height in rows (1+). A height of 2 is approximately 256px."
+    )
+    min_h: int = Field(default=2, description="Minimum height in rows (1+).")
+
+    @validator("x", pre=True, always=True)
+    def clamp_x(cls, v: int) -> int:
+        return max(0, min(v, GRID_WIDTH - 1))
+
+    @validator("w", pre=True, always=True)
+    def clamp_w(cls, v: int) -> int:
+        return max(1, min(v, GRID_WIDTH))
+
+    @validator("h", pre=True, always=True)
+    def clamp_h(cls, v: int) -> int:
+        return max(1, v)
+
+    @validator("min_h", pre=True, always=True)
+    def clamp_min_h(cls, v: int) -> int:
+        return max(1, v)
+
+    @validator("w", always=True)
+    def fit_within_grid(cls, w: int, values: dict) -> int:
+        x = values.get("x", 0)
+        if x + w > GRID_WIDTH:
+            return GRID_WIDTH - x
+        return w
+
+
+class DashboardWidget(BaseModel):
+    title: str = Field(description="Widget title")
+    description: str = Field(description="A description of the widget")
+    display_type: Literal["line", "area", "stacked_area", "bar", "table", "big_number"] = Field(
+        description="Chart type for the widget"
+    )
+    widget_type: Literal[
+        "issue",
+        "error-events",
+        "spans",
+        "logs",
+        "tracemetrics",
+    ] = Field(description="Data source type for the widget")
+    queries: list[DashboardWidgetQuery] = Field(
+        description="One or more queries providing data for this widget"
+    )
+    layout: DashboardWidgetLayout | None = None
+
+
+class DashboardParams(BaseModel):
+    title: str
+    widgets: list[DashboardWidget]
+
+
+class DashboardValidationTool(ExplorerTool[DashboardParams]):
+    """Custom tool that validates a dashboard configuration before it is emitted."""
+
+    params_model = DashboardParams
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Use this tool when creating a dashboard to validate the JSON, and present it to the user."
+            "Returns 'valid' or a list of errors to fix."
+            "Attempt to fix the errors and call this tool again."
+            "Do not respond to the user, the dashboard will be rendered automatically"
+        )
+
+    @classmethod
+    def execute(cls, organization: Organization, params: DashboardParams) -> str:
+        return "valid"
+        # from types import SimpleNamespace
+
+        # from django.contrib.auth.models import AnonymousUser
+
+        # from sentry.api.serializers.rest_framework.dashboard import DashboardDetailsSerializer
+
+        # context = {
+        #     "organization": organization,
+        #     "projects": [],
+        #     "environment": [],
+        #     "request": SimpleNamespace(user=AnonymousUser()),
+        # }
+
+        # serializer = DashboardDetailsSerializer(data=params.dict(), context=context)
+        # if serializer.is_valid():
+        #     return "valid"
+
+        # errors: list[str] = []
+        # for field, field_errors in serializer.errors.items():
+        #     if isinstance(field_errors, list):
+        #         for err in field_errors:
+        #             errors.append(f"{field}: {err}")
+        #     else:
+        #         errors.append(f"{field}: {field_errors}")
+
+        # return "Invalid dashboard:\n" + "\n".join(f"- {e}" for e in errors)

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -13,6 +13,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
+from sentry.seer.dashboards.dashboard_validation_tool import DashboardValidationTool
 from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.explorer.client_utils import has_seer_explorer_access_with_detail
 from sentry.seer.models import SeerPermissionError
@@ -128,6 +129,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
                 request.user,
                 is_interactive=True,
                 enable_coding=enable_coding,
+                custom_tools=[DashboardValidationTool],
             )
             if run_id:
                 # Continue existing conversation

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1364,6 +1364,11 @@ function buildRoutes(): RouteObject[] {
       ],
     },
     {
+      path: '/dashboards/new/seer/',
+      component: make(() => import('sentry/views/dashboards/createWithSeer')),
+      withOrgPath: true,
+    },
+    {
       path: '/dashboards/new/',
       component: make(() => import('sentry/views/dashboards/create')),
       withOrgPath: true,

--- a/static/app/views/dashboards/createWithSeer.tsx
+++ b/static/app/views/dashboards/createWithSeer.tsx
@@ -1,0 +1,154 @@
+import {useEffect, useMemo, useRef, useState} from 'react';
+
+import {Alert} from '@sentry/scraps/alert';
+
+import Feature from 'sentry/components/acl/feature';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
+import {uniqueId} from 'sentry/utils/guid';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
+import {openSeerExplorer} from 'sentry/views/seerExplorer/openSeerExplorer';
+import type {Block} from 'sentry/views/seerExplorer/types';
+import {makeSeerExplorerQueryKey} from 'sentry/views/seerExplorer/utils';
+
+import {EMPTY_DASHBOARD} from './data';
+import DashboardDetail from './detail';
+import type {DashboardDetails, Widget, WidgetLayout} from './types';
+import {DashboardState} from './types';
+import {cloneDashboard} from './utils';
+
+// Sent as the opening message to orient the agent toward dashboard creation.
+const SEER_SYSTEM_PROMPT = 'Help me build a Sentry dashboard.';
+
+interface DashboardToolCallParams {
+  title: string;
+  widgets: Array<{
+    description: string;
+    display_type: Widget['displayType'];
+    layout: WidgetLayout;
+    queries: Widget['queries'];
+    title: string;
+    widget_type: Widget['widgetType'];
+  }>;
+}
+
+function getLatestDashboardToolCall(blocks: Block[]): DashboardToolCallParams | null {
+  let latest: DashboardToolCallParams | null = null;
+
+  for (const block of blocks) {
+    for (const call of block.message.tool_calls ?? []) {
+      if (call.function === 'DashboardValidationTool') {
+        try {
+          latest = JSON.parse(call.args);
+        } catch {
+          // ignore malformed args
+        }
+      }
+    }
+  }
+
+  return latest;
+}
+
+function toolCallToDashboard(params: DashboardToolCallParams): DashboardDetails {
+  const base = cloneDashboard(EMPTY_DASHBOARD);
+  return {
+    ...base,
+    title: params.title,
+    widgets: (params.widgets ?? []).map(w => ({
+      tempId: uniqueId(),
+      title: w.title,
+      displayType: w.display_type,
+      widgetType: w.widget_type,
+      layout: w.layout,
+      queries: (w.queries ?? []).map(q => ({
+        name: q.name ?? '',
+        aggregates: q.aggregates ?? [],
+        columns: q.columns ?? [],
+        conditions: q.conditions ?? '',
+        orderby: q.orderby ?? '',
+        fields: q.fields ?? [...(q.aggregates ?? []), ...(q.columns ?? [])],
+      })),
+    })) as Widget[],
+  };
+}
+
+export default function CreateWithSeer() {
+  const organization = useOrganization();
+  const [runId, setRunId] = useState<number | null>(null);
+
+  useEffect(() => {
+    openSeerExplorer({
+      startNewRun: true,
+      initialMessage: SEER_SYSTEM_PROMPT,
+      onRunCreated: setRunId,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally run once on mount
+
+  const {data} = useApiQuery<SeerExplorerResponse>(
+    makeSeerExplorerQueryKey(organization.slug, runId),
+    {
+      staleTime: 0,
+      enabled: !!runId,
+      refetchInterval: 500,
+    }
+  );
+
+  const dashboardParams = useMemo(() => {
+    const blocks = data?.session?.blocks ?? [];
+    return getLatestDashboardToolCall(blocks);
+  }, [data]);
+
+  // Bump a version counter whenever the tool call params change to remount DashboardDetail
+  // with fresh props. The class component doesn't sync modifiedDashboard from props,
+  // so remounting is the cleanest way to reflect each iteration from the agent.
+  const prevParamsRef = useRef(dashboardParams);
+  const [dashboardVersion, setDashboardVersion] = useState(0);
+  useEffect(() => {
+    if (dashboardParams !== prevParamsRef.current) {
+      prevParamsRef.current = dashboardParams;
+      setDashboardVersion(v => v + 1);
+    }
+  }, [dashboardParams]);
+
+  const dashboard = useMemo(
+    () =>
+      dashboardParams
+        ? toolCallToDashboard(dashboardParams)
+        : cloneDashboard(EMPTY_DASHBOARD),
+    [dashboardParams]
+  );
+
+  function renderDisabled() {
+    return (
+      <Layout.Page withPadding>
+        <Alert.Container>
+          <Alert variant="warning" showIcon={false}>
+            {t("You don't have access to this feature")}
+          </Alert>
+        </Alert.Container>
+      </Layout.Page>
+    );
+  }
+
+  return (
+    <Feature
+      features="dashboards-edit"
+      organization={organization}
+      renderDisabled={renderDisabled}
+    >
+      <ErrorBoundary>
+        <DashboardDetail
+          key={dashboardVersion}
+          initialState={DashboardState.CREATE}
+          dashboard={dashboard}
+          dashboards={[]}
+        />
+      </ErrorBoundary>
+    </Feature>
+  );
+}

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -54,6 +54,7 @@ import type {DashboardsLayout} from 'sentry/views/dashboards/manage/types';
 import type {DashboardDetails, DashboardListItem} from 'sentry/views/dashboards/types';
 import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import RouteError from 'sentry/views/routeError';
+import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
 
 import DashboardGrid from './dashboardGrid';
 import {
@@ -586,6 +587,24 @@ function ManageDashboards() {
                         />
                       </TemplateSwitch>
                       <FeedbackButton />
+                      {isSeerExplorerEnabled(organization) && (
+                        <Button
+                          data-test-id="dashboard-create-with-seer"
+                          onClick={event => {
+                            event.preventDefault();
+                            navigate(
+                              normalizeUrl({
+                                pathname: `/organizations/${organization.slug}/dashboards/new/seer/`,
+                                query: location.query,
+                              })
+                            );
+                          }}
+                          size="sm"
+                          icon={<IconAdd />}
+                        >
+                          {t('Create with Seer')}
+                        </Button>
+                      )}
                       <DashboardCreateLimitWrapper>
                         {({
                           hasReachedDashboardLimit,


### PR DESCRIPTION
Adds a DashboardValidationTool that the Seer Explorer agent calls to produce structured dashboard JSON, registers it on the explorer chat endpoint, and introduces a new /dashboards/new/seer/ route that opens the Seer panel and live-renders the dashboard as the agent iterates. A "Create with Seer" button is shown on the manage page when seer explorer is enabled for the org.
