### PR TITLE
bug(preprod): Fix snapshot zoom related issues

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -162,7 +162,8 @@ function SplitView({
             <Flex
               justify="center"
               align="center"
-              paddingTop="xl"
+              width="100%"
+              height="100%"
               style={zoomTransformStyle(zoom1.transform)}
             >
               <ZoomableImage src={baseImageUrl} alt={t('Base')} />
@@ -178,7 +179,8 @@ function SplitView({
             <Flex
               justify="center"
               align="center"
-              paddingTop="xl"
+              width="100%"
+              height="100%"
               style={zoomTransformStyle(zoom2.transform)}
             >
               <ImageWrapper>
@@ -238,7 +240,14 @@ function OnionView({
   opacity: number;
 }) {
   return (
-    <Flex direction="column" gap="md" flex="1" minHeight="0" align="center">
+    <Flex
+      direction="column"
+      gap="md"
+      flex="1"
+      minHeight="0"
+      align="center"
+      justify="center"
+    >
       <Flex
         justify="center"
         border="primary"

--- a/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.tsx
@@ -24,7 +24,8 @@ export function SingleImageDisplay({imageUrl, alt}: SingleImageDisplayProps) {
           <Flex
             justify="center"
             align="center"
-            paddingTop="xl"
+            width="100%"
+            height="100%"
             style={zoomTransformStyle(transform)}
           >
             <ZoomableImage src={imageUrl} alt={alt} />

--- a/static/app/views/preprod/snapshots/main/imageDisplay/zoomControls.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/zoomControls.tsx
@@ -70,6 +70,7 @@ export const ZoomContainer = styled('div')`
 `;
 
 export const ZoomableImage = styled(Image)`
+  width: auto;
   max-width: 100%;
   max-height: 60vh;
   object-fit: contain;


### PR DESCRIPTION
There were a few zoom related bugs in snapshots (fixes EME-946, EME-928). This handles those:

| Before      | After |
| ----------- | ----------- |
| <img width="1996" height="1342" alt="Screenshot 2026-03-12 at 3 55 43 PM" src="https://github.com/user-attachments/assets/192e8377-8674-4db7-85f2-341a397a4eb4" /> | <img width="2004" height="1350" alt="Screenshot 2026-03-12 at 4 00 36 PM" src="https://github.com/user-attachments/assets/63c3fea8-79d0-4e4a-acf9-21f4a4b573ab" /> |
| <img width="1841" height="1435" alt="Screenshot 2026-03-12 at 4 01 32 PM" src="https://github.com/user-attachments/assets/1705095a-ec75-47ca-8539-4155d5643c6c" /> | <img width="1842" height="1441" alt="Screenshot 2026-03-12 at 4 01 27 PM" src="https://github.com/user-attachments/assets/d10fbeee-a461-4f6a-996d-d6125794dc91" /> |
| <img width="1994" height="1314" alt="Screenshot 2026-03-12 at 4 00 57 PM" src="https://github.com/user-attachments/assets/36f03513-0f02-418f-a4f5-51a131b2b234" /> | <img width="1999" height="1305" alt="Screenshot 2026-03-12 at 4 00 51 PM" src="https://github.com/user-attachments/assets/2fd6927d-caa7-484c-9bea-ede8e9eb3a14" /> |
