### PR TITLE
fix(tests): Use relative date in EAP escalating test frozen time

### DIFF
--- a/tests/sentry/issues/escalating/test_escalating.py
+++ b/tests/sentry/issues/escalating/test_escalating.py
@@ -345,7 +345,9 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
 
 
 class TestEAPIsEscalating(TestCase, SnubaTestCase):
-    FROZEN_TIME = datetime(2026, 2, 11, 6, 30, 0, tzinfo=timezone.utc)
+    FROZEN_TIME = (datetime.now(timezone.utc) - timedelta(hours=24)).replace(
+        hour=6, minute=30, second=0, microsecond=0
+    )
 
     def _event_timestamp(self, hours_ago: int = 0) -> float:
         return (


### PR DESCRIPTION
The `TestEAPIsEscalating` class used a hardcoded `FROZEN_TIME` of `datetime(2026, 2, 11, ...)`. As of March 13 this date is exactly 30 days old, exceeding Snuba's retention window. Events stored via `store_events_to_snuba_and_eap()` were silently dropped by Snuba, causing all 5 tests to return 0 results.

The fix replaces the hardcoded absolute date with a relative one (`datetime.now() - 24h`), matching the `TIME_YESTERDAY` pattern already used by the other test classes in the same file. This ensures the frozen time is always ~1 day old and will never hit the retention cutoff.