### PR TITLE
partial-revert(llm-detection): Revert frontend issue type filtering

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -526,7 +526,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
       }
 
       for (const occurrence of c.occurrences) {
-        traceNode.addOccurrence(occurrence);
+        traceNode.occurrences.add(occurrence);
       }
 
       if (c.value && 'measurements' in c.value) {
@@ -667,7 +667,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
     }
 
     for (const occurrence of additionalTraceNode.occurrences) {
-      baseTraceNode.addOccurrence(occurrence);
+      baseTraceNode.occurrences.add(occurrence);
     }
 
     for (const profiledEvent of tree.profiled_events) {
@@ -1019,7 +1019,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
 
             if (node.children[j]!.occurrences.size > 0) {
               for (const occurrence of node.children[j]!.occurrences) {
-                autoGroupedNode.addOccurrence(occurrence);
+                autoGroupedNode.occurrences.add(occurrence);
               }
             }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.spec.tsx
@@ -409,32 +409,6 @@ describe('BaseNode', () => {
       expect(nodeWithOccurrences.hasIssues).toBe(true);
     });
 
-    it('should not add hidden occurrence types via addOccurrence', () => {
-      const extra = createMockExtra();
-      const node = new TestNode(null, createMockValue({event_id: 'test-id'}), extra);
-
-      node.addOccurrence(
-        makeEAPOccurrence({
-          issue_id: 1,
-          event_id: 'normal-occurrence',
-          issue_type: 1000, // Not a hidden type
-        })
-      );
-      expect(node.occurrences.size).toBe(1);
-
-      node.addOccurrence(
-        makeEAPOccurrence({
-          issue_id: 2,
-          event_id: 'hidden-occurrence',
-          issue_type: 3501, // Currently a hidden type
-        })
-      );
-      expect(node.occurrences.size).toBe(1);
-
-      const occurrenceIds = Array.from(node.occurrences).map(o => o.issue_id);
-      expect(occurrenceIds).toEqual([1]);
-    });
-
     it('should return correct maxIssueSeverity based on error levels', () => {
       const extra = createMockExtra();
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
@@ -3,7 +3,6 @@ import type {Theme} from '@emotion/react';
 import type {Client} from 'sentry/api';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import type {Level, Measurement} from 'sentry/types/event';
-import {HIDDEN_OCCURRENCE_TYPE_IDS} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
 import type {TraceMetaQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
@@ -175,7 +174,7 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
       }
 
       if ('occurrences' in value && Array.isArray(value.occurrences)) {
-        value.occurrences.forEach(occurrence => this.addOccurrence(occurrence));
+        value.occurrences.forEach(occurrence => this.occurrences.add(occurrence));
       }
     }
   }
@@ -274,13 +273,6 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
 
   get hasIssues(): boolean {
     return this.hasErrors || this.hasOccurrences;
-  }
-
-  addOccurrence(occurrence: TraceTree.TraceOccurrence): void {
-    const issueType = 'type' in occurrence ? occurrence.type : occurrence.issue_type;
-    if (!HIDDEN_OCCURRENCE_TYPE_IDS.includes(issueType)) {
-      this.occurrences.add(occurrence);
-    }
   }
 
   get visibleChildren(): BaseNode[] {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
@@ -59,7 +59,7 @@ export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
       // Propagate occurrences to the closest EAP transaction for visibility in the initially collapsed
       // eap-transactions only view, on load
       for (const occurrence of value.occurrences) {
-        closestEAPTransaction.addOccurrence(occurrence);
+        closestEAPTransaction.occurrences.add(occurrence);
       }
     }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
@@ -70,7 +70,7 @@ export class TransactionNode extends BaseNode<TraceTree.Transaction> {
       }
 
       if ('performance_issues' in value && Array.isArray(value.performance_issues)) {
-        value.performance_issues.forEach(issue => this.addOccurrence(issue));
+        value.performance_issues.forEach(issue => this.occurrences.add(issue));
       }
     }
 
@@ -371,7 +371,7 @@ export class TransactionNode extends BaseNode<TraceTree.Transaction> {
       for (const performanceIssue of this.getRelatedPerformanceIssuesFromTransaction(
         node
       )) {
-        node.addOccurrence(performanceIssue);
+        node.occurrences.add(performanceIssue);
       }
 
       for (const error of this.getRelatedSpanErrorsFromTransaction(node)) {


### PR DESCRIPTION
partially reverts https://github.com/getsentry/sentry/pull/109929 - the issue type filtering is now done at the api (https://github.com/getsentry/sentry/pull/110356) which makes the frontend filtering redundant.

removes:
- `addOccurrence()` method and its `HIDDEN_OCCURRENCE_TYPE_IDS` filtering
- The test for `addOccurrence` filtering
- All `addOccurrence()` calls → back to `occurrences.add()`

keeps:
- `EAPOccurrence.issue_type` field name (bug fix)
- anrRootCause.tsx handling of both `type` and `issue_type`
    - Unfortunately, `TraceOccurrence` = `TracePerformanceIssue | EAPOccurrence`. `TracePerformanceIssue` uses `type` while `EAPOccurrence` now uses `issue_type` so both fields need to be checked on a `TraceOccurrence`.
