### PR TITLE
fix(ownership): serialize owner IDs as strings to match Actor type contract

### DIFF
--- a/src/sentry/issues/ownership/grammar.py
+++ b/src/sentry/issues/ownership/grammar.py
@@ -527,7 +527,7 @@ def add_owner_ids_to_schema(rules: list[dict[str, Any]], owners_id: dict[str, in
     for rule in rules:
         for rule_owner in rule["owners"]:
             if rule_owner["identifier"] in owners_id.keys():
-                rule_owner["id"] = owners_id[rule_owner["identifier"]]
+                rule_owner["id"] = str(owners_id[rule_owner["identifier"]])
 
 
 def create_schema_from_issue_owners(

--- a/static/app/components/core/avatar/useAvatar.spec.tsx
+++ b/static/app/components/core/avatar/useAvatar.spec.tsx
@@ -43,6 +43,14 @@ describe('useAvatar', () => {
       );
       expect(screen.getByText('?')).toBeInTheDocument();
     });
+
+    it('handles numeric name values defensively', () => {
+      render(
+        // @ts-expect-error testing defensive handling of non-string name
+        <Avatar type="letter_avatar" identifier="team-123" name={2251960} />
+      );
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
   });
 
   describe('identifier vs name', () => {

--- a/static/app/components/core/avatar/useAvatar.ts
+++ b/static/app/components/core/avatar/useAvatar.ts
@@ -158,7 +158,7 @@ async function hashGravatarId(gravatarId: string): Promise<string> {
  * the svg, etc) will also need to be changed there.
  */
 function getInitials(name: string | undefined): Tagged<string, '__avatar'> {
-  const sanitizedName = name?.trim();
+  const sanitizedName = String(name ?? '').trim();
 
   if (!sanitizedName) {
     return '?' as Tagged<string, '__avatar'>;

--- a/static/app/stores/teamStore.spec.tsx
+++ b/static/app/stores/teamStore.spec.tsx
@@ -110,4 +110,25 @@ describe('TeamStore', () => {
       });
     });
   });
+
+  describe('getById', () => {
+    beforeEach(() => {
+      TeamStore.loadInitialData([teamFoo, teamBar]);
+    });
+
+    it('returns team by string ID', () => {
+      const team = TeamStore.getById('1');
+      expect(team).toEqual(teamFoo);
+    });
+
+    it('returns team by numeric ID (defensive handling)', () => {
+      const team = TeamStore.getById(1 as any);
+      expect(team).toEqual(teamFoo);
+    });
+
+    it('returns null for non-existent ID', () => {
+      const team = TeamStore.getById('999');
+      expect(team).toBeNull();
+    });
+  });
 });

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -138,7 +138,8 @@ const teamStoreConfig: TeamStoreDefinition = {
 
   getById(id: string) {
     const {teams} = this.state;
-    return teams.find(item => item.id.toString() === id.toString()) || null;
+    const normalizedId = String(id);
+    return teams.find(item => item.id === normalizedId) || null;
   },
 
   getBySlug(slug: string) {

--- a/tests/sentry/issues/endpoints/test_project_codeowners_index.py
+++ b/tests/sentry/issues/endpoints/test_project_codeowners_index.py
@@ -342,8 +342,12 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 {
                     "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
-                        {"id": self.user.id, "identifier": self.user.email, "type": "user"},
-                        {"id": self.team.id, "identifier": self.team.slug, "type": "team"},
+                        {
+                            "id": str(self.user.id),
+                            "identifier": self.user.email,
+                            "type": "user",
+                        },
+                        {"id": str(self.team.id), "identifier": self.team.slug, "type": "team"},
                     ],
                 }
             ],
@@ -431,8 +435,12 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 {
                     "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
-                        {"id": self.user.id, "identifier": self.user.email, "type": "user"},
-                        {"id": self.team.id, "identifier": self.team.slug, "type": "team"},
+                        {
+                            "id": str(self.user.id),
+                            "identifier": self.user.email,
+                            "type": "user",
+                        },
+                        {"id": str(self.team.id), "identifier": self.team.slug, "type": "team"},
                     ],
                 }
             ],
@@ -455,8 +463,12 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 {
                     "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
-                        {"id": self.user.id, "identifier": self.user.email, "type": "user"},
-                        {"id": self.team.id, "identifier": self.team.slug, "type": "team"},
+                        {
+                            "id": str(self.user.id),
+                            "identifier": self.user.email,
+                            "type": "user",
+                        },
+                        {"id": str(self.team.id), "identifier": self.team.slug, "type": "team"},
                     ],
                 }
             ],
@@ -545,8 +557,12 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 {
                     "matcher": {"type": "codeowners", "pattern": "docs/*"},
                     "owners": [
-                        {"type": "user", "id": self.user.id, "identifier": "admin@sentry.io"},
-                        {"type": "team", "id": self.team.id, "identifier": "tiger-team"},
+                        {
+                            "type": "user",
+                            "id": str(self.user.id),
+                            "identifier": "admin@sentry.io",
+                        },
+                        {"type": "team", "id": str(self.team.id), "identifier": "tiger-team"},
                     ],
                 }
             ],
