### PR TITLE
chore(webhooks): Include tags by default

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -431,9 +431,7 @@ def _record_delivery_time_metrics(payload: WebhookPayload) -> None:
         if payload.destination_type == DestinationType.SENTRY_REGION
         else "codecov"
     )
-    tags = {"region_sent_to": region_sent_to}
-    if options.get("hybridcloud.deliver_webhooks.delivery_time_include_github_tags"):
-        tags |= _get_github_delivery_time_tags(payload)
+    tags = {"region_sent_to": region_sent_to} | _get_github_delivery_time_tags(payload)
     metrics.distribution(
         "hybridcloud.deliver_webhooks.delivery_time_ms",
         # e.g. 0.123 seconds → 123 milliseconds

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2492,11 +2492,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "hybridcloud.deliver_webhooks.delivery_time_include_github_tags",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "hybridcloud.webhookpayload.skip_on_failure_providers",
     type=Sequence,
     default=["github"],

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1099,7 +1099,6 @@ class DeliveryTimeMetricsTest(TestCase):
 
     @responses.activate
     @override_regions(region_config)
-    @override_options({"hybridcloud.deliver_webhooks.delivery_time_include_github_tags": True})
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_delivery_time_metrics_github_event_and_action(self, mock_metrics: MagicMock) -> None:
         responses.add(
@@ -1132,7 +1131,6 @@ class DeliveryTimeMetricsTest(TestCase):
 
     @responses.activate
     @override_regions(region_config)
-    @override_options({"hybridcloud.deliver_webhooks.delivery_time_include_github_tags": True})
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_delivery_time_metrics_github_event_only(self, mock_metrics: MagicMock) -> None:
         responses.add(


### PR DESCRIPTION
The logic for including GitHub tags has been integrated directly into the `_record_delivery_time_metrics` function, ensuring consistent behavior without the need for the option in the tests.