### PR TITLE
feat(metrics): Add canary metrics for HMAC failures and unsigned Seer requests

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -1046,6 +1046,11 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
 
         if secret is None:
             logger.warning("github.webhook.missing-secret", extra=self.get_logging_data())
+            metrics.incr(
+                "github.webhook.hmac_failure",
+                tags={"reason": "missing_secret"},
+                sample_rate=1.0,
+            )
             return HttpResponse(status=401)
 
         body = bytes(request.body)
@@ -1080,6 +1085,11 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
 
         if not self.is_valid_signature(method, body, secret, signature):
             logger.warning("github.webhook.invalid-signature", extra=self.get_logging_data())
+            metrics.incr(
+                "github.webhook.hmac_failure",
+                tags={"reason": "invalid_signature"},
+                sample_rate=1.0,
+            )
             return HttpResponse(status=401)
 
         try:

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -494,6 +494,7 @@ def sign_with_seer_secret(body: bytes) -> dict[str, str]:
         logger.warning(
             "settings.SEER_API_SHARED_SECRET is not set. Unable to add auth headers for call to Seer."
         )
+        metrics.incr("seer.unsigned_request", sample_rate=1.0)
     return auth_headers
 
 

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -74,6 +74,43 @@ class WebhookTest(APITestCase):
 
         assert response.status_code == 401
 
+    @patch("sentry.integrations.github.webhook.metrics")
+    def test_invalid_signature_emits_hmac_failure_metric(self, mock_metrics: MagicMock) -> None:
+        self.client.post(
+            path=self.url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=33521abeaaf9a57c2abf486e0ccd54d23cf36fec",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        mock_metrics.incr.assert_called_with(
+            "github.webhook.hmac_failure",
+            tags={"reason": "invalid_signature"},
+            sample_rate=1.0,
+        )
+
+    @patch("sentry.integrations.github.webhook.metrics")
+    @patch.object(GitHubIntegrationsWebhookEndpoint, "get_secret", return_value=None)
+    def test_missing_secret_emits_hmac_failure_metric(
+        self, mock_get_secret: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        self.client.post(
+            path=self.url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=2b116e7c1f7510b62727673b0f9acc0db951263a",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        mock_metrics.incr.assert_called_with(
+            "github.webhook.hmac_failure",
+            tags={"reason": "missing_secret"},
+            sample_rate=1.0,
+        )
+
     def test_missing_signature_event(self) -> None:
         response = self.client.post(
             path=self.url,

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -91,6 +91,14 @@ def test_uses_shared_secret_missing_secret() -> None:
 
 
 @pytest.mark.django_db
+@patch("sentry.seer.signed_seer_api.metrics")
+def test_missing_secret_emits_unsigned_request_metric(mock_metrics: MagicMock) -> None:
+    run_test_case(shared_secret="")
+
+    mock_metrics.incr.assert_any_call("seer.unsigned_request", sample_rate=1.0)
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("path", [PATH, f"{PATH}?dogs=great"])
 @patch("sentry.seer.signed_seer_api.metrics.timer")
 def test_times_request(mock_metrics_timer: MagicMock, path: str) -> None:


### PR DESCRIPTION
Adds two low-volume canary metrics to make auth misconfigurations immediately visible in dashboards and alerting.

**`github.webhook.hmac_failure`** (with `reason` tag) is emitted when `GitHubIntegrationsWebhookEndpoint.handle()` returns 401. The two possible reasons are `missing_secret` (no webhook secret configured) and `invalid_signature` (HMAC mismatch). Previously, detecting these failures required scraping error logs or relying on downstream gaps in processing.

**`seer.unsigned_request`** is emitted in `sign_with_seer_secret()` when `SEER_API_SHARED_SECRET` is not set. This existing code path already logged a warning; the metric makes it alertable.

Both are emitted at `sample_rate=1.0` since the failure paths are expected to be very low volume.

Refs https://linear.app/getsentry/issue/CW-1014
Refs https://linear.app/getsentry/issue/CW-1015