### PR TITLE
feat(dashboards): Hide detail/summary prebuilt dashboards from list by default

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -178,27 +178,22 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.AI_AGENTS_MODELS,
         "title": "AI Agents Model Details",
-        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.AI_AGENTS_TOOLS,
         "title": "AI Agents Tool Details",
-        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MCP_TOOLS,
         "title": "MCP Tool Details",
-        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MCP_RESOURCES,
         "title": "MCP Resource Details",
-        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MCP_PROMPTS,
         "title": "MCP Prompt Details",
-        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.AI_AGENTS_OVERVIEW,

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -96,6 +96,7 @@ class PrebuiltDashboardId(IntEnum):
 class PrebuiltDashboard(TypedDict, total=False):
     prebuilt_id: Required[PrebuiltDashboardId]
     title: Required[str]
+    hidden: bool
 
 
 # Prebuilt dashboards store minimal fields in the database. The actual dashboard and widget settings are
@@ -119,6 +120,7 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_QUERIES_SUMMARY,
         "title": "Query Details",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.HTTP,
@@ -127,6 +129,7 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.HTTP_DOMAIN_SUMMARY,
         "title": "Domain Details",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.WEB_VITALS,
@@ -135,6 +138,7 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.WEB_VITALS_SUMMARY,
         "title": "Web Vitals Page Summary",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MOBILE_VITALS,
@@ -143,14 +147,17 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.MOBILE_VITALS_APP_STARTS,
         "title": "Mobile Vitals App Starts",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MOBILE_VITALS_SCREEN_LOADS,
         "title": "Mobile Vitals Screen Loads",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MOBILE_VITALS_SCREEN_RENDERING,
         "title": "Mobile Vitals Screen Rendering",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_OVERVIEW,
@@ -171,22 +178,27 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.AI_AGENTS_MODELS,
         "title": "AI Agents Model Details",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.AI_AGENTS_TOOLS,
         "title": "AI Agents Tool Details",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MCP_TOOLS,
         "title": "MCP Tool Details",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MCP_RESOURCES,
         "title": "MCP Resource Details",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MCP_PROMPTS,
         "title": "MCP Prompt Details",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.AI_AGENTS_OVERVIEW,
@@ -207,6 +219,7 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.FRONTEND_ASSETS_SUMMARY,
         "title": "Frontend Assets Summary",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_QUEUES,
@@ -215,6 +228,7 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_QUEUE_SUMMARY,
         "title": "Queue Summary",
+        "hidden": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_CACHES,
@@ -402,6 +416,13 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 dashboards = dashboards.exclude(prebuilt_id__isnull=False)
             elif f == "onlyPrebuilt":
                 dashboards = dashboards.filter(prebuilt_id__isnull=False)
+
+        if "showHidden" not in filters:
+            hidden_prebuilt_ids = [
+                d["prebuilt_id"] for d in PREBUILT_DASHBOARDS if d.get("hidden", False)
+            ]
+            if hidden_prebuilt_ids:
+                dashboards = dashboards.exclude(prebuilt_id__in=hidden_prebuilt_ids)
 
         query = request.GET.get("query")
         prebuilt_ids = request.GET.getlist("prebuiltId")

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2283,6 +2283,41 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 assert len(response.data) == prebuilt_dashboards_count
                 assert all(d.get("prebuiltId") is not None for d in response.data)
 
+    def test_hidden_prebuilt_dashboards_excluded_by_default(self) -> None:
+        """Hidden prebuilt dashboards are synced to the DB but excluded from the API response."""
+        # IDs 1, 2, 3 correspond to Frontend Session Health, Queries, Query Details
+        # Query Details (id=3) is marked as isHidden=True
+        with self.feature("organizations:dashboards-prebuilt-insights-dashboards"):
+            with override_options({"dashboards.prebuilt-dashboard-ids": [1, 2, 3]}):
+                response = self.do_request("get", self.url)
+
+        assert response.status_code == 200
+
+        # All 3 should be synced to the DB
+        prebuilt_count = Dashboard.objects.filter(
+            organization=self.organization, prebuilt_id__isnull=False
+        ).count()
+        assert prebuilt_count == 3
+
+        # But only 2 non-hidden ones should appear in the response
+        prebuilt_in_response = [d for d in response.data if d.get("prebuiltId") is not None]
+        assert len(prebuilt_in_response) == 2
+        prebuilt_ids_in_response = {d["prebuiltId"] for d in prebuilt_in_response}
+        assert PrebuiltDashboardId.BACKEND_QUERIES_SUMMARY not in prebuilt_ids_in_response
+
+    def test_hidden_prebuilt_dashboards_included_with_show_hidden_filter(self) -> None:
+        """Hidden prebuilt dashboards are included in the response when showHidden filter is set."""
+        with self.feature("organizations:dashboards-prebuilt-insights-dashboards"):
+            with override_options({"dashboards.prebuilt-dashboard-ids": [1, 2, 3]}):
+                response = self.do_request("get", self.url, {"filter": "showHidden"})
+
+        assert response.status_code == 200
+
+        prebuilt_in_response = [d for d in response.data if d.get("prebuiltId") is not None]
+        assert len(prebuilt_in_response) == 3
+        prebuilt_ids_in_response = {d["prebuiltId"] for d in prebuilt_in_response}
+        assert PrebuiltDashboardId.BACKEND_QUERIES_SUMMARY in prebuilt_ids_in_response
+
     def test_post_with_text_widget(self) -> None:
         with self.feature("organizations:dashboards-text-widgets"):
             data = {

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2184,7 +2184,8 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 for d in response.data
                 if "prebuiltId" in d and d["prebuiltId"] == prebuilt_dashboard["prebuilt_id"]
             ]
-            assert len(matching_response_data) == 1
+            is_hidden = prebuilt_dashboard.get("hidden", False)
+            assert len(matching_response_data) == (0 if is_hidden else 1)
 
     def test_endpoint_does_not_create_duplicate_prebuilt_dashboards_when_exist(self) -> None:
         with self.feature("organizations:dashboards-prebuilt-insights-dashboards"):
@@ -2279,8 +2280,12 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 ).count()
                 assert prebuilt_dashboards_count == 3
 
+                # Response excludes hidden prebuilt dashboards (ID 3 is hidden)
+                visible_count = len(
+                    [d for d in PREBUILT_DASHBOARDS[:3] if not d.get("hidden", False)]
+                )
                 assert response.status_code == 200
-                assert len(response.data) == prebuilt_dashboards_count
+                assert len(response.data) == visible_count
                 assert all(d.get("prebuiltId") is not None for d in response.data)
 
     def test_hidden_prebuilt_dashboards_excluded_by_default(self) -> None:


### PR DESCRIPTION
Adds a `hidden` field to the `PrebuiltDashboard` config so certain prebuilt dashboards
can be excluded from the dashboards list API response while still being synced to the
database (so they remain accessible via direct navigation).

Detail and summary dashboards are navigated to contextually from their parent pages
rather than browsed from the main dashboards list, so showing them clutters the list.
Hidden dashboards can still be included by passing `?filter=showHidden`.