### PR TITLE
chore(tracemetrics): Clean up multi-agg overlay feature flag

### DIFF
--- a/static/app/views/explore/metrics/hooks/useMetricTimeseries.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTimeseries.spec.tsx
@@ -1,5 +1,4 @@
 import type {ReactNode} from 'react';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
@@ -130,166 +129,153 @@ describe('useMetricTimeseries', () => {
     );
   });
 
-  describe('with tracemetrics-overlay-charts-ui feature', () => {
-    const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
-    });
+  it('requests multiple yAxis values from the API', async () => {
+    const mockTimeSeries1 = TimeSeriesFixture();
+    const mockTimeSeries2 = TimeSeriesFixture();
+    const mockTimeSeries3 = TimeSeriesFixture();
 
-    beforeEach(() => {
-      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
-      jest.clearAllMocks();
-    });
-
-    it('requests multiple yAxis values from the API', async () => {
-      const mockTimeSeries1 = TimeSeriesFixture();
-      const mockTimeSeries2 = TimeSeriesFixture();
-      const mockTimeSeries3 = TimeSeriesFixture();
-
-      const mockRequest = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/events-timeseries/',
-        body: {
-          timeSeries: [
-            {
-              ...mockTimeSeries1,
-              yAxis: 'p50(value,test_metric,distribution,-)',
-            },
-            {
-              ...mockTimeSeries2,
-              yAxis: 'p75(value,test_metric,distribution,-)',
-            },
-            {
-              ...mockTimeSeries3,
-              yAxis: 'p99(value,test_metric,distribution,-)',
-            },
-          ],
-        },
-        method: 'GET',
-      });
-
-      renderHookWithProviders(useMetricTimeseries, {
-        initialProps: {
-          traceMetric: {name: 'test_metric', type: 'distribution'},
-          enabled: true,
-        },
-        additionalWrapper: MockMetricQueryParamsContextWithMultiVisualize,
-        organization,
-      });
-
-      await waitFor(() => {
-        expect(mockRequest).toHaveBeenCalledTimes(1);
-      });
-
-      expect(mockRequest).toHaveBeenCalledWith(
-        '/organizations/org-slug/events-timeseries/',
-        expect.objectContaining({
-          query: expect.objectContaining({
-            yAxis: [
-              'p50(value,test_metric,distribution,-)',
-              'p75(value,test_metric,distribution,-)',
-              'p99(value,test_metric,distribution,-)',
-            ],
-          }),
-        })
-      );
-    });
-
-    it('triggers high accuracy for all visualizes', async () => {
-      const mockTimeSeries = TimeSeriesFixture();
-
-      const mockNormalRequest = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/events-timeseries/',
-        body: {
-          timeSeries: [
-            {
-              ...mockTimeSeries,
-              yAxis: 'p50(value,test_metric,distribution,-)',
-              values: [
-                {
-                  ...mockTimeSeries.values[0]!,
-                  value: 0,
-                },
-              ],
-              meta: {
-                ...mockTimeSeries.meta,
-                dataScanned: 'partial',
-              },
-            },
-            {
-              ...mockTimeSeries,
-              yAxis: 'p75(value,test_metric,distribution,-)',
-              values: [
-                {
-                  ...mockTimeSeries.values[0]!,
-                  value: 0,
-                },
-              ],
-              meta: {
-                ...mockTimeSeries.meta,
-                dataScanned: 'partial',
-              },
-            },
-            {
-              ...mockTimeSeries,
-              yAxis: 'p99(value,test_metric,distribution,-)',
-              values: [
-                {
-                  ...mockTimeSeries.values[0]!,
-                  value: 0,
-                },
-              ],
-              meta: {
-                ...mockTimeSeries.meta,
-                dataScanned: 'partial',
-              },
-            },
-          ],
-        },
-        method: 'GET',
-        match: [
-          function (_url: string, options: Record<string, any>) {
-            return options.query.sampling === SAMPLING_MODE.NORMAL;
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [
+          {
+            ...mockTimeSeries1,
+            yAxis: 'p50(value,test_metric,distribution,-)',
+          },
+          {
+            ...mockTimeSeries2,
+            yAxis: 'p75(value,test_metric,distribution,-)',
+          },
+          {
+            ...mockTimeSeries3,
+            yAxis: 'p99(value,test_metric,distribution,-)',
           },
         ],
-      });
+      },
+      method: 'GET',
+    });
 
