### PR TITLE
fix(storybook): convert missed default imports to named

### DIFF
--- a/static/app/components/core/avatar/avatar.mdx
+++ b/static/app/components/core/avatar/avatar.mdx
@@ -11,7 +11,7 @@ import {Fragment, useEffect} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 
-import {Placeholder} from 'sentry/components/placeholder';
+import Placeholder from 'sentry/components/placeholder';
 import * as Storybook from 'sentry/stories';
 import {useMembers} from 'sentry/utils/useMembers';
 import {useUserTeams} from 'sentry/utils/useUserTeams';

--- a/static/app/components/core/avatar/avatar.mdx
+++ b/static/app/components/core/avatar/avatar.mdx
@@ -11,7 +11,7 @@ import {Fragment, useEffect} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 
-import Placeholder from 'sentry/components/placeholder';
+import {Placeholder} from 'sentry/components/placeholder';
 import * as Storybook from 'sentry/stories';
 import {useMembers} from 'sentry/utils/useMembers';
 import {useUserTeams} from 'sentry/utils/useUserTeams';

--- a/static/app/components/emptyMessage.mdx
+++ b/static/app/components/emptyMessage.mdx
@@ -8,8 +8,8 @@ resources:
 
 import {Button} from '@sentry/scraps/button';
 
-import EmptyMessage from 'sentry/components/emptyMessage';
-import Panel from 'sentry/components/panels/panel';
+import {EmptyMessage} from 'sentry/components/emptyMessage';
+import {Panel} from 'sentry/components/panels/panel';
 import {IconSearch} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 


### PR DESCRIPTION
I missed these in #110263. No builds fail, they just print warnings. See `pnpm build`.

```plaintext
WARNING in ./app/components/core/avatar/avatar.mdx 129:21-31
  ⚠ ESModulesLinkingWarning: export 'Placeholder' (imported as 'Placeholder') was not found in 'sentry/components/placeholder' (possible exports: default)
     ╭─[129:20]
 127 │     const { members, fetching } = useLoadedMembers();
 128 │     if (fetching || isLoading) {
 129 │         return _jsx(Placeholder, {});
     ·                     ───────────
 130 │     }
 131 │     return _jsxs(Flex, {
     ╰────


WARNING in ./app/components/core/avatar/avatar.mdx 149:21-31
  ⚠ ESModulesLinkingWarning: export 'Placeholder' (imported as 'Placeholder') was not found in 'sentry/components/placeholder' (possible exports: default)
     ╭─[149:20]
 147 │     const { members, fetching } = useLoadedMembers();
 148 │     if (isLoading || fetching) {
 149 │         return _jsx(Placeholder, {});
     ·                     ───────────
 150 │     }
 151 │     return _jsx(AvatarList, {
     ╰────


WARNING in ./app/components/core/avatar/avatar.mdx 160:21-31
  ⚠ ESModulesLinkingWarning: export 'Placeholder' (imported as 'Placeholder') was not found in 'sentry/components/placeholder' (possible exports: default)
     ╭─[160:20]
 158 │     const { members, fetching } = useLoadedMembers();
 159 │     if (isLoading || fetching) {
 160 │         return _jsx(Placeholder, {});
     ·                     ───────────
 161 │     }
 162 │     return _jsx(Fragment, {
     ╰────


WARNING in ./app/components/core/avatar/avatar.mdx 174:21-31
  ⚠ ESModulesLinkingWarning: export 'Placeholder' (imported as 'Placeholder') was not found in 'sentry/components/placeholder' (possible exports: default)
     ╭─[174:20]
 172 │     const { members, fetching } = useLoadedMembers();
 173 │     if (fetching) {
 174 │         return _jsx(Placeholder, {});
     ·                     ───────────
 175 │     }
 176 │     return _jsx(AvatarList, {
     ╰────
```