### PR TITLE
feat(dashboards): Update AI Agents Trace Table widget to use spans global filter

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -264,6 +264,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
         <AgentsTracesTableWidgetVisualization
           limit={widget.limit}
           tableWidths={widget.tableWidths}
+          dashboardFilters={props.dashboardFilters}
           frameless
         />
       </TableWrapper>

--- a/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
@@ -1,8 +1,10 @@
+import type {DashboardFilters} from 'sentry/views/dashboards/types';
 import {DEFAULT_TRACES_TABLE_WIDTHS} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview';
 import {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
 import {TracesTable} from 'sentry/views/insights/pages/agents/components/tracesTable';
 
 interface AgentsTracesTableWidgetVisualizationProps {
+  dashboardFilters?: DashboardFilters;
   frameless?: boolean;
   limit?: number;
   tableWidths?: number[];
@@ -11,6 +13,7 @@ interface AgentsTracesTableWidgetVisualizationProps {
 export function AgentsTracesTableWidgetVisualization({
   limit,
   tableWidths = DEFAULT_TRACES_TABLE_WIDTHS,
+  dashboardFilters,
   frameless,
 }: AgentsTracesTableWidgetVisualizationProps) {
   const {openTraceViewDrawer} = useTraceViewDrawer();
@@ -20,6 +23,7 @@ export function AgentsTracesTableWidgetVisualization({
       openTraceViewDrawer={openTraceViewDrawer}
       limit={limit}
       tableWidths={tableWidths}
+      dashboardFilters={dashboardFilters}
       frameless={frameless}
     />
   );

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -24,6 +24,8 @@ import {t} from 'sentry/locale';
 import {isOverflown} from 'sentry/utils/useHoverOverlay';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {WidgetType, type DashboardFilters} from 'sentry/views/dashboards/types';
+import {applyDashboardFilters} from 'sentry/views/dashboards/utils';
 import {FRAMELESS_STYLES} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTraces} from 'sentry/views/explore/hooks/useTraces';
@@ -90,6 +92,7 @@ const DEFAULT_LIMIT = 10;
 
 interface TracesTableProps {
   openTraceViewDrawer: ReturnType<typeof useTraceViewDrawer>['openTraceViewDrawer'];
+  dashboardFilters?: DashboardFilters;
   frameless?: boolean;
   limit?: number;
   tableWidths?: number[];
@@ -98,6 +101,7 @@ interface TracesTableProps {
 export function TracesTable({
   openTraceViewDrawer,
   frameless,
+  dashboardFilters,
   limit = DEFAULT_LIMIT,
   tableWidths,
 }: TracesTableProps) {
@@ -112,7 +116,13 @@ export function TracesTable({
         : defaultColumnOrder,
   });
 
-  const combinedQuery = useCombinedQuery(getHasAiSpansFilter());
+  const combinedQuery =
+    applyDashboardFilters(
+      useCombinedQuery(getHasAiSpansFilter()),
+      dashboardFilters,
+      WidgetType.SPANS // This widget technically has its own widget type, but it uses the spans dataset
+    ) ?? '';
+
   const {cursor, setCursor} = useTableCursor();
 
   const tracesRequest = useTraces({


### PR DESCRIPTION
Updates the `TracesTable` component to accept dashboard filters.