### PR TITLE
fix(stories): wrap StoryTabPanels in Stack

### DIFF
--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -7,7 +7,7 @@ import {parseAsString, useQueryState} from 'nuqs';
 import {Alert} from '@sentry/scraps/alert';
 import {Tag} from '@sentry/scraps/badge';
 import {InlineCode} from '@sentry/scraps/code';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -58,9 +58,9 @@ function StoryLayout() {
       {isMDXStory(story) ? <MDXStoryTitle story={story} /> : null}
       <StoryGrid>
         <StoryContainer>
-          <Flex flexGrow={1} minWidth="0px">
+          <Stack flexGrow={1} minWidth="0px">
             <StoryTabPanels documentation={documentation} />
-          </Flex>
+          </Stack>
           <ErrorBoundary>
             <StorySourceLinks />
           </ErrorBoundary>


### PR DESCRIPTION
Fixes `*.stories.tsx` files that export `documentation`.

| Before | After |
|--------|--------|
| <img width="1232" height="770" alt="Screenshot 2026-03-13 at 2 09 14 PM" src="https://github.com/user-attachments/assets/31afeeb4-203c-4874-9ad4-7f590fe1a5c8" /> | <img width="1228" height="766" alt="Screenshot 2026-03-13 at 2 11 42 PM" src="https://github.com/user-attachments/assets/b6b5a52b-c765-430d-9fd0-6a027be9f46d" /> | [Example](https://sentry.sentry.io/stories/product/components/dropdownmenu/dropdownmenu/) | [Example](https://sentry-git-stories-nmde-1006.sentry.dev/stories/product/components/dropdownmenu/dropdownmenu/) | 

We previously assumed that `.stories.tsx` files would have a single default export and used `Flex` to layout the content. When `export const documentation` was added to `static/app/components/dropdownMenu/index.stories.tsx`, both the main content and props table were being rendered next to each other, breaking the layout.

Closes DE-1006