### PR TITLE
fix(dashboards): Validate linked dashboard fields against columns instead of fields

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1017,15 +1017,15 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             if len(linked_fields) != len(set(linked_fields)):
                 raise serializers.ValidationError("Duplicate fields in linked dashboards")
 
-            # check if the linked dashboard appears in the fields of the query
+            # check if the linked dashboard field appears in the columns (group bys) of the query
             if not all(
-                field in query.fields
+                field in (query.columns or [])
                 for field in [
                     linked_dashboard.get("field") for linked_dashboard in linked_dashboards
                 ]
             ):
                 raise serializers.ValidationError(
-                    "Linked dashboard does not appear in the fields of the query"
+                    "Linked dashboard field does not appear in the columns of the widget query"
                 )
 
             # Validate all linked dashboard IDs belong to this organization

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3725,7 +3725,10 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         }
         response = self.do_request("put", self.url(dashboard.id), data=data)
         assert response.status_code == 400, response.data
-        assert b"Linked dashboard does not appear in the fields of the query" in response.content
+        assert (
+            b"Linked dashboard field does not appear in the columns of the widget query"
+            in response.content
+        )
 
     def test_rejects_cross_org_linked_dashboard(self) -> None:
         other_org = self.create_organization(name="other-org")

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3443,7 +3443,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                             "id": str(widget_query.id),
                             "name": "Query with Links",
                             "fields": ["count()", "project", "environment"],
-                            "columns": ["project"],
+                            "columns": ["project", "environment"],
                             "aggregates": ["count()"],
                             "conditions": "event.type:error",
                             "linkedDashboards": [


### PR DESCRIPTION
`fields` contains both aggregates and group bys, but `columns` contains only group bys. Linked dashboards are not supported on aggregates, so the validation should check against `columns` instead of `fields`.

Also updated the error message to be more descriptive.

Refs BROWSE-432