-      const mockHighAccuracyRequest = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/events-timeseries/',
-        match: [
-          function (_url: string, options: Record<string, any>) {
-            return options.query.sampling === SAMPLING_MODE.HIGH_ACCURACY;
+    renderHookWithProviders(useMetricTimeseries, {
+      initialProps: {
+        traceMetric: {name: 'test_metric', type: 'distribution'},
+        enabled: true,
+      },
+      additionalWrapper: MockMetricQueryParamsContextWithMultiVisualize,
+    });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          yAxis: [
+            'p50(value,test_metric,distribution,-)',
+            'p75(value,test_metric,distribution,-)',
+            'p99(value,test_metric,distribution,-)',
+          ],
+        }),
+      })
+    );
+  });
+
+  it('triggers high accuracy for all visualizes', async () => {
+    const mockTimeSeries = TimeSeriesFixture();
+
+    const mockNormalRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [
+          {
+            ...mockTimeSeries,
+            yAxis: 'p50(value,test_metric,distribution,-)',
+            values: [
+              {
+                ...mockTimeSeries.values[0]!,
+                value: 0,
+              },
+            ],
+            meta: {
+              ...mockTimeSeries.meta,
+              dataScanned: 'partial',
+            },
+          },
+          {
+            ...mockTimeSeries,
+            yAxis: 'p75(value,test_metric,distribution,-)',
+            values: [
+              {
+                ...mockTimeSeries.values[0]!,
+                value: 0,
+              },
+            ],
+            meta: {
+              ...mockTimeSeries.meta,
+              dataScanned: 'partial',
+            },
+          },
+          {
+            ...mockTimeSeries,
+            yAxis: 'p99(value,test_metric,distribution,-)',
+            values: [
+              {
+                ...mockTimeSeries.values[0]!,
+                value: 0,
+              },
+            ],
+            meta: {
+              ...mockTimeSeries.meta,
+              dataScanned: 'partial',
+            },
           },
         ],
-        method: 'GET',
-      });
-
-      renderHookWithProviders(useMetricTimeseries, {
-        initialProps: {
-          traceMetric: {name: 'test_metric', type: 'distribution'},
-          enabled: true,
+      },
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === SAMPLING_MODE.NORMAL;
         },
-        additionalWrapper: MockMetricQueryParamsContextWithMultiVisualize,
-        organization,
-      });
-
-      expect(mockNormalRequest).toHaveBeenCalledTimes(1);
-
-      await waitFor(() => {
-        expect(mockHighAccuracyRequest).toHaveBeenCalledTimes(1);
-      });
-
-      expect(mockHighAccuracyRequest).toHaveBeenCalledWith(
-        '/organizations/org-slug/events-timeseries/',
-        expect.objectContaining({
-          query: expect.objectContaining({
-            sampling: SAMPLING_MODE.HIGH_ACCURACY,
-            yAxis: [
-              'p50(value,test_metric,distribution,-)',
-              'p75(value,test_metric,distribution,-)',
-              'p99(value,test_metric,distribution,-)',
-            ],
-          }),
-        })
-      );
+      ],
     });
+
+    const mockHighAccuracyRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === SAMPLING_MODE.HIGH_ACCURACY;
+        },
+      ],
+      method: 'GET',
+    });
+
+    renderHookWithProviders(useMetricTimeseries, {
+      initialProps: {
+        traceMetric: {name: 'test_metric', type: 'distribution'},
+        enabled: true,
+      },
+      additionalWrapper: MockMetricQueryParamsContextWithMultiVisualize,
+    });
+
+    expect(mockNormalRequest).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(mockHighAccuracyRequest).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockHighAccuracyRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          sampling: SAMPLING_MODE.HIGH_ACCURACY,
+          yAxis: [
+            'p50(value,test_metric,distribution,-)',
+            'p75(value,test_metric,distribution,-)',
+            'p99(value,test_metric,distribution,-)',
+          ],
+        }),
+      })
+    );
   });
 });

