### PR TITLE
fix(workflow_engine): Skip workflow processing for inactive projects

### DIFF
--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -4,6 +4,8 @@ from django.db.models import Value
 
 from sentry.eventstream.base import GroupState
 from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.models.project import Project
 from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
@@ -13,6 +15,7 @@ from sentry.utils import metrics
 from sentry.utils.exceptions import timeout_grouping_context
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.tasks.utils import (
+    ProjectNotActiveError,
     build_workflow_event_data_from_activity,
     build_workflow_event_data_from_event,
 )
@@ -74,7 +77,12 @@ def build_trigger_action_task_params(
     retry=Retry(times=3, delay=5),
     silo_mode=SiloMode.REGION,
 )
-@retry(timeouts=True, raise_on_no_retries=False, ignore_and_capture=Action.DoesNotExist)
+@retry(
+    timeouts=True,
+    raise_on_no_retries=False,
+    ignore_and_capture=Action.DoesNotExist,
+    ignore=(Group.DoesNotExist, Project.DoesNotExist, ProjectNotActiveError),
+)
 def trigger_action(
     action_id: int,
     workflow_id: int,

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -80,8 +80,8 @@ def build_trigger_action_task_params(
 @retry(
     timeouts=True,
     raise_on_no_retries=False,
-    ignore_and_capture=Action.DoesNotExist,
-    ignore=(Group.DoesNotExist, Project.DoesNotExist, ProjectNotActiveError),
+    ignore_and_capture=(Action.DoesNotExist, Group.DoesNotExist),
+    ignore=(Project.DoesNotExist, ProjectNotActiveError),
 )
 def trigger_action(
     action_id: int,

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -1,6 +1,7 @@
 from google.api_core.exceptions import DeadlineExceeded, RetryError, ServiceUnavailable
 
 from sentry import nodestore
+from sentry.constants import ObjectStatus
 from sentry.eventstream.base import GroupState
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.activity import Activity
@@ -62,6 +63,12 @@ class EventNotFoundError(Exception):
         super().__init__(msg)
 
 
+class ProjectNotActiveError(Exception):
+    def __init__(self, project_id: int):
+        msg = f"Project not active: project_id={project_id}"
+        super().__init__(msg)
+
+
 @scopedstats.timer()
 def build_workflow_event_data_from_event(
     event_id: str,
@@ -78,6 +85,11 @@ def build_workflow_event_data_from_event(
     """
     group = Group.objects.get_from_cache(id=group_id)
     project_id = group.project_id
+
+    project = Project.objects.get_from_cache(id=project_id)
+    if project.status != ObjectStatus.ACTIVE:
+        raise ProjectNotActiveError(project_id)
+
     event = fetch_event(event_id, project_id)
     if event is None:
         raise EventNotFoundError(event_id, project_id)

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -86,13 +86,12 @@ def build_workflow_event_data_from_event(
     group = Group.objects.get_from_cache(id=group_id)
     project_id = group.project_id
 
-    project = Project.objects.get_from_cache(id=project_id)
-    if project.status != ObjectStatus.ACTIVE:
-        raise ProjectNotActiveError(project_id)
-
     event = fetch_event(event_id, project_id)
     if event is None:
         raise EventNotFoundError(event_id, project_id)
+
+    if event.project.status != ObjectStatus.ACTIVE:
+        raise ProjectNotActiveError(project_id)
 
     occurrence = IssueOccurrence.fetch(occurrence_id, project_id) if occurrence_id else None
 

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -24,6 +24,7 @@ from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.models import DataConditionGroup, Detector
 from sentry.workflow_engine.tasks.utils import (
     EventNotFoundError,
+    ProjectNotActiveError,
     build_workflow_event_data_from_event,
 )
 from sentry.workflow_engine.types import WorkflowEventData
@@ -94,7 +95,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
 @retry(
     timeouts=True,
     exclude=EventNotFoundError,
-    ignore=(Group.DoesNotExist, Project.DoesNotExist),
+    ignore=(Group.DoesNotExist, Project.DoesNotExist, ProjectNotActiveError),
     on_silent=DataConditionGroup.DoesNotExist,
 )
 def process_workflows_event(

--- a/tests/sentry/workflow_engine/tasks/test_utils.py
+++ b/tests/sentry/workflow_engine/tasks/test_utils.py
@@ -1,8 +1,12 @@
+from unittest import mock
+
 import pytest
 
 from sentry.constants import ObjectStatus
+from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.tasks.utils import (
+    EventNotFoundError,
     ProjectNotActiveError,
     build_workflow_event_data_from_event,
 )
@@ -30,3 +34,29 @@ class TestBuildWorkflowEventDataFromEvent(TestCase):
                 event_id="fake-event-id",
                 group_id=self.group.id,
             )
+
+    def test_raises_event_not_found(self) -> None:
+        with (
+            mock.patch(
+                "sentry.workflow_engine.tasks.utils.nodestore.backend.get", return_value=None
+            ),
+            pytest.raises(EventNotFoundError),
+        ):
+            build_workflow_event_data_from_event(
+                event_id="nonexistent-event-id",
+                group_id=self.group.id,
+            )
+
+    def test_returns_workflow_event_data(self) -> None:
+        with mock.patch(
+            "sentry.workflow_engine.tasks.utils.nodestore.backend.get",
+            return_value={"event_id": "test-event-id", "project": self.project.id},
+        ):
+            result = build_workflow_event_data_from_event(
+                event_id="test-event-id",
+                group_id=self.group.id,
+            )
+
+        assert isinstance(result.event, GroupEvent)
+        assert result.event.event_id == "test-event-id"
+        assert result.group.id == self.group.id

--- a/tests/sentry/workflow_engine/tasks/test_utils.py
+++ b/tests/sentry/workflow_engine/tasks/test_utils.py
@@ -20,7 +20,13 @@ class TestBuildWorkflowEventDataFromEvent(TestCase):
     def test_raises_for_pending_deletion_project(self) -> None:
         self.project.update(status=ObjectStatus.PENDING_DELETION)
 
-        with pytest.raises(ProjectNotActiveError):
+        with (
+            mock.patch(
+                "sentry.workflow_engine.tasks.utils.nodestore.backend.get",
+                return_value={"event_id": "fake-event-id", "project": self.project.id},
+            ),
+            pytest.raises(ProjectNotActiveError),
+        ):
             build_workflow_event_data_from_event(
                 event_id="fake-event-id",
                 group_id=self.group.id,
@@ -29,7 +35,13 @@ class TestBuildWorkflowEventDataFromEvent(TestCase):
     def test_raises_for_deletion_in_progress_project(self) -> None:
         self.project.update(status=ObjectStatus.DELETION_IN_PROGRESS)
 
-        with pytest.raises(ProjectNotActiveError):
+        with (
+            mock.patch(
+                "sentry.workflow_engine.tasks.utils.nodestore.backend.get",
+                return_value={"event_id": "fake-event-id", "project": self.project.id},
+            ),
+            pytest.raises(ProjectNotActiveError),
+        ):
             build_workflow_event_data_from_event(
                 event_id="fake-event-id",
                 group_id=self.group.id,

--- a/tests/sentry/workflow_engine/tasks/test_utils.py
+++ b/tests/sentry/workflow_engine/tasks/test_utils.py
@@ -1,0 +1,32 @@
+import pytest
+
+from sentry.constants import ObjectStatus
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.tasks.utils import (
+    ProjectNotActiveError,
+    build_workflow_event_data_from_event,
+)
+
+
+class TestBuildWorkflowEventDataFromEvent(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project()
+        self.group = self.create_group(project=self.project)
+
+    def test_raises_for_pending_deletion_project(self) -> None:
+        self.project.update(status=ObjectStatus.PENDING_DELETION)
+
+        with pytest.raises(ProjectNotActiveError):
+            build_workflow_event_data_from_event(
+                event_id="fake-event-id",
+                group_id=self.group.id,
+            )
+
+    def test_raises_for_deletion_in_progress_project(self) -> None:
+        self.project.update(status=ObjectStatus.DELETION_IN_PROGRESS)
+
+        with pytest.raises(ProjectNotActiveError):
+            build_workflow_event_data_from_event(
+                event_id="fake-event-id",
+                group_id=self.group.id,
+            )


### PR DESCRIPTION
Fixes SENTRY-5JH0

Projects pending deletion or being deleted may have already had their detectors removed, causing `Detector.DoesNotExist` errors later on in the pipeline when looking for the issue stream detector. This PR adds an early check in `build_workflow_event_data_from_event()` to raise `ProjectNotActiveError` and ignores that error in the task definition.