### PR TITLE
feat(cells): Add the rpc methods for project key mapping

### DIFF
--- a/src/sentry/hybridcloud/services/project_key_mapping/__init__.py
+++ b/src/sentry/hybridcloud/services/project_key_mapping/__init__.py
@@ -1,0 +1,1 @@
+from .model import *  # noqa

--- a/src/sentry/hybridcloud/services/project_key_mapping/model.py
+++ b/src/sentry/hybridcloud/services/project_key_mapping/model.py
@@ -1,0 +1,7 @@
+from sentry.hybridcloud.rpc import RpcModel
+
+
+class RpcProjectKey(RpcModel):
+    id: int
+    public_key: str
+    cell_name: str

--- a/src/sentry/hybridcloud/services/project_key_mapping/model.py
+++ b/src/sentry/hybridcloud/services/project_key_mapping/model.py
@@ -1,7 +1,7 @@
 from sentry.hybridcloud.rpc import RpcModel
 
 
-class RpcProjectKey(RpcModel):
+class RpcProjectKeyMapping(RpcModel):
     id: int
     public_key: str
     cell_name: str

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -378,24 +378,24 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
         handle_replication(Team, destination)
 
     def upsert_project_key_mapping(self, *, project_key: RpcProjectKey) -> None:
-        rows_updated = ProjectKeyMapping.objects.filter(
-            project_key_id=project_key.id, cell_name=project_key.cell_name
-        ).update(public_key=project_key.public_key)
+        try:
+            with transaction.atomic(router.db_for_write(ProjectKeyMapping)):
+                rows_updated = ProjectKeyMapping.objects.filter(
+                    project_key_id=project_key.id, cell_name=project_key.cell_name
+                ).update(public_key=project_key.public_key)
 
-        if not rows_updated:
-            try:
-                with transaction.atomic(router.db_for_write(ProjectKeyMapping)):
+                if not rows_updated:
                     ProjectKeyMapping.objects.create(
                         project_key_id=project_key.id,
                         public_key=project_key.public_key,
                         cell_name=project_key.cell_name,
                     )
