### PR TITLE
feat(explore) Adding epm, eps columns to occurrences dataset

### DIFF
--- a/src/sentry/search/eap/common_formulas.py
+++ b/src/sentry/search/eap/common_formulas.py
@@ -1,10 +1,4 @@
-"""
-Shared formula builders for EAP datasets.
-
-Each dataset has an "always-present" attribute used as a row counter.
-These factories accept that key so spans, occurrences, and any future
-dataset can share the same eps/epm logic.
-"""
+"""Shared formula builders for EAP datasets."""
 
 from collections.abc import Callable
 

--- a/src/sentry/search/eap/common_formulas.py
+++ b/src/sentry/search/eap/common_formulas.py
@@ -1,0 +1,83 @@
+"""
+Shared formula builders for EAP datasets.
+
+Each dataset has an "always-present" attribute used as a row counter.
+These factories accept that key so spans, occurrences, and any future
+dataset can share the same eps/epm logic.
+"""
+
+from collections.abc import Callable
+
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
+from sentry_protos.snuba.v1.formula_pb2 import Literal as LiteralValue
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    Function,
+)
+
+from sentry.search.eap.columns import ResolvedArguments, ResolverSettings
+
+
+def make_eps(
+    count_key: AttributeKey,
+) -> Callable[[ResolvedArguments, ResolverSettings], Column.BinaryFormula]:
+    """Return an eps formula resolver that counts *count_key* rows per second."""
+
+    def eps(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+        extrapolation_mode = settings["extrapolation_mode"]
+        is_timeseries_request = settings["snuba_params"].is_timeseries_request
+
+        divisor = (
+            settings["snuba_params"].timeseries_granularity_secs
+            if is_timeseries_request
+            else settings["snuba_params"].interval
+        )
+
+        return Column.BinaryFormula(
+            left=Column(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_COUNT,
+                    key=count_key,
+                    extrapolation_mode=extrapolation_mode,
+                ),
+            ),
+            op=Column.BinaryFormula.OP_DIVIDE,
+            right=Column(
+                literal=LiteralValue(val_double=float(divisor)),
+            ),
+        )
+
+    return eps
+
+
+def make_epm(
+    count_key: AttributeKey,
+) -> Callable[[ResolvedArguments, ResolverSettings], Column.BinaryFormula]:
+    """Return an epm formula resolver that counts *count_key* rows per minute."""
+
+    def epm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+        extrapolation_mode = settings["extrapolation_mode"]
+        is_timeseries_request = settings["snuba_params"].is_timeseries_request
+
+        divisor = (
+            settings["snuba_params"].timeseries_granularity_secs
+            if is_timeseries_request
+            else settings["snuba_params"].interval
+        )
+
+        return Column.BinaryFormula(
+            left=Column(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_COUNT,
+                    key=count_key,
+                    extrapolation_mode=extrapolation_mode,
+                ),
+            ),
+            op=Column.BinaryFormula.OP_DIVIDE,
+            right=Column(
+                literal=LiteralValue(val_double=divisor / 60.0),
+            ),
+        )
+
+    return epm

--- a/src/sentry/search/eap/occurrences/aggregates.py
+++ b/src/sentry/search/eap/occurrences/aggregates.py
@@ -11,8 +11,12 @@ from sentry.search.eap.columns import (
 )
 from sentry.search.eap.validator import literal_validator, number_validator
 
