### PR TITLE
fix(build): Exclude snapshot test files from rspack type-checker

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -486,6 +486,7 @@ const appConfig: Configuration = {
                   'node_modules/**/*',
                   'tests/**/*',
                   '**/*.spec.*',
+                  '**/*.snapshots.*',
                   'static/eslint/**/*',
                   'scripts/**/*',
                 ],


### PR DESCRIPTION
The `TsCheckerRspackPlugin` in rspack.config.ts excludes `tests/**/*`, which
strips the `it.snapshot` type augmentation defined in
`tests/js/sentry-test/snapshots/snapshot-framework.ts`. However, it still
processes `*.snapshots.tsx` files under `static/`, causing TS2339 errors
because `it.snapshot` is undefined without that augmentation.

This adds `'**/*.snapshots.*'` to the exclude list, matching the existing
`'**/*.spec.*'` pattern. Introduced by b3def8dd550 feat(frontend): Web
snapshot testing (#107971).