-            except IntegrityError:
-                logger.error(
-                    "project_key_mapping.conflict",
-                    extra={"project_key_id": project_key.id, "cell_name": project_key.cell_name},
-                )
-                raise
+        except IntegrityError:
+            logger.error(
+                "project_key_mapping.conflict",
+                extra={"project_key_id": project_key.id, "cell_name": project_key.cell_name},
+            )
+            raise
 
     def delete_project_key_mapping(self, *, project_key_id: int, cell_name: str) -> None:
         ProjectKeyMapping.objects.filter(

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -1,8 +1,11 @@
+import logging
 from collections.abc import Iterator, Mapping
 from typing import Any
 
-from django.db import router, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Q
+
+logger = logging.getLogger(__name__)
 
 from sentry.auth.services.auth import RpcApiKey, RpcApiToken, RpcAuthIdentity, RpcAuthProvider
 from sentry.auth.services.orgauthtoken.model import RpcOrgAuthToken
@@ -21,7 +24,11 @@ from sentry.hybridcloud.services.control_organization_provisioning import (
     RpcOrganizationSlugReservation,
 )
 from sentry.hybridcloud.services.project_key_mapping import RpcProjectKey
-from sentry.hybridcloud.services.replica.service import ControlReplicaService, RegionReplicaService
+from sentry.hybridcloud.services.replica.service import (
+    ControlReplicaService,
+    RegionReplicaService,
+    region_replica_service,
+)
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.integration import Integration
 from sentry.models.apikey import ApiKey
@@ -318,6 +325,11 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
         with enforce_constraints(transaction.atomic(router.db_for_write(AuthProviderReplica))):
             AuthProviderReplica.objects.filter(auth_provider_id=auth_provider_id).delete()
 
+    def delete_project_key(self, *, project_key_id: int, cell_name: str | None = None) -> None:
+        from sentry.models.projectkey import ProjectKey
+
+        ProjectKey.objects.filter(id=project_key_id).delete()
+
 
 class DatabaseBackedControlReplicaService(ControlReplicaService):
     def upsert_external_actor_replica(self, *, external_actor: RpcExternalActor) -> None:
@@ -372,21 +384,25 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
         handle_replication(Team, destination)
 
     def upsert_project_key_mapping(self, *, project_key: RpcProjectKey) -> None:
-        # We lookup on (project_key_id, cell_name) rather than public_key because
-        # public_key can be reassigned (e.g. during relocation). This ensures the
-        # old mapping does not get orphaned in the control silo.
-
-        # TODO(cells): handle conflicting public_key unique constraint here
         with transaction.atomic(router.db_for_write(ProjectKeyMapping)):
-            rows_updated = ProjectKeyMapping.objects.filter(
-                project_key_id=project_key.id, cell_name=project_key.cell_name
-            ).update(public_key=project_key.public_key)
+            try:
+                rows_updated = ProjectKeyMapping.objects.filter(
+                    project_key_id=project_key.id, cell_name=project_key.cell_name
+                ).update(public_key=project_key.public_key)
 
-            if not rows_updated:
-                ProjectKeyMapping.objects.create(
-                    project_key_id=project_key.id,
-                    public_key=project_key.public_key,
-                    cell_name=project_key.cell_name,
+                if not rows_updated:
+                    ProjectKeyMapping.objects.create(
+                        project_key_id=project_key.id,
+                        public_key=project_key.public_key,
+                        cell_name=project_key.cell_name,
+                    )
+            except IntegrityError:
+                logger.error(
+                    "project_key_mapping.conflict",
+                    extra={"project_key_id": project_key.id, "cell_name": project_key.cell_name},
+                )
+                region_replica_service.delete_project_key(
+                    project_key_id=project_key.id, cell_name=project_key.cell_name
                 )
 
     def delete_project_key_mapping(self, *, project_key_id: int, cell_name: str) -> None:

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -379,11 +379,12 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
 
     def upsert_project_key_mapping(self, *, project_key: RpcProjectKeyMapping) -> None:
         try:
-            ProjectKeyMapping.objects.update_or_create(
-                project_key_id=project_key.id,
-                cell_name=project_key.cell_name,
-                defaults={"public_key": project_key.public_key},
-            )
+            with transaction.atomic(router.db_for_write(ProjectKeyMapping)):
+                ProjectKeyMapping.objects.update_or_create(
+                    project_key_id=project_key.id,
+                    cell_name=project_key.cell_name,
+                    defaults={"public_key": project_key.public_key},
+                )
         except IntegrityError:
             logger.error(
                 "project_key_mapping.conflict",

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -27,7 +27,6 @@ from sentry.hybridcloud.services.project_key_mapping import RpcProjectKey
 from sentry.hybridcloud.services.replica.service import (
     ControlReplicaService,
     RegionReplicaService,
-    region_replica_service,
 )
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.integration import Integration
@@ -325,11 +324,6 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
         with enforce_constraints(transaction.atomic(router.db_for_write(AuthProviderReplica))):
             AuthProviderReplica.objects.filter(auth_provider_id=auth_provider_id).delete()
 
-    def delete_project_key(self, *, project_key_id: int, cell_name: str | None = None) -> None:
-        from sentry.models.projectkey import ProjectKey
-
-        ProjectKey.objects.filter(id=project_key_id).delete()
-
 
 class DatabaseBackedControlReplicaService(ControlReplicaService):
     def upsert_external_actor_replica(self, *, external_actor: RpcExternalActor) -> None:
@@ -401,9 +395,7 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
                     "project_key_mapping.conflict",
                     extra={"project_key_id": project_key.id, "cell_name": project_key.cell_name},
                 )
-                region_replica_service.delete_project_key(
-                    project_key_id=project_key.id, cell_name=project_key.cell_name
-                )
+                raise
 
     def delete_project_key_mapping(self, *, project_key_id: int, cell_name: str) -> None:
         ProjectKeyMapping.objects.filter(

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -5,8 +5,6 @@ from typing import Any
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 
-logger = logging.getLogger(__name__)
-
 from sentry.auth.services.auth import RpcApiKey, RpcApiToken, RpcAuthIdentity, RpcAuthProvider
 from sentry.auth.services.orgauthtoken.model import RpcOrgAuthToken
 from sentry.db.models import BaseModel, FlexibleForeignKey
@@ -47,6 +45,8 @@ from sentry.models.teamreplica import TeamReplica
 from sentry.notifications.services import RpcExternalActor
 from sentry.organizations.services.organization import RpcOrganizationMemberTeam, RpcTeam
 from sentry.users.models.user import User
+
+logger = logging.getLogger(__name__)
 
 
 def get_foreign_key_columns(

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -20,6 +20,7 @@ from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.services.control_organization_provisioning import (
     RpcOrganizationSlugReservation,
 )
+from sentry.hybridcloud.services.project_key_mapping import RpcProjectKey
 from sentry.hybridcloud.services.replica.service import ControlReplicaService, RegionReplicaService
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.integration import Integration
@@ -34,6 +35,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.models.organizationslugreservationreplica import OrganizationSlugReservationReplica
 from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.models.projectkeymapping import ProjectKeyMapping
 from sentry.models.team import Team
 from sentry.models.teamreplica import TeamReplica
 from sentry.notifications.services import RpcExternalActor
@@ -368,3 +370,26 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
         )
 
         handle_replication(Team, destination)
+
+    def upsert_project_key_mapping(self, *, project_key: RpcProjectKey) -> None:
+        # We lookup on (project_key_id, cell_name) rather than public_key because
+        # public_key can be reassigned (e.g. during relocation). This ensures the
+        # old mapping does not get orphaned in the control silo.
+
+        # TODO(cells): handle conflicting public_key unique constraint here
+        with transaction.atomic(router.db_for_write(ProjectKeyMapping)):
+            rows_updated = ProjectKeyMapping.objects.filter(
+                project_key_id=project_key.id, cell_name=project_key.cell_name
+            ).update(public_key=project_key.public_key)
+
+            if not rows_updated:
+                ProjectKeyMapping.objects.create(
+                    project_key_id=project_key.id,
+                    public_key=project_key.public_key,
+                    cell_name=project_key.cell_name,
+                )
+
+    def delete_project_key_mapping(self, *, project_key_id: int, cell_name: str) -> None:
+        ProjectKeyMapping.objects.filter(
+            project_key_id=project_key_id, cell_name=cell_name
+        ).delete()

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -377,7 +377,7 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
 
         handle_replication(Team, destination)
 
-    def upsert_project_key_mapping(self, *, project_key: RpcProjectKeyMapping) -> None:
+    def upsert_project_key_mapping(self, *, project_key: RpcProjectKeyMapping) -> bool:
         try:
             with transaction.atomic(router.db_for_write(ProjectKeyMapping)):
                 ProjectKeyMapping.objects.update_or_create(
@@ -390,7 +390,8 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
                 "project_key_mapping.conflict",
                 extra={"project_key_id": project_key.id, "cell_name": project_key.cell_name},
             )
-            raise
+            return False
+        return True
 
     def delete_project_key_mapping(self, *, project_key_id: int, cell_name: str) -> None:
         ProjectKeyMapping.objects.filter(

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -23,7 +23,7 @@ from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.services.control_organization_provisioning import (
     RpcOrganizationSlugReservation,
 )
-from sentry.hybridcloud.services.project_key_mapping import RpcProjectKey
+from sentry.hybridcloud.services.project_key_mapping import RpcProjectKeyMapping
 from sentry.hybridcloud.services.replica.service import (
     ControlReplicaService,
     RegionReplicaService,
@@ -377,7 +377,7 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
 
         handle_replication(Team, destination)
 
-    def upsert_project_key_mapping(self, *, project_key: RpcProjectKey) -> None:
+    def upsert_project_key_mapping(self, *, project_key: RpcProjectKeyMapping) -> None:
         try:
             ProjectKeyMapping.objects.update_or_create(
                 project_key_id=project_key.id,

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -379,17 +379,11 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
 
     def upsert_project_key_mapping(self, *, project_key: RpcProjectKey) -> None:
         try:
-            with transaction.atomic(router.db_for_write(ProjectKeyMapping)):
-                rows_updated = ProjectKeyMapping.objects.filter(
-                    project_key_id=project_key.id, cell_name=project_key.cell_name
-                ).update(public_key=project_key.public_key)
-
-                if not rows_updated:
-                    ProjectKeyMapping.objects.create(
-                        project_key_id=project_key.id,
-                        public_key=project_key.public_key,
-                        cell_name=project_key.cell_name,
-                    )
+            ProjectKeyMapping.objects.update_or_create(
+                project_key_id=project_key.id,
+                cell_name=project_key.cell_name,
+                defaults={"public_key": project_key.public_key},
+            )
         except IntegrityError:
             logger.error(
                 "project_key_mapping.conflict",

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -384,13 +384,13 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
         handle_replication(Team, destination)
 
     def upsert_project_key_mapping(self, *, project_key: RpcProjectKey) -> None:
-        with transaction.atomic(router.db_for_write(ProjectKeyMapping)):
-            try:
-                rows_updated = ProjectKeyMapping.objects.filter(
-                    project_key_id=project_key.id, cell_name=project_key.cell_name
-                ).update(public_key=project_key.public_key)
+        rows_updated = ProjectKeyMapping.objects.filter(
+            project_key_id=project_key.id, cell_name=project_key.cell_name
+        ).update(public_key=project_key.public_key)
 
-                if not rows_updated:
+        if not rows_updated:
+            try:
+                with transaction.atomic(router.db_for_write(ProjectKeyMapping)):
                     ProjectKeyMapping.objects.create(
                         project_key_id=project_key.id,
                         public_key=project_key.public_key,

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -7,6 +7,7 @@ from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method, rpc_
 from sentry.hybridcloud.services.control_organization_provisioning import (
     RpcOrganizationSlugReservation,
 )
+from sentry.hybridcloud.services.project_key_mapping import RpcProjectKey
 from sentry.notifications.services import RpcExternalActor
 from sentry.organizations.services.organization import RpcOrganizationMemberTeam, RpcTeam
 from sentry.silo.base import SiloMode
@@ -36,6 +37,16 @@ class ControlReplicaService(RpcService):
     @rpc_method
     @abc.abstractmethod
     def upsert_external_actor_replica(self, *, external_actor: RpcExternalActor) -> None:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def upsert_project_key_mapping(self, *, project_key: RpcProjectKey) -> None:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def delete_project_key_mapping(self, *, project_key_id: int, cell_name: str) -> None:
         pass
 
     @classmethod

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -41,7 +41,11 @@ class ControlReplicaService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
-    def upsert_project_key_mapping(self, *, project_key: RpcProjectKeyMapping) -> None:
+    def upsert_project_key_mapping(self, *, project_key: RpcProjectKeyMapping) -> bool:
+        """
+        Returns True if the mapping was successfully created or updated, False if there was a
+        conflict (e.g. a duplicate public_key).
+        """
         pass
 
     @rpc_method

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -7,7 +7,7 @@ from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method, rpc_
 from sentry.hybridcloud.services.control_organization_provisioning import (
     RpcOrganizationSlugReservation,
 )
-from sentry.hybridcloud.services.project_key_mapping import RpcProjectKey
+from sentry.hybridcloud.services.project_key_mapping import RpcProjectKeyMapping
 from sentry.notifications.services import RpcExternalActor
 from sentry.organizations.services.organization import RpcOrganizationMemberTeam, RpcTeam
 from sentry.silo.base import SiloMode
@@ -41,7 +41,7 @@ class ControlReplicaService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
-    def upsert_project_key_mapping(self, *, project_key: RpcProjectKey) -> None:
+    def upsert_project_key_mapping(self, *, project_key: RpcProjectKeyMapping) -> None:
         pass
 
     @rpc_method

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -147,11 +147,6 @@ class RegionReplicaService(RpcService):
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByCellName())
-    @abc.abstractmethod
-    def delete_project_key(self, *, project_key_id: int, cell_name: str | None = None) -> None:
-        pass
-
     @classmethod
     def get_local_implementation(cls) -> RpcService:
         from .impl import DatabaseBackedRegionReplicaService

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -147,6 +147,11 @@ class RegionReplicaService(RpcService):
     ) -> None:
         pass
 
+    @regional_rpc_method(resolve=ByCellName())
+    @abc.abstractmethod
+    def delete_project_key(self, *, project_key_id: int, cell_name: str | None = None) -> None:
+        pass
+
     @classmethod
     def get_local_implementation(cls) -> RpcService:
         from .impl import DatabaseBackedRegionReplicaService


### PR DESCRIPTION
3 new rpc methods are added:

1. ControlReplicaService.upsert_project_key_mapping - handles insert or update of project key
2. ControlReplicaService.delete_project_key_mapping - project key deletion
3. RegionReplicaService.delete_project_key - delete the project key on the cell silo in case an integrity error was encountered in control (e.g. duplicate public key in 2 cells)

These will be needed by https://github.com/getsentry/sentry/pull/110231/ as we will start syncing these mappings from the cell to the control silo

