### PR TITLE
fix(dashboards): Fix broken issue counts table in new issues widget

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -558,6 +558,8 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
             display_type = data.get("display_type")
             if display_type == DashboardWidgetDisplayTypes.CATEGORICAL_BAR_CHART:
                 max_allowed = 25
+            elif display_type == DashboardWidgetDisplayTypes.TABLE:
+                max_allowed = 20
             else:
                 max_allowed = 10
             if widget_limit > max_allowed:

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -603,6 +603,11 @@ function WidgetViewerModal(props: Props) {
     widget.displayType !== DisplayType.TABLE &&
     widget.displayType !== DisplayType.AGENTS_TRACES_TABLE;
 
+  // At the moment, issue tables do not support aggregates, so we should never render the table in full screen for timeseries widgets
+  const shouldRenderTable = !(
+    widget.widgetType === WidgetType.ISSUE && shouldRenderChartVisualization
+  );
+
   function renderWidgetViewer() {
     return (
       <Fragment>
@@ -736,7 +741,7 @@ function WidgetViewerModal(props: Props) {
             )}
           </QueryContainer>
         )}
-        {renderWidgetViewerTable()}
+        {shouldRenderTable && renderWidgetViewerTable()}
       </Fragment>
     );
   }

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -82,6 +82,7 @@ import {
   getWidgetReleasesUrl,
   isUsingPerformanceScore,
   performanceScoreTooltip,
+  usesTimeSeriesData,
 } from 'sentry/views/dashboards/utils';
 import {checkUserHasEditAccess} from 'sentry/views/dashboards/utils/checkUserHasEditAccess';
 import {
@@ -603,10 +604,11 @@ function WidgetViewerModal(props: Props) {
     widget.displayType !== DisplayType.TABLE &&
     widget.displayType !== DisplayType.AGENTS_TRACES_TABLE;
 
-  // At the moment, issue tables do not support aggregates, so we should never render the table in full screen for timeseries widgets
-  const shouldRenderTable = !(
-    widget.widgetType === WidgetType.ISSUE && shouldRenderChartVisualization
-  );
+  const shouldRenderTable =
+    // At the moment, issue tables do not support aggregates, so we should never render the table in full screen for timeseries widgets
+    !(widget.widgetType === WidgetType.ISSUE && usesTimeSeriesData(widget.displayType)) &&
+    widget.displayType !== DisplayType.RAGE_AND_DEAD_CLICKS &&
+    widget.displayType !== DisplayType.SERVER_TREE;
 
   function renderWidgetViewer() {
     return (


### PR DESCRIPTION
Fixes issues with the issue counts table in the new issues timeseries widget:

1. **Hide table in full screen view for issues timeseries widgets** — Issue tables don't support aggregates, so rendering the table below a timeseries chart for issue widgets was broken. Also hides the table for rage/dead clicks and server tree display types.

2. **Use `usesTimeSeriesData` helper and hide table for more display types** — Consolidates the logic for determining when to show/hide the table below charts.

3. **Allow table widgets to have a limit up to 20** — The backend validator was rejecting table widget limits above 10, but the frontend hardcodes a table limit of 20. Added `TABLE` as a specific display type with `max_allowed = 20`.