### PR TITLE
test(navigation): Use async assertions in collapse/expand sidebar test

### DIFF
--- a/static/app/views/navigation/index.spec.tsx
+++ b/static/app/views/navigation/index.spec.tsx
@@ -257,13 +257,17 @@ describe('Navigation', () => {
 
         await userEvent.click(screen.getByRole('button', {name: 'Collapse'}));
 
-        expect(screen.getByTestId('collapsed-secondary-sidebar')).toBeInTheDocument();
+        expect(
+          await screen.findByTestId('collapsed-secondary-sidebar')
+        ).toBeInTheDocument();
 
         await userEvent.click(screen.getByRole('button', {name: 'Expand'}));
 
-        expect(
-          screen.queryByTestId('collapsed-secondary-sidebar')
-        ).not.toBeInTheDocument();
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId('collapsed-secondary-sidebar')
+          ).not.toBeInTheDocument();
+        });
       });
 
       it('remembers collapsed state', async () => {


### PR DESCRIPTION
Change nav sidebar test to use async wait for removal.

It appears that this test only fails in CI, so I'm going to re-run it here a couple of times to attempt and confirm it resolves the flaky failures