### PR TITLE
fix(compact-select): Boost exact matches in default search matcher

### DIFF
--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -709,6 +709,33 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument(); // score 1, hidden
     });
 
+    it('default matcher ranks exact matches above partial matches', async () => {
+      render(
+        <CompactSelect
+          search={{placeholder: 'Search here…'}}
+          options={[
+            {value: 'binary_path', label: 'binary_path'},
+            {value: 'file_path', label: 'file_path'},
+            {value: 'path', label: 'path'},
+            {value: 'path_arg', label: 'path_arg'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('path');
+
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(4);
+      expect(options[0]).toHaveTextContent('path');
+      expect(options[1]).toHaveTextContent('binary_path');
+      expect(options[2]).toHaveTextContent('file_path');
+      expect(options[3]).toHaveTextContent('path_arg');
+    });
+
     it('passes option and search string to searchMatcher', async () => {
       const searchMatcher = jest.fn().mockReturnValue({score: 1});
 

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -128,7 +128,8 @@ function defaultSearchMatcher<Value extends SelectKey>(
   if (!text) {
     return {score: 0};
   }
-  const result = fzf(text, search.toLowerCase(), false);
+  const lowerSearch = search.toLowerCase();
+  const result = fzf(text, lowerSearch, false);
   // fzf returns end=-1 when no subsequence match exists (score is also 0).
   // For valid matches fzf may return negative scores due to gap penalties, so we
   // cannot rely on score > 0 to detect a match. Use end !== -1 instead and clamp
@@ -136,7 +137,12 @@ function defaultSearchMatcher<Value extends SelectKey>(
   if (result.end === -1) {
     return {score: 0};
   }
-  return {score: Math.max(1, result.score)};
+  const score = Math.max(1, result.score);
+  // Boost exact matches so they sort above partial/substring matches.
+  if (text.toLowerCase() === lowerSearch) {
+    return {score: score + 1000};
+  }
+  return {score};
 }
 
 /**


### PR DESCRIPTION
When searching in a CompactSelect with the default fuzzy matcher, an exact match (e.g. "path") could appear far down the list because fzf gives similar boundary-bonus scores to partial matches like "binary_path" and "file_path". Add a +1000 score boost for exact case-insensitive matches so they always sort to the top.

Before:
<img width="466" height="611" alt="Screenshot 2026-03-13 at 1 11 44 PM" src="https://github.com/user-attachments/assets/c2c3e2d7-6abf-48c2-8680-3ca8d8f93a50" />
