### PR TITLE
fix(dashboards): Include hidden dashboards in linked dashboard lookup

### DIFF
--- a/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
+++ b/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
@@ -45,7 +45,10 @@ const usePopulatePrebuiltIdsWithActualIds = (
         path: {organizationIdOrSlug: organization.slug},
       }),
       {
-        query: {prebuiltId: [...prebuiltIds.sort(), prebuiltId].filter(defined)},
+        query: {
+          prebuiltId: [...prebuiltIds.sort(), prebuiltId].filter(defined),
+          filter: 'showHidden',
+        },
       },
     ],
     {


### PR DESCRIPTION
Add `showHidden` filter to the prebuilt dashboard ID query in
`usePopulateLinkedDashboards` so that hidden dashboards (i.e the detail dashboards)
are included when resolving linked dashboard detail links.

Without this filter, the API excludes hidden dashboards from results,
causing detail links for mobile vitals dashboards to break since those
dashboards are marked as hidden.

Fixes DAIN-1339