### PR TITLE
fix(dashboards): Hide table in full screen view for issues timeseries widgets

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -603,6 +603,11 @@ function WidgetViewerModal(props: Props) {
     widget.displayType !== DisplayType.TABLE &&
     widget.displayType !== DisplayType.AGENTS_TRACES_TABLE;
 
+  // At the moment, issue tables do not support aggregates, so we should never render the table in full screen for timeseries widgets
+  const shouldRenderTable = !(
+    widget.widgetType === WidgetType.ISSUE && shouldRenderChartVisualization
+  );
+
   function renderWidgetViewer() {
     return (
       <Fragment>
@@ -736,7 +741,7 @@ function WidgetViewerModal(props: Props) {
             )}
           </QueryContainer>
         )}
-        {renderWidgetViewerTable()}
+        {shouldRenderTable && renderWidgetViewerTable()}
       </Fragment>
     );
   }

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -82,6 +82,7 @@ import {
   getWidgetReleasesUrl,
   isUsingPerformanceScore,
   performanceScoreTooltip,
+  usesTimeSeriesData,
 } from 'sentry/views/dashboards/utils';
 import {checkUserHasEditAccess} from 'sentry/views/dashboards/utils/checkUserHasEditAccess';
 import {
@@ -603,10 +604,11 @@ function WidgetViewerModal(props: Props) {
     widget.displayType !== DisplayType.TABLE &&
     widget.displayType !== DisplayType.AGENTS_TRACES_TABLE;
 
-  // At the moment, issue tables do not support aggregates, so we should never render the table in full screen for timeseries widgets
-  const shouldRenderTable = !(
-    widget.widgetType === WidgetType.ISSUE && shouldRenderChartVisualization
-  );
+  const shouldRenderTable =
+    // At the moment, issue tables do not support aggregates, so we should never render the table in full screen for timeseries widgets
+    !(widget.widgetType === WidgetType.ISSUE && usesTimeSeriesData(widget.displayType)) &&
+    widget.displayType !== DisplayType.RAGE_AND_DEAD_CLICKS &&
+    widget.displayType !== DisplayType.SERVER_TREE;
 
   function renderWidgetViewer() {
     return (


### PR DESCRIPTION
## Summary
- Hide the table in the widget full screen modal when the widget uses the ISSUES dataset and is a timeseries visualization (line, bar, area, etc.)
- Issue tables do not support aggregates, so showing a table alongside a timeseries chart produces broken/misleading results
- Also removes table view for rage and dead clicks + server tree.

Fixes DAIN-1333