### PR TITLE
fix(detectors): Fix WorkflowEngineDetectorSerializer snooze field

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -439,6 +439,9 @@ class WorkflowEngineDetectorSerializer(Serializer):
             "detectionType": obj.config.get("detection_type"),
         }
 
+        if not obj.enabled:
+            data["snooze"] = True
+
         if "latestIncident" in self.expand:
             data["latestIncident"] = attrs.get("latestIncident", None)
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -266,6 +266,31 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
             "LIST should return count() to user, hiding internal upsampled_count() storage"
         )
 
+    def test_workflow_engine_serializer_snoozed_detector(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+        self.detector.update(enabled=False)
+        self.login_as(self.user)
+
+        with self.feature(
+            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
+        ):
+            resp = self.get_success_response(self.organization.slug)
+
+        assert resp.data[0]["snooze"] is True
+
+    def test_workflow_engine_serializer_enabled_detector_no_snooze(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+        self.login_as(self.user)
+
+        with self.feature(
+            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
+        ):
+            resp = self.get_success_response(self.organization.slug)
+
+        assert "snooze" not in resp.data[0]
+
 
 @freeze_time("2024-12-11 03:21:34")
 class AlertRuleListDeltaTest(AlertRuleIndexBase, TestWorkflowEngineSerializer):

--- a/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
@@ -190,6 +190,15 @@ class TestDetectorSerializer(TestWorkflowEngineSerializer):
         )
         assert self._sort_triggers(serialized_detector) == self._sort_triggers(sentry_app_expected)
 
+    def test_snooze_enabled_detector(self) -> None:
+        serialized = serialize(self.detector, self.user, WorkflowEngineDetectorSerializer())
+        assert "snooze" not in serialized
+
+    def test_snooze_disabled_detector(self) -> None:
+        self.detector.update(enabled=False)
+        serialized = serialize(self.detector, self.user, WorkflowEngineDetectorSerializer())
+        assert serialized["snooze"] is True
+
     def test_new_models_only(self) -> None:
         # test that we can still serialize if objects do not have lookup table entries
         # this is required for firing actions


### PR DESCRIPTION
To be consistent with AlertRule serializers, 'snooze' should be set to True if snoozed and unset otherwise.
