### PR TITLE
fix(taskbroker): Allow taskbroker_send_tasks to run indefinitely

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -500,7 +500,9 @@ def taskbroker_send_tasks(
     from sentry.conf.server import KAFKA_CLUSTERS
     from sentry.utils.imports import import_string
 
-    KAFKA_CLUSTERS["default"]["common"]["bootstrap.servers"] = bootstrap_servers
+    if bootstrap_servers:
+        KAFKA_CLUSTERS["default"]["common"]["bootstrap.servers"] = bootstrap_servers
+
     if kafka_topic and namespace:
         options.set("taskworker.route.overrides", {namespace: kafka_topic})
 
@@ -533,10 +535,11 @@ def taskbroker_send_tasks(
         while True:
             func.delay(*task_args, **task_kwargs)
             sent += 1.0
-            if sent % 1000 == 0 and time.time() - start_time > 10:
-                throughput = sent / (time.time() - start_time)
+            interval = time.time() - start_time
+            if sent % 1000 == 0 and interval > 10:
+                throughput = sent / interval
                 click.echo(
-                    message=f"Sent {sent} messages in {time.time() - start_time} seconds. Throughput: {throughput} messages/second."
+                    message=f"Sent {sent} messages in {interval} seconds. Throughput: {throughput} messages/second."
                 )
                 start_time = time.time()
                 sent = 0.0

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -433,6 +433,18 @@ def run_taskworker(
     show_default=True,
 )
 @click.option(
+    "--infinite",
+    is_flag=True,
+    default=False,
+    help="Send tasks indefinitely",
+)
+@click.option(
+    "--infinite-delay-ms",
+    type=int,
+    help="The delay in milliseconds between each task",
+    default=0,
+)
+@click.option(
     "--kwargs",
     type=str,
     help="Task function keyword arguments",
@@ -477,6 +489,8 @@ def taskbroker_send_tasks(
     args: str,
     kwargs: str,
     repeat: int,
+    infinite: bool,
+    infinite_delay_ms: int,
     bootstrap_servers: str,
     kafka_topic: str,
     namespace: str,
@@ -505,13 +519,30 @@ def taskbroker_send_tasks(
         )
         task_args.append(extra_padding_arg)
 
-    checkmarks = {int(repeat * (i / 10)) for i in range(1, 10)}
-    for i in range(repeat):
-        func.delay(*task_args, **task_kwargs)
-        if i in checkmarks:
-            click.echo(message=f"{int((i / repeat) * 100)}% complete")
+    if not infinite:
+        checkmarks = {int(repeat * (i / 10)) for i in range(1, 10)}
+        for i in range(repeat):
+            func.delay(*task_args, **task_kwargs)
+            if i in checkmarks:
+                click.echo(message=f"{int((i / repeat) * 100)}% complete")
 
-    click.echo(message=f"Successfully sent {repeat} messages.")
+        click.echo(message=f"Successfully sent {repeat} messages.")
+    else:
+        sent = 0.0
+        start_time = time.time()
+        while True:
+            func.delay(*task_args, **task_kwargs)
+            sent += 1.0
+            if sent % 1000 == 0 and time.time() - start_time > 10:
+                throughput = sent / (time.time() - start_time)
+                click.echo(
+                    message=f"Sent {sent} messages in {time.time() - start_time} seconds. Throughput: {throughput} messages/second."
+                )
+                start_time = time.time()
+                sent = 0.0
+
+            if infinite_delay_ms > 0:
+                time.sleep(infinite_delay_ms / 1000.0)
 
 
 @run.command("consumer")


### PR DESCRIPTION
The function currently will create a set number of tasks. Provide an option that lets the script run
indefinitely without stopping. This will be used in test environments to provide constant automatic
throughput.