### PR TITLE
fix(github-copilot): Lower problem_statement truncation limit

### DIFF
--- a/src/sentry/integrations/github_copilot/client.py
+++ b/src/sentry/integrations/github_copilot/client.py
@@ -12,7 +12,6 @@ from sentry.integrations.github_copilot.models import (
     GithubPRFromGraphQL,
 )
 from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentState, CodingAgentStatus
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -46,35 +45,22 @@ class GithubCopilotAgentClient(CodingAgentClient):
         owner = request.repository.owner
         repo = request.repository.name
 
-        # GitHub Copilot has a 30000 character limit for problem_statement,
-        # measured on the JSON-serialized string value. Characters like \n, \",
-        # and \\ expand during JSON encoding (e.g. one newline char becomes two
-        # chars: \n), so we must truncate based on the encoded length.
-        max_encoded_length = 29900
+        # GitHub Copilot has a 30,000 character limit for problem_statement.
+        # Use 25,000 to leave headroom for JSON encoding expansion.
+        max_prompt_length = 25000
         prompt = request.prompt
-        json_encoded = json.dumps(prompt)
-        encoded_length = len(json_encoded) - 2  # subtract surrounding quotes
 
-        if encoded_length > max_encoded_length:
-            original_encoded_length = encoded_length
-            # Scale down raw string proportionally to the encoding expansion ratio
-            ratio = len(prompt) / encoded_length if encoded_length > 0 else 1.0
-            prompt = prompt[: int(max_encoded_length * ratio)]
-
-            # Safety: verify and trim further if still over (edge case: cut lands
-            # on a cluster of escapable chars)
-            while len(json.dumps(prompt)) - 2 > max_encoded_length:
-                prompt = prompt[: len(prompt) - 100]
-
+        if len(prompt) > max_prompt_length:
             logger.warning(
                 "coding_agent.github_copilot.prompt_truncated",
                 extra={
                     "owner": owner,
                     "repo": repo,
-                    "original_encoded_length": original_encoded_length,
-                    "truncated_encoded_length": len(json.dumps(prompt)) - 2,
+                    "original_length": len(prompt),
+                    "truncated_length": max_prompt_length,
                 },
             )
