### PR TITLE
fix(billing): Prevent checkout form resetting when payment details are updated

### DIFF
--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -747,14 +747,11 @@ describe('Default Tier Checkout', () => {
       );
     });
 
-    // Free subscriptions default to Business plan
     expect(screen.getByRole('radio', {name: 'Business'})).toBeChecked();
 
-    // User selects Team plan
     await userEvent.click(screen.getByRole('radio', {name: 'Team'}));
     expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
 
-    // Simulate a subscription store update (e.g. from a payment method update)
     act(() => {
       SubscriptionStore.set(organization.slug, {
         ...sub,
@@ -769,11 +766,9 @@ describe('Default Tier Checkout', () => {
       });
     });
 
-    // Plan selection should be preserved — Team should still be selected
     expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
     expect(screen.getByRole('radio', {name: 'Business'})).not.toBeChecked();
 
-    // Billing config should only have been fetched once
     expect(mockBillingConfigResponse).toHaveBeenCalledTimes(1);
   });
 

--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -5,7 +5,7 @@ import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixt
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import {AddOnCategory, OnDemandBudgetMode, PlanTier} from 'getsentry/types';
@@ -717,6 +717,64 @@ describe('Default Tier Checkout', () => {
       reservedProfileDuration: 0,
       reservedSpans: 0,
     });
+  });
+
+  it('does not reset plan selection when subscription store updates', async () => {
+    const sub = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      isFree: true,
+    });
+    SubscriptionStore.set(organization.slug, sub);
+
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        navigate={jest.fn()}
+        api={api}
+        checkoutTier={PlanTier.AM3}
+      />,
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(mockBillingConfigResponse).toHaveBeenCalledWith(
+        `/customers/${organization.slug}/billing-config/`,
+        expect.objectContaining({
+          method: 'GET',
+          data: {tier: 'am3'},
+        })
+      );
+    });
+
+    // Free subscriptions default to Business plan
+    expect(screen.getByRole('radio', {name: 'Business'})).toBeChecked();
+
+    // User selects Team plan
+    await userEvent.click(screen.getByRole('radio', {name: 'Team'}));
+    expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
+
+    // Simulate a subscription store update (e.g. from a payment method update)
+    act(() => {
+      SubscriptionStore.set(organization.slug, {
+        ...sub,
+        paymentSource: {
+          last4: '4242',
+          brand: 'visa',
+          expMonth: 12,
+          expYear: 2030,
+          countryCode: 'US',
+          zipCode: '94107',
+        },
+      });
+    });
+
+    // Plan selection should be preserved — Team should still be selected
+    expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
+    expect(screen.getByRole('radio', {name: 'Business'})).not.toBeChecked();
+
+    // Billing config should only have been fetched once
+    expect(mockBillingConfigResponse).toHaveBeenCalledTimes(1);
   });
 
   it('does not use trial volumes for trial subscriptions', async () => {

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {loadStripe} from '@stripe/stripe-js';
@@ -111,6 +111,7 @@ function AMCheckout(props: Props) {
     promotionData,
   } = props;
 
+  const hasFetchedBillingConfig = useRef(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | boolean>(false);
   const [formData, setFormData] = useState<CheckoutFormData | null>(null);
@@ -574,7 +575,10 @@ function AMCheckout(props: Props) {
 
   useEffect(() => {
     if (subscription.canSelfServe) {
-      fetchBillingConfig();
+      if (!hasFetchedBillingConfig.current) {
+        hasFetchedBillingConfig.current = true;
+        fetchBillingConfig();
+      }
     } else {
       handleRedirect();
     }


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/BIL-2186/checkout-form-resets-plan-when-payment-details-are-entered