### PR TITLE
fix(autofix): Reset sections on re-run

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -371,8 +371,10 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
     // A step marker means this block starts a new section.
     // Finalize the previous section and start a fresh one.
     const metadata = message.metadata;
-    if (metadata?.step) {
-      finalizeSection();
+    if (defined(metadata) && defined(metadata.step)) {
+      if (metadata.step !== section.step) {
+        finalizeSection();
+      }
 
       section = {
         step: metadata.step,


### PR DESCRIPTION
When the same step is re-run, the contents from the previous run should be discarded to make for a cleaner loading state.