### PR TITLE
fix(logs): Pass boolean attributes object to the logs table prop

### DIFF
--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -515,8 +515,9 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
           <LogsItemContainer>
             {tableTab === 'logs' ? (
               <LogsInfiniteTable
-                stringAttributes={stringAttributes}
+                booleanAttributes={booleanAttributes}
                 numberAttributes={numberAttributes}
+                stringAttributes={stringAttributes}
               />
             ) : (
               <LogsAggregateTable aggregatesTableResult={aggregatesTableResult} />


### PR DESCRIPTION
Fixing a small bug where the boolean attributes object wasn't being passed to the logs table.