### PR TITLE
fix(tracemetrics): Preserve all visualizes when changing chart type

### DIFF
--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -24,7 +24,7 @@ import {
   useMetricName,
   useMetricVisualize,
   useMetricVisualizes,
-  useSetMetricVisualize,
+  useSetMetricVisualizes,
   useTraceMetric,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {METRICS_CHART_GROUP} from 'sentry/views/explore/metrics/metricsTab';
@@ -70,7 +70,7 @@ export function MetricsGraph({
   const metricQueries = useMultiMetricsQueryParams();
   const visualize = useMetricVisualize();
   const visualizes = useMetricVisualizes();
-  const setVisualize = useSetMetricVisualize();
+  const setVisualizes = useSetMetricVisualizes();
 
   const hasMultiVisualize = canUseMetricsMultiAggregateUI(organization);
 
@@ -81,7 +81,7 @@ export function MetricsGraph({
   );
 
   function handleChartTypeChange(newChartType: ChartType) {
-    setVisualize(visualize.replace({chartType: newChartType}));
+    setVisualizes(visualizes.map(v => v.replace({chartType: newChartType})));
   }
 
   return (


### PR DESCRIPTION
Changing the chart type (line/area/bar) in the metrics view was dropping all aggregate/visualization selections except the first one.

`handleChartTypeChange` called `useSetMetricVisualize` (singular), which replaced the entire visualizes array with a single-element array containing only the updated first visualize. Switching to `useSetMetricVisualizes` (plural) and mapping over all visualizes preserves the full list while updating the chart type on each.

Fixes LOGS-607