### PR TITLE
feat(alerts): Include single-written detectors in AlertRuleFetchMixin.fetch_metric_alerts

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -1,9 +1,11 @@
 import logging
+from collections.abc import Sequence
 from copy import deepcopy
 from datetime import UTC, datetime
 
 from django.db.models import Case, DateTimeField, IntegerField, OuterRef, Q, Subquery, Value, When
-from django.db.models.functions import Coalesce
+from django.db.models.fields import BigIntegerField
+from django.db.models.functions import Cast, Coalesce
 from django.http.response import HttpResponseBase
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers, status
@@ -74,7 +76,7 @@ from sentry.relay.config.metric_extraction import (
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import ExtrapolationMode
+from sentry.snuba.models import ExtrapolationMode, QuerySubscription
 from sentry.uptime.types import (
     DATA_SOURCE_UPTIME_SUBSCRIPTION,
     GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
@@ -88,6 +90,27 @@ from sentry.workflow_engine.types import DetectorPriorityLevel
 from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 logger = logging.getLogger(__name__)
+
+
+def filter_detectors_by_dataset(
+    detectors: BaseQuerySet[Detector], dataset: Dataset
+) -> BaseQuerySet[Detector]:
+    """Filter detectors to only those with the specified dataset."""
+    # Filter by joining through Detector -> DataSource -> QuerySubscription -> SnubaQuery
+    # Cast DataSource.source_id (string) to int so the subquery can use the index on QuerySubscription.id
+    return (
+        detectors.annotate(
+            source_id_as_int=Cast("data_sources__source_id", output_field=BigIntegerField())
+        )
+        .filter(
+            data_sources__type="snuba_query_subscription",
+            source_id_as_int__in=QuerySubscription.objects.filter(
+                snuba_query__dataset=dataset.value
+            ).values_list("id", flat=True),
+        )
+        .distinct()
+    )
+
 
 # Valid sort keys for combined rules endpoint
 VALID_COMBINED_RULE_SORT_KEYS = {"date_added", "name", "incident_status", "date_triggered"}
@@ -177,14 +200,14 @@ class AlertRuleFetchMixin(Endpoint):
     Can be used with any endpoint base class (OrganizationEndpoint, ProjectEndpoint, etc).
     """
 
-    def fetch_metric_alert(
-        self, request: Request, organization: Organization, alert_rules: BaseQuerySet[AlertRule]
+    def fetch_metric_alerts(
+        self,
+        request: Request,
+        organization: Organization,
+        projects: Sequence[Project],
     ) -> HttpResponseBase:
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
-
-        if not features.has("organizations:performance-view", organization):
-            alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
 
         if "latestIncident" in request.GET.getlist("expand", []) and not is_frontend_request(
             request
@@ -194,10 +217,18 @@ class AlertRuleFetchMixin(Endpoint):
                 extra={"organization": organization.id},
             )
 
-        if features.has("organizations:workflow-engine-rule-serializers", organization):
+        use_workflow_engine = features.has(
+            "organizations:workflow-engine-rule-serializers", organization
+        )
+
+        if use_workflow_engine:
             detectors = Detector.objects.filter(
-                alertruledetector__alert_rule_id__in=alert_rules.values_list("id", flat=True)
+                Q(alertruledetector__isnull=False)  # Dual-written
+                | Q(alertruledetector__isnull=True, type="metric_issue"),  # Single-written
+                project__in=projects,
             )
+            if not features.has("organizations:performance-view", organization):
+                detectors = filter_detectors_by_dataset(detectors, Dataset.Events)
             response = self.paginate(
                 request,
                 queryset=detectors,
@@ -207,7 +238,11 @@ class AlertRuleFetchMixin(Endpoint):
                 default_per_page=25,
                 count_hits=True,
             )
+            response[ALERT_RULES_COUNT_HEADER] = detectors.count()
         else:
+            alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
+            if not features.has("organizations:performance-view", organization):
+                alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
             response = self.paginate(
                 request,
                 queryset=alert_rules,
@@ -217,7 +252,7 @@ class AlertRuleFetchMixin(Endpoint):
                 default_per_page=25,
                 count_hits=True,
             )
-        response[ALERT_RULES_COUNT_HEADER] = len(alert_rules)
+            response[ALERT_RULES_COUNT_HEADER] = alert_rules.count()
         response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = get_max_metric_alert_subscriptions(organization)
         return response
 
@@ -648,8 +683,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         project.
         """
         projects = self.get_projects(request, organization)
-        alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
-        return self.fetch_metric_alert(request, organization, alert_rules)
+        return self.fetch_metric_alerts(request, organization, projects)
 
     @extend_schema(
         operation_id="(DEPRECATED) Create a Metric Alert Rule for an Organization",

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -222,11 +222,18 @@ class AlertRuleFetchMixin(Endpoint):
         )
 
         if use_workflow_engine:
-            detectors = Detector.objects.filter(
-                Q(alertruledetector__isnull=False)  # Dual-written
-                | Q(alertruledetector__isnull=True, type="metric_issue"),  # Single-written
-                project__in=projects,
-            ).distinct()  # Deduplicate after JOIN
+            # Filter to metric alerts only, then check if dual-written or single-written
+            detectors = (
+                Detector.objects.filter(
+                    type="metric_issue",
+                    project__in=projects,
+                )
+                .filter(
+                    Q(alertruledetector__alert_rule_id__isnull=False)  # Dual-written
+                    | Q(alertruledetector__isnull=True)  # Single-written
+                )
+                .distinct()
+            )  # Deduplicate after JOIN
             if not features.has("organizations:performance-view", organization):
                 detectors = filter_detectors_by_dataset(detectors, Dataset.Events)
             response = self.paginate(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -226,7 +226,7 @@ class AlertRuleFetchMixin(Endpoint):
                 Q(alertruledetector__isnull=False)  # Dual-written
                 | Q(alertruledetector__isnull=True, type="metric_issue"),  # Single-written
                 project__in=projects,
-            )
+            ).distinct()  # Deduplicate after JOIN
             if not features.has("organizations:performance-view", organization):
                 detectors = filter_detectors_by_dataset(detectors, Dataset.Events)
             response = self.paginate(

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -11,7 +11,6 @@ from sentry.incidents.endpoints.organization_alert_rule_index import (
     AlertRuleFetchMixin,
     create_metric_alert,
 )
-from sentry.incidents.models.alert_rule import AlertRule
 from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 
@@ -29,8 +28,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
         """
         Fetches metric alert rules for a project - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.
         """
-        alert_rules = AlertRule.objects.fetch_for_project(project)
-        return self.fetch_metric_alert(request, project.organization, alert_rules)
+        return self.fetch_metric_alerts(request, project.organization, [project])
 
     @track_alert_endpoint_execution("POST", "sentry-api-0-project-alert-rules")
     def post(self, request: Request, project) -> HttpResponseBase:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -24,6 +24,7 @@ from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     WorkflowEngineDetectorSerializer,
 )
+from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import INVALID_TIME_WINDOW
 from sentry.incidents.models.alert_rule import (
     AlertRule,
@@ -49,7 +50,7 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
-from sentry.snuba.models import SnubaQueryEventType
+from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
 from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.tasks import create_subscription_in_snuba
@@ -63,7 +64,7 @@ from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.snuba import _snuba_pool
-from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.models import Action, DataSource, Detector
 from tests.sentry.incidents.serializers.test_workflow_engine_base import (
     TestWorkflowEngineSerializer,
 )
@@ -290,6 +291,82 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
             resp = self.get_success_response(self.organization.slug)
 
         assert "snooze" not in resp.data[0]
+
+    def test_workflow_engine_serializer_includes_single_written_detectors(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+
+        # Create single-written detector by reusing existing query infrastructure
+        query_subscription = QuerySubscription.objects.get(snuba_query=self.alert_rule.snuba_query)
+        data_source, _ = DataSource.objects.get_or_create(
+            type="snuba_query_subscription",
+            source_id=str(query_subscription.id),
+            defaults={"organization_id": self.organization.id},
+        )
+        single_written_detector = self.create_detector(
+            project=self.project,
+            type=MetricIssue.slug,
+            name="Single Written Detector",
+        )
+        data_source.detectors.add(single_written_detector)
+
+        self.login_as(self.user)
+        with self.feature(
+            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
+        ):
+            resp = self.get_success_response(self.organization.slug)
+
+        assert len(resp.data) == 2
+        detector_names = {item["name"] for item in resp.data}
+        assert self.detector.name in detector_names
+        assert "Single Written Detector" in detector_names
+
+    def test_workflow_engine_count_includes_single_written_detectors(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+
+        # Create single-written detector
+        query_subscription = QuerySubscription.objects.get(snuba_query=self.alert_rule.snuba_query)
+        data_source, _ = DataSource.objects.get_or_create(
+            type="snuba_query_subscription",
+            source_id=str(query_subscription.id),
+            defaults={"organization_id": self.organization.id},
+        )
+        single_written_detector = self.create_detector(
+            project=self.project,
+            type=MetricIssue.slug,
+            name="Single Written Detector",
+        )
+        data_source.detectors.add(single_written_detector)
+
+        self.login_as(self.user)
+        with self.feature(
+            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
+        ):
+            resp = self.get_success_response(self.organization.slug)
+
+        assert resp[ALERT_RULES_COUNT_HEADER] == "2"
+
+    def test_workflow_engine_serializer_scopes_to_project(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+
+        # Create detector in different project
+        other_project = self.create_project(organization=self.organization)
+        self.create_detector(
+            project=other_project,
+            type=MetricIssue.slug,
+            name="Other Project Detector",
+        )
+
+        self.login_as(self.user)
+        with self.feature(
+            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
+        ):
+            resp = self.get_success_response(self.organization.slug)
+
+        assert len(resp.data) == 1
+        assert resp.data[0]["name"] == self.detector.name
 
 
 @freeze_time("2024-12-11 03:21:34")


### PR DESCRIPTION
OrganizationAlertRuleIndexEndpoint and ProjectAlertRuleIndexEndpoint need to be able to include single-written Detectors when organizations:workflow-engine-rule-serializers is enabled.

In addition to single-written support, this removes dependency on AlertRule entirely in that path, ensures we have the appropriate filtering, and sets the count header.
Also, renamed the method to plural to be less confusing, as that confused me previously.
