### PR TITLE
fix(dashboards): Prevent dashboard manage view forwarding search parameter when navigating to dashboard

### DIFF
--- a/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
@@ -174,6 +174,27 @@ describe('Dashboards - DashboardGrid', () => {
     );
   });
 
+  it('does not forward search query parameter to dashboard links', () => {
+    render(
+      <DashboardGrid
+        onDashboardsChange={jest.fn()}
+        organization={organization}
+        dashboards={dashboards}
+        location={{
+          ...LocationFixture(),
+          query: {query: 'agent', statsPeriod: '7d'},
+        }}
+        columnCount={3}
+        rowCount={3}
+      />
+    );
+
+    expect(screen.getByRole('link', {name: 'Dashboard 1'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/dashboard/1/?statsPeriod=7d'
+    );
+  });
+
   it('can delete dashboards', async () => {
     render(
       <DashboardGrid

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -180,10 +180,9 @@ function DashboardGrid({
 
   // TODO(__SENTRY_USING_REACT_ROUTER_SIX): We can remove this later, react
   // router 6 handles empty query objects without appending a trailing ?
+  const {query: _searchQuery, ...queryWithoutSearch} = location.query;
   const queryLocation = {
-    ...(location.query && Object.keys(location.query).length > 0
-      ? {query: location.query}
-      : {}),
+    ...(Object.keys(queryWithoutSearch).length > 0 ? {query: queryWithoutSearch} : {}),
   };
 
   function renderMiniDashboards() {

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -171,6 +171,25 @@ describe('Dashboards - DashboardTable', () => {
     );
   });
 
+  it('does not forward search query parameter to dashboard links', async () => {
+    render(
+      <DashboardTable
+        onDashboardsChange={jest.fn()}
+        organization={organization}
+        dashboards={dashboards}
+        location={{
+          ...LocationFixture(),
+          query: {query: 'agent', statsPeriod: '7d'},
+        }}
+      />
+    );
+
+    expect(await screen.findByRole('link', {name: 'Dashboard 1'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/dashboard/1/?statsPeriod=7d'
+    );
+  });
+
   it('can delete dashboards', async () => {
     render(
       <DashboardTable

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -145,10 +145,9 @@ function DashboardTable({
 
   // TODO(__SENTRY_USING_REACT_ROUTER_SIX): We can remove this later, react
   // router 6 handles empty query objects without appending a trailing ?
+  const {query: _searchQuery, ...queryWithoutSearch} = location.query;
   const queryLocation = {
-    ...(location.query && Object.keys(location.query).length > 0
-      ? {query: location.query}
-      : {}),
+    ...(Object.keys(queryWithoutSearch).length > 0 ? {query: queryWithoutSearch} : {}),
   };
 
   function renderHeadCell(column: GridColumnOrder<string>) {

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -550,10 +550,11 @@ function ManageDashboards() {
   }
 
   function loadDashboard(dashboardId: string) {
+    const {query: _query, ...queryWithoutSearch} = location.query;
     navigate(
       normalizeUrl({
         pathname: `/organizations/${organization.slug}/dashboards/${dashboardId}/`,
-        query: location.query,
+        query: queryWithoutSearch,
       })
     );
   }

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -565,10 +565,12 @@ function ManageDashboards() {
       dashboard_id: dashboardId,
     });
 
+    const {query: _query, ...queryWithoutSearch} = location.query;
+
     navigate(
       normalizeUrl({
         pathname: `/organizations/${organization.slug}/dashboards/new/${dashboardId}/`,
-        query: location.query,
+        query: queryWithoutSearch,
       })
     );
   }

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -518,6 +518,8 @@ function ManageDashboards() {
     );
   }
 
+  const {query: _query, ...queryWithoutSearch} = location.query;
+
   function onCreate() {
     trackAnalytics('dashboards_manage.create.start', {
       organization,
@@ -526,7 +528,7 @@ function ManageDashboards() {
     navigate(
       normalizeUrl({
         pathname: `/organizations/${organization.slug}/dashboards/new/`,
-        query: location.query,
+        query: queryWithoutSearch,
       })
     );
   }
@@ -550,7 +552,6 @@ function ManageDashboards() {
   }
 
   function loadDashboard(dashboardId: string) {
-    const {query: _query, ...queryWithoutSearch} = location.query;
     navigate(
       normalizeUrl({
         pathname: `/organizations/${organization.slug}/dashboards/${dashboardId}/`,
@@ -564,8 +565,6 @@ function ManageDashboards() {
       organization,
       dashboard_id: dashboardId,
     });
-
-    const {query: _query, ...queryWithoutSearch} = location.query;
 
     navigate(
       normalizeUrl({


### PR DESCRIPTION
Update dashboard manage views to not forward search query parameter when opening up a dashboard. The query parameter was interfering with some widgets, and it is not needed in the dashboard anyways.