### PR TITLE
fix(ui): align upsell modal feature list

### DIFF
--- a/static/gsApp/components/upsellModal/featureList.tsx
+++ b/static/gsApp/components/upsellModal/featureList.tsx
@@ -123,9 +123,10 @@ const FeatureLink = styled(motion.div)`
   display: grid;
   grid-template-columns: max-content auto;
   gap: ${p => p.theme.space.md};
-  align-items: center;
-  align-content: baseline;
+  align-items: flex-start;
+  align-content: center;
   margin-bottom: ${p => p.theme.space.xs};
+  white-space: nowrap;
 
   &:hover {
     color: ${p => p.theme.tokens.content.primary};

--- a/static/gsApp/components/upsellModal/featureList.tsx
+++ b/static/gsApp/components/upsellModal/featureList.tsx
@@ -124,7 +124,7 @@ const FeatureLink = styled(motion.div)`
   grid-template-columns: max-content auto;
   gap: ${p => p.theme.space.md};
   align-items: center;
-  align-content: center;
+  align-content: baseline;
   margin-bottom: ${p => p.theme.space.xs};
 
   &:hover {


### PR DESCRIPTION
Upsell modal items were misaligned. Two fixes: `white-space: nowrap` to avoid wrapping. If that ever needs to be removed, I also set `align-items: flex-start` for redundancy.

| Before | After |
|--------|--------|
| <img width="999" height="627" alt="Screenshot 2026-03-13 at 4 08 23 PM" src="https://github.com/user-attachments/assets/9795921b-1238-4aee-a716-d2867a6d921d" /> | <img width="996" height="511" alt="Screenshot 2026-03-13 at 4 08 16 PM" src="https://github.com/user-attachments/assets/5a16c0b2-f9a4-4acc-ab01-ab342797edf8" /> |

Closes DE-1005