### PR TITLE
feat(autofix): Allow users to add feedback when rethinking

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -541,10 +541,20 @@ export function useExplorerAutofix(
    * @param runId - Optional run ID to continue an existing run
    */
   const startStep = useCallback(
-    async (step: AutofixExplorerStep, runId?: number) => {
+    async (step: AutofixExplorerStep, runId?: number, userFeedback?: string) => {
       setWaitingForResponse(true);
 
       try {
+        const data: Record<string, any> = {step};
+
+        if (defined(runId)) {
+          data.run_id = runId;
+        }
+
+        if (userFeedback) {
+          data.user_feedback = userFeedback;
+        }
+
         const response = await api.requestPromise(
           getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/autofix/', {
             path: {organizationIdOrSlug: orgSlug, issueId: groupId},
@@ -552,11 +562,7 @@ export function useExplorerAutofix(
           {
             method: 'POST',
             query: {mode: 'explorer'},
-            data: {
-              step,
-              intelligence_level: 'low',
-              ...(runId !== undefined && {run_id: runId}),
-            },
+            data,
           }
         );
 

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -541,7 +541,7 @@ export function useExplorerAutofix(
    * @param runId - Optional run ID to continue an existing run
    */
   const startStep = useCallback(
-    async (step: AutofixExplorerStep, runId?: number, userFeedback?: string) => {
+    async (step: AutofixExplorerStep, runId?: number, userContext?: string) => {
       setWaitingForResponse(true);
 
       try {
@@ -551,8 +551,8 @@ export function useExplorerAutofix(
           data.run_id = runId;
         }
 
-        if (userFeedback) {
-          data.user_feedback = userFeedback;
+        if (userContext) {
+          data.user_context = userContext;
         }
 
         const response = await api.requestPromise(

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -69,13 +69,46 @@ describe('SeerDrawerNextStep', () => {
       expect(autofix.startStep).toHaveBeenCalledWith('solution', 1);
     });
 
-    it('calls startStep with root_cause on no click', async () => {
+    it('shows feedback UI on no click', async () => {
       const autofix = makeAutofix();
       render(
         <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
-      expect(autofix.startStep).toHaveBeenCalledWith('root_cause', 1);
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Rethink root cause'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Nevermind, make an implementation plan'})
+      ).toBeInTheDocument();
+    });
+
+    it('calls startStep with root_cause and feedback on rethink click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      await userEvent.type(screen.getByRole('textbox'), 'Try a different approach');
+      await userEvent.click(screen.getByRole('button', {name: 'Rethink root cause'}));
+      expect(autofix.startStep).toHaveBeenCalledWith(
+        'root_cause',
+        1,
+        'Try a different approach'
+      );
+    });
+
+    it('proceeds like yes on nevermind click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Nevermind, make an implementation plan'})
+      );
+      expect(autofix.startStep).toHaveBeenCalledWith('solution', 1);
     });
   });
 
@@ -103,13 +136,48 @@ describe('SeerDrawerNextStep', () => {
       expect(autofix.startStep).toHaveBeenCalledWith('code_changes', 1);
     });
 
-    it('calls startStep with solution on no click', async () => {
+    it('shows feedback UI on no click', async () => {
       const autofix = makeAutofix();
       render(
         <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
-      expect(autofix.startStep).toHaveBeenCalledWith('solution', 1);
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Rethink implementation plan'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Nevermind, write a code fix'})
+      ).toBeInTheDocument();
+    });
+
+    it('calls startStep with solution and feedback on rethink click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      await userEvent.type(screen.getByRole('textbox'), 'Consider edge cases');
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Rethink implementation plan'})
+      );
+      expect(autofix.startStep).toHaveBeenCalledWith(
+        'solution',
+        1,
+        'Consider edge cases'
+      );
+    });
+
+    it('proceeds like yes on nevermind click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Nevermind, write a code fix'})
+      );
+      expect(autofix.startStep).toHaveBeenCalledWith('code_changes', 1);
     });
   });
 
@@ -135,13 +203,44 @@ describe('SeerDrawerNextStep', () => {
       expect(autofix.createPR).toHaveBeenCalledWith(1);
     });
 