+OCCURRENCE_GROUP_ID_KEY = AttributeKey(
+    name="group_id",
+    type=AttributeKey.Type.TYPE_INT,
+)
 OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES = [
-    AttributeKey(name="group_id", type=AttributeKey.Type.TYPE_INT),
+    OCCURRENCE_GROUP_ID_KEY,
 ]
 
 OCCURRENCE_AGGREGATE_DEFINITIONS = {

--- a/src/sentry/search/eap/occurrences/definitions.py
+++ b/src/sentry/search/eap/occurrences/definitions.py
@@ -6,10 +6,11 @@ from sentry.search.eap.occurrences.attributes import (
     OCCURRENCE_ATTRIBUTE_DEFINITIONS,
     OCCURRENCE_VIRTUAL_CONTEXTS,
 )
+from sentry.search.eap.occurrences.formulas import OCCURRENCE_FORMULA_DEFINITIONS
 
 OCCURRENCE_DEFINITIONS = ColumnDefinitions(
     aggregates=OCCURRENCE_AGGREGATE_DEFINITIONS,
-    formulas={},
+    formulas=OCCURRENCE_FORMULA_DEFINITIONS,
     columns=OCCURRENCE_ATTRIBUTE_DEFINITIONS,
     contexts=OCCURRENCE_VIRTUAL_CONTEXTS,
     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE,

--- a/src/sentry/search/eap/occurrences/formulas.py
+++ b/src/sentry/search/eap/occurrences/formulas.py
@@ -1,25 +1,18 @@
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
-
 from sentry.search.eap.columns import FormulaDefinition
 from sentry.search.eap.common_formulas import make_epm, make_eps
-
-# group_id is always present on occurrences (OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES).
-_OCCURRENCE_COUNT_KEY = AttributeKey(
-    name="group_id",
-    type=AttributeKey.Type.TYPE_INT,
-)
+from sentry.search.eap.occurrences.aggregates import OCCURRENCE_GROUP_ID_KEY
 
 OCCURRENCE_FORMULA_DEFINITIONS = {
     "eps": FormulaDefinition(
         default_search_type="rate",
         arguments=[],
-        formula_resolver=make_eps(_OCCURRENCE_COUNT_KEY),
+        formula_resolver=make_eps(OCCURRENCE_GROUP_ID_KEY),
         is_aggregate=True,
     ),
     "epm": FormulaDefinition(
         default_search_type="rate",
         arguments=[],
-        formula_resolver=make_epm(_OCCURRENCE_COUNT_KEY),
+        formula_resolver=make_epm(OCCURRENCE_GROUP_ID_KEY),
         is_aggregate=True,
     ),
 }

--- a/src/sentry/search/eap/occurrences/formulas.py
+++ b/src/sentry/search/eap/occurrences/formulas.py
@@ -1,0 +1,94 @@
+"""
+Rate aggregates for the occurrences EAP dataset (events per second/minute).
+
+Semantics match legacy errors eps/epm: count of rows over time window.
+Spans use count(sentry.exclusive_time_ms) because that attribute exists on every span;
+occurrences use count(group_id) as the always-present attribute for row count.
+"""
+
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
+from sentry_protos.snuba.v1.formula_pb2 import Literal as LiteralValue
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    Function,
+)
+
+from sentry.search.eap.columns import (
+    FormulaDefinition,
+    ResolvedArguments,
+    ResolverSettings,
+)
+
+# group_id is always present on occurrences (OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES).
+# Counting it yields row count; dividing by time gives events per second/minute.
+_OCCURRENCE_COUNT_KEY = AttributeKey(
+    name="group_id",
+    type=AttributeKey.Type.TYPE_INT,
+)
+
+
+def eps(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+    extrapolation_mode = settings["extrapolation_mode"]
+    is_timeseries_request = settings["snuba_params"].is_timeseries_request
+
+    divisor = (
+        settings["snuba_params"].timeseries_granularity_secs
+        if is_timeseries_request
+        else settings["snuba_params"].interval
+    )
+
+    return Column.BinaryFormula(
+        left=Column(
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_COUNT,
+                key=_OCCURRENCE_COUNT_KEY,
+                extrapolation_mode=extrapolation_mode,
+            ),
+        ),
+        op=Column.BinaryFormula.OP_DIVIDE,
+        right=Column(
+            literal=LiteralValue(val_double=float(divisor)),
+        ),
+    )
+
+
+def epm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+    extrapolation_mode = settings["extrapolation_mode"]
+    is_timeseries_request = settings["snuba_params"].is_timeseries_request
+
+    divisor = (
+        settings["snuba_params"].timeseries_granularity_secs
+        if is_timeseries_request
+        else settings["snuba_params"].interval
+    )
+
+    return Column.BinaryFormula(
+        left=Column(
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_COUNT,
+                key=_OCCURRENCE_COUNT_KEY,
+                extrapolation_mode=extrapolation_mode,
+            ),
+        ),
+        op=Column.BinaryFormula.OP_DIVIDE,
+        right=Column(
+            literal=LiteralValue(val_double=divisor / 60.0),
+        ),
+    )
+
+
+OCCURRENCE_FORMULA_DEFINITIONS = {
+    "eps": FormulaDefinition(
+        default_search_type="rate",
+        arguments=[],
+        formula_resolver=eps,
+        is_aggregate=True,
+    ),
+    "epm": FormulaDefinition(
+        default_search_type="rate",
+        arguments=[],
+        formula_resolver=epm,
+        is_aggregate=True,
+    ),
+}

