### PR TITLE
fix(codeowners): Align frontend types with backend endpoint

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -528,6 +528,11 @@ export interface ParsedOwnershipRule {
   owners: Actor[];
 }
 
+export interface OwnershipSchema {
+  $version: number;
+  rules: ParsedOwnershipRule[];
+}
+
 export type IssueOwnership = {
   autoAssignment:
     | 'Auto Assign to Suspect Commits'
@@ -539,7 +544,7 @@ export type IssueOwnership = {
   isActive: boolean;
   lastUpdated: string | null;
   raw: string | null;
-  schema?: {rules: ParsedOwnershipRule[]; version: number};
+  schema?: OwnershipSchema | null;
 };
 
 export enum GroupActivityType {

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -11,7 +11,7 @@ import type {
 } from 'sentry/views/settings/organizationIntegrations/constants';
 
 import type {Avatar, Choice, Choices, ObjectStatus, Scope} from './core';
-import type {ParsedOwnershipRule} from './group';
+import type {OwnershipSchema} from './group';
 import type {PlatformKey} from './project';
 import type {BaseRelease} from './release';
 import type {User} from './user';
@@ -601,11 +601,11 @@ export type CodeOwner = {
     users_without_access: string[];
   };
   id: string;
-  provider: 'github' | 'gitlab' | 'perforce';
+  provider: 'github' | 'gitlab' | 'perforce' | 'unknown';
   raw: string;
   codeMapping?: RepositoryProjectPathConfig;
   ownershipSyntax?: string;
-  schema?: {rules: ParsedOwnershipRule[]; version: number};
+  schema?: OwnershipSchema | null;
 };
 
 export type CodeownersFile = {

--- a/static/app/views/settings/project/projectOwnership/ownershipRulesTable.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownershipRulesTable.tsx
@@ -61,10 +61,7 @@ export function OwnershipRulesTable({
    * All unique actors from both codeowners and project rules
    */
   const allActors = useMemo(() => {
-    const actors = combinedRules
-      .flatMap(rule => rule.owners)
-      .filter(actor => actor.name)
-      .map(owner => ({...owner, id: owner.id}));
+    const actors = combinedRules.flatMap(rule => rule.owners).filter(actor => actor.name);
     return (
       uniqBy(actors, actor => `${actor.type}:${actor.id}`)
         // Sort by type, then by name
@@ -167,8 +164,7 @@ export function OwnershipRulesTable({
       >
         {chunkedRules[page]?.map((rule, index) => {
           let name: string | undefined = 'unknown';
-          // ID might not be a string, so we need to convert it
-          const owners = rule.owners.map(owner => ({...owner, id: owner.id}));
+          const {owners} = rule;
           if (owners[0]?.type === 'team') {
             const team = TeamStore.getById(owners[0].id);
             if (team?.slug) {


### PR DESCRIPTION
Fix OwnershipSchema to use $version (matching the actual API key) instead of version, make schema nullable, widen CodeOwner.provider to include 'unknown', and remove stale id-coercion code in ownershipRulesTable now that the backend returns string IDs.
