### PR TITLE
chore(perf-detectors): Export PerformanceNPlusOneGroupType at new location

### DIFF
--- a/src/sentry/issue_detection/grouptype.py
+++ b/src/sentry/issue_detection/grouptype.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType
+
+__all__ = ["PerformanceNPlusOneGroupType"]


### PR DESCRIPTION
We want to move the Performance detectors to sentry.issue_detection.grouptype, but there's a dependency on the current location in getsentry for PerformanceNPlusOneGroupType. By re-exporting it in the new location, we can then update getsentry and do the real move without breaking anything.

Full move PR is https://github.com/getsentry/sentry/pull/110150