--- a/src/sentry/search/eap/occurrences/formulas.py
+++ b/src/sentry/search/eap/occurrences/formulas.py
@@ -1,94 +1,25 @@
-"""
-Rate aggregates for the occurrences EAP dataset (events per second/minute).
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
-Semantics match legacy errors eps/epm: count of rows over time window.
-Spans use count(sentry.exclusive_time_ms) because that attribute exists on every span;
-occurrences use count(group_id) as the always-present attribute for row count.
-"""
-
-from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
-from sentry_protos.snuba.v1.formula_pb2 import Literal as LiteralValue
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
-    AttributeAggregation,
-    AttributeKey,
-    Function,
-)
-
-from sentry.search.eap.columns import (
-    FormulaDefinition,
-    ResolvedArguments,
-    ResolverSettings,
-)
+from sentry.search.eap.columns import FormulaDefinition
+from sentry.search.eap.common_formulas import make_epm, make_eps
 
 # group_id is always present on occurrences (OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES).
-# Counting it yields row count; dividing by time gives events per second/minute.
 _OCCURRENCE_COUNT_KEY = AttributeKey(
     name="group_id",
     type=AttributeKey.Type.TYPE_INT,
 )
 
-
-def eps(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
-    extrapolation_mode = settings["extrapolation_mode"]
-    is_timeseries_request = settings["snuba_params"].is_timeseries_request
-
-    divisor = (
-        settings["snuba_params"].timeseries_granularity_secs
-        if is_timeseries_request
-        else settings["snuba_params"].interval
-    )
-
-    return Column.BinaryFormula(
-        left=Column(
-            aggregation=AttributeAggregation(
-                aggregate=Function.FUNCTION_COUNT,
-                key=_OCCURRENCE_COUNT_KEY,
-                extrapolation_mode=extrapolation_mode,
-            ),
-        ),
-        op=Column.BinaryFormula.OP_DIVIDE,
-        right=Column(
-            literal=LiteralValue(val_double=float(divisor)),
-        ),
-    )
-
-
-def epm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
-    extrapolation_mode = settings["extrapolation_mode"]
-    is_timeseries_request = settings["snuba_params"].is_timeseries_request
-
-    divisor = (
-        settings["snuba_params"].timeseries_granularity_secs
-        if is_timeseries_request
-        else settings["snuba_params"].interval
-    )
-
-    return Column.BinaryFormula(
-        left=Column(
-            aggregation=AttributeAggregation(
-                aggregate=Function.FUNCTION_COUNT,
-                key=_OCCURRENCE_COUNT_KEY,
-                extrapolation_mode=extrapolation_mode,
-            ),
-        ),
-        op=Column.BinaryFormula.OP_DIVIDE,
-        right=Column(
-            literal=LiteralValue(val_double=divisor / 60.0),
-        ),
-    )
-
-
 OCCURRENCE_FORMULA_DEFINITIONS = {
     "eps": FormulaDefinition(
         default_search_type="rate",
         arguments=[],
-        formula_resolver=eps,
+        formula_resolver=make_eps(_OCCURRENCE_COUNT_KEY),
         is_aggregate=True,
     ),
     "epm": FormulaDefinition(
         default_search_type="rate",
         arguments=[],
-        formula_resolver=epm,
+        formula_resolver=make_epm(_OCCURRENCE_COUNT_KEY),
         is_aggregate=True,
     ),
 }

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -28,6 +28,7 @@ from sentry.search.eap.columns import (
     ResolverSettings,
     ValueArgumentDefinition,
 )
+from sentry.search.eap.common_formulas import make_epm, make_eps
 from sentry.search.eap.constants import RESPONSE_CODE_MAP
 from sentry.search.eap.spans.utils import (
     WEB_VITALS_MEASUREMENTS,
@@ -726,31 +727,6 @@ def tpm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormul
     )
 
 
-def epm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
-    extrapolation_mode = settings["extrapolation_mode"]
-    is_timeseries_request = settings["snuba_params"].is_timeseries_request
-
-    divisor = (
-        settings["snuba_params"].timeseries_granularity_secs
-        if is_timeseries_request
-        else settings["snuba_params"].interval
-    )
-
-    return Column.BinaryFormula(
-        left=Column(
-            aggregation=AttributeAggregation(
-                aggregate=Function.FUNCTION_COUNT,
-                key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.exclusive_time_ms"),
-                extrapolation_mode=extrapolation_mode,
-            ),
-        ),
-        op=Column.BinaryFormula.OP_DIVIDE,
-        right=Column(
-            literal=LiteralValue(val_double=divisor / 60),
-        ),
-    )
-
-
 def failure_count(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
     extrapolation_mode = settings["extrapolation_mode"]
 
@@ -781,31 +757,6 @@ def failure_count(_: ResolvedArguments, settings: ResolverSettings) -> Column.Bi
         ),
         op=Column.BinaryFormula.OP_MULTIPLY,
         right=Column(literal=LiteralValue(val_double=1.0)),
-    )
-
-
-def eps(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
-    extrapolation_mode = settings["extrapolation_mode"]
-    is_timeseries_request = settings["snuba_params"].is_timeseries_request
-
-    divisor = (
-        settings["snuba_params"].timeseries_granularity_secs
-        if is_timeseries_request
-        else settings["snuba_params"].interval
-    )
-
-    return Column.BinaryFormula(
-        left=Column(
-            aggregation=AttributeAggregation(
-                aggregate=Function.FUNCTION_COUNT,
-                key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.exclusive_time_ms"),
-                extrapolation_mode=extrapolation_mode,
-            ),
-        ),
-        op=Column.BinaryFormula.OP_DIVIDE,
-        right=Column(
-            literal=LiteralValue(val_double=divisor),
-        ),
     )
 
 
@@ -1037,6 +988,8 @@ def user_misery(args: ResolvedArguments, settings: ResolverSettings) -> Column.B
     )
 
 
