### PR TITLE
fix(ui): Update route error page with troubleshooting guide and support instructions

### DIFF
--- a/static/app/views/routeError.tsx
+++ b/static/app/views/routeError.tsx
@@ -137,9 +137,7 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
           {tct(
             `If the guide does not help, [link:contact support] — include as many of these details as you can:`,
             {
-              link: (
-                <ExternalLink href="https://sentry.zendesk.com/hc/en-us/requests/new" />
-              ),
+              link: <ExternalLink href="https://sentry.zendesk.com/hc/en-us" />,
             }
           )}
         </p>

--- a/static/app/views/routeError.tsx
+++ b/static/app/views/routeError.tsx
@@ -90,7 +90,6 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
   // Remove the report dialog on unmount
   useEffect(() => () => document.querySelector('.sentry-error-embed-wrapper')?.remove());
 
-  // TODO(dcramer): show additional resource links
   return (
     <Alert.Container>
       <Alert variant="danger" showIcon={false}>
@@ -101,7 +100,9 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
           We use Sentry to monitor Sentry and it's likely we're already looking into this!
           `)}
         </p>
-        <p>{t("If you're daring, you may want to try the following:")}</p>
+        <p style={{marginBottom: 0}}>
+          {t("If you're daring, you may want to try the following:")}
+        </p>
         <List symbol="bullet">
           {window?.adblockSuspected && (
             <ListItem>
@@ -122,11 +123,37 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
             })}
           </ListItem>
           <ListItem>
-            {tct(`If all else fails, [link:contact us] with more details.`, {
+            {tct(
+              `Still stuck? Our [link:troubleshooting guide] has tips for common browser-related issues.`,
+              {
+                link: (
+                  <ExternalLink href="https://sentry.zendesk.com/hc/en-us/articles/22088541158555-Why-Sentry-io-is-not-loading" />
+                ),
+              }
+            )}
+          </ListItem>
+        </List>
+        <p style={{marginTop: '1em', marginBottom: 0}}>
+          {tct(
+            `If the guide does not help, [link:contact support] — include as many of these details as you can:`,
+            {
               link: (
-                <ExternalLink href="https://github.com/getsentry/sentry/issues/new/choose" />
+                <ExternalLink href="https://sentry.zendesk.com/hc/en-us/requests/new" />
               ),
-            })}
+            }
+          )}
+        </p>
+        <List symbol="bullet">
+          <ListItem>{t('Browser logs (console and network tab errors)')}</ListItem>
+          <ListItem>
+            {t(
+              'Whether anyone else in your organization sees the same error on that page'
+            )}
+          </ListItem>
+          <ListItem>{t('Which browser(s) and version(s) you are using')}</ListItem>
+          <ListItem>{t('Whether the error is intermittent or consistent')}</ListItem>
+          <ListItem>
+            {t('Whether the error only appears on that page, or on other pages too')}
           </ListItem>
         </List>
       </Alert>


### PR DESCRIPTION
The route error page previously linked users to open a GitHub issue when something went wrong. This replaces that with more actionable guidance:

- Links to the Zendesk troubleshooting guide for common browser-related issues
- Adds a support contact section with a checklist of useful diagnostic details to include (browser logs, affected users, browser/version, consistency, affected URLs)
- Fulfills the existing (10year old 😅 ) `TODO` to show additional resource links 

NOTE: I used inline styles on purpose - this is the error page that must render when CSS/JS bundles fail to load, so I wanted the formatting degrade gracefully.

before
<img width="1021" height="183" alt="Screenshot 2026-03-13 at 1 15 10 PM" src="https://github.com/user-attachments/assets/bab2252d-0867-48f5-8937-4418d0d5f84d" />


after
<img width="1021" height="311" alt="Screenshot 2026-03-13 at 2 01 17 PM" src="https://github.com/user-attachments/assets/627a0b3d-d5d7-42f1-8c14-96753e15e924" />


