### PR TITLE
fix(explore): Remove empty field params from Explore URL

### DIFF
--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -107,7 +107,9 @@ export function getTargetWithReadableQueryParams(
   updateNullableLocation(
     target,
     LOGS_FIELDS_KEY,
-    writableQueryParams.fields?.filter(Boolean)
+    writableQueryParams.fields === null
+      ? null
+      : writableQueryParams.fields?.filter(Boolean)
   );
   updateNullableLocation(
     target,

--- a/static/app/views/explore/logs/logsQueryParams.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.tsx
@@ -104,7 +104,11 @@ export function getTargetWithReadableQueryParams(
   updateNullableLocation(target, LOGS_QUERY_KEY, writableQueryParams.query);
 
   updateNullableLocation(target, LOGS_CURSOR_KEY, writableQueryParams.cursor);
-  updateNullableLocation(target, LOGS_FIELDS_KEY, writableQueryParams.fields);
+  updateNullableLocation(
+    target,
+    LOGS_FIELDS_KEY,
+    writableQueryParams.fields?.filter(Boolean)
+  );
   updateNullableLocation(
     target,
     LOGS_SORT_BYS_KEY,

--- a/static/app/views/explore/queryParams/field.ts
+++ b/static/app/views/explore/queryParams/field.ts
@@ -3,7 +3,7 @@ import type {Location} from 'history';
 import {decodeList} from 'sentry/utils/queryString';
 
 export function getFieldsFromLocation(location: Location, key: string): string[] | null {
-  const fields = decodeList(location.query?.[key]);
+  const fields = decodeList(location.query?.[key]).filter(Boolean);
 
   if (fields.length) {
     return fields;

--- a/static/app/views/explore/spans/spansQueryParams.spec.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.spec.tsx
@@ -130,6 +130,20 @@ describe('getReadableQueryParamsFromLocation', () => {
     expect(queryParams).toEqual(new ReadableQueryParams(readableQueryParamOptions()));
   });
 
+  it('strips empty field values from location', () => {
+    const location = locationFixture({field: ['timestamp', '', 'span.op']});
+    const queryParams = getReadableQueryParamsFromLocation(location);
+
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          fields: ['timestamp', 'span.op'],
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        })
+      )
+    );
+  });
+
   it('decodes custom fields correctly', () => {
     const location = locationFixture({
       field: ['id', 'span.op', 'span.duration', 'timestamp'],

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -123,7 +123,11 @@ export function getTargetWithReadableQueryParams(
   updateNullableLocation(target, SPANS_QUERY_KEY, writableQueryParams.query);
   updateNullableLocation(target, SPANS_MODE_KEY, writableQueryParams.mode);
 
-  updateNullableLocation(target, SPANS_FIELD_KEY, writableQueryParams.fields);
+  updateNullableLocation(
+    target,
+    SPANS_FIELD_KEY,
+    writableQueryParams.fields?.filter(Boolean)
+  );
   updateNullableLocation(
     target,
     SPANS_SORT_KEY,

--- a/static/app/views/explore/spans/spansQueryParams.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.tsx
@@ -126,7 +126,9 @@ export function getTargetWithReadableQueryParams(
   updateNullableLocation(
     target,
     SPANS_FIELD_KEY,
-    writableQueryParams.fields?.filter(Boolean)
+    writableQueryParams.fields === null
+      ? null
+      : writableQueryParams.fields?.filter(Boolean)
   );
   updateNullableLocation(
     target,


### PR DESCRIPTION
Empty `field=` parameters in the Explore page URL (e.g. `&field=timestamp&field=&field=parent_span`) cause validation errors when saving a query, because the empty string is treated as a required-but-blank field name.

This adds defense-in-depth filtering at both the read and write boundaries:

- **Read**: `getFieldsFromLocation` now filters out empty strings after `decodeList()`, so any stale `field=` in the URL is stripped before the app sees it.
- **Write**: Both spans and logs `getTargetWithReadableQueryParams` filter empty strings before writing fields back to the URL.

Fixes EXP-838