### PR TITLE
fix(github-copilot): Fall back to now() when started_at is missing from API response

### DIFF
--- a/src/sentry/integrations/github_copilot/client.py
+++ b/src/sentry/integrations/github_copilot/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sentry.integrations.coding_agent.client import CodingAgentClient
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
@@ -103,8 +103,8 @@ class GithubCopilotAgentClient(CodingAgentClient):
 
         agent_id = self.encode_agent_id(owner, repo, task.id)
 
-        # Get created_at from the response
-        started_at = None
+        # Get created_at from the response, falling back to now if missing/unparseable
+        started_at = datetime.now(UTC)
         created_at_str = task.created_at
         if created_at_str:
             try:

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -1,7 +1,11 @@
+from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
+from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.github_copilot.client import GithubCopilotAgentClient
 from sentry.integrations.github_copilot.models import GithubCopilotTask
+from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentStatus
+from sentry.seer.models import SeerRepoDefinition
 from sentry.testutils.cases import TestCase
 
 
@@ -98,6 +102,66 @@ class GithubCopilotAgentClientTest(TestCase):
         assert result.id == "task-123"
         assert result.status == "running"
         assert result.artifacts is None
+
+    def _make_launch_request(self) -> CodingAgentLaunchRequest:
+        return CodingAgentLaunchRequest(
+            prompt="Fix the bug",
+            repository=SeerRepoDefinition(
+                provider="github",
+                owner="getsentry",
+                name="sentry",
+                external_id="123",
+            ),
+            branch_name="main",
+        )
+
+    @patch.object(GithubCopilotAgentClient, "post")
+    def test_launch_with_created_at(self, mock_post: Mock) -> None:
+        """Test launch correctly parses created_at from the response"""
+        mock_response = Mock()
+        mock_response.json = {
+            "task": {
+                "id": "task-123",
+                "status": "in_progress",
+                "created_at": "2024-06-01T12:00:00Z",
+            }
+        }
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        result = self.copilot_client.launch(
+            webhook_url="https://example.com/webhook",
+            request=self._make_launch_request(),
+        )
+
+        assert result.id == "getsentry:sentry:task-123"
+        assert result.status == CodingAgentStatus.RUNNING
+        assert result.provider == CodingAgentProviderType.GITHUB_COPILOT_AGENT
+        assert result.started_at == datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+    @patch.object(GithubCopilotAgentClient, "post")
+    def test_launch_with_missing_created_at(self, mock_post: Mock) -> None:
+        """Test launch falls back to now() when created_at is missing"""
+        mock_response = Mock()
+        mock_response.json = {
+            "task": {
+                "id": "task-456",
+                "status": "in_progress",
+            }
+        }
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        before = datetime.now(UTC)
+        result = self.copilot_client.launch(
+            webhook_url="https://example.com/webhook",
+            request=self._make_launch_request(),
+        )
+        after = datetime.now(UTC)
+
+        assert result.id == "getsentry:sentry:task-456"
+        assert result.status == CodingAgentStatus.RUNNING
+        assert before <= result.started_at <= after
 
     @patch.object(GithubCopilotAgentClient, "post")
     def test_get_pr_from_graphql_success(self, mock_post: Mock) -> None:


### PR DESCRIPTION
Handle the case where the GitHub Copilot task API returns a response
without `created_at`, which caused a `ValidationError` when constructing
`CodingAgentState` since `started_at` is a required `datetime` field.

The fix defaults `started_at` to `datetime.now(UTC)` instead of `None`,
so the model always receives a valid value even when the API omits
`created_at` or returns an unparseable value.

Also adds test coverage for the `launch` method which previously had none.

Fixes SENTRY-5M3C


Agent transcript: https://claudescope.sentry.dev/share/5qkI2aryj526Coe9fx0te4tGVYgGTo4Qxopds0Sqdgk