### PR TITLE
ref: migrate remaining non-component default export values to named

### DIFF
--- a/src/sentry/management/commands/generate_controlsilo_urls.py
+++ b/src/sentry/management/commands/generate_controlsilo_urls.py
@@ -155,11 +155,9 @@ class Command(BaseCommand):
             pattern_code = "\n  ".join(js_regex)
             ts_code = f"""// This is generated code.
 // To update it run `getsentry django generate_controlsilo_urls --format=js --output=/path/to/thisfile.ts`
-const patterns: RegExp[] = [
+export const controlsiloUrlPatterns: RegExp[] = [
   {pattern_code}
 ];
-
-export default patterns;
 """
             return ts_code
 

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -10,7 +10,7 @@ import {
   SUDO_REQUIRED,
   SUPERUSER_REQUIRED,
 } from 'sentry/constants/apiErrorCodes';
-import controlsilopatterns from 'sentry/data/controlsiloUrlPatterns';
+import {controlsiloUrlPatterns} from 'sentry/data/controlsiloUrlPatterns';
 import {metric} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
@@ -767,7 +767,7 @@ function detectControlSiloPath(path: string): boolean {
   const url = new URL(path, 'https://sentry.io');
   path = url.pathname;
   path = path.startsWith('/') ? path.substring(1) : path;
-  for (const pattern of controlsilopatterns) {
+  for (const pattern of controlsiloUrlPatterns) {
     if (pattern.test(path)) {
       return true;
     }

--- a/static/app/bootstrap/boostrapRequests.spec.tsx
+++ b/static/app/bootstrap/boostrapRequests.spec.tsx
@@ -13,7 +13,7 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
 import {FeatureFlagOverrides} from 'sentry/utils/featureFlagOverrides';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {
   DEFAULT_QUERY_CLIENT_CONFIG,
   QueryClient,

--- a/static/app/components/activity/note/inputWithStorage.spec.tsx
+++ b/static/app/components/activity/note/inputWithStorage.spec.tsx
@@ -1,7 +1,7 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {NoteInputWithStorage} from 'sentry/components/activity/note/inputWithStorage';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 jest.mock('sentry/utils/localStorage');
 

--- a/static/app/components/activity/note/inputWithStorage.tsx
+++ b/static/app/components/activity/note/inputWithStorage.tsx
@@ -5,7 +5,7 @@ import debounce from 'lodash/debounce';
 import {NoteInput} from 'sentry/components/activity/note/input';
 import type {MentionChangeEvent} from 'sentry/components/activity/note/types';
 import type {NoteType} from 'sentry/types/alerts';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {StreamlinedNoteInput} from 'sentry/views/issueDetails/streamline/sidebar/note';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 

--- a/static/app/components/events/interfaces/stackTraceContext.spec.tsx
+++ b/static/app/components/events/interfaces/stackTraceContext.spec.tsx
@@ -1,7 +1,7 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {StackType, StackView} from 'sentry/types/stacktrace';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 import {StacktraceContext, useStacktraceContext} from './stackTraceContext';
 

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -15,7 +15,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Event} from 'sentry/types/event';
 import {EntryType, EventOrGroupType} from 'sentry/types/event';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 describe('Threads', () => {
   const organization = OrganizationFixture();

--- a/static/app/components/modals/redirectToProject.spec.tsx
+++ b/static/app/components/modals/redirectToProject.spec.tsx
@@ -4,7 +4,9 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {RedirectToProjectModal} from 'sentry/components/modals/redirectToProject';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 
-jest.mock('sentry/utils/recreateRoute', () => jest.fn(() => '/org-slug/new-slug/'));
+jest.mock('sentry/utils/recreateRoute', () => ({
+  recreateRoute: jest.fn(() => '/org-slug/new-slug/'),
+}));
 
 describe('RedirectToProjectModal', () => {
   it('has timer to redirect to new slug after mounting', () => {

--- a/static/app/components/modals/redirectToProject.tsx
+++ b/static/app/components/modals/redirectToProject.tsx
@@ -6,7 +6,7 @@ import {Text} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {t, tct} from 'sentry/locale';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';

--- a/static/app/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted.ts
@@ -40,9 +40,7 @@ export function useLoadGettingStarted({
   projectKeyId: Project['id'] | undefined;
   refetch: () => void;
 } {
-  const [module, setModule] = useState<undefined | 'none' | {default: Docs<any>}>(
-    undefined
-  );
+  const [module, setModule] = useState<undefined | 'none' | {docs: Docs<any>}>(undefined);
 
   const projectKeys = useProjectKeys({orgSlug, projSlug});
 
@@ -87,10 +85,7 @@ export function useLoadGettingStarted({
     refetch: projectKeys.refetch,
     isLoading: projectKeys.isPending || module === undefined,
     isError: projectKeys.isError,
-    docs:
-      module === 'none'
-        ? null
-        : (module?.default ?? (module as {docs?: Docs<any>})?.docs ?? null),
+    docs: module === 'none' ? null : (module?.docs ?? null),
     dsn: projectKeys.data?.[0]?.dsn,
     projectKeyId: projectKeys.data?.[0]?.id,
   };

--- a/static/app/components/pageFilters/actions.spec.tsx
+++ b/static/app/components/pageFilters/actions.spec.tsx
@@ -17,7 +17,7 @@ import * as PageFilterPersistence from 'sentry/components/pageFilters/persistenc
 import PageFiltersStore from 'sentry/components/pageFilters/store';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 jest.mock('sentry/utils/localStorage');
 

--- a/static/app/components/pageFilters/container.spec.tsx
+++ b/static/app/components/pageFilters/container.spec.tsx
@@ -11,7 +11,7 @@ import PageFiltersStore from 'sentry/components/pageFilters/store';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 describe('PageFiltersContainer', () => {
   const organization = OrganizationFixture();

--- a/static/app/components/pageFilters/persistence.tsx
+++ b/static/app/components/pageFilters/persistence.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/react';
 import PageFiltersStore from 'sentry/components/pageFilters/store';
 import type {PinnedPageFilter} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 import {getStateFromQuery} from './parse';
 

--- a/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.spec.tsx
+++ b/static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.spec.tsx
@@ -4,7 +4,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {PreventQueryParamsProvider} from 'sentry/components/prevent/container/preventParamsProvider';
 import {IntegratedOrgSelector} from 'sentry/components/prevent/integratedOrgSelector/integratedOrgSelector';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 const MOCK_INTEGRATED_ORG_NAME = 'my-other-org-with-a-super-long-name';
 const MOCK_INTEGRATED_ORG_NAME_2 = 'other-org';

--- a/static/app/components/replays/preferences/replayPreferences.tsx
+++ b/static/app/components/replays/preferences/replayPreferences.tsx
@@ -1,4 +1,4 @@
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 const LOCAL_STORAGE_KEY = 'replay-config';
 

--- a/static/app/components/replays/unmaskAlert.spec.tsx
+++ b/static/app/components/replays/unmaskAlert.spec.tsx
@@ -4,7 +4,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import {useUserViewedReplays} from 'sentry/components/replays/useUserViewedReplays';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 import {UnmaskAlert} from './unmaskAlert';
 

--- a/static/app/components/reprocessedBox.tsx
+++ b/static/app/components/reprocessedBox.tsx
@@ -8,7 +8,7 @@ import {IconCheckmark, IconClose} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import type {GroupActivityReprocess} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 type Props = {
   groupCount: number;

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -1,6 +1,6 @@
 // This is generated code.
 // To update it run `getsentry django generate_controlsilo_urls --format=js --output=/path/to/thisfile.ts`
-const patterns: RegExp[] = [
+export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^remote/heroku/resources(?:/[^/]+)?$'),
   new RegExp('^remote/heroku/sso-login/?$'),
   new RegExp('^remote/beacon/$'),
@@ -237,5 +237,3 @@ const patterns: RegExp[] = [
   new RegExp('^extensions/discord/link-identity/[^/]+/$'),
   new RegExp('^extensions/discord/unlink-identity/[^/]+/$'),
 ];
-
-export default patterns;

--- a/static/app/gettingStartedDocs/android/index.tsx
+++ b/static/app/gettingStartedDocs/android/index.tsx
@@ -7,7 +7,7 @@ import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 import {sessionReplay} from './sessionReplay';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: feedback,
@@ -16,5 +16,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/android/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/android/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('android onboarding doc', () => {
   it('renders doc correctly', async () => {

--- a/static/app/gettingStartedDocs/apple-ios/index.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/index.tsx
@@ -6,7 +6,7 @@ import {sessionReplay} from 'sentry/gettingStartedDocs/apple-ios/sessionReplay';
 import {crashReport} from 'sentry/gettingStartedDocs/apple-macos/crashReport';
 import {profiling} from 'sentry/gettingStartedDocs/apple-macos/profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: crashReport,
   crashReportOnboarding: crashReport,
@@ -15,5 +15,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/apple-ios/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('apple-ios onboarding docs', () => {
   it('renders docs correctly', async () => {

--- a/static/app/gettingStartedDocs/apple-macos/index.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/index.tsx
@@ -5,7 +5,7 @@ import {metrics} from 'sentry/gettingStartedDocs/apple-macos/metrics';
 import {onboarding} from 'sentry/gettingStartedDocs/apple-macos/onboarding';
 import {profiling} from 'sentry/gettingStartedDocs/apple-macos/profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: crashReport,
   crashReportOnboarding: crashReport,
@@ -13,5 +13,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/apple-macos/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('apple-macos onboarding docs', () => {
   it('renders docs correctly', async () => {

--- a/static/app/gettingStartedDocs/apple/index.tsx
+++ b/static/app/gettingStartedDocs/apple/index.tsx
@@ -1,5 +1,3 @@
-import docs from 'sentry/gettingStartedDocs/apple-macos';
-
 // apple is the legacy platform key for apple-macos
 // So we simply re-export the docs from apple-macos
-export default docs;
+export {docs} from 'sentry/gettingStartedDocs/apple-macos';

--- a/static/app/gettingStartedDocs/apple/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/apple/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('apple onboarding docs', () => {
   it('renders docs correctly', async () => {

--- a/static/app/gettingStartedDocs/bun/index.tsx
+++ b/static/app/gettingStartedDocs/bun/index.tsx
@@ -8,7 +8,7 @@ import {getNodeLogsOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport,
@@ -18,5 +18,3 @@ const docs: Docs = {
     packageName: '@sentry/bun',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/bun/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/bun/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('bun onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/capacitor/index.tsx
+++ b/static/app/gettingStartedDocs/capacitor/index.tsx
@@ -6,12 +6,10 @@ import {sessionReplay} from './sessionReplay';
 import {userFeedback} from './userFeedback';
 import {platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   onboarding,
   platformOptions,
   feedbackOnboardingNpm: userFeedback,
   replayOnboarding: sessionReplay,
   crashReportOnboarding: crashReport,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/capacitor/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/capacitor/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 
 import {SiblingOption} from './utils';
-import docs from '.';
+import {docs} from '.';
 
 describe('capacitor onboarding docs', () => {
   it('renders docs correctly', () => {

--- a/static/app/gettingStartedDocs/cocoa-objc/index.tsx
+++ b/static/app/gettingStartedDocs/cocoa-objc/index.tsx
@@ -1,5 +1,3 @@
-import docs from 'sentry/gettingStartedDocs/apple-ios';
-
 // cocoa-objc is an API-only platform key
 // Re-export docs from apple-ios which contains both Swift and Obj-C examples
-export default docs;
+export {docs} from 'sentry/gettingStartedDocs/apple-ios';

--- a/static/app/gettingStartedDocs/cocoa-swift/index.tsx
+++ b/static/app/gettingStartedDocs/cocoa-swift/index.tsx
@@ -1,5 +1,3 @@
-import docs from 'sentry/gettingStartedDocs/apple-ios';
-
 // cocoa-swift is an API-only platform key
 // Re-export docs from apple-ios which contains both Swift and Obj-C examples
-export default docs;
+export {docs} from 'sentry/gettingStartedDocs/apple-ios';

--- a/static/app/gettingStartedDocs/cordova/index.tsx
+++ b/static/app/gettingStartedDocs/cordova/index.tsx
@@ -2,9 +2,7 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {crashReport} from 'sentry/gettingStartedDocs/cordova/crashReport';
 import {onboarding} from 'sentry/gettingStartedDocs/cordova/onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/cordova/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/cordova/onboarding.spec.tsx
@@ -1,7 +1,7 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('cordova onboarding docs', () => {
   it('renders docs correctly', () => {

--- a/static/app/gettingStartedDocs/dart/index.tsx
+++ b/static/app/gettingStartedDocs/dart/index.tsx
@@ -4,11 +4,9 @@ import {crashReport} from './crashReport';
 import {logs} from './logs';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: crashReport,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dart/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dart/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('dart onboarding docs', () => {
   it('renders docs correctly', async () => {

--- a/static/app/gettingStartedDocs/deno/index.tsx
+++ b/static/app/gettingStartedDocs/deno/index.tsx
@@ -6,10 +6,8 @@ import {
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   feedbackOnboardingJsLoader,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/deno/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/deno/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('deno onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/dotnet-aspnet/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet-aspnet/index.tsx
@@ -9,7 +9,7 @@ import {
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport,
@@ -17,5 +17,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dotnet-aspnet/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet-aspnet/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './index';
+import {docs} from './index';
 
 describe('aspnet onboarding docs', () => {
   it('renders errors onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet-aspnetcore/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet-aspnetcore/index.tsx
@@ -9,7 +9,7 @@ import {
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport,
@@ -17,5 +17,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dotnet-aspnetcore/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet-aspnetcore/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './index';
+import {docs} from './index';
 
 describe('aspnetcore onboarding docs', () => {
   it('renders errors onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet-awslambda/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet-awslambda/index.tsx
@@ -6,12 +6,10 @@ import {metrics} from 'sentry/gettingStartedDocs/dotnet/metrics';
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dotnet-awslambda/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet-awslambda/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './index';
+import {docs} from './index';
 
 describe('awslambda onboarding docs', () => {
   it('renders errors onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet-gcpfunctions/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet-gcpfunctions/index.tsx
@@ -6,12 +6,10 @@ import {metrics} from 'sentry/gettingStartedDocs/dotnet/metrics';
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dotnet-gcpfunctions/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet-gcpfunctions/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './index';
+import {docs} from './index';
 
 describe('gcpfunctions onboarding docs', () => {
   it('renders docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet-maui/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet-maui/index.tsx
@@ -6,12 +6,10 @@ import {metrics} from 'sentry/gettingStartedDocs/dotnet/metrics';
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dotnet-maui/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet-maui/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './index';
+import {docs} from './index';
 
 describe('maui onboarding docs', () => {
   it('renders errors onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet-winforms/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet-winforms/index.tsx
@@ -6,12 +6,10 @@ import {metrics} from 'sentry/gettingStartedDocs/dotnet/metrics';
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dotnet-winforms/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet-winforms/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './index';
+import {docs} from './index';
 
 describe('winforms onboarding docs', () => {
   it('renders errors onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet-wpf/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet-wpf/index.tsx
@@ -6,12 +6,10 @@ import {metrics} from 'sentry/gettingStartedDocs/dotnet/metrics';
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dotnet-wpf/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet-wpf/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './index';
+import {docs} from './index';
 
 describe('wpf onboarding docs', () => {
   it('renders errors onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet-xamarin/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet-xamarin/index.tsx
@@ -4,10 +4,8 @@ import {feedback} from 'sentry/gettingStartedDocs/dotnet/feedback';
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dotnet-xamarin/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet-xamarin/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from './index';
+import {docs} from './index';
 
 describe('xamarin onboarding docs', () => {
   it('renders errors onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet/index.tsx
@@ -7,7 +7,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
@@ -15,5 +15,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/dotnet/logs.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/logs.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('dotnet logs onboarding docs', () => {
   it('renders logs onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/dotnet/metrics.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/metrics.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('metrics', () => {
   it('dotnet metrics onboarding docs', () => {

--- a/static/app/gettingStartedDocs/dotnet/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('dotnet onboarding docs', () => {
   it('renders errors onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/electron/index.tsx
+++ b/static/app/gettingStartedDocs/electron/index.tsx
@@ -5,11 +5,9 @@ import {feedback} from './feedback';
 import {onboarding} from './onboarding';
 import {replay} from './replay';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
   crashReportOnboarding: crashReport,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/electron/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/electron/onboarding.spec.tsx
@@ -1,7 +1,7 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('electron onboarding docs', () => {
   it('renders docs correctly', () => {

--- a/static/app/gettingStartedDocs/elixir/index.tsx
+++ b/static/app/gettingStartedDocs/elixir/index.tsx
@@ -6,11 +6,9 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport,
   feedbackOnboardingJsLoader,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/elixir/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/elixir/onboarding.spec.tsx
@@ -1,7 +1,7 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('elixir onboarding docs', () => {
   it('renders docs correctly', () => {

--- a/static/app/gettingStartedDocs/flutter/index.tsx
+++ b/static/app/gettingStartedDocs/flutter/index.tsx
@@ -6,7 +6,7 @@ import {onboarding} from 'sentry/gettingStartedDocs/flutter/onboarding';
 import {sessionReplay} from 'sentry/gettingStartedDocs/flutter/sessionReplay';
 import {userFeedback} from 'sentry/gettingStartedDocs/flutter/userFeedback';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: userFeedback,
   crashReportOnboarding: crashReport,
@@ -14,5 +14,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/flutter/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/flutter/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('flutter onboarding docs', () => {
   it('renders docs correctly', async () => {

--- a/static/app/gettingStartedDocs/go-echo/index.tsx
+++ b/static/app/gettingStartedDocs/go-echo/index.tsx
@@ -8,7 +8,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport({
@@ -21,5 +21,3 @@ const docs: Docs = {
   }),
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/go-echo/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/go-echo/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('echo onboarding docs', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/go-fasthttp/index.tsx
+++ b/static/app/gettingStartedDocs/go-fasthttp/index.tsx
@@ -8,7 +8,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport({
@@ -21,5 +21,3 @@ const docs: Docs = {
   }),
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/go-fasthttp/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/go-fasthttp/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('fasthttp onboarding docs', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/go-fiber/index.tsx
+++ b/static/app/gettingStartedDocs/go-fiber/index.tsx
@@ -8,7 +8,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport({
@@ -21,5 +21,3 @@ const docs: Docs = {
   }),
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/go-fiber/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/go-fiber/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('fiber onboarding docs', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/go-gin/index.tsx
+++ b/static/app/gettingStartedDocs/go-gin/index.tsx
@@ -8,7 +8,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport({
@@ -21,5 +21,3 @@ const docs: Docs = {
   }),
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/go-gin/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/go-gin/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('gin onboarding docs', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/go-http/index.tsx
+++ b/static/app/gettingStartedDocs/go-http/index.tsx
@@ -8,7 +8,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport({
@@ -21,5 +21,3 @@ const docs: Docs = {
   }),
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/go-http/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/go-http/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('http onboarding docs', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/go-iris/index.tsx
+++ b/static/app/gettingStartedDocs/go-iris/index.tsx
@@ -8,7 +8,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport({
@@ -21,5 +21,3 @@ const docs: Docs = {
   }),
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/go-iris/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/go-iris/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('iris onboarding docs', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/go-negroni/index.tsx
+++ b/static/app/gettingStartedDocs/go-negroni/index.tsx
@@ -8,7 +8,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport({
@@ -21,5 +21,3 @@ const docs: Docs = {
   }),
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/go-negroni/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/go-negroni/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('negroni onboarding docs', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/go/index.tsx
+++ b/static/app/gettingStartedDocs/go/index.tsx
@@ -8,7 +8,7 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport({
@@ -21,5 +21,3 @@ const docs: Docs = {
   }),
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/go/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/go/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('go onboarding docs', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/godot/index.tsx
+++ b/static/app/gettingStartedDocs/godot/index.tsx
@@ -2,9 +2,7 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {logs} from 'sentry/gettingStartedDocs/godot/logs';
 import {onboarding} from 'sentry/gettingStartedDocs/godot/onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   logsOnboarding: logs,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/godot/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/godot/onboarding.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from '.';
+import {docs} from '.';
 
 function renderMockRequests() {
   MockApiClient.addMockResponse({

--- a/static/app/gettingStartedDocs/ionic/index.tsx
+++ b/static/app/gettingStartedDocs/ionic/index.tsx
@@ -1,5 +1,3 @@
-import docs from 'sentry/gettingStartedDocs/capacitor';
-
 // Ionic is a special case as it is closely intertwined with Capacitor and often used together.
 // Consequently, they can utilize the same SDK documentation, specifically that of Capacitor.
-export default docs;
+export {docs} from 'sentry/gettingStartedDocs/capacitor';

--- a/static/app/gettingStartedDocs/java-log4j2/index.tsx
+++ b/static/app/gettingStartedDocs/java-log4j2/index.tsx
@@ -7,7 +7,7 @@ import {logs} from './logs';
 import {onboarding} from './onboarding';
 import {platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   platformOptions,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: feedback,
@@ -16,5 +16,3 @@ const docs: Docs<PlatformOptions> = {
   metricsOnboarding: metrics,
   profilingOnboarding: profiling,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/java-log4j2/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-log4j2/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {PackageManager} from 'sentry/gettingStartedDocs/java/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('getting started with log4j2', () => {
   it('renders gradle docs correctly', async () => {

--- a/static/app/gettingStartedDocs/java-logback/index.tsx
+++ b/static/app/gettingStartedDocs/java-logback/index.tsx
@@ -7,7 +7,7 @@ import {logs} from './logs';
 import {onboarding} from './onboarding';
 import {platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: feedback,
@@ -16,5 +16,3 @@ const docs: Docs<PlatformOptions> = {
   metricsOnboarding: metrics,
   profilingOnboarding: profiling,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/java-logback/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-logback/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {PackageManager} from 'sentry/gettingStartedDocs/java/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('getting started with logback', () => {
   it('renders gradle docs correctly', async () => {

--- a/static/app/gettingStartedDocs/java-spring-boot/index.tsx
+++ b/static/app/gettingStartedDocs/java-spring-boot/index.tsx
@@ -11,7 +11,7 @@ import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 import {platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   onboarding,
   platformOptions,
   replayOnboardingJsLoader,
@@ -21,5 +21,3 @@ const docs: Docs<PlatformOptions> = {
   metricsOnboarding: metrics,
   profilingOnboarding: profiling,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/java-spring-boot/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-spring-boot/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {PackageManager} from 'sentry/gettingStartedDocs/java/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('java-spring-boot onboarding docs', () => {
   it('renders gradle docs correctly', async () => {

--- a/static/app/gettingStartedDocs/java-spring/index.tsx
+++ b/static/app/gettingStartedDocs/java-spring/index.tsx
@@ -11,7 +11,7 @@ import {logs} from './logs';
 import {onboarding} from './onboarding';
 import {platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   onboarding,
   platformOptions,
   crashReportOnboarding: feedback,
@@ -21,5 +21,3 @@ const docs: Docs<PlatformOptions> = {
   metricsOnboarding: metrics,
   profilingOnboarding: profiling,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/java-spring/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-spring/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/ty
 import {PackageManager} from 'sentry/gettingStartedDocs/java/utils';
 
 import {SpringVersion} from './utils';
-import docs from '.';
+import {docs} from '.';
 
 describe('GettingStartedWithSpring', () => {
   it('renders gradle docs correctly', async () => {

--- a/static/app/gettingStartedDocs/java/index.tsx
+++ b/static/app/gettingStartedDocs/java/index.tsx
@@ -7,7 +7,7 @@ import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 import {platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   platformOptions,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: feedback,
@@ -16,5 +16,3 @@ const docs: Docs<PlatformOptions> = {
   onboarding,
   profilingOnboarding: profiling,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/java/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java/onboarding.spec.tsx
@@ -3,7 +3,7 @@ import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {PackageManager} from './utils';
-import docs from '.';
+import {docs} from '.';
 
 describe('java-spring-boot onboarding docs', () => {
   it('renders gradle docs correctly', async () => {

--- a/static/app/gettingStartedDocs/javascript-angular/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/index.tsx
@@ -11,7 +11,7 @@ import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock, platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -37,5 +37,3 @@ const docs: Docs<PlatformOptions> = {
     packageName: '@sentry/angular',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-angular/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/onboarding.spec.tsx
@@ -5,7 +5,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
 import {AngularConfigType} from './utils';
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-angular onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-astro/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-astro/index.tsx
@@ -11,7 +11,7 @@ import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {replay} from './replay';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -39,5 +39,3 @@ const docs: Docs = {
   }),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-astro/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-astro/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-astro onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-ember/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/index.tsx
@@ -11,7 +11,7 @@ import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock} from './utils';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -36,5 +36,3 @@ const docs: Docs = {
     packageName: '@sentry/ember',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-ember/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-ember onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-gatsby/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/index.tsx
@@ -11,7 +11,7 @@ import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock} from './utils';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -36,5 +36,3 @@ const docs: Docs = {
     packageName: '@sentry/gatsby',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-gatsby/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-gatsby onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-nextjs/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/index.tsx
@@ -13,7 +13,7 @@ import {onboarding} from './onboarding';
 import {performance} from './performance';
 import {replay} from './replay';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -94,5 +94,3 @@ const docs: Docs = {
   }),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-nextjs/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-nextjs onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-nuxt/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-nuxt/index.tsx
@@ -12,7 +12,7 @@ import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock} from './utils';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -38,5 +38,3 @@ const docs: Docs = {
   }),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-nuxt/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-nuxt/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-nuxt onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-react-router/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/index.tsx
@@ -11,7 +11,7 @@ import {onboarding} from './onboarding';
 import {performance} from './performance';
 import {replay} from './replay';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboarding: replay,
   feedbackOnboardingNpm: feedback,
@@ -39,5 +39,3 @@ const docs: Docs = {
   }),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-react-router/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-react-router onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-react/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/index.tsx
@@ -12,7 +12,7 @@ import {performance} from './performance';
 import {replay} from './replay';
 import {installSnippetBlock} from './utils';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -38,5 +38,3 @@ const docs: Docs = {
     packageName: '@sentry/react',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-react/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-react onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-remix/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-remix/index.tsx
@@ -11,7 +11,7 @@ import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {replay} from './replay';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -39,5 +39,3 @@ const docs: Docs = {
   }),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-remix/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-remix/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-remix onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-solid/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/index.tsx
@@ -11,7 +11,7 @@ import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock} from './utils';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -36,5 +36,3 @@ const docs: Docs = {
     packageName: '@sentry/solid',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-solid/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-solid onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-solidstart/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-solidstart/index.tsx
@@ -12,7 +12,7 @@ import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock} from './utils';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -38,5 +38,3 @@ const docs: Docs = {
   }),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-solidstart/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-solidstart/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-solidstart onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-svelte/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/index.tsx
@@ -11,7 +11,7 @@ import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock} from './utils';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -36,5 +36,3 @@ const docs: Docs = {
     packageName: '@sentry/svelte',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-svelte/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-svelte onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-sveltekit/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-sveltekit/index.tsx
@@ -11,7 +11,7 @@ import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 import {replay} from './replay';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   replayOnboarding: replay,
@@ -39,5 +39,3 @@ const docs: Docs = {
   }),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-sveltekit/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-sveltekit/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-sveltekit onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/index.tsx
@@ -7,7 +7,7 @@ import {profilingFullStack} from 'sentry/gettingStartedDocs/javascript/profiling
 import {mcp} from './mcp';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   profilingOnboarding: profilingFullStack({
     packageName: '@sentry/tanstackstart-react',
@@ -31,5 +31,3 @@ const docs: Docs = {
   }),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-tanstackstart-react onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript-vue/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/index.tsx
@@ -11,7 +11,7 @@ import {onboarding} from './onboarding';
 import {replay} from './replay';
 import {installSnippetBlock, platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   onboarding,
   platformOptions,
   feedbackOnboardingNpm: feedback,
@@ -37,5 +37,3 @@ const docs: Docs<PlatformOptions> = {
     packageName: '@sentry/vue',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript-vue/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript-vue onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/javascript/index.tsx
+++ b/static/app/gettingStartedDocs/javascript/index.tsx
@@ -16,7 +16,7 @@ import {profiling} from './profiling';
 import {replay} from './replay';
 import {installSnippetBlock, platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   onboarding,
   feedbackOnboardingNpm: feedback,
   feedbackOnboardingJsLoader,
@@ -42,5 +42,3 @@ const docs: Docs<PlatformOptions> = {
   }),
   agentMonitoringOnboarding: agentMonitoring(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/javascript/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/onboarding.spec.tsx
@@ -5,7 +5,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
 import {InstallationMode} from './utils';
-import docs from '.';
+import {docs} from '.';
 
 describe('javascript onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/kotlin/index.tsx
+++ b/static/app/gettingStartedDocs/kotlin/index.tsx
@@ -4,11 +4,9 @@ import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 import {platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   platformOptions,
   feedbackOnboardingCrashApi: crashReport,
   crashReportOnboarding: crashReport,
   onboarding,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/kotlin/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/kotlin/onboarding.spec.tsx
@@ -3,7 +3,7 @@ import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {PackageManager} from './utils';
-import docs from '.';
+import {docs} from '.';
 
 describe('GettingStartedWithKotlin', () => {
   it('renders gradle docs correctly', async () => {

--- a/static/app/gettingStartedDocs/minidump/index.tsx
+++ b/static/app/gettingStartedDocs/minidump/index.tsx
@@ -2,9 +2,7 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {onboarding} from 'sentry/gettingStartedDocs/minidump/onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/minidump/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/minidump/onboarding.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from '.';
+import {docs} from '.';
 
 function renderMockRequests() {
   MockApiClient.addMockResponse({

--- a/static/app/gettingStartedDocs/native-qt/index.tsx
+++ b/static/app/gettingStartedDocs/native-qt/index.tsx
@@ -3,9 +3,7 @@ import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingS
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/native-qt/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/native-qt/onboarding.spec.tsx
@@ -1,7 +1,7 @@
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('getting started with native-qt', () => {
   it('renders gradle docs correctly', () => {

--- a/static/app/gettingStartedDocs/native/index.tsx
+++ b/static/app/gettingStartedDocs/native/index.tsx
@@ -4,10 +4,8 @@ import {CrashReportWebApiOnboarding} from 'sentry/components/onboarding/gettingS
 import {logs} from './logs';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
   logsOnboarding: logs,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/native/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/native/onboarding.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from '.';
+import {docs} from '.';
 
 function renderMockRequests() {
   MockApiClient.addMockResponse({

--- a/static/app/gettingStartedDocs/nintendo-switch/index.tsx
+++ b/static/app/gettingStartedDocs/nintendo-switch/index.tsx
@@ -2,8 +2,6 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-awslambda/index.tsx
+++ b/static/app/gettingStartedDocs/node-awslambda/index.tsx
@@ -9,7 +9,7 @@ import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 import {platformOptions, type PlatformOptions} from './utils';
 
-const docs: Docs<PlatformOptions> = {
+export const docs: Docs<PlatformOptions> = {
   onboarding,
   crashReportOnboarding: crashReport,
   profilingOnboarding: profiling,
@@ -21,5 +21,3 @@ const docs: Docs<PlatformOptions> = {
   platformOptions,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-awslambda/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-awslambda/onboarding.spec.tsx
@@ -5,7 +5,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
 import {InstallationMethod} from './utils';
-import docs from '.';
+import {docs} from '.';
 
 describe('awslambda onboarding docs', () => {
   describe('Lambda Layer', () => {

--- a/static/app/gettingStartedDocs/node-azurefunctions/index.tsx
+++ b/static/app/gettingStartedDocs/node-azurefunctions/index.tsx
@@ -8,7 +8,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
   profilingOnboarding: profiling,
@@ -17,5 +17,3 @@ const docs: Docs = {
   mcpOnboarding: mcp,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-azurefunctions/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-azurefunctions/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('express onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-cloudflare-pages/index.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-pages/index.tsx
@@ -7,7 +7,7 @@ import {mcp} from './mcp';
 import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
@@ -17,5 +17,3 @@ const docs: Docs = {
   mcpOnboarding: mcp,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-cloudflare-pages/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-pages/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('cloudflare-pages onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-cloudflare-workers/index.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-workers/index.tsx
@@ -7,7 +7,7 @@ import {mcp} from './mcp';
 import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
@@ -17,5 +17,3 @@ const docs: Docs = {
   mcpOnboarding: mcp,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('cloudflare-workers onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-connect/index.tsx
+++ b/static/app/gettingStartedDocs/node-connect/index.tsx
@@ -8,7 +8,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
   profilingOnboarding: profiling,
@@ -17,5 +17,3 @@ const docs: Docs = {
   agentMonitoringOnboarding: agentMonitoring(),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-connect/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-connect/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('connect onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-express/index.tsx
+++ b/static/app/gettingStartedDocs/node-express/index.tsx
@@ -12,7 +12,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport,
@@ -23,5 +23,3 @@ const docs: Docs = {
   agentMonitoringOnboarding: agentMonitoring(),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('express onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-fastify/index.tsx
+++ b/static/app/gettingStartedDocs/node-fastify/index.tsx
@@ -12,7 +12,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport,
@@ -23,5 +23,3 @@ const docs: Docs = {
   agentMonitoringOnboarding: agentMonitoring(),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-fastify/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-fastify/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('fastify onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-gcpfunctions/index.tsx
+++ b/static/app/gettingStartedDocs/node-gcpfunctions/index.tsx
@@ -8,7 +8,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
   profilingOnboarding: profiling,
@@ -19,5 +19,3 @@ const docs: Docs = {
   mcpOnboarding: mcp,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-gcpfunctions/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-gcpfunctions/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('gcpfunctions onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-hapi/index.tsx
+++ b/static/app/gettingStartedDocs/node-hapi/index.tsx
@@ -9,7 +9,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
@@ -19,5 +19,3 @@ const docs: Docs = {
   mcpOnboarding: mcp,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-hapi/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-hapi/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('hapi onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-hono/index.tsx
+++ b/static/app/gettingStartedDocs/node-hono/index.tsx
@@ -9,7 +9,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
@@ -19,5 +19,3 @@ const docs: Docs = {
   mcpOnboarding: mcp,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-hono/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-hono/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('hono onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-koa/index.tsx
+++ b/static/app/gettingStartedDocs/node-koa/index.tsx
@@ -9,7 +9,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
@@ -19,5 +19,3 @@ const docs: Docs = {
   agentMonitoringOnboarding: agentMonitoring(),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('koa onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node-nestjs/index.tsx
+++ b/static/app/gettingStartedDocs/node-nestjs/index.tsx
@@ -9,7 +9,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
@@ -21,5 +21,3 @@ const docs: Docs = {
   }),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node-nestjs/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-nestjs/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('Nest.js onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/node/index.tsx
+++ b/static/app/gettingStartedDocs/node/index.tsx
@@ -13,7 +13,7 @@ import {onboarding} from './onboarding';
 import {performance} from './performance';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   performanceOnboarding: performance,
@@ -28,5 +28,3 @@ const docs: Docs = {
   agentMonitoringOnboarding: agentMonitoring(),
   mcpOnboarding: mcp,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/node/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('node onboarding docs', () => {
   it('renders onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/php-laravel/index.tsx
+++ b/static/app/gettingStartedDocs/php-laravel/index.tsx
@@ -10,7 +10,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingJsLoader,
   crashReportOnboarding: crashReport,
@@ -19,5 +19,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/php-laravel/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/php-laravel/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('laravel onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/php-symfony/index.tsx
+++ b/static/app/gettingStartedDocs/php-symfony/index.tsx
@@ -10,7 +10,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling,
@@ -19,5 +19,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/php-symfony/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/php-symfony/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('symfony onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/php/index.tsx
+++ b/static/app/gettingStartedDocs/php/index.tsx
@@ -11,7 +11,7 @@ import {onboarding} from './onboarding';
 import {performance} from './performance';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   performanceOnboarding: performance,
@@ -21,5 +21,3 @@ const docs: Docs = {
   logsOnboarding: logs,
   metricsOnboarding: metrics,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/php/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/php/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('php onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/playstation/index.tsx
+++ b/static/app/gettingStartedDocs/playstation/index.tsx
@@ -3,9 +3,7 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {onboarding} from './onboarding';
 import {platformOptions} from './utils';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   platformOptions,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/powershell/index.tsx
+++ b/static/app/gettingStartedDocs/powershell/index.tsx
@@ -3,9 +3,7 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: crashReport,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/powershell/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/powershell/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('powershell onboarding docs', () => {
   it('renders docs correctly', async () => {

--- a/static/app/gettingStartedDocs/python-aiohttp/index.tsx
+++ b/static/app/gettingStartedDocs/python-aiohttp/index.tsx
@@ -13,7 +13,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling(),
@@ -25,5 +25,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-aiohttp/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-aiohttp/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('aiohttp onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-asgi/index.tsx
+++ b/static/app/gettingStartedDocs/python-asgi/index.tsx
@@ -8,7 +8,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
   profilingOnboarding: profiling(),
@@ -17,5 +17,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-asgi/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-asgi/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('asgi onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-awslambda/index.tsx
+++ b/static/app/gettingStartedDocs/python-awslambda/index.tsx
@@ -7,7 +7,7 @@ import {metrics} from 'sentry/gettingStartedDocs/python/metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
   profilingOnboarding: profiling,
@@ -15,5 +15,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-awslambda/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-awslambda/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('awslambda onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-bottle/index.tsx
+++ b/static/app/gettingStartedDocs/python-bottle/index.tsx
@@ -13,7 +13,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling(),
@@ -25,5 +25,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-bottle/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-bottle/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('bottle onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-celery/index.tsx
+++ b/static/app/gettingStartedDocs/python-celery/index.tsx
@@ -7,7 +7,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   profilingOnboarding: profiling(),
   crashReportOnboarding: crashReport,
@@ -15,5 +15,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-celery/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-celery/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('celery onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-chalice/index.tsx
+++ b/static/app/gettingStartedDocs/python-chalice/index.tsx
@@ -8,7 +8,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   profilingOnboarding: profiling(),
   crashReportOnboarding: crashReport,
@@ -17,5 +17,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-chalice/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-chalice/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('chalice onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-django/index.tsx
+++ b/static/app/gettingStartedDocs/python-django/index.tsx
@@ -14,7 +14,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 import {onboarding} from './onboarding';
 import {performance} from './performance';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling(),
@@ -27,5 +27,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-django/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-django/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('django onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-falcon/index.tsx
+++ b/static/app/gettingStartedDocs/python-falcon/index.tsx
@@ -13,7 +13,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling(),
@@ -25,5 +25,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-falcon/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-falcon/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('falcon onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-fastapi/index.tsx
+++ b/static/app/gettingStartedDocs/python-fastapi/index.tsx
@@ -13,7 +13,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling(),
@@ -25,5 +25,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-fastapi/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-fastapi/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('flask onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-flask/index.tsx
+++ b/static/app/gettingStartedDocs/python-flask/index.tsx
@@ -14,7 +14,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 import {onboarding} from './onboarding';
 import {performance} from './performance';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling(),
@@ -27,5 +27,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-flask/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-flask/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('flask onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-gcpfunctions/index.tsx
+++ b/static/app/gettingStartedDocs/python-gcpfunctions/index.tsx
@@ -8,7 +8,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
   profilingOnboarding: profiling(),
@@ -17,5 +17,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-gcpfunctions/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-gcpfunctions/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('gcpfunctions onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-pyramid/index.tsx
+++ b/static/app/gettingStartedDocs/python-pyramid/index.tsx
@@ -12,7 +12,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport,
@@ -23,5 +23,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-pyramid/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-pyramid/onboarding.spec.tsx
@@ -3,7 +3,7 @@ import {screen} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('aiohttp onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-quart/index.tsx
+++ b/static/app/gettingStartedDocs/python-quart/index.tsx
@@ -13,7 +13,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling(),
@@ -25,5 +25,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-quart/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-quart/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('quart onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-rq/index.tsx
+++ b/static/app/gettingStartedDocs/python-rq/index.tsx
@@ -7,7 +7,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   profilingOnboarding: profiling(),
   crashReportOnboarding: crashReport,
@@ -15,5 +15,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-rq/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-rq/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('rq onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-sanic/index.tsx
+++ b/static/app/gettingStartedDocs/python-sanic/index.tsx
@@ -13,7 +13,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport,
@@ -25,5 +25,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-sanic/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-sanic/onboarding.spec.tsx
@@ -3,7 +3,7 @@ import {screen} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('sanic onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-serverless/index.tsx
+++ b/static/app/gettingStartedDocs/python-serverless/index.tsx
@@ -6,12 +6,10 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   profilingOnboarding: profiling(),
   crashReportOnboarding: crashReport,
   agentMonitoringOnboarding: agentMonitoring,
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-serverless/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-serverless/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('serverless onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-starlette/index.tsx
+++ b/static/app/gettingStartedDocs/python-starlette/index.tsx
@@ -13,7 +13,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling(),
@@ -25,5 +25,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-starlette/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-starlette/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('starlette onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-tornado/index.tsx
+++ b/static/app/gettingStartedDocs/python-tornado/index.tsx
@@ -13,7 +13,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   profilingOnboarding: profiling(),
@@ -25,5 +25,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-tornado/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-tornado/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('tornado onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-tryton/index.tsx
+++ b/static/app/gettingStartedDocs/python-tryton/index.tsx
@@ -8,7 +8,7 @@ import {metrics} from 'sentry/gettingStartedDocs/python/metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   profilingOnboarding: profiling,
   crashReportOnboarding: crashReport,
@@ -17,5 +17,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-tryton/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-tryton/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('tryton onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python-wsgi/index.tsx
+++ b/static/app/gettingStartedDocs/python-wsgi/index.tsx
@@ -8,7 +8,7 @@ import {profiling} from 'sentry/gettingStartedDocs/python/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   profilingOnboarding: profiling(),
   crashReportOnboarding: crashReport,
@@ -17,5 +17,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python-wsgi/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python-wsgi/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('wsgi onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/python/index.tsx
+++ b/static/app/gettingStartedDocs/python/index.tsx
@@ -10,7 +10,7 @@ import {onboarding} from './onboarding';
 import {performance} from './performance';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   performanceOnboarding: performance,
   crashReportOnboarding: crashReport,
@@ -21,5 +21,3 @@ const docs: Docs = {
   logsOnboarding: logs(),
   metricsOnboarding: metrics(),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/python/logs.spec.tsx
+++ b/static/app/gettingStartedDocs/python/logs.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('python logs onboarding docs', () => {
   it('renders logs onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/python/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/python/onboarding.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('python onboarding docs', () => {
   it('renders doc correctly', () => {

--- a/static/app/gettingStartedDocs/react-native/index.tsx
+++ b/static/app/gettingStartedDocs/react-native/index.tsx
@@ -8,7 +8,7 @@ import {profiling} from './profiling';
 import {sessionReplay} from './sessionReplay';
 import {userFeedback} from './userFeedback';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: userFeedback,
   crashReportOnboarding: crashReport,
@@ -17,5 +17,3 @@ const docs: Docs = {
   metricsOnboarding: metrics,
   logsOnboarding: logs,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/react-native/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('getting started with react-native', () => {
   it('renders docs correctly', async () => {

--- a/static/app/gettingStartedDocs/ruby-rack/index.tsx
+++ b/static/app/gettingStartedDocs/ruby-rack/index.tsx
@@ -6,7 +6,7 @@ import {profiling} from 'sentry/gettingStartedDocs/ruby/profiling';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
   profilingOnboarding: profiling(),
@@ -17,5 +17,3 @@ const docs: Docs = {
     docsPlatform: 'rack',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/ruby-rack/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/ruby-rack/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('getting started with rack', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/ruby-rails/index.tsx
+++ b/static/app/gettingStartedDocs/ruby-rails/index.tsx
@@ -10,7 +10,7 @@ import {profiling} from 'sentry/gettingStartedDocs/ruby/profiling';
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   crashReportOnboarding: crashReport,
@@ -23,5 +23,3 @@ const docs: Docs = {
     docsPlatform: 'rails',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/ruby-rails/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/ruby-rails/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('rails onboarding docs', () => {
   it('renders errors onboarding doc correctly', () => {

--- a/static/app/gettingStartedDocs/ruby/index.tsx
+++ b/static/app/gettingStartedDocs/ruby/index.tsx
@@ -6,7 +6,7 @@ import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: CrashReportWebApiOnboarding,
   profilingOnboarding: profiling(),
@@ -17,5 +17,3 @@ const docs: Docs = {
     docsPlatform: 'ruby',
   }),
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/ruby/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/ruby/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('getting started with ruby', () => {
   it('renders errors onboarding docs correctly', () => {

--- a/static/app/gettingStartedDocs/rust/index.tsx
+++ b/static/app/gettingStartedDocs/rust/index.tsx
@@ -4,10 +4,8 @@ import {crashReport} from './crashReport';
 import {logs} from './logs';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/rust/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/rust/onboarding.spec.tsx
@@ -2,7 +2,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 describe('rust onboarding docs', () => {
   it('renders onboarding docs correctly', async () => {

--- a/static/app/gettingStartedDocs/unity/index.tsx
+++ b/static/app/gettingStartedDocs/unity/index.tsx
@@ -4,11 +4,9 @@ import {crashReport} from './crashReport';
 import {logs} from './logs';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: crashReport,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/unity/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/unity/onboarding.spec.tsx
@@ -4,7 +4,7 @@ import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboa
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import docs from '.';
+import {docs} from '.';
 
 function renderMockRequests() {
   MockApiClient.addMockResponse({

--- a/static/app/gettingStartedDocs/unreal/index.tsx
+++ b/static/app/gettingStartedDocs/unreal/index.tsx
@@ -4,11 +4,9 @@ import {crashReport} from './crashReport';
 import {logs} from './logs';
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: crashReport,
   crashReportOnboarding: crashReport,
   logsOnboarding: logs,
 };
-
-export default docs;

--- a/static/app/gettingStartedDocs/unreal/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/unreal/onboarding.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import docs from '.';
+import {docs} from '.';
 
 function renderMockRequests() {
   MockApiClient.addMockResponse({

--- a/static/app/gettingStartedDocs/xbox/index.tsx
+++ b/static/app/gettingStartedDocs/xbox/index.tsx
@@ -2,8 +2,6 @@ import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
 import {onboarding} from './onboarding';
 
-const docs: Docs = {
+export const docs: Docs = {
   onboarding,
 };
-
-export default docs;

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -5,14 +5,14 @@ import Jed from 'jed';
 import {sprintf} from 'sprintf-js';
 
 import {toArray} from 'sentry/utils/array/toArray';
-import localStorage from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 const markerStyles = {
   background: '#ff801790',
   outline: '2px solid #ff801790',
 };
 
-const LOCALE_DEBUG = localStorage.getItem('localeDebug') === '1';
+const LOCALE_DEBUG = localStorageWrapper.getItem('localeDebug') === '1';
 
 export const DEFAULT_LOCALE_DATA = {
   '': {
@@ -23,7 +23,7 @@ export const DEFAULT_LOCALE_DATA = {
 };
 
 function setLocaleDebug(value: boolean) {
-  localStorage.setItem('localeDebug', value ? '1' : '0');
+  localStorageWrapper.setItem('localeDebug', value ? '1' : '0');
   // eslint-disable-next-line no-console
   console.log(`Locale debug is: ${value ? 'on' : 'off'}. Reload page to apply changes!`);
 }
@@ -33,7 +33,7 @@ function setLocaleDebug(value: boolean) {
  * page. The caller should do this.
  */
 export function toggleLocaleDebug() {
-  const currentValue = localStorage.getItem('localeDebug');
+  const currentValue = localStorageWrapper.getItem('localeDebug');
   setLocaleDebug(currentValue !== '1');
 }
 

--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -1,7 +1,7 @@
 import {createStore} from 'reflux';
 
 import {defined} from 'sentry/utils';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import type {AlertVariant} from 'sentry/utils/theme';
 
 import type {StrictStoreDefinition} from './types';

--- a/static/app/utils/__mocks__/localStorage.tsx
+++ b/static/app/utils/__mocks__/localStorage.tsx
@@ -16,4 +16,4 @@ const localStorageMock = function () {
   };
 };
 
-export default localStorageMock();
+export const localStorageWrapper = localStorageMock();

--- a/static/app/utils/__mocks__/recreateRoute.tsx
+++ b/static/app/utils/__mocks__/recreateRoute.tsx
@@ -1,3 +1,1 @@
-const mockFn = jest.fn((name: any) => name);
-
-export default mockFn;
+export const recreateRoute = jest.fn((name: any) => name);

--- a/static/app/utils/featureFlagOverrides.spec.ts
+++ b/static/app/utils/featureFlagOverrides.spec.ts
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {FeatureFlagOverrides} from 'sentry/utils/featureFlagOverrides';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 const LOCALSTORAGE_KEY = 'feature-flag-overrides';
 

--- a/static/app/utils/featureFlagOverrides.ts
+++ b/static/app/utils/featureFlagOverrides.ts
@@ -1,7 +1,7 @@
 import type {FlagMap} from '@sentry/toolbar';
 
 import type {Organization} from 'sentry/types/organization';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 type OverrideState = Record<string, boolean>;
 

--- a/static/app/utils/localStorage.tsx
+++ b/static/app/utils/localStorage.tsx
@@ -1,5 +1,3 @@
 import {createStorage} from './createStorage';
 
-const Storage = createStorage(() => window.localStorage);
-
-export default Storage;
+export const localStorageWrapper = createStorage(() => window.localStorage);

--- a/static/app/utils/recreateRoute.spec.tsx
+++ b/static/app/utils/recreateRoute.spec.tsx
@@ -1,6 +1,6 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 
 jest.unmock('sentry/utils/recreateRoute');
 

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -26,7 +26,7 @@ type Options = {
  *
  * See tests for examples
  */
-export default function recreateRoute(to: string | PlainRoute, options: Options): string {
+export function recreateRoute(to: string | PlainRoute, options: Options): string {
   const {routes, params, location, stepBack} = options;
   const paths = routes.map(({path}) => {
     path = path || '';

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -5,7 +5,7 @@ import {duration, type Duration} from 'moment-timezone';
 
 import {defined} from 'sentry/utils';
 import type {FeedbackEvent} from 'sentry/utils/feedback/types';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {clamp} from 'sentry/utils/number/clamp';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import extractDomNodes from 'sentry/utils/replays/extractDomNodes';

--- a/static/app/utils/sessionStorage.tsx
+++ b/static/app/utils/sessionStorage.tsx
@@ -1,5 +1,3 @@
 import {createStorage} from './createStorage';
 
-const Storage = createStorage(() => window.sessionStorage);
-
-export default Storage;
+export const sessionStorageWrapper = createStorage(() => window.sessionStorage);

--- a/static/app/utils/useDismissAlert.spec.tsx
+++ b/static/app/utils/useDismissAlert.spec.tsx
@@ -1,7 +1,7 @@
 import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 import {setMockDate} from 'sentry-test/utils';
 
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useDismissAlert} from 'sentry/utils/useDismissAlert';
 
 jest.mock('sentry/utils/localStorage');

--- a/static/app/utils/useLocalStorageState.spec.tsx
+++ b/static/app/utils/useLocalStorageState.spec.tsx
@@ -1,6 +1,6 @@
 import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 describe('useLocalStorageState', () => {

--- a/static/app/utils/useLocalStorageState.ts
+++ b/static/app/utils/useLocalStorageState.ts
@@ -1,6 +1,6 @@
 import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 import {scheduleMicroTask} from './scheduleMicroTask';
 

--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useState} from 'react';
 
-import sessionStorageWrapper from 'sentry/utils/sessionStorage';
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 const isBrowser = typeof window !== 'undefined';
 

--- a/static/app/utils/useSyncedLocalStorageState.spec.tsx
+++ b/static/app/utils/useSyncedLocalStorageState.spec.tsx
@@ -1,6 +1,6 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 
 describe('useSyncedLocalStorageState', () => {

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -6,7 +6,7 @@ import trimStart from 'lodash/trimStart';
 import {Redirect} from 'sentry/components/redirect';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {RouteComponent} from 'sentry/types/legacyReactRouter';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useParams} from 'sentry/utils/useParams';

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -63,7 +63,7 @@ import {metric, trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {getDisplayName} from 'sentry/utils/environment';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {withOrganization} from 'sentry/utils/withOrganization';
 import {withProjects} from 'sentry/utils/withProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';

--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -7,7 +7,7 @@ import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingL
 import {selectEvent} from 'sentry-test/selectEvent';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import ManageDashboards, {LAYOUT_KEY} from 'sentry/views/dashboards/manage';

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -32,7 +32,7 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -49,7 +49,7 @@ import {
   MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES,
   SavedQueryDatasets,
 } from 'sentry/utils/discover/types';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -2,7 +2,7 @@ import {useLayoutEffect} from 'react';
 import type {Location} from 'history';
 
 import type {Sort} from 'sentry/utils/discover/fields';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
 import {logsTimestampDescendingSortBy} from 'sentry/views/explore/contexts/logs/sortBys';

--- a/static/app/views/insights/common/utils/domainRedirect.tsx
+++ b/static/app/views/insights/common/utils/domainRedirect.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {domainViews, useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';

--- a/static/app/views/insights/mobile/screenload/components/platformSelector.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/platformSelector.spec.tsx
@@ -1,6 +1,6 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/components/platformSelector';
 import {MobileCursors} from 'sentry/views/insights/mobile/screenload/constants';
 

--- a/static/app/views/insights/mobile/screenload/components/platformSelector.tsx
+++ b/static/app/views/insights/mobile/screenload/components/platformSelector.tsx
@@ -4,7 +4,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 
 import {t} from 'sentry/locale';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';

--- a/static/app/views/issueDetails/streamline/foldSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.spec.tsx
@@ -6,7 +6,7 @@ import {setWindowLocation} from 'sentry-test/utils';
 import {Button} from '@sentry/scraps/button';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {SectionKey, useIssueDetails} from 'sentry/views/issueDetails/streamline/context';
 import {
   FoldSection,

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -21,7 +21,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import PageFiltersStore from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TagStore} from 'sentry/stores/tagStore';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import * as parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import IssueListOverview from 'sentry/views/issueList/overview';
 import {DEFAULT_QUERY} from 'sentry/views/issueList/utils';

--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -19,7 +19,7 @@ import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {TeamWithProjects} from 'sentry/types/project';
 import {uniq} from 'sentry/utils/array/uniq';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 

--- a/static/app/views/organizationStats/teamInsights/health.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.spec.tsx
@@ -11,7 +11,7 @@ import {TeamStore} from 'sentry/stores/teamStore';
 import type {Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import TeamStatsHealth from 'sentry/views/organizationStats/teamInsights/health';
 
 jest.mock('sentry/utils/localStorage');

--- a/static/app/views/organizationStats/teamInsights/health.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.tsx
@@ -7,7 +7,7 @@ import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {TeamWithProjects} from 'sentry/types/project';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useLocation} from 'sentry/utils/useLocation';

--- a/static/app/views/organizationStats/teamInsights/issues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.spec.tsx
@@ -11,7 +11,7 @@ import {TeamStore} from 'sentry/stores/teamStore';
 import type {Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import TeamStatsIssues from 'sentry/views/organizationStats/teamInsights/issues';
 
 jest.mock('sentry/utils/localStorage');

--- a/static/app/views/organizationStats/teamInsights/issues.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.tsx
@@ -7,7 +7,7 @@ import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {TeamWithProjects} from 'sentry/types/project';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -1,5 +1,5 @@
 import type {Organization} from 'sentry/types/organization';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import type {MetricsEnhancedSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {

--- a/static/app/views/prevent/tests/tests.spec.tsx
+++ b/static/app/views/prevent/tests/tests.spec.tsx
@@ -4,7 +4,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PreventQueryParamsProvider} from 'sentry/components/prevent/container/preventParamsProvider';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import TestsPage from 'sentry/views/prevent/tests/tests';
 

--- a/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.spec.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.spec.tsx
@@ -6,7 +6,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {PreventQueryParamsProvider} from 'sentry/components/prevent/container/preventParamsProvider';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 import RepoTokenTable from './repoTokenTable';
 

--- a/static/app/views/prevent/tokens/tokens.spec.tsx
+++ b/static/app/views/prevent/tokens/tokens.spec.tsx
@@ -3,7 +3,7 @@ import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegration
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PreventQueryParamsProvider} from 'sentry/components/prevent/container/preventParamsProvider';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {parseSortFromQuery} from 'sentry/views/prevent/tokens/repoTokenTable/repoTokenTable';
 import {TokensPage} from 'sentry/views/prevent/tokens/tokens';
 

--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -6,7 +6,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getRouteStringFromRoutes} from 'sentry/utils/getRouteStringFromRoutes';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 
 import {useBreadcrumbsPathmap} from './context';
 import {Divider} from './divider';

--- a/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {resolveRoute} from 'sentry/utils/resolveRoute';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';

--- a/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
@@ -5,7 +5,7 @@ import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {IdBadge} from 'sentry/components/idBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {replaceRouterParams} from 'sentry/utils/replaceRouterParams';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
@@ -3,7 +3,7 @@ import {TeamAvatar} from '@sentry/scraps/avatar';
 import {IdBadge} from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
 import {useTeams} from 'sentry/utils/useTeams';

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
@@ -10,7 +10,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {openCreateTeamModal} from 'sentry/actionCreators/modal';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {OrganizationTeams} from 'sentry/views/settings/organizationTeams/organizationTeams';
 
 jest.mocked(recreateRoute).mockReturnValue('');

--- a/static/app/views/settings/project/projectEnvironments.spec.tsx
+++ b/static/app/views/settings/project/projectEnvironments.spec.tsx
@@ -6,7 +6,7 @@ import {
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import ProjectEnvironments from 'sentry/views/settings/project/projectEnvironments';
 
 jest.mock('sentry/utils/recreateRoute');

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -21,7 +21,7 @@ import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Environment, Project} from 'sentry/types/project';
 import {getDisplayName, getUrlRoutingName} from 'sentry/utils/environment';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -5,7 +5,7 @@ import {TabList, Tabs} from '@sentry/scraps/tabs';
 
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useParams} from 'sentry/utils/useParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -13,7 +13,7 @@ import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Project, ProjectKey} from 'sentry/types/project';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {ProjectKeyCredentials} from 'sentry/views/settings/project/projectKeys/credentials';
 import {LoaderScript} from 'sentry/views/settings/project/projectKeys/list/loaderScript';
 

--- a/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
+++ b/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
@@ -9,7 +9,7 @@ import {TextCopyInput} from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {ProjectKey} from 'sentry/types/project';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 
 type Props = {
   projectKey: ProjectKey;

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -38,7 +38,7 @@ import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';

--- a/static/app/views/settings/projectPlugins/projectPluginRow.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginRow.tsx
@@ -14,7 +14,7 @@ import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {withOrganization} from 'sentry/utils/withOrganization';
 
 const grayText = css`

--- a/static/app/views/settings/projectSecurityHeaders/index.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/index.tsx
@@ -15,7 +15,7 @@ import {t, tct} from 'sentry/locale';
 import type {ProjectKey} from 'sentry/types/project';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import recreateRoute from 'sentry/utils/recreateRoute';
+import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {routeTitleGen} from 'sentry/utils/routeTitle';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -11,7 +11,7 @@ import Indicators from 'sentry/components/indicators';
 import {ListLink} from 'sentry/components/links/listLink';
 import {IconSentry, IconSliders} from 'sentry/icons';
 import {ScrapsProviders} from 'sentry/scrapsProviders';
-import localStorageWrapper from 'sentry/utils/localStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 // eslint-disable-next-line no-restricted-imports
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import SystemAlerts from 'sentry/views/app/systemAlerts';

--- a/static/gsApp/hooks/analyticsInitUser.spec.tsx
+++ b/static/gsApp/hooks/analyticsInitUser.spec.tsx
@@ -5,7 +5,7 @@ import {UserFixture} from 'sentry-fixture/user';
 import {setWindowLocation} from 'sentry-test/utils';
 
 import {ConfigStore} from 'sentry/stores/configStore';
-import sessionStorageWrapper from 'sentry/utils/sessionStorage';
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 import {analyticsInitUser} from 'getsentry/hooks/analyticsInitUser';
 import {trackMarketingEvent} from 'getsentry/utils/trackMarketingEvent';

--- a/static/gsApp/hooks/analyticsInitUser.tsx
+++ b/static/gsApp/hooks/analyticsInitUser.tsx
@@ -4,7 +4,7 @@ import * as qs from 'query-string';
 
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {User} from 'sentry/types/user';
-import sessionStorageWrapper from 'sentry/utils/sessionStorage';
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 import {trackMarketingEvent} from 'getsentry/utils/trackMarketingEvent';
 

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
@@ -6,7 +6,7 @@ import {setWindowLocation} from 'sentry-test/utils';
 import {CUSTOM_REFERRER_KEY} from 'sentry/constants';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {uniqueId} from 'sentry/utils/guid';
-import sessionStorageWrapper from 'sentry/utils/sessionStorage';
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 import {rawTrackAnalyticsEvent} from 'getsentry/utils/rawTrackAnalyticsEvent';
 import {trackAmplitudeEvent} from 'getsentry/utils/trackAmplitudeEvent';

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
@@ -7,8 +7,8 @@ import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
 import {uniqueId} from 'sentry/utils/guid';
-import localStorageWrapper from 'sentry/utils/localStorage';
-import sessionStorageWrapper from 'sentry/utils/sessionStorage';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 import {readStorageValue} from 'sentry/utils/useSessionStorage';
 
 import type {Subscription} from 'getsentry/types';

--- a/tests/sentry/management/commands/test_generate_controlsilo_urls.py
+++ b/tests/sentry/management/commands/test_generate_controlsilo_urls.py
@@ -28,8 +28,7 @@ class TestGenerateControlsiloUrls(TestCase):
         result = self.call_command(format="js")
         assert "new RegExp('^api/0/users/$')," in result
         assert "new RegExp('^api/0/internal/integration-proxy/$')," in result
-        assert "const patterns" in result
-        assert "export default patterns;" in result
+        assert "export const controlsiloUrlPatterns: RegExp[] = [" in result
 
     def test_write_file(self) -> None:
         with tempfile.NamedTemporaryFile() as tf:
@@ -37,8 +36,7 @@ class TestGenerateControlsiloUrls(TestCase):
             tf.seek(0)
             result = tf.read().decode("utf8")
         assert "This is generated code" in result
-        assert "const patterns" in result
-        assert "export default patterns;" in result
+        assert "export const controlsiloUrlPatterns: RegExp[] = [" in result
         assert "new RegExp('^api/0/users/$')," in result
         # Wizard is an HTML view that gets POST from UI code.
         assert "new RegExp('^account/settings/wizard/[^/]+/$')," in result


### PR DESCRIPTION
Splits out the source & test changes from #110517. That PR expands the `no-default-export-components` lint rule to apply to non-component-likes and renames it to `no-default-exports`.

The lint rule expansion itself is in #110631.

In `static/app` excluding mocks, this reduces:

* `export default \w+`: from ~900 to ~800
* `import \w+ from`: from ~5.8k to ~5.6k

Fixes ENG-7040.