### PR TITLE
fix(notifications): Attach occurrence to GroupEvent for test notifications

### DIFF
--- a/src/sentry/notifications/notification_action/grouptype.py
+++ b/src/sentry/notifications/notification_action/grouptype.py
@@ -79,4 +79,6 @@ def get_test_notification_event_data(project) -> GroupEvent | None:
     if event is None:
         return None
 
-    return GroupEvent.from_event(event, generic_group)
+    group_event = GroupEvent.from_event(event, generic_group)
+    group_event.occurrence = occurrence
+    return group_event

--- a/tests/sentry/notifications/notification_action/test_grouptype.py
+++ b/tests/sentry/notifications/notification_action/test_grouptype.py
@@ -1,0 +1,23 @@
+from sentry.notifications.notification_action.grouptype import get_test_notification_event_data
+from sentry.testutils.cases import TestCase
+from sentry.testutils.skips import requires_snuba
+
+pytestmark = [requires_snuba]
+
+
+class TestGetTestNotificationEventData(TestCase):
+    def test_returns_group_event_with_occurrence(self):
+        project = self.create_project()
+        group_event = get_test_notification_event_data(project)
+
+        assert group_event is not None
+        assert group_event.occurrence is not None
+        assert group_event.occurrence.issue_title == "Test Issue"
+
+    def test_email_subject_uses_occurrence_title(self):
+        project = self.create_project()
+        group_event = get_test_notification_event_data(project)
+
+        assert group_event is not None
+        short_id = group_event.group.qualified_short_id
+        assert group_event.get_email_subject() == f"{short_id} - Test Issue"

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -99,7 +99,9 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         assert mock_send_trigger.call_count == 1
         pagerduty_data = mock_send_trigger.call_args.kwargs.get("data")
         assert pagerduty_data is not None
-        assert pagerduty_data["payload"]["summary"].startswith(f"[{self.detector.name}]:")
+        assert pagerduty_data["payload"]["summary"].startswith(
+            f"[{self.issue_stream_detector.name}]:"
+        )
 
     @mock.patch.object(NotifyEventAction, "after")
     @mock.patch(


### PR DESCRIPTION
The test notification email showed `<untitled>` in the subject and body because the IssueOccurrence (with issue_title="Test Issue") was not attached to the GroupEvent returned by get_test_notification_event_data. Without the occurrence, the email subject fell back to GenericEvent's get_title() which returns `<untitled>`.

Refs RTC-1265