### PR TITLE
fix(tests): Prerequisite test fixes for xdist parallelization

### DIFF
--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -44,6 +44,7 @@ class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
         super().setUp()
         self.widget_1 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=0,
             title="Widget 1",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
@@ -52,6 +53,7 @@ class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
         )
         self.widget_2 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=1,
             title="Widget 2",
             display_type=DashboardWidgetDisplayTypes.TABLE,
             widget_type=DashboardWidgetTypes.DISCOVER,
@@ -916,12 +918,14 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         self.create_user_member_role()
         self.widget_3 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=2,
             title="Widget 3",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
         )
         self.widget_4 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=3,
             title="Widget 4",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -12,6 +12,8 @@ from sentry.spans.buffer import FlushedSegment, OutputSpan, Span, SpansBuffer
 from sentry.spans.segment_key import SegmentKey, parse_segment_key
 from sentry.testutils.helpers.options import override_options
 
+pytestmark = [pytest.mark.django_db]
+
 DEFAULT_OPTIONS = {
     "spans.buffer.timeout": 60,
     "spans.buffer.root-timeout": 10,


### PR DESCRIPTION
Test fixes that are required for xdist, but not necessarily xdist-specific.

### 1. Fix nondeterministic widget ordering (`test_organization_dashboard_details.py`)

`DashboardWidget.order` is a `BoundedPositiveIntegerField(null=True)`. Four widgets in the test fixtures were created without `order=`, leaving them NULL. The query uses `ORDER BY (order, id)` — PostgreSQL's ordering of NULL values is nondeterministic, causing intermittent assertion failures on widget position.

**Fix:** Add explicit `order=0,1,2,3` to the four widget fixtures.

### 2. Add `django_db` marker to `test_buffer.py`

`flush_segments()` calls `Project.objects.get_from_cache()` which requires DB access. Without the `django_db` marker, this causes "Database access not allowed" errors under parallel execution. This is a rare case — almost all Sentry tests inherit from `TestCase` (which implicitly grants DB access), but `test_buffer.py` is one of the few function-based test files that relies on pytest-django's marker system.

**Fix:** Add `pytestmark = [pytest.mark.django_db]`.