### PR TITLE
feat(webhooks): Composite GitHub tag

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -401,7 +401,7 @@ def _discard_stale_mailbox_payloads(payload: WebhookPayload) -> None:
 def _get_github_delivery_time_tags(payload: WebhookPayload) -> dict[str, str]:
     """Extract GitHub event and action from payload for delivery_time_ms metric tags.
 
-    Returns a single tag github_event_and_action as "<event>:<action>", using "unknown"
+    Returns a single tag github_event_and_action as "<event>.<action>", using "unknown"
     when the request body has no action (e.g. push, ping).
     """
     if payload.provider != "github":
@@ -428,7 +428,7 @@ def _get_github_delivery_time_tags(payload: WebhookPayload) -> dict[str, str]:
             body_action = body.get("action")
             if isinstance(body_action, str) and body_action:
                 action = body_action
-    return {"github_event_and_action": f"{event_type}:{action}"}
+    return {"github_event_and_action": f"{event_type}.{action}"}
 
 
 def _record_delivery_time_metrics(payload: WebhookPayload) -> None:

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -399,10 +399,14 @@ def _discard_stale_mailbox_payloads(payload: WebhookPayload) -> None:
 
 
 def _get_github_delivery_time_tags(payload: WebhookPayload) -> dict[str, str]:
-    """Extract GitHub event type and action from payload for delivery_time_ms metric tags."""
+    """Extract GitHub event and action from payload for delivery_time_ms metric tags.
+
+    Returns a single tag github_event_and_action as "<event>:<action>", using "unknown"
+    when the request body has no action (e.g. push, ping).
+    """
     if payload.provider != "github":
         return {}
-    tags: dict[str, str] = {}
+    event_type: str | None = None
     try:
         headers = orjson.loads(payload.request_headers)
     except orjson.JSONDecodeError:
@@ -410,17 +414,21 @@ def _get_github_delivery_time_tags(payload: WebhookPayload) -> dict[str, str]:
     if isinstance(headers, dict):
         for key, value in headers.items():
             if key.upper() == "X-GITHUB-EVENT" and isinstance(value, str) and value:
-                tags["github_event_type"] = value
+                event_type = value
                 break
+    if not event_type:
+        return {}
+    action = "unknown"
     try:
         body = orjson.loads(payload.request_body)
     except orjson.JSONDecodeError:
-        return tags
-    if isinstance(body, dict):
-        action = body.get("action")
-        if isinstance(action, str) and action:
-            tags["github_action"] = action
-    return tags
+        pass
+    else:
+        if isinstance(body, dict):
+            body_action = body.get("action")
+            if isinstance(body_action, str) and body_action:
+                action = body_action
+    return {"github_event_and_action": f"{event_type}:{action}"}
 
 
 def _record_delivery_time_metrics(payload: WebhookPayload) -> None:

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1127,7 +1127,7 @@ class DeliveryTimeMetricsTest(TestCase):
         assert len(delivery_time_ms_calls) == 1
         tags = delivery_time_ms_calls[0][1].get("tags", {})
         assert tags.get("region_sent_to") == "us"
-        assert tags.get("github_event_and_action") == "pull_request:opened"
+        assert tags.get("github_event_and_action") == "pull_request.opened"
 
     @responses.activate
     @override_regions(region_config)
@@ -1159,7 +1159,7 @@ class DeliveryTimeMetricsTest(TestCase):
         assert len(delivery_time_ms_calls) == 1
         tags = delivery_time_ms_calls[0][1].get("tags", {})
         assert tags.get("region_sent_to") == "us"
-        assert tags.get("github_event_and_action") == "push:unknown"
+        assert tags.get("github_event_and_action") == "push.unknown"
 
     @responses.activate
     @override_regions(region_config)

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1127,8 +1127,7 @@ class DeliveryTimeMetricsTest(TestCase):
         assert len(delivery_time_ms_calls) == 1
         tags = delivery_time_ms_calls[0][1].get("tags", {})
         assert tags.get("region_sent_to") == "us"
-        assert tags.get("github_event_type") == "pull_request"
-        assert tags.get("github_action") == "opened"
+        assert tags.get("github_event_and_action") == "pull_request:opened"
 
     @responses.activate
     @override_regions(region_config)
@@ -1160,8 +1159,7 @@ class DeliveryTimeMetricsTest(TestCase):
         assert len(delivery_time_ms_calls) == 1
         tags = delivery_time_ms_calls[0][1].get("tags", {})
         assert tags.get("region_sent_to") == "us"
-        assert tags.get("github_event_type") == "push"
-        assert "github_action" not in tags
+        assert tags.get("github_event_and_action") == "push:unknown"
 
     @responses.activate
     @override_regions(region_config)
@@ -1188,8 +1186,7 @@ class DeliveryTimeMetricsTest(TestCase):
         assert len(delivery_time_ms_calls) == 1
         tags = delivery_time_ms_calls[0][1].get("tags", {})
         assert tags.get("region_sent_to") == "us"
-        assert "github_event_type" not in tags
-        assert "github_action" not in tags
+        assert "github_event_and_action" not in tags
 
 
 @control_silo_test


### PR DESCRIPTION
This composite tag simplifies metric slicing. The current implementation makes Datadog filtering very complex.

This adds support for filtering by the metrics Code Review cares about:

* check_run.rerequested
* issue_comment.created
* pull_request.closed
* pull_request.opened
* pull_request.ready_for_review
* pull_request.synchronize