### PR TITLE
fix(avatar): Coerce owner id and avatar name to string before trim

### DIFF
--- a/static/app/components/core/avatar/useAvatar.ts
+++ b/static/app/components/core/avatar/useAvatar.ts
@@ -158,7 +158,8 @@ async function hashGravatarId(gravatarId: string): Promise<string> {
  * the svg, etc) will also need to be changed there.
  */
 function getInitials(name: string | undefined): Tagged<string, '__avatar'> {
-  const sanitizedName = name?.trim();
+  const sanitizedName =
+    name === null || name === undefined ? undefined : String(name).trim();
 
   if (!sanitizedName) {
     return '?' as Tagged<string, '__avatar'>;

--- a/static/app/views/settings/project/projectOwnership/ownershipRulesTable.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownershipRulesTable.tsx
@@ -168,7 +168,7 @@ export function OwnershipRulesTable({
         {chunkedRules[page]?.map((rule, index) => {
           let name: string | undefined = 'unknown';
           // ID might not be a string, so we need to convert it
-          const owners = rule.owners.map(owner => ({...owner, id: owner.id}));
+          const owners = rule.owners.map(owner => ({...owner, id: String(owner.id)}));
           if (owners[0]?.type === 'team') {
             const team = TeamStore.getById(owners[0].id);
             if (team?.slug) {

--- a/static/app/views/settings/project/projectOwnership/ownershipRulesTable.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownershipRulesTable.tsx
@@ -168,7 +168,7 @@ export function OwnershipRulesTable({
         {chunkedRules[page]?.map((rule, index) => {
           let name: string | undefined = 'unknown';
           // ID might not be a string, so we need to convert it
-          const owners = rule.owners.map(owner => ({...owner, id: String(owner.id)}));
+          const owners = rule.owners.map(owner => ({...owner, id: owner.id}));
           if (owners[0]?.type === 'team') {
             const team = TeamStore.getById(owners[0].id);
             if (team?.slug) {


### PR DESCRIPTION
Add a runtime check for avatar initial values

Fixes JAVASCRIPT-37Y7