### PR TITLE
fix(billing): Prevent checkout form resetting when payment details are updated

### DIFF
--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -5,7 +5,7 @@ import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixt
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import {AddOnCategory, OnDemandBudgetMode, PlanTier} from 'getsentry/types';
@@ -789,5 +789,187 @@ describe('Default Tier Checkout', () => {
     expect(screen.getByTestId('attachments-volume-item')).toHaveTextContent('1 GB');
     expect(screen.getByTestId('spans-volume-item')).toHaveTextContent('10M');
     expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('50');
+  });
+
+  describe('plan selection persistence', () => {
+    it('does not reset plan selection when subscription store updates (free user)', async () => {
+      const sub = SubscriptionFixture({
+        organization,
+        plan: 'am3_f',
+        isFree: true,
+      });
+      SubscriptionStore.set(organization.slug, sub);
+
+      render(
+        <AMCheckout
+          {...RouteComponentPropsFixture()}
+          navigate={jest.fn()}
+          api={api}
+          checkoutTier={PlanTier.AM3}
+        />,
+        {organization}
+      );
+
+      await waitFor(() => {
+        expect(mockBillingConfigResponse).toHaveBeenCalledWith(
+          `/customers/${organization.slug}/billing-config/`,
+          expect.objectContaining({method: 'GET', data: {tier: 'am3'}})
+        );
+      });
+
+      // Free users should default to Business
+      expect(screen.getByRole('radio', {name: 'Business'})).toBeChecked();
+
+      // User selects Team
+      await userEvent.click(screen.getByRole('radio', {name: 'Team'}));
+      expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
+
+      // Simulate subscription store update (e.g., after saving credit card)
+      act(() => {
+        SubscriptionStore.set(organization.slug, {
+          ...sub,
+          paymentSource: {
+            last4: '4242',
+            brand: 'visa',
+            expMonth: 12,
+            expYear: 2030,
+            countryCode: 'US',
+            zipCode: '94107',
+          },
+        });
+      });
+
+      // Plan selection should be preserved
+      expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
+      expect(screen.getByRole('radio', {name: 'Business'})).not.toBeChecked();
+
+      // Billing config should only be fetched once
+      expect(mockBillingConfigResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reset plan selection when subscription store updates (trial user)', async () => {
+      const sub = SubscriptionFixture({
+        organization,
+        plan: 'am3_t',
+        isTrial: true,
+      });
+      SubscriptionStore.set(organization.slug, sub);
+
+      render(
+        <AMCheckout
+          {...RouteComponentPropsFixture()}
+          navigate={jest.fn()}
+          api={api}
+          checkoutTier={PlanTier.AM3}
+        />,
+        {organization}
+      );
+
+      await waitFor(() => {
+        expect(mockBillingConfigResponse).toHaveBeenCalledWith(
+          `/customers/${organization.slug}/billing-config/`,
+          expect.objectContaining({method: 'GET', data: {tier: 'am3'}})
+        );
+      });
+
+      // Trial users should default to Business
+      expect(screen.getByRole('radio', {name: 'Business'})).toBeChecked();
+
+      // User selects Team
+      await userEvent.click(screen.getByRole('radio', {name: 'Team'}));
+      expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
+
+      // Simulate subscription store update
+      act(() => {
+        SubscriptionStore.set(organization.slug, {
+          ...sub,
+          paymentSource: {
+            last4: '4242',
+            brand: 'visa',
+            expMonth: 12,
+            expYear: 2030,
+            countryCode: 'US',
+            zipCode: '94107',
+          },
+        });
+      });
+
+      // Plan selection should be preserved
+      expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
+      expect(screen.getByRole('radio', {name: 'Business'})).not.toBeChecked();
+
+      // Billing config should only be fetched once
+      expect(mockBillingConfigResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves form data across multiple subscription store updates', async () => {
+      const sub = SubscriptionFixture({
+        organization,
+        plan: 'am3_f',
+        isFree: true,
+      });
+      SubscriptionStore.set(organization.slug, sub);
+
+      render(
+        <AMCheckout
+          {...RouteComponentPropsFixture()}
+          navigate={jest.fn()}
+          api={api}
+          checkoutTier={PlanTier.AM3}
+        />,
+        {organization}
+      );
+
+      await waitFor(() => {
+        expect(mockBillingConfigResponse).toHaveBeenCalledWith(
+          `/customers/${organization.slug}/billing-config/`,
+          expect.objectContaining({method: 'GET', data: {tier: 'am3'}})
+        );
+      });
+
+      // User selects Team
+      await userEvent.click(screen.getByRole('radio', {name: 'Team'}));
+      expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
+
+      // First subscription store update
+      act(() => {
+        SubscriptionStore.set(organization.slug, {
+          ...sub,
+          paymentSource: {
+            last4: '4242',
+            brand: 'visa',
+            expMonth: 12,
+            expYear: 2030,
+            countryCode: 'US',
+            zipCode: '94107',
+          },
+        });
+      });
+
+      // Team should still be selected after first update
+      expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
+
+      // Second subscription store update with different payment data
+      act(() => {
+        SubscriptionStore.set(organization.slug, {
+          ...sub,
+          paymentSource: {
+            last4: '1234',
+            brand: 'mastercard',
+            expMonth: 6,
+            expYear: 2031,
+            countryCode: 'US',
+            zipCode: '10001',
+          },
+        });
+      });
+
+      // Team should STILL be selected after second update
+      expect(screen.getByRole('radio', {name: 'Team'})).toBeChecked();
+      expect(screen.getByRole('radio', {name: 'Business'})).not.toBeChecked();
+
+      // Billing config should only be fetched once
+      expect(mockBillingConfigResponse).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -471,9 +471,7 @@ function AMCheckout(props: Props) {
 
       setBillingConfig(newBillingConfig);
 
-      // Initialize form data only once. The ref guard prevents re-initialization
-      // when the subscription object changes (e.g. after saving payment details),
-      // which would reset the user's plan selection.
+      // Prevent overwriting the user's plan selection on subsequent calls.
       if (!isFormInitialized.current) {
         const initialFormData = getInitialData(newBillingConfig);
         setFormData(initialFormData);
@@ -585,11 +583,8 @@ function AMCheckout(props: Props) {
     } else {
       handleRedirect();
     }
-    // Only re-fetch when checkoutTier changes, matching the original class
-    // component's componentDidUpdate behavior. fetchBillingConfig and
-    // handleRedirect are excluded because their identity changes on
-    // subscription updates, which would cause an unintended form data
-    // reset.
+    // fetchBillingConfig excluded — its identity is unstable across renders,
+    // and re-fetching would overwrite the user's in-progress form selections.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [subscription.canSelfServe, checkoutTier]);
 

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {loadStripe} from '@stripe/stripe-js';
@@ -111,6 +111,7 @@ function AMCheckout(props: Props) {
     promotionData,
   } = props;
 
+  const isFormInitialized = useRef(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | boolean>(false);
   const [formData, setFormData] = useState<CheckoutFormData | null>(null);
@@ -467,14 +468,20 @@ function AMCheckout(props: Props) {
 
       const planList = getPlans(config);
       const newBillingConfig = {...config, planList};
-      const initialFormData = getInitialData(newBillingConfig);
 
       setBillingConfig(newBillingConfig);
-      setFormData(initialFormData);
-      setFormDataForPreview(getFormDataForPreview(initialFormData));
+
+      // Initialize form data only once. The ref guard prevents re-initialization
+      // when the subscription object changes (e.g. after saving payment details),
+      // which would reset the user's plan selection.
+      if (!isFormInitialized.current) {
+        const initialFormData = getInitialData(newBillingConfig);
+        setFormData(initialFormData);
+        setFormDataForPreview(getFormDataForPreview(initialFormData));
+        isFormInitialized.current = true;
+      }
     } catch (err: any) {
       setError(err);
-      setLoading(false);
       if (err.status !== 401 && err.status !== 403) {
         Sentry.captureException(err);
       }
@@ -578,7 +585,13 @@ function AMCheckout(props: Props) {
     } else {
       handleRedirect();
     }
-  }, [subscription.canSelfServe, fetchBillingConfig, handleRedirect]);
+    // Only re-fetch when checkoutTier changes, matching the original class
+    // component's componentDidUpdate behavior. fetchBillingConfig and
+    // handleRedirect are excluded because their identity changes on
+    // subscription updates, which would cause an unintended form data
+    // reset.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [subscription.canSelfServe, checkoutTier]);
 
   // Scroll to step after billing config and form data are ready
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Fix checkout form silently resetting from Team to Business when users save payment details during checkout
- Add comprehensive tests for plan selection persistence across subscription store updates

## Problem

When a free/trial user selects the **Team** plan during checkout and then saves their credit card, the plan selection silently resets to **Business**. Multiple customers reported being charged for the wrong plan.

**Root cause:** PR #105861 converted `AMCheckout` from a class component to a function component. The old `componentDidUpdate` only re-fetched billing config when `checkoutTier` changed. The new `useEffect` includes `fetchBillingConfig` in its dependency array, whose identity changes on every `subscription` prop update (via `SubscriptionStore`). This causes the effect to re-run `fetchBillingConfig()`, which re-initializes form data with the default Business plan for free/trial users.

## Fix

Two complementary defenses:
1. **Ref guard** (`isFormInitialized`): Inside `fetchBillingConfig`, form data initialization is wrapped in a ref guard that prevents re-initialization after the first successful load
2. **Stable useEffect deps**: The fetch effect dependency array is changed to `[subscription.canSelfServe, checkoutTier]` (primitives only), matching the original class component's `componentDidUpdate` behavior

Follows React best practices:
- [`rerender-dependencies`](https://react.dev/learn/removing-effect-dependencies): Narrow effect dependencies to primitives instead of object references
- [`advanced-init-once`](https://react.dev/learn/you-might-not-need-an-effect#initializing-the-application): Ref guard for one-time initialization

## Test plan

- [x] New test: free user selects Team → subscription store update → Team preserved
- [x] New test: trial user selects Team → subscription store update → Team preserved
- [x] New test: multiple rapid subscription store updates → form data preserved
- [x] All 96 existing checkout tests pass (13 test suites)
- [x] Pre-commit (eslint, prettier, stylelint) passes

Closes https://linear.app/getsentry/issue/BIL-2186/checkout-form-resets-plan-when-payment-details-are-entered