### PR TITLE
chore: Add toggle for context engine enable/disable

### DIFF
--- a/static/app/views/seerExplorer/explorerPanel.spec.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.spec.tsx
@@ -213,8 +213,8 @@ describe('ExplorerPanel', () => {
           switchToRun: jest.fn(),
           respondToUserInput: jest.fn(),
           createPR: jest.fn(),
-          overrideCeEnable: true,
-          setOverrideCeEnable: jest.fn(),
+          overrideCtxEngEnable: true,
+          setOverrideCtxEngEnable: jest.fn(),
         });
 
       renderWithPanelContext(<ExplorerPanel />, true, {organization});
@@ -277,8 +277,8 @@ describe('ExplorerPanel', () => {
         respondToUserInput: jest.fn(),
         switchToRun: jest.fn(),
         createPR: jest.fn(),
-        overrideCeEnable: true,
-        setOverrideCeEnable: jest.fn(),
+        overrideCtxEngEnable: true,
+        setOverrideCtxEngEnable: jest.fn(),
       });
 
       renderWithPanelContext(<ExplorerPanel />, true, {organization});

--- a/static/app/views/seerExplorer/explorerPanel.spec.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.spec.tsx
@@ -213,6 +213,8 @@ describe('ExplorerPanel', () => {
           switchToRun: jest.fn(),
           respondToUserInput: jest.fn(),
           createPR: jest.fn(),
+          overrideCeEnable: true,
+          setOverrideCeEnable: jest.fn(),
         });
 
       renderWithPanelContext(<ExplorerPanel />, true, {organization});
@@ -275,6 +277,8 @@ describe('ExplorerPanel', () => {
         respondToUserInput: jest.fn(),
         switchToRun: jest.fn(),
         createPR: jest.fn(),
+        overrideCeEnable: true,
+        setOverrideCeEnable: jest.fn(),
       });
 
       renderWithPanelContext(<ExplorerPanel />, true, {organization});
@@ -518,6 +522,102 @@ describe('ExplorerPanel', () => {
       expect(textarea).toHaveAttribute(
         'placeholder',
         'Type your message or / command and press Enter ↵'
+      );
+    });
+  });
+
+  describe('Context Engine Toggle', () => {
+    const orgWithFlag = OrganizationFixture({
+      features: ['seer-explorer', 'seer-explorer-context-engine-fe-override-ui-flag'],
+      hideAiFeatures: false,
+      openMembership: true,
+    });
+
+    it('does not render the toggle when the feature flag is disabled', () => {
+      renderWithPanelContext(<ExplorerPanel />, true, {organization});
+
+      expect(
+        screen.queryByRole('checkbox', {name: 'Toggle context engine'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the toggle when the feature flag is enabled', () => {
+      renderWithPanelContext(<ExplorerPanel />, true, {organization: orgWithFlag});
+
+      expect(
+        screen.getByRole('checkbox', {name: 'Toggle context engine'})
+      ).toBeInTheDocument();
+    });
+
+    it('sends override_ce_enable: true by default', async () => {
+      const postMock = MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithFlag.slug}/seer/explorer-chat/`,
+        method: 'POST',
+        body: {run_id: 'new-run', message: {}},
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithFlag.slug}/seer/explorer-chat/new-run/`,
+        method: 'GET',
+        body: {
+          session: {
+            blocks: [],
+            run_id: 'new-run',
+            status: 'completed',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        },
+      });
+
+      renderWithPanelContext(<ExplorerPanel />, true, {organization: orgWithFlag});
+
+      const textarea = screen.getByTestId('seer-explorer-input');
+      await userEvent.type(textarea, 'Test message');
+      await userEvent.keyboard('{Enter}');
+
+      expect(postMock).toHaveBeenCalledWith(
+        `/organizations/${orgWithFlag.slug}/seer/explorer-chat/`,
+        expect.objectContaining({
+          data: expect.objectContaining({override_ce_enable: true}),
+        })
+      );
+    });
+
+    it('sends override_ce_enable: false after toggling off', async () => {
+      const postMock = MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithFlag.slug}/seer/explorer-chat/`,
+        method: 'POST',
+        body: {run_id: 'new-run', message: {}},
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithFlag.slug}/seer/explorer-chat/new-run/`,
+        method: 'GET',
+        body: {
+          session: {
+            blocks: [],
+            run_id: 'new-run',
+            status: 'completed',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        },
+      });
+
+      renderWithPanelContext(<ExplorerPanel />, true, {organization: orgWithFlag});
+
+      await userEvent.click(
+        screen.getByRole('checkbox', {name: 'Toggle context engine'})
+      );
+
+      const textarea = screen.getByTestId('seer-explorer-input');
+      await userEvent.type(textarea, 'Test message');
+      await userEvent.keyboard('{Enter}');
+
+      expect(postMock).toHaveBeenCalledWith(
+        `/organizations/${orgWithFlag.slug}/seer/explorer-chat/`,
+        expect.objectContaining({
+          data: expect.objectContaining({override_ce_enable: false}),
+        })
       );
     });
   });

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -100,6 +100,8 @@ export function ExplorerPanel() {
     switchToRun,
     respondToUserInput,
     createPR,
+    overrideCeEnable,
+    setOverrideCeEnable,
   } = useSeerExplorer();
 
   const copySessionEnabled = Boolean(runId && organization?.slug);
