### PR TITLE
fix(tracemetrics): Use dataset specific label formatter to generate correct labels

### DIFF
--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -30,6 +30,7 @@ import {WidgetType} from 'sentry/views/dashboards/types';
 import {getNumEquations} from 'sentry/views/dashboards/utils';
 import type {AxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import type {HookWidgetQueryResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import type {FieldValue} from 'sentry/views/discover/table/types';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
@@ -227,6 +228,12 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
   filterYAxisOptions?: (
     displayType: DisplayType
   ) => (option: FieldValueOption) => boolean;
+  /**
+   * Custom label formatter for time series in chart legends.
+   * When provided, this overrides the default label computation
+   * in transformWidgetSeriesToTimeSeries.
+   */
+  formatSeriesLabel?: (timeSeries: TimeSeries, widgetQuery: WidgetQuery) => string;
   /**
    * Used to select custom renderers for field types.
    */

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -189,6 +189,8 @@ export const TraceMetricsConfig: DatasetConfig<
   enableEquations: false,
   SearchBar: TraceMetricsSearchBar,
   useSearchBarDataProvider: useTraceMetricsSearchBarDataProvider,
+  formatSeriesLabel: (timeSeries, widgetQuery) =>
+    formatMetricsTimeseriesLabel({widgetQuery, timeSeries}),
   filterSeriesSortOptions,
   getTableFieldOptions: getPrimaryFieldOptions,
   getTimeseriesSortOptions: (organization, widgetQuery, tags) =>
@@ -237,15 +239,10 @@ export const TraceMetricsConfig: DatasetConfig<
           value: value.value ?? 0,
         })),
 
-        label: formatMetricsTimeseriesLabel({
+        seriesName: formatMetricsTimeseriesLabel({
           widgetQuery,
           timeSeries,
         }),
-
-        seriesName:
-          widgetQuery.columns.length > 0
-            ? `${timeSeries.meta.isOther ? 'Other' : timeSeries.groupBy?.map(groupBy => groupBy.value).join(',')} : ${timeSeries.yAxis}`
-            : timeSeries.yAxis,
       };
     });
   },
@@ -338,7 +335,7 @@ function filterSeriesSortOptions(columns: Set<string>) {
   };
 }
 
-export function formatMetricsTimeseriesLabel({
+function formatMetricsTimeseriesLabel({
   widgetQuery,
   timeSeries,
 }: {

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -239,10 +239,10 @@ export const TraceMetricsConfig: DatasetConfig<
           value: value.value ?? 0,
         })),
 
-        seriesName: formatMetricsTimeseriesLabel({
-          widgetQuery,
-          timeSeries,
-        }),
+        seriesName:
+          widgetQuery.columns.length > 0
+            ? `${timeSeries.meta.isOther ? 'Other' : timeSeries.groupBy?.map(groupBy => groupBy.value).join(',')} : ${timeSeries.yAxis}`
+            : timeSeries.yAxis,
       };
     });
   },

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -236,12 +236,16 @@ export const TraceMetricsConfig: DatasetConfig<
           name: value.timestamp,
           value: value.value ?? 0,
         })),
+
         label: formatMetricsTimeseriesLabel({
           widgetQuery,
           timeSeries,
         }),
 
-        seriesName: timeSeries.yAxis,
+        seriesName:
+          widgetQuery.columns.length > 0
+            ? `${timeSeries.meta.isOther ? 'Other' : timeSeries.groupBy?.map(groupBy => groupBy.value).join(',')} : ${timeSeries.yAxis}`
+            : timeSeries.yAxis,
       };
     });
   },
@@ -334,7 +338,7 @@ function filterSeriesSortOptions(columns: Set<string>) {
   };
 }
 
-function formatMetricsTimeseriesLabel({
+export function formatMetricsTimeseriesLabel({
   widgetQuery,
   timeSeries,
 }: {

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -236,11 +236,12 @@ export const TraceMetricsConfig: DatasetConfig<
           name: value.timestamp,
           value: value.value ?? 0,
         })),
-
-        seriesName: formatMetricsTimeseriesLabel({
+        label: formatMetricsTimeseriesLabel({
           widgetQuery,
           timeSeries,
         }),
+
+        seriesName: timeSeries.yAxis,
       };
     });
   },

--- a/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
+++ b/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
@@ -4,8 +4,8 @@ import {
   SERIES_NAME_PART_DELIMITER,
   transformLegacySeriesToTimeSeries,
 } from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
-import {formatMetricsTimeseriesLabel} from 'sentry/views/dashboards/datasetConfig/traceMetrics';
-import {WidgetType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
+import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 
@@ -60,10 +60,10 @@ export function transformWidgetSeriesToTimeSeries(
     return null;
   }
 
-  // Trace metrics have their own label formatting that already handles
-  // query names, groupings, and multiple aggregates — use it directly.
-  if (widget.widgetType === WidgetType.TRACEMETRICS) {
-    const label = formatMetricsTimeseriesLabel({widgetQuery, timeSeries});
+  // If the dataset config provides a custom label formatter, use it directly.
+  const datasetConfig = getDatasetConfig(widget.widgetType);
+  if (datasetConfig.formatSeriesLabel) {
+    const label = datasetConfig.formatSeriesLabel(timeSeries, widgetQuery);
     return {timeSeries, label, seriesName, widgetQuery};
   }
 

--- a/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
+++ b/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
@@ -4,7 +4,8 @@ import {
   SERIES_NAME_PART_DELIMITER,
   transformLegacySeriesToTimeSeries,
 } from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
-import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
+import {formatMetricsTimeseriesLabel} from 'sentry/views/dashboards/datasetConfig/traceMetrics';
+import {WidgetType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 
@@ -57,6 +58,13 @@ export function transformWidgetSeriesToTimeSeries(
 
   if (!timeSeries) {
     return null;
+  }
+
+  // Trace metrics have their own label formatting that already handles
+  // query names, groupings, and multiple aggregates — use it directly.
+  if (widget.widgetType === WidgetType.TRACEMETRICS) {
+    const label = formatMetricsTimeseriesLabel({widgetQuery, timeSeries});
+    return {timeSeries, label, seriesName, widgetQuery};
   }
 
   const fieldIndex = fields.indexOf(yAxis);


### PR DESCRIPTION
Adds a config option to override the label based on the widget type (e.g. tracemetrics). This is necessary because we do some last minute handling to the label to change its series name/aggregate to be more human friendly in the UI.

Resolves JAVASCRIPT-37VC
Closes DAIN-1222