### PR TITLE
ref(autofix): Split explorer response into sections

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -399,7 +399,7 @@ export function isCodeChangesSection(section: AutofixSection): boolean {
 }
 
 export function isPullRequestSection(section: AutofixSection): boolean {
-  return section.step === 'pull_requests';
+  return section.step === 'pull_request';
 }
 
 export type AutofixArtifact = Artifact<unknown> | ExplorerFilePatch[] | RepoPRState[];

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -24,8 +24,11 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
+import {AutofixSection} from 'sentry/views/issueDetails/streamline/sidebar/autofixSection';
 import {
   isArtifact,
+  isExplorerFilePatch,
+  isRepoPRState,
   type Artifact,
   type Block,
   type ExplorerCodingAgentState,
@@ -129,6 +132,14 @@ interface SuggestedAssignee {
 export interface TriageArtifact {
   suggested_assignee?: SuggestedAssignee | null;
   suspect_commit?: SuspectCommit | null;
+}
+
+export function isCodeChangesArtifact(value: unknown): value is ExplorerFilePatch[] {
+  return isArrayOf(value, isExplorerFilePatch) && value.length > 0;
+}
+
+export function isPullRequestArtifact(value: unknown): value is RepoPRState[] {
+  return isArrayOf(value, isRepoPRState) && value.length > 0;
 }
 
 /**
@@ -290,78 +301,137 @@ export function getOrderedArtifactKeys(
   });
 }
 
-const CODE_CHANGES_KEY = Symbol('codeChanges');
+export interface AutofixSection {
+  artifacts: AutofixArtifact[];
+  messages: Array<Block['message']>;
+  status: 'processing' | 'completed';
+  step: string;
+}
 
-type ArtifactKey = string | typeof CODE_CHANGES_KEY;
-export type AutofixArtifact = Artifact<unknown> | ExplorerFilePatch[] | RepoPRState[];
-
-export function getOrderedAutofixArtifacts(
-  runState: ExplorerAutofixState | null
-): AutofixArtifact[] {
+export function getOrderedAutofixSections(runState: ExplorerAutofixState | null) {
   const blocks = runState?.blocks ?? [];
   if (!blocks.length) {
     return [];
   }
 
-  type OrderedArtifact = {
-    artifact: Artifact;
-    index: number;
-    type: 'artifact';
-  };
-
-  type OrderedExplorerFilePatch = {
-    index: number;
-    patches: Map<string, ExplorerFilePatch>;
-    type: 'patch';
-  };
-
-  const artifactsByKey = new Map<
-    ArtifactKey,
-    OrderedArtifact | OrderedExplorerFilePatch
-  >();
   const mergedByFile = new Map<string, ExplorerFilePatch>();
 
-  for (let index = 0; index < blocks.length; index++) {
-    const block = blocks[index]!;
+  const sections: AutofixSection[] = [];
 
-    for (const artifact of block.artifacts ?? []) {
-      artifactsByKey.set(artifact.key, {
-        type: 'artifact',
-        index,
-        artifact,
-      });
+  let section: AutofixSection = {
+    step: 'unknown',
+    artifacts: [],
+    messages: [],
+    status: 'processing',
+  };
+
+  function finalizeSection() {
+    if (section.messages.length) {
+      const lastMessage = section.messages[section.messages.length - 1];
+      if (isLastMessageOfSection(lastMessage)) {
+        section.status = 'completed';
+      }
+
+      if (section.step === 'code_changes') {
+        // if this is a code changes section, we should take the current
+        // merged file patches and turn it into an artifact for the section
+        section.artifacts.push(Array.from(mergedByFile.values()));
+      }
+
+      sections.push(section);
     }
+  }
 
+  for (const block of blocks) {
+    // we always collect the file patches at every block as they need to be merged
     if (block.merged_file_patches?.length) {
       for (const patch of block.merged_file_patches) {
         const key = `${patch.repo_name}:${patch.patch.path}`;
         mergedByFile.set(key, patch);
       }
-      artifactsByKey.set(CODE_CHANGES_KEY, {
-        type: 'patch',
-        index,
-        patches: mergedByFile,
-      });
     }
+
+    const message = block.message;
+
+    const metadata = message.metadata;
+    if (metadata?.step) {
+      finalizeSection();
+
+      section = {
+        step: metadata.step,
+        artifacts: [],
+        messages: [],
+        status: 'processing',
+      };
+    }
+
+    section.messages.push(message);
+    section.artifacts.push(...(block.artifacts ?? []));
   }
 
-  const artifacts: AutofixArtifact[] = [...artifactsByKey.values()]
-    .sort((artifact1, artifact2) => artifact1.index - artifact2.index)
-    .map(artifact => {
-      if (artifact.type === 'artifact') {
-        return artifact.artifact;
-      }
-      return Array.from(artifact.patches.values());
+  finalizeSection();
+
+  const artifact = Object.values(runState?.repo_pr_states ?? {});
+  if (artifact.length) {
+    sections.push({
+      step: 'pull_request',
+      artifacts: [artifact],
+      messages: [],
+      status: artifact.some(pullRequest => pullRequest.pr_creation_status === 'creating')
+        ? 'processing'
+        : 'completed',
     });
-
-  if (runState?.repo_pr_states) {
-    const states = Object.values(runState.repo_pr_states);
-    if (states.length) {
-      artifacts.push(states);
-    }
   }
 
-  return artifacts;
+  return sections;
+}
+
+export function isRootCauseSection(section: AutofixSection): boolean {
+  return section.step === 'root_cause';
+}
+
+export function isSolutionSection(section: AutofixSection): boolean {
+  return section.step === 'solution';
+}
+
+export function isCodeChangesSection(section: AutofixSection): boolean {
+  return section.step === 'code_changes';
+}
+
+export function isPullRequestSection(section: AutofixSection): boolean {
+  return section.step === 'pull_requests';
+}
+
+export type AutofixArtifact = Artifact<unknown> | ExplorerFilePatch[] | RepoPRState[];
+
+export function getOrderedAutofixArtifacts(
+  runState: ExplorerAutofixState | null
+): AutofixArtifact[] {
+  return getOrderedAutofixSections(runState)
+    .map(section => {
+      if (isRootCauseSection(section)) {
+        return section.artifacts.findLast(isRootCauseArtifact) ?? null;
+      }
+      if (isSolutionSection(section)) {
+        return section.artifacts.findLast(isSolutionArtifact) ?? null;
+      }
+      if (isCodeChangesSection(section)) {
+        return section.artifacts.findLast(isCodeChangesArtifact) ?? null;
+      }
+      if (isPullRequestSection(section)) {
+        return section.artifacts.findLast(isPullRequestArtifact) ?? null;
+      }
+      return null;
+    })
+    .filter(defined);
+}
+
+function isLastMessageOfSection(message?: Block['message']): boolean {
+  return (
+    message?.role === 'assistant' &&
+    message?.content !== 'Thinking...' &&
+    !message?.tool_calls?.length
+  );
 }
 
 /**

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -307,16 +307,30 @@ export interface AutofixSection {
   step: string;
 }
 
+/**
+ * Groups a flat list of autofix blocks into ordered sections.
+ *
+ * Blocks arrive as a flat stream from the backend. Each block may carry a
+ * `metadata.step` field that signals the start of a new logical section
+ * (e.g. "root_cause", "code_changes", "pull_request"). This function walks
+ * the blocks in order, splitting them into sections at each step boundary,
+ * and attaches the relevant artifacts (file patches, PR states) to each section.
+ */
 export function getOrderedAutofixSections(runState: ExplorerAutofixState | null) {
   const blocks = runState?.blocks ?? [];
   if (!blocks.length) {
     return [];
   }
 
+  // Accumulates file patches across all blocks, keyed by "repo:path".
+  // Patches are merged globally (later patches for the same file overwrite
+  // earlier ones) and snapshotted into the code_changes section when it finalizes.
   const mergedByFile = new Map<string, ExplorerFilePatch>();
 
   const sections: AutofixSection[] = [];
 
+  // The "current" section being built. Blocks without a step marker are
+  // appended to whatever section is in progress (initially an 'unknown' one).
   let section: AutofixSection = {
     step: 'unknown',
     artifacts: [],
@@ -324,16 +338,17 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
     status: 'processing',
   };
 
+  // Closes the current section and pushes it to `sections` (if non-empty).
   function finalizeSection() {
     if (section.messages.length) {
+      // Mark the section as completed if the last message is a terminal marker.
       const lastMessage = section.messages[section.messages.length - 1];
       if (isLastMessageOfSection(lastMessage)) {
         section.status = 'completed';
       }
 
       if (section.step === 'code_changes') {
-        // if this is a code changes section, we should take the current
-        // merged file patches and turn it into an artifact for the section
+        // Snapshot the accumulated file patches as an artifact for this section.
         section.artifacts.push(Array.from(mergedByFile.values()));
       }
 
@@ -342,7 +357,8 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
   }
 
   for (const block of blocks) {
-    // we always collect the file patches at every block as they need to be merged
+    // Accumulate file patches globally — they need to be merged across all
+    // blocks regardless of section boundaries so later patches win per file.
     if (block.merged_file_patches?.length) {
       for (const patch of block.merged_file_patches) {
         const key = `${patch.repo_name}:${patch.patch.path}`;
@@ -352,6 +368,8 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
 
     const message = block.message;
 
+    // A step marker means this block starts a new section.
+    // Finalize the previous section and start a fresh one.
     const metadata = message.metadata;
     if (metadata?.step) {
       finalizeSection();
@@ -364,12 +382,15 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
       };
     }
 
+    // Append the block's message and any inline artifacts to the current section.
     section.messages.push(message);
     section.artifacts.push(...(block.artifacts ?? []));
   }
 
+  // Finalize the last in-progress section.
   finalizeSection();
 
+  // If there are any PR states, append a synthetic "pull_request" section.
   const artifact = Object.values(runState?.repo_pr_states ?? {});
   if (artifact.length) {
     sections.push({

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -24,7 +24,6 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
-import {AutofixSection} from 'sentry/views/issueDetails/streamline/sidebar/autofixSection';
 import {
   isArtifact,
   isExplorerFilePatch,

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1,14 +1,12 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {
+  AutofixArtifact,
+  AutofixSection,
   RootCauseArtifact,
   SolutionArtifact,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
-import type {
-  Artifact,
-  ExplorerFilePatch,
-  RepoPRState,
-} from 'sentry/views/seerExplorer/types';
+import type {ExplorerFilePatch, RepoPRState} from 'sentry/views/seerExplorer/types';
 
 import {
   CodeChangesCard,
@@ -20,6 +18,14 @@ import {
 jest.mock('sentry/views/seerExplorer/fileDiffViewer', () => ({
   FileDiffViewer: () => <div data-testid="file-diff-viewer" />,
 }));
+
+function makeSection(
+  step: string,
+  status: AutofixSection['status'],
+  artifacts: AutofixArtifact[]
+): AutofixSection {
+  return {step, artifacts, messages: [], status};
+}
 
 function makePatch(repoName: string, path: string): ExplorerFilePatch {
   return {
@@ -52,35 +58,47 @@ function makePR(overrides: Partial<RepoPRState> = {}): RepoPRState {
   };
 }
 
+function makeRootCauseArtifact(data: RootCauseArtifact | null) {
+  return {
+    key: 'root-cause',
+    reason: 'Found root cause',
+    data,
+  };
+}
+
+function makeSolutionArtifact(data: SolutionArtifact | null) {
+  return {
+    key: 'solution',
+    reason: 'Found solution',
+    data,
+  };
+}
+
 describe('RootCauseCard', () => {
   it('renders title and one_line_description summary', () => {
-    const artifact: Artifact<RootCauseArtifact> = {
-      key: 'root-cause',
-      reason: 'Found root cause',
-      data: {
-        one_line_description: 'Null pointer in user handler',
-        five_whys: ['why1', 'why2'],
-        reproduction_steps: ['step1'],
-      },
-    };
+    const artifact = makeRootCauseArtifact({
+      one_line_description: 'Null pointer in user handler',
+      five_whys: ['why1', 'why2'],
+      reproduction_steps: ['step1'],
+    });
 
-    render(<RootCauseCard artifact={artifact} />);
+    render(
+      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+    );
 
     expect(screen.getByText('Root Cause')).toBeInTheDocument();
     expect(screen.getByText('Null pointer in user handler')).toBeInTheDocument();
   });
 
   it('renders five_whys list items and heading', () => {
-    const artifact: Artifact<RootCauseArtifact> = {
-      key: 'root-cause',
-      reason: 'Found root cause',
-      data: {
-        one_line_description: 'Bug',
-        five_whys: ['First why', 'Second why', 'Third why'],
-      },
-    };
+    const artifact = makeRootCauseArtifact({
+      one_line_description: 'Bug',
+      five_whys: ['First why', 'Second why', 'Third why'],
+    });
 
-    render(<RootCauseCard artifact={artifact} />);
+    render(
+      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+    );
 
     expect(screen.getByText('Why did this happen?')).toBeInTheDocument();
     expect(screen.getByText('First why')).toBeInTheDocument();
@@ -89,46 +107,40 @@ describe('RootCauseCard', () => {
   });
 
   it('renders reproduction_steps when present', () => {
-    const artifact: Artifact<RootCauseArtifact> = {
-      key: 'root-cause',
-      reason: 'Found root cause',
-      data: {
-        one_line_description: 'Bug',
-        five_whys: ['why1'],
-        reproduction_steps: ['Open the page', 'Click button'],
-      },
-    };
+    const artifact = makeRootCauseArtifact({
+      one_line_description: 'Bug',
+      five_whys: ['why1'],
+      reproduction_steps: ['Open the page', 'Click button'],
+    });
 
-    render(<RootCauseCard artifact={artifact} />);
+    render(
+      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+    );
 
     expect(screen.getByText('Reproduction Steps')).toBeInTheDocument();
     expect(screen.getByText('Open the page')).toBeInTheDocument();
     expect(screen.getByText('Click button')).toBeInTheDocument();
   });
 
-  it('handles null data with placeholder', () => {
-    const artifact: Artifact<RootCauseArtifact> = {
-      key: 'root-cause',
-      reason: 'No data',
-      data: null,
-    };
+  it('returns null when artifact data is null', () => {
+    const artifact = makeRootCauseArtifact(null);
 
-    render(<RootCauseCard artifact={artifact} />);
+    const {container} = render(
+      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+    );
 
-    expect(screen.getByText('Root Cause')).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('handles empty five_whys with placeholder', () => {
-    const artifact: Artifact<RootCauseArtifact> = {
-      key: 'root-cause',
-      reason: 'Found root cause',
-      data: {
-        one_line_description: 'Bug',
-        five_whys: [],
-      },
-    };
+    const artifact = makeRootCauseArtifact({
+      one_line_description: 'Bug',
+      five_whys: [],
+    });
 
-    render(<RootCauseCard artifact={artifact} />);
+    render(
+      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+    );
 
     expect(screen.getByText('Root Cause')).toBeInTheDocument();
     expect(screen.queryByText('Why did this happen?')).not.toBeInTheDocument();
@@ -137,35 +149,27 @@ describe('RootCauseCard', () => {
 
 describe('SolutionCard', () => {
   it('renders title and one_line_summary', () => {
-    const artifact: Artifact<SolutionArtifact> = {
-      key: 'solution',
-      reason: 'Found solution',
-      data: {
-        one_line_summary: 'Add null check before accessing user',
-        steps: [{title: 'Step 1', description: 'Add guard'}],
-      },
-    };
+    const artifact = makeSolutionArtifact({
+      one_line_summary: 'Add null check before accessing user',
+      steps: [{title: 'Step 1', description: 'Add guard'}],
+    });
 
-    render(<SolutionCard artifact={artifact} />);
+    render(<SolutionCard section={makeSection('solution', 'completed', [artifact])} />);
 
     expect(screen.getByText('Implementation Plan')).toBeInTheDocument();
     expect(screen.getByText('Add null check before accessing user')).toBeInTheDocument();
   });
 
   it('renders steps with title and description', () => {
-    const artifact: Artifact<SolutionArtifact> = {
-      key: 'solution',
-      reason: 'Found solution',
-      data: {
-        one_line_summary: 'Fix the bug',
-        steps: [
-          {title: 'Add validation', description: 'Check input is not null'},
-          {title: 'Update handler', description: 'Handle edge case'},
-        ],
-      },
-    };
+    const artifact = makeSolutionArtifact({
+      one_line_summary: 'Fix the bug',
+      steps: [
+        {title: 'Add validation', description: 'Check input is not null'},
+        {title: 'Update handler', description: 'Handle edge case'},
+      ],
+    });
 
-    render(<SolutionCard artifact={artifact} />);
+    render(<SolutionCard section={makeSection('solution', 'completed', [artifact])} />);
 
     expect(screen.getByText('Steps to Resolve')).toBeInTheDocument();
     expect(screen.getByText('Add validation')).toBeInTheDocument();
@@ -174,28 +178,26 @@ describe('SolutionCard', () => {
     expect(screen.getByText('Handle edge case')).toBeInTheDocument();
   });
 
-  it('handles null data with placeholder', () => {
-    const artifact: Artifact<SolutionArtifact> = {
-      key: 'solution',
-      reason: 'No data',
-      data: null,
-    };
+  it('returns null when artifact data is null', () => {
+    const artifact = makeSolutionArtifact(null);
 
-    render(<SolutionCard artifact={artifact} />);
+    const {container} = render(
+      <SolutionCard section={makeSection('solution', 'completed', [artifact])} />
+    );
 
-    expect(screen.getByText('Implementation Plan')).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 });
 
 describe('CodeChangesCard', () => {
-  // The component uses Map.entries().map() which returns an iterator —
-  // React warns about this. Suppress until the component is fixed.
-  beforeEach(() => {
-    jest.spyOn(console, 'error').mockImplementation();
-  });
-
   it('renders single file in single repo', () => {
-    render(<CodeChangesCard artifact={[makePatch('org/repo', 'src/app.py')]} />);
+    render(
+      <CodeChangesCard
+        section={makeSection('code_changes', 'completed', [
+          [makePatch('org/repo', 'src/app.py')],
+        ])}
+      />
+    );
 
     expect(screen.getByText('Code Changes')).toBeInTheDocument();
     expect(screen.getByText('1 file changed in 1 repo')).toBeInTheDocument();
@@ -204,11 +206,13 @@ describe('CodeChangesCard', () => {
   it('renders multiple files in single repo', () => {
     render(
       <CodeChangesCard
-        artifact={[
-          makePatch('org/repo', 'src/app.py'),
-          makePatch('org/repo', 'src/utils.py'),
-          makePatch('org/repo', 'src/models.py'),
-        ]}
+        section={makeSection('code_changes', 'completed', [
+          [
+            makePatch('org/repo', 'src/app.py'),
+            makePatch('org/repo', 'src/utils.py'),
+            makePatch('org/repo', 'src/models.py'),
+          ],
+        ])}
       />
     );
 
@@ -218,11 +222,13 @@ describe('CodeChangesCard', () => {
   it('renders multiple files in multiple repos', () => {
     render(
       <CodeChangesCard
-        artifact={[
-          makePatch('org/repo-a', 'src/app.py'),
-          makePatch('org/repo-a', 'src/utils.py'),
-          makePatch('org/repo-b', 'src/index.ts'),
-        ]}
+        section={makeSection('code_changes', 'completed', [
+          [
+            makePatch('org/repo-a', 'src/app.py'),
+            makePatch('org/repo-a', 'src/utils.py'),
+            makePatch('org/repo-b', 'src/index.ts'),
+          ],
+        ])}
       />
     );
 
@@ -232,10 +238,12 @@ describe('CodeChangesCard', () => {
   it('renders repository name labels', () => {
     render(
       <CodeChangesCard
-        artifact={[
-          makePatch('org/repo-a', 'src/app.py'),
-          makePatch('org/repo-b', 'src/index.ts'),
-        ]}
+        section={makeSection('code_changes', 'completed', [
+          [
+            makePatch('org/repo-a', 'src/app.py'),
+            makePatch('org/repo-b', 'src/index.ts'),
+          ],
+        ])}
       />
     );
 
@@ -243,16 +251,22 @@ describe('CodeChangesCard', () => {
     expect(screen.getByText('org/repo-b')).toBeInTheDocument();
   });
 
-  it('handles empty array with placeholder', () => {
-    render(<CodeChangesCard artifact={[]} />);
+  it('returns null when no code changes artifact found', () => {
+    const {container} = render(
+      <CodeChangesCard section={makeSection('code_changes', 'completed', [])} />
+    );
 
-    expect(screen.getByText('Code Changes')).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 });
 
 describe('PullRequestsCard', () => {
   it('renders PR link buttons with correct text and href', () => {
-    render(<PullRequestsCard artifact={[makePR()]} />);
+    render(
+      <PullRequestsCard
+        section={makeSection('pull_request', 'completed', [[makePR()]])}
+      />
+    );
 
     expect(screen.getByText('Pull Requests')).toBeInTheDocument();
     const button = screen.getByRole('button', {
@@ -264,10 +278,12 @@ describe('PullRequestsCard', () => {
   it('renders multiple PR buttons', () => {
     render(
       <PullRequestsCard
-        artifact={[
-          makePR({repo_name: 'org/repo-a', pr_number: 10, pr_url: 'https://pr/10'}),
-          makePR({repo_name: 'org/repo-b', pr_number: 20, pr_url: 'https://pr/20'}),
-        ]}
+        section={makeSection('pull_request', 'completed', [
+          [
+            makePR({repo_name: 'org/repo-a', pr_number: 10, pr_url: 'https://pr/10'}),
+            makePR({repo_name: 'org/repo-b', pr_number: 20, pr_url: 'https://pr/20'}),
+          ],
+        ])}
       />
     );
 
@@ -282,15 +298,17 @@ describe('PullRequestsCard', () => {
   it('skips PRs with missing pr_url or pr_number', () => {
     render(
       <PullRequestsCard
-        artifact={[
-          makePR({pr_url: null}),
-          makePR({pr_number: null}),
-          makePR({
-            repo_name: 'org/valid',
-            pr_number: 55,
-            pr_url: 'https://pr/55',
-          }),
-        ]}
+        section={makeSection('pull_request', 'completed', [
+          [
+            makePR({pr_url: null}),
+            makePR({pr_number: null}),
+            makePR({
+              repo_name: 'org/valid',
+              pr_number: 55,
+              pr_url: 'https://pr/55',
+            }),
+          ],
+        ])}
       />
     );
 
@@ -303,31 +321,27 @@ describe('PullRequestsCard', () => {
 
 describe('ArtifactCard expand/collapse', () => {
   it('children are visible by default', () => {
-    const artifact: Artifact<RootCauseArtifact> = {
-      key: 'root-cause',
-      reason: 'Found root cause',
-      data: {
-        one_line_description: 'Bug',
-        five_whys: ['Visible why'],
-      },
-    };
+    const artifact = makeRootCauseArtifact({
+      one_line_description: 'Bug',
+      five_whys: ['Visible why'],
+    });
 
-    render(<RootCauseCard artifact={artifact} />);
+    render(
+      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+    );
 
     expect(screen.getByText('Visible why')).toBeInTheDocument();
   });
 
   it('clicking collapse button hides children', async () => {
-    const artifact: Artifact<RootCauseArtifact> = {
-      key: 'root-cause',
-      reason: 'Found root cause',
-      data: {
-        one_line_description: 'Bug',
-        five_whys: ['Hidden why'],
-      },
-    };
+    const artifact = makeRootCauseArtifact({
+      one_line_description: 'Bug',
+      five_whys: ['Hidden why'],
+    });
 
-    render(<RootCauseCard artifact={artifact} />);
+    render(
+      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+    );
 
     await userEvent.click(screen.getByRole('button', {name: 'Root Cause'}));
 
@@ -336,16 +350,14 @@ describe('ArtifactCard expand/collapse', () => {
   });
 
   it('clicking again re-shows children', async () => {
-    const artifact: Artifact<RootCauseArtifact> = {
-      key: 'root-cause',
-      reason: 'Found root cause',
-      data: {
-        one_line_description: 'Bug',
-        five_whys: ['Toggle why'],
-      },
-    };
+    const artifact = makeRootCauseArtifact({
+      one_line_description: 'Bug',
+      five_whys: ['Toggle why'],
+    });
 
-    render(<RootCauseCard artifact={artifact} />);
+    render(
+      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+    );
 
     expect(screen.getByText('Bug')).toBeVisible();
     expect(screen.getByText('Toggle why')).toBeVisible();

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -5,9 +5,12 @@ import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container, Flex, type FlexProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import type {
-  RootCauseArtifact,
-  SolutionArtifact,
+import {
+  isCodeChangesArtifact,
+  isPullRequestArtifact,
+  isRootCauseArtifact,
+  isSolutionArtifact,
+  type AutofixSection,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import Placeholder from 'sentry/components/placeholder';
 import {IconBug} from 'sentry/icons/iconBug';
@@ -15,18 +18,24 @@ import {IconCode} from 'sentry/icons/iconCode';
 import {IconList} from 'sentry/icons/iconList';
 import {IconPullRequest} from 'sentry/icons/iconPullRequest';
 import {t, tn} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/fileDiffViewer';
-import {
-  type Artifact,
-  type ExplorerFilePatch,
-  type RepoPRState,
-} from 'sentry/views/seerExplorer/types';
+import {type ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
-interface RootCauseCardProps {
-  artifact: Artifact<RootCauseArtifact>;
+interface AutofixCardProps {
+  section: AutofixSection;
 }
 
-export function RootCauseCard({artifact}: RootCauseCardProps) {
+export function RootCauseCard({section}: AutofixCardProps) {
+  const artifact = useMemo(
+    () => section.artifacts.findLast(isRootCauseArtifact),
+    [section.artifacts]
+  );
+
+  if (!defined(artifact)) {
+    return null; // TODO
+  }
+
   return (
     <ArtifactCard icon={<IconBug />} title={t('Root Cause')}>
       <Text>{artifact.data?.one_line_description}</Text>
@@ -62,11 +71,16 @@ export function RootCauseCard({artifact}: RootCauseCardProps) {
   );
 }
 
-interface SolutionCardProps {
-  artifact: Artifact<SolutionArtifact>;
-}
+export function SolutionCard({section}: AutofixCardProps) {
+  const artifact = useMemo(
+    () => section.artifacts.findLast(isSolutionArtifact),
+    [section.artifacts]
+  );
 
-export function SolutionCard({artifact}: SolutionCardProps) {
+  if (!defined(artifact)) {
+    return null; // TODO
+  }
+
   return (
     <ArtifactCard icon={<IconList />} title={t('Implementation Plan')}>
       <Text>{artifact?.data?.one_line_summary}</Text>
@@ -93,14 +107,15 @@ export function SolutionCard({artifact}: SolutionCardProps) {
   );
 }
 
-interface CodeChangesCardProps {
-  artifact: ExplorerFilePatch[];
-}
+export function CodeChangesCard({section}: AutofixCardProps) {
+  const artifact = useMemo(
+    () => section.artifacts.findLast(isCodeChangesArtifact),
+    [section.artifacts]
+  );
 
-export function CodeChangesCard({artifact}: CodeChangesCardProps) {
   const patchesForRepos = useMemo(() => {
     const patchesByRepo = new Map<string, ExplorerFilePatch[]>();
-    for (const patch of artifact) {
+    for (const patch of artifact ?? []) {
       const existing = patchesByRepo.get(patch.repo_name) || [];
       existing.push(patch);
       patchesByRepo.set(patch.repo_name, existing);
@@ -129,6 +144,10 @@ export function CodeChangesCard({artifact}: CodeChangesCardProps) {
 
     return t('%s files changed in %s repos', filesChanged.size, reposChanged);
   }, [patchesForRepos]);
+
+  if (!defined(artifact)) {
+    return null; // TODO
+  }
 
   return (
     <ArtifactCard icon={<IconCode />} title={t('Code Changes')}>
@@ -160,11 +179,16 @@ export function CodeChangesCard({artifact}: CodeChangesCardProps) {
   );
 }
 
-interface PullRequestsCardProps {
-  artifact: RepoPRState[];
-}
+export function PullRequestsCard({section}: AutofixCardProps) {
+  const artifact = useMemo(
+    () => section.artifacts.findLast(isPullRequestArtifact),
+    [section.artifacts]
+  );
 
-export function PullRequestsCard({artifact}: PullRequestsCardProps) {
+  if (!artifact) {
+    return null; // TODO
+  }
+
   return (
     <ArtifactCard icon={<IconPullRequest />} title={t('Pull Requests')}>
       {artifact.map(pullRequest => {

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -3,11 +3,13 @@ import {Fragment, useMemo} from 'react';
 import {Flex} from '@sentry/scraps/layout';
 
 import {
-  getOrderedAutofixArtifacts,
-  isRootCauseArtifact,
-  isSolutionArtifact,
+  getOrderedAutofixSections,
+  isCodeChangesSection,
+  isPullRequestSection,
+  isRootCauseSection,
+  isSolutionSection,
   useExplorerAutofix,
-  type AutofixArtifact,
+  type AutofixSection,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {
   CodeChangesCard,
@@ -17,9 +19,7 @@ import {
 } from 'sentry/components/events/autofix/v3/autofixCards';
 import {SeerDrawerNextStep} from 'sentry/components/events/autofix/v3/nextStep';
 import Placeholder from 'sentry/components/placeholder';
-import {isArrayOf} from 'sentry/types/utils';
 import type {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
-import {isExplorerFilePatch, isRepoPRState} from 'sentry/views/seerExplorer/types';
 
 interface SeerDrawerContentProps {
   aiConfig: ReturnType<typeof useAiConfig>;
@@ -27,8 +27,8 @@ interface SeerDrawerContentProps {
 }
 
 export function SeerDrawerContent({aiConfig, autofix}: SeerDrawerContentProps) {
-  const artifacts = useMemo(
-    () => getOrderedAutofixArtifacts(autofix.runState),
+  const sections = useMemo(
+    () => getOrderedAutofixSections(autofix.runState),
     [autofix.runState]
   );
 
@@ -47,37 +47,36 @@ export function SeerDrawerContent({aiConfig, autofix}: SeerDrawerContentProps) {
 
   return (
     <Flex direction="column" gap="lg">
-      <SeerDrawerArtifacts artifacts={artifacts} />
+      <SeerDrawerArtifacts sections={sections} />
       {autofix.runState?.status === 'completed' && (
-        <SeerDrawerNextStep autofix={autofix} artifacts={artifacts} />
+        <SeerDrawerNextStep autofix={autofix} sections={sections} />
       )}
     </Flex>
   );
 }
 
 interface SeerDrawerArtifactsProps {
-  artifacts: AutofixArtifact[];
+  sections: AutofixSection[];
 }
 
-function SeerDrawerArtifacts({artifacts}: SeerDrawerArtifactsProps) {
+function SeerDrawerArtifacts({sections}: SeerDrawerArtifactsProps) {
   return (
     <Fragment>
-      {artifacts.map(artifact => {
-        // there should only be 1 artifact of each type
-        if (isRootCauseArtifact(artifact)) {
-          return <RootCauseCard key="root-cause" artifact={artifact} />;
+      {sections.map(section => {
+        if (isRootCauseSection(section)) {
+          return <RootCauseCard key={section.step} section={section} />;
         }
 
-        if (isSolutionArtifact(artifact)) {
-          return <SolutionCard key="solution" artifact={artifact} />;
+        if (isSolutionSection(section)) {
+          return <SolutionCard key={section.step} section={section} />;
         }
 
-        if (isArrayOf(artifact, isExplorerFilePatch) && artifact.length) {
-          return <CodeChangesCard key="code-changes" artifact={artifact} />;
+        if (isCodeChangesSection(section)) {
+          return <CodeChangesCard key={section.step} section={section} />;
         }
 
-        if (isArrayOf(artifact, isRepoPRState) && artifact.length) {
-          return <PullRequestsCard key="pull-requests" artifact={artifact} />;
+        if (isPullRequestSection(section)) {
+          return <PullRequestsCard key={section.step} section={section} />;
         }
 
         // TODO: maybe send a log?

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -1,11 +1,9 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {
-  RootCauseArtifact,
-  SolutionArtifact,
+  AutofixSection,
   useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
-import type {Artifact, ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
 import {SeerDrawerNextStep} from './nextStep';
 
@@ -25,54 +23,25 @@ function makeAutofix(
   } as ReturnType<typeof useExplorerAutofix>;
 }
 
-function makeRootCauseArtifact(): Artifact<RootCauseArtifact> {
+function makeSection(step: string): AutofixSection {
   return {
-    key: 'root-cause',
-    reason: 'Found root cause',
-    data: {
-      one_line_description: 'Null pointer dereference',
-      five_whys: ['Why 1', 'Why 2'],
-    },
+    step,
+    artifacts: [],
+    messages: [],
+    status: 'completed',
   };
-}
-
-function makeSolutionArtifact(): Artifact<SolutionArtifact> {
-  return {
-    key: 'solution',
-    reason: 'Found solution',
-    data: {
-      one_line_summary: 'Add null check',
-      steps: [{title: 'Step 1', description: 'Add guard clause'}],
-    },
-  };
-}
-
-function makePatch(): ExplorerFilePatch {
-  return {
-    repo_name: 'org/repo',
-    diff: 'diff content',
-    patch: {
-      path: 'src/file.py',
-      added: 1,
-      removed: 0,
-      hunks: [],
-      source_file: 'src/file.py',
-      target_file: 'src/file.py',
-      type: 'M',
-    },
-  } as ExplorerFilePatch;
 }
 
 describe('SeerDrawerNextStep', () => {
   it('returns null when no runId', () => {
     const autofix = makeAutofix({runState: null});
-    const {container} = render(<SeerDrawerNextStep artifacts={[]} autofix={autofix} />);
+    const {container} = render(<SeerDrawerNextStep sections={[]} autofix={autofix} />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('returns null when artifact type does not match any case', () => {
+  it('returns null when sections are empty', () => {
     const autofix = makeAutofix();
-    const {container} = render(<SeerDrawerNextStep artifacts={[]} autofix={autofix} />);
+    const {container} = render(<SeerDrawerNextStep sections={[]} autofix={autofix} />);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -80,7 +49,7 @@ describe('SeerDrawerNextStep', () => {
     it('renders prompt and yes button', () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep artifacts={[makeRootCauseArtifact()]} autofix={autofix} />
+        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
       );
       expect(screen.getByText('Are you happy with this root cause?')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'No'})).toBeInTheDocument();
@@ -92,7 +61,7 @@ describe('SeerDrawerNextStep', () => {
     it('calls startStep with solution on yes click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep artifacts={[makeRootCauseArtifact()]} autofix={autofix} />
+        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
       );
       await userEvent.click(
         screen.getByRole('button', {name: 'Yes, make an implementation plan'})
@@ -103,7 +72,7 @@ describe('SeerDrawerNextStep', () => {
     it('calls startStep with root_cause on no click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep artifacts={[makeRootCauseArtifact()]} autofix={autofix} />
+        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       expect(autofix.startStep).toHaveBeenCalledWith('root_cause', 1);
@@ -114,7 +83,7 @@ describe('SeerDrawerNextStep', () => {
     it('renders prompt and yes button', () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep artifacts={[makeSolutionArtifact()]} autofix={autofix} />
+        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
       );
       expect(
         screen.getByText('Are you happy with this implementation plan?')
@@ -128,7 +97,7 @@ describe('SeerDrawerNextStep', () => {
     it('calls startStep with code_changes on yes click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep artifacts={[makeSolutionArtifact()]} autofix={autofix} />
+        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
       );
       await userEvent.click(screen.getByRole('button', {name: 'Yes, write a code fix'}));
       expect(autofix.startStep).toHaveBeenCalledWith('code_changes', 1);
@@ -137,7 +106,7 @@ describe('SeerDrawerNextStep', () => {
     it('calls startStep with solution on no click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep artifacts={[makeSolutionArtifact()]} autofix={autofix} />
+        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       expect(autofix.startStep).toHaveBeenCalledWith('solution', 1);
@@ -147,7 +116,9 @@ describe('SeerDrawerNextStep', () => {
   describe('CodeChangesNextStep', () => {
     it('renders prompt and yes button', () => {
       const autofix = makeAutofix();
-      render(<SeerDrawerNextStep artifacts={[[makePatch()]]} autofix={autofix} />);
+      render(
+        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+      );
       expect(
         screen.getByText('Are you happy with these code changes?')
       ).toBeInTheDocument();
@@ -157,24 +128,20 @@ describe('SeerDrawerNextStep', () => {
 
     it('calls createPR on yes click', async () => {
       const autofix = makeAutofix();
-      render(<SeerDrawerNextStep artifacts={[[makePatch()]]} autofix={autofix} />);
+      render(
+        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+      );
       await userEvent.click(screen.getByRole('button', {name: 'Yes, draft a PR'}));
       expect(autofix.createPR).toHaveBeenCalledWith(1);
     });
 
     it('calls startStep with code_changes on no click', async () => {
       const autofix = makeAutofix();
-      render(<SeerDrawerNextStep artifacts={[[makePatch()]]} autofix={autofix} />);
+      render(
+        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+      );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       expect(autofix.startStep).toHaveBeenCalledWith('code_changes', 1);
-    });
-
-    it('returns null for empty file patches array', () => {
-      const autofix = makeAutofix();
-      const {container} = render(
-        <SeerDrawerNextStep artifacts={[[]]} autofix={autofix} />
-      );
-      expect(container).toBeEmptyDOMElement();
     });
   });
 });

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -5,37 +5,37 @@ import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
-  isRootCauseArtifact,
-  isSolutionArtifact,
-  type AutofixArtifact,
+  isCodeChangesSection,
+  isRootCauseSection,
+  isSolutionSection,
+  type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {t} from 'sentry/locale';
-import {isArrayOf} from 'sentry/types/utils';
-import {isExplorerFilePatch} from 'sentry/views/seerExplorer/types';
+import {defined} from 'sentry/utils';
 
 interface SeerDrawerNextStepProps {
-  artifacts: AutofixArtifact[];
   autofix: ReturnType<typeof useExplorerAutofix>;
+  sections: AutofixSection[];
 }
 
-export function SeerDrawerNextStep({artifacts, autofix}: SeerDrawerNextStepProps) {
+export function SeerDrawerNextStep({sections, autofix}: SeerDrawerNextStepProps) {
   const runId = autofix.runState?.run_id;
-  if (!runId) {
+  const lastSection = sections[sections.length - 1];
+
+  if (!defined(runId) || !defined(lastSection)) {
     return null;
   }
 
-  const lastArtifact = artifacts[artifacts.length - 1];
-
-  if (isRootCauseArtifact(lastArtifact)) {
+  if (isRootCauseSection(lastSection)) {
     return <RootCauseNextStep autofix={autofix} runId={runId} />;
   }
 
-  if (isSolutionArtifact(lastArtifact)) {
+  if (isSolutionSection(lastSection)) {
     return <SolutionNextStep autofix={autofix} runId={runId} />;
   }
 
-  if (isArrayOf(lastArtifact, isExplorerFilePatch) && lastArtifact.length) {
+  if (isCodeChangesSection(lastSection)) {
     return <CodeChangesNextStep autofix={autofix} runId={runId} />;
   }
 

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
@@ -116,7 +116,11 @@ describe('AutofixSection', () => {
           blocks: [
             {
               id: 'block-1',
-              message: {content: 'Found root cause', role: 'assistant'},
+              message: {
+                content: 'Found root cause',
+                role: 'assistant',
+                metadata: {step: 'root_cause'},
+              },
               timestamp: new Date().toISOString(),
               artifacts: [
                 {
@@ -155,7 +159,11 @@ describe('AutofixSection', () => {
           blocks: [
             {
               id: 'block-1',
-              message: {content: 'Found solution', role: 'assistant'},
+              message: {
+                content: 'Found solution',
+                role: 'assistant',
+                metadata: {step: 'solution'},
+              },
               timestamp: new Date().toISOString(),
               artifacts: [
                 {
@@ -193,7 +201,11 @@ describe('AutofixSection', () => {
           blocks: [
             {
               id: 'block-1',
-              message: {content: 'Made changes', role: 'assistant'},
+              message: {
+                content: 'Made changes',
+                role: 'assistant',
+                metadata: {step: 'code_changes'},
+              },
               timestamp: new Date().toISOString(),
               merged_file_patches: [
                 {
@@ -249,7 +261,11 @@ describe('AutofixSection', () => {
           blocks: [
             {
               id: 'block-1',
-              message: {content: 'Created PR', role: 'assistant'},
+              message: {
+                content: 'Created PR',
+                role: 'assistant',
+                metadata: {step: 'code_changes'},
+              },
               timestamp: new Date().toISOString(),
               merged_file_patches: [
                 {
@@ -305,7 +321,11 @@ describe('AutofixSection', () => {
           blocks: [
             {
               id: 'block-1',
-              message: {content: 'Created PR', role: 'assistant'},
+              message: {
+                content: 'Created PR',
+                role: 'assistant',
+                metadata: {step: 'code_changes'},
+              },
               timestamp: new Date().toISOString(),
               merged_file_patches: [
                 {
@@ -377,7 +397,11 @@ describe('AutofixSection', () => {
           blocks: [
             {
               id: 'block-1',
-              message: {content: 'Analysis complete', role: 'assistant'},
+              message: {
+                content: 'Found root cause',
+                role: 'assistant',
+                metadata: {step: 'root_cause'},
+              },
               timestamp: new Date().toISOString(),
               artifacts: [
                 {
@@ -389,6 +413,17 @@ describe('AutofixSection', () => {
                     reproduction_steps: ['step'],
                   },
                 },
+              ],
+            },
+            {
+              id: 'block-2',
+              message: {
+                content: 'Proposed fix',
+                role: 'assistant',
+                metadata: {step: 'solution'},
+              },
+              timestamp: new Date().toISOString(),
+              artifacts: [
                 {
                   key: 'solution',
                   reason: 'Proposed fix',
@@ -398,6 +433,15 @@ describe('AutofixSection', () => {
                   },
                 },
               ],
+            },
+            {
+              id: 'block-3',
+              message: {
+                content: 'Made code changes',
+                role: 'assistant',
+                metadata: {step: 'code_changes'},
+              },
+              timestamp: new Date().toISOString(),
               merged_file_patches: [
                 {
                   diff: '',

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -101,6 +101,7 @@ export interface ToolCall {
 interface Message {
   content: string;
   role: 'user' | 'assistant' | 'tool_use';
+  metadata?: Record<string, string> | null;
   thinking_content?: string;
   tool_calls?: ToolCall[];
 }


### PR DESCRIPTION
Directly extracting the artifacts makes it hard to handle the loading states. This refactors it so the response is split into sections according to the step, then we find the last matching artifact from the step.