-    it('calls startStep with code_changes on no click', async () => {
+    it('shows feedback UI on no click', async () => {
       const autofix = makeAutofix();
       render(
         <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
-      expect(autofix.startStep).toHaveBeenCalledWith('code_changes', 1);
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Rethink code changes'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Nevermind, draft a PR'})
+      ).toBeInTheDocument();
+    });
+
+    it('calls startStep with code_changes and feedback on rethink click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      await userEvent.type(screen.getByRole('textbox'), 'Fix the error handling');
+      await userEvent.click(screen.getByRole('button', {name: 'Rethink code changes'}));
+      expect(autofix.startStep).toHaveBeenCalledWith(
+        'code_changes',
+        1,
+        'Fix the error handling'
+      );
+    });
+
+    it('proceeds like yes on nevermind click', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Nevermind, draft a PR'}));
+      expect(autofix.createPR).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -1,8 +1,9 @@
-import {useCallback, type ReactNode} from 'react';
+import {useCallback, useState, type ReactNode} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
+import {TextArea} from '@sentry/scraps/textarea';
 
 import {
   isCodeChangesSection,
@@ -54,18 +55,24 @@ function RootCauseNextStep({autofix, runId}: NextStepProps) {
     startStep('solution', runId);
   }, [startStep, runId]);
 
-  const handleNoClick = useCallback(() => {
-    // for now, just re run the current step
-    startStep('root_cause', runId);
-  }, [startStep, runId]);
+  const handleNoClick = useCallback(
+    (userFeedback: string) => {
+      startStep('root_cause', runId, userFeedback);
+    },
+    [startStep, runId]
+  );
 
   return (
-    <NextStep
+    <NextStepTemplate
       prompt={t('Are you happy with this root cause?')}
       labelYes={t('Yes, make an implementation plan')}
       onClickYes={handleYesClick}
       labelNo={t('No')}
       onClickNo={handleNoClick}
+      placeholderPrompt={t('Give seer additional context to improve this root cause.')}
+      rethinkPrompt={t('How can this root cause be improved?')}
+      labelNevermind={t('Nevermind, make an implementation plan')}
+      labelRethink={t('Rethink root cause')}
     />
   );
 }
@@ -77,18 +84,26 @@ function SolutionNextStep({autofix, runId}: NextStepProps) {
     startStep('code_changes', runId);
   }, [startStep, runId]);
 
-  const handleNoClick = useCallback(() => {
-    // for now, just re run the current step
-    startStep('solution', runId);
-  }, [startStep, runId]);
+  const handleNoClick = useCallback(
+    (userFeedback: string) => {
+      startStep('solution', runId, userFeedback);
+    },
+    [startStep, runId]
+  );
 
   return (
-    <NextStep
+    <NextStepTemplate
       prompt={t('Are you happy with this implementation plan?')}
       labelYes={t('Yes, write a code fix')}
       onClickYes={handleYesClick}
       labelNo={t('No')}
       onClickNo={handleNoClick}
+      placeholderPrompt={t(
+        'Give seer additional context to improve this implementation plan.'
+      )}
+      rethinkPrompt={t('How can this implementation plan be improved?')}
+      labelNevermind={t('Nevermind, write a code fix')}
+      labelRethink={t('Rethink implementation plan')}
     />
   );
 }
@@ -100,41 +115,80 @@ function CodeChangesNextStep({autofix, runId}: NextStepProps) {
     createPR(runId);
   }, [createPR, runId]);
 
-  const handleNoClick = useCallback(() => {
-    startStep('code_changes', runId);
-  }, [startStep, runId]);
+  const handleNoClick = useCallback(
+    (userFeedback: string) => {
+      startStep('code_changes', runId, userFeedback);
+    },
+    [startStep, runId]
+  );
 
   return (
-    <NextStep
+    <NextStepTemplate
       prompt={t('Are you happy with these code changes?')}
       labelYes={t('Yes, draft a PR')}
       onClickYes={handleYesClick}
       labelNo={t('No')}
       onClickNo={handleNoClick}
+      placeholderPrompt={t('Give seer additional context to improve this code change.')}
+      rethinkPrompt={t('How can this code change be improved?')}
+      labelNevermind={t('Nevermind, draft a PR')}
+      labelRethink={t('Rethink code changes')}
     />
   );
 }
 
 interface NextStepTemplateProps {
+  labelNevermind: ReactNode;
   labelNo: ReactNode;
+  labelRethink: ReactNode;
   labelYes: ReactNode;
-  onClickNo: () => void;
+  onClickNo: (prompt: string) => void;
   onClickYes: () => void;
+  placeholderPrompt: string;
   prompt: ReactNode;
+  rethinkPrompt: ReactNode;
 }
 
