### PR TITLE
Dain backlog simple items

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/utils.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/utils.spec.tsx
@@ -1,0 +1,63 @@
+import type {Location} from 'history';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
+
+import {
+  decodeEventsDisplayFilterFromLocation,
+  EventsDisplayFilterName,
+  eventsRouteWithQuery,
+} from './utils';
+
+describe('Performance > Transaction Summary > Transaction Events > Utils', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+
+  it('maps the default transaction summary filter to p95 on events route', () => {
+    const route = eventsRouteWithQuery({
+      organization,
+      transaction: '/performance',
+      query: {
+        project: '1',
+        query: 'user.email:test@example.com',
+      },
+    });
+
+    expect(route.query.showTransactions).toBe(EventsDisplayFilterName.P95);
+  });
+
+  it('preserves percentile filters when routing to events', () => {
+    const route = eventsRouteWithQuery({
+      organization,
+      transaction: '/performance',
+      query: {
+        project: '1',
+        query: 'user.email:test@example.com',
+        showTransactions: EventsDisplayFilterName.P50,
+      },
+    });
+
+    expect(route.query.showTransactions).toBe(EventsDisplayFilterName.P50);
+  });
+
+  it('maps legacy transaction list filters to percentile filters', () => {
+    const route = eventsRouteWithQuery({
+      organization,
+      transaction: '/performance',
+      query: {
+        project: '1',
+        query: 'user.email:test@example.com',
+        showTransactions: TransactionFilterOptions.SLOW,
+      },
+    });
+
+    expect(route.query.showTransactions).toBe(EventsDisplayFilterName.P95);
+  });
+
+  it('decodes legacy location filters to percentile filters', () => {
+    const decoded = decodeEventsDisplayFilterFromLocation({
+      query: {showTransactions: TransactionFilterOptions.SLOW},
+    } as Location);
+
+    expect(decoded).toBe(EventsDisplayFilterName.P95);
+  });
+});

--- a/static/app/views/performance/transactionSummary/transactionEvents/utils.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/utils.spec.tsx
@@ -56,7 +56,7 @@ describe('Performance > Transaction Summary > Transaction Events > Utils', () =>
   it('decodes legacy location filters to percentile filters', () => {
     const decoded = decodeEventsDisplayFilterFromLocation({
       query: {showTransactions: TransactionFilterOptions.SLOW},
-    } as Location);
+    } as unknown as Location);
 
     expect(decoded).toBe(EventsDisplayFilterName.P95);
   });

--- a/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
@@ -153,9 +153,8 @@ function getEventsDisplayFilterName(
 
 export function decodeEventsDisplayFilterFromLocation(location: Location) {
   return (
-    getEventsDisplayFilterName(
-      decodeScalar(location.query.showTransactions, undefined)
-    ) ?? EventsDisplayFilterName.P100
+    getEventsDisplayFilterName(decodeScalar(location.query.showTransactions, '')) ??
+    EventsDisplayFilterName.P100
   );
 }
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
@@ -113,6 +113,10 @@ export function eventsRouteWithQuery({
   view?: DomainView;
 }) {
   const pathname = `${getTransactionSummaryBaseUrl(organization, view)}/events/`;
+  const showTransactions = getEventsDisplayFilterName(
+    decodeScalar(query.showTransactions, TransactionFilterOptions.SLOW)
+  );
+
   return {
     pathname,
     query: {
@@ -123,6 +127,7 @@ export function eventsRouteWithQuery({
       start: query.start,
       end: query.end,
       query: query.query,
+      showTransactions,
     },
   };
 }
@@ -134,11 +139,23 @@ function stringToFilter(option: string) {
     return option as EventsDisplayFilterName;
   }
 
-  return EventsDisplayFilterName.P100;
+  return undefined;
 }
+
+function getEventsDisplayFilterName(
+  showTransactions: string | undefined
+): EventsDisplayFilterName | undefined {
+  return (
+    stringToFilter(showTransactions ?? '') ??
+    mapShowTransactionToPercentile(showTransactions)
+  );
+}
+
 export function decodeEventsDisplayFilterFromLocation(location: Location) {
-  return stringToFilter(
-    decodeScalar(location.query.showTransactions, EventsDisplayFilterName.P100)
+  return (
+    getEventsDisplayFilterName(
+      decodeScalar(location.query.showTransactions, undefined)
+    ) ?? EventsDisplayFilterName.P100
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Describe your PR here. -->
Fixes DAIN-597.

Ensures the correct percentile is displayed and used in the Transaction Events tab by normalizing and preserving percentile query parameters during navigation. Previously, navigating to the tab would drop the percentile context, leading to a mismatch (e.g., dropdown showing p100 but listing p50 events). This change maps legacy filters (like `slow` to `p95`) and maintains explicit percentile values in the URL.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<div><a href="https://cursor.com/agents/bc-46fddbec-d7b1-4546-adab-7bb2cd86d013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46fddbec-d7b1-4546-adab-7bb2cd86d013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->