### PR TITLE
fix(traces): Downgrade Group.DoesNotExist log to warning in trace serialization

### DIFF
--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -136,8 +136,8 @@ def _serialize_rpc_issue(
         else:
             try:
                 issue = Group.objects.get(id=issue_id, project__id=occurrence.project_id)
-            except Group.DoesNotExist as e:
-                logger.error(e)
+            except Group.DoesNotExist:
+                logger.warning("Group %s not found while serializing trace", issue_id)
                 return None
             group_cache[issue_id] = issue
         return SerializedIssue(
@@ -167,8 +167,8 @@ def _serialize_rpc_issue(
         else:
             try:
                 issue = Group.objects.get(id=issue_id, project__id=event["project.id"])
-            except Group.DoesNotExist as e:
-                logger.error(e)
+            except Group.DoesNotExist:
+                logger.warning("Group %s not found while serializing trace", issue_id)
                 return None
             group_cache[issue_id] = issue
 


### PR DESCRIPTION
+ logger.error() causes Sentry to capture these as error events (68K+), but a deleted group during trace rendering is an expected stale refernce that _serialize_rpc_issue already handles gracefully by returning None. Downgrade to logger.warning to stop generating noise while preserving observability.
+ Related to this issue: https://sentry.sentry.io/issues/7312916675/events/ff63b8a75c364b7696d3a8a7c5246a51/?project=1&referrer=previous-event&statsPeriod=24h