### PR TITLE
test(occurrences on eap): Use relative frozen timestamps in tests

### DIFF
--- a/tests/sentry/api/endpoints/release_thresholds/utils/test_get_errors_counts_timeseries.py
+++ b/tests/sentry/api/endpoints/release_thresholds/utils/test_get_errors_counts_timeseries.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from typing import Any
 from unittest import mock
 
@@ -11,7 +11,7 @@ from sentry.api.endpoints.release_thresholds.utils.get_errors_counts_timeseries 
     _get_errors_counts_timeseries_snuba,
 )
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 
 
 class GetErrorCountTimeseriesSnubaTest(TestCase):
@@ -60,7 +60,7 @@ class GetErrorCountTimeseriesSnubaTest(TestCase):
 
 
 class TestEAPGetErrorsCountsTimeseries(TestCase, SnubaTestCase):
-    FROZEN_TIME = datetime(2026, 2, 12, 6, 0, 0, tzinfo=UTC)
+    FROZEN_TIME = before_now(hours=24).replace(hour=6, minute=0, second=0)
 
     def _query_both(
         self,

--- a/tests/sentry/api/helpers/test_events.py
+++ b/tests/sentry/api/helpers/test_events.py
@@ -7,11 +7,11 @@ from sentry.api.helpers.events import get_events_for_group_eap, get_query_builde
 from sentry.models.group import Group
 from sentry.search.events.types import SnubaParams
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 
 
 class TestEAPRunGroupEventsQuery(TestCase, SnubaTestCase):
-    FROZEN_TIME = datetime.datetime(2026, 2, 12, 6, 0, 0, tzinfo=datetime.UTC)
+    FROZEN_TIME = before_now(hours=24).replace(hour=6, minute=0, second=0)
 
     def _query_both(self, group_id: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         group = Group.objects.get(id=group_id)

--- a/tests/sentry/integrations/source_code_management/test_commit_context.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context.py
@@ -16,7 +16,7 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError, ApiHostError
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric, assert_slo_metric
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.users.models.identity import Identity
 
 
@@ -215,7 +215,7 @@ class TestCommitContextIntegrationSLO(TestCase):
 
 
 class TestEAPGetTop5IssuesByCount(TestCase, SnubaTestCase):
-    FROZEN_TIME = datetime.datetime(2026, 2, 12, 6, 0, 0, tzinfo=datetime.UTC)
+    FROZEN_TIME = before_now(hours=24).replace(hour=6, minute=0, second=0)
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/issues/escalating/test_escalating.py
+++ b/tests/sentry/issues/escalating/test_escalating.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
 from unittest.mock import patch
@@ -96,6 +96,8 @@ class HistoricGroupCounts(
     @pytest.mark.skip(reason="flaky: #95139")
     @freeze_time(TIME_YESTERDAY)
     def test_query_different_group_categories(self) -> None:
+        from django.utils import timezone
+
         timestamp = timezone.now() - timedelta(minutes=1)
         # This builds an error group and a profiling group
         profile_error_event, _, profile_issue_occurrence = self.store_search_issue(

--- a/tests/sentry/issues/escalating/test_escalating.py
+++ b/tests/sentry/issues/escalating/test_escalating.py
@@ -28,7 +28,7 @@ from sentry.testutils.cases import (
     SnubaTestCase,
     TestCase,
 )
-from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.types.group import GroupSubStatus
 from sentry.utils.cache import cache
 from sentry.utils.snuba import to_start_of_hour
@@ -96,8 +96,6 @@ class HistoricGroupCounts(
     @pytest.mark.skip(reason="flaky: #95139")
     @freeze_time(TIME_YESTERDAY)
     def test_query_different_group_categories(self) -> None:
-        from django.utils import timezone
-
         timestamp = timezone.now() - timedelta(minutes=1)
         # This builds an error group and a profiling group
         profile_error_event, _, profile_issue_occurrence = self.store_search_issue(
@@ -345,9 +343,7 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
 
 
 class TestEAPIsEscalating(TestCase, SnubaTestCase):
-    FROZEN_TIME = (datetime.now(timezone.utc) - timedelta(hours=24)).replace(
-        hour=6, minute=30, second=0, microsecond=0
-    )
+    FROZEN_TIME = before_now(hours=24).replace(hour=6, minute=30, second=0)
 
     def _event_timestamp(self, hours_ago: int = 0) -> float:
         return (

--- a/tests/sentry/issues/related/test_trace_connected.py
+++ b/tests/sentry/issues/related/test_trace_connected.py
@@ -8,11 +8,11 @@ from sentry.issues.related.trace_connected import (
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 
 
 class TestEAPTraceConnectedIssues(TestCase, SnubaTestCase):
-    FROZEN_TIME = datetime.datetime(2026, 2, 12, 6, 0, 0, tzinfo=datetime.UTC)
+    FROZEN_TIME = before_now(hours=24).replace(hour=6, minute=0, second=0)
 
     def _query_both(self, trace_id: str, exclude_group_id: int) -> tuple[set[int], set[int]]:
         organization = Organization.objects.get(id=self.organization.id)

--- a/tests/sentry/issues/test_suspect_flags.py
+++ b/tests/sentry/issues/test_suspect_flags.py
@@ -11,7 +11,7 @@ from sentry.issues.suspect_flags import (
     query_selection_set,
 )
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 
 
 class _FlagResult(TypedDict):
@@ -148,7 +148,7 @@ class SnubaTest(TestCase, SnubaTestCase):
 
 
 class TestEAPQueryErrorCounts(TestCase, SnubaTestCase):
-    FROZEN_TIME = datetime.datetime(2026, 2, 12, 6, 0, 0, tzinfo=datetime.UTC)
+    FROZEN_TIME = before_now(hours=24).replace(hour=6, minute=0, second=0)
 
     def _query_both(self, group_id: int | None = None) -> tuple[int, int]:
         start = self.FROZEN_TIME - datetime.timedelta(hours=1)

--- a/tests/sentry/issues/test_suspect_tags.py
+++ b/tests/sentry/issues/test_suspect_tags.py
@@ -10,7 +10,7 @@ from sentry.issues.suspect_tags import (
     query_selection_set,
 )
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 
 
 class SuspectTagsTest(TestCase, SnubaTestCase):
@@ -73,7 +73,7 @@ class SuspectTagsTest(TestCase, SnubaTestCase):
 
 
 class TestEAPQueryErrorCounts(TestCase, SnubaTestCase):
-    FROZEN_TIME = datetime.datetime(2026, 2, 12, 6, 0, 0, tzinfo=datetime.UTC)
+    FROZEN_TIME = before_now(hours=24).replace(hour=6, minute=0, second=0)
 
     def _query_both(self, group_id: int | None = None) -> tuple[int, int]:
         start = self.FROZEN_TIME - datetime.timedelta(hours=1)

--- a/tests/sentry/monitors/test_utils.py
+++ b/tests/sentry/monitors/test_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -13,7 +13,7 @@ from sentry.monitors.utils import (
     get_detector_for_monitor,
 )
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.workflow_engine.models import DataSource, DataSourceDetector, Detector
 
 
@@ -213,7 +213,7 @@ class EnsureCronDetectorDeletionTest(TestCase):
 
 
 class TestEAPFetchAssociatedGroups(TestCase, SnubaTestCase):
-    FROZEN_TIME = datetime(2026, 2, 12, 6, 0, 0, tzinfo=timezone.utc)
+    FROZEN_TIME = before_now(hours=24).replace(hour=6, minute=0, second=0)
 
     def _event_timestamp(self) -> float:
         return (self.FROZEN_TIME - timedelta(minutes=5)).timestamp()


### PR DESCRIPTION
Replacing the absolute values for these frozen timestamps in test files with relative values.