### PR TITLE
feat(coding integrations): Limit coding agent integrations to one per organization

### DIFF
--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -7,6 +7,7 @@ from typing import Any, TypedDict
 from django.contrib.auth.models import AnonymousUser
 
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationProvider
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
@@ -229,6 +230,7 @@ class IntegrationProviderSerializer(Serializer):
             existing = integration_service.get_integrations(
                 organization_id=organization.id,
                 providers=[obj.key],
+                status=ObjectStatus.ACTIVE,
             )
             if existing:
                 can_add = False

--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -219,16 +219,26 @@ class IntegrationProviderSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> IntegrationProviderResponse:
-        org_slug = kwargs.pop("organization").slug
+        organization = kwargs.pop("organization")
+        org_slug = organization.slug
         metadata: Any = obj.metadata
         metadata = metadata and metadata.asdict() or None
+
+        can_add = obj.can_add
+        if can_add and not obj.allow_multiple:
+            existing = integration_service.get_integrations(
+                organization_id=organization.id,
+                providers=[obj.key],
+            )
+            if existing:
+                can_add = False
 
         return {
             "key": obj.key,
             "slug": obj.key,
             "name": obj.name,
             "metadata": metadata,
-            "canAdd": obj.can_add,
+            "canAdd": can_add,
             "canDisable": obj.can_disable,
             "features": [f.value for f in obj.features],
             "setupDialog": dict(

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -224,6 +224,9 @@ class IntegrationProvider(PipelineProvider["IntegrationPipeline"], abc.ABC):
     can_add = True
     """whether or not the integration installation be initiated from Sentry"""
 
+    allow_multiple = True
+    """whether multiple installations of this integration are allowed per organization"""
+
     can_disable = False
     """
     if the integration can be uninstalled in Sentry, set to False

--- a/src/sentry/integrations/coding_agent/integration.py
+++ b/src/sentry/integrations/coding_agent/integration.py
@@ -45,6 +45,7 @@ class CodingAgentIntegrationProvider(IntegrationProvider, abc.ABC):
     """Abstract base provider for coding agent integrations."""
 
     can_add = True
+    allow_multiple = False
     setup_dialog_config = {"width": 600, "height": 700}
     requires_feature_flag = True
     features = frozenset([IntegrationFeatures.CODING_AGENT])

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -29,3 +29,39 @@ class OrganizationConfigIntegrationsTest(APITestCase):
         )
         assert len(response.data["providers"]) == 1
         assert response.data["providers"][0]["name"] == "Example Server"
+
+    def test_allow_multiple_false_can_add_true_when_no_installation(self) -> None:
+        """Coding agent providers with allow_multiple=False show canAdd=True when not yet installed."""
+        with self.feature("organizations:integrations-claude-code"):
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"provider_key": "claude_code"}
+            )
+        assert len(response.data["providers"]) == 1
+        assert response.data["providers"][0]["canAdd"] is True
+
+    def test_allow_multiple_false_can_add_false_when_installed(self) -> None:
+        """Coding agent providers with allow_multiple=False show canAdd=False when already installed."""
+        self.create_integration(
+            organization=self.organization,
+            provider="claude_code",
+            external_id="claude-ext-1",
+        )
+        with self.feature("organizations:integrations-claude-code"):
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"provider_key": "claude_code"}
+            )
+        assert len(response.data["providers"]) == 1
+        assert response.data["providers"][0]["canAdd"] is False
+
+    def test_allow_multiple_true_can_add_unaffected_by_existing(self) -> None:
+        """Regular providers with allow_multiple=True (default) still show canAdd=True even when installed."""
+        self.create_integration(
+            organization=self.organization,
+            provider="example",
+            external_id="example-ext-1",
+        )
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"provider_key": "example"}
+        )
+        assert len(response.data["providers"]) == 1
+        assert response.data["providers"][0]["canAdd"] is True

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -1,3 +1,4 @@
+from sentry.constants import ObjectStatus
 from sentry.testutils.cases import APITestCase
 
 
@@ -52,6 +53,36 @@ class OrganizationConfigIntegrationsTest(APITestCase):
             )
         assert len(response.data["providers"]) == 1
         assert response.data["providers"][0]["canAdd"] is False
+
+    def test_allow_multiple_false_can_add_true_when_disabled(self) -> None:
+        """Disabled integrations should not block re-adding for allow_multiple=False providers."""
+        self.create_integration(
+            organization=self.organization,
+            provider="claude_code",
+            external_id="claude-ext-1",
+            status=ObjectStatus.DISABLED,
+        )
+        with self.feature("organizations:integrations-claude-code"):
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"provider_key": "claude_code"}
+            )
+        assert len(response.data["providers"]) == 1
+        assert response.data["providers"][0]["canAdd"] is True
+
+    def test_allow_multiple_false_can_add_true_when_pending_deletion(self) -> None:
+        """Integrations pending deletion should not block re-adding."""
+        self.create_integration(
+            organization=self.organization,
+            provider="claude_code",
+            external_id="claude-ext-1",
+            status=ObjectStatus.PENDING_DELETION,
+        )
+        with self.feature("organizations:integrations-claude-code"):
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"provider_key": "claude_code"}
+            )
+        assert len(response.data["providers"]) == 1
+        assert response.data["providers"][0]["canAdd"] is True
 
     def test_allow_multiple_true_can_add_unaffected_by_existing(self) -> None:
         """Regular providers with allow_multiple=True (default) still show canAdd=True even when installed."""


### PR DESCRIPTION
For both claude and cursor organizations. For now we will limit to one per org, if asked for this could always be increased in the future if asked for. This only hides the "Add agent" button if 1 + exists, so any existing orgs that did this shouldn't have a problem.

This is V2 because missed a commit before merging originally.