### PR TITLE
feat(dashboards): Track failed query runs on generated widgets

### DIFF
--- a/static/app/views/dashboards/contexts/widgetErrorContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetErrorContext.tsx
@@ -1,0 +1,11 @@
+import {createContext, useContext} from 'react';
+
+type WidgetErrorCallback = (widget: {title: string}, errorMessage: string) => void;
+
+const WidgetErrorContext = createContext<WidgetErrorCallback | null>(null);
+
+export const WidgetErrorProvider = WidgetErrorContext.Provider;
+
+export function useWidgetErrorCallback(): WidgetErrorCallback | null {
+  return useContext(WidgetErrorContext);
+}

--- a/static/app/views/dashboards/contexts/widgetErrorContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetErrorContext.tsx
@@ -1,6 +1,8 @@
 import {createContext, useContext} from 'react';
 
-type WidgetErrorCallback = (widget: {title: string}, errorMessage: string) => void;
+import type {Widget} from 'sentry/views/dashboards/types';
+
+type WidgetErrorCallback = (widget: Widget, errorMessage: string) => void;
 
 const WidgetErrorContext = createContext<WidgetErrorCallback | null>(null);
 

--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -148,7 +148,7 @@ export default function CreateFromSeer() {
   const isLoading =
     !!seerRunId && sessionStatus !== 'completed' && sessionStatus !== 'error' && !isError;
 
-  // Prevent repeat errors on the same widget and session
+  // Prevent repeat errors on the same widget
   const reportedWidgetErrors = useRef(new Set<string>());
 
   const handleWidgetError = useCallback(

--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -152,7 +152,7 @@ export default function CreateFromSeer() {
   const reportedWidgetErrors = useRef(new Set<string>());
 
   const handleWidgetError = useCallback(
-    (widget: {title: string}, errorMessage: string) => {
+    (widget: Widget, errorMessage: string) => {
       const errorKey = `${widget.title}:${errorMessage}`;
       if (reportedWidgetErrors.current.has(errorKey)) {
         return;

--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -1,5 +1,6 @@
-import {useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Flex} from '@sentry/scraps/layout';
@@ -16,6 +17,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
 import {makeSeerExplorerQueryKey} from 'sentry/views/seerExplorer/utils';
 
+import {WidgetErrorProvider} from './contexts/widgetErrorContext';
 import {EMPTY_DASHBOARD} from './data';
 import DashboardDetail from './detail';
 import {assignDefaultLayout, assignTempId, getInitialColumnDepths} from './layoutUtils';
@@ -146,6 +148,32 @@ export default function CreateFromSeer() {
   const isLoading =
     !!seerRunId && sessionStatus !== 'completed' && sessionStatus !== 'error' && !isError;
 
+  // Prevent repeat errors on the same widget and session
+  const reportedWidgetErrors = useRef(new Set<string>());
+
+  const handleWidgetError = useCallback(
+    (widget: {title: string}, errorMessage: string) => {
+      const errorKey = `${widget.title}:${errorMessage}`;
+      if (reportedWidgetErrors.current.has(errorKey)) {
+        return;
+      }
+      reportedWidgetErrors.current.add(errorKey);
+
+      Sentry.withScope(scope => {
+        scope.setFingerprint(['dashboard-widget-query-error']);
+        scope.setTag('seer.run_id', seerRunId);
+        scope.setLevel('error');
+        Sentry.captureMessage('Generated dashboard widget query error', {
+          extra: {
+            widget_title: widget.title,
+            error_message: errorMessage,
+          },
+        });
+      });
+    },
+    [seerRunId]
+  );
+
   useEffect(() => {
     if (sessionStatus === 'error' || isError) {
       addErrorMessage(t('Failed to generate dashboard'));
@@ -183,11 +211,13 @@ export default function CreateFromSeer() {
 
   return (
     <ErrorBoundary>
-      <DashboardDetail
-        initialState={DashboardState.PREVIEW}
-        dashboard={dashboard}
-        dashboards={[]}
-      />
+      <WidgetErrorProvider value={handleWidgetError}>
+        <DashboardDetail
+          initialState={DashboardState.PREVIEW}
+          dashboard={dashboard}
+          dashboards={[]}
+        />
+      </WidgetErrorProvider>
     </ErrorBoundary>
   );
 }

--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -160,7 +160,7 @@ export default function CreateFromSeer() {
       reportedWidgetErrors.current.add(errorKey);
 
       Sentry.withScope(scope => {
-        scope.setFingerprint(['dashboard-widget-query-error']);
+        scope.setFingerprint(['generated-dashboard-widget-query-error']);
         scope.setTag('seer.run_id', seerRunId);
         scope.setLevel('error');
         Sentry.captureMessage('Generated dashboard widget query error', {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -843,7 +843,23 @@ class DashboardDetail extends Component<Props, State> {
                 }
               );
             },
-            () => undefined
+            error => {
+              const seerRunId = location.query?.seerRunId;
+              // Currently only runs for seer-generated dashboards
+              if (seerRunId && typeof seerRunId === 'string') {
+                Sentry.withScope(scope => {
+                  scope.setFingerprint(['generated-dashboard-save-failed']);
+                  scope.setTag('seer.run_id', seerRunId);
+                  scope.setLevel('error');
+                  Sentry.captureMessage('Generated dashboard failed to save', {
+                    extra: {
+                      dashboard_title: newModifiedDashboard.title,
+                      error_message: error?.message,
+                    },
+                  });
+                });
+              }
+            }
           );
         }
         break;

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -141,7 +141,11 @@ export function SortableWidget(props: Props) {
     dashboardFilters,
     widgetLegendState,
     renderErrorMessage: errorMessage => {
-      if (typeof errorMessage === 'string' && onWidgetError) {
+      if (
+        typeof errorMessage === 'string' &&
+        errorMessage !== t('No data found') &&
+        onWidgetError
+      ) {
         onWidgetError(widget, errorMessage);
       }
       return (

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -15,6 +15,7 @@ import {useWidgetSlideout} from 'sentry/views/dashboards/utils/useWidgetSlideout
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
 
+import {useWidgetErrorCallback} from './contexts/widgetErrorContext';
 import {checkUserHasEditAccess} from './utils/checkUserHasEditAccess';
 import {DashboardsMEPProvider} from './widgetCard/dashboardsMEPContext';
 import {Toolbar} from './widgetCard/toolbar';
@@ -84,6 +85,7 @@ export function SortableWidget(props: Props) {
   const organization = useOrganization();
   const currentUser = useUser();
   const {teams: userTeams} = useUserTeams();
+  const onWidgetError = useWidgetErrorCallback();
   const hasEditAccess =
     checkUserHasEditAccess(
       currentUser,
@@ -139,6 +141,9 @@ export function SortableWidget(props: Props) {
     dashboardFilters,
     widgetLegendState,
     renderErrorMessage: errorMessage => {
+      if (typeof errorMessage === 'string' && onWidgetError) {
+        onWidgetError(widget, errorMessage);
+      }
       return (
         typeof errorMessage === 'string' && (
           <PanelAlert variant="danger">{errorMessage}</PanelAlert>


### PR DESCRIPTION
Captures a Sentry error when a seer generated dashboard widget errors out during query or save. 
- Creates and uses `useWidgetErrorCallback` provider and context to pass handler from `createFromSeer` to `sortableWidget`
- Widget errors are fingerprinted to one key and save dashboard errors are fingerprinted to another