### PR TITLE
fix(trace): Retry trace endpoints with wider window when response is empty

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
@@ -25,115 +25,108 @@ describe('useTrace', () => {
 
   describe('retry with wider period', () => {
     it('retries with 90d when initial response is empty', async () => {
-      window.history.pushState({}, '', '/?statsPeriod=14d');
-      useIsEAPTraceEnabled.mockReturnValue(false);
+      useIsEAPTraceEnabled.mockReturnValue(true);
 
       const initialMock = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        url: `/organizations/${organization.slug}/trace/test-trace-id/`,
         method: 'GET',
         match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-        body: {transactions: [], orphan_errors: []},
+        body: [],
       });
 
       const fallbackMock = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        url: `/organizations/${organization.slug}/trace/test-trace-id/`,
         method: 'GET',
         match: [MockApiClient.matchQuery({statsPeriod: '90d'})],
-        body: {
-          transactions: [{event_id: 'abc123', transaction: '/foo'}],
-          orphan_errors: [],
-        },
+        body: [{event_id: 'abc123', event_type: 'error'}],
       });
 
-      const {result} = renderHookWithProviders(() =>
-        useTrace({traceSlug: 'test-trace-id'})
-      );
+      const {result} = renderHookWithProviders(useTrace, {
+        initialProps: {traceSlug: 'test-trace-id'},
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/performance/trace/test-trace-id/`,
+            query: {statsPeriod: '14d'},
+          },
+        },
+      });
 
       await waitFor(() => expect(fallbackMock).toHaveBeenCalled());
 
       expect(initialMock).toHaveBeenCalledTimes(1);
       expect(fallbackMock).toHaveBeenCalledTimes(1);
       expect(result.current.data).toEqual(
-        expect.objectContaining({
-          transactions: expect.arrayContaining([
-            expect.objectContaining({event_id: 'abc123'}),
-          ]),
-        })
+        expect.arrayContaining([expect.objectContaining({event_id: 'abc123'})])
       );
     });
 
     it('does not retry when initial response has data', async () => {
-      window.history.pushState({}, '', '/?statsPeriod=14d');
-      useIsEAPTraceEnabled.mockReturnValue(false);
+      useIsEAPTraceEnabled.mockReturnValue(true);
 
       const initialMock = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        url: `/organizations/${organization.slug}/trace/test-trace-id/`,
         method: 'GET',
         match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-        body: {
-          transactions: [{event_id: 'abc123', transaction: '/foo'}],
-          orphan_errors: [],
-        },
+        body: [{event_id: 'abc123', event_type: 'error'}],
       });
 
       const fallbackMock = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        url: `/organizations/${organization.slug}/trace/test-trace-id/`,
         method: 'GET',
         match: [MockApiClient.matchQuery({statsPeriod: '90d'})],
-        body: {transactions: [], orphan_errors: []},
+        body: [],
       });
 
-      const {result} = renderHookWithProviders(() =>
-        useTrace({traceSlug: 'test-trace-id'})
-      );
+      const {result} = renderHookWithProviders(useTrace, {
+        initialProps: {traceSlug: 'test-trace-id'},
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/performance/trace/test-trace-id/`,
+            query: {statsPeriod: '14d'},
+          },
+        },
+      });
 
       await waitFor(() => expect(result.current.status).toBe('success'));
 
       expect(initialMock).toHaveBeenCalledTimes(1);
       expect(fallbackMock).not.toHaveBeenCalled();
       expect(result.current.data).toEqual(
-        expect.objectContaining({
-          transactions: expect.arrayContaining([
-            expect.objectContaining({event_id: 'abc123'}),
-          ]),
-        })
+        expect.arrayContaining([expect.objectContaining({event_id: 'abc123'})])
       );
     });
 
     it('does not retry when timestamp is set', async () => {
-      window.history.pushState({}, '', '/?statsPeriod=14d');
-      useIsEAPTraceEnabled.mockReturnValue(false);
+      useIsEAPTraceEnabled.mockReturnValue(true);
 
       const initialMock = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        url: `/organizations/${organization.slug}/trace/test-trace-id/`,
         method: 'GET',
-        body: {transactions: [], orphan_errors: []},
+        body: [],
       });
 
       const fallbackMock = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        url: `/organizations/${organization.slug}/trace/test-trace-id/`,
         method: 'GET',
         match: [MockApiClient.matchQuery({statsPeriod: '90d'})],