@@ -588,8 +604,8 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             {
                 "matcher": {"type": "codeowners", "pattern": "docs/*"},
                 "owners": [
-                    {"type": "user", "identifier": "admin@sentry.io", "id": self.user.id},
-                    {"type": "team", "identifier": "tiger-team", "id": self.team.id},
+                    {"type": "user", "identifier": "admin@sentry.io", "id": str(self.user.id)},
+                    {"type": "team", "identifier": "tiger-team", "id": str(self.team.id)},
                 ],
             }
         ]

--- a/tests/sentry/issues/endpoints/test_project_codeowners_index.py
+++ b/tests/sentry/issues/endpoints/test_project_codeowners_index.py
@@ -73,8 +73,8 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 {
                     "matcher": {"type": "codeowners", "pattern": "docs/*"},
                     "owners": [
-                        {"type": "user", "id": self.user.id, "name": self.user.email},
-                        {"type": "team", "id": self.team.id, "name": self.team.slug},
+                        {"type": "user", "id": str(self.user.id), "name": self.user.email},
+                        {"type": "team", "id": str(self.team.id), "name": self.team.slug},
                     ],
                 }
             ],
@@ -124,7 +124,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             "rules": [
                 {
                     "matcher": {"type": "codeowners", "pattern": "*.js"},
-                    "owners": [{"type": "team", "id": self.team.id, "name": self.team.slug}],
+                    "owners": [{"type": "team", "id": str(self.team.id), "name": self.team.slug}],
                 }
             ],
         }
@@ -156,7 +156,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             "rules": [
                 {
                     "matcher": {"type": "codeowners", "pattern": "*.js"},
-                    "owners": [{"type": "team", "id": self.team.id, "name": self.team.slug}],
+                    "owners": [{"type": "team", "id": str(self.team.id), "name": self.team.slug}],
                 }
             ],
         }
@@ -572,10 +572,10 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                     "owners": [
                         {
                             "type": "user",
-                            "id": self.user.id,
+                            "id": str(self.user.id),
                             "name": "admin@sentry.io",
                         },
-                        {"type": "team", "id": self.team.id, "name": "tiger-team"},
+                        {"type": "team", "id": str(self.team.id), "name": "tiger-team"},
                     ],
                 }
             ],
@@ -632,9 +632,9 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                             {
                                 "type": "user",
                                 "name": self.member_user_delete.email,
-                                "id": self.member_user_delete.id,
+                                "id": str(self.member_user_delete.id),
                             },
-                            {"type": "team", "name": self.team.slug, "id": self.team.id},
+                            {"type": "team", "name": self.team.slug, "id": str(self.team.id)},
                         ],
                     }
                 ],
@@ -669,7 +669,9 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 "rules": [
                     {
                         "matcher": {"type": "codeowners", "pattern": "docs/*"},
-                        "owners": [{"type": "team", "name": self.team.slug, "id": self.team.id}],
+                        "owners": [
+                            {"type": "team", "name": self.team.slug, "id": str(self.team.id)}
+                        ],
                     }
                 ],
             }
@@ -712,7 +714,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                             {
                                 "type": "user",
                                 "name": self.member_user_delete.email,
-                                "id": self.member_user_delete.id,
+                                "id": str(self.member_user_delete.id),
                             }
                         ],
                     }
@@ -801,18 +803,18 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                             {
                                 "type": "user",
                                 "name": self.member_user_delete_1.email,
-                                "id": self.member_user_delete_1.id,
+                                "id": str(self.member_user_delete_1.id),
                             }
                         ],
                     },
                     {
                         "matcher": {"type": "codeowners", "pattern": "*.py"},
                         "owners": [
-                            {"type": "team", "name": self.team.slug, "id": self.team.id},
+                            {"type": "team", "name": self.team.slug, "id": str(self.team.id)},
                             {
                                 "type": "user",
                                 "name": self.member_user_delete_1.email,
-                                "id": self.member_user_delete_1.id,
+                                "id": str(self.member_user_delete_1.id),
                             },
                         ],
                     },
@@ -825,7 +827,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                             {
                                 "type": "user",
                                 "name": self.member_user_delete_2.email,
-                                "id": self.member_user_delete_2.id,
+                                "id": str(self.member_user_delete_2.id),
                             },
                         ],
                     },
@@ -835,7 +837,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                             {
                                 "type": "user",
                                 "name": self.user.email,
-                                "id": self.user.id,
+                                "id": str(self.user.id),
                             }
                         ],
                     },
