### PR TITLE
ref(cells): Switch callers to new rpc methods

### DIFF
--- a/src/sentry/sentry_apps/api/utils/webhook_requests.py
+++ b/src/sentry/sentry_apps/api/utils/webhook_requests.py
@@ -89,9 +89,9 @@ def get_buffer_requests_from_cells(
 ) -> list[BufferedRequest]:
     requests: list[RpcSentryAppRequest] = []
     for cell_name in find_all_cell_names():
-        buffer_requests = app_request_service.get_buffer_requests_for_region(
+        buffer_requests = app_request_service.get_buffer_requests_for_cell(
             sentry_app_id=sentry_app_id,
-            region_name=cell_name,
+            cell_name=cell_name,
             filter=filter,
         )
         if buffer_requests:

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -123,8 +123,8 @@ def _get_public_dsn() -> str | None:
 
     result = cache.get(cache_key)
     if result is None:
-        key = project_key_service.get_project_key_by_region(
-            region_name=settings.SENTRY_MONOLITH_REGION,
+        key = project_key_service.get_project_key_by_cell(
+            cell_name=settings.SENTRY_MONOLITH_REGION,
             project_id=project_id,
             role=ProjectKeyRole.store,
         )

--- a/src/sentry/web/frontend/shared_group_details.py
+++ b/src/sentry/web/frontend/shared_group_details.py
@@ -18,8 +18,8 @@ class SharedGroupDetailsView(GenericReactPageView):
             group = issue_service.get_shared_for_org(slug=org_slug, share_id=share_id)
         else:
             # Backwards compatibility for Self-hosted and single tenants
-            group = issue_service.get_shared_for_region(
-                region_name=settings.SENTRY_MONOLITH_REGION, share_id=share_id
+            group = issue_service.get_shared_for_cell(
+                cell_name=settings.SENTRY_MONOLITH_REGION, share_id=share_id
             )
 
         if not group:


### PR DESCRIPTION
- DatabaseBackedIssueService.get_shared_for_region -> get_shared_for_cell
- DatabaseBackedProjectKeyService.get_project_key_by_region -> get_project_key_by_cell
- DatabaseBackedSentryAppRequestService.get_buffer_requests_for_region -> get_buffer_requests_for_cell
