### PR TITLE
ref(cells): Remove SiloMode.REGION

### DIFF
--- a/src/sentry/silo/base.py
+++ b/src/sentry/silo/base.py
@@ -36,7 +36,7 @@ class SiloMode(Enum):
             return SiloMode.MONOLITH
         if isinstance(mode, SiloMode):
             return mode
-        return cls[mode]
+        return cls(mode)
 
     def __str__(self) -> str:
         return str(self.value)

--- a/src/sentry/silo/base.py
+++ b/src/sentry/silo/base.py
@@ -29,8 +29,6 @@ class SiloMode(Enum):
     MONOLITH = "MONOLITH"
     CONTROL = "CONTROL"
     CELL = "REGION"
-    # TODO(cells): remove once getsentry migrates to CELL
-    REGION = "REGION"
 
     @classmethod
     def resolve(cls, mode: str | SiloMode | None) -> SiloMode:


### PR DESCRIPTION
this was a temporary alias for SiloMode.CELL and is no longer needed
