### PR TITLE
feat(onboarding): Register onboarding-scm feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -188,6 +188,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-copy-setup-instructions-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new onboarding welcome and SDK setup UI
     manager.add("organizations:onboarding-new-welcome-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable SCM-first onboarding flow with provider connection, platform detection, and feature selection steps
+    manager.add("organizations:onboarding-scm", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable large ownership rule file size limit
     manager.add("organizations:ownership-size-limit-large", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable xlarge ownership rule file size limit


### PR DESCRIPTION
## Summary
- Register `organizations:onboarding-scm` feature flag in `temporary.py` with FLAGPOLE strategy and `api_expose=True`
- Gates the upcoming SCM-first onboarding flow (provider connection, platform detection, feature selection steps)

## Companion PR
- https://github.com/getsentry/sentry-options-automator/pull/6801

## Test plan
- [ ] Flag is registered and accessible via `features.has("organizations:onboarding-scm", org, actor=user)`
- [ ] Frontend can check `organization.features.includes('onboarding-scm')`

Refs VDY-18