### PR TITLE
ref(traces): Prefer transaction over span.name for trace naming

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -311,6 +311,7 @@ class TracesExecutor:
                 "sdk.name",
                 "span.op",
                 "parent_span",
+                "transaction",
                 "span.name",
                 "precise.start_ts",
                 "precise.finish_ts",
@@ -446,7 +447,8 @@ class TracesExecutor:
 
             name: tuple[str, str, float] = (
                 span["project"],
-                span["span.name"],
+                # transaction for Sentry SDK spans, span.name for OTel spans
+                span.get("transaction") or span["span.name"],
                 # to minmimize the impact of floating point errors,
                 # multiply by 1e3 first then do the subtraction
                 # once we move to eap_items, this can be just `span["span.duration"]`

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -1206,7 +1206,8 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
 
             result_data = sorted(response.data["data"], key=lambda trace: trace["duration"])
 
-            assert result_data[0]["name"] == "bar"
+            # transaction name is preferred over span.name
+            assert result_data[0]["name"] == "foo"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/107543 addressed issues with OTel spans in Explore's Trace Samples tab, but it caused a worse experience for some Sentry SDK spans (see https://github.com/getsentry/sentry/issues/109629).

This PR additionally queries `transaction` in the trace samples query and uses it as the trace name when present, falling back to `span.name`. This should give us the best of both worlds, bringing back the more descriptive `transaction` values for Sentry SDK users while falling back for OTel span where `transaction` is blank.

Fixes https://github.com/getsentry/sentry/issues/109629.