@@ -620,6 +622,13 @@ export function ExplorerPanel() {
         onSizeToggleClick={handleSizeToggle}
         panelSize={panelSize}
         sessionHistoryButtonRef={sessionHistoryButtonRef}
+        overrideCeEnable={overrideCeEnable}
+        onOverrideCeEnableToggle={() => setOverrideCeEnable(v => !v)}
+        showContextEngineToggle={
+          !!organization?.features.includes(
+            'seer-explorer-context-engine-fe-override-ui-flag'
+          )
+        }
       />
       {menu}
       <BlocksContainer ref={scrollContainerRef} onClick={handlePanelBackgroundClick}>

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -100,8 +100,8 @@ export function ExplorerPanel() {
     switchToRun,
     respondToUserInput,
     createPR,
-    overrideCeEnable,
-    setOverrideCeEnable,
+    overrideCtxEngEnable,
+    setOverrideCtxEngEnable,
   } = useSeerExplorer();
 
   const copySessionEnabled = Boolean(runId && organization?.slug);
@@ -622,8 +622,8 @@ export function ExplorerPanel() {
         onSizeToggleClick={handleSizeToggle}
         panelSize={panelSize}
         sessionHistoryButtonRef={sessionHistoryButtonRef}
-        overrideCeEnable={overrideCeEnable}
-        onOverrideCeEnableToggle={() => setOverrideCeEnable(v => !v)}
+        overrideCtxEngEnable={overrideCtxEngEnable}
+        onOverrideCtxEngEnableToggle={() => setOverrideCtxEngEnable(v => !v)}
         showContextEngineToggle={
           !!organization?.features.includes(
             'seer-explorer-context-engine-fe-override-ui-flag'

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -110,6 +110,7 @@ export const useSeerExplorer = () => {
   const organization = useOrganization({allowNull: true});
   const orgSlug = organization?.slug;
   const captureAsciiSnapshot = useAsciiSnapshot();
+  const [overrideCeEnable, setOverrideCeEnable] = useState<boolean>(true);
 
   const [runId, setRunId] = useSessionStorage<number | null>(
     'seer-explorer-run-id',
@@ -252,6 +253,7 @@ export const useSeerExplorer = () => {
             query,
             insert_index: calculatedInsertIndex,
             on_page_context: screenshot,
+            override_ce_enable: overrideCeEnable,
           },
         })) as SeerExplorerChatResponse;
 
@@ -289,6 +291,7 @@ export const useSeerExplorer = () => {
       setRunId,
       getPageReferrer,
       organization,
+      overrideCeEnable,
     ]
   );
 
@@ -581,5 +584,7 @@ export const useSeerExplorer = () => {
     clearWasJustInterrupted: useCallback(() => setWasJustInterrupted(false), []),
     respondToUserInput,
     createPR,
+    overrideCeEnable,
+    setOverrideCeEnable,
   };
 };

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -110,7 +110,7 @@ export const useSeerExplorer = () => {
   const organization = useOrganization({allowNull: true});
   const orgSlug = organization?.slug;
   const captureAsciiSnapshot = useAsciiSnapshot();
-  const [overrideCeEnable, setOverrideCeEnable] = useState<boolean>(true);
+  const [overrideCtxEngEnable, setOverrideCtxEngEnable] = useState<boolean>(true);
 
   const [runId, setRunId] = useSessionStorage<number | null>(
     'seer-explorer-run-id',
@@ -253,7 +253,7 @@ export const useSeerExplorer = () => {
             query,
             insert_index: calculatedInsertIndex,
             on_page_context: screenshot,
-            override_ce_enable: overrideCeEnable,
+            override_ce_enable: overrideCtxEngEnable,
           },
         })) as SeerExplorerChatResponse;
 
