### PR TITLE
chore(client-reports): Remove feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -170,8 +170,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:on-demand-metrics-extraction-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # This spec version includes the environment in the query hash
     manager.add("organizations:on-demand-metrics-query-spec-version-two", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable the new Client Report pipeline in Relay.
-    manager.add("organizations:new-client-report-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use the new OrganizationMemberInvite endpoints
     manager.add("organizations:new-organization-member-invite", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Use the OrganizationObjectstoreEndpoint

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -80,7 +80,6 @@ EXPOSABLE_FEATURES = [
     "projects:trace-attachment-processing",
     "organizations:span-v2-otlp-processing",
     "projects:relay-upload-endpoint",
-    "organizations:new-client-report-processing",
 ]
 
 EXTRACT_METRICS_VERSION = 1


### PR DESCRIPTION
The new client-report processor has been running for a week now without anyone complaining so this now removes the old code.

Ref: https://linear.app/getsentry/issue/INGEST-791/remove-old-process-client-reports