### PR TITLE
fix(dashboards): Lower agent traces widget limit to 10 in pre-built dashboard

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -28,6 +28,7 @@ export type LegendType = 'default' | 'breakdown';
 export const MAX_WIDGETS = 30;
 
 export const DEFAULT_TABLE_LIMIT = 5;
+export const MAX_TABLE_LIMIT = 10;
 
 export const DEFAULT_CATEGORICAL_BAR_LIMIT = 20;
 export const MAX_CATEGORICAL_BAR_LIMIT = 25;

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -4,6 +4,7 @@ import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
+import {RESULTS_LIMIT} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
 const AGENT_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:agent`;
@@ -187,7 +188,7 @@ const AGENTS_TRACES_TABLE = {
   displayType: DisplayType.AGENTS_TRACES_TABLE,
   interval: '1h',
   tableWidths: DEFAULT_TRACES_TABLE_WIDTHS,
-  limit: 10,
+  limit: RESULTS_LIMIT,
   queries: [
     {
       conditions: '',

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -1,10 +1,9 @@
 import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {DisplayType, MAX_TABLE_LIMIT, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
-import {RESULTS_LIMIT} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
 const AGENT_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:agent`;
@@ -188,7 +187,7 @@ const AGENTS_TRACES_TABLE = {
   displayType: DisplayType.AGENTS_TRACES_TABLE,
   interval: '1h',
   tableWidths: DEFAULT_TRACES_TABLE_WIDTHS,
-  limit: RESULTS_LIMIT,
+  limit: MAX_TABLE_LIMIT,
   queries: [
     {
       conditions: '',

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -187,7 +187,7 @@ const AGENTS_TRACES_TABLE = {
   displayType: DisplayType.AGENTS_TRACES_TABLE,
   interval: '1h',
   tableWidths: DEFAULT_TRACES_TABLE_WIDTHS,
-  limit: 20,
+  limit: 10,
   queries: [
     {
       conditions: '',

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -4,7 +4,7 @@ import {WidgetType} from 'sentry/views/dashboards/types';
 
 // Used in the widget builder to limit the number of lines plotted in the chart
 export const DEFAULT_RESULTS_LIMIT = 5;
-export const RESULTS_LIMIT = 10;
+const RESULTS_LIMIT = 10;
 
 // Both dashboards and widgets use the 'new' keyword when creating
 export const NEW_DASHBOARD_ID = 'new';

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -4,7 +4,7 @@ import {WidgetType} from 'sentry/views/dashboards/types';
 
 // Used in the widget builder to limit the number of lines plotted in the chart
 export const DEFAULT_RESULTS_LIMIT = 5;
-const RESULTS_LIMIT = 10;
+export const RESULTS_LIMIT = 10;
 
 // Both dashboards and widgets use the 'new' keyword when creating
 export const NEW_DASHBOARD_ID = 'new';


### PR DESCRIPTION
Lower the `limit` on the AI Agents Overview dashboard's traces table widget from 20 to 10.

The backend serializer rejects non-categorical-bar-chart widgets with a limit greater than 10, which caused dashboard duplication to fail for this prebuilt dashboard.

Refs DAIN-1331