### PR TITLE
feat(explorer): gate coding tools on org feature flag and org option

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -300,6 +300,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-context-engine-allow-fe-override", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable frontend override UI component for context engine (only for AI/ML/Reasoning platform team)
     manager.add("organizations:seer-explorer-context-engine-fe-override-ui-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable code editing tools in Seer Explorer chat
+    manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Autofix to use Seer Explorer instead of legacy Celery pipeline
     manager.add("organizations:autofix-on-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Autofix to use Seer Explorer V2 designs

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -41,11 +42,6 @@ class SeerExplorerChatSerializer(serializers.Serializer):
         required=False,
         default=True,
         help_text="Override context engine rollout flag (applies to reasoning platform only).",
-    )
-    enable_coding = serializers.BooleanField(
-        required=False,
-        default=False,
-        help_text="Enable code editing tools.",
     )
 
 
@@ -133,8 +129,10 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
         override_ce_enable = validated_data["override_ce_enable"]
 
         try:
-            enable_coding = validated_data.get("enable_coding", False) and organization.get_option(
+            enable_coding = organization.get_option(
                 "sentry:enable_seer_coding", False
+            ) and features.has(
+                "organizations:seer-explorer-chat-coding", organization, actor=request.user
             )
             client = SeerExplorerClient(
                 organization,

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -42,6 +42,11 @@ class SeerExplorerChatSerializer(serializers.Serializer):
         default=True,
         help_text="Override context engine rollout flag (applies to reasoning platform only).",
     )
+    enable_coding = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Enable code editing tools.",
+    )
 
 
 class OrganizationSeerExplorerChatPermission(OrganizationPermission):
@@ -128,7 +133,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
         override_ce_enable = validated_data["override_ce_enable"]
 
         try:
-            enable_coding = organization.get_option("sentry:enable_seer_coding", True)
+            enable_coding = validated_data.get("enable_coding", False)
             client = SeerExplorerClient(
                 organization,
                 request.user,

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -133,7 +133,9 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
         override_ce_enable = validated_data["override_ce_enable"]
 
         try:
-            enable_coding = validated_data.get("enable_coding", False)
+            enable_coding = validated_data.get("enable_coding", False) and organization.get_option(
+                "sentry:enable_seer_coding", False
+            )
             client = SeerExplorerClient(
                 organization,
                 request.user,

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -71,10 +71,8 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
 
         assert response.status_code == 200
         assert response.data == {"run_id": 456}
-
-        # Verify client was called correctly. Default org option for enable_seer_coding is True.
         mock_client_class.assert_called_once_with(
-            self.organization, ANY, is_interactive=True, enable_coding=True
+            self.organization, ANY, is_interactive=True, enable_coding=False
         )
         mock_client.start_run.assert_called_once_with(
             prompt="What is this error about?",
@@ -83,28 +81,31 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
-    def test_post_new_conversation_with_coding_option(self, mock_client_class: MagicMock):
-        for i, option_value in enumerate([False, True]):
-            self.organization.update_option("sentry:enable_seer_coding", option_value)
+    def test_post_new_conversation_enable_coding(self, mock_client_class: MagicMock):
+        for i, (feature_enabled, option_enabled) in enumerate(
+            [(True, True), (True, False), (False, True)]
+        ):
+            self.organization.update_option("sentry:enable_seer_coding", option_enabled)
             mock_client = MagicMock()
             mock_client.start_run.return_value = 456
             mock_client_class.return_value = mock_client
 
             data = {"query": "What is this error about?"}
-            response = self.client.post(self.url, data, format="json")
+            features_ctx = (
+                self.feature("organizations:seer-explorer-chat-coding")
+                if feature_enabled
+                else self.feature({"organizations:seer-explorer-chat-coding": False})
+            )
+            with features_ctx:
+                response = self.client.post(self.url, data, format="json")
 
             assert response.status_code == 200
-            assert response.data == {"run_id": 456}
-
-            # Verify client was called correctly with enable_coding matching option_value.
             assert mock_client_class.call_count == i + 1
             mock_client_class.assert_called_with(
-                self.organization, ANY, is_interactive=True, enable_coding=option_value
-            )
-            mock_client.start_run.assert_called_once_with(
-                prompt="What is this error about?",
-                on_page_context=None,
-                override_ce_enable=True,
+                self.organization,
+                ANY,
+                is_interactive=True,
+                enable_coding=feature_enabled and option_enabled,
             )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
@@ -121,10 +122,8 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
 
         assert response.status_code == 200
         assert response.data == {"run_id": 789}
-
-        # Verify client was called correctly. Default org option for enable_seer_coding is True.
         mock_client_class.assert_called_once_with(
-            self.organization, ANY, is_interactive=True, enable_coding=True
+            self.organization, ANY, is_interactive=True, enable_coding=False
         )
         mock_client.continue_run.assert_called_once_with(
             run_id=789,
@@ -134,34 +133,26 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
-    def test_post_continue_conversation_with_coding_option(
-        self, mock_client_class: MagicMock
-    ) -> None:
-        for i, option_value in enumerate([False, True]):
-            self.organization.update_option("sentry:enable_seer_coding", option_value)
+    def test_post_continue_conversation_enable_coding(self, mock_client_class: MagicMock) -> None:
+        for i, (feature_enabled, option_enabled) in enumerate(
+            [(True, True), (True, False), (False, True), (False, False)]
+        ):
             mock_client = MagicMock()
             mock_client.continue_run.return_value = 789
             mock_client_class.return_value = mock_client
 
-            data = {
-                "query": "Follow up question",
-                "insert_index": 2,
-            }
-            response = self.client.post(f"{self.url}789/", data, format="json")
+            data = {"query": "Follow up question", "insert_index": 2}
+            self.organization.update_option("sentry:enable_seer_coding", option_enabled)
+            with self.feature({"organizations:seer-explorer-chat-coding": feature_enabled}):
+                response = self.client.post(f"{self.url}789/", data, format="json")
 
             assert response.status_code == 200
-            assert response.data == {"run_id": 789}
-
-            # Verify client was called correctly with enable_coding matching option_value.
             assert mock_client_class.call_count == i + 1
             mock_client_class.assert_called_with(
-                self.organization, ANY, is_interactive=True, enable_coding=option_value
-            )
-            mock_client.continue_run.assert_called_once_with(
-                run_id=789,
-                prompt="Follow up question",
-                insert_index=2,
-                on_page_context=None,
+                self.organization,
+                ANY,
+                is_interactive=True,
+                enable_coding=feature_enabled and option_enabled,
             )
 
 


### PR DESCRIPTION
Gate the Seer Explorer coding tools (`enable_coding`) behind two independent controls: the `organizations:seer-explorer-chat-coding` Flagpole feature flag and the existing `sentry:enable_seer_coding` org option. Both must be enabled for coding tools to be active.

Previously, `enable_coding` was only controlled by org option. This endpoint is used for chat feature and for now, we've decided to disable in-chat coding for external orgs. 