### PR TITLE
ref(seer): Add random 50% rollout for context engine in start_run

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1352,6 +1352,12 @@ register(
     default=0.0,
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "seer.explorer.context-engine-rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Custom model costs mapping for AI Agent Monitoring. Used to map alternative model ids to existing model ids.
 # {"alternative_model_id": "gpt-4o", "existing_model_id": "openai/gpt-4o"}

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 import time
 from datetime import datetime
 from typing import Any, Literal, overload
@@ -9,7 +10,7 @@ from django.contrib.auth.models import AnonymousUser
 from pydantic import BaseModel
 from rest_framework.request import Request
 
-from sentry import features
+from sentry import features, options
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.explorer.client_models import ExplorerRun, ExplorerRunWithPrs, SeerRunState
@@ -310,8 +311,9 @@ class SeerExplorerClient:
 
         if features.has(
             "organizations:seer-explorer-context-engine", self.organization, actor=self.user
-        ):  # Set to True at the start of the run and persist in Seer explorer run state
-            chat_body["is_context_engine_enabled"] = True
+        ):
+            if random.random() < options.get("seer.explorer.context-engine-rollout"):
+                chat_body["is_context_engine_enabled"] = True
 
         response = make_explorer_chat_request(chat_body, viewer_context=self.viewer_context)
 
@@ -369,6 +371,8 @@ class SeerExplorerClient:
             chat_body["artifact_key"] = artifact_key
             chat_body["artifact_schema"] = artifact_schema.schema()
 
+        # No random rollout here — Seer ANDs this with the persisted value from start_run,
+        # so the start_run coin flip is the single source of truth.
         if features.has(
             "organizations:seer-explorer-context-engine",
             self.organization,


### PR DESCRIPTION
+ Gate context engine enablement behind a random coin flip for runs in sentry org with the feature flag.
+ `contuinue_run` always just checks the feature flag since in seer for continue runs we have the condition `current_state.is_context_engine_enabled and self.request.is_context_engine_enabled:`. So if the start run sets the context flag to True this condition is always true other wise false. 
+ Currently set to 0. Will set to 0.5 in options automator.
+ Options automator PR needs to be merged first though: https://github.com/getsentry/sentry-options-automator/pull/6797