### PR TITLE
ref(grouping): Cache parameterization on context

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -393,6 +393,8 @@ def get_grouping_variants_for_event(
 
     # Otherwise we go to the various forms of grouping based on fingerprints and/or event data
     # (stacktrace, message, etc.)
+    context = GroupingContext(config or _load_default_grouping_config(), event)
+
     raw_fingerprint = event.data.get("fingerprint") or ["{{ default }}"]
     fingerprint_info = event.data.get("_fingerprint_info", {})
     fingerprint_type = get_fingerprint_type(raw_fingerprint)
@@ -415,7 +417,6 @@ def get_grouping_variants_for_event(
 
     # Run all of the event-data-based grouping strategies. Any which apply will create grouping
     # components, which will then be grouped into variants by variant type (system, app, default).
-    context = GroupingContext(config or _load_default_grouping_config(), event)
     strategy_component_variants: dict[str, ComponentVariant] = _get_variants_from_strategies(
         event, context
     )

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -404,6 +404,7 @@ def get_grouping_variants_for_event(
         else resolve_fingerprint_values(
             raw_fingerprint,
             event,
+            context,
             use_legacy_unknown_variable_handling=use_legacy_unknown_variable_handling,
         )
     )

--- a/src/sentry/grouping/context.py
+++ b/src/sentry/grouping/context.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Self
 
+from sentry.grouping.parameterization import experimental_parameterizer
+from sentry.grouping.parameterization import parameterizer as default_parameterizer
+from sentry.grouping.utils import get_canonical_message_from_event
+from sentry.options.rollout import in_rollout_group
+
 if TYPE_CHECKING:
     from sentry.grouping.strategies.base import StrategyConfiguration
     from sentry.services.eventstore.models import Event
@@ -37,6 +42,24 @@ class GroupingContext:
         self._stack = [strategy_config.initial_context]
         self.config = strategy_config
         self.event = event
+
+        # Store the event's message, in both raw and parameterized form, as well as the
+        # parameterizer. This will save us having to recheck which parameterizer to use, and save us
+        # from having to reparameterize the message if it's used in multiple places during grouping
+        # (in the error value component and a custom fingerprint, for example).
+        event_message = get_canonical_message_from_event(event)
+        parameterizer = (
+            experimental_parameterizer
+            if in_rollout_group("grouping.experimental_parameterization", event.project_id)
+            else default_parameterizer
+        )
+        self.parameterizer = parameterizer
+        # "Canonical" because it's the message which is used for the `{{ message }}` variable and
+        # for message-based grouping. (When grouping is based on error message, in case of an error
+        # chain we use all messages.)
+        self.canonical_event_message = event_message
+        self.canonical_message_parameterized = parameterizer.parameterize(event_message)
+
         self._push_context_layer()
 
     def __setitem__(self, key: str, value: Any) -> None:

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -15,6 +15,7 @@ from sentry.utils.safe import get_path
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 
 if TYPE_CHECKING:
+    from sentry.grouping.context import GroupingContext
     from sentry.services.eventstore.models import Event
 
 
@@ -301,7 +302,10 @@ def resolve_fingerprint_variable(
 
 
 def resolve_fingerprint_values(
-    fingerprint: list[str], event: Event, use_legacy_unknown_variable_handling: bool = False
+    fingerprint: list[str],
+    event: Event,
+    context: GroupingContext,
+    use_legacy_unknown_variable_handling: bool = False,
 ) -> list[str]:
     def _resolve_single_entry(entry: str) -> str:
         variable_key = parse_fingerprint_entry_as_variable(entry)

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -327,7 +327,7 @@ def resolve_fingerprint_values(
 
         if variable_key == "message" and resolved_value != "<no-message>":
             return normalize_message_for_grouping(
-                resolved_value, event, context, reason="fingerprint", trim_message=False
+                resolved_value, context, reason="fingerprint", trim_message=False
             )
 
         return resolved_value

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -327,7 +327,7 @@ def resolve_fingerprint_values(
 
         if variable_key == "message" and resolved_value != "<no-message>":
             return normalize_message_for_grouping(
-                resolved_value, event, reason="fingerprint", trim_message=False
+                resolved_value, event, context, reason="fingerprint", trim_message=False
             )
 
         return resolved_value

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -27,7 +27,7 @@ def message_v1(
     if context["normalize_message"]:
         raw_message = interface.message or interface.formatted or ""
         normalized = normalize_message_for_grouping(
-            raw_message, event, reason="message_component", trim_message=True
+            raw_message, event, context, reason="message_component", trim_message=True
         )
         hint = "stripped event-specific values" if raw_message != normalized else None
         return {variant_name: MessageGroupingComponent(values=[normalized], hint=hint)}

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -27,7 +27,7 @@ def message_v1(
     if context["normalize_message"]:
         raw_message = interface.message or interface.formatted or ""
         normalized = normalize_message_for_grouping(
-            raw_message, event, context, reason="message_component", trim_message=True
+            raw_message, context, reason="message_component", trim_message=True
         )
         hint = "stripped event-specific values" if raw_message != normalized else None
         return {variant_name: MessageGroupingComponent(values=[normalized], hint=hint)}

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -597,7 +597,7 @@ def single_exception(
         raw = exception.value
         if raw is not None:
             normalized = normalize_message_for_grouping(
-                raw, event, reason="value_component", trim_message=True
+                raw, event, context, reason="value_component", trim_message=True
             )
             hint = "stripped event-specific values" if raw != normalized else None
             if normalized:

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -597,7 +597,7 @@ def single_exception(
         raw = exception.value
         if raw is not None:
             normalized = normalize_message_for_grouping(
-                raw, event, context, reason="value_component", trim_message=True
+                raw, context, reason="value_component", trim_message=True
             )
             hint = "stripped event-specific values" if raw != normalized else None
             if normalized:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -61,7 +61,11 @@ def normalize_message_for_grouping(
     Replace values from a event's message with placeholders (in order to improve grouping). If
     `trim_message` is True, trim the message to at most 2 lines.
     """
-    parameterized = context.parameterizer.parameterize(message)
+    if message == context.canonical_event_message:
+        parameterized = context.canonical_message_parameterized
+    else:
+        parameterized = context.parameterizer.parameterize(message)
+
     message_parameterized = parameterized != message
 
     if message_parameterized:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -55,7 +55,7 @@ def bool_from_string(value: str) -> bool | None:
 # lines.
 @metrics.wraps("grouping.normalize_message_for_grouping")
 def normalize_message_for_grouping(
-    message: str, event: Event, context: GroupingContext, *, reason: str, trim_message: bool
+    message: str, context: GroupingContext, *, reason: str, trim_message: bool
 ) -> str:
     """
     Replace values from a event's message with placeholders (in order to improve grouping). If

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -16,6 +16,7 @@ from sentry.utils.safe import get_path
 
 if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
+    from sentry.grouping.context import GroupingContext
     from sentry.services.eventstore.models import Event
 
 
@@ -57,7 +58,7 @@ def bool_from_string(value: str) -> bool | None:
 # lines.
 @metrics.wraps("grouping.normalize_message_for_grouping")
 def normalize_message_for_grouping(
-    message: str, event: Event, *, reason: str, trim_message: bool
+    message: str, event: Event, context: GroupingContext, *, reason: str, trim_message: bool
 ) -> str:
     """
     Replace values from a event's message with placeholders (in order to improve grouping). If

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -61,20 +61,13 @@ def normalize_message_for_grouping(
     Replace values from a event's message with placeholders (in order to improve grouping). If
     `trim_message` is True, trim the message to at most 2 lines.
     """
-
-    if trim_message:
-        # If there are multiple lines, grab the first two non-empty ones
-        trimmed = _trim_extra_lines(message)
-        normalized = context.parameterizer.parameterize(trimmed)
-        message_parameterized = normalized != trimmed
-    else:
-        normalized = context.parameterizer.parameterize(message)
-        message_parameterized = normalized != message
+    parameterized = context.parameterizer.parameterize(message)
+    message_parameterized = parameterized != message
 
     if message_parameterized:
         metrics.incr("grouping.message_parameterized", tags={"source": reason})
 
-    return normalized
+    return _trim_extra_lines(parameterized) if trim_message else parameterized
 
 
 def _trim_extra_lines(input_str: str) -> str:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -8,9 +8,6 @@ from uuid import UUID
 
 from django.utils.encoding import force_bytes
 
-from sentry.grouping.parameterization import experimental_parameterizer
-from sentry.grouping.parameterization import parameterizer as default_parameterizer
-from sentry.options.rollout import in_rollout_group
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
 
@@ -64,19 +61,14 @@ def normalize_message_for_grouping(
     Replace values from a event's message with placeholders (in order to improve grouping). If
     `trim_message` is True, trim the message to at most 2 lines.
     """
-    parameterizer = (
-        experimental_parameterizer
-        if in_rollout_group("grouping.experimental_parameterization", event.project_id)
-        else default_parameterizer
-    )
 
     if trim_message:
         # If there are multiple lines, grab the first two non-empty ones
         trimmed = _trim_extra_lines(message)
-        normalized = parameterizer.parameterize(trimmed)
+        normalized = context.parameterizer.parameterize(trimmed)
         message_parameterized = normalized != trimmed
     else:
-        normalized = parameterizer.parameterize(message)
+        normalized = context.parameterizer.parameterize(message)
         message_parameterized = normalized != message
 
     if message_parameterized:

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -10,9 +10,11 @@ from sentry.grouping.api import (
     get_grouping_variants_for_event,
     load_grouping_config,
 )
+from sentry.grouping.context import GroupingContext
 from sentry.grouping.fingerprinting import FingerprintingConfig
 from sentry.grouping.fingerprinting.exceptions import InvalidFingerprintingConfig
 from sentry.grouping.fingerprinting.utils import resolve_fingerprint_values
+from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.grouping.variants import BaseVariant
 from sentry.services.eventstore.models import Event
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
@@ -267,10 +269,12 @@ release:foo                                     -> release-foo
     )
 
 
+@django_db_all  # Because initializing context checks options
 def test_variable_resolution() -> None:
     # TODO: This should be fleshed out to test way more cases, at which point we'll need to add some
     # actual data here
     event = Event(project_id=908415, event_id="11211231", data={})
+    context = GroupingContext(StrategyConfiguration(), event)
 
     for fingerprint_entry, expected_resolved_value in [
         ("{{ default }}", "{{ default }}"),
@@ -278,7 +282,7 @@ def test_variable_resolution() -> None:
         ("{{  default }}", "{{ default }}"),
         ("{{ dog }}", "<unrecognized-variable-dog>"),
     ]:
-        assert resolve_fingerprint_values([fingerprint_entry], event) == [
+        assert resolve_fingerprint_values([fingerprint_entry], event, context) == [
             expected_resolved_value
         ], f"Entry {fingerprint_entry} resolved incorrectly"
 
@@ -309,6 +313,9 @@ def test_resolves_unknown_variables_correctly_given_config_value() -> None:
     ):
         get_grouping_variants_for_event(event, winter_2023_config)
 
+        context = mock_resolve_fingerprint_values.call_args.args[2]
+        assert isinstance(context, GroupingContext)
+
         assert mock_resolve_fingerprint_values.call_count == 1
         assert mock_apply_custom_title_if_needed.call_count == 1
         assert (
@@ -322,7 +329,7 @@ def test_resolves_unknown_variables_correctly_given_config_value() -> None:
             is True
         )
         assert resolve_fingerprint_values(
-            fingerprint, event, use_legacy_unknown_variable_handling=True
+            fingerprint, event, context, use_legacy_unknown_variable_handling=True
         ) == ["{{ dog }}"]
 
     # Under the new config, we ask for non-legacy behavior, and as a result the unknown fingerprint
@@ -337,6 +344,9 @@ def test_resolves_unknown_variables_correctly_given_config_value() -> None:
     ):
         get_grouping_variants_for_event(event, fall_2025_config)
 
+        context = mock_resolve_fingerprint_values.call_args.args[2]
+        assert isinstance(context, GroupingContext)
+
         assert mock_resolve_fingerprint_values.call_count == 1
         assert mock_apply_custom_title_if_needed.call_count == 1
         assert (
@@ -350,7 +360,7 @@ def test_resolves_unknown_variables_correctly_given_config_value() -> None:
             is False
         )
         assert resolve_fingerprint_values(
-            fingerprint, event, use_legacy_unknown_variable_handling=False
+            fingerprint, event, context, use_legacy_unknown_variable_handling=False
         ) == ["<unrecognized-variable-dog>"]
 
 

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -1,11 +1,20 @@
+from unittest.mock import patch
+
 import pytest
 
+from sentry.grouping.api import _get_variants_from_strategies
+from sentry.grouping.component import MessageGroupingComponent
+from sentry.grouping.context import GroupingContext
 from sentry.grouping.parameterization import (
     DEFAULT_PARAMETERIZATION_REGEXES_MAP,
     EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP,
     experimental_parameterizer,
     parameterizer,
 )
+from sentry.grouping.variants import ComponentVariant, CustomFingerprintVariant
+from sentry.models.project import Project
+from sentry.services.eventstore.models import Event
+from sentry.testutils.pytest.fixtures import django_db_all
 
 standard_cases = [
     ("email", "test@email.com", "<email>"),
@@ -244,3 +253,50 @@ incorrect_cases = [
 def test_incorrect_parameterization(name: str, input: str, desired: str, actual: str) -> None:
     assert parameterizer.parameterize(input) != desired
     assert parameterizer.parameterize(input) == actual
+
+
+@django_db_all
+def test_parameterized_message_stored_on_context(default_project: Project) -> None:
+    with patch(
+        "sentry.grouping.api._get_variants_from_strategies", wraps=_get_variants_from_strategies
+    ) as mock_get_variants:
+        event = Event(default_project.id, "11211231", data={"message": "Dog number 1, #1 dog"})
+        event.get_grouping_variants()
+
+        context = mock_get_variants.call_args.args[1]
+
+        assert isinstance(context, GroupingContext)
+        assert context.canonical_event_message == "Dog number 1, #1 dog"
+        assert context.canonical_message_parameterized == "Dog number <int>, #<int> dog"
+
+
+@django_db_all
+def test_stored_parameterized_message_used(default_project: Project) -> None:
+    with patch(
+        "sentry.grouping.parameterization.parameterizer.parameterize",
+        wraps=parameterizer.parameterize,
+    ) as parameterize_spy:
+        event = Event(
+            default_project.id,
+            "11211231",
+            data={
+                "message": "Dog number 1, #1 dog",
+                "fingerprint": ["{{ message }}"],
+            },
+        )
+        variants = event.get_grouping_variants()
+
+        assert len(variants) == 2
+        message_variant = variants["default"]
+        fingerprint_variant = variants["custom_client_fingerprint"]
+
+        assert isinstance(message_variant, ComponentVariant)
+        assert isinstance(message_variant.contributing_component, MessageGroupingComponent)
+        assert message_variant.contributing_component.values == ["Dog number <int>, #<int> dog"]
+
+        assert isinstance(fingerprint_variant, CustomFingerprintVariant)
+        assert fingerprint_variant.values == ["Dog number <int>, #<int> dog"]
+
+        # Even though the parameterized message was used in two places, the parameterizer only ran
+        # once, meaning the stored value must have been used
+        assert parameterize_spy.call_count == 1


### PR DESCRIPTION
In our grouping algorithms, there are a number of places we use and parameterize message values, specifically when creating `MessageGroupingComponent` and/or `ErrorValueGroupingComponent` objects, and when evaluating the `{{ message }}` variable in client fingerprints and server fingerprint rules. Because more than one of these can apply to a single event, we can end up reparameterizing the same message multiple times. And though it's a less expensive operation, in those cases we also end up checking the `in_rollout_group` status of the event's project multiple times, to decide whether to use the default or experimental parameterizer.

To avoid this extra work in a straightforward way, this PR takes advantage of two things about the way our grouping works:

- As our grouping functions run, they pass around a `GroupingContext` object, which is a place where shared data can be stored. This means we have an easy, pre-existing spot to stick a parameterization result, where it can be accessed by other parts of the grouping process.

- Essentially every event has either a log message or an error message (or both), so the value to which `{{ message }}` evaluates pretty much always ends up getting used (and parameterized), even if that's not how we're referring to it. Because of that, we can do the parameterization up front without worrying that we're doing unnecessary work.

This PR therefore adds `{{ message }}`-value parameterization to context initialization, so that any place we're tempted to run the parameterizer, we can instead just check the context for an answer. (Other messages in the event, such as error messages from chained errors, aren't included because they're only used in one place.)

To keep things simple, metrics tracking this will be added separately, as part of an upcoming PR which also makes a number of other parameterization metrics changes.