+_SPAN_COUNT_KEY = AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="sentry.exclusive_time_ms")
+
 SPAN_FORMULA_DEFINITIONS = {
     "http_response_rate": FormulaDefinition(
         default_search_type="percentage",
@@ -1224,7 +1177,10 @@ SPAN_FORMULA_DEFINITIONS = {
         private=True,
     ),
     "epm": FormulaDefinition(
-        default_search_type="rate", arguments=[], formula_resolver=epm, is_aggregate=True
+        default_search_type="rate",
+        arguments=[],
+        formula_resolver=make_epm(_SPAN_COUNT_KEY),
+        is_aggregate=True,
     ),
     "tpm": FormulaDefinition(
         default_search_type="rate", arguments=[], formula_resolver=tpm, is_aggregate=True
@@ -1236,7 +1192,10 @@ SPAN_FORMULA_DEFINITIONS = {
         is_aggregate=True,
     ),
     "eps": FormulaDefinition(
-        default_search_type="rate", arguments=[], formula_resolver=eps, is_aggregate=True
+        default_search_type="rate",
+        arguments=[],
+        formula_resolver=make_eps(_SPAN_COUNT_KEY),
+        is_aggregate=True,
     ),
     "apdex": FormulaDefinition(
         default_search_type="number",

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.testutils.cases import OccurrenceTestCase
 from tests.snuba.api.endpoints.test_organization_events import (
@@ -110,7 +112,7 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
-        assert abs(data[0]["eps()"] - (2 / 7200)) < 0.0001
+        assert data[0]["eps()"] == pytest.approx(2 / 7200, abs=0.0001)
         meta = response.data["meta"]
         assert meta["fields"]["eps()"] == "rate"
         assert meta["units"]["eps()"] == "1/second"
@@ -121,7 +123,7 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
-        assert abs(data[0]["epm()"] - (2 / (7200 / 60))) < 0.001
+        assert data[0]["epm()"] == pytest.approx(2 / (7200 / 60), abs=0.001)
         meta = response.data["meta"]
         assert meta["fields"]["epm()"] == "rate"
         assert meta["units"]["epm()"] == "1/minute"

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -75,3 +75,53 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
             )
         assert response.status_code == 200, response.content
         assert response.data["data"][0]["count()"] == 1
+
+    def _request_table_rate(self, field: str):
+        """Store two occurrences in a 2h window and request /events/ with the given rate field."""
+        group = self.create_group(project=self.project)
+        occurrences = [
+            self.create_eap_occurrence(
+                group_id=group.id,
+                project=self.project,
+                attributes={"fingerprint": ["g1"]},
+            ),
+            self.create_eap_occurrence(
+                group_id=group.id,
+                project=self.project,
+                attributes={"fingerprint": ["g1"]},
+            ),
+        ]
+        self.store_eap_items(occurrences)
+        with self.options(
+            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+        ):
+            return self.do_request(
+                {
+                    "field": [field],
+                    "statsPeriod": "2h",
+                    "project": [self.project.id],
+                    "dataset": "occurrences",
+                }
+            )
+
+    def test_eps_rate_aggregate(self) -> None:
+        # 2 events / 7200 seconds (2h).
+        response = self._request_table_rate("eps()")
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert abs(data[0]["eps()"] - (2 / 7200)) < 0.0001
+        meta = response.data["meta"]
+        assert meta["fields"]["eps()"] == "rate"
+        assert meta["units"]["eps()"] == "1/second"
+
+    def test_epm_rate_aggregate(self) -> None:
+        # 2 events / (7200/60) = 2/120 per minute.
+        response = self._request_table_rate("epm()")
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert abs(data[0]["epm()"] - (2 / (7200 / 60))) < 0.001
+        meta = response.data["meta"]
+        assert meta["fields"]["epm()"] == "rate"
+        assert meta["units"]["epm()"] == "1/minute"

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
@@ -17,7 +17,26 @@ from tests.snuba.api.endpoints.test_organization_events_timeseries_spans import 
 
 any_confidence = AnyConfidence()
 
-pytestmark = pytest.mark.sentry_metrics
+
+def _assert_timeseries_values_approx(
+    actual_values: list[dict[str, Any]],
+    start: Any,
+    interval: int,
+    expected_values: list[float],
+    abs_tolerance: float,
+) -> None:
+    """Assert actual timeseries values match expected with pytest.approx. Use for rate/float series."""
+    expected_list = build_expected_timeseries(start, interval, expected_values)
+    sorted_actual = sorted(actual_values, key=lambda r: r["timestamp"])
+    assert len(sorted_actual) == len(expected_list), (
+        f"expected {len(expected_list)} buckets, got {len(sorted_actual)}. "
+        f"First row keys (from backend): {list(sorted_actual[0].keys()) if sorted_actual else 'no values'}"
+    )
+    for i, (actual_row, expected_row) in enumerate(zip(sorted_actual, expected_list)):
+        assert actual_row["timestamp"] == expected_row["timestamp"]
+        assert actual_row["value"] == pytest.approx(expected_row["value"], abs=abs_tolerance), (
+            f"bucket {i}: got {actual_row['value']!r}, expected {expected_row['value']!r}"
+        )
 
 
 class OrganizationEventsTimeseriesOccurrencesEndpointTest(
@@ -132,21 +151,16 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
         assert timeseries["meta"]["valueUnit"] == value_unit
         assert timeseries["meta"]["interval"] == 3_600_000
         expected_rates = [c / divisor for c in event_counts]
-        values = sorted(timeseries["values"], key=lambda r: r["timestamp"])
-        assert len(values) == 6, (
-            f"expected 6 buckets, got {len(values)}. "
-            f"First row keys (from backend): {list(values[0].keys()) if values else 'no values'}"
+        _assert_timeseries_values_approx(
+            timeseries["values"],
+            self.start,
+            3_600_000,
+            expected_rates,
+            abs_tolerance=tolerance,
         )
-        for i, row in enumerate(values):
-            actual = row["value"]
-            expected = expected_rates[i]
-            assert abs(actual - expected) < tolerance, (
-                f"bucket {i}: got {actual!r}, expected {expected!r}"
-            )
 
     def test_eps_timeseries(self) -> None:
-        """Rate aggregate eps() on /events-timeseries: events/sec per bucket, meta rate/1/second.
-        eps() counts on group_id (OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES); occurrences must have group_id set."""
+        """Rate aggregate eps() on /events-timeseries: events/sec per bucket, meta rate/1/second."""
         self._run_rate_timeseries_test(
             "eps()",
             "1/second",

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Any
 
 import pytest
 from django.urls import reverse
@@ -46,35 +47,44 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
         with self.feature(features):
             return self.client.get(self.url if url is None else url, data=data, format="json")
 
-    def test_count(self) -> None:
-        event_counts = [6, 0, 6, 3, 0, 3]
-        occurrences = []
-        for hour, count in enumerate(event_counts):
-            occurrences.extend(
-                [
-                    self.create_eap_occurrence(
-                        tags={"status": "success"},
-                        timestamp=self.start + timedelta(hours=hour, minutes=minute),
-                        attributes={"description": "foo"},
-                    )
-                    for minute in range(count)
-                ],
+    def _store_occurrences_and_request_timeseries(
+        self, event_counts: list[int], y_axis: str, **occurrence_kwargs: Any
+    ):
+        """Create a group, build occurrences from event_counts (with group_id), store them, run timeseries request."""
+        group = self.create_group(project=self.project)
+        occurrences = [
+            self.create_eap_occurrence(
+                group_id=group.id,
+                project=self.project,
+                timestamp=self.start + timedelta(hours=hour, minutes=minute),
+                **occurrence_kwargs,
             )
+            for hour, count in enumerate(event_counts)
+            for minute in range(count)
+        ]
         self.store_eap_items(occurrences)
-
         with self.options(
             {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
         ):
-            response = self._do_request(
+            return self._do_request(
                 data={
                     "start": self.start,
                     "end": self.end,
                     "interval": "1h",
-                    "yAxis": "count()",
+                    "yAxis": y_axis,
                     "project": self.project.id,
                     "dataset": "occurrences",
                 },
             )
+
+    def test_count(self) -> None:
+        event_counts = [6, 0, 6, 3, 0, 3]
+        response = self._store_occurrences_and_request_timeseries(
+            event_counts,
+            "count()",
+            tags={"status": "success"},
+            attributes={"description": "foo"},
+        )
         assert response.status_code == 200, response.content
         assert response.data["meta"] == {
             "dataset": "occurrences",
@@ -99,3 +109,52 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
             "valueUnit": None,
             "interval": 3_600_000,
         }
+
+    def _run_rate_timeseries_test(
+        self,
+        y_axis: str,
+        value_unit: str,
+        divisor: float,
+        *,
+        tolerance: float = 0.001,
+    ) -> None:
+        """Helper for eps/epm timeseries: request yAxis, assert rate per bucket."""
+        event_counts = [2, 0, 2, 1, 0, 1]  # per 1h bucket
+        response = self._store_occurrences_and_request_timeseries(
+            event_counts, y_axis, attributes={"fingerprint": ["g1"]}
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"]["dataset"] == "occurrences"
+        assert len(response.data["timeSeries"]) == 1
+        timeseries = response.data["timeSeries"][0]
+        assert timeseries["yAxis"] == y_axis
+        assert timeseries["meta"]["valueType"] == "rate"
+        assert timeseries["meta"]["valueUnit"] == value_unit
+        assert timeseries["meta"]["interval"] == 3_600_000
+        expected_rates = [c / divisor for c in event_counts]
+        values = sorted(timeseries["values"], key=lambda r: r["timestamp"])
+        assert len(values) == 6, (
+            f"expected 6 buckets, got {len(values)}. "
+            f"First row keys (from backend): {list(values[0].keys()) if values else 'no values'}"
+        )
+        for i, row in enumerate(values):
+            actual = row["value"]
+            expected = expected_rates[i]
+            assert abs(actual - expected) < tolerance, (
+                f"bucket {i}: got {actual!r}, expected {expected!r}"
+            )
+
+    def test_eps_timeseries(self) -> None:
+        """Rate aggregate eps() on /events-timeseries: events/sec per bucket, meta rate/1/second.
+        eps() counts on group_id (OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES); occurrences must have group_id set."""
+        self._run_rate_timeseries_test(
+            "eps()",
+            "1/second",
+            3600.0,
+            tolerance=0.0001,
+        )
+
+    def test_epm_timeseries(self) -> None:
+        """Rate aggregate epm() on /events-timeseries: events/min per bucket, meta rate/1/minute.
+        epm() counts on group_id (OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES); occurrences must have group_id set."""
+        self._run_rate_timeseries_test("epm()", "1/minute", 60.0)

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
@@ -18,27 +18,6 @@ from tests.snuba.api.endpoints.test_organization_events_timeseries_spans import 
 any_confidence = AnyConfidence()
 
 
-def _assert_timeseries_values_approx(
-    actual_values: list[dict[str, Any]],
-    start: Any,
-    interval: int,
-    expected_values: list[float],
-    abs_tolerance: float,
-) -> None:
-    """Assert actual timeseries values match expected with pytest.approx. Use for rate/float series."""
-    expected_list = build_expected_timeseries(start, interval, expected_values)
-    sorted_actual = sorted(actual_values, key=lambda r: r["timestamp"])
-    assert len(sorted_actual) == len(expected_list), (
-        f"expected {len(expected_list)} buckets, got {len(sorted_actual)}. "
-        f"First row keys (from backend): {list(sorted_actual[0].keys()) if sorted_actual else 'no values'}"
-    )
-    for i, (actual_row, expected_row) in enumerate(zip(sorted_actual, expected_list)):
-        assert actual_row["timestamp"] == expected_row["timestamp"]
-        assert actual_row["value"] == pytest.approx(expected_row["value"], abs=abs_tolerance), (
-            f"bucket {i}: got {actual_row['value']!r}, expected {expected_row['value']!r}"
-        )
-
-
 class OrganizationEventsTimeseriesOccurrencesEndpointTest(
     OrganizationEventsEndpointTestBase, OccurrenceTestCase
 ):
@@ -134,8 +113,6 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
         y_axis: str,
         value_unit: str,
         divisor: float,
-        *,
-        tolerance: float = 0.001,
     ) -> None:
         """Helper for eps/epm timeseries: request yAxis, assert rate per bucket."""
         event_counts = [2, 0, 2, 1, 0, 1]  # per 1h bucket
@@ -150,13 +127,14 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
         assert timeseries["meta"]["valueType"] == "rate"
         assert timeseries["meta"]["valueUnit"] == value_unit
         assert timeseries["meta"]["interval"] == 3_600_000
-        expected_rates = [c / divisor for c in event_counts]
-        _assert_timeseries_values_approx(
-            timeseries["values"],
+
+        assert timeseries["values"] == build_expected_timeseries(
             self.start,
             3_600_000,
-            expected_rates,
-            abs_tolerance=tolerance,
+            [pytest.approx(c / divisor, 0.001) for c in event_counts],
+            sample_count=event_counts,
+            sample_rate=[1 if val else None for val in event_counts],
+            confidence=[any_confidence if val else None for val in event_counts],
         )
 
     def test_eps_timeseries(self) -> None:
@@ -165,10 +143,8 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
             "eps()",
             "1/second",
             3600.0,
-            tolerance=0.0001,
         )
 
     def test_epm_timeseries(self) -> None:
-        """Rate aggregate epm() on /events-timeseries: events/min per bucket, meta rate/1/minute.
-        epm() counts on group_id (OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES); occurrences must have group_id set."""
+        """Rate aggregate epm() on /events-timeseries: events/min per bucket, meta rate/1/minute."""
         self._run_rate_timeseries_test("epm()", "1/minute", 60.0)


### PR DESCRIPTION
Adds integration tests for the new occurrences EAP dataset on /api/0/organizations/{org}/events/ and /events-stats/ endpoints, introduced in https://github.com/getsentry/sentry/pull/109727.

Add `eps()` and `epm()` columns for occurrences.