-function NextStep({
+function NextStepTemplate({
   prompt,
   labelYes,
   onClickYes,
   labelNo,
   onClickNo,
+  placeholderPrompt,
+  rethinkPrompt,
+  labelNevermind,
+  labelRethink,
 }: NextStepTemplateProps) {
+  const [clickedNo, handleClickedNo] = useState(false);
+  const [userFeedback, setUserFeedback] = useState('');
+
+  if (clickedNo) {
+    return (
+      <Flex direction="column" gap="lg">
+        <Text>{rethinkPrompt}</Text>
+        <TextArea
+          autosize
+          rows={2}
+          placeholder={placeholderPrompt}
+          value={userFeedback}
+          onChange={event => setUserFeedback(event.target.value)}
+        />
+        <Flex gap="md">
+          <Button onClick={onClickYes}>{labelNevermind}</Button>
+          <Button priority="primary" onClick={() => onClickNo(userFeedback)}>
+            {labelRethink}
+          </Button>
+        </Flex>
+      </Flex>
+    );
+  }
+
   return (
     <Flex direction="column" gap="lg">
       <Text>{prompt}</Text>
       <Flex gap="md">
-        <Button onClick={onClickNo}>{labelNo}</Button>
+        <Button onClick={() => handleClickedNo(true)}>{labelNo}</Button>
         <Button priority="primary" onClick={onClickYes}>
           {labelYes}
         </Button>

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -56,8 +56,8 @@ function RootCauseNextStep({autofix, runId}: NextStepProps) {
   }, [startStep, runId]);
 
   const handleNoClick = useCallback(
-    (userFeedback: string) => {
-      startStep('root_cause', runId, userFeedback);
+    (userContext: string) => {
+      startStep('root_cause', runId, userContext);
     },
     [startStep, runId]
   );
@@ -85,8 +85,8 @@ function SolutionNextStep({autofix, runId}: NextStepProps) {
   }, [startStep, runId]);
 
   const handleNoClick = useCallback(
-    (userFeedback: string) => {
-      startStep('solution', runId, userFeedback);
+    (userContext: string) => {
+      startStep('solution', runId, userContext);
     },
     [startStep, runId]
   );
@@ -116,8 +116,8 @@ function CodeChangesNextStep({autofix, runId}: NextStepProps) {
   }, [createPR, runId]);
 
   const handleNoClick = useCallback(
-    (userFeedback: string) => {
-      startStep('code_changes', runId, userFeedback);
+    (userContext: string) => {
+      startStep('code_changes', runId, userContext);
     },
     [startStep, runId]
   );
@@ -161,7 +161,7 @@ function NextStepTemplate({
   labelRethink,
 }: NextStepTemplateProps) {
   const [clickedNo, handleClickedNo] = useState(false);
-  const [userFeedback, setUserFeedback] = useState('');
+  const [userContext, setUserContext] = useState('');
 
   if (clickedNo) {
     return (
@@ -171,12 +171,12 @@ function NextStepTemplate({
           autosize
           rows={2}
           placeholder={placeholderPrompt}
-          value={userFeedback}
-          onChange={event => setUserFeedback(event.target.value)}
+          value={userContext}
+          onChange={event => setUserContext(event.target.value)}
         />
         <Flex gap="md">
           <Button onClick={onClickYes}>{labelNevermind}</Button>
-          <Button priority="primary" onClick={() => onClickNo(userFeedback)}>
+          <Button priority="primary" onClick={() => onClickNo(userContext)}>
             {labelRethink}
           </Button>
         </Flex>


### PR DESCRIPTION
We want to allow users to give some feedback to the agent when rethinking. This shows a textarea to accept input and passes that along when rethinking.