### PR TITLE
fix(broadcasts): Guard against non-array broadcasts value to prevent crash

### DIFF
--- a/static/app/views/navigation/primary/whatsNew.tsx
+++ b/static/app/views/navigation/primary/whatsNew.tsx
@@ -189,7 +189,7 @@ export function PrimaryNavigationWhatsNew() {
           <WhatsNewContent
             unseenPostIds={unseenPostIds}
             isPending={isPending}
-            broadcasts={broadcasts}
+            broadcasts={Array.isArray(broadcasts) ? broadcasts : []}
           />
         </PrimaryButtonOverlay>
       )}

--- a/static/app/views/navigation/primary/whatsNew.tsx
+++ b/static/app/views/navigation/primary/whatsNew.tsx
@@ -66,7 +66,7 @@ function WhatsNewContent({
           }),
           {query: {show: 'latest', limit: '3'}},
         ],
-        data => (data ? data.map(item => ({...item, hasSeen: true})) : [])
+        data => (Array.isArray(data) ? data.map(item => ({...item, hasSeen: true})) : [])
       );
     },
   });
@@ -151,7 +151,10 @@ export function PrimaryNavigationWhatsNew() {
     }
   );
   const unseenPostIds = useMemo(
-    () => (broadcasts ?? []).filter(item => !item.hasSeen).map(item => item.id),
+    () =>
+      (Array.isArray(broadcasts) ? broadcasts : [])
+        .filter(item => !item.hasSeen)
+        .map(item => item.id),
     [broadcasts]
   );
 


### PR DESCRIPTION
Add some defensive guards for broadcasts filtering

Fixes JAVASCRIPT-380B