### PR TITLE
ref(preprod): Sidebar polish

### DIFF
--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -1,6 +1,7 @@
 import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -9,6 +10,7 @@ import {Text} from '@sentry/scraps/text';
 import {
   IconAdd,
   IconCheckmark,
+  IconChevron,
   IconCopy,
   IconEdit,
   IconSearch,
@@ -112,8 +114,8 @@ export function SnapshotSidebarContent({
   const isGroupedDiff = isDiffMode && groupedItems !== null;
 
   return (
-    <Flex direction="column" gap="md" height="100%" width="100%">
-      <Flex padding="xl" paddingBottom="0">
+    <Stack height="100%" width="100%">
+      <Stack gap="xl" padding="xl" borderBottom="primary">
         <InputGroup style={{flex: 1}}>
           <InputGroup.LeadingItems disablePointerEvents>
             <IconSearch size="sm" />
@@ -125,94 +127,93 @@ export function SnapshotSidebarContent({
             onChange={e => onSearchChange(e.target.value)}
           />
         </InputGroup>
-      </Flex>
-      <Stack overflow="auto" flex="1">
-        {isGroupedDiff
-          ? SECTION_ORDER.map(section => {
-              const sectionItems = groupedItems.get(section.type);
-              if (!sectionItems || sectionItems.length === 0) {
-                return null;
-              }
-              const isExpanded = isSearching || expandedSections[section.type];
-              return (
-                <SectionWrapper key={section.type}>
-                  <Disclosure
-                    size="xs"
-                    expanded={isExpanded}
-                    onExpandedChange={expanded =>
-                      handleExpandedChange(section.type, expanded)
-                    }
-                  >
-                    <Disclosure.Title
-                      trailingItems={
-                        <Flex align="center" gap="xs">
-                          <Text size="xs" bold>
-                            {sectionItems.length}
-                          </Text>
-                          {section.icon}
-                        </Flex>
-                      }
-                    >
-                      <Text size="xs" bold uppercase>
+      </Stack>
+      <Stack overflow="auto" flex="1" paddingRight="0">
+        {isGroupedDiff &&
+          SECTION_ORDER.map(section => {
+            const sectionItems = groupedItems.get(section.type);
+            if (!sectionItems || sectionItems.length === 0) {
+              return null;
+            }
+            const isExpanded = isSearching || expandedSections[section.type];
+            return (
+              <Disclosure key={section.type} size="md" expanded={isExpanded}>
+                <SidebarSectionTitle
+                  priority="transparent"
+                  size="md"
+                  onClick={() => handleExpandedChange(section.type, !isExpanded)}
+                >
+                  <Flex align="center" justify="between" width="100%">
+                    <Flex align="center" gap="xs">
+                      <IconChevron direction={isExpanded ? 'down' : 'right'} size="sm" />
+                      <Text size="sm" bold uppercase>
                         {section.label}
                       </Text>
-                    </Disclosure.Title>
-                    <Disclosure.Content>
-                      {sectionItems.map(item => (
-                        <SidebarItemRow
-                          key={item.name}
-                          isSelected={item.name === currentItemName}
-                          onClick={() => onSelectItem(item.name)}
-                        >
-                          <Flex align="center" gap="sm" flex="1" minWidth="0">
-                            <Text
-                              size="md"
-                              variant={item.name === currentItemName ? 'accent' : 'muted'}
-                              bold={item.name === currentItemName}
-                              ellipsis
-                            >
-                              {item.name}
-                            </Text>
-                          </Flex>
-                          {item.type === 'changed' && item.pair.diff !== null && (
-                            <Text variant="muted" size="xs">
-                              {`${(item.pair.diff * 100).toFixed(1)}%`}
-                            </Text>
-                          )}
-                        </SidebarItemRow>
-                      ))}
-                    </Disclosure.Content>
-                  </Disclosure>
-                </SectionWrapper>
-              );
-            })
-          : items.map(item => {
-              const isSelected = item.name === currentItemName;
-
-              return (
-                <SidebarItemRow
-                  key={item.name}
-                  isSelected={isSelected}
-                  onClick={() => onSelectItem(item.name)}
-                >
-                  <Flex align="center" gap="sm" flex="1" minWidth="0">
-                    <Text
-                      size="md"
-                      variant={isSelected ? 'accent' : 'muted'}
-                      bold={isSelected}
-                      ellipsis
-                    >
-                      {item.name}
-                    </Text>
+                    </Flex>
+                    <Flex align="center" gap="xs">
+                      <Text size="sm">{sectionItems.length}</Text>
+                      {section.icon}
+                    </Flex>
                   </Flex>
-                  {item.type === 'solo' && item.images.length > 1 && (
-                    <Text variant="muted" size="xs">
-                      {item.images.length}
-                    </Text>
-                  )}
-                </SidebarItemRow>
-              );
-            })}
+                </SidebarSectionTitle>
+                {isExpanded && (
+                  <SidebarSectionContent>
+                    {sectionItems.map(item => (
+                      <SidebarItemRow
+                        key={item.name}
+                        isSelected={item.name === currentItemName}
+                        onClick={() => onSelectItem(item.name)}
+                      >
+                        <Flex align="center" gap="sm" flex="1" minWidth="0">
+                          <Text
+                            size="md"
+                            variant={item.name === currentItemName ? 'accent' : 'muted'}
+                            bold={item.name === currentItemName}
+                            ellipsis
+                          >
+                            {item.name}
+                          </Text>
+                        </Flex>
+                        {item.type === 'changed' && item.pair.diff !== null && (
+                          <Text variant="muted" size="xs">
+                            {`${(item.pair.diff * 100).toFixed(1)}%`}
+                          </Text>
+                        )}
+                      </SidebarItemRow>
+                    ))}
+                  </SidebarSectionContent>
+                )}
+              </Disclosure>
+            );
+          })}
+        {!isGroupedDiff &&
+          items.map(item => {
+            const isSelected = item.name === currentItemName;
+
+            return (
+              <SidebarItemRow
+                key={item.name}
+                isSelected={isSelected}
+                onClick={() => onSelectItem(item.name)}
+              >
+                <Flex align="center" gap="sm" flex="1" minWidth="0">
+                  <Text
+                    size="md"
+                    variant={isSelected ? 'accent' : 'muted'}
+                    bold={isSelected}
+                    ellipsis
+                  >
+                    {item.name}
+                  </Text>
+                </Flex>
+                {item.type === 'solo' && item.images.length > 1 && (
+                  <Text variant="muted" size="xs">
+                    {item.images.length}
+                  </Text>
+                )}
+              </SidebarItemRow>
+            );
+          })}
         {items.length === 0 && (
           <Flex align="center" justify="center" padding="lg">
             <Text variant="muted" size="sm">
@@ -221,44 +222,47 @@ export function SnapshotSidebarContent({
           </Flex>
         )}
       </Stack>
-    </Flex>
+    </Stack>
   );
 }
 
-const SectionWrapper = styled('div')`
-  &:not(:first-child) {
-    border-top: 1px solid ${p => p.theme.tokens.border.primary};
-  }
+const SidebarSectionTitle = styled(Button)`
+  padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
+  display: block;
+  width: 100%;
+  border-radius: 0;
+  border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
 
-  [data-disclosure] > :not(:first-child) {
-    padding-left: 0;
-    padding-right: 0;
+  &:hover {
+    background: ${p => p.theme.tokens.background.secondary};
   }
+`;
 
-  [data-disclosure] > div > button {
-    min-width: 0;
-    overflow: hidden;
-  }
+const SidebarSectionContent = styled('div')`
+  width: 100%;
 
-  [data-disclosure] > div > button ~ * {
-    flex-shrink: 0;
-    padding-right: ${p => p.theme.space.md};
+  &:last-child {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   }
 `;
 
 const SidebarItemRow = styled('div')<{isSelected: boolean}>`
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: ${p => p.theme.space.sm};
   padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
+  gap: ${p => p.theme.space.sm};
   cursor: pointer;
   border-right: 3px solid
     ${p => (p.isSelected ? p.theme.tokens.border.accent.vibrant : 'transparent')};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   background: ${p =>
     p.isSelected ? p.theme.tokens.background.transparent.accent.muted : 'transparent'};
 
   &:hover {
     background: ${p => p.theme.tokens.background.secondary};
+  }
+
+  &:last-child {
+    border-bottom: none;
   }
 `;


### PR DESCRIPTION
Fixes EME-924. This was a bit tricky as emotion styling didn't work on `Disclosure.Title` as there seems to be a bug where `...rest` is passed to the child button rather than the top-level `Flex`. This required me to essentially implement a custom `Disclosure.Title` with a Button, but works pretty well overall.

Before:
<img width="371" height="382" alt="Screenshot 2026-03-12 at 11 20 10 AM" src="https://github.com/user-attachments/assets/141c7d8b-5d20-4f32-9714-a8b925b8087c" />

After:
<img width="376" height="268" alt="Screenshot 2026-03-12 at 12 51 32 PM" src="https://github.com/user-attachments/assets/24c5834d-e67e-4323-82f5-7873f18521ad" />
<img width="382" height="306" alt="Screenshot 2026-03-12 at 12 51 26 PM" src="https://github.com/user-attachments/assets/7144d856-8b11-45b5-9730-7de5c6c08e1a" />



Designs (after matches):
https://www.figma.com/design/noaq47E7GgvQhcRNxj5OAF/Emerge-Merge?node-id=3298-2462&t=YVvX3NErHrgtNHpV-1