### PR TITLE
fix(logs): Show span_id in log detail view

### DIFF
--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -57,7 +57,6 @@ export const HiddenLogDetailFields: OurLogFieldKey[] = [
   'sentry.timestamp_nanos',
   'sentry.observed_timestamp_nanos',
   'tags[sentry.trace_flags,number]',
-  'span_id',
 ];
 
 export const DeprecatedLogDetailFields: OurLogFieldKey[] = [

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -266,9 +266,6 @@ describe('logsTableRow', () => {
     expect(screen.getByText('test log body')).toBeInTheDocument();
     expect(screen.getByText('Apr 10, 2025 7:21:10.049 PM')).toBeInTheDocument(); // This is using precise timestamp on log fixture, which overrides passed regular timestamp.
 
-    // Check that the span ID is not rendered
-    expect(screen.queryByText('span_id')).not.toBeInTheDocument();
-
     // Expand the row to show the attributes
     const logTableRow = await screen.findByTestId('log-table-row');
     expect(logTableRow).toBeInTheDocument();
@@ -319,6 +316,9 @@ describe('logsTableRow', () => {
         }),
       })
     );
+
+    // Check that the span ID is rendered in the expanded details
+    expect(screen.getByTestId('tree-key-span_id')).toBeInTheDocument();
 
     // Check that the attribute values are rendered
     expect(screen.queryByText(projects[0]!.id)).not.toBeInTheDocument();


### PR DESCRIPTION
`span_id` is the [preferred field](https://github.com/getsentry/sentry-docs/blob/c5c916e03d8e6dda9555836657043e2ecf984ef2/develop-docs/sdk/telemetry/logs.mdx?plain=1#L28-L30) for storing the active span ID from when a log was recorded, and is a [supported search field in Explore > Logs](https://github.com/getsentry/sentry/blob/7a701584e61d8a093132eb37c45fd0359c1652ee/static/app/utils/fields/index.ts#L2640-L2645). Stop hiding it from the details panel.