+            prompt = prompt[:max_prompt_length]
 
         payload = GithubCopilotTaskRequest(
             problem_statement=prompt,

--- a/src/sentry/integrations/github_copilot/client.py
+++ b/src/sentry/integrations/github_copilot/client.py
@@ -12,6 +12,7 @@ from sentry.integrations.github_copilot.models import (
     GithubPRFromGraphQL,
 )
 from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentState, CodingAgentStatus
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -45,20 +46,33 @@ class GithubCopilotAgentClient(CodingAgentClient):
         owner = request.repository.owner
         repo = request.repository.name
 
-        # GitHub Copilot has a 30000 character limit for problem_statement.
-        # Truncate with some buffer and log a warning if needed.
-        max_prompt_length = 29900
+        # GitHub Copilot has a 30000 character limit for problem_statement,
+        # measured on the JSON-serialized string value. Characters like \n, \",
+        # and \\ expand during JSON encoding (e.g. one newline char becomes two
+        # chars: \n), so we must truncate based on the encoded length.
+        max_encoded_length = 29900
         prompt = request.prompt
-        if len(prompt) > max_prompt_length:
-            original_length = len(prompt)
-            prompt = prompt[:max_prompt_length]
+        json_encoded = json.dumps(prompt)
+        encoded_length = len(json_encoded) - 2  # subtract surrounding quotes
+
+        if encoded_length > max_encoded_length:
+            original_encoded_length = encoded_length
+            # Scale down raw string proportionally to the encoding expansion ratio
+            ratio = len(prompt) / encoded_length if encoded_length > 0 else 1.0
+            prompt = prompt[: int(max_encoded_length * ratio)]
+
+            # Safety: verify and trim further if still over (edge case: cut lands
+            # on a cluster of escapable chars)
+            while len(json.dumps(prompt)) - 2 > max_encoded_length:
+                prompt = prompt[: len(prompt) - 100]
+
             logger.warning(
                 "coding_agent.github_copilot.prompt_truncated",
                 extra={
                     "owner": owner,
                     "repo": repo,
-                    "original_length": original_length,
-                    "truncated_length": max_prompt_length,
+                    "original_encoded_length": original_encoded_length,
+                    "truncated_encoded_length": len(json.dumps(prompt)) - 2,
                 },
             )
 

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -7,6 +7,7 @@ from sentry.integrations.github_copilot.models import GithubCopilotTask
 from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentStatus
 from sentry.seer.models import SeerRepoDefinition
 from sentry.testutils.cases import TestCase
+from sentry.utils import json
 
 
 class GithubCopilotAgentClientTest(TestCase):
@@ -103,9 +104,9 @@ class GithubCopilotAgentClientTest(TestCase):
         assert result.status == "running"
         assert result.artifacts is None
 
-    def _make_launch_request(self) -> CodingAgentLaunchRequest:
+    def _make_launch_request(self, prompt: str = "Fix the bug") -> CodingAgentLaunchRequest:
         return CodingAgentLaunchRequest(
-            prompt="Fix the bug",
+            prompt=prompt,
             repository=SeerRepoDefinition(
                 provider="github",
                 owner="getsentry",
@@ -213,3 +214,57 @@ class GithubCopilotAgentClientTest(TestCase):
         result = self.copilot_client.get_pr_from_graphql(global_id="PR_invalid")
 
         assert result is None
+
+    @patch.object(GithubCopilotAgentClient, "post")
+    def test_launch_truncates_prompt_with_json_escaping(self, mock_post: Mock) -> None:
+        """Prompt with many escapable chars is truncated based on JSON-encoded length"""
+        # Build a prompt full of newlines — each \n is 1 Python char but 2 JSON chars
+        prompt = "line\n" * 20000  # 100,000 Python chars, ~120,000 JSON-encoded chars
+        request = self._make_launch_request(prompt)
+
+        mock_response = Mock()
+        mock_response.json = {"task": {"id": "t-1", "created_at": "2026-01-01T00:00:00Z"}}
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        self.copilot_client.launch(webhook_url="https://example.com/hook", request=request)
+
+        call_data = mock_post.call_args[1]["data"]
+        sent_prompt = call_data["problem_statement"]
+        encoded_length = len(json.dumps(sent_prompt)) - 2
+        assert encoded_length <= 29900
+
+    @patch.object(GithubCopilotAgentClient, "post")
+    def test_launch_does_not_truncate_short_prompt(self, mock_post: Mock) -> None:
+        """Short prompts are sent as-is without truncation"""
+        prompt = "Fix this bug please."
+        request = self._make_launch_request(prompt)
+
+        mock_response = Mock()
+        mock_response.json = {"task": {"id": "t-1", "created_at": "2026-01-01T00:00:00Z"}}
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        self.copilot_client.launch(webhook_url="https://example.com/hook", request=request)
+
+        call_data = mock_post.call_args[1]["data"]
+        assert call_data["problem_statement"] == prompt
+
+    @patch.object(GithubCopilotAgentClient, "post")
+    def test_launch_truncates_prompt_with_heavy_escaping(self, mock_post: Mock) -> None:
+        """Prompt with backslashes and quotes (like minified JS) stays under limit"""
+        # Each char here expands to 2 chars in JSON: \" and \\
+        prompt = '\\"' * 20000  # 40,000 Python chars, ~80,000 JSON-encoded chars
+        request = self._make_launch_request(prompt)
+
+        mock_response = Mock()
+        mock_response.json = {"task": {"id": "t-1", "created_at": "2026-01-01T00:00:00Z"}}
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        self.copilot_client.launch(webhook_url="https://example.com/hook", request=request)
+
+        call_data = mock_post.call_args[1]["data"]
+        sent_prompt = call_data["problem_statement"]
+        encoded_length = len(json.dumps(sent_prompt)) - 2
+        assert encoded_length <= 29900

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -7,7 +7,6 @@ from sentry.integrations.github_copilot.models import GithubCopilotTask
 from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentStatus
 from sentry.seer.models import SeerRepoDefinition
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
 
 
 class GithubCopilotAgentClientTest(TestCase):
@@ -216,10 +215,9 @@ class GithubCopilotAgentClientTest(TestCase):
         assert result is None
 
     @patch.object(GithubCopilotAgentClient, "post")
-    def test_launch_truncates_prompt_with_json_escaping(self, mock_post: Mock) -> None:
-        """Prompt with many escapable chars is truncated based on JSON-encoded length"""
-        # Build a prompt full of newlines — each \n is 1 Python char but 2 JSON chars
-        prompt = "line\n" * 20000  # 100,000 Python chars, ~120,000 JSON-encoded chars
+    def test_launch_truncates_long_prompt(self, mock_post: Mock) -> None:
+        """Prompts exceeding 25,000 chars are truncated"""
+        prompt = "a" * 30000
         request = self._make_launch_request(prompt)
 
         mock_response = Mock()
@@ -231,8 +229,7 @@ class GithubCopilotAgentClientTest(TestCase):
 
         call_data = mock_post.call_args[1]["data"]
         sent_prompt = call_data["problem_statement"]
-        encoded_length = len(json.dumps(sent_prompt)) - 2
-        assert encoded_length <= 29900
+        assert len(sent_prompt) == 25000
 
     @patch.object(GithubCopilotAgentClient, "post")
     def test_launch_does_not_truncate_short_prompt(self, mock_post: Mock) -> None:
@@ -249,22 +246,3 @@ class GithubCopilotAgentClientTest(TestCase):
 
         call_data = mock_post.call_args[1]["data"]
         assert call_data["problem_statement"] == prompt
-
-    @patch.object(GithubCopilotAgentClient, "post")
-    def test_launch_truncates_prompt_with_heavy_escaping(self, mock_post: Mock) -> None:
-        """Prompt with backslashes and quotes (like minified JS) stays under limit"""
-        # Each char here expands to 2 chars in JSON: \" and \\
-        prompt = '\\"' * 20000  # 40,000 Python chars, ~80,000 JSON-encoded chars
-        request = self._make_launch_request(prompt)
-
-        mock_response = Mock()
-        mock_response.json = {"task": {"id": "t-1", "created_at": "2026-01-01T00:00:00Z"}}
-        mock_response.status_code = 200
-        mock_post.return_value = mock_response
-
-        self.copilot_client.launch(webhook_url="https://example.com/hook", request=request)
-
-        call_data = mock_post.call_args[1]["data"]
-        sent_prompt = call_data["problem_statement"]
-        encoded_length = len(json.dumps(sent_prompt)) - 2
-        assert encoded_length <= 29900


### PR DESCRIPTION
GitHub Copilot's API rejects `problem_statement` values exceeding 30,000 characters. The previous truncation at 29,900 raw characters was too close to the limit — JSON encoding expansion (e.g. `\n`, `\"`, `\\`) could push the serialized length over 30,000.

Lowers the limit to 25,000 characters to leave headroom for encoding expansion.

Fixes SENTRY-5M31