### PR TITLE
fix(preprod): Enable retry on transient API errors in PR comment task

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -13,7 +13,11 @@ from sentry.preprod.build_distribution_utils import is_installable_artifact
 from sentry.preprod.integration_utils import get_commit_context_client
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.vcs.pr_comments.templates import format_pr_comment
-from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigurationError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiRateLimitedError,
+    IntegrationConfigurationError,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
@@ -27,7 +31,7 @@ logger = logging.getLogger(__name__)
     namespace=preprod_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
-    retry=Retry(times=5, delay=60 * 5),
+    retry=Retry(times=5, delay=60 * 5, on=(ApiError,), ignore=(ApiRateLimitedError,)),
 )
 def create_preprod_pr_comment_task(
     preprod_artifact_id: int, caller: str | None = None, **kwargs: Any


### PR DESCRIPTION
The `create_preprod_pr_comment_task` had `Retry(times=5, delay=300)` configured
but without the `on` parameter. The taskworker `Retry` class requires explicit
exception types in `on` to trigger retries — without it, only `RetryTaskError`
and `TimeoutError` are retried. This meant transient GitHub API errors (like the
502 in SENTRY-5M28) were never actually retried despite the retry config suggesting
otherwise.

Adds `on=(ApiError,)` so transient 5xx errors from GitHub trigger retries.
Explicitly excludes `ApiRateLimitedError` via `ignore` to avoid amplifying
GitHub rate limits — a 429 should fail immediately rather than burning through
5 retries over 25 minutes.

Fixes SENTRY-5M28