### PR TITLE
ref(grouping): Improve message parameterization metrics

### DIFF
--- a/src/sentry/grouping/context.py
+++ b/src/sentry/grouping/context.py
@@ -60,6 +60,11 @@ class GroupingContext:
         self.canonical_event_message = event_message
         self.canonical_message_parameterized = parameterizer.parameterize(event_message)
 
+        # Track use of the cached values for metrics purposes. Any use past the first one signifies
+        # a reuse of the value, thus proving caching worthwhile.
+        self.cached_parameterizer_used = False
+        self.cached_param_result_used = False
+
         self._push_context_layer()
 
     def __setitem__(self, key: str, value: Any) -> None:

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -10,6 +10,7 @@ from sentry.grouping.utils import get_canonical_message_from_event, normalize_me
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
+from sentry.utils import metrics
 from sentry.utils.event_frames import find_stack_frames
 from sentry.utils.safe import get_path
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
@@ -340,6 +341,9 @@ def expand_title_template(
 ) -> str:
     def _handle_match(match: re.Match[str]) -> str:
         variable_key = match.group(1)
+        if variable_key == "message":
+            metrics.incr("grouping.message_used", tags={"reason": "custom_title"})
+
         # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we
         # can remove `use_legacy_unknown_variable_handling` and just return the value given by
         # `resolve_fingerprint_variable`

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -312,6 +312,11 @@ class Parameterizer:
 
         parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
 
+        metrics.incr(
+            "grouping.parameterizer_called",
+            tags={"changed": parameterized != input_str, "experimental": self._experimental},
+        )
+
         for key, value in matches_counter.items():
             # Track the kinds of replacements being made
             metrics.incr("grouping.value_parameterized", amount=value, tags={"key": key})

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -63,8 +63,10 @@ def normalize_message_for_grouping(
     """
     if message == context.canonical_event_message:
         parameterized = context.canonical_message_parameterized
+        context.cached_param_result_used = True
     else:
         parameterized = context.parameterizer.parameterize(message)
+        context.cached_parameterizer_used = True
 
     return _trim_extra_lines(parameterized) if trim_message else parameterized
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -66,11 +66,6 @@ def normalize_message_for_grouping(
     else:
         parameterized = context.parameterizer.parameterize(message)
 
-    message_parameterized = parameterized != message
-
-    if message_parameterized:
-        metrics.incr("grouping.message_parameterized", tags={"source": reason})
-
     return _trim_extra_lines(parameterized) if trim_message else parameterized
 
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -85,6 +85,8 @@ def normalize_message_for_grouping(
 
         context.cached_parameterizer_used = True
 
+    metrics.incr("grouping.message_used", tags={"reason": reason})
+
     return _trim_extra_lines(parameterized) if trim_message else parameterized
 
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -63,9 +63,26 @@ def normalize_message_for_grouping(
     """
     if message == context.canonical_event_message:
         parameterized = context.canonical_message_parameterized
+
+        # Before we mark the value as having been used, check if it's already marked that way. If
+        # so, that means our use of the value here is at least the second use, thus proving the
+        # caching worthwhile.
+        if context.cached_param_result_used:
+            # This represents a saved call to `parameterizer.parameterize`
+            metrics.incr("grouping.cached_param_result_used")
+
         context.cached_param_result_used = True
     else:
         parameterized = context.parameterizer.parameterize(message)
+
+        # Before we mark the parameterizer as having been used, check if it's already marked that
+        # way. If so, that means our use of it here is at least the second use, thus proving the
+        # caching worthwhile.
+        if context.cached_parameterizer_used:
+            # This represents a saved call to `in_rollout_group` on the project vis-à-vis
+            # experimental parameterization
+            metrics.incr("grouping.cached_parameterizer_used")
+
         context.cached_parameterizer_used = True
 
     return _trim_extra_lines(parameterized) if trim_message else parameterized


### PR DESCRIPTION
This makes a number of adjustments to our parameterization metrics, both to improve them and to reflect recent changes to the code.

- Right now, we have a `message_parameterized` metric, which only fires when the parameterized message doesn't match the original message, not every time we run parameterization. We therefore can't answer the question of how often parameterization has any effect. To answer that question, this adds a new metric inside the `parameterize` function, `parameterizer_called`, which fires any time the function runs, and which includes a boolean `changed` tag.

- Now that we [cache parameterization results](https://github.com/getsentry/sentry/pull/110605), firing the `message_parameterized` metric any time `normalize_message_for_grouping` is called isn't actually accurate anymore. This therefore replaces it with a new `message_used` metric, so that we can continue to track our various reasons for using messages.

- Caching parameterization results doesn't actually make things any better if we only use the cached value once. To better track how effective caching is, this adds to the context usage flags for both the parameterization result and the parameterizer itself (which is also cached, to save us having to check which one to use over and over). These are then checked (and flipped to `True` if they weren't already) each time we use one, and new metrics (`cached_param_result_used` and `cached_parameterizer_used`, respectively) are fired any time the flag indicates multiple usages.