--- a/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTimeseries.tsx
@@ -2,7 +2,6 @@ import {useCallback, useMemo} from 'react';
 
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {shouldTriggerHighAccuracy} from 'sentry/views/explore/hooks/useExploreTimeseries';
 import {
@@ -11,11 +10,7 @@ import {
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {canUseMetricsMultiAggregateUI} from 'sentry/views/explore/metrics/metricsFlags';
-import {
-  useMetricVisualize,
-  useMetricVisualizes,
-} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {useMetricVisualizes} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {
   useQueryParamsAggregateSortBys,
   useQueryParamsGroupBys,
@@ -29,22 +24,14 @@ interface UseMetricTimeseriesOptions {
 }
 
 export function useMetricTimeseries({traceMetric, enabled}: UseMetricTimeseriesOptions) {
-  const organization = useOrganization();
-  const hasMultiVisualize = canUseMetricsMultiAggregateUI(organization);
-
-  const visualize = useMetricVisualize();
   const visualizes = useMetricVisualizes();
 
   const topEvents = useTopEvents();
   const canTriggerHighAccuracy = useCallback(
     (result: ReturnType<typeof useMetricTimeseriesImpl>['result']) => {
-      if (hasMultiVisualize) {
-        return shouldTriggerHighAccuracy(result.data, visualizes, !!topEvents);
-      }
-
-      return shouldTriggerHighAccuracy(result.data, [visualize], !!topEvents);
+      return shouldTriggerHighAccuracy(result.data, visualizes, !!topEvents);
     },
-    [hasMultiVisualize, topEvents, visualize, visualizes]
+    [topEvents, visualizes]
   );
   return useProgressiveQuery<typeof useMetricTimeseriesImpl>({
     queryHookImplementation: useMetricTimeseriesImpl,
@@ -64,7 +51,6 @@ function useMetricTimeseriesImpl({
   queryExtras,
   enabled,
 }: UseMetricTimeseriesImplOptions) {
-  const visualize = useMetricVisualize();
   const visualizes = useMetricVisualizes();
   const groupBys = useQueryParamsGroupBys();
   const [interval] = useChartInterval();
@@ -72,15 +58,9 @@ function useMetricTimeseriesImpl({
   const search = useQueryParamsSearch();
   const sortBys = useQueryParamsAggregateSortBys();
 
-  const organization = useOrganization();
-  const hasMultiVisualize = canUseMetricsMultiAggregateUI(organization);
-
   const yAxis = useMemo(() => {
-    if (hasMultiVisualize) {
-      return visualizes.map(v => v.yAxis);
-    }
-    return [visualize.yAxis];
-  }, [hasMultiVisualize, visualize.yAxis, visualizes]);
+    return visualizes.map(v => v.yAxis);
+  }, [visualizes]);
 
   const timeseriesResult = useSortedTimeSeries(
     {

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -10,14 +10,12 @@ import {defined} from 'sentry/utils';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
 import {ConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
 import type {TableOrientation} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
-import {canUseMetricsMultiAggregateUI} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   useMetricLabel,
   useMetricName,
@@ -65,13 +63,10 @@ export function MetricsGraph({
   infoContentHidden,
   isMetricOptionsEmpty,
 }: MetricsGraphProps) {
-  const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const visualize = useMetricVisualize();
   const visualizes = useMetricVisualizes();
   const setVisualizes = useSetMetricVisualizes();
-
-  const hasMultiVisualize = canUseMetricsMultiAggregateUI(organization);
 
   useSynchronizeCharts(
     metricQueries.length,
@@ -87,7 +82,6 @@ export function MetricsGraph({
     <Graph
       visualize={visualize}
       visualizes={visualizes}
-      hasMultiVisualize={hasMultiVisualize}
       timeseriesResult={timeseriesResult}
       onChartTypeChange={handleChartTypeChange}
       orientation={orientation}
@@ -99,7 +93,6 @@ export function MetricsGraph({
 }
 
 interface GraphProps extends MetricsGraphProps {
-  hasMultiVisualize: boolean;
   onChartTypeChange: (chartType: ChartType) => void;
   visualize: ReturnType<typeof useMetricVisualize>;
   visualizes: ReturnType<typeof useMetricVisualizes>;
@@ -111,7 +104,6 @@ function Graph({
   orientation,
   visualize,
   visualizes,
-  hasMultiVisualize,
   infoContentHidden,
   additionalActions,
   isMetricOptionsEmpty,
@@ -131,14 +123,14 @@ function Graph({
 
   const chartInfo = useMemo(() => {
     const isTopEvents = defined(topEventsLimit);
-    const yAxes = hasMultiVisualize ? visualizes.map(v => v.yAxis) : [visualize.yAxis];
+    const yAxes = visualizes.map(v => v.yAxis);
     const rawSeries = yAxes.flatMap(yAxis => timeseriesResult.data[yAxis] ?? []);
 
     // When displaying multiple aggregates, simplify the legend labels
     // to just show the function name (e.g., "p50" instead of "p50(metric.name)")
     // For series with groupBy, show "groupByValue : functionName"
     let series = rawSeries;
-    if (hasMultiVisualize && visualizes.length > 1) {
+    if (visualizes.length > 1) {
       series = rawSeries.map(s => {
         const parsed = parseFunction(s.yAxis);
         if (!parsed) {
@@ -175,22 +167,14 @@ function Graph({
       samplingMode: undefined,
       topEvents: isTopEvents ? series.filter(s => !s.meta.isOther).length : undefined,
     };
-  }, [
-    visualize.chartType,
-    visualize.yAxis,
-    timeseriesResult,
-    aggregate,
-    topEventsLimit,
-    hasMultiVisualize,
-    visualizes,
-  ]);
+  }, [visualize.chartType, timeseriesResult, aggregate, topEventsLimit, visualizes]);
 
   const chartTitle = useMemo(() => {
-    if (hasMultiVisualize && visualizes.length > 1) {
+    if (visualizes.length > 1) {
       return metricName;
     }
     return metricLabel ?? prettifyAggregation(aggregate) ?? aggregate;
-  }, [aggregate, hasMultiVisualize, metricLabel, metricName, visualizes.length]);
+  }, [aggregate, metricLabel, metricName, visualizes.length]);
 
   const Title = <Widget.WidgetTitle title={chartTitle} />;
 

--- a/static/app/views/explore/metrics/metricQuery.spec.tsx
+++ b/static/app/views/explore/metrics/metricQuery.spec.tsx
@@ -7,7 +7,7 @@ import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQuer
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 
 describe('decodeMetricsQueryParams', () => {
-  it('parses only first visualize when multiVisualize=false', () => {
+  it('parses all visualizes', () => {
     const json = JSON.stringify({
       metric: {name: 'test_metric', type: 'distribution'},
       query: '',
@@ -20,28 +20,7 @@ describe('decodeMetricsQueryParams', () => {
       mode: 'samples',
     });
 
-    const result = decodeMetricsQueryParams(json, false);
-
-    expect(result).not.toBeNull();
-    expect(result?.queryParams.aggregateFields).toEqual([
-      new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-    ]);
-  });
-
-  it('parses all visualizes when multiVisualize=true', () => {
-    const json = JSON.stringify({
-      metric: {name: 'test_metric', type: 'distribution'},
-      query: '',
-      aggregateFields: [
-        {yAxes: ['p50(value,test_metric,distribution,-)']},
-        {yAxes: ['p75(value,test_metric,distribution,-)']},
-        {yAxes: ['p99(value,test_metric,distribution,-)']},
-      ],
-      aggregateSortBys: [],
-      mode: 'samples',
-    });
-
-    const result = decodeMetricsQueryParams(json, true);
+    const result = decodeMetricsQueryParams(json);
 
     expect(result).not.toBeNull();
     expect(result?.queryParams.aggregateFields).toEqual([
@@ -52,7 +31,7 @@ describe('decodeMetricsQueryParams', () => {
   });
 
   it('returns null for invalid JSON', () => {
-    const result = decodeMetricsQueryParams('invalid json', false);
+    const result = decodeMetricsQueryParams('invalid json');
     expect(result).toBeNull();
   });
 
@@ -64,7 +43,7 @@ describe('decodeMetricsQueryParams', () => {
       mode: 'samples',
     });
 
-    const result = decodeMetricsQueryParams(json, false);
+    const result = decodeMetricsQueryParams(json);
     expect(result).toBeNull();
   });
 
@@ -77,11 +56,11 @@ describe('decodeMetricsQueryParams', () => {
       mode: 'samples',
     });
 
-    const result = decodeMetricsQueryParams(json, false);
+    const result = decodeMetricsQueryParams(json);
     expect(result).toBeNull();
   });
 
-  it('handles groupBys correctly with multiVisualize', () => {
+  it('handles groupBys correctly', () => {
     const json = JSON.stringify({
       metric: {name: 'test_metric', type: 'distribution'},
       query: '',
@@ -94,7 +73,7 @@ describe('decodeMetricsQueryParams', () => {
       mode: 'samples',
     });
 
-    const result = decodeMetricsQueryParams(json, true);
+    const result = decodeMetricsQueryParams(json);
 
     expect(result).not.toBeNull();
     expect(result?.queryParams.aggregateFields).toEqual([
@@ -104,7 +83,7 @@ describe('decodeMetricsQueryParams', () => {
     ]);
   });
 
-  it('round-trips encode/decode with multiVisualize', () => {
+  it('round-trips encode/decode', () => {
     const original = {
       metric: {name: 'test_metric', type: 'counter'},
       queryParams: new ReadableQueryParams({
@@ -126,7 +105,7 @@ describe('decodeMetricsQueryParams', () => {
     };
 
     const encoded = encodeMetricQueryParams(original);
-    const decoded = decodeMetricsQueryParams(encoded, true);
+    const decoded = decodeMetricsQueryParams(encoded);
 
     expect(decoded).not.toBeNull();
     expect(decoded?.metric).toEqual(original.metric);

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -44,10 +44,7 @@ export interface MetricQuery extends BaseMetricQuery {
   setTraceMetric: (traceMetric: TraceMetric) => void;
 }
 
-export function decodeMetricsQueryParams(
-  value: string,
-  multiVisualize = false
-): BaseMetricQuery | null {
+export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null {
   let json: any;
   try {
     json = JSON.parse(value);
@@ -61,7 +58,7 @@ export function decodeMetricsQueryParams(
 
   const metric = json.metric;
   const query = parseQuery(json.query);
-  const visualizes = parseVisualizes(json.aggregateFields, multiVisualize);
+  const visualizes = parseVisualizes(json.aggregateFields);
 
   if (!visualizes.length) {
     return null;
@@ -190,17 +187,12 @@ function parseQuery(value: unknown): string {
   return typeof value === 'string' ? value : defaultQuery();
 }
 
-function parseVisualizes(value: unknown, multiVisualize = false): Visualize[] {
+function parseVisualizes(value: unknown): Visualize[] {
   if (!Array.isArray(value)) {
     return [];
   }
 
-  if (multiVisualize) {
-    return value.filter(isBaseVisualize).flatMap(Visualize.fromJSON);
-  }
-
-  const baseVisualize = value.find(isBaseVisualize);
-  return baseVisualize ? Visualize.fromJSON(baseVisualize) : [];
+  return value.filter(isBaseVisualize).flatMap(Visualize.fromJSON);
 }
 
 function parseGroupBys(value: unknown): GroupBy[] {

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -77,32 +77,9 @@ describe('AggregateDropdown', () => {
     jest.restoreAllMocks();
   });
 
-  it('renders single-select dropdown without feature flag', async () => {
+  it('renders multi-select dropdown with grouped options', async () => {
     const organization = OrganizationFixture({
-      features: [],
-    });
-
-    render(
-      <AggregateDropdown traceMetric={{name: 'test_metric', type: 'distribution'}} />,
-      {
-        organization,
-        additionalWrapper: createWrapper(),
-      }
-    );
-
-    const trigger = screen.getByRole('button', {name: /Agg/});
-    expect(trigger).toBeInTheDocument();
-
-    await userEvent.click(trigger);
-
-    expect(await screen.findByRole('option', {name: 'p50'})).toBeInTheDocument();
-    expect(await screen.findByRole('option', {name: 'p75'})).toBeInTheDocument();
-    expect(await screen.findByRole('option', {name: 'p99'})).toBeInTheDocument();
-  });
-
-  it('renders multi-select dropdown with grouped options when feature enabled', async () => {
-    const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
+      features: ['tracemetrics-enabled'],
     });
 
     const queryParams = new ReadableQueryParams({
@@ -149,7 +126,7 @@ describe('AggregateDropdown', () => {
 
   it('updates multiple visualizes on selection change', async () => {
     const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
+      features: ['tracemetrics-enabled'],
     });
 
     const setQueryParams = jest.fn();
@@ -194,7 +171,7 @@ describe('AggregateDropdown', () => {
 
   it('defaults to the type yAxis when all selections are cleared', async () => {
     const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
+      features: ['tracemetrics-enabled'],
     });
 
     const setQueryParams = jest.fn();
@@ -247,7 +224,7 @@ describe('AggregateDropdown', () => {
 
   it('shows correct options for counter metric type', async () => {
     const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
+      features: ['tracemetrics-enabled'],
     });
 
     const queryParams = new ReadableQueryParams({
@@ -283,7 +260,7 @@ describe('AggregateDropdown', () => {
 
   it('deselects incompatible aggregates when selecting from a different group', async () => {
     const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
+      features: ['tracemetrics-enabled'],
     });
 
     const setQueryParams = jest.fn();
@@ -339,7 +316,7 @@ describe('AggregateDropdown', () => {
 
   it('allows multiple selections within the same group', async () => {
     const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
+      features: ['tracemetrics-enabled'],
     });
 
     const setQueryParams = jest.fn();
@@ -387,7 +364,7 @@ describe('AggregateDropdown', () => {
 
   it('switches groups correctly when going from math to rate', async () => {
     const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
+      features: ['tracemetrics-enabled'],
     });
 
     const setQueryParams = jest.fn();

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -2,18 +2,14 @@ import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {t} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   DEFAULT_YAXIS_BY_TYPE,
   GROUPED_OPTIONS_BY_TYPE,
-  OPTIONS_BY_TYPE,
 } from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {canUseMetricsMultiAggregateUI} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   useMetricVisualize,
   useMetricVisualizes,
-  useSetMetricVisualize,
   useSetMetricVisualizes,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {updateVisualizeYAxis} from 'sentry/views/explore/metrics/utils';
@@ -39,70 +35,14 @@ function findGroupKey(
 
 export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
   const visualize = useMetricVisualize();
-  const setVisualize = useSetMetricVisualize();
 
   const visualizes = useMetricVisualizes();
   const setMetricVisualizes = useSetMetricVisualizes();
-  const organization = useOrganization();
-  const hasMultiSelect = canUseMetricsMultiAggregateUI(organization);
-
-  if (hasMultiSelect) {
-    return (
-      <CompactSelect
-        multiple
-        style={{width: '100%'}}
-        trigger={triggerProps => (
-          <OverlayTrigger.Button
-            {...triggerProps}
-            prefix={t('Agg')}
-            style={{width: '100%'}}
-          />
-        )}
-        options={GROUPED_OPTIONS_BY_TYPE[traceMetric.type] ?? []}
-        value={visualizes.map(v => v.parsedFunction?.name ?? '')}
-        onChange={(option: Array<SelectOption<string>>) => {
-          if (option.length === 0) {
-            setMetricVisualizes([
-              updateVisualizeYAxis(
-                visualize,
-                DEFAULT_YAXIS_BY_TYPE[traceMetric.type]!,
-                traceMetric
-              ),
-            ]);
-          } else {
-            // Find the newly selected aggregate by comparing with current selection
-            const currentValues = new Set(
-              visualizes.map(v => v.parsedFunction?.name ?? '')
-            );
-            const newlySelected = option.find(o => !currentValues.has(o.value));
-
-            // If something new was selected, use its group; otherwise keep existing group
-            const targetGroup = newlySelected
-              ? findGroupKey(traceMetric.type, newlySelected.value)
-              : findGroupKey(
-                  traceMetric.type,
-                  visualizes?.[0]?.parsedFunction?.name ?? ''
-                );
-
-            // Filter to only keep aggregates from the same group
-            // This auto-deselects incompatible aggregates when switching groups
-            const compatibleOptions = option.filter(
-              o => findGroupKey(traceMetric.type, o.value) === targetGroup
-            );
-
-            setMetricVisualizes(
-              compatibleOptions.map(o =>
-                updateVisualizeYAxis(visualize, o.value, traceMetric)
-              )
-            );
-          }
-        }}
-      />
-    );
-  }
 
   return (
     <CompactSelect
+      multiple
+      style={{width: '100%'}}
       trigger={triggerProps => (
         <OverlayTrigger.Button
           {...triggerProps}
@@ -110,12 +50,42 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
           style={{width: '100%'}}
         />
       )}
-      options={OPTIONS_BY_TYPE[traceMetric.type] ?? []}
-      value={visualize.parsedFunction?.name ?? ''}
-      onChange={option => {
-        setVisualize(updateVisualizeYAxis(visualize, option.value, traceMetric));
+      options={GROUPED_OPTIONS_BY_TYPE[traceMetric.type] ?? []}
+      value={visualizes.map(v => v.parsedFunction?.name ?? '')}
+      onChange={(option: Array<SelectOption<string>>) => {
+        if (option.length === 0) {
+          setMetricVisualizes([
+            updateVisualizeYAxis(
+              visualize,
+              DEFAULT_YAXIS_BY_TYPE[traceMetric.type]!,
+              traceMetric
+            ),
+          ]);
+        } else {
+          // Find the newly selected aggregate by comparing with current selection
+          const currentValues = new Set(
+            visualizes.map(v => v.parsedFunction?.name ?? '')
+          );
+          const newlySelected = option.find(o => !currentValues.has(o.value));
+
+          // If something new was selected, use its group; otherwise keep existing group
+          const targetGroup = newlySelected
+            ? findGroupKey(traceMetric.type, newlySelected.value)
+            : findGroupKey(traceMetric.type, visualizes?.[0]?.parsedFunction?.name ?? '');
+
+          // Filter to only keep aggregates from the same group
+          // This auto-deselects incompatible aggregates when switching groups
+          const compatibleOptions = option.filter(
+            o => findGroupKey(traceMetric.type, o.value) === targetGroup
+          );
+
+          setMetricVisualizes(
+            compatibleOptions.map(o =>
+              updateVisualizeYAxis(visualize, o.value, traceMetric)
+            )
+          );
+        }
       }}
-      style={{width: '100%'}}
     />
   );
 }

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -21,13 +21,6 @@ export const canUseMetricsAlertsUI = (organization: Organization) => {
   );
 };
 
-export const canUseMetricsMultiAggregateUI = (organization: Organization) => {
-  return (
-    canUseMetricsUI(organization) &&
-    organization.features.includes('tracemetrics-overlay-charts-ui')
-  );
-};
-
 export const canUseMetricsSidePanelUI = (organization: Organization) => {
   return (
     canUseMetricsUI(organization) &&

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -1,5 +1,4 @@
 import type {ReactNode} from 'react';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
@@ -167,108 +166,99 @@ describe('MultiMetricsQueryParamsProvider', () => {
     ]);
   });
 
-  describe('with tracemetrics-overlay-charts-ui feature', () => {
-    const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
+  it('parses multiple visualizes from URL params', () => {
+    const metricQuery = JSON.stringify({
+      metric: {name: 'test_metric', type: 'distribution'},
+      query: '',
+      aggregateFields: [
+        {yAxes: ['p50(value,test_metric,distribution,-)']},
+        {yAxes: ['p75(value,test_metric,distribution,-)']},
+        {yAxes: ['p99(value,test_metric,distribution,-)']},
+      ],
+      aggregateSortBys: [],
+      mode: 'samples',
     });
 
-    it('parses multiple visualizes from URL params', () => {
-      const metricQuery = JSON.stringify({
-        metric: {name: 'test_metric', type: 'distribution'},
-        query: '',
-        aggregateFields: [
-          {yAxes: ['p50(value,test_metric,distribution,-)']},
-          {yAxes: ['p75(value,test_metric,distribution,-)']},
-          {yAxes: ['p99(value,test_metric,distribution,-)']},
-        ],
-        aggregateSortBys: [],
-        mode: 'samples',
-      });
-
-      const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
-        additionalWrapper: Wrapper,
-        organization,
-        initialRouterConfig: {
-          location: {
-            pathname: '/organizations/org-slug/explore/metrics/',
-            query: {
-              metric: [metricQuery],
-            },
+    const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/metrics/',
+          query: {
+            metric: [metricQuery],
           },
         },
-      });
+      },
+    });
 
-      expect(result.current).toEqual([
-        expect.objectContaining({
-          metric: {name: 'test_metric', type: 'distribution'},
-          queryParams: expect.objectContaining({
-            aggregateFields: [
-              new VisualizeFunction('p50(value,test_metric,distribution,-)'),
-              new VisualizeFunction('p75(value,test_metric,distribution,-)'),
-              new VisualizeFunction('p99(value,test_metric,distribution,-)'),
-            ],
-          }),
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'test_metric', type: 'distribution'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [
+            new VisualizeFunction('p50(value,test_metric,distribution,-)'),
+            new VisualizeFunction('p75(value,test_metric,distribution,-)'),
+            new VisualizeFunction('p99(value,test_metric,distribution,-)'),
+          ],
         }),
-      ]);
+      }),
+    ]);
+  });
+
+  it('sets multiple visualizes when changing aggregates', () => {
+    const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
+      additionalWrapper: Wrapper,
     });
 
-    it('sets multiple visualizes when changing aggregates', () => {
-      const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
-        additionalWrapper: Wrapper,
-        organization,
-      });
+    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'distribution'}));
+    act(() =>
+      result.current[0]!.setQueryParams(
+        result.current[0]!.queryParams.replace({
+          aggregateFields: [
+            new VisualizeFunction('p50(value,foo,distribution,-)'),
+            new VisualizeFunction('p75(value,foo,distribution,-)'),
+            new VisualizeFunction('p99(value,foo,distribution,-)'),
+          ],
+        })
+      )
+    );
 
-      act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'distribution'}));
-      act(() =>
-        result.current[0]!.setQueryParams(
-          result.current[0]!.queryParams.replace({
-            aggregateFields: [
-              new VisualizeFunction('p50(value,foo,distribution,-)'),
-              new VisualizeFunction('p75(value,foo,distribution,-)'),
-              new VisualizeFunction('p99(value,foo,distribution,-)'),
-            ],
-          })
-        )
-      );
-
-      expect(result.current).toEqual([
-        expect.objectContaining({
-          metric: {name: 'foo', type: 'distribution'},
-          queryParams: expect.objectContaining({
-            aggregateFields: [
-              new VisualizeFunction('p50(value,foo,distribution,-)'),
-              new VisualizeFunction('p75(value,foo,distribution,-)'),
-              new VisualizeFunction('p99(value,foo,distribution,-)'),
-            ],
-          }),
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'foo', type: 'distribution'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [
+            new VisualizeFunction('p50(value,foo,distribution,-)'),
+            new VisualizeFunction('p75(value,foo,distribution,-)'),
+            new VisualizeFunction('p99(value,foo,distribution,-)'),
+          ],
         }),
-      ]);
+      }),
+    ]);
+  });
+
+  it('keeps the first visualize when changing metric type', () => {
+    const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
+      additionalWrapper: Wrapper,
     });
 
-    it('keeps the first visualize when changing metric type', () => {
-      const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
-        additionalWrapper: Wrapper,
-        organization,
-      });
+    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'distribution'}));
+    act(() =>
+      result.current[0]!.setQueryParams(
+        result.current[0]!.queryParams.replace({
+          aggregateFields: [
+            new VisualizeFunction('p50(value,foo,distribution,-)'),
+            new VisualizeFunction('p75(value,foo,distribution,-)'),
+          ],
+        })
+      )
+    );
 
-      act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'distribution'}));
-      act(() =>
-        result.current[0]!.setQueryParams(
-          result.current[0]!.queryParams.replace({
-            aggregateFields: [
-              new VisualizeFunction('p50(value,foo,distribution,-)'),
-              new VisualizeFunction('p75(value,foo,distribution,-)'),
-            ],
-          })
-        )
-      );
+    act(() => result.current[0]!.setTraceMetric({name: 'bar', type: 'distribution'}));
 
-      act(() => result.current[0]!.setTraceMetric({name: 'bar', type: 'distribution'}));
-
-      // Only the first visualize is updated when changing metric type
-      expect(result.current[0]!.queryParams.aggregateFields).toEqual([
-        new VisualizeFunction('p50(value,bar,distribution,-)'),
-      ]);
-    });
+    // Only the first visualize is updated when changing metric type
+    expect(result.current[0]!.queryParams.aggregateFields).toEqual([
+      new VisualizeFunction('p50(value,bar,distribution,-)'),
+    ]);
   });
 });

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -6,7 +6,6 @@ import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
 import {decodeList} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   DEFAULT_YAXIS_BY_TYPE,
   OPTIONS_BY_TYPE,
@@ -19,7 +18,6 @@ import {
   type MetricQuery,
   type TraceMetric,
 } from 'sentry/views/explore/metrics/metricQuery';
-import {canUseMetricsMultiAggregateUI} from 'sentry/views/explore/metrics/metricsFlags';
 import {updateVisualizeYAxis} from 'sentry/views/explore/metrics/utils';
 import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import type {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
@@ -49,15 +47,8 @@ export function MultiMetricsQueryParamsProvider({
   const location = useLocation();
   const navigate = useNavigate();
 
-  const organization = useOrganization();
-  const hasMultiVisualize = canUseMetricsMultiAggregateUI(organization);
-
   const value = useMemo(() => {
-    const metricQueries = getMultiMetricsQueryParamsFromLocation(
-      location,
-      allowUpTo,
-      hasMultiVisualize
-    );
+    const metricQueries = getMultiMetricsQueryParamsFromLocation(location, allowUpTo);
 
     function setQueryParamsForIndex(i: number) {
       return function (newQueryParams: ReadableQueryParams) {
@@ -162,7 +153,7 @@ export function MultiMetricsQueryParamsProvider({
         };
       }),
     };
-  }, [allowUpTo, hasMultiVisualize, location, navigate]);
+  }, [allowUpTo, location, navigate]);
 
   return (
     <MultiMetricsQueryParamsContext value={value}>
@@ -173,13 +164,12 @@ export function MultiMetricsQueryParamsProvider({
 
 function getMultiMetricsQueryParamsFromLocation(
   location: Location,
-  limit?: number,
-  multiVisualize = false
+  limit?: number
 ): BaseMetricQuery[] {
   const rawQueryParams = decodeList(location.query.metric);
 
   const metricQueries = rawQueryParams
-    .map(value => decodeMetricsQueryParams(value, multiVisualize))
+    .map(value => decodeMetricsQueryParams(value))
     .filter(defined);
 
   const queries = metricQueries.length ? metricQueries : [defaultMetricQuery()];

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -28,7 +28,7 @@ const mockOpenSaveQueryModal = jest.mocked(modal.openSaveQueryModal);
 
 describe('useSaveAsMetricItems', () => {
   const organization = OrganizationFixture({
-    features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
+    features: ['tracemetrics-enabled'],
   });
   const project = ProjectFixture({id: '1'});
   const queryClient = makeTestQueryClient();


### PR DESCRIPTION
## Summary
- Remove the `tracemetrics-overlay-charts-ui` feature flag from the frontend, making multi-aggregate overlay chart behavior always-on
- Remove `canUseMetricsMultiAggregateUI` from `metricsFlags.tsx` and the `multiVisualize` parameter from `decodeMetricsQueryParams`/`parseVisualizes`
- Remove flag checks and single-select fallbacks from `aggregateDropdown`, `multiMetricsQueryParams`, `useMetricTimeseries`, and `metricGraph`

Recommended to review with whitespaces hidden.

Ticket: LOGS-551