### PR TITLE
ref(preprod): Extract section chrome from diff components into parent

### DIFF
--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -172,26 +172,26 @@ export function InsightComparisonSection({
     <Stack gap="md">
       <Flex align="center" gap="sm" wrap="wrap">
         <SegmentedControl value={selectedTab} onChange={setSelectedTab}>
-          {statusCounts.all > 0 ? (
+          {statusCounts.all > 0 && (
             <SegmentedControl.Item key="all">
               {t('All (%s)', statusCounts.all)}
             </SegmentedControl.Item>
-          ) : null}
-          {statusCounts.new > 0 ? (
+          )}
+          {statusCounts.new > 0 && (
             <SegmentedControl.Item key="new">
               {t('New (%s)', statusCounts.new)}
             </SegmentedControl.Item>
-          ) : null}
-          {statusCounts.unresolved > 0 ? (
+          )}
+          {statusCounts.unresolved > 0 && (
             <SegmentedControl.Item key="unresolved">
               {t('Unresolved (%s)', statusCounts.unresolved)}
             </SegmentedControl.Item>
-          ) : null}
-          {statusCounts.resolved > 0 ? (
+          )}
+          {statusCounts.resolved > 0 && (
             <SegmentedControl.Item key="resolved">
               {t('Resolved (%s)', statusCounts.resolved)}
             </SegmentedControl.Item>
-          ) : null}
+          )}
         </SegmentedControl>
       </Flex>
 

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -2,8 +2,6 @@ import {useMemo, useState} from 'react';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
-import {Separator} from '@sentry/scraps/separator';
-import {Heading} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 import {FileInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/fileInsightDiffTable';
@@ -171,68 +169,59 @@ export function InsightComparisonSection({
   }
 
   return (
-    <Stack gap="xl">
-      <Separator orientation="horizontal" border="primary" />
+    <Stack gap="md">
+      <Flex align="center" gap="sm" wrap="wrap">
+        <SegmentedControl value={selectedTab} onChange={setSelectedTab}>
+          {statusCounts.all > 0 ? (
+            <SegmentedControl.Item key="all">
+              {t('All (%s)', statusCounts.all)}
+            </SegmentedControl.Item>
+          ) : null}
+          {statusCounts.new > 0 ? (
+            <SegmentedControl.Item key="new">
+              {t('New (%s)', statusCounts.new)}
+            </SegmentedControl.Item>
+          ) : null}
+          {statusCounts.unresolved > 0 ? (
+            <SegmentedControl.Item key="unresolved">
+              {t('Unresolved (%s)', statusCounts.unresolved)}
+            </SegmentedControl.Item>
+          ) : null}
+          {statusCounts.resolved > 0 ? (
+            <SegmentedControl.Item key="resolved">
+              {t('Resolved (%s)', statusCounts.resolved)}
+            </SegmentedControl.Item>
+          ) : null}
+        </SegmentedControl>
+      </Flex>
 
       <Stack gap="md">
-        <Flex direction="column" gap="md">
-          <Heading as="h2">{t('Insights')}</Heading>
-          <Flex align="center" gap="sm" wrap="wrap">
-            <SegmentedControl value={selectedTab} onChange={setSelectedTab}>
-              {statusCounts.all > 0 ? (
-                <SegmentedControl.Item key="all">
-                  {t('All (%s)', statusCounts.all)}
-                </SegmentedControl.Item>
-              ) : null}
-              {statusCounts.new > 0 ? (
-                <SegmentedControl.Item key="new">
-                  {t('New (%s)', statusCounts.new)}
-                </SegmentedControl.Item>
-              ) : null}
-              {statusCounts.unresolved > 0 ? (
-                <SegmentedControl.Item key="unresolved">
-                  {t('Unresolved (%s)', statusCounts.unresolved)}
-                </SegmentedControl.Item>
-              ) : null}
-              {statusCounts.resolved > 0 ? (
-                <SegmentedControl.Item key="resolved">
-                  {t('Resolved (%s)', statusCounts.resolved)}
-                </SegmentedControl.Item>
-              ) : null}
-            </SegmentedControl>
-          </Flex>
-        </Flex>
-
-        <Stack gap="md">
-          {filteredInsights.map(insight => {
-            if (FILE_DIFF_INSIGHT_TYPES.includes(insight.insight_type)) {
-              return (
-                <InsightDiffRow
-                  key={insight.insight_type}
-                  insight={insight}
-                  totalInstallSizeBytes={totalInstallSizeBytes}
-                >
-                  <FileInsightItemDiffTable fileDiffItems={insight.file_diffs} />
-                </InsightDiffRow>
-              );
-            }
-            if (GROUP_DIFF_INSIGHT_TYPES.includes(insight.insight_type)) {
-              return (
-                <InsightDiffRow
-                  key={insight.insight_type}
-                  insight={insight}
-                  totalInstallSizeBytes={totalInstallSizeBytes}
-                >
-                  <GroupInsightItemDiffTable groupDiffItems={insight.group_diffs} />
-                </InsightDiffRow>
-              );
-            }
-            return null;
-          })}
-        </Stack>
+        {filteredInsights.map(insight => {
+          if (FILE_DIFF_INSIGHT_TYPES.includes(insight.insight_type)) {
+            return (
+              <InsightDiffRow
+                key={insight.insight_type}
+                insight={insight}
+                totalInstallSizeBytes={totalInstallSizeBytes}
+              >
+                <FileInsightItemDiffTable fileDiffItems={insight.file_diffs} />
+              </InsightDiffRow>
+            );
+          }
+          if (GROUP_DIFF_INSIGHT_TYPES.includes(insight.insight_type)) {
+            return (
+              <InsightDiffRow
+                key={insight.insight_type}
+                insight={insight}
+                totalInstallSizeBytes={totalInstallSizeBytes}
+              >
+                <GroupInsightItemDiffTable groupDiffItems={insight.group_diffs} />
+              </InsightDiffRow>
+            );
+          }
+          return null;
+        })}
       </Stack>
-
-      <Separator orientation="horizontal" border="primary" />
     </Stack>
   );
 }

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -172,26 +172,26 @@ export function InsightComparisonSection({
     <Stack gap="md">
       <Flex align="center" gap="sm" wrap="wrap">
         <SegmentedControl value={selectedTab} onChange={setSelectedTab}>
-          {statusCounts.all > 0 && (
+          {statusCounts.all > 0 ? (
             <SegmentedControl.Item key="all">
               {t('All (%s)', statusCounts.all)}
             </SegmentedControl.Item>
-          )}
-          {statusCounts.new > 0 && (
+          ) : null}
+          {statusCounts.new > 0 ? (
             <SegmentedControl.Item key="new">
               {t('New (%s)', statusCounts.new)}
             </SegmentedControl.Item>
-          )}
-          {statusCounts.unresolved > 0 && (
+          ) : null}
+          {statusCounts.unresolved > 0 ? (
             <SegmentedControl.Item key="unresolved">
               {t('Unresolved (%s)', statusCounts.unresolved)}
             </SegmentedControl.Item>
-          )}
-          {statusCounts.resolved > 0 && (
+          ) : null}
+          {statusCounts.resolved > 0 ? (
             <SegmentedControl.Item key="resolved">
               {t('Resolved (%s)', statusCounts.resolved)}
             </SegmentedControl.Item>
-          )}
+          ) : null}
         </SegmentedControl>
       </Flex>
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -5,6 +5,7 @@ import {parseAsBoolean, useQueryState} from 'nuqs';
 import {Button} from '@sentry/scraps/button';
 import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Separator} from '@sentry/scraps/separator';
 import {Switch} from '@sentry/scraps/switch';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -296,12 +297,19 @@ export function SizeCompareMainContent() {
       {/* Insights Section */}
       {comparisonDataQuery.data?.insight_diff_items &&
         comparisonDataQuery.data.insight_diff_items.length > 0 && (
-          <InsightComparisonSection
-            totalInstallSizeBytes={
-              comparisonDataQuery.data?.size_metric_diff_item.head_install_size
-            }
-            insightDiffItems={comparisonDataQuery.data.insight_diff_items}
-          />
+          <Stack gap="xl">
+            <Separator orientation="horizontal" border="primary" />
+            <Stack gap="md">
+              <Heading as="h2">{t('Insight Diff')}</Heading>
+              <InsightComparisonSection
+                totalInstallSizeBytes={
+                  comparisonDataQuery.data?.size_metric_diff_item.head_install_size
+                }
+                insightDiffItems={comparisonDataQuery.data.insight_diff_items}
+              />
+            </Stack>
+            <Separator orientation="horizontal" border="primary" />
+          </Stack>
         )}
 
       {/* Items Changed Section */}
@@ -376,7 +384,13 @@ export function SizeCompareMainContent() {
       {/* Treemap Diff Section */}
       {comparisonDataQuery.data?.diff_items &&
         comparisonDataQuery.data.diff_items.length > 0 && (
-          <TreemapDiffSection diffItems={comparisonDataQuery.data.diff_items} />
+          <Stack gap="xl">
+            <Separator orientation="horizontal" border="primary" />
+            <Stack gap="md">
+              <Heading as="h2">{t('X-Ray Diff')}</Heading>
+              <TreemapDiffSection diffItems={comparisonDataQuery.data.diff_items} />
+            </Stack>
+          </Stack>
         )}
     </Flex>
   );

--- a/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
@@ -5,8 +5,7 @@ import type {ECharts, TreemapSeriesOption} from 'echarts';
 import {Tag} from '@sentry/scraps/badge';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {useRenderToString} from '@sentry/scraps/renderToString';
-import {Separator} from '@sentry/scraps/separator';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Text} from '@sentry/scraps/text';
 
 import BaseChart, {type TooltipOption} from 'sentry/components/charts/baseChart';
 import {IconContract} from 'sentry/icons';
@@ -229,42 +228,35 @@ export function TreemapDiffSection({diffItems}: TreemapDiffSectionProps) {
   };
 
   return (
-    <Stack gap="xl">
-      <Separator orientation="horizontal" border="primary" />
-
-      <Stack gap="md">
-        <Heading as="h2">{t('X-Ray Diff')}</Heading>
-        <Stack paddingBottom="xl">
-          <Container
-            height="400px"
-            width="100%"
-            position="relative"
-            onMouseDown={handleContainerMouseDown}
-            style={{minHeight: 0}}
-          >
-            <BaseChart
-              height={400}
-              renderer="canvas"
-              xAxis={null}
-              yAxis={null}
-              series={series}
-              tooltip={tooltip}
-              onChartReady={handleChartReady}
-            />
-            <TreemapControlButtons
-              buttons={[
-                {
-                  ariaLabel: t('Recenter View'),
-                  title: t('Recenter'),
-                  icon: <IconContract />,
-                  onClick: handleRecenter,
-                  disabled: !isZoomed,
-                },
-              ]}
-            />
-          </Container>
-        </Stack>
-      </Stack>
+    <Stack paddingBottom="xl">
+      <Container
+        height="400px"
+        width="100%"
+        position="relative"
+        onMouseDown={handleContainerMouseDown}
+        style={{minHeight: 0}}
+      >
+        <BaseChart
+          height={400}
+          renderer="canvas"
+          xAxis={null}
+          yAxis={null}
+          series={series}
+          tooltip={tooltip}
+          onChartReady={handleChartReady}
+        />
+        <TreemapControlButtons
+          buttons={[
+            {
+              ariaLabel: t('Recenter View'),
+              title: t('Recenter'),
+              icon: <IconContract />,
+              onClick: handleRecenter,
+              disabled: !isZoomed,
+            },
+          ]}
+        />
+      </Container>
     </Stack>
   );
 }


### PR DESCRIPTION
goal to not repeat headers when using these components in other places, i.e. insight page. 

prod
<img width="2144" height="1138" alt="CleanShot 2026-03-12 at 20 16 29@2x" src="https://github.com/user-attachments/assets/c67d5960-d31e-4d3a-bca2-e7992a1b5be7" />

PR
<img width="2066" height="968" alt="CleanShot 2026-03-12 at 20 16 47@2x" src="https://github.com/user-attachments/assets/b47b33fc-bf9f-447d-b4f7-003582d0f0cf" />



---
Extract headings, separators, and outer layout wrappers from `TreemapDiffSection` and `InsightComparisonSection` into their call site in `SizeCompareMainContent`. This makes the components context-agnostic so they can be reused in other views (e.g. issue detail insight diff section for EME-942) without rendering double headings.

No visual change to the build comparison view — the same headings and separators still render, just sourced from the parent now.