### PR TITLE
fix(performance): Hide Tags tab in EAP transaction summary

### DIFF
--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -79,4 +79,44 @@ describe('Performance > Transaction Summary Header', () => {
 
     expect(await screen.findByRole('tab', {name: 'Overview'})).toBeInTheDocument();
   });
+
+  it('should show Tags tab by default', async () => {
+    const {project, organization, router, eventView} = initializeData();
+
+    render(
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        projectId={project.id}
+        transactionName="transaction_name"
+        currentTab={Tab.TRANSACTION_SUMMARY}
+      />
+    );
+
+    expect(await screen.findByRole('tab', {name: 'Tags'})).toBeInTheDocument();
+  });
+
+  it('should hide Tags tab when EAP feature is enabled', async () => {
+    const {project, organization, router, eventView} = initializeData({
+      features: ['performance-transaction-summary-eap'],
+    });
+
+    render(
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        projectId={project.id}
+        transactionName="transaction_name"
+        currentTab={Tab.TRANSACTION_SUMMARY}
+      />,
+      {organization}
+    );
+
+    await screen.findByRole('tab', {name: 'Overview'});
+    expect(screen.queryByRole('tab', {name: 'Tags'})).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -33,6 +33,7 @@ import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader'
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import Breadcrumb, {getTabCrumbs} from 'sentry/views/performance/breadcrumb';
+import {useTransactionSummaryEAP} from 'sentry/views/performance/eap/useTransactionSummaryEAP';
 import {TAB_ANALYTICS} from 'sentry/views/performance/transactionSummary/pageLayout';
 import {eventsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionEvents/utils';
 import {profilesRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionProfiles/utils';
@@ -124,6 +125,8 @@ export function TransactionHeader({
     },
     [getNewRoute, organization, location, projects, currentTab, navigate]
   );
+
+  const isEAP = useTransactionSummaryEAP();
 
   function handleCreateAlertSuccess() {
     trackAnalytics('performance_views.summary.create_alert_clicked', {
@@ -319,7 +322,9 @@ export function TransactionHeader({
       >
         <TabList.Item key={Tab.TRANSACTION_SUMMARY}>{t('Overview')}</TabList.Item>
         <TabList.Item key={Tab.EVENTS}>{t('Sampled Events')}</TabList.Item>
-        <TabList.Item key={Tab.TAGS}>{t('Tags')}</TabList.Item>
+        <TabList.Item key={Tab.TAGS} hidden={isEAP}>
+          {t('Tags')}
+        </TabList.Item>
         <TabList.Item
           key={Tab.REPLAYS}
           textValue={t('Replays')}

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -160,7 +160,9 @@ export function TransactionHeader({
     >
       <TabList.Item key={Tab.TRANSACTION_SUMMARY}>{t('Overview')}</TabList.Item>
       <TabList.Item key={Tab.EVENTS}>{t('Sampled Events')}</TabList.Item>
-      <TabList.Item key={Tab.TAGS}>{t('Tags')}</TabList.Item>
+      <TabList.Item key={Tab.TAGS} hidden={isEAP}>
+        {t('Tags')}
+      </TabList.Item>
       <TabList.Item key={Tab.REPLAYS} textValue={t('Replays')} hidden={!hasSessionReplay}>
         {t('Replays')}
         <ReplayCountBadge count={replaysCount} />


### PR DESCRIPTION
We don't support the Tags tab in EAP yet. Hide it for now.