### PR TITLE
feat(attributes): Add batch attribute validation endpoint for trace items - Round 2

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -762,7 +762,7 @@ class OrganizationTraceItemAttributeValidateSerializer(serializers.Serializer):
     )
 
 
-def coarsen_type(search_type: constants.SearchType) -> str:
+def serialize_type(search_type: constants.SearchType) -> str:
     proto_type = constants.TYPE_MAP.get(search_type)
     if proto_type == constants.STRING:
         return "string"
@@ -812,7 +812,7 @@ class OrganizationTraceItemAttributeValidateEndpoint(OrganizationTraceItemAttrib
                 resolved, _context = resolver.resolve_attribute(attr_name)
                 results[attr_name] = {
                     "valid": True,
-                    "type": coarsen_type(resolved.search_type),
+                    "type": serialize_type(resolved.search_type),
                 }
             except InvalidSearchQuery as e:
                 results[attr_name] = {

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -28,6 +28,7 @@ from sentry.api.serializers import serialize
 from sentry.api.utils import handle_query_errors
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.models.release import Release
 from sentry.models.releaseenvironment import ReleaseEnvironment
@@ -747,3 +748,73 @@ def adjust_start_end_window(start_date: datetime, end_date: datetime) -> tuple[d
     start_date = start_date.replace(hour=0, minute=0, second=0, microsecond=0)
     end_date = end_date.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
     return start_date, end_date
+
+
+class OrganizationTraceItemAttributeValidateSerializer(serializers.Serializer):
+    itemType = serializers.ChoiceField(
+        [e.value for e in SupportedTraceItemType], required=True, source="item_type"
+    )
+    attributes = serializers.ListField(
+        child=serializers.CharField(max_length=300),
+        min_length=1,
+        max_length=100,
+        required=True,
+    )
+
+
+def coarsen_type(search_type: constants.SearchType) -> str:
+    proto_type = constants.TYPE_MAP.get(search_type)
+    if proto_type == constants.STRING:
+        return "string"
+    if proto_type == constants.BOOLEAN:
+        return "boolean"
+    # DOUBLE, INT, or anything else numeric
+    return "number"
+
+
+@cell_silo_endpoint
+class OrganizationTraceItemAttributeValidateEndpoint(OrganizationTraceItemAttributesEndpointBase):
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.DATA_BROWSING
+
+    def post(self, request: Request, organization: Organization) -> Response:
+        if not self.has_feature(organization, request):
+            return Response(status=404)
+
+        serializer = OrganizationTraceItemAttributeValidateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        validated = serializer.validated_data
+        item_type = SupportedTraceItemType(validated["item_type"])
+        attribute_names: list[str] = validated["attributes"]
+
+        try:
+            snuba_params = self.get_snuba_params(request, organization)
+        except NoProjects:
+            return Response({"attributes": {}})
+
+        definitions = get_column_definitions(item_type)
+        resolver = SearchResolver(
+            params=snuba_params,
+            config=SearchResolverConfig(),
+            definitions=definitions,
+        )
+
+        results: dict[str, dict[str, Any]] = {}
+        for attr_name in attribute_names:
+            try:
+                resolved, _context = resolver.resolve_attribute(attr_name)
+                results[attr_name] = {
+                    "valid": True,
+                    "type": coarsen_type(resolved.search_type),
+                }
+            except InvalidSearchQuery as e:
+                results[attr_name] = {
+                    "valid": False,
+                    "error": str(e),
+                }
+
+        return Response({"attributes": results})

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -796,7 +796,10 @@ class OrganizationTraceItemAttributeValidateEndpoint(OrganizationTraceItemAttrib
         except NoProjects:
             return Response({"attributes": {}})
 
-        definitions = get_column_definitions(item_type)
+        try:
+            definitions = get_column_definitions(item_type)
+        except ValueError:
+            return Response({"detail": f"Unsupported item type: {item_type.value}"}, status=400)
         resolver = SearchResolver(
             params=snuba_params,
             config=SearchResolverConfig(),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -40,6 +40,7 @@ from sentry.api.endpoints.organization_sampling_project_span_counts import (
 from sentry.api.endpoints.organization_stats_summary import OrganizationStatsSummaryEndpoint
 from sentry.api.endpoints.organization_trace_item_attributes import (
     OrganizationTraceItemAttributesEndpoint,
+    OrganizationTraceItemAttributeValidateEndpoint,
     OrganizationTraceItemAttributeValuesEndpoint,
 )
 from sentry.api.endpoints.organization_trace_item_attributes_ranked import (
@@ -1741,6 +1742,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/trace-items/attributes/$",
         OrganizationTraceItemAttributesEndpoint.as_view(),
         name="sentry-api-0-organization-trace-item-attributes",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/trace-items/attributes/validate/$",
+        OrganizationTraceItemAttributeValidateEndpoint.as_view(),
+        name="sentry-api-0-organization-trace-item-attributes-validate",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/trace-items/attributes/(?P<key>[^/]+)/values/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -582,6 +582,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/trace-items/attributes/'
   | '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/'
   | '/organizations/$organizationIdOrSlug/trace-items/attributes/ranked/'
+  | '/organizations/$organizationIdOrSlug/trace-items/attributes/validate/'
   | '/organizations/$organizationIdOrSlug/trace-items/stats/'
   | '/organizations/$organizationIdOrSlug/trace-logs/'
   | '/organizations/$organizationIdOrSlug/trace-meta/$traceId/'

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -2164,6 +2164,16 @@ class OrganizationTraceItemAttributeValidateEndpointTest(APITestCase, SnubaTestC
         )
         assert response.status_code == 400
 
+    def test_unsupported_item_type(self):
+        response = self.do_request(
+            payload={
+                "itemType": "uptime_results",
+                "attributes": ["some.attr"],
+            },
+        )
+        assert response.status_code == 400
+        assert "Unsupported item type" in response.data["detail"]
+
     def test_well_known_attributes(self):
         response = self.do_request(
             payload={

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -2096,3 +2096,167 @@ class OrganizationTraceItemAttributeValuesEndpointTraceMetricsTest(
         values = {item["value"] for item in response.data}
         assert "GET" in values
         assert "POST" in values
+
+
+class OrganizationTraceItemAttributeValidateEndpointTest(APITestCase, SnubaTestCase, SpanTestCase):
+    viewname = "sentry-api-0-organization-trace-item-attributes-validate"
+    feature_flags = {
+        "organizations:visibility-explore-view": True,
+    }
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.project = self.create_project()
+
+    def do_request(self, payload=None, features=None, **kwargs):
+        if features is None:
+            features = self.feature_flags
+
+        with self.feature(features):
+            url = reverse(
+                self.viewname,
+                kwargs={"organization_id_or_slug": self.organization.slug},
+            )
+            return self.client.post(url, payload, format="json", **kwargs)
+
+    def test_no_feature(self):
+        response = self.do_request(
+            payload={
+                "itemType": "spans",
+                "attributes": ["span.duration"],
+            },
+            features={},
+        )
+        assert response.status_code == 404
+
+    def test_missing_item_type(self):
+        response = self.do_request(
+            payload={
+                "attributes": ["span.duration"],
+            },
+        )
+        assert response.status_code == 400
+
+    def test_missing_attributes(self):
+        response = self.do_request(
+            payload={
+                "itemType": "spans",
+            },
+        )
+        assert response.status_code == 400
+
+    def test_empty_attributes_list(self):
+        response = self.do_request(
+            payload={
+                "itemType": "spans",
+                "attributes": [],
+            },
+        )
+        assert response.status_code == 400
+
+    def test_too_many_attributes(self):
+        response = self.do_request(
+            payload={
+                "itemType": "spans",
+                "attributes": [f"attr{i}" for i in range(101)],
+            },
+        )
+        assert response.status_code == 400
+
+    def test_well_known_attributes(self):
+        response = self.do_request(
+            payload={
+                "itemType": "spans",
+                "attributes": ["span.duration"],
+            },
+        )
+        assert response.status_code == 200
+        attr = response.data["attributes"]["span.duration"]
+        assert attr["valid"] is True
+        assert attr["type"] == "number"
+
+    def test_virtual_context_attributes(self):
+        response = self.do_request(
+            payload={
+                "itemType": "spans",
+                "attributes": ["project"],
+            },
+        )
+        assert response.status_code == 200
+        attr = response.data["attributes"]["project"]
+        assert attr["valid"] is True
+        assert attr["type"] == "string"
+
+    def test_user_tags(self):
+        response = self.do_request(
+            payload={
+                "itemType": "spans",
+                "attributes": [
+                    "my.custom.tag",
+                    "tags[x,string]",
+                    "tags[numberAttr,number]",
+                    "tags[booleanAttr,boolean]",
+                ],
+            },
+        )
+        assert response.status_code == 200
+        tag1 = response.data["attributes"]["my.custom.tag"]
+        assert tag1["valid"] is True
+        assert tag1["type"] == "string"
+
+        tag2 = response.data["attributes"]["tags[x,string]"]
+        assert tag2["valid"] is True
+        assert tag2["type"] == "string"
+
+        tag3 = response.data["attributes"]["tags[numberAttr,number]"]
+        assert tag3["valid"] is True
+        assert tag3["type"] == "number"
+
+        tag4 = response.data["attributes"]["tags[booleanAttr,boolean]"]
+        assert tag4["valid"] is True
+        assert tag4["type"] == "boolean"
+
+    def test_invalid_attributes(self):
+        long_attr = "a" * 201
+        response = self.do_request(
+            payload={
+                "itemType": "spans",
+                "attributes": [long_attr, "tags[foo,faketype]"],
+            },
+        )
+        assert response.status_code == 200
+
+        assert response.data["attributes"][long_attr]["valid"] is False
+        assert "error" in response.data["attributes"][long_attr]
+
+        assert response.data["attributes"]["tags[foo,faketype]"]["valid"] is False
+        assert "error" in response.data["attributes"]["tags[foo,faketype]"]
+
+    def test_mixed_valid_and_invalid(self):
+        long_attr = "a" * 201
+        response = self.do_request(
+            payload={
+                "itemType": "spans",
+                "attributes": [
+                    "span.duration",
+                    "project",
+                    "my.custom.tag",
+                    long_attr,
+                ],
+            },
+        )
+        assert response.status_code == 200
+        attrs = response.data["attributes"]
+
+        assert attrs["span.duration"]["valid"] is True
+        assert attrs["span.duration"]["type"] == "number"
+
+        assert attrs["project"]["valid"] is True
+        assert attrs["project"]["type"] == "string"
+
+        assert attrs["my.custom.tag"]["valid"] is True
+        assert attrs["my.custom.tag"]["type"] == "string"
+
+        assert attrs[long_attr]["valid"] is False
+        assert "error" in attrs[long_attr]


### PR DESCRIPTION
Adds a new POST endpoint at `/api/0/organizations/{org}/trace-items/attributes/validate/` that accepts a list of attribute names and an item type, then returns per-attribute validity and type information.

This enables pre-flight validation for callers that need to check whether a set of attribute names are valid before using them in queries, without having to look them up one-by-one or list all attributes.

The endpoint uses the existing `SearchResolver.resolve_attribute()` for validation and `constants.TYPE_MAP` to coarsen internal search types into `"string"`, `"number"`, or `"boolean"`. Request body is capped at 100 attributes.