### PR TITLE
fix(dashboards): Allow table widgets to have a limit up to 20

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -558,6 +558,8 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
             display_type = data.get("display_type")
             if display_type == DashboardWidgetDisplayTypes.CATEGORICAL_BAR_CHART:
                 max_allowed = 25
+            elif display_type == DashboardWidgetDisplayTypes.TABLE:
+                max_allowed = 20
             else:
                 max_allowed = 10
             if widget_limit > max_allowed:


### PR DESCRIPTION
The backend widget serializer validates widget limits by display type, but had no
specific case for table widgets — they fell through to the default max of 10. The
frontend hardcodes a table limit of 20 (via `TABLE_ITEM_LIMIT` in `sortableWidget.tsx`),
so saving or updating table widgets with the default limit would fail validation.

Adds `TABLE` as a recognized display type with `max_allowed = 20` in the validation chain.