### PR TITLE
fix(events): Don't link to trace explorer when trace id is missing

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -254,35 +254,6 @@ describe('Performance GridEditable Table', () => {
   });
 
   it('does not render trace link when trace id is missing', async () => {
-    data = data.map(event => ({...event, trace: null}));
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      headers: {
-        Link:
-          '<http://localhost/api/0/organizations/org-slug/events/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
-          '<http://localhost/api/0/organizations/org-slug/events/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
-      },
-      body: {
-        meta: {
-          fields: {
-            id: 'string',
-            'user.display': 'string',
-            'transaction.duration': 'duration',
-            'project.id': 'integer',
-            timestamp: 'date',
-            trace: 'string',
-          },
-        },
-        data,
-      },
-      match: [
-        (_url, options) => {
-          return options.query?.field?.includes('user.display');
-        },
-      ],
-    });
-
     const initialData = initializeData();
     const eventView = EventView.fromNewQueryWithLocation(
       {
@@ -310,14 +281,12 @@ describe('Performance GridEditable Table', () => {
       />
     );
 
-    // Event ID links should still render
-    expect(await screen.findByRole('link', {name: 'deadbeef'})).toBeInTheDocument();
+    // First event has a trace and should render a trace link
+    expect(await screen.findByRole('link', {name: '1234'})).toBeInTheDocument();
 
-    // Trace column values should not be wrapped in links when trace is null
-    const noValueElements = screen.getAllByText('(no value)');
-    for (const el of noValueElements) {
-      expect(el.closest('a')).toBeNull();
-    }
+    // Second event has no trace - its (no value) should not be a link
+    const noValueElement = screen.getByText('(no value)');
+    expect(noValueElement.closest('a')).toBeNull();
   });
 
   it('renders replay id', async () => {

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -253,6 +253,73 @@ describe('Performance GridEditable Table', () => {
     );
   });
 
+  it('does not render trace link when trace id is missing', async () => {
+    data = data.map(event => ({...event, trace: null}));
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      headers: {
+        Link:
+          '<http://localhost/api/0/organizations/org-slug/events/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
+          '<http://localhost/api/0/organizations/org-slug/events/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
+      },
+      body: {
+        meta: {
+          fields: {
+            id: 'string',
+            'user.display': 'string',
+            'transaction.duration': 'duration',
+            'project.id': 'integer',
+            timestamp: 'date',
+            trace: 'string',
+          },
+        },
+        data,
+      },
+      match: [
+        (_url, options) => {
+          return options.query?.field?.includes('user.display');
+        },
+      ],
+    });
+
+    const initialData = initializeData();
+    const eventView = EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        version: 2,
+        name: 'transactionName',
+        fields,
+        query,
+        projects: [],
+        orderby: '-timestamp',
+      },
+      initialData.router.location
+    );
+
+    render(
+      <EventsTable
+        theme={theme}
+        eventView={eventView}
+        organization={organization}
+        routes={initialData.router.routes}
+        location={initialData.router.location}
+        setError={() => {}}
+        columnTitles={transactionsListTitles}
+        transactionName={transactionName}
+      />
+    );
+
+    // Event ID links should still render
+    expect(await screen.findByRole('link', {name: 'deadbeef'})).toBeInTheDocument();
+
+    // Trace column values should not be wrapped in links when trace is null
+    const noValueElements = screen.getAllByText('(no value)');
+    for (const el of noValueElements) {
+      expect(el.closest('a')).toBeNull();
+    }
+  });
+
   it('renders replay id', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/replay-count/',

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -255,6 +255,9 @@ export function EventsTable({
           }
         }
 
+        const hasValidTarget =
+          'pathname' in target ? !!target.pathname : !isEmptyObject(target);
+
         return (
           <CellAction
             column={column}
@@ -262,7 +265,7 @@ export function EventsTable({
             handleCellAction={cellActionHandler}
             allowActions={allowActions}
           >
-            <Link to={target}>{rendered}</Link>
+            {hasValidTarget ? <Link to={target}>{rendered}</Link> : rendered}
           </CellAction>
         );
       }

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -232,31 +232,28 @@ export function EventsTable({
 
       if (field === 'id' || field === 'trace') {
         const isIssue = !!issueId;
-        let target: LocationDescriptor = {};
+        let target: LocationDescriptor | null = null;
         if (isIssue && !isRegressionIssue && field === 'id') {
-          target.pathname = `/organizations/${organization.slug}/issues/${issueId}/events/${dataRow.id}/`;
-        } else {
-          if (field === 'id') {
-            target = generateLinkToEventInTraceView({
-              traceSlug: dataRow.trace?.toString()!,
-              eventId: dataRow.id,
-              timestamp: dataRow.timestamp!,
-              location,
-              organization,
-              source: TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY,
-              view: domainViewFilters?.view,
-            });
-          } else {
-            target = generateTraceLink(transactionName, domainViewFilters?.view)(
-              organization,
-              dataRow,
-              location
-            );
-          }
+          target = {
+            pathname: `/organizations/${organization.slug}/issues/${issueId}/events/${dataRow.id}/`,
+          };
+        } else if (field === 'id') {
+          target = generateLinkToEventInTraceView({
+            traceSlug: dataRow.trace?.toString()!,
+            eventId: dataRow.id,
+            timestamp: dataRow.timestamp!,
+            location,
+            organization,
+            source: TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY,
+            view: domainViewFilters?.view,
+          });
+        } else if (dataRow.trace) {
+          target = generateTraceLink(transactionName, domainViewFilters?.view)(
+            organization,
+            dataRow,
+            location
+          );
         }
-
-        const hasValidTarget =
-          'pathname' in target ? !!target.pathname : !isEmptyObject(target);
 
         return (
           <CellAction
@@ -265,7 +262,7 @@ export function EventsTable({
             handleCellAction={cellActionHandler}
             allowActions={allowActions}
           >
-            {hasValidTarget ? <Link to={target}>{rendered}</Link> : rendered}
+            {target ? <Link to={target}>{rendered}</Link> : rendered}
           </CellAction>
         );
       }

--- a/static/app/views/performance/transactionSummary/transactionEvents/testUtils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/testUtils.tsx
@@ -24,7 +24,6 @@ export const MOCK_EVENTS_TABLE_DATA = [
     'transaction.duration': 600,
     'project.id': 1,
     timestamp: '2020-05-22T15:31:18+00:00',
-    trace: '4321',
     'span_ops_breakdown.relative': '',
     'spans.browser': 100,
     'spans.db': 300,

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -138,7 +138,7 @@ export function generateTraceLink(dateSelection: any, view?: DomainView) {
     tableRow: TableDataRow,
     location: Location
   ): LocationDescriptor => {
-    const traceId = `${tableRow.trace}`;
+    const traceId = tableRow.trace ? `${tableRow.trace}` : '';
     if (!traceId) {
       return {};
     }


### PR DESCRIPTION
When an event has no trace id, the trace column in the events table still rendered a clickable link navigating to the trace explorer with a null trace id. Now the trace value renders as plain text without a link when no trace id is present.

Also fix generateTraceLink converting null/undefined to the string "null"/"undefined" via template literal, bypassing the empty check.

Refs ISWF-2234

Before: https://linear.app/getsentry/issue/ISWF-2234/dont-link-to-trace-explorer-if-no-trace-id-is-present

After:
<img width="432" height="271" alt="Screenshot 2026-03-13 at 12 20 57 PM" src="https://github.com/user-attachments/assets/e34698f1-6a1f-420a-9424-397da4073bac" />