### PR TITLE
fix(explore): disable drop transition on group-by sortable items

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -57,8 +57,9 @@ export function ToolbarGroupByDropdown({
   loading,
   onClose,
 }: ToolbarGroupByDropdownProps) {
-  const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
+  const {attributes, listeners, setNodeRef, transform} = useSortable({
     id: column.id,
+    transition: null,
   });
 
   function handleColumnChange(option: SelectOption<SelectKey>) {
@@ -76,7 +77,7 @@ export function ToolbarGroupByDropdown({
     <ToolbarRow
       key={column.id}
       ref={setNodeRef}
-      style={{transform: CSS.Transform.toString(transform), transition}}
+      style={{transform: CSS.Transform.toString(transform)}}
       {...attributes}
     >
       {canDelete ? (


### PR DESCRIPTION
Disable the dnd-kit drop transition on group-by sortable items in the explore toolbar to fix a visual animation glitch when reordering.

The state update on drop already handles visual reordering instantly. The dnd-kit drop transition conflicts with this, causing items to briefly animate from a stale position. Setting `transition: null` in `useSortable` matches the pattern already used in `SortableVisualizeFieldWrapper` and `SortableQueryField`.

I'd noticed & fixed this same kind of bug when QAing #110648. Example place where this one pops up: Explore > Traces.

https://github.com/user-attachments/assets/b7cb46ba-d39e-449a-9d5e-c0a32a35ef5e


Fixes EXP-842. 

Made with [Cursor](https://cursor.com)