### PR TITLE
fix(integrations): Reload integrations after installing coding agent

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -236,12 +236,26 @@ export default function IntegrationDetailedView() {
 
   const onInstall = useCallback(
     (integration: Integration) => {
-      // send the user to the configure integration view for that integration
+      if (provider?.features.includes('coding-agent')) {
+        queryClient.invalidateQueries({
+          queryKey: makeIntegrationQueryKey({
+            orgSlug: organization.slug,
+            integrationSlug,
+          }),
+        });
+        queryClient.invalidateQueries({
+          queryKey: [
+            getApiUrl(`/organizations/$organizationIdOrSlug/config/integrations/`, {
+              path: {organizationIdOrSlug: organization.slug},
+            }),
+          ],
+        });
+      }
       navigate(
         `/settings/${organization.slug}/integrations/${integration.provider.key}/${integration.id}/`
       );
     },
-    [organization.slug, navigate]
+    [organization.slug, integrationSlug, navigate, queryClient, provider?.features]
   );
 
   const onRemove = useCallback(


### PR DESCRIPTION
After creating an integration, it wasn't immediately shown on the page which could cause confusion. Now all coding agent integrations reload (I assume previously existing integrations were okay with that setup).