### PR TITLE
fix(ci): Exclude .venv from pyc cache cleanup

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -90,8 +90,8 @@ runs:
         WORKDIR: ${{ inputs.workdir }}
       run: |
         cd "$WORKDIR"
-        find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
-        find . -type f -name "*.pyc" -delete 2>/dev/null || true
+        find . -not -path './.venv/*' -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+        find . -not -path './.venv/*' -type f -name "*.pyc" -delete 2>/dev/null || true
 
     - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
       with:


### PR DESCRIPTION
So in `action.yml` we have two steps where we first:
- restore the virtual environment form cache (`action-setup-venv`)
and then immediately after
- clears Python cache, essentially negating the first step

Deleting these forces Python to recompile every installed package on first import during every CI run, undermining the purpose of the venv cache.

We add `-not -path './.venv/*'` to both `find` commands so we only clear pycache dirs and not the venv.