@@ -291,7 +291,7 @@ export const useSeerExplorer = () => {
       setRunId,
       getPageReferrer,
       organization,
-      overrideCeEnable,
+      overrideCtxEngEnable,
     ]
   );
 
@@ -584,7 +584,7 @@ export const useSeerExplorer = () => {
     clearWasJustInterrupted: useCallback(() => setWasJustInterrupted(false), []),
     respondToUserInput,
     createPR,
-    overrideCeEnable,
-    setOverrideCeEnable,
+    overrideCtxEngEnable,
+    setOverrideCtxEngEnable,
   };
 };

--- a/static/app/views/seerExplorer/topBar.tsx
+++ b/static/app/views/seerExplorer/topBar.tsx
@@ -33,10 +33,10 @@ interface TopBarProps {
   onCopySessionClick: () => void;
   onFeedbackClick: () => void;
   onNewChatClick: () => void;
-  onOverrideCeEnableToggle: () => void;
+  onOverrideCtxEngEnableToggle: () => void;
   onSessionHistoryClick: (buttonRef: React.RefObject<HTMLElement | null>) => void;
   onSizeToggleClick: () => void;
-  overrideCeEnable: boolean;
+  overrideCtxEngEnable: boolean;
   panelSize: 'max' | 'med';
   sessionHistoryButtonRef: React.RefObject<HTMLButtonElement | null>;
   showContextEngineToggle: boolean;
@@ -54,8 +54,8 @@ export function TopBar({
   onCopySessionClick,
   onCopyLinkClick,
   onSizeToggleClick,
-  onOverrideCeEnableToggle,
-  overrideCeEnable,
+  onOverrideCtxEngEnableToggle,
+  overrideCtxEngEnable,
   showContextEngineToggle,
   panelSize,
   isCopySessionEnabled,
@@ -115,7 +115,7 @@ export function TopBar({
         {showContextEngineToggle && (
           <Tooltip
             title={
-              overrideCeEnable
+              overrideCtxEngEnable
                 ? t('Context engine enabled (click to disable)')
                 : t('Context engine disabled (click to enable)')
             }
@@ -123,8 +123,8 @@ export function TopBar({
             <ContextEngineToggle>
               <Switch
                 size="sm"
-                checked={overrideCeEnable}
-                onChange={onOverrideCeEnableToggle}
+                checked={overrideCtxEngEnable}
+                onChange={onOverrideCtxEngEnableToggle}
                 aria-label={t('Toggle context engine')}
               />
               <Text size="sm" variant="muted">

--- a/static/app/views/seerExplorer/topBar.tsx
+++ b/static/app/views/seerExplorer/topBar.tsx
@@ -120,7 +120,7 @@ export function TopBar({
                 : t('Context engine disabled (click to enable)')
             }
           >
-            <ContextEngineToggle>
+            <Flex align="center" gap="xs" padding="xs sm" height="100%">
               <Switch
                 size="sm"
                 checked={overrideCtxEngEnable}
@@ -130,7 +130,7 @@ export function TopBar({
               <Text size="sm" variant="muted">
                 {t('CE')}
               </Text>
-            </ContextEngineToggle>
+            </Flex>
           </Tooltip>
         )}
       </Flex>
@@ -202,19 +202,5 @@ const SessionHistoryButtonWrapper = styled('div')<{isSelected: boolean}>`
       p.isSelected
         ? p.theme.tokens.interactive.transparent.neutral.background.active
         : 'transparent'};
-  }
-`;
-
-const ContextEngineToggle = styled('label')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
-  cursor: pointer;
-  user-select: none;
-
-  &:hover {
-    background-color: ${p =>
-      p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
 `;

--- a/static/app/views/seerExplorer/topBar.tsx
+++ b/static/app/views/seerExplorer/topBar.tsx
@@ -3,6 +3,9 @@ import {AnimatePresence, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {Switch} from '@sentry/scraps/switch';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {
   IconAdd,
@@ -30,10 +33,13 @@ interface TopBarProps {
   onCopySessionClick: () => void;
   onFeedbackClick: () => void;
   onNewChatClick: () => void;
+  onOverrideCeEnableToggle: () => void;
   onSessionHistoryClick: (buttonRef: React.RefObject<HTMLElement | null>) => void;
   onSizeToggleClick: () => void;
+  overrideCeEnable: boolean;
   panelSize: 'max' | 'med';
   sessionHistoryButtonRef: React.RefObject<HTMLButtonElement | null>;
+  showContextEngineToggle: boolean;
 }
 
 export function TopBar({
@@ -48,6 +54,9 @@ export function TopBar({
   onCopySessionClick,
   onCopyLinkClick,
   onSizeToggleClick,
+  onOverrideCeEnableToggle,
+  overrideCeEnable,
+  showContextEngineToggle,
   panelSize,
   isCopySessionEnabled,
   isCopyLinkEnabled,
@@ -103,6 +112,27 @@ export function TopBar({
           tooltipProps={{title: t('Copy link to current chat and web page')}}
           disabled={!isCopyLinkEnabled}
         />
+        {showContextEngineToggle && (
+          <Tooltip
+            title={
+              overrideCeEnable
+                ? t('Context engine enabled (click to disable)')
+                : t('Context engine disabled (click to enable)')
+            }
+          >
+            <ContextEngineToggle>
+              <Switch
+                size="sm"
+                checked={overrideCeEnable}
+                onChange={onOverrideCeEnableToggle}
+                aria-label={t('Toggle context engine')}
+              />
+              <Text size="sm" variant="muted">
+                {t('CE')}
+              </Text>
+            </ContextEngineToggle>
+          </Tooltip>
+        )}
       </Flex>
       <AnimatePresence initial={false}>
         {!isEmptyState && (
@@ -172,5 +202,19 @@ const SessionHistoryButtonWrapper = styled('div')<{isSelected: boolean}>`
       p.isSelected
         ? p.theme.tokens.interactive.transparent.neutral.background.active
         : 'transparent'};
+  }
+`;
+
+const ContextEngineToggle = styled('label')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    background-color: ${p =>
+      p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
 `;


### PR DESCRIPTION
Adds a toggle in the chat toolbar to allow AI/ML team to enable or
disable context engine
<img width="405" height="135" alt="Screenshot 2026-03-13 at 12 36 09 PM" src="https://github.com/user-attachments/assets/644c40a4-05d7-4a6f-8d5b-3f8c876b1aea" />

