### PR TITLE
chore(explore): Remove duplicate number attributes that exist as boolean tags

### DIFF
--- a/static/app/views/explore/contexts/traceItemAttributeContext.spec.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.spec.tsx
@@ -1,0 +1,286 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/components/pageFilters/store';
+import {
+  extractBaseKey,
+  shouldRemoveAttributeKey,
+  useTraceItemAttributes,
+} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+describe('extractBaseKey', () => {
+  it('returns plain key as-is', () => {
+    expect(extractBaseKey('is_transaction')).toBe('is_transaction');
+  });
+
+  it('extracts base key from tags[key,boolean] format', () => {
+    expect(extractBaseKey('tags[is_transaction,boolean]')).toBe('is_transaction');
+  });
+
+  it('extracts base key from tags[key,number] format', () => {
+    expect(extractBaseKey('tags[is_transaction,number]')).toBe('is_transaction');
+  });
+
+  it('extracts base key from tags[key,string] format', () => {
+    expect(extractBaseKey('tags[my_tag,string]')).toBe('my_tag');
+  });
+
+  it('returns key with dots as-is', () => {
+    expect(extractBaseKey('span.duration')).toBe('span.duration');
+  });
+});
+
+describe('shouldRemoveNumberKey', () => {
+  it('returns true when plain number key has a boolean counterpart', () => {
+    const booleanBaseKeys = new Set(['is_transaction']);
+    expect(shouldRemoveAttributeKey('is_transaction', booleanBaseKeys)).toBe(true);
+  });
+
+  it('returns true when tags[key,number] has a boolean counterpart', () => {
+    const booleanBaseKeys = new Set(['is_transaction']);
+    expect(shouldRemoveAttributeKey('tags[is_transaction,number]', booleanBaseKeys)).toBe(
+      true
+    );
+  });
+
+  it('returns false when number key has no boolean counterpart', () => {
+    const booleanBaseKeys = new Set(['is_transaction']);
+    expect(shouldRemoveAttributeKey('span.duration', booleanBaseKeys)).toBe(false);
+  });
+
+  it('returns false for empty boolean set', () => {
+    const booleanBaseKeys = new Set<string>();
+    expect(shouldRemoveAttributeKey('is_transaction', booleanBaseKeys)).toBe(false);
+  });
+});
+
+function addAttributeMock(
+  attributeType: string,
+  body: Array<{key: string; name: string; secondaryAliases?: string[]}>
+) {
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/trace-items/attributes/',
+    body,
+    match: [
+      (_url, options) => {
+        const query = options?.query || {};
+        return query.attributeType === attributeType;
+      },
+    ],
+  });
+}
+
+describe('useTraceItemAttributes number filtering', () => {
+  beforeEach(() => {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('does not filter number attributes when flag is off', async () => {
+    const organization = OrganizationFixture({features: []});
+    addAttributeMock('number', [{key: 'is_transaction', name: 'is_transaction'}]);
+    addAttributeMock('string', []);
+    addAttributeMock('boolean', []);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceItemAttributes(
+          {
+            traceItemType: TraceItemDataset.SPANS,
+            enabled: true,
+          },
+          'number'
+        ),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // is_transaction should still be present as a number attribute
+    expect('is_transaction' in result.current.attributes).toBe(true);
+  });
+
+  it('filters out number attributes that overlap with boolean attributes when flag is on', async () => {
+    const organization = OrganizationFixture({
+      features: ['search-query-builder-explicit-boolean-filters'],
+    });
+
+    addAttributeMock('number', [
+      {key: 'is_transaction', name: 'is_transaction'},
+      {key: 'custom_metric', name: 'custom_metric'},
+    ]);
+    addAttributeMock('string', []);
+    addAttributeMock('boolean', [{key: 'is_transaction', name: 'is_transaction'}]);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceItemAttributes(
+          {
+            traceItemType: TraceItemDataset.SPANS,
+            enabled: true,
+          },
+          'number'
+        ),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect('is_transaction' in result.current.attributes).toBe(false);
+    expect('custom_metric' in result.current.attributes).toBe(true);
+  });
+
+  it('filters number attributes that overlap with default boolean attributes', async () => {
+    const organization = OrganizationFixture({
+      features: ['search-query-builder-explicit-boolean-filters'],
+    });
+
+    addAttributeMock('number', [
+      {key: 'is_transaction', name: 'is_transaction'},
+      {key: 'custom_metric', name: 'custom_metric'},
+    ]);
+    addAttributeMock('string', []);
+    addAttributeMock('boolean', []);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceItemAttributes(
+          {
+            traceItemType: TraceItemDataset.SPANS,
+            enabled: true,
+          },
+          'number'
+        ),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect('is_transaction' in result.current.attributes).toBe(false);
+    expect('custom_metric' in result.current.attributes).toBe(true);
+  });
+
+  it('filters tags[key,number] format when boolean version exists', async () => {
+    const organization = OrganizationFixture({
+      features: ['search-query-builder-explicit-boolean-filters'],
+    });
+
+    addAttributeMock('number', [
+      {key: 'tags[is_transaction,number]', name: 'tags[is_transaction,number]'},
+      {key: 'custom_metric', name: 'custom_metric'},
+    ]);
+    addAttributeMock('string', []);
+    addAttributeMock('boolean', [
+      {key: 'tags[is_transaction,boolean]', name: 'tags[is_transaction,boolean]'},
+    ]);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceItemAttributes(
+          {
+            traceItemType: TraceItemDataset.SPANS,
+            enabled: true,
+          },
+          'number'
+        ),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect('tags[is_transaction,number]' in result.current.attributes).toBe(false);
+    expect('custom_metric' in result.current.attributes).toBe(true);
+  });
+
+  it('filters overlapping number secondary aliases when boolean version exists', async () => {
+    const organization = OrganizationFixture({
+      features: ['search-query-builder-explicit-boolean-filters'],
+    });
+
+    addAttributeMock('number', [
+      {
+        key: 'custom_metric',
+        name: 'custom_metric',
+        secondaryAliases: ['tags[is_transaction,number]', 'tags[custom_metric,number]'],
+      },
+    ]);
+    addAttributeMock('string', []);
+    addAttributeMock('boolean', [
+      {key: 'tags[is_transaction,boolean]', name: 'tags[is_transaction,boolean]'},
+    ]);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceItemAttributes(
+          {
+            traceItemType: TraceItemDataset.SPANS,
+            enabled: true,
+          },
+          'number'
+        ),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect('tags[is_transaction,number]' in result.current.secondaryAliases).toBe(false);
+    expect('tags[custom_metric,number]' in result.current.secondaryAliases).toBe(true);
+  });
+
+  it('preserves non-overlapping number attributes', async () => {
+    const organization = OrganizationFixture({
+      features: ['search-query-builder-explicit-boolean-filters'],
+    });
+
+    addAttributeMock('number', [
+      {key: 'custom_metric', name: 'custom_metric'},
+      {key: 'another_metric', name: 'another_metric'},
+    ]);
+    addAttributeMock('string', []);
+    addAttributeMock('boolean', [{key: 'is_transaction', name: 'is_transaction'}]);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceItemAttributes(
+          {
+            traceItemType: TraceItemDataset.SPANS,
+            enabled: true,
+          },
+          'number'
+        ),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect('custom_metric' in result.current.attributes).toBe(true);
+    expect('another_metric' in result.current.attributes).toBe(true);
+  });
+});

--- a/static/app/views/explore/contexts/traceItemAttributeContext.spec.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.spec.tsx
@@ -11,48 +11,41 @@ import {
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 describe('extractBaseKey', () => {
-  it('returns plain key as-is', () => {
-    expect(extractBaseKey('is_transaction')).toBe('is_transaction');
-  });
+  const testCases = [
+    {input: 'is_transaction', expected: 'is_transaction'},
+    {input: 'tags[is_transaction,boolean]', expected: 'is_transaction'},
+    {input: 'tags[is_transaction,number]', expected: 'is_transaction'},
+    {input: 'tags[my_tag,string]', expected: 'my_tag'},
+    {input: 'span.duration', expected: 'span.duration'},
+    {input: 'tags[my.tag.name,boolean]', expected: 'my.tag.name'},
+    {input: 'tags[my-tag,number]', expected: 'my-tag'},
+    {input: 'tags[my:tag,string]', expected: 'my:tag'},
+  ];
 
-  it('extracts base key from tags[key,boolean] format', () => {
-    expect(extractBaseKey('tags[is_transaction,boolean]')).toBe('is_transaction');
-  });
-
-  it('extracts base key from tags[key,number] format', () => {
-    expect(extractBaseKey('tags[is_transaction,number]')).toBe('is_transaction');
-  });
-
-  it('extracts base key from tags[key,string] format', () => {
-    expect(extractBaseKey('tags[my_tag,string]')).toBe('my_tag');
-  });
-
-  it('returns key with dots as-is', () => {
-    expect(extractBaseKey('span.duration')).toBe('span.duration');
+  testCases.forEach(({input, expected}) => {
+    it(`returns ${expected} for ${input}`, () => {
+      expect(extractBaseKey(input)).toBe(expected);
+    });
   });
 });
 
 describe('shouldRemoveNumberKey', () => {
-  it('returns true when plain number key has a boolean counterpart', () => {
-    const booleanBaseKeys = new Set(['is_transaction']);
-    expect(shouldRemoveAttributeKey('is_transaction', booleanBaseKeys)).toBe(true);
-  });
+  const testCases = [
+    {input: 'is_transaction', booleanBaseKeys: ['is_transaction'], expected: true},
+    {
+      input: 'tags[is_transaction,number]',
+      booleanBaseKeys: ['is_transaction'],
+      expected: true,
+    },
+    {input: 'span.duration', booleanBaseKeys: ['is_transaction'], expected: false},
+    {input: 'tags[my-tag,number]', booleanBaseKeys: ['is_transaction'], expected: false},
+    {input: 'tags[my:tag,string]', booleanBaseKeys: ['is_transaction'], expected: false},
+  ];
 
-  it('returns true when tags[key,number] has a boolean counterpart', () => {
-    const booleanBaseKeys = new Set(['is_transaction']);
-    expect(shouldRemoveAttributeKey('tags[is_transaction,number]', booleanBaseKeys)).toBe(
-      true
-    );
-  });
-
-  it('returns false when number key has no boolean counterpart', () => {
-    const booleanBaseKeys = new Set(['is_transaction']);
-    expect(shouldRemoveAttributeKey('span.duration', booleanBaseKeys)).toBe(false);
-  });
-
-  it('returns false for empty boolean set', () => {
-    const booleanBaseKeys = new Set<string>();
-    expect(shouldRemoveAttributeKey('is_transaction', booleanBaseKeys)).toBe(false);
+  testCases.forEach(({input, booleanBaseKeys, expected}) => {
+    it(`returns ${expected} for ${input}`, () => {
+      expect(shouldRemoveAttributeKey(input, new Set(booleanBaseKeys))).toBe(expected);
+    });
   });
 });
 

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -349,31 +349,19 @@ export function usePreprodItemAttributes(
   );
 }
 
+const TAGS_REGEX = /^tags\[(?<tagKey>\w+),(?<attributeType>boolean|number|string)\]$/;
+
 /**
  * Extracts the base key from a tag key, handling both plain keys and
  * explicit format like `tags[key,type]`.
  */
 export function extractBaseKey(key: string): string {
-  if (!key.startsWith('tags[') || !key.endsWith(']')) {
+  const match = TAGS_REGEX.exec(key);
+  if (!match?.groups) {
     return key;
   }
 
-  const inner = key.slice(5, -1);
-  const typeSeparatorIndex = inner.lastIndexOf(',');
-  if (typeSeparatorIndex === -1) {
-    return key;
-  }
-
-  const attributeType = inner.slice(typeSeparatorIndex + 1).trim();
-  if (
-    attributeType !== 'boolean' &&
-    attributeType !== 'number' &&
-    attributeType !== 'string'
-  ) {
-    return key;
-  }
-
-  return inner.slice(0, typeSeparatorIndex);
+  return match.groups.tagKey;
 }
 
 /**

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -349,7 +349,8 @@ export function usePreprodItemAttributes(
   );
 }
 
-const TAGS_REGEX = /^tags\[(?<tagKey>\w+),(?<attributeType>boolean|number|string)\]$/;
+const TAGS_REGEX =
+  /^tags\[(?<tagKey>[a-zA-Z0-9_.:-]+),(?<attributeType>boolean|number|string)\]$/;
 
 /**
  * Extracts the base key from a tag key, handling both plain keys and
@@ -361,7 +362,7 @@ export function extractBaseKey(key: string): string {
     return key;
   }
 
-  return match.groups.tagKey;
+  return match.groups.tagKey ?? key;
 }
 
 /**

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -49,6 +49,8 @@ type TraceItemAttributeResult = {
   secondaryAliases: TagCollection;
 };
 
+const EMPTY_STRING_SET = new Set<string>();
+
 export type TraceItemAttributeConfig = {
   enabled: boolean;
   traceItemType: TraceItemDataset;
@@ -114,23 +116,56 @@ function useTraceItemAttributeConfig({
       query,
     });
 
+  const booleanBaseKeys = useMemo(() => {
+    if (!hasBooleanFilters) {
+      return EMPTY_STRING_SET;
+    }
+
+    const keys = new Set(getDefaultBooleanAttributes(traceItemType));
+    for (const key of Object.keys(booleanAttributes ?? {})) {
+      keys.add(extractBaseKey(key));
+    }
+
+    return keys;
+  }, [booleanAttributes, hasBooleanFilters, traceItemType]);
+
   const allNumberAttributes = useMemo(() => {
-    const measurements = getDefaultNumberAttributes(traceItemType).map(measurement => [
-      measurement,
-      {key: measurement, name: measurement, kind: FieldKind.MEASUREMENT},
-    ]);
+    const shouldRemove = hasBooleanFilters && booleanBaseKeys.size > 0;
+    const attributes: TagCollection = {};
+    const secondaryAliases: TagCollection = {};
 
-    const secondaryAliases: TagCollection = Object.fromEntries(
-      Object.values(numberAttributes ?? {})
-        .flatMap(value => value.secondaryAliases ?? [])
-        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.MEASUREMENT}])
-    );
+    for (const measurement of getDefaultNumberAttributes(traceItemType)) {
+      if (shouldRemove && shouldRemoveAttributeKey(measurement, booleanBaseKeys)) {
+        continue;
+      }
 
-    return {
-      attributes: {...numberAttributes, ...Object.fromEntries(measurements)},
-      secondaryAliases,
-    };
-  }, [numberAttributes, traceItemType]);
+      attributes[measurement] = {
+        key: measurement,
+        name: measurement,
+        kind: FieldKind.MEASUREMENT,
+      };
+    }
+
+    for (const [key, value] of Object.entries(numberAttributes ?? {})) {
+      if (!shouldRemove || !shouldRemoveAttributeKey(key, booleanBaseKeys)) {
+        attributes[key] = value;
+      }
+
+      for (const alias of value.secondaryAliases ?? []) {
+        if (shouldRemove && shouldRemoveAttributeKey(alias, booleanBaseKeys)) {
+          continue;
+        }
+
+        secondaryAliases[alias] = {
+          key: alias,
+          name: alias,
+          kind: FieldKind.MEASUREMENT,
+        };
+      }
+    }
+
+    return {attributes, secondaryAliases};
+  }, [numberAttributes, traceItemType, booleanBaseKeys, hasBooleanFilters]);
 
   const allStringAttributes = useMemo(() => {
     const tags = getDefaultStringAttributes(traceItemType).map(tag => [
@@ -312,6 +347,44 @@ export function usePreprodItemAttributes(
     type,
     hiddenKeys
   );
+}
+
+/**
+ * Extracts the base key from a tag key, handling both plain keys and
+ * explicit format like `tags[key,type]`.
+ */
+export function extractBaseKey(key: string): string {
+  if (!key.startsWith('tags[') || !key.endsWith(']')) {
+    return key;
+  }
+
+  const inner = key.slice(5, -1);
+  const typeSeparatorIndex = inner.lastIndexOf(',');
+  if (typeSeparatorIndex === -1) {
+    return key;
+  }
+
+  const attributeType = inner.slice(typeSeparatorIndex + 1).trim();
+  if (
+    attributeType !== 'boolean' &&
+    attributeType !== 'number' &&
+    attributeType !== 'string'
+  ) {
+    return key;
+  }
+
+  return inner.slice(0, typeSeparatorIndex);
+}
+
+/**
+ * Returns true if an attribute key should be removed because an attribute with the same
+ * base key exists.
+ */
+export function shouldRemoveAttributeKey(
+  key: string,
+  booleanBaseKeys: Set<string>
+): boolean {
+  return booleanBaseKeys.has(extractBaseKey(key));
 }
 
 function getDefaultStringAttributes(itemType: TraceItemDataset) {

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -134,18 +134,6 @@ function useTraceItemAttributeConfig({
     const attributes: TagCollection = {};
     const secondaryAliases: TagCollection = {};
 
-    for (const measurement of getDefaultNumberAttributes(traceItemType)) {
-      if (shouldRemove && shouldRemoveAttributeKey(measurement, booleanBaseKeys)) {
-        continue;
-      }
-
-      attributes[measurement] = {
-        key: measurement,
-        name: measurement,
-        kind: FieldKind.MEASUREMENT,
-      };
-    }
-
     for (const [key, value] of Object.entries(numberAttributes ?? {})) {
       if (!shouldRemove || !shouldRemoveAttributeKey(key, booleanBaseKeys)) {
         attributes[key] = value;
@@ -162,6 +150,18 @@ function useTraceItemAttributeConfig({
           kind: FieldKind.MEASUREMENT,
         };
       }
+    }
+
+    for (const measurement of getDefaultNumberAttributes(traceItemType)) {
+      if (shouldRemove && shouldRemoveAttributeKey(measurement, booleanBaseKeys)) {
+        continue;
+      }
+
+      attributes[measurement] = {
+        key: measurement,
+        name: measurement,
+        kind: FieldKind.MEASUREMENT,
+      };
     }
 
     return {attributes, secondaryAliases};


### PR DESCRIPTION
Some attributes (like `is_transaction`) exist as both boolean tags and number attributes. This causes duplicates to appear in the explore attribute list.

This filters out number attributes when a boolean tag with the same base key exists. It extracts base keys from the explicit `tags[key,type]` format to detect overlaps, then removes the number variant.

Also adds tests for `extractBaseKey`, `shouldRemoveAttributeKey`, and the `useTraceItemAttributes` hook covering deduplication behavior.

Refs EXP-832