### PR TITLE
fix(dashboards): Filter metadata keys in MultiSeriesEventsStats transformation

### DIFF
--- a/static/app/views/dashboards/utils/transformEventsResponseToSeries.spec.tsx
+++ b/static/app/views/dashboards/utils/transformEventsResponseToSeries.spec.tsx
@@ -94,6 +94,49 @@ describe('transformEventsResponseToSeries', () => {
     ]);
   });
 
+  it('skips metadata keys like order in multi series response', () => {
+    const rawData = {
+      'count()': {
+        data: [
+          [1737731713, [{count: 17}]],
+          [1737731773, [{count: 22}]],
+        ],
+        order: 0,
+      },
+      order: 0,
+      'avg(transaction.duration)': {
+        data: [
+          [1737731713, [{count: 12.4}]],
+          [1737731773, [{count: 17.7}]],
+        ],
+        order: 1,
+      },
+    } as MultiSeriesEventsStats;
+
+    const widgetQuery = WidgetQueryFixture({
+      fields: ['count()', 'avg(transaction.duration)'],
+      aggregates: ['count()', 'avg(transaction.duration)'],
+      columns: [],
+    });
+
+    expect(transformEventsResponseToSeries(rawData, widgetQuery)).toEqual([
+      {
+        data: [
+          {name: 1737731713000, value: 17},
+          {name: 1737731773000, value: 22},
+        ],
+        seriesName: 'count()',
+      },
+      {
+        data: [
+          {name: 1737731713000, value: 12.4},
+          {name: 1737731773000, value: 17.7},
+        ],
+        seriesName: 'avg(transaction.duration)',
+      },
+    ]);
+  });
+
   it('converts a grouped series response to an array', () => {
     const rawData: GroupedMultiSeriesEventsStats = {
       prod: {

--- a/static/app/views/dashboards/utils/transformEventsResponseToSeries.tsx
+++ b/static/app/views/dashboards/utils/transformEventsResponseToSeries.tsx
@@ -29,7 +29,15 @@ export function transformEventsResponseToSeries(
     seriesWithOrdering.push([0, transformEventsStatsToSeries(data, prefixedName, field)]);
   } else if (isMultiSeriesEventsStats(data)) {
     Object.keys(data).forEach(seriesName => {
+      if (seriesName === 'order') {
+        // `order` is a metadata key on MultiSeriesEventsStats responses, skip it
+        return;
+      }
       const seriesData = data[seriesName]!;
+      if (!isEventsStats(seriesData)) {
+        // Skip non-series metadata keys; only process actual EventsStats series
+        return;
+      }
       const prefixedName = queryAlias ? `${queryAlias} : ${seriesName}` : seriesName;
 
       seriesWithOrdering.push([


### PR DESCRIPTION
Filter metadata keys from MultiSeriesEventsStats before passing to transformation functions so non-field keys (e.g. `order`) are never passed to `transformEventsStatsToSeries` and thus never reach `parseFunction`/getAggregateAlias, preventing `undefined.match()` when the API returns metadata alongside series data (e.g. in spans widget builder).

**Changes:**
- In `transformEventsResponseToSeries`, in the `isMultiSeriesEventsStats` branch: skip the `order` key (same pattern as `isGroupedMultiSeriesEventsStats`) and skip any entry whose value is not `EventsStats` (so only actual series are transformed).
- Add a test that MultiSeriesEventsStats with a top-level `order` metadata key is handled without error and only series data is converted.

Fixes JAVASCRIPT-37ZS. Fixes EXP-833

Made with [Cursor](https://cursor.com)