### PR TITLE
fix(auth): Block token creation/modification during impersonation

### DIFF
--- a/src/sentry/api/endpoints/api_token_details.py
+++ b/src/sentry/api/endpoints/api_token_details.py
@@ -12,7 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.endpoints.api_tokens import get_appropriate_user_id
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import SentryIsAuthenticated
+from sentry.api.permissions import DisallowImpersonatedTokenCreation, SentryIsAuthenticated
 from sentry.api.serializers import serialize
 from sentry.models.apitoken import ApiToken
 
@@ -31,7 +31,7 @@ class ApiTokenDetailsEndpoint(Endpoint):
         "DELETE": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.SECURITY
-    permission_classes = (SentryIsAuthenticated,)
+    permission_classes = (SentryIsAuthenticated, DisallowImpersonatedTokenCreation)
 
     def convert_args(self, request: Request, token_id: int, *args, **kwargs):
         user_id = get_appropriate_user_id(request=request)

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -15,7 +15,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import SentryIsAuthenticated
+from sentry.api.permissions import DisallowImpersonatedTokenCreation, SentryIsAuthenticated
 from sentry.api.serializers import serialize
 from sentry.auth.elevated_mode import has_elevated_mode
 from sentry.hybridcloud.models.outbox import outbox_context
@@ -65,7 +65,7 @@ class ApiTokensEndpoint(Endpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = (SessionNoAuthTokenAuthentication,)
-    permission_classes = (SentryIsAuthenticated,)
+    permission_classes = (SentryIsAuthenticated, DisallowImpersonatedTokenCreation)
 
     @method_decorator(never_cache)
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/organization_auth_token_details.py
+++ b/src/sentry/api/endpoints/organization_auth_token_details.py
@@ -10,6 +10,7 @@ from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrgAuthTokenPermission
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.permissions import DisallowImpersonatedTokenCreation
 from sentry.api.serializers import serialize
 from sentry.models.orgauthtoken import MAX_NAME_LENGTH, OrgAuthToken
 from sentry.organizations.services.organization.model import RpcOrganization
@@ -24,7 +25,7 @@ class OrganizationAuthTokenDetailsEndpoint(ControlSiloOrganizationEndpoint):
     }
     owner = ApiOwner.ENTERPRISE
     authentication_classes = (SessionNoAuthTokenAuthentication,)
-    permission_classes = (OrgAuthTokenPermission,)
+    permission_classes = (OrgAuthTokenPermission, DisallowImpersonatedTokenCreation)
 
     def convert_args(self, request: Request, token_id, *args, **kwargs):
         args, kwargs = super().convert_args(request, *args, **kwargs)

--- a/src/sentry/api/endpoints/organization_auth_tokens.py
+++ b/src/sentry/api/endpoints/organization_auth_tokens.py
@@ -16,6 +16,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrgAuthTokenPermission
+from sentry.api.permissions import DisallowImpersonatedTokenCreation
 from sentry.api.serializers import serialize
 from sentry.api.utils import generate_locality_url
 from sentry.models.organizationmapping import OrganizationMapping
@@ -43,7 +44,7 @@ class OrganizationAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
     }
     owner = ApiOwner.ENTERPRISE
     authentication_classes = (SessionNoAuthTokenAuthentication,)
-    permission_classes = (OrgAuthTokenPermission,)
+    permission_classes = (OrgAuthTokenPermission, DisallowImpersonatedTokenCreation)
 
     @method_decorator(never_cache)
     def get(

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -25,6 +26,8 @@ from sentry.organizations.services.organization import (
     organization_service,
 )
 from sentry.utils import auth
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from rest_framework.views import APIView
@@ -343,6 +346,30 @@ class DemoSafePermission(SentryPermission):
                 return False
 
         return super().has_object_permission(request, view, obj)
+
+
+class DisallowImpersonatedTokenCreation(BasePermission):
+    """
+    Blocks non-safe requests (POST, PUT, DELETE) during impersonation sessions.
+    Prevents creating/modifying/revoking tokens as another user.
+    """
+
+    def has_permission(self, request: Request, view: object) -> bool:
+        if request.method in SAFE_METHODS:
+            return True
+        actual_user = getattr(request, "actual_user", None)
+        if actual_user is not None:
+            logger.warning(
+                "impersonation.token_creation_blocked",
+                extra={
+                    "actual_user_id": actual_user.id,
+                    "impersonated_user_id": request.user.id,
+                    "method": request.method,
+                    "path": request.path,
+                },
+            )
+            return False
+        return True
 
 
 class SentryIsAuthenticated(IsAuthenticated):

--- a/src/sentry/releases/endpoints/project_releases_token.py
+++ b/src/sentry/releases/endpoints/project_releases_token.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, StrictProjectPermission
+from sentry.api.permissions import DisallowImpersonatedTokenCreation
 from sentry.models.options.project_option import ProjectOption
 from sentry.types.region import get_local_locality
 
@@ -40,7 +41,7 @@ class ProjectReleasesTokenEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.UNKNOWN,
         "POST": ApiPublishStatus.UNKNOWN,
     }