@@ -889,7 +891,9 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 "rules": [
                     {
                         "matcher": {"type": "codeowners", "pattern": "*.py"},
-                        "owners": [{"type": "team", "name": self.team.slug, "id": self.team.id}],
+                        "owners": [
+                            {"type": "team", "name": self.team.slug, "id": str(self.team.id)}
+                        ],
                     },
                     {
                         "matcher": {"type": "codeowners", "pattern": "*.rb"},
@@ -897,7 +901,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                             {
                                 "type": "user",
                                 "name": self.user.email,
-                                "id": self.user.id,
+                                "id": str(self.user.id),
                             }
                         ],
                     },

--- a/tests/sentry/issues/endpoints/test_project_ownership.py
+++ b/tests/sentry/issues/endpoints/test_project_ownership.py
@@ -493,3 +493,31 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         resp = self.client.put(self.path, {"raw": "*.js #tiger-team #other-team"})
         assert resp.status_code == 200
         assert resp.data["raw"] == "*.js #tiger-team #other-team"
+
+    def test_owner_ids_serialized_as_strings(self) -> None:
+        """
+        Test that owner IDs in the schema are serialized as strings to match the frontend Actor type.
+        This prevents the "trim is not a function" error when numeric IDs are passed to avatar rendering.
+        """
+        self.login_as(user=self.user)
+
+        resp = self.client.put(self.path, {"raw": "*.js admin@localhost #tiger-team"})
+        assert resp.status_code == 200
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+
+        schema = resp.data.get("schema")
+        assert schema is not None
+
+        rules = schema.get("rules")
+        assert rules is not None
+        assert len(rules) > 0
+
+        for rule in rules:
+            owners = rule.get("owners", [])
+            for owner in owners:
+                if "id" in owner:
+                    assert isinstance(owner["id"], str), (
+                        f"Owner ID should be string, got {type(owner['id'])}"
+                    )

--- a/tests/sentry/issues/ownership/test_grammar.py
+++ b/tests/sentry/issues/ownership/test_grammar.py
@@ -1252,7 +1252,7 @@ def test_add_owner_ids_to_schema_serializes_ids_as_strings() -> None:
     Test that add_owner_ids_to_schema converts numeric IDs to strings.
     This ensures the frontend Actor type contract (id: string) is respected.
     """
-    rules = [
+    rules: list[dict[str, Any]] = [
         {
             "matcher": {"type": "path", "pattern": "*.js"},
             "owners": [
@@ -1265,7 +1265,9 @@ def test_add_owner_ids_to_schema_serializes_ids_as_strings() -> None:
 
     add_owner_ids_to_schema(rules, owners_id)
 
-    assert rules[0]["owners"][0]["id"] == "12345"
-    assert rules[0]["owners"][1]["id"] == "67890"
-    assert isinstance(rules[0]["owners"][0]["id"], str)
-    assert isinstance(rules[0]["owners"][1]["id"], str)
+    first_rule = rules[0]
+    owners = first_rule["owners"]
+    assert owners[0]["id"] == "12345"
+    assert owners[1]["id"] == "67890"
+    assert isinstance(owners[0]["id"], str)
+    assert isinstance(owners[1]["id"], str)

--- a/tests/sentry/issues/ownership/test_grammar.py
+++ b/tests/sentry/issues/ownership/test_grammar.py
@@ -7,6 +7,7 @@ from sentry.issues.ownership.grammar import (
     Matcher,
     Owner,
     Rule,
+    add_owner_ids_to_schema,
     convert_codeowners_syntax,
     convert_schema_to_rules_text,
     dump_schema,
@@ -1244,3 +1245,27 @@ def test_codeowners_double_star_matching(
     "/**/example.py" pattern should only match files named exactly "example.py" at any directory depth.
     """
     _assert_matcher(Matcher("codeowners", pattern), path_details, expected)
+
+
+def test_add_owner_ids_to_schema_serializes_ids_as_strings() -> None:
+    """
+    Test that add_owner_ids_to_schema converts numeric IDs to strings.
+    This ensures the frontend Actor type contract (id: string) is respected.
+    """
+    rules = [
+        {
+            "matcher": {"type": "path", "pattern": "*.js"},
+            "owners": [
+                {"type": "team", "identifier": "frontend"},
+                {"type": "user", "identifier": "user@example.com"},
+            ],
+        }
+    ]
+    owners_id = {"frontend": 12345, "user@example.com": 67890}
+
+    add_owner_ids_to_schema(rules, owners_id)
+
+    assert rules[0]["owners"][0]["id"] == "12345"
+    assert rules[0]["owners"][1]["id"] == "67890"
+    assert isinstance(rules[0]["owners"][0]["id"], str)
+    assert isinstance(rules[0]["owners"][1]["id"], str)


### PR DESCRIPTION
Fixes ownership rules widget crash by ensuring owner IDs are consistently serialized as strings.

The "e?.trim is not a function" error occurred because the backend's ownership rules GET endpoint returned numeric owner IDs, while the frontend's `Actor` type expected string IDs. When a numeric ID was passed to avatar rendering logic, it caused a crash.

Fixes  #110588
