### PR TITLE
chore: fix broken imports from default->named and class->function commit conflicts

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRow.tsx
@@ -24,7 +24,7 @@ import {
 
 import AlertContainer from './integrationAlertContainer';
 import {IntegrationStatus} from './integrationStatus';
-import PluginDeprecationAlert from './pluginDeprecationAlert';
+import {PluginDeprecationAlert} from './pluginDeprecationAlert';
 
 type Props = {
   categories: string[];

--- a/static/app/views/settings/organizationIntegrations/pluginDeprecationAlert.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDeprecationAlert.tsx
@@ -14,7 +14,7 @@ type Props = {
   plugin: PluginWithProjectList;
 };
 
-function PluginDeprecationAlert({organization, plugin}: Props) {
+export function PluginDeprecationAlert({organization, plugin}: Props) {
   // Short-circuit if not deprecated.
   if (!plugin.deprecationDate) {
     return <Fragment />;
@@ -56,5 +56,3 @@ const UpgradeNowButton = styled(LinkButton)`
   color: ${p => p.theme.tokens.content.secondary};
   float: right;
 `;
-
-export default PluginDeprecationAlert;

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -39,7 +39,7 @@ import IntegrationLayout from 'sentry/views/settings/organizationIntegrations/de
 import {useIntegrationTabs} from 'sentry/views/settings/organizationIntegrations/detailedView/useIntegrationTabs';
 import InstalledPlugin from 'sentry/views/settings/organizationIntegrations/installedPlugin';
 import {RequestIntegrationButton} from 'sentry/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton';
-import PluginDeprecationAlert from 'sentry/views/settings/organizationIntegrations/pluginDeprecationAlert';
+import {PluginDeprecationAlert} from 'sentry/views/settings/organizationIntegrations/pluginDeprecationAlert';
 
 // TODO @sentaur-athena: remove this once we have a solution to deprecate these plugins
 const TEMPORARY_PERMITTED_PLUGINS = new Set(['amazon-sqs']);

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -28,7 +28,7 @@ type Props = {
   setSelected: (id: string) => void;
 };
 
-function OrganizationRoleSelect({
+export function OrganizationRoleSelect({
   disabled,
   enforceRetired,
   enforceAllowed,
@@ -79,5 +79,3 @@ const StyledPanelHeader = styled(PanelHeader)`
   gap: ${p => p.theme.space.xs};
   justify-content: left;
 `;
-
-export default OrganizationRoleSelect;

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -48,7 +48,7 @@ import {useParams} from 'sentry/utils/useParams';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {TeamSelect as TeamSelectForMember} from 'sentry/views/settings/components/teamSelect/teamSelectForMember';
 
-import OrganizationRoleSelect from './inviteMember/orgRoleSelect';
+import {OrganizationRoleSelect} from './inviteMember/orgRoleSelect';
 
 const MULTIPLE_ORGS = t('Cannot be reset since user is in more than one organization');
 const NOT_ENROLLED = t('Not enrolled in two-factor authentication');

--- a/static/app/views/settings/project/projectKeys/details/index.tsx
+++ b/static/app/views/settings/project/projectKeys/details/index.tsx
@@ -14,7 +14,7 @@ import {useParams} from 'sentry/utils/useParams';
 import RouteError from 'sentry/views/routeError';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {KeySettings} from 'sentry/views/settings/project/projectKeys/details/keySettings';
-import KeyStats from 'sentry/views/settings/project/projectKeys/details/keyStats';
+import {KeyStats} from 'sentry/views/settings/project/projectKeys/details/keyStats';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 

--- a/static/app/views/settings/project/projectKeys/details/keyStats.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyStats.tsx
@@ -44,7 +44,7 @@ type StateSuccess = {
   until: number;
 };
 
-function KeyStats({api, organization, params, theme}: Props) {
+export function KeyStats({api, organization, params, theme}: Props) {
   const {keyId, projectId} = params;
   const queryBase = useMemo(() => {
     const until = Math.floor(Date.now() / 1000);
@@ -135,5 +135,3 @@ function KeyStats({api, organization, params, theme}: Props) {
     </Panel>
   );
 }
-
-export default KeyStats;


### PR DESCRIPTION
This should fix CI.

```plaintext
/home/runner/work/sentry/sentry/static/app/views/settings/organizationIntegrations/pluginDeprecationAlert.tsx
Error:   60:1  error  We prefer named exports. Default exports are not allowed unless this file is lazy-imported  @sentry/no-default-export-components

/home/runner/work/sentry/sentry/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
Error:   83:1  error  We prefer named exports. Default exports are not allowed unless this file is lazy-imported  @sentry/no-default-export-components

/home/runner/work/sentry/sentry/static/app/views/settings/project/projectKeys/details/keyStats.tsx
Error:   139:1  error  We prefer named exports. Default exports are not allowed unless this file is lazy-imported  @sentry/no-default-export-components
```