-        body: {
-          transactions: [{event_id: 'abc123', transaction: '/foo'}],
-          orphan_errors: [],
-        },
+        body: [{event_id: 'abc123', event_type: 'error'}],
       });
 
-      const {result} = renderHookWithProviders(() =>
-        useTrace({traceSlug: 'test-trace-id', timestamp: 1234567890})
-      );
+      const {result} = renderHookWithProviders(useTrace, {
+        initialProps: {traceSlug: 'test-trace-id', timestamp: 1234567890},
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/performance/trace/test-trace-id/`,
+            query: {statsPeriod: '14d'},
+          },
+        },
+      });
 
       await waitFor(() => expect(result.current.status).toBe('success'));
 
       expect(initialMock).toHaveBeenCalledTimes(1);
       expect(fallbackMock).not.toHaveBeenCalled();
-      expect(result.current.data).toEqual(
-        expect.objectContaining({
-          transactions: [],
-          orphan_errors: [],
-        })
-      );
+      expect(result.current.data).toEqual([]);
     });
   });
 
@@ -162,11 +155,9 @@ describe('useTrace', () => {
         body: [],
       });
 
-      renderHookWithProviders(() =>
-        useTrace({
-          traceSlug: 'test-trace-id',
-        })
-      );
+      renderHookWithProviders(useTrace, {
+        initialProps: {traceSlug: 'test-trace-id'},
+      });
 
       // Wait for the hook to make the API call
       await waitFor(() => {
@@ -248,11 +239,9 @@ describe('useTrace', () => {
           body: [],
         });
 
-        renderHookWithProviders(() =>
-          useTrace({
-            traceSlug: 'trace-test-id',
-          })
-        );
+        renderHookWithProviders(useTrace, {
+          initialProps: {traceSlug: 'trace-test-id'},
+        });
 
         await waitFor(() => {
           expect(eapTraceMock).toHaveBeenCalled();

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
@@ -23,6 +23,120 @@ describe('useTrace', () => {
     MockApiClient.clearMockResponses();
   });
 
+  describe('retry with wider period', () => {
+    it('retries with 90d when initial response is empty', async () => {
+      window.history.pushState({}, '', '/?statsPeriod=14d');
+      useIsEAPTraceEnabled.mockReturnValue(false);
+
+      const initialMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        method: 'GET',
+        match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
+        body: {transactions: [], orphan_errors: []},
+      });
+
+      const fallbackMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        method: 'GET',
+        match: [MockApiClient.matchQuery({statsPeriod: '90d'})],
+        body: {
+          transactions: [{event_id: 'abc123', transaction: '/foo'}],
+          orphan_errors: [],
+        },
+      });
+
+      const {result} = renderHookWithProviders(() =>
+        useTrace({traceSlug: 'test-trace-id'})
+      );
+
+      await waitFor(() => expect(fallbackMock).toHaveBeenCalled());
+
+      expect(initialMock).toHaveBeenCalledTimes(1);
+      expect(fallbackMock).toHaveBeenCalledTimes(1);
+      expect(result.current.data).toEqual(
+        expect.objectContaining({
+          transactions: expect.arrayContaining([
+            expect.objectContaining({event_id: 'abc123'}),
+          ]),
+        })
+      );
+    });
+
+    it('does not retry when initial response has data', async () => {
+      window.history.pushState({}, '', '/?statsPeriod=14d');
+      useIsEAPTraceEnabled.mockReturnValue(false);
+
+      const initialMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        method: 'GET',
+        match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
+        body: {
+          transactions: [{event_id: 'abc123', transaction: '/foo'}],
+          orphan_errors: [],
+        },
+      });
+
+      const fallbackMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        method: 'GET',
+        match: [MockApiClient.matchQuery({statsPeriod: '90d'})],
+        body: {transactions: [], orphan_errors: []},
+      });
+
+      const {result} = renderHookWithProviders(() =>
+        useTrace({traceSlug: 'test-trace-id'})
+      );
+
+      await waitFor(() => expect(result.current.status).toBe('success'));
+
+      expect(initialMock).toHaveBeenCalledTimes(1);
+      expect(fallbackMock).not.toHaveBeenCalled();
+      expect(result.current.data).toEqual(
+        expect.objectContaining({
+          transactions: expect.arrayContaining([
+            expect.objectContaining({event_id: 'abc123'}),
+          ]),
+        })
+      );
+    });
+
+    it('does not retry when timestamp is set', async () => {
+      window.history.pushState({}, '', '/?statsPeriod=14d');
+      useIsEAPTraceEnabled.mockReturnValue(false);
+
+      const initialMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        method: 'GET',
+        body: {transactions: [], orphan_errors: []},
+      });
+
+      const fallbackMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-trace/test-trace-id/`,
+        method: 'GET',
+        match: [MockApiClient.matchQuery({statsPeriod: '90d'})],
+        body: {
+          transactions: [{event_id: 'abc123', transaction: '/foo'}],
+          orphan_errors: [],
+        },
+      });
+
+      const {result} = renderHookWithProviders(() =>
+        useTrace({traceSlug: 'test-trace-id', timestamp: 1234567890})
+      );
+
+      await waitFor(() => expect(result.current.status).toBe('success'));
+
+      expect(initialMock).toHaveBeenCalledTimes(1);
+      expect(fallbackMock).not.toHaveBeenCalled();
+      expect(result.current.data).toEqual(
+        expect.objectContaining({
+          transactions: [],
+          orphan_errors: [],
+        })
+      );
+    });
+  });
+
   describe('tracing endpoint query params', () => {
     const validUUid = '550e8400e29b41d4a716446655440000';
     const invalidUUid = 'notAuuid';

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -10,6 +10,7 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {useDefaultMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {useIsEAPTraceEnabled} from 'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled';
@@ -269,12 +270,16 @@ export function useTrace(
   const isDemoMode = Boolean(queryParams.demo);
   const demoTrace = useDemoTrace(queryParams.demo, organization);
 
+  const maxPickableDays = useDefaultMaxPickableDays();
+
   // Only retry when using statsPeriod (no specific timestamp or absolute date range)
-  const canRetryWithWiderPeriod = !options.timestamp && 'statsPeriod' in queryParams;
+  // and only when the org's plan allows a wider window than the default 14d.
+  const canRetryWithWiderPeriod =
+    !options.timestamp && 'statsPeriod' in queryParams && maxPickableDays > 14;
 
   const fallbackQueryParams = useMemo(
-    () => ({...queryParams, statsPeriod: '90d'}),
-    [queryParams]
+    () => ({...queryParams, statsPeriod: `${maxPickableDays}d`}),
+    [queryParams, maxPickableDays]
   );
 
   const traceQuery = useApiQuery<TraceSplitResults<TraceTree.Transaction>>(

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -269,6 +269,14 @@ export function useTrace(
   const isDemoMode = Boolean(queryParams.demo);
   const demoTrace = useDemoTrace(queryParams.demo, organization);
 
+  // Only retry when using statsPeriod (no specific timestamp or absolute date range)
+  const canRetryWithWiderPeriod = !options.timestamp && 'statsPeriod' in queryParams;
+
+  const fallbackQueryParams = useMemo(
+    () => ({...queryParams, statsPeriod: '90d'}),
+    [queryParams]
+  );
+
   const traceQuery = useApiQuery<TraceSplitResults<TraceTree.Transaction>>(
     [
       getApiUrl(`/organizations/$organizationIdOrSlug/events-trace/$traceId/`, {
@@ -302,7 +310,66 @@ export function useTrace(
     }
   );
 
-  return isDemoMode ? demoTrace : isEAPEnabled ? eapTraceQuery : traceQuery;
+  const isInitialTraceEmpty =
+    traceQuery.status === 'success' &&
+    traceQuery.data?.transactions?.length === 0 &&
+    traceQuery.data?.orphan_errors?.length === 0;
+
+  const isInitialEAPTraceEmpty =
+    eapTraceQuery.status === 'success' &&
+    Array.isArray(eapTraceQuery.data) &&
+    eapTraceQuery.data.length === 0;
+
+  const traceFallbackQuery = useApiQuery<TraceSplitResults<TraceTree.Transaction>>(
+    [
+      getApiUrl(`/organizations/$organizationIdOrSlug/events-trace/$traceId/`, {
+        path: {organizationIdOrSlug: organization.slug, traceId: options.traceSlug ?? ''},
+      }),
+      {query: fallbackQueryParams},
+    ],
+    {
+      staleTime: Infinity,
+      enabled:
+        hasValidTrace &&
+        !isDemoMode &&
+        !isEAPEnabled &&
+        isInitialTraceEmpty &&
+        canRetryWithWiderPeriod,
+    }
+  );
+
+  const eapTraceFallbackQuery = useApiQuery<TraceTree.EAPTrace>(
+    [
+      getApiUrl(`/organizations/$organizationIdOrSlug/trace/$traceId/`, {
+        path: {organizationIdOrSlug: organization.slug, traceId: options.traceSlug ?? ''},
+      }),
+      {
+        query: {
+          ...fallbackQueryParams,
+          project: -1,
+          additional_attributes: options.additionalAttributes,
+        },
+      },
+    ],
+    {
+      staleTime: Infinity,
+      retry: false,
+      enabled:
+        hasValidTrace &&
+        !isDemoMode &&
+        isEAPEnabled &&
+        isInitialEAPTraceEmpty &&
+        canRetryWithWiderPeriod,
+    }
+  );
+
+  if (isDemoMode) return demoTrace;
+  if (isEAPEnabled) {
+    return isInitialEAPTraceEmpty && canRetryWithWiderPeriod
+      ? eapTraceFallbackQuery
+      : eapTraceQuery;
+  }
+  return isInitialTraceEmpty && canRetryWithWiderPeriod ? traceFallbackQuery : traceQuery;
 }
 
 const isValidEventUUID = (id: string): boolean => {

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -4,6 +4,7 @@ import * as qs from 'query-string';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import type {PageFilters} from 'sentry/types/core';
 import type {EventTransaction} from 'sentry/types/event';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -273,9 +274,12 @@ export function useTrace(
   const maxPickableDays = useDefaultMaxPickableDays();
 
   // Only retry when using statsPeriod (no specific timestamp or absolute date range)
-  // and only when the org's plan allows a wider window than the default 14d.
+  // and only when the org's plan allows a wider window than the default stats period.
+  const defaultStatsDays = parseInt(DEFAULT_STATS_PERIOD, 10);
   const canRetryWithWiderPeriod =
-    !options.timestamp && 'statsPeriod' in queryParams && maxPickableDays > 14;
+    !options.timestamp &&
+    'statsPeriod' in queryParams &&
+    maxPickableDays > defaultStatsDays;
 
   const fallbackQueryParams = useMemo(
     () => ({...queryParams, statsPeriod: `${maxPickableDays}d`}),

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -254,6 +254,7 @@ describe('useTraceMeta', () => {
   });
 
   it('Retries with 90d when initial 14d response has no data', async () => {
+    const org = OrganizationFixture({features: ['trace-spans-format']});
     const tracesWithoutTimestamp: ReplayTrace[] = [
       {traceSlug: 'slug1', timestamp: undefined},
       {traceSlug: 'slug2', timestamp: undefined},
@@ -261,52 +262,53 @@ describe('useTraceMeta', () => {
 
     const emptyBody = {
       errors: 0,
+      logs: 0,
       performance_issues: 0,
-      projects: 0,
-      transactions: 0,
-      transaction_child_count_map: [],
       span_count: 0,
       span_count_map: {},
+      transaction_child_count_map: [],
+      uptime_checks: 0,
     };
 
     const mockSlug1_14d = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      url: '/organizations/org-slug/trace-meta/slug1/',
       match: [MockApiClient.matchData({statsPeriod: '14d'})],
       body: emptyBody,
     });
     const mockSlug2_14d = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug2/',
+      url: '/organizations/org-slug/trace-meta/slug2/',
       match: [MockApiClient.matchData({statsPeriod: '14d'})],
       body: emptyBody,
     });
 
     const realBody = {
       errors: 1,
+      logs: 1,
       performance_issues: 1,
-      projects: 1,
-      transactions: 1,
-      transaction_child_count_map: [{'transaction.id': 'tx1', count: 1}],
       span_count: 1,
       span_count_map: {op1: 1},
+      transaction_child_count_map: [{'transaction.id': 'tx1', count: 1}],
+      uptime_checks: 0,
     };
 
     const mockSlug1_90d = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      url: '/organizations/org-slug/trace-meta/slug1/',
       match: [MockApiClient.matchData({statsPeriod: '90d'})],
       body: realBody,
     });
     const mockSlug2_90d = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug2/',
+      url: '/organizations/org-slug/trace-meta/slug2/',
       match: [MockApiClient.matchData({statsPeriod: '90d'})],
       body: realBody,
     });
 
-    const {result} = renderHookWithProviders(() => useTraceMeta(tracesWithoutTimestamp), {
-      organization,
+    const {result} = renderHookWithProviders(useTraceMeta, {
+      organization: org,
+      initialProps: tracesWithoutTimestamp,
     });
 
     await waitFor(() => expect(result.current.status === 'success').toBe(true));
@@ -321,42 +323,44 @@ describe('useTraceMeta', () => {
   });
 
   it('Does not retry when initial response has data', async () => {
+    const org = OrganizationFixture({features: ['trace-spans-format']});
     const tracesWithoutTimestamp: ReplayTrace[] = [
       {traceSlug: 'slug1', timestamp: undefined},
     ];
 
     const mockSlug1_14d = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      url: '/organizations/org-slug/trace-meta/slug1/',
       match: [MockApiClient.matchData({statsPeriod: '14d'})],
       body: {
         errors: 1,
+        logs: 1,
         performance_issues: 1,
-        projects: 1,
-        transactions: 1,
-        transaction_child_count_map: [],
         span_count: 1,
         span_count_map: {op1: 1},
+        transaction_child_count_map: [],
+        uptime_checks: 0,
       },
     });
 
     const mockSlug1_90d = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      url: '/organizations/org-slug/trace-meta/slug1/',
       match: [MockApiClient.matchData({statsPeriod: '90d'})],
       body: {
         errors: 2,
+        logs: 2,
         performance_issues: 2,
-        projects: 1,
-        transactions: 2,
-        transaction_child_count_map: [],
         span_count: 2,
         span_count_map: {},
+        transaction_child_count_map: [],
+        uptime_checks: 0,
       },
     });
 
-    const {result} = renderHookWithProviders(() => useTraceMeta(tracesWithoutTimestamp), {
-      organization,
+    const {result} = renderHookWithProviders(useTraceMeta, {
+      organization: org,
+      initialProps: tracesWithoutTimestamp,
     });
 
     await waitFor(() => expect(result.current.status === 'success').toBe(true));
@@ -367,39 +371,41 @@ describe('useTraceMeta', () => {
   });
 
   it('Does not retry when all traces have timestamps', async () => {
+    const org = OrganizationFixture({features: ['trace-spans-format']});
     const tracesWithTimestamps: ReplayTrace[] = [{traceSlug: 'slug1', timestamp: 123}];
 
     const mockSlug1_timestamp = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      url: '/organizations/org-slug/trace-meta/slug1/',
       body: {
         errors: 0,
+        logs: 0,
         performance_issues: 0,
-        projects: 0,
-        transactions: 0,
-        transaction_child_count_map: [],
         span_count: 0,
         span_count_map: {},
+        transaction_child_count_map: [],
+        uptime_checks: 0,
       },
     });
 
     const mockSlug1_90d = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      url: '/organizations/org-slug/trace-meta/slug1/',
       match: [MockApiClient.matchData({statsPeriod: '90d'})],
       body: {
         errors: 1,
+        logs: 1,
         performance_issues: 1,
-        projects: 1,
-        transactions: 1,
-        transaction_child_count_map: [],
         span_count: 1,
         span_count_map: {},
+        transaction_child_count_map: [],
+        uptime_checks: 0,
       },
     });
 
-    const {result} = renderHookWithProviders(() => useTraceMeta(tracesWithTimestamps), {
-      organization,
+    const {result} = renderHookWithProviders(useTraceMeta, {
+      organization: org,
+      initialProps: tracesWithTimestamps,
     });
 
     await waitFor(() => expect(result.current.status === 'success').toBe(true));

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -253,6 +253,162 @@ describe('useTraceMeta', () => {
     expect(mockRequest3).toHaveBeenCalled();
   });
 
+  it('Retries with 90d when initial 14d response has no data', async () => {
+    const tracesWithoutTimestamp: ReplayTrace[] = [
+      {traceSlug: 'slug1', timestamp: undefined},
+      {traceSlug: 'slug2', timestamp: undefined},
+    ];
+
+    const emptyBody = {
+      errors: 0,
+      performance_issues: 0,
+      projects: 0,
+      transactions: 0,
+      transaction_child_count_map: [],
+      span_count: 0,
+      span_count_map: {},
+    };
+
+    const mockSlug1_14d = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      match: [MockApiClient.matchData({statsPeriod: '14d'})],
+      body: emptyBody,
+    });
+    const mockSlug2_14d = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trace-meta/slug2/',
+      match: [MockApiClient.matchData({statsPeriod: '14d'})],
+      body: emptyBody,
+    });
+
+    const realBody = {
+      errors: 1,
+      performance_issues: 1,
+      projects: 1,
+      transactions: 1,
+      transaction_child_count_map: [{'transaction.id': 'tx1', count: 1}],
+      span_count: 1,
+      span_count_map: {op1: 1},
+    };
+
+    const mockSlug1_90d = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      match: [MockApiClient.matchData({statsPeriod: '90d'})],
+      body: realBody,
+    });
+    const mockSlug2_90d = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trace-meta/slug2/',
+      match: [MockApiClient.matchData({statsPeriod: '90d'})],
+      body: realBody,
+    });
+
+    const {result} = renderHookWithProviders(() => useTraceMeta(tracesWithoutTimestamp), {
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.status === 'success').toBe(true));
+
+    expect(mockSlug1_14d).toHaveBeenCalledTimes(1);
+    expect(mockSlug2_14d).toHaveBeenCalledTimes(1);
+    expect(mockSlug1_90d).toHaveBeenCalledTimes(1);
+    expect(mockSlug2_90d).toHaveBeenCalledTimes(1);
+
+    expect(result.current.data?.span_count).toBe(2);
+    expect(result.current.data?.errors).toBe(2);
+  });
+
+  it('Does not retry when initial response has data', async () => {
+    const tracesWithoutTimestamp: ReplayTrace[] = [
+      {traceSlug: 'slug1', timestamp: undefined},
+    ];
+
+    const mockSlug1_14d = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      match: [MockApiClient.matchData({statsPeriod: '14d'})],
+      body: {
+        errors: 1,
+        performance_issues: 1,
+        projects: 1,
+        transactions: 1,
+        transaction_child_count_map: [],
+        span_count: 1,
+        span_count_map: {op1: 1},
+      },
+    });
+
+    const mockSlug1_90d = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      match: [MockApiClient.matchData({statsPeriod: '90d'})],
+      body: {
+        errors: 2,
+        performance_issues: 2,
+        projects: 1,
+        transactions: 2,
+        transaction_child_count_map: [],
+        span_count: 2,
+        span_count_map: {},
+      },
+    });
+
+    const {result} = renderHookWithProviders(() => useTraceMeta(tracesWithoutTimestamp), {
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.status === 'success').toBe(true));
+
+    expect(mockSlug1_14d).toHaveBeenCalledTimes(1);
+    expect(mockSlug1_90d).not.toHaveBeenCalled();
+    expect(result.current.data?.span_count).toBe(1);
+  });
+
+  it('Does not retry when all traces have timestamps', async () => {
+    const tracesWithTimestamps: ReplayTrace[] = [{traceSlug: 'slug1', timestamp: 123}];
+
+    const mockSlug1_timestamp = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      body: {
+        errors: 0,
+        performance_issues: 0,
+        projects: 0,
+        transactions: 0,
+        transaction_child_count_map: [],
+        span_count: 0,
+        span_count_map: {},
+      },
+    });
+
+    const mockSlug1_90d = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      match: [MockApiClient.matchData({statsPeriod: '90d'})],
+      body: {
+        errors: 1,
+        performance_issues: 1,
+        projects: 1,
+        transactions: 1,
+        transaction_child_count_map: [],
+        span_count: 1,
+        span_count_map: {},
+      },
+    });
+
+    const {result} = renderHookWithProviders(() => useTraceMeta(tracesWithTimestamps), {
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.status === 'success').toBe(true));
+
+    expect(mockSlug1_timestamp).toHaveBeenCalledTimes(1);
+    expect(mockSlug1_90d).not.toHaveBeenCalled();
+    expect(result.current.data?.span_count).toBe(0);
+  });
+
   it('Accumulates metaResults and collects errors from rejected api calls', async () => {
     const mockRequest1 = MockApiClient.addMockResponse({
       method: 'GET',

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -11,6 +11,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {QueryStatus} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useApi} from 'sentry/utils/useApi';
+import {useDefaultMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useIsEAPTraceEnabled} from 'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled';
 import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
@@ -168,6 +169,7 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
   const filters = usePageFilters();
   const organization = useOrganization();
   const isEAP = useIsEAPTraceEnabled();
+  const maxPickableDays = useDefaultMaxPickableDays();
 
   const normalizedParams = useMemo(() => {
     const query = qs.parse(location.search);
@@ -200,10 +202,12 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
       );
 
       const hasStatsPeriodTrace = replayTraces.some(t => !t.timestamp);
+      const defaultStatsDays = parseInt(DEFAULT_STATS_PERIOD, 10);
       if (
         result.apiErrors.length === 0 &&
         isEmptyMeta(result.meta) &&
-        hasStatsPeriodTrace
+        hasStatsPeriodTrace &&
+        maxPickableDays > defaultStatsDays
       ) {
         return fetchTraceMetaInBatches(
           isEAP ? 'eap' : 'non-eap',
@@ -212,7 +216,7 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
           replayTraces,
           normalizedParams,
           filters.selection,
-          '90d'
+          `${maxPickableDays}d`
         );
       }
 

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -27,10 +27,15 @@ type TraceMetaQueryParams =
       timestamp: number;
     };
 
+function isEmptyMeta(meta: TraceMeta | EAPTraceMeta): boolean {
+  return meta.span_count === 0 && meta.errors === 0 && meta.performance_issues === 0;
+}
+
 function getMetaQueryParams(
   row: ReplayTrace,
   normalizedParams: any,
-  filters: Partial<PageFilters> = {}
+  filters: Partial<PageFilters> = {},
+  statsPeriodOverride?: string
 ): TraceMetaQueryParams {
   const statsPeriod = decodeScalar(normalizedParams.statsPeriod);
 
@@ -39,7 +44,10 @@ function getMetaQueryParams(
     ...(row.timestamp
       ? {timestamp: row.timestamp}
       : {
-          statsPeriod: (statsPeriod || filters?.datetime?.period) ?? DEFAULT_STATS_PERIOD,
+          statsPeriod:
+            statsPeriodOverride ??
+            (statsPeriod || filters?.datetime?.period) ??
+            DEFAULT_STATS_PERIOD,
         }),
   };
 }
@@ -69,7 +77,8 @@ async function fetchTraceMetaInBatches(
   organization: Organization,
   replayTraces: ReplayTrace[],
   normalizedParams: any,
-  filters: Partial<PageFilters> = {}
+  filters: Partial<PageFilters> = {},
+  statsPeriodOverride?: string
 ) {
   const clonedTraceIds = [...replayTraces];
   const meta: TraceMeta | EAPTraceMeta =
@@ -99,7 +108,12 @@ async function fetchTraceMetaInBatches(
     const batch = clonedTraceIds.splice(0, 3);
     const results = await Promise.allSettled<TraceMeta | EAPTraceMeta>(
       batch.map(replayTrace => {
-        const queryParams = getMetaQueryParams(replayTrace, normalizedParams, filters);
+        const queryParams = getMetaQueryParams(
+          replayTrace,
+          normalizedParams,
+          filters,
+          statsPeriodOverride
+        );
         return fetchSingleTraceMetaNew(type, api, organization, replayTrace, queryParams);
       })
     );
@@ -175,15 +189,35 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
   >({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: ['traceData', replayTraces.map(trace => trace.traceSlug)],
-    queryFn: () =>
-      fetchTraceMetaInBatches(
+    queryFn: async () => {
+      const result = await fetchTraceMetaInBatches(
         isEAP ? 'eap' : 'non-eap',
         api,
         organization,
         replayTraces,
         normalizedParams,
         filters.selection
-      ),
+      );
+
+      const hasStatsPeriodTrace = replayTraces.some(t => !t.timestamp);
+      if (
+        result.apiErrors.length === 0 &&
+        isEmptyMeta(result.meta) &&
+        hasStatsPeriodTrace
+      ) {
+        return fetchTraceMetaInBatches(
+          isEAP ? 'eap' : 'non-eap',
+          api,
+          organization,
+          replayTraces,
+          normalizedParams,
+          filters.selection,
+          '90d'
+        );
+      }
+
+      return result;
+    },
     staleTime: 1000 * 60 * 10,
     enabled: replayTraces.length > 0,
   });


### PR DESCRIPTION
Both the `trace` and `trace-meta` endpoints default to a 14-day `statsPeriod` when no timestamp is provided. When a user navigates to a trace older than 14 days, both endpoints return empty data (zero counts / empty arrays) rather than an error, leaving the waterfall blank with no indication of why.

This adds an automatic retry with a wider time window when a `statsPeriod`-based request succeeds but returns empty data:

- `useTraceMeta`: retries the batch fetch with the wider period if all requests succeeded but the aggregated meta has zero spans, errors, and performance issues, and at least one trace has no timestamp anchor.
- `useTrace`: adds a conditional fallback query (for both EAP and non-EAP paths) that fires only when the initial query resolves empty.

The retry period is driven by `useDefaultMaxPickableDays()`, or falls back to 90 days. The retry is skipped entirely when the org's plan retention is already at or below the default 14-day window.

Refs EXP-839