### PR TITLE
feat(code-review): Add handler_duration_ms timing metric for region silo webhook processing

### DIFF
--- a/src/sentry/seer/code_review/metrics.py
+++ b/src/sentry/seer/code_review/metrics.py
@@ -1,3 +1,4 @@
+import time
 from enum import StrEnum
 
 from sentry.integrations.github.webhook_types import GithubWebhookType
@@ -99,6 +100,7 @@ def record_webhook_filtered(
 def record_webhook_enqueued(
     github_event: GithubWebhookType,
     github_event_action: str,
+    handler_started_at: float | None = None,
 ) -> None:
     """
     Record that a task was successfully enqueued for processing.
@@ -109,12 +111,24 @@ def record_webhook_enqueued(
     Args:
         github_event: The GitHub webhook event type
         github_event_action: The webhook action (e.g., created, rerequested, synchronize)
+        handler_started_at: Monotonic timestamp from time.monotonic() captured at the start of
+            handle_webhook_event(), after the integration guards. When provided, emits a
+            handler_duration_ms timing metric measuring synchronous region silo processing time.
     """
+    tags = _build_webhook_tags(github_event, github_event_action)
     metrics.incr(
         f"{METRICS_PREFIX}.webhook.enqueued",
-        tags=_build_webhook_tags(github_event, github_event_action),
+        tags=tags,
         sample_rate=1.0,
     )
+    if handler_started_at is not None:
+        duration_ms = (time.monotonic() - handler_started_at) * 1000
+        metrics.timing(
+            f"{METRICS_PREFIX}.webhook.handler_duration_ms",
+            duration_ms,
+            tags=tags,
+            sample_rate=1.0,
+        )
 
 
 def record_webhook_handler_error(

--- a/src/sentry/seer/code_review/webhooks/check_run.py
+++ b/src/sentry/seer/code_review/webhooks/check_run.py
@@ -71,6 +71,7 @@ def handle_check_run_event(
     github_event: GithubWebhookType,
     event: Mapping[str, Any],
     tags: Mapping[str, Any],
+    handler_started_at: float | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -130,7 +131,7 @@ def handle_check_run_event(
         enqueued_at_str=datetime.now(timezone.utc).isoformat(),
         tags=tags,
     )
-    record_webhook_enqueued(github_event, action)
+    record_webhook_enqueued(github_event, action, handler_started_at=handler_started_at)
 
 
 def _validate_github_check_run_event(event: Mapping[str, Any]) -> GitHubCheckRunEvent:

--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -68,6 +69,8 @@ def handle_webhook_event(
     if integration.provider == IntegrationProviderSlug.GITHUB_ENTERPRISE:
         return
 
+    handler_started_at = time.monotonic()
+
     # Set Sentry scope tags so all logs, errors, and spans in this scope carry them automatically.
     tags = {}
     try:
@@ -131,4 +134,5 @@ def handle_webhook_event(
         integration=integration,
         org_code_review_settings=preflight.settings,
         tags=tags,
+        handler_started_at=handler_started_at,
     )

--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -52,6 +52,7 @@ def handle_issue_comment_event(
     repo: Repository,
     tags: Mapping[str, Any],
     integration: RpcIntegration | None = None,
+    handler_started_at: float | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -118,4 +119,5 @@ def handle_issue_comment_event(
         repo=repo,
         target_commit_sha=target_commit_sha,
         tags=tags,
+        handler_started_at=handler_started_at,
     )

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -95,6 +95,7 @@ def handle_pull_request_event(
     tags: Mapping[str, Any],
     integration: RpcIntegration | None = None,
     org_code_review_settings: CodeReviewSettings | None = None,
+    handler_started_at: float | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -184,4 +185,5 @@ def handle_pull_request_event(
         repo=repo,
         target_commit_sha=_get_target_commit_sha(github_event, event, repo, integration),
         tags=tags,
+        handler_started_at=handler_started_at,
     )

--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -49,6 +49,7 @@ def schedule_task(
     repo: Repository,
     target_commit_sha: str,
     tags: Mapping[str, object],
+    handler_started_at: float | None = None,
 ) -> None:
     """Transform and forward a webhook event to Seer for processing."""
     from .task import process_github_webhook_event
@@ -99,7 +100,9 @@ def schedule_task(
         enqueued_at_str=datetime.now(timezone.utc).isoformat(),
         tags=tags,
     )
-    record_webhook_enqueued(github_event, github_event_action)
+    record_webhook_enqueued(
+        github_event, github_event_action, handler_started_at=handler_started_at
+    )
 
 
 @instrumented_task(

--- a/tests/sentry/seer/code_review/test_metrics.py
+++ b/tests/sentry/seer/code_review/test_metrics.py
@@ -81,6 +81,42 @@ class TestCodeReviewMetrics:
             tags={"github_event": "check_run", "github_event_action": "rerequested"},
             sample_rate=1.0,
         )
+        mock_metrics.timing.assert_not_called()
+
+    @patch("sentry.seer.code_review.metrics.metrics")
+    @patch("sentry.seer.code_review.metrics.time")
+    def test_record_webhook_enqueued_emits_timing_when_started_at_provided(
+        self, mock_time: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        mock_time.monotonic.return_value = 1.5
+        started_at = 1.0  # 500 ms ago
+
+        record_webhook_enqueued(
+            GithubWebhookType.CHECK_RUN,
+            "rerequested",
+            handler_started_at=started_at,
+        )
+
+        mock_metrics.incr.assert_called_once_with(
+            f"{METRICS_PREFIX}.webhook.enqueued",
+            tags={"github_event": "check_run", "github_event_action": "rerequested"},
+            sample_rate=1.0,
+        )
+        mock_metrics.timing.assert_called_once_with(
+            f"{METRICS_PREFIX}.webhook.handler_duration_ms",
+            500.0,
+            tags={"github_event": "check_run", "github_event_action": "rerequested"},
+            sample_rate=1.0,
+        )
+
+    @patch("sentry.seer.code_review.metrics.metrics")
+    def test_record_webhook_enqueued_no_timing_without_started_at(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        record_webhook_enqueued(GithubWebhookType.CHECK_RUN, "rerequested")
+
+        mock_metrics.incr.assert_called_once()
+        mock_metrics.timing.assert_not_called()
 
     @patch("sentry.seer.code_review.metrics.metrics")
     def test_record_webhook_handler_error(self, mock_metrics: MagicMock) -> None:

--- a/tests/sentry/seer/code_review/webhooks/test_handlers.py
+++ b/tests/sentry/seer/code_review/webhooks/test_handlers.py
@@ -195,3 +195,21 @@ class TestHandleWebhookEvent(TestCase):
         )
 
         self.mock_pull_request_handler.assert_called_once()
+
+    def test_handler_called_with_handler_started_at(self) -> None:
+        """handle_webhook_event passes a float handler_started_at to the downstream handler."""
+        integration = MagicMock()
+        integration.provider = IntegrationProviderSlug.GITHUB
+        integration.id = 123
+
+        handle_webhook_event(
+            github_event=GithubWebhookType.PULL_REQUEST,
+            event={"action": "opened", "pull_request": {"number": 1, "draft": False}},
+            organization=self.organization,
+            repo=MagicMock(),
+            integration=integration,
+        )
+
+        call_kwargs = self.mock_pull_request_handler.call_args.kwargs
+        assert "handler_started_at" in call_kwargs
+        assert isinstance(call_kwargs["handler_started_at"], float)


### PR DESCRIPTION
Adds `seer.code_review.webhook.handler_duration_ms`, a timing metric that measures synchronous wall-clock time in the region silo from just after the integration/provider guards in `handle_webhook_event()` through to the Kafka enqueue call.

The existing `e2e_latency` metric starts at Kafka enqueue time, so it can't distinguish slow region silo work (preflight DB queries, Redis dedup, handler execution including synchronous GitHub API calls, transform, Pydantic validation) from Kafka consumer lag. When `e2e_latency` rises there's currently no way to tell which component is responsible.

The new metric fires only on the successful enqueue path and carries `github_event` and `github_event_action` tags, matching the existing `enqueued` counter it complements.

Implementation: `handler_started_at = time.monotonic()` is captured once in `handle_webhook_event()` and threaded as an explicit `float | None = None` kwarg through all three handler paths (`pull_request`, `issue_comment`, `check_run`) and `schedule_task()` to `record_webhook_enqueued()`, where `metrics.timing()` is emitted.

Refs CW-1009