-    permission_classes = (StrictProjectPermission,)
+    permission_classes = (StrictProjectPermission, DisallowImpersonatedTokenCreation)
 
     def _regenerate_token(self, project):
         token = uuid1().hex
@@ -51,6 +52,9 @@ class ProjectReleasesTokenEndpoint(ProjectEndpoint):
         token = ProjectOption.objects.get_value(project, "sentry:release-token")
 
         if token is None:
+            # Block implicit token creation during impersonation. Return 404 not found instead of regenerating.
+            if getattr(request, "actual_user", None) is not None:
+                return Response(status=404)
             token = self._regenerate_token(project)
 
         return Response({"token": token, "webhookUrl": _get_webhook_url(project, "builtin", token)})

--- a/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_token_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_token_details.py
@@ -11,6 +11,7 @@ from sentry.analytics.events.sentry_app_installation_token_deleted import (
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
+from sentry.api.permissions import DisallowImpersonatedTokenCreation
 from sentry.models.apitoken import ApiToken
 from sentry.sentry_apps.api.bases.sentryapps import (
     SentryAppBaseEndpoint,
@@ -27,7 +28,7 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
     }
-    permission_classes = (SentryInternalAppTokenPermission,)
+    permission_classes = (SentryInternalAppTokenPermission, DisallowImpersonatedTokenCreation)
 
     def convert_args(self, request: Request, sentry_app_id_or_slug, api_token_id, *args, **kwargs):
         # get the sentry_app from the SentryAppBaseEndpoint class

--- a/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_tokens.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_tokens.py
@@ -7,6 +7,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import control_silo_endpoint
+from sentry.api.permissions import DisallowImpersonatedTokenCreation
 from sentry.api.serializers.models.apitoken import ApiTokenSerializer
 from sentry.exceptions import ApiTokenLimitError
 from sentry.models.apitoken import ApiToken
@@ -31,7 +32,7 @@ class SentryInternalAppTokensEndpoint(SentryAppBaseEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = (SessionNoAuthTokenAuthentication,)
-    permission_classes = (SentryInternalAppTokenPermission,)
+    permission_classes = (SentryInternalAppTokenPermission, DisallowImpersonatedTokenCreation)
 
     def get(self, request: Request, sentry_app) -> Response:
         if not sentry_app.is_internal:

--- a/src/sentry/testutils/helpers/impersonation.py
+++ b/src/sentry/testutils/helpers/impersonation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from django.contrib.auth.models import AnonymousUser
+
+from sentry.api.base import Endpoint
+from sentry.users.models.user import User
+
+
+def simulate_impersonation(impersonator: User | AnonymousUser) -> Any:
+    """
+    Context manager that patches Endpoint.initialize_request to set actual_user.
+
+    Usage::
+
+        with simulate_impersonation(impersonator_user):
+            response = self.client.post(url, data={...})
+        assert response.status_code == 403
+    """
+    original = Endpoint.initialize_request
+
+    def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+        drf_request = original(endpoint_self, request, *args, **kwargs)
+        drf_request.actual_user = impersonator  # type: ignore[attr-defined]
+        return drf_request
+
+    return patch.object(Endpoint, "initialize_request", patched)

--- a/tests/sentry/api/endpoints/test_api_token_details.py
+++ b/tests/sentry/api/endpoints/test_api_token_details.py
@@ -1,11 +1,9 @@
-from typing import Any
-from unittest.mock import patch
-
 from django.urls import reverse
 from rest_framework import status
 
 from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.impersonation import simulate_impersonation
 from sentry.testutils.silo import control_silo_test
 
 
@@ -186,23 +184,11 @@ class ApiTokenDetailsImpersonationTest(APITestCase):
         self.impersonator = self.create_user(is_superuser=True)
         self.target_user = self.create_user()
 
-    def _simulate_impersonation(self) -> Any:
-        from sentry.api.base import Endpoint
-
-        original = Endpoint.initialize_request
-
-        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
-            drf_request = original(endpoint_self, request, *args, **kwargs)
-            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
-            return drf_request
-
-        return patch.object(Endpoint, "initialize_request", patched)
-
     def test_impersonated_put_blocked(self) -> None:
         token = ApiToken.objects.create(user=self.target_user, name="token 1")
         url = reverse("sentry-api-0-api-token-details", args=[token.id])
         self.login_as(self.target_user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.put(url, data={"name": "renamed"})
         assert response.status_code == status.HTTP_403_FORBIDDEN
         token.refresh_from_db()
@@ -212,7 +198,7 @@ class ApiTokenDetailsImpersonationTest(APITestCase):
         token = ApiToken.objects.create(user=self.target_user, name="token 1")
         url = reverse("sentry-api-0-api-token-details", args=[token.id])
         self.login_as(self.target_user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.delete(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert ApiToken.objects.filter(id=token.id).exists()
@@ -221,6 +207,6 @@ class ApiTokenDetailsImpersonationTest(APITestCase):
         token = ApiToken.objects.create(user=self.target_user, name="token 1")
         url = reverse("sentry-api-0-api-token-details", args=[token.id])
         self.login_as(self.target_user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK

--- a/tests/sentry/api/endpoints/test_api_token_details.py
+++ b/tests/sentry/api/endpoints/test_api_token_details.py
@@ -1,3 +1,7 @@
+from typing import Any
+from unittest.mock import patch
+
+from django.urls import reverse
 from rest_framework import status
 
 from sentry.models.apitoken import ApiToken
@@ -174,3 +178,49 @@ class ApiTokenDeleteTest(APITestCase):
         self.get_error_response(
             token.id, qs_params={"userId": "abc"}, status_code=status.HTTP_404_NOT_FOUND
         )
+
+
+@control_silo_test
+class ApiTokenDetailsImpersonationTest(APITestCase):
+    def setUp(self) -> None:
+        self.impersonator = self.create_user(is_superuser=True)
+        self.target_user = self.create_user()
+
+    def _simulate_impersonation(self) -> Any:
+        from sentry.api.base import Endpoint
+
+        original = Endpoint.initialize_request
+
+        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+            drf_request = original(endpoint_self, request, *args, **kwargs)
+            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
+            return drf_request
+
+        return patch.object(Endpoint, "initialize_request", patched)
+
+    def test_impersonated_put_blocked(self) -> None:
+        token = ApiToken.objects.create(user=self.target_user, name="token 1")
+        url = reverse("sentry-api-0-api-token-details", args=[token.id])
+        self.login_as(self.target_user)
+        with self._simulate_impersonation():
+            response = self.client.put(url, data={"name": "renamed"})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        token.refresh_from_db()
+        assert token.name == "token 1"
+
+    def test_impersonated_delete_blocked(self) -> None:
+        token = ApiToken.objects.create(user=self.target_user, name="token 1")
+        url = reverse("sentry-api-0-api-token-details", args=[token.id])
+        self.login_as(self.target_user)
+        with self._simulate_impersonation():
+            response = self.client.delete(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert ApiToken.objects.filter(id=token.id).exists()
+
+    def test_impersonated_get_allowed(self) -> None:
+        token = ApiToken.objects.create(user=self.target_user, name="token 1")
+        url = reverse("sentry-api-0-api-token-details", args=[token.id])
+        self.login_as(self.target_user)
+        with self._simulate_impersonation():
+            response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -1,6 +1,4 @@
 from collections.abc import Generator
-from typing import Any
-from unittest.mock import patch
 
 from django.urls import reverse
 from pytest import fixture
@@ -8,6 +6,7 @@ from rest_framework import status
 
 from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.impersonation import simulate_impersonation
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
@@ -325,22 +324,9 @@ class ApiTokensImpersonationTest(APITestCase):
         self.impersonator = self.create_user(is_superuser=True)
         self.target_user = self.create_user()
 
-    def _simulate_impersonation(self) -> Any:
-        """Patch Endpoint.initialize_request to set actual_user, simulating ViewAs middleware."""
-        from sentry.api.base import Endpoint
-
-        original = Endpoint.initialize_request
-
-        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
-            drf_request = original(endpoint_self, request, *args, **kwargs)
-            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
-            return drf_request
-
-        return patch.object(Endpoint, "initialize_request", patched)
-
     def test_impersonated_post_blocked(self) -> None:
         self.login_as(self.target_user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.post(self.url, data={"scopes": ["event:read"]})
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert not ApiToken.objects.filter(user=self.target_user).exists()
@@ -348,7 +334,7 @@ class ApiTokensImpersonationTest(APITestCase):
     def test_impersonated_delete_blocked(self) -> None:
         token = ApiToken.objects.create(user=self.target_user)
         self.login_as(self.target_user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.delete(self.url, data={"tokenId": token.id})
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert ApiToken.objects.filter(id=token.id).exists()
@@ -356,7 +342,7 @@ class ApiTokensImpersonationTest(APITestCase):
     def test_impersonated_get_allowed(self) -> None:
         ApiToken.objects.create(user=self.target_user)
         self.login_as(self.target_user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
 

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -1,4 +1,6 @@
 from collections.abc import Generator
+from typing import Any
+from unittest.mock import patch
 
 from django.urls import reverse
 from pytest import fixture
@@ -313,3 +315,52 @@ class ApiTokensStaffTest(APITestCase):
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert ApiToken.objects.filter(id=self.user_token.id).exists()
         assert ApiToken.objects.filter(id=self.staff_token.id).exists()
+
+
+@control_silo_test
+class ApiTokensImpersonationTest(APITestCase):
+    url = reverse("sentry-api-0-api-tokens")
+
+    def setUp(self) -> None:
+        self.impersonator = self.create_user(is_superuser=True)
+        self.target_user = self.create_user()
+
+    def _simulate_impersonation(self) -> Any:
+        """Patch Endpoint.initialize_request to set actual_user, simulating ViewAs middleware."""
+        from sentry.api.base import Endpoint
+
+        original = Endpoint.initialize_request
+
+        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+            drf_request = original(endpoint_self, request, *args, **kwargs)
+            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
+            return drf_request
+
+        return patch.object(Endpoint, "initialize_request", patched)
+
+    def test_impersonated_post_blocked(self) -> None:
+        self.login_as(self.target_user)
+        with self._simulate_impersonation():
+            response = self.client.post(self.url, data={"scopes": ["event:read"]})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert not ApiToken.objects.filter(user=self.target_user).exists()
+
+    def test_impersonated_delete_blocked(self) -> None:
+        token = ApiToken.objects.create(user=self.target_user)
+        self.login_as(self.target_user)
+        with self._simulate_impersonation():
+            response = self.client.delete(self.url, data={"tokenId": token.id})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert ApiToken.objects.filter(id=token.id).exists()
+
+    def test_impersonated_get_allowed(self) -> None:
+        ApiToken.objects.create(user=self.target_user)
+        self.login_as(self.target_user)
+        with self._simulate_impersonation():
+            response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_non_impersonated_post_allowed(self) -> None:
+        self.login_as(self.target_user)
+        response = self.client.post(self.url, data={"scopes": ["event:read"]})
+        assert response.status_code == status.HTTP_201_CREATED

--- a/tests/sentry/api/endpoints/test_organization_auth_token_details.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_token_details.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework import status
@@ -445,3 +447,64 @@ class OrganizationAuthTokenDetailsPermissionTest(PermissionTestCase):
 
     def test_member_cannot_delete(self) -> None:
         self.assert_member_cannot_access(self.path, method="DELETE")
+
+
+@control_silo_test
+class OrganizationAuthTokenDetailsImpersonationTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.impersonator = self.create_user(is_superuser=True)
+        self.token = OrgAuthToken.objects.create(
+            organization_id=self.organization.id,
+            name="token 1",
+            token_hashed="ABCDEF",
+            token_last_characters="xyz1",
+            scope_list=["org:ci"],
+            date_last_used=None,
+        )
+
+    def _simulate_impersonation(self) -> Any:
+        from sentry.api.base import Endpoint
+
+        original = Endpoint.initialize_request
+
+        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+            drf_request = original(endpoint_self, request, *args, **kwargs)
+            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
+            return drf_request
+
+        return patch.object(Endpoint, "initialize_request", patched)
+
+    def test_impersonated_put_blocked(self) -> None:
+        url = reverse(
+            "sentry-api-0-org-auth-token-details",
+            args=[self.organization.slug, self.token.id],
+        )
+        self.login_as(self.user)
+        with self._simulate_impersonation():
+            response = self.client.put(url, data={"name": "renamed"})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        self.token.refresh_from_db()
+        assert self.token.name == "token 1"
+
+    def test_impersonated_delete_blocked(self) -> None:
+        url = reverse(
+            "sentry-api-0-org-auth-token-details",
+            args=[self.organization.slug, self.token.id],
+        )
+        self.login_as(self.user)
+        with self._simulate_impersonation():
+            response = self.client.delete(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        self.token.refresh_from_db()
+        assert self.token.date_deactivated is None
+
+    def test_impersonated_get_allowed(self) -> None:
+        url = reverse(
+            "sentry-api-0-org-auth-token-details",
+            args=[self.organization.slug, self.token.id],
+        )
+        self.login_as(self.user)
+        with self._simulate_impersonation():
+            response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK

--- a/tests/sentry/api/endpoints/test_organization_auth_token_details.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_token_details.py
@@ -1,6 +1,4 @@
 from datetime import datetime, timezone
-from typing import Any
-from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework import status
@@ -8,6 +6,7 @@ from rest_framework import status
 from sentry.models.apitoken import ApiToken
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.testutils.cases import APITestCase, PermissionTestCase
+from sentry.testutils.helpers.impersonation import simulate_impersonation
 from sentry.testutils.silo import control_silo_test
 
 
@@ -463,25 +462,13 @@ class OrganizationAuthTokenDetailsImpersonationTest(APITestCase):
             date_last_used=None,
         )
 
-    def _simulate_impersonation(self) -> Any:
-        from sentry.api.base import Endpoint
-
-        original = Endpoint.initialize_request
-
-        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
-            drf_request = original(endpoint_self, request, *args, **kwargs)
-            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
-            return drf_request
-
-        return patch.object(Endpoint, "initialize_request", patched)
-
     def test_impersonated_put_blocked(self) -> None:
         url = reverse(
             "sentry-api-0-org-auth-token-details",
             args=[self.organization.slug, self.token.id],
         )
         self.login_as(self.user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.put(url, data={"name": "renamed"})
         assert response.status_code == status.HTTP_403_FORBIDDEN
         self.token.refresh_from_db()
@@ -493,7 +480,7 @@ class OrganizationAuthTokenDetailsImpersonationTest(APITestCase):
             args=[self.organization.slug, self.token.id],
         )
         self.login_as(self.user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.delete(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         self.token.refresh_from_db()
@@ -505,6 +492,6 @@ class OrganizationAuthTokenDetailsImpersonationTest(APITestCase):
             args=[self.organization.slug, self.token.id],
         )
         self.login_as(self.user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK

--- a/tests/sentry/api/endpoints/test_organization_auth_tokens.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_tokens.py
@@ -1,3 +1,6 @@
+from typing import Any
+from unittest.mock import patch
+
 from django.urls import reverse
 from rest_framework import status
 
@@ -225,3 +228,39 @@ class OrganizationAuthTokensPermissionTest(PermissionTestCase):
 
     def test_member_can_post(self) -> None:
         self.assert_member_can_access(self.path, method="POST", data=self.postData)
+
+
+@control_silo_test
+class OrganizationAuthTokensImpersonationTest(APITestCase):
+    endpoint = "sentry-api-0-org-auth-tokens"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.impersonator = self.create_user(is_superuser=True)
+
+    def _simulate_impersonation(self) -> Any:
+        from sentry.api.base import Endpoint
+
+        original = Endpoint.initialize_request
+
+        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+            drf_request = original(endpoint_self, request, *args, **kwargs)
+            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
+            return drf_request
+
+        return patch.object(Endpoint, "initialize_request", patched)
+
+    def test_impersonated_post_blocked(self) -> None:
+        self.login_as(self.user)
+        url = reverse("sentry-api-0-org-auth-tokens", args=[self.organization.slug])
+        with self._simulate_impersonation():
+            response = self.client.post(url, data={"name": "test token"})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert not OrgAuthToken.objects.filter(organization_id=self.organization.id).exists()
+
+    def test_impersonated_get_allowed(self) -> None:
+        self.login_as(self.user)
+        url = reverse("sentry-api-0-org-auth-tokens", args=[self.organization.slug])
+        with self._simulate_impersonation():
+            response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK

--- a/tests/sentry/api/endpoints/test_organization_auth_tokens.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_tokens.py
@@ -1,6 +1,3 @@
-from typing import Any
-from unittest.mock import patch
-
 from django.urls import reverse
 from rest_framework import status
 
@@ -8,6 +5,7 @@ from sentry import options
 from sentry.models.apitoken import ApiToken
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.testutils.cases import APITestCase, PermissionTestCase
+from sentry.testutils.helpers.impersonation import simulate_impersonation
 from sentry.testutils.silo import control_silo_test, create_test_regions
 from sentry.types.region import get_cell_by_name
 from sentry.utils.security.orgauthtoken_token import parse_token
@@ -238,22 +236,10 @@ class OrganizationAuthTokensImpersonationTest(APITestCase):
         super().setUp()
         self.impersonator = self.create_user(is_superuser=True)
 
-    def _simulate_impersonation(self) -> Any:
-        from sentry.api.base import Endpoint
-
-        original = Endpoint.initialize_request
-
-        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
-            drf_request = original(endpoint_self, request, *args, **kwargs)
-            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
-            return drf_request
-
-        return patch.object(Endpoint, "initialize_request", patched)
-
     def test_impersonated_post_blocked(self) -> None:
         self.login_as(self.user)
         url = reverse("sentry-api-0-org-auth-tokens", args=[self.organization.slug])
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.post(url, data={"name": "test token"})
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert not OrgAuthToken.objects.filter(organization_id=self.organization.id).exists()
@@ -261,6 +247,6 @@ class OrganizationAuthTokensImpersonationTest(APITestCase):
     def test_impersonated_get_allowed(self) -> None:
         self.login_as(self.user)
         url = reverse("sentry-api-0-org-auth-tokens", args=[self.organization.slug])
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK

--- a/tests/sentry/api/test_permissions.py
+++ b/tests/sentry/api/test_permissions.py
@@ -2,6 +2,7 @@ from rest_framework.views import APIView
 
 from sentry.api.permissions import (
     DemoSafePermission,
+    DisallowImpersonatedTokenCreation,
     SentryIsAuthenticated,
     StaffPermission,
     SuperuserOrStaffFeatureFlaggedPermission,
@@ -44,6 +45,32 @@ class PermissionsTest(DRFPermissionTestCase):
         assert self.superuser_staff_flagged_permission.has_permission(
             self.superuser_request, APIView()
         )
+
+
+class DisallowImpersonatedTokenCreationTest(DRFPermissionTestCase):
+    permission = DisallowImpersonatedTokenCreation()
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.normal_user = self.create_user()
+        self.impersonator = self.create_user(is_superuser=True)
+
+    def test_safe_methods_allowed_during_impersonation(self) -> None:
+        for method in ("GET", "HEAD", "OPTIONS"):
+            request = self.make_request(user=self.normal_user, method=method)
+            request.actual_user = self.impersonator  # type: ignore[attr-defined]
+            assert self.permission.has_permission(request, APIView())
+
+    def test_unsafe_methods_blocked_during_impersonation(self) -> None:
+        for method in ("POST", "PUT", "DELETE"):
+            request = self.make_request(user=self.normal_user, method=method)
+            request.actual_user = self.impersonator  # type: ignore[attr-defined]
+            assert not self.permission.has_permission(request, APIView())
+
+    def test_unsafe_methods_allowed_without_impersonation(self) -> None:
+        for method in ("POST", "PUT", "DELETE"):
+            request = self.make_request(user=self.normal_user, method=method)
+            assert self.permission.has_permission(request, APIView())
 
 
 class IsAuthenticatedPermissionsTest(DRFPermissionTestCase):

--- a/tests/sentry/releases/endpoints/test_project_releases_token.py
+++ b/tests/sentry/releases/endpoints/test_project_releases_token.py
@@ -1,3 +1,6 @@
+from typing import Any
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from sentry.models.options.project_option import ProjectOption
@@ -85,3 +88,71 @@ class ReleaseTokenGetTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["token"] is not None
         assert response.data["token"] != "abcdefghijklmnop"
+
+
+class ReleaseTokenImpersonationTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.impersonator = self.create_user(is_superuser=True)
+
+    def _simulate_impersonation(self) -> Any:
+        from sentry.api.base import Endpoint
+
+        original = Endpoint.initialize_request
+
+        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+            drf_request = original(endpoint_self, request, *args, **kwargs)
+            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
+            return drf_request
+
+        return patch.object(Endpoint, "initialize_request", patched)
+
+    def test_impersonated_post_blocked(self) -> None:
+        project = self.create_project(name="foo")
+        token = "abcdefghijklmnop"
+        ProjectOption.objects.set_value(project, "sentry:release-token", token)
+
+        url = reverse(
+            "sentry-api-0-project-releases-token",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        self.login_as(user=self.user)
+        with self._simulate_impersonation():
+            response = self.client.post(url, {"project": project.slug})
+        assert response.status_code == 403
+        assert ProjectOption.objects.get_value(project, "sentry:release-token") == token
+
+    def test_impersonated_get_allowed_when_token_exists(self) -> None:
+        project = self.create_project(name="foo")
+        ProjectOption.objects.set_value(project, "sentry:release-token", "abcdefghijklmnop")
+
+        url = reverse(
+            "sentry-api-0-project-releases-token",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        self.login_as(user=self.user)
+        with self._simulate_impersonation():
+            response = self.client.get(url)
+        assert response.status_code == 200
+
+    def test_impersonated_get_blocked_when_no_token_exists(self) -> None:
+        project = self.create_project(name="foo")
+
+        url = reverse(
+            "sentry-api-0-project-releases-token",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        self.login_as(user=self.user)
+        with self._simulate_impersonation():
+            response = self.client.get(url)
+        assert response.status_code == 404
+        assert ProjectOption.objects.get_value(project, "sentry:release-token") is None

--- a/tests/sentry/releases/endpoints/test_project_releases_token.py
+++ b/tests/sentry/releases/endpoints/test_project_releases_token.py
@@ -1,10 +1,8 @@
-from typing import Any
-from unittest.mock import patch
-
 from django.urls import reverse
 
 from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.impersonation import simulate_impersonation
 from sentry.types.region import get_local_locality
 
 
@@ -95,18 +93,6 @@ class ReleaseTokenImpersonationTest(APITestCase):
         super().setUp()
         self.impersonator = self.create_user(is_superuser=True)
 
-    def _simulate_impersonation(self) -> Any:
-        from sentry.api.base import Endpoint
-
-        original = Endpoint.initialize_request
-
-        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
-            drf_request = original(endpoint_self, request, *args, **kwargs)
-            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
-            return drf_request
-
-        return patch.object(Endpoint, "initialize_request", patched)
-
     def test_impersonated_post_blocked(self) -> None:
         project = self.create_project(name="foo")
         token = "abcdefghijklmnop"
@@ -120,7 +106,7 @@ class ReleaseTokenImpersonationTest(APITestCase):
             },
         )
         self.login_as(user=self.user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.post(url, {"project": project.slug})
         assert response.status_code == 403
         assert ProjectOption.objects.get_value(project, "sentry:release-token") == token
@@ -137,7 +123,7 @@ class ReleaseTokenImpersonationTest(APITestCase):
             },
         )
         self.login_as(user=self.user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.get(url)
         assert response.status_code == 200
 
@@ -152,7 +138,7 @@ class ReleaseTokenImpersonationTest(APITestCase):
             },
         )
         self.login_as(user=self.user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.client.get(url)
         assert response.status_code == 404
         assert ProjectOption.objects.get_value(project, "sentry:release-token") is None

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_token_details.py
@@ -1,3 +1,6 @@
+from typing import Any
+from unittest.mock import patch
+
 from django.test import override_settings
 from rest_framework import status
 
@@ -132,3 +135,44 @@ class SentryInternalAppTokenCreationTest(APITestCase):
             status_code=status.HTTP_204_NO_CONTENT,
         )
         assert not ApiToken.objects.filter(pk=self.api_token.id).exists()
+
+
+@control_silo_test
+class SentryInternalAppTokenDetailsImpersonationTest(APITestCase):
+    endpoint = "sentry-api-0-sentry-internal-app-token-details"
+    method = "delete"
+
+    def setUp(self) -> None:
+        self.user = self.create_user(email="boop@example.com")
+        self.org = self.create_organization(owner=self.user, name="My Org")
+        self.project = self.create_project(organization=self.org)
+        self.internal_sentry_app = self.create_internal_integration(
+            name="My Internal App", organization=self.org
+        )
+        self.api_token = self.create_internal_integration_token(
+            user=self.user, internal_integration=self.internal_sentry_app
+        )
+        self.impersonator = self.create_user(is_superuser=True)
+
+    def _simulate_impersonation(self) -> Any:
+        from sentry.api.base import Endpoint
+
+        original = Endpoint.initialize_request
+
+        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+            drf_request = original(endpoint_self, request, *args, **kwargs)
+            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
+            return drf_request
+
+        return patch.object(Endpoint, "initialize_request", patched)
+
+    def test_impersonated_delete_blocked(self) -> None:
+        self.login_as(self.user)
+        with self._simulate_impersonation():
+            response = self.get_error_response(
+                self.internal_sentry_app.slug,
+                self.api_token.id,
+                status_code=status.HTTP_403_FORBIDDEN,
+            )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert ApiToken.objects.filter(pk=self.api_token.id).exists()

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_token_details.py
@@ -1,6 +1,3 @@
-from typing import Any
-from unittest.mock import patch
-
 from django.test import override_settings
 from rest_framework import status
 
@@ -8,6 +5,7 @@ from sentry import audit_log
 from sentry.models.apitoken import ApiToken
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.impersonation import simulate_impersonation
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
@@ -154,21 +152,9 @@ class SentryInternalAppTokenDetailsImpersonationTest(APITestCase):
         )
         self.impersonator = self.create_user(is_superuser=True)
 
-    def _simulate_impersonation(self) -> Any:
-        from sentry.api.base import Endpoint
-
-        original = Endpoint.initialize_request
-
-        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
-            drf_request = original(endpoint_self, request, *args, **kwargs)
-            drf_request.actual_user = self.impersonator  # type: ignore[attr-defined]
-            return drf_request
-
-        return patch.object(Endpoint, "initialize_request", patched)
-
     def test_impersonated_delete_blocked(self) -> None:
         self.login_as(self.user)
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.impersonator):
             response = self.get_error_response(
                 self.internal_sentry_app.slug,
                 self.api_token.id,

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
@@ -1,6 +1,3 @@
-from typing import Any
-from unittest.mock import patch
-
 from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
@@ -10,6 +7,7 @@ from sentry.models.apitoken import ApiToken
 from sentry.sentry_apps.models.sentry_app import MASKED_VALUE
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.impersonation import simulate_impersonation
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
@@ -180,19 +178,6 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
 
 @control_silo_test
 class SentryInternalAppTokenImpersonationTest(SentryInternalAppTokenTest):
-    def _simulate_impersonation(self) -> Any:
-        from sentry.api.base import Endpoint
-
-        original = Endpoint.initialize_request
-        impersonator = self.superuser
-
-        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
-            drf_request = original(endpoint_self, request, *args, **kwargs)
-            drf_request.actual_user = impersonator  # type: ignore[attr-defined]
-            return drf_request
-
-        return patch.object(Endpoint, "initialize_request", patched)
-
     def test_impersonated_post_blocked(self) -> None:
         self.login_as(self.user)
         token_count = ApiToken.objects.filter(
@@ -201,7 +186,7 @@ class SentryInternalAppTokenImpersonationTest(SentryInternalAppTokenTest):
         url = reverse(
             "sentry-api-0-sentry-internal-app-tokens", args=[self.internal_sentry_app.slug]
         )
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.superuser):
             response = self.client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert (
@@ -214,6 +199,6 @@ class SentryInternalAppTokenImpersonationTest(SentryInternalAppTokenTest):
         url = reverse(
             "sentry-api-0-sentry-internal-app-tokens", args=[self.internal_sentry_app.slug]
         )
-        with self._simulate_impersonation():
+        with simulate_impersonation(self.superuser):
             response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
@@ -1,4 +1,8 @@
+from typing import Any
+from unittest.mock import patch
+
 from django.test import override_settings
+from django.urls import reverse
 from rest_framework import status
 
 from sentry import audit_log
@@ -172,3 +176,44 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
 
         self.add_user_permission(self.superuser, "superuser.write")
         self.get_success_response(self.internal_sentry_app.slug)
+
+
+@control_silo_test
+class SentryInternalAppTokenImpersonationTest(SentryInternalAppTokenTest):
+    def _simulate_impersonation(self) -> Any:
+        from sentry.api.base import Endpoint
+
+        original = Endpoint.initialize_request
+        impersonator = self.superuser
+
+        def patched(endpoint_self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+            drf_request = original(endpoint_self, request, *args, **kwargs)
+            drf_request.actual_user = impersonator  # type: ignore[attr-defined]
+            return drf_request
+
+        return patch.object(Endpoint, "initialize_request", patched)
+
+    def test_impersonated_post_blocked(self) -> None:
+        self.login_as(self.user)
+        token_count = ApiToken.objects.filter(
+            application_id=self.internal_sentry_app.application_id
+        ).count()
+        url = reverse(
+            "sentry-api-0-sentry-internal-app-tokens", args=[self.internal_sentry_app.slug]
+        )
+        with self._simulate_impersonation():
+            response = self.client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert (
+            ApiToken.objects.filter(application_id=self.internal_sentry_app.application_id).count()
+            == token_count
+        )
+
+    def test_impersonated_get_allowed(self) -> None:
+        self.login_as(self.user)
+        url = reverse(
+            "sentry-api-0-sentry-internal-app-tokens", args=[self.internal_sentry_app.slug]
+        )
+        with self._simulate_impersonation():
+            response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Add DisallowImpersonatedTokenCreation permission class that blocks non-safe HTTP methods (POST, PUT, DELETE) when request.actual_user is set by the ViewAs middleware. This prevents an impersonating superuser from creating long-lived API tokens as the impersonated user.

Applied to all token-creating endpoints: ApiTokens, ApiTokenDetails, OrganizationAuthTokens, OrganizationAuthTokenDetails, SentryInternalAppTokens, SentryInternalAppTokenDetails, and ProjectReleasesToken.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
