### PR TITLE
fix(dashboards): Only trigger echarts dispatch sync for visible widgets

### DIFF
--- a/static/app/views/dashboards/contexts/widgetSyncContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.tsx
@@ -31,14 +31,13 @@ export function WidgetSyncContextProvider({
 }: WidgetSyncContextProviderProps) {
   // Stabilize the default groupName so it doesn't change on every render
   const stableGroupName = useMemo(() => groupName ?? uniqueId(), [groupName]);
-  const chartsRef = useRef<Map<Element, EChartsType>>(new Map());
   const observerRef = useRef<IntersectionObserver | null>(null);
 
   const getOrCreateObserver = useCallback(() => {
     if (!observerRef.current) {
       observerRef.current = new IntersectionObserver(entries => {
         for (const entry of entries) {
-          const chart = chartsRef.current.get(entry.target);
+          const chart = echarts.getInstanceByDom(entry.target as HTMLElement);
           if (!chart) {
             continue;
           }
@@ -70,7 +69,6 @@ export function WidgetSyncContextProvider({
         return () => {};
       }
 
-      chartsRef.current.set(dom, chart);
       getOrCreateObserver().observe(dom);
 
       // Set the group immediately for charts that may already be visible
@@ -79,7 +77,6 @@ export function WidgetSyncContextProvider({
 
       // Return a function to unregister the chart
       return () => {
-        chartsRef.current.delete(dom);
         observerRef.current?.unobserve(dom);
         chart.group = '';
       };

--- a/static/app/views/dashboards/contexts/widgetSyncContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.tsx
@@ -1,12 +1,13 @@
 import type {ReactNode} from 'react';
-import {useCallback, useEffect, useRef} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import type {EChartsType} from 'echarts';
 import * as echarts from 'echarts';
 
 import {uniqueId} from 'sentry/utils/guid';
 import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
 
-type RegistrationFunction = (chart: EChartsType) => void;
+type UnregisterFunction = () => void;
+type RegistrationFunction = (chart: EChartsType) => UnregisterFunction;
 
 interface WidgetSyncContext {
   groupName: string;
@@ -26,56 +27,71 @@ interface WidgetSyncContextProviderProps {
 
 export function WidgetSyncContextProvider({
   children,
-  groupName = uniqueId(),
+  groupName,
 }: WidgetSyncContextProviderProps) {
+  // Stabilize the default groupName so it doesn't change on every render
+  const stableGroupName = useMemo(() => groupName ?? uniqueId(), [groupName]);
   const chartsRef = useRef<Map<Element, EChartsType>>(new Map());
   const observerRef = useRef<IntersectionObserver | null>(null);
 
+  const getOrCreateObserver = useCallback(() => {
+    if (!observerRef.current) {
+      observerRef.current = new IntersectionObserver(entries => {
+        for (const entry of entries) {
+          const chart = chartsRef.current.get(entry.target);
+          if (!chart) {
+            continue;
+          }
+
+          if (entry.isIntersecting) {
+            chart.group = stableGroupName;
+          } else {
+            chart.group = '';
+          }
+        }
+
+        echarts?.connect(stableGroupName);
+      });
+    }
+    return observerRef.current;
+  }, [stableGroupName]);
+
   useEffect(() => {
-    observerRef.current = new IntersectionObserver(entries => {
-      for (const entry of entries) {
-        const chart = chartsRef.current.get(entry.target);
-        if (!chart) {
-          continue;
-        }
-
-        if (entry.isIntersecting) {
-          chart.group = groupName;
-        } else {
-          chart.group = '';
-        }
-      }
-
-      echarts?.connect(groupName);
-    });
-
     return () => {
       observerRef.current?.disconnect();
+      observerRef.current = null;
     };
-  }, [groupName]);
+  }, [stableGroupName]);
 
   const register = useCallback(
-    (chart: EChartsType) => {
+    (chart: EChartsType): UnregisterFunction => {
       const dom = chart.getDom();
       if (!dom) {
-        return;
+        return () => {};
       }
 
       chartsRef.current.set(dom, chart);
-      observerRef.current?.observe(dom);
+      getOrCreateObserver().observe(dom);
 
       // Set the group immediately for charts that may already be visible
-      chart.group = groupName;
-      echarts?.connect(groupName);
+      chart.group = stableGroupName;
+      echarts?.connect(stableGroupName);
+
+      // Return a function to unregister the chart
+      return () => {
+        chartsRef.current.delete(dom);
+        observerRef.current?.unobserve(dom);
+        chart.group = '';
+      };
     },
-    [groupName]
+    [stableGroupName, getOrCreateObserver]
   );
 
   return (
     <_WidgetSyncProvider
       value={{
         register,
-        groupName,
+        groupName: stableGroupName,
       }}
     >
       {children}
@@ -89,7 +105,7 @@ export function useWidgetSyncContext(): WidgetSyncContext {
   if (!context) {
     // The provider was not registered, return a dummy function
     return {
-      register: (_p: any) => null,
+      register: (_p: any) => () => {},
       groupName: '',
     };
   }

--- a/static/app/views/dashboards/contexts/widgetSyncContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.tsx
@@ -1,4 +1,5 @@
 import type {ReactNode} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import type {EChartsType} from 'echarts';
 import * as echarts from 'echarts';
 
@@ -27,10 +28,48 @@ export function WidgetSyncContextProvider({
   children,
   groupName = uniqueId(),
 }: WidgetSyncContextProviderProps) {
-  const register: RegistrationFunction = chart => {
-    chart.group = groupName;
-    echarts?.connect(groupName);
-  };
+  const chartsRef = useRef<Map<Element, EChartsType>>(new Map());
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    observerRef.current = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        const chart = chartsRef.current.get(entry.target);
+        if (!chart) {
+          continue;
+        }
+
+        if (entry.isIntersecting) {
+          chart.group = groupName;
+        } else {
+          chart.group = '';
+        }
+      }
+
+      echarts?.connect(groupName);
+    });
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [groupName]);
+
+  const register = useCallback(
+    (chart: EChartsType) => {
+      const dom = chart.getDom();
+      if (!dom) {
+        return;
+      }
+
+      chartsRef.current.set(dom, chart);
+      observerRef.current?.observe(dom);
+
+      // Set the group immediately for charts that may already be visible
+      chart.group = groupName;
+      echarts?.connect(groupName);
+    },
+    [groupName]
+  );
 
   return (
     <_WidgetSyncProvider

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import {mergeRefs} from '@react-aria/utils';
 import * as Sentry from '@sentry/react';
@@ -136,7 +136,14 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   // the backend zerofills the data
 
   const chartRef = useRef<ReactEchartsRef | null>(null);
+  const unregisterRef = useRef<(() => void) | null>(null);
   const {register: registerWithWidgetSyncContext, groupName} = useWidgetSyncContext();
+
+  useEffect(() => {
+    return () => {
+      unregisterRef.current?.();
+    };
+  }, []);
 
   const pageFilters = usePageFilters();
   const {start, end, period, utc} =
@@ -445,7 +452,8 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const handleChartReady = useCallback(
     (instance: echarts.ECharts) => {
       onChartReadyZoom(instance);
-      registerWithWidgetSyncContext(instance);
+      unregisterRef.current?.();
+      unregisterRef.current = registerWithWidgetSyncContext(instance);
     },
     [onChartReadyZoom, registerWithWidgetSyncContext]
   );


### PR DESCRIPTION
Uses an intersection observer to register echarts instances to groups when the charts are visible in the viewport. This way, we don't dispatch cursor sync calls to widgets that are not visible, bypassing some of the load echarts needs to do to properly place the crosshairs

This only impacts hover performance when a user has scrolled and triggered all of the widgets to load in, which we expect users to scroll on this page. I crudely profiled this interaction by initializing all of the widgets on the page and then hovering over and around a single timeseries chart to show a difference in magnitude over multiple events. This was done with a production build locally (i.e. `NODE_ENV=production pnpm dev-ui`) and I consistently witnessed better performance with the new strategy.

These screenshots following are filtered to `mousemove` events

Before:
<img width="1100" height="246" alt="Screenshot 2026-03-13 at 4 39 21 PM" src="https://github.com/user-attachments/assets/58907d5b-65cd-46a4-853c-b870490da564" />

After:
<img width="1068" height="291" alt="Screenshot 2026-03-13 at 4 39 02 PM" src="https://github.com/user-attachments/assets/b51c2cfa-f381-475a-af44-e0750343ed7c" />
