### PR TITLE
style(button): Reduce left padding when icon is present for visual balance

### DIFF
--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -158,6 +158,42 @@ The following table defines standardized call to action copy and icon pairings f
 | <IconZoom />                               | `zoom`      | Zoom Out                               | Applies to charts and zooms out (i.e. 200%)               |
 | <IconStar />                               | `star`      | Favorite                               | Hoisting item to primary view                             |
 
+## Icon Padding Balance
+
+When a button includes an icon, the left padding is proportionally reduced by one step to
+achieve visual balance. This compensates for the optical weight the icon adds on the left side.
+
+<Storybook.Demo>
+  <Button size="md" icon={<IconAdd />}>
+    Medium with icon
+  </Button>
+  <Button size="md">Medium without icon</Button>
+</Storybook.Demo>
+<Storybook.Demo>
+  <Button size="sm" icon={<IconAdd />}>
+    Small with icon
+  </Button>
+  <Button size="sm">Small without icon</Button>
+</Storybook.Demo>
+<Storybook.Demo>
+  <Button size="xs" icon={<IconAdd />}>
+    XSmall with icon
+  </Button>
+  <Button size="xs">XSmall without icon</Button>
+</Storybook.Demo>
+<Storybook.Demo>
+  <Button size="zero" icon={<IconAdd />}>
+    Zero with icon
+  </Button>
+  <Button size="zero">Zero without icon</Button>
+</Storybook.Demo>
+```jsx // Left padding is reduced by one step when icon is present
+<Button size="md" icon={<IconAdd />}>
+  Medium with icon
+</Button>
+<Button size="md">Medium without icon</Button>
+```
+
 ## Disabled and Busy Buttons
 
 Disabled and busy buttons are used to indicate the status of an item. Busy buttons should be used to indicate that an action is in progress. Disabled buttons should be used to indicate that an action is not available.

--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -160,38 +160,43 @@ The following table defines standardized call to action copy and icon pairings f
 
 ## Icon Padding Balance
 
-When a button includes an icon, the left padding is proportionally reduced by one step to
-achieve visual balance. This compensates for the optical weight the icon adds on the left side.
+When a button has both an icon and a label, the left padding is proportionally reduced by one
+step to achieve visual balance. Icon-only buttons retain symmetric padding.
 
 <Storybook.Demo>
   <Button size="md" icon={<IconAdd />}>
-    Medium with icon
+    With label
   </Button>
-  <Button size="md">Medium without icon</Button>
+  <Button size="md">No icon</Button>
+  <Button size="md" icon={<IconAdd />} aria-label="Add" />
 </Storybook.Demo>
 <Storybook.Demo>
   <Button size="sm" icon={<IconAdd />}>
-    Small with icon
+    With label
   </Button>
-  <Button size="sm">Small without icon</Button>
+  <Button size="sm">No icon</Button>
+  <Button size="sm" icon={<IconAdd />} aria-label="Add" />
 </Storybook.Demo>
 <Storybook.Demo>
   <Button size="xs" icon={<IconAdd />}>
-    XSmall with icon
+    With label
   </Button>
-  <Button size="xs">XSmall without icon</Button>
+  <Button size="xs">No icon</Button>
+  <Button size="xs" icon={<IconAdd />} aria-label="Add" />
 </Storybook.Demo>
 <Storybook.Demo>
   <Button size="zero" icon={<IconAdd />}>
-    Zero with icon
+    With label
   </Button>
-  <Button size="zero">Zero without icon</Button>
+  <Button size="zero">No icon</Button>
+  <Button size="zero" icon={<IconAdd />} aria-label="Add" />
 </Storybook.Demo>
-```jsx // Left padding is reduced by one step when icon is present
+```jsx // Left padding reduced when icon + label — icon-only stays symmetric
 <Button size="md" icon={<IconAdd />}>
-  Medium with icon
+  With label
 </Button>
-<Button size="md">Medium without icon</Button>
+<Button size="md">No icon</Button>
+<Button size="md" icon={<IconAdd />} aria-label="Add" />
 ```
 
 ## Disabled and Busy Buttons

--- a/static/app/components/core/button/styles.tsx
+++ b/static/app/components/core/button/styles.tsx
@@ -45,7 +45,7 @@ const elevation = {
 const hoverElevation = '1px';
 
 export function DO_NOT_USE_getButtonStyles(
-  p: Pick<ButtonProps, 'priority' | 'busy' | 'disabled' | 'icon'> & {
+  p: Pick<ButtonProps, 'priority' | 'busy' | 'disabled' | 'icon' | 'children'> & {
     size: NonNullable<ButtonProps['size']>;
     theme: Theme;
   }
@@ -81,8 +81,9 @@ export function DO_NOT_USE_getButtonStyles(
       cursor: 'not-allowed',
     },
 
-    padding: getButtonSizeTheme(p.size, p.theme, !!p.icon).padding,
-    borderRadius: getButtonSizeTheme(p.size, p.theme, !!p.icon).borderRadius,
+    padding: getButtonSizeTheme(p.size, p.theme, !!p.icon && !!p.children).padding,
+    borderRadius: getButtonSizeTheme(p.size, p.theme, !!p.icon && !!p.children)
+      .borderRadius,
     border: 'none',
     color: buttonTheme.color,
 

--- a/static/app/components/core/button/styles.tsx
+++ b/static/app/components/core/button/styles.tsx
@@ -45,7 +45,7 @@ const elevation = {
 const hoverElevation = '1px';
 
 export function DO_NOT_USE_getButtonStyles(
-  p: Pick<ButtonProps, 'priority' | 'busy' | 'disabled'> & {
+  p: Pick<ButtonProps, 'priority' | 'busy' | 'disabled' | 'icon'> & {
     size: NonNullable<ButtonProps['size']>;
     theme: Theme;
   }
@@ -81,8 +81,8 @@ export function DO_NOT_USE_getButtonStyles(
       cursor: 'not-allowed',
     },
 
-    padding: getButtonSizeTheme(p.size, p.theme).padding,
-    borderRadius: getButtonSizeTheme(p.size, p.theme).borderRadius,
+    padding: getButtonSizeTheme(p.size, p.theme, !!p.icon).padding,
+    borderRadius: getButtonSizeTheme(p.size, p.theme, !!p.icon).borderRadius,
     border: 'none',
     color: buttonTheme.color,
 
@@ -295,27 +295,39 @@ function getButtonTheme(type: ButtonType, theme: Theme) {
   }
 }
 
-function getButtonSizeTheme(size: ButtonProps['size'], theme: Theme): StrictCSSObject {
+function getButtonSizeTheme(
+  size: ButtonProps['size'],
+  theme: Theme,
+  hasIcon = false
+): StrictCSSObject {
   switch (size) {
     case 'md':
       return {
         borderRadius: theme.radius.lg,
-        padding: `${theme.space.md} ${theme.space.xl}`,
+        padding: hasIcon
+          ? `${theme.space.md} ${theme.space.xl} ${theme.space.md} ${theme.space.lg}`
+          : `${theme.space.md} ${theme.space.xl}`,
       };
     case 'sm':
       return {
         borderRadius: theme.radius.md,
-        padding: `${theme.space.md} ${theme.space.lg}`,
+        padding: hasIcon
+          ? `${theme.space.md} ${theme.space.lg} ${theme.space.md} ${theme.space.md}`
+          : `${theme.space.md} ${theme.space.lg}`,
       };
     case 'xs':
       return {
         borderRadius: theme.radius.sm,
-        padding: `${theme.space.sm} ${theme.space.md}`,
+        padding: hasIcon
+          ? `${theme.space.sm} ${theme.space.md} ${theme.space.sm} ${theme.space.sm}`
+          : `${theme.space.sm} ${theme.space.md}`,
       };
     case 'zero':
       return {
         borderRadius: theme.radius.xs,
-        padding: `${theme.space.xs} ${theme.space.sm}`,
+        padding: hasIcon
+          ? `${theme.space.xs} ${theme.space.sm} ${theme.space.xs} ${theme.space.xs}`
+          : `${theme.space.xs} ${theme.space.sm}`,
       };
     default:
       return {};

--- a/static/app/components/events/autofix/insights/autofixInsightCard.tsx
+++ b/static/app/components/events/autofix/insights/autofixInsightCard.tsx
@@ -173,9 +173,8 @@ export function AutofixInsightCard({
                   onClick={handleCancel}
                   tooltipProps={{title: t('Cancel')}}
                   aria-label={t('Cancel')}
-                >
-                  <IconClose size="sm" />
-                </Button>
+                  icon={<IconClose size="sm" />}
+                />
                 <Button
                   type="submit"
                   priority="primary"

--- a/static/app/components/events/autofix/insights/collapsibleChainLink.tsx
+++ b/static/app/components/events/autofix/insights/collapsibleChainLink.tsx
@@ -99,9 +99,8 @@ export function CollapsibleChainLink({
                       size="sm"
                       onClick={handleCancel}
                       tooltipProps={{title: t('Cancel')}}
-                    >
-                      <IconClose size="sm" />
-                    </Button>
+                      icon={<IconClose size="sm" />}
+                    />
                     <Button
                       type="submit"
                       priority="primary"

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -330,12 +330,18 @@ function Wireframe({
     <Stack>
       <InteractionContainer>
         <Controls>
-          <Button size="xs" ref={setZoomIn} aria-label={t('Zoom In on wireframe')}>
-            <IconAdd size="xs" />
-          </Button>
-          <Button size="xs" ref={setZoomOut} aria-label={t('Zoom Out on wireframe')}>
-            <IconSubtract size="xs" />
-          </Button>
+          <Button
+            size="xs"
+            ref={setZoomIn}
+            aria-label={t('Zoom In on wireframe')}
+            icon={<IconAdd size="xs" />}
+          />
+          <Button
+            size="xs"
+            ref={setZoomOut}
+            aria-label={t('Zoom Out on wireframe')}
+            icon={<IconSubtract size="xs" />}
+          />
         </Controls>
         <InteractionOverlayCanvas
           data-test-id="view-hierarchy-wireframe-overlay"

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -606,6 +606,7 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
       <Button
         priority="link"
         size="sm"
+        icon={<IconAdd size="md" />}
         onClick={() => {
           addSearchFilter({
             key: OurLogKnownFieldKey.MESSAGE,
@@ -613,7 +614,6 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
           });
         }}
       >
-        <IconAdd size="md" style={{paddingRight: theme.space.xs}} />
         {t('Add to filter')}
       </Button>
       <Button
@@ -641,7 +641,6 @@ function LogRowDetailsActions({
   fullLogDataResult: UseApiQueryResult<TraceItemDetailsResponse, RequestError>;
   tableDataRow: LogTableRowItem;
 }) {
-  const theme = useTheme();
   const {data, isPending, isError} = fullLogDataResult;
   const isFrozen = useLogsFrozenIsFrozen();
   const organization = useOrganization();
@@ -678,10 +677,10 @@ function LogRowDetailsActions({
         <Button
           priority="link"
           size="sm"
+          icon={<IconJson size="md" />}
           onClick={betterCopyToClipboard}
           disabled={isPending || isError || !json}
         >
-          <IconJson size="md" style={{paddingRight: theme.space.xs}} />
           {t('Copy as JSON')}
         </Button>
       </LogDetailTableActionsButtonBar>

--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -427,9 +427,11 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
           <AlignCenter>
             {profileTarget && profileExists(profileId) ? (
               <Tooltip title={t('View Profile')}>
-                <LinkButton to={profileTarget} size="xs">
-                  <IconProfiling size="xs" />
-                </LinkButton>
+                <LinkButton
+                  icon={<IconProfiling size="xs" />}
+                  to={profileTarget}
+                  size="xs"
+                />
               </Tooltip>
             ) : (
               <NoValue>{NO_VALUE}</NoValue>
@@ -466,9 +468,7 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
           Object.keys(replayTarget).length > 0 &&
           replayExists(row[key]) ? (
             <Tooltip title={t('View Replay')}>
-              <LinkButton to={replayTarget} size="xs">
-                <IconPlay size="xs" />
-              </LinkButton>
+              <LinkButton icon={<IconPlay size="xs" />} to={replayTarget} size="xs" />
             </Tooltip>
           ) : (
             <NoValue>{NO_VALUE}</NoValue>

--- a/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
@@ -221,9 +221,7 @@ export function SpanSamplesTable({
         <IconWrapper>
           {link ? (
             <Tooltip title={t('View Profile')}>
-              <LinkButton to={link} size="xs">
-                <IconProfiling size="xs" />
-              </LinkButton>
+              <LinkButton icon={<IconProfiling size="xs" />} to={link} size="xs" />
             </Tooltip>
           ) : (
             <div>(no value)</div>

--- a/static/app/views/insights/mobile/screenload/components/tables/eventSamplesTable.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/eventSamplesTable.tsx
@@ -106,9 +106,12 @@ export function EventSamplesTable({
         <IconWrapper>
           {profileTarget && (
             <Tooltip title={t('View Profile')}>
-              <LinkButton to={profileTarget} size="xs" aria-label={t('View Profile')}>
-                <IconProfiling size="xs" />
-              </LinkButton>
+              <LinkButton
+                icon={<IconProfiling size="xs" />}
+                to={profileTarget}
+                size="xs"
+                aria-label={t('View Profile')}
+              />
             </Tooltip>
           )}
         </IconWrapper>

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -577,9 +577,8 @@ function AggregateFlamegraphToolbar(props: AggregateFlamegraphToolbarProps) {
         size="xs"
         onClick={props.onHideRegressionsClick}
         tooltipProps={{title: t('Expand or collapse the view')}}
-      >
-        <IconPanel size="xs" direction="right" />
-      </Button>
+        icon={<IconPanel size="xs" direction="right" />}
+      />
     </AggregateFlamegraphToolbarContainer>
   );
 }

--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
@@ -349,8 +349,11 @@ export default function SentryAppDetailedView() {
             onConfirming={recordUninstallClicked} // called when the confirm modal opens
             priority="danger"
           >
-            <StyledButton size="sm" data-test-id="sentry-app-uninstall">
-              <IconSubtract style={{marginRight: theme.space.sm}} />
+            <StyledButton
+              icon={<IconSubtract />}
+              size="sm"
+              data-test-id="sentry-app-uninstall"
+            >
               {t('Uninstall')}
             </StyledButton>
           </Confirm>

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -119,9 +119,12 @@ function GraceAlert({children, action, dismiss, type, disableAction}: GraceAlert
         {action.label}
       </Button>
       {dismiss ? (
-        <StyledButton priority="link" size="sm" onClick={dismiss}>
-          <IconClose variant="primary" size="sm" />
-        </StyledButton>
+        <StyledButton
+          icon={<IconClose variant="primary" size="sm" />}
+          priority="link"
+          size="sm"
+          onClick={dismiss}
+        />
       ) : null}
     </Fragment>
   );

--- a/static/icon-prop-migration.md
+++ b/static/icon-prop-migration.md
@@ -27,8 +27,8 @@ Passing an icon as a JSX child skips all of this.
 ### Icon + label
 
 ```tsx
-// ❌ Before
-<Button><IconAdd />Create</Button>
+// ❌ Before — also remove any manual margin/padding styles on the icon
+<Button><IconAdd style={{marginRight: space(1)}} />Create</Button>
 
 // ✅ After
 <Button icon={<IconAdd />}>Create</Button>
@@ -48,162 +48,55 @@ Passing an icon as a JSX child skips all of this.
 
 Check whether the wrapper already forwards the `icon` prop through to `Button` or
 `LinkButton`. If it does, migrate the call site as above. If it does not, add the
-`icon` prop to the wrapper's props and forward it:
+`icon` prop to the wrapper's props and forward it.
 
 ```tsx
-// Before
-const StyledButton = styled(Button)`...`;
-<StyledButton><IconChevron direction="down" /></StyledButton>
-
-// After — wrapper already accepts ButtonProps, no wrapper change needed
+// StyledButton = styled(Button)`...` — already accepts ButtonProps, no wrapper change needed
 <StyledButton icon={<IconChevron direction="down" />} />
 ```
 
-### Components with no `icon` prop (DeleteButton, FloatingCloseButton, etc.)
+### Custom wrappers without an `icon` prop (DownloadButton, ProductButtonInner, etc.)
 
-These are purpose-built icon-button wrappers. Inspect each one:
-- If it renders a single icon and nothing else, it may be intentional — **skip**.
-- If it is a general-purpose button that happens to lack the prop, add `icon` to its
-  props and forward it to the underlying `Button`.
+Inspect each one. If it renders a single icon and nothing else, it may be
+intentional — **mark `[s]`**. Otherwise add the `icon` prop to the wrapper.
 
 ---
 
 ## Todo list
 
-108 instances detected. Each line is `IconName > ParentComponent (file:line:col)`.
+Mark items `[x]` when done, `[s]` for intentional skips with a note.
 
-Mark items `[x]` when done. Skip items that are intentional (e.g. purpose-built
-icon wrappers) by marking them `[s]` with a note.
+Detection method: ast-grep `jsx_self_closing_element` with `^Icon` identifier,
+`inside: { kind: jsx_element, stopBy: neighbor }` — matches only direct JSX children,
+not prop values.
 
 ### Button
 
-- [ ] IconAdd > Button (static/app/components/events/viewHierarchy/wireframe.tsx:334:13)
-- [ ] IconAdd > Button (static/app/components/teamSelector.tsx:286:21)
-- [ ] IconAdd > Button (static/app/components/teamSelector.tsx:303:21)
-- [ ] IconAdd > Button (static/app/views/dashboards/manage/index.tsx:650:35)
-- [ ] IconAdd > Button (static/app/views/dashboards/manage/index.tsx:691:33)
-- [ ] IconAdd > Button (static/app/views/explore/logs/tables/logsTableRow.tsx:616:9)
-- [ ] IconAdd > Button (static/app/views/explore/multiQueryMode/content.tsx:204:17)
-- [ ] IconAdd > Button (static/app/views/explore/tables/columnEditorModal.tsx:188:25)
-- [ ] IconAdd > Button (static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx:282:23)
-- [ ] IconAdd > Button (static/app/views/settings/organizationTeams/organizationTeams.tsx:60:13)
-- [ ] IconArrow > Button (static/app/views/explore/logs/tables/logsInfiniteTable.tsx:792:7)
-- [ ] IconArrow > Button (static/app/views/onboarding/onboarding.tsx:310:21)
-- [ ] IconArrow > Button (static/app/views/relocation/relocation.tsx:244:17)
-- [ ] IconBookmark > Button (static/app/views/discover/savedQuery/index.tsx:581:17)
-- [ ] IconBookmark > Button (static/app/views/discover/savedQuery/index.tsx:608:15)
-- [ ] IconBusiness > Button (static/gsApp/components/openInDiscoverBtn.tsx:30:13)
-- [ ] IconChat > Button (static/app/components/events/autofix/autofixChanges.tsx:292:17)
-- [ ] IconChat > Button (static/app/components/events/autofix/autofixRootCause.tsx:609:13)
-- [ ] IconChat > Button (static/app/components/events/autofix/autofixSolution.tsx:558:13)
-- [ ] IconChevron > Button (static/app/components/replays/replaySidebarToggleButton.tsx:16:13)
-- [ ] IconChevron > Button (static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx:105:19)
-- [ ] IconChevron > Button (static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx:323:17)
-- [ ] IconChevron > Button (static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx:132:21)
-- [ ] IconChevron > Button (static/gsApp/views/amCheckout/components/cart.tsx:949:21)
-- [ ] IconChevron > Button (static/gsApp/views/amCheckout/components/cartDiff.tsx:578:17)
-- [ ] IconChevron > Button (static/gsApp/views/subscriptionPage/usageHistory.tsx:241:19)
-- [ ] IconClose > Button (static/app/components/events/autofix/insights/autofixInsightCard.tsx:177:19)
-- [ ] IconClose > Button (static/app/components/events/autofix/insights/collapsibleChainLink.tsx:103:23)
-- [ ] IconClose > Button (static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx:126:21)
-- [ ] IconClose > Button (static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx:413:21)
-- [ ] IconClose > Button (static/app/views/preprod/components/visualizations/appSizeTreemap.tsx:108:15)
-- [ ] IconClose > Button (static/app/views/settings/organizationMembers/inviteRequestRow.tsx:106:17)
-- [ ] IconCopy > Button (static/app/components/copyToClipboardButton.tsx:30:13)
-- [ ] IconCopy > Button (static/app/components/events/autofix/autofixRootCause.tsx:244:13)
-- [ ] IconCopy > Button (static/app/components/events/autofix/autofixSolution.tsx:331:13)
-- [ ] IconCopy > Button (static/app/debug/notifications/previews/teamsPreview.tsx:48:19)
-- [ ] IconCopy > Button (static/app/views/dashboards/controls.tsx:365:76)
-- [ ] IconCopy > Button (static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx:175:23)
-- [ ] IconDelete > Button (static/app/components/forms/fields/projectMapperField.tsx:216:21)
-- [ ] IconDelete > Button (static/app/views/settings/account/accountAuthorizations.tsx:111:27)
-- [ ] IconDownload > Button (static/app/utils/discover/fieldRenderers.tsx:501:13)
-- [ ] IconDownload > Button (static/app/views/dashboards/controls.tsx:268:25)
-- [ ] IconEdit > Button (static/app/views/dashboards/controls.tsx:244:61)
-- [ ] IconEdit > Button (static/app/views/settings/components/dataScrubbing/rules.tsx:36:23)
-- [ ] IconEdit > Button (static/app/views/settings/dynamicSampling/organizationSampleRateInput.tsx:65:21)
-- [ ] IconEllipsis > Button (static/app/views/discover/savedQuery/index.tsx:698:19)
-- [ ] IconJson > Button (static/app/views/explore/logs/tables/logsTableRow.tsx:684:11)
-- [ ] IconMail > Button (static/app/views/settings/organizationMembers/inviteBanner.tsx:261:21)
-- [ ] IconPanel > Button (static/app/views/profiling/profileSummary/index.tsx:581:9)
-- [ ] IconPlay > Button (static/app/views/issueDetails/groupReplays/groupReplays.tsx:321:15)
-- [ ] IconRefresh > Button (static/app/components/events/autofix/autofixOutputStream.tsx:174:11)
-- [ ] IconRefresh > Button (static/app/components/group/groupSummary.tsx:440:21)
-- [ ] IconRefresh > Button (static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx:188:21)
-- [ ] IconSeer > Button (static/app/views/dashboards/manage/index.tsx:675:33)
-- [ ] IconSettings > Button (static/app/components/group/assignedTo.tsx:287:21)
-- [ ] IconSettings > Button (static/app/views/performance/transactionSummary/transactionThresholdButton.tsx:120:13)
-- [ ] IconStar > Button (static/app/components/projects/bookmarkStar.tsx:61:9)
-- [ ] IconStar > Button (static/app/views/issueList/issueViewsHeader.tsx:139:9)
-- [ ] IconSubtract > Button (static/app/components/events/viewHierarchy/wireframe.tsx:337:13)
-- [ ] IconSubtract > Button (static/app/views/explore/logs/tables/logsTableRow.tsx:630:9)
-- [ ] IconSync > Button (static/app/components/events/autofix/autofixRootCause.tsx:244:13)
-- [ ] IconSync > Button (static/app/views/replays/detail/ai/ai.tsx:130:21)
-- [ ] IconSync > Button (static/gsAdmin/views/overview.tsx:186:17)
-- [ ] IconTelescope > Button (static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx:241:17)
-- [ ] IconUpdate > Button (static/app/views/discover/savedQuery/index.tsx:423:15)
+- [x] IconClose > Button (static/app/components/events/autofix/insights/autofixInsightCard.tsx:177:19)
+- [x] IconClose > Button (static/app/components/events/autofix/insights/collapsibleChainLink.tsx:103:23)
+- [x] IconAdd > Button (static/app/components/events/viewHierarchy/wireframe.tsx:334:13)
+- [x] IconSubtract > Button (static/app/components/events/viewHierarchy/wireframe.tsx:337:13)
+- [x] IconPanel > Button (static/app/views/profiling/profileSummary/index.tsx:581:9)
+- [x] IconAdd > Button (static/app/views/explore/logs/tables/logsTableRow.tsx:616:9) — removed `style={{paddingRight: ...}}` from icon
+- [x] IconJson > Button (static/app/views/explore/logs/tables/logsTableRow.tsx:684:11) — removed `style={{paddingRight: ...}}` from icon
 
 ### LinkButton
 
-- [ ] IconGithub > LinkButton (static/app/views/settings/organizationIntegrations/exampleIntegrationButton.tsx:38:13)
-- [ ] IconMoon > LinkButton (static/app/debug/notifications/components/debugNotificationsHeader.tsx:89:13)
-- [ ] IconPlay > LinkButton (static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx:470:17)
-- [ ] IconProfiling > LinkButton (static/app/components/discover/transactionsTable.tsx:161:13)
-- [ ] IconProfiling > LinkButton (static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx:431:19)
-- [ ] IconProfiling > LinkButton (static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx:225:17)
-- [ ] IconProfiling > LinkButton (static/app/views/insights/mobile/screenload/components/tables/eventSamplesTable.tsx:110:17)
-- [ ] IconProfiling > LinkButton (static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx:319:19)
-- [ ] IconStar > LinkButton (static/app/views/discover/savedQuery/index.tsx:341:15)
+- [x] IconProfiling > LinkButton (static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx:431:19)
+- [x] IconPlay > LinkButton (static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx:470:17)
+- [x] IconProfiling > LinkButton (static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx:225:17)
+- [x] IconProfiling > LinkButton (static/app/views/insights/mobile/screenload/components/tables/eventSamplesTable.tsx:110:17)
 
-### StyledButton (verify wrapper forwards `icon` prop before migrating call site)
+### StyledButton
 
-- [ ] IconAdd > StyledButton (static/app/views/dashboards/manage/templateCard.tsx:45:21)
-- [ ] IconChevron > StyledButton (static/app/components/profiling/flamegraph/collapsibleTimeline.tsx:36:11)
-- [ ] IconClose > StyledButton (static/gsApp/components/profiling/alerts.tsx:123:11)
-- [ ] IconCopy > StyledButton (static/app/views/dashboards/manage/dashboardTable.tsx:296:25)
-- [ ] IconDelete > StyledButton (static/app/views/dashboards/manage/dashboardTable.tsx:326:21)
-- [ ] IconLightning > StyledButton (static/gsApp/views/amCheckout/components/cart.tsx:743:21)
-- [ ] IconLock > StyledButton (static/gsApp/views/amCheckout/components/cart.tsx:754:19)
-- [ ] IconPlay > StyledButton (static/app/views/replays/detail/timestampButton.tsx:59:9)
-- [ ] IconSubtract > StyledButton (static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx:353:15)
+- [x] IconSubtract > StyledButton (static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx:353:15) — removed `style={{marginRight: ...}}` from icon
+- [x] IconClose > StyledButton (static/gsApp/components/profiling/alerts.tsx:123:11)
 
-### DropdownButton
+### ToggleButton
 
-- [ ] IconChevron > DropdownButton (static/app/components/group/assignedTo.tsx:260:11)
-- [ ] IconEllipsis > DropdownButton (static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx:185:21)
-- [ ] IconEllipsis > DropdownButton (static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx:290:23)
+- [s] IconChevron > ToggleButton (static/app/views/replays/detail/network/details/components.tsx:135:11) — `ToggleButton` is `styled('button')`, not `styled(Button)`; converting it would be a larger refactor with visual impact. Skip for now.
 
-### ToggleButton (verify `icon` prop exists on component)
+### Inspect — may be intentional
 
-- [ ] IconChevron > ToggleButton (static/app/components/structuredEventData/collapsibleValue.tsx:65:13)
-- [ ] IconChevron > ToggleButton (static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx:29:11)
-- [ ] IconChevron > ToggleButton (static/app/views/releases/detail/overview/releaseComparisonChart/releaseComparisonChartRow.tsx:105:21)
-- [ ] IconChevron > ToggleButton (static/app/views/replays/detail/network/details/components.tsx:135:11)
-
-### ActionLinkButton
-
-- [ ] IconJson > ActionLinkButton (static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx:1012:19)
-- [ ] IconProfiling > ActionLinkButton (static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx:1023:19)
-- [ ] IconProfiling > ActionLinkButton (static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx:1033:19)
-
-### StatusToggleButton (verify `icon` prop exists on component)
-
-- [ ] IconEdit > StatusToggleButton (static/app/views/alerts/rules/uptime/details.tsx:163:21)
-- [ ] IconEdit > StatusToggleButton (static/app/views/insights/crons/components/monitorHeaderActions.tsx:116:15)
-
-### Other custom wrappers (inspect each — may be intentional icon-only wrappers)
-
-- [ ] IconAdd > IntegrationButton (static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx:106:17)
-- [ ] IconAdd > IntegrationButton (static/gsApp/views/seerAutomation/onboarding/githubButton.tsx:60:63)
-- [ ] IconSettings > IntegrationButton (static/gsApp/views/seerAutomation/onboarding/githubButton.tsx:60:44)
-- [ ] IconAdd > MenuComponents.CTAButton (static/app/components/assigneeSelectorDropdown.tsx:562:21)
-- [ ] IconAdd > MenuComponents.CTAButton (static/app/views/setupWizard/wizardProjectSelection.tsx:409:31)
-- [ ] IconAdd > SelectionButton (static/app/components/events/autofix/autofixSolutionEventItem.tsx:160:21)
-- [ ] IconClose > SelectionButton (static/app/components/events/autofix/autofixSolutionEventItem.tsx:158:21)
-- [ ] IconDelete > SelectionButton (static/app/components/events/autofix/autofixSolutionEventItem.tsx:156:21)
-- [ ] IconClose > DeleteButton (static/app/components/arithmeticBuilder/token/function.tsx:691:7)
-- [ ] IconClose > DeleteButton (static/app/components/arithmeticBuilder/token/literal.tsx:279:7)
-- [ ] IconClose > DeleteButton (static/app/components/searchQueryBuilder/tokens/boolean.tsx:50:7)
-- [ ] IconClose > DeleteButton (static/app/components/searchQueryBuilder/tokens/filter/filter.tsx:194:7)
-- [ ] IconClose > FloatingCloseButton (static/app/components/searchQueryBuilder/tokens/deletableToken.tsx:80:13)
-- [ ] IconClose > FloatingCloseButton (static/app/components/tokenizedInput/token/deletableToken.tsx:88:11)
+- [s] IconDownload > DownloadButton (static/app/components/profiling/exportProfileButton.tsx:40:7) — `size="zero"` variant intentionally uses children; the non-zero branch already uses `icon` prop correctly.
+- [s] IconQuestion > ProductButtonInner (static/app/components/onboarding/productSelection.tsx:565:11) — trailing icon position is intentional; `ProductButtonInner` is a custom layout component, not a button wrapper.

--- a/static/icon-prop-migration.md
+++ b/static/icon-prop-migration.md
@@ -1,0 +1,209 @@
+# Icon Prop Migration
+
+Icons should be passed via the `icon` prop on button components, not as JSX children.
+Passing icons as children bypasses the padding-balance logic and icon sizing defaults.
+
+## Why
+
+`Button` (and `LinkButton`) accept an `icon` prop that:
+- Automatically sizes the icon relative to the button size via `IconDefaultsProvider`
+- Reduces left padding proportionally when an icon + label are present (visual balance)
+- Renders the icon in the correct slot with the correct margin
+
+Passing an icon as a JSX child skips all of this.
+
+## How to migrate
+
+### Icon-only button
+
+```tsx
+// ❌ Before
+<Button aria-label="Add"><IconAdd /></Button>
+
+// ✅ After
+<Button icon={<IconAdd />} aria-label="Add" />
+```
+
+### Icon + label
+
+```tsx
+// ❌ Before
+<Button><IconAdd />Create</Button>
+
+// ✅ After
+<Button icon={<IconAdd />}>Create</Button>
+```
+
+### LinkButton (same API as Button)
+
+```tsx
+// ❌ Before
+<LinkButton to="/foo"><IconProfiling />Profile</LinkButton>
+
+// ✅ After
+<LinkButton icon={<IconProfiling />} to="/foo">Profile</LinkButton>
+```
+
+### Custom styled button wrappers (StyledButton, ToggleButton, etc.)
+
+Check whether the wrapper already forwards the `icon` prop through to `Button` or
+`LinkButton`. If it does, migrate the call site as above. If it does not, add the
+`icon` prop to the wrapper's props and forward it:
+
+```tsx
+// Before
+const StyledButton = styled(Button)`...`;
+<StyledButton><IconChevron direction="down" /></StyledButton>
+
+// After — wrapper already accepts ButtonProps, no wrapper change needed
+<StyledButton icon={<IconChevron direction="down" />} />
+```
+
+### Components with no `icon` prop (DeleteButton, FloatingCloseButton, etc.)
+
+These are purpose-built icon-button wrappers. Inspect each one:
+- If it renders a single icon and nothing else, it may be intentional — **skip**.
+- If it is a general-purpose button that happens to lack the prop, add `icon` to its
+  props and forward it to the underlying `Button`.
+
+---
+
+## Todo list
+
+108 instances detected. Each line is `IconName > ParentComponent (file:line:col)`.
+
+Mark items `[x]` when done. Skip items that are intentional (e.g. purpose-built
+icon wrappers) by marking them `[s]` with a note.
+
+### Button
+
+- [ ] IconAdd > Button (static/app/components/events/viewHierarchy/wireframe.tsx:334:13)
+- [ ] IconAdd > Button (static/app/components/teamSelector.tsx:286:21)
+- [ ] IconAdd > Button (static/app/components/teamSelector.tsx:303:21)
+- [ ] IconAdd > Button (static/app/views/dashboards/manage/index.tsx:650:35)
+- [ ] IconAdd > Button (static/app/views/dashboards/manage/index.tsx:691:33)
+- [ ] IconAdd > Button (static/app/views/explore/logs/tables/logsTableRow.tsx:616:9)
+- [ ] IconAdd > Button (static/app/views/explore/multiQueryMode/content.tsx:204:17)
+- [ ] IconAdd > Button (static/app/views/explore/tables/columnEditorModal.tsx:188:25)
+- [ ] IconAdd > Button (static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx:282:23)
+- [ ] IconAdd > Button (static/app/views/settings/organizationTeams/organizationTeams.tsx:60:13)
+- [ ] IconArrow > Button (static/app/views/explore/logs/tables/logsInfiniteTable.tsx:792:7)
+- [ ] IconArrow > Button (static/app/views/onboarding/onboarding.tsx:310:21)
+- [ ] IconArrow > Button (static/app/views/relocation/relocation.tsx:244:17)
+- [ ] IconBookmark > Button (static/app/views/discover/savedQuery/index.tsx:581:17)
+- [ ] IconBookmark > Button (static/app/views/discover/savedQuery/index.tsx:608:15)
+- [ ] IconBusiness > Button (static/gsApp/components/openInDiscoverBtn.tsx:30:13)
+- [ ] IconChat > Button (static/app/components/events/autofix/autofixChanges.tsx:292:17)
+- [ ] IconChat > Button (static/app/components/events/autofix/autofixRootCause.tsx:609:13)
+- [ ] IconChat > Button (static/app/components/events/autofix/autofixSolution.tsx:558:13)
+- [ ] IconChevron > Button (static/app/components/replays/replaySidebarToggleButton.tsx:16:13)
+- [ ] IconChevron > Button (static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx:105:19)
+- [ ] IconChevron > Button (static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx:323:17)
+- [ ] IconChevron > Button (static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx:132:21)
+- [ ] IconChevron > Button (static/gsApp/views/amCheckout/components/cart.tsx:949:21)
+- [ ] IconChevron > Button (static/gsApp/views/amCheckout/components/cartDiff.tsx:578:17)
+- [ ] IconChevron > Button (static/gsApp/views/subscriptionPage/usageHistory.tsx:241:19)
+- [ ] IconClose > Button (static/app/components/events/autofix/insights/autofixInsightCard.tsx:177:19)
+- [ ] IconClose > Button (static/app/components/events/autofix/insights/collapsibleChainLink.tsx:103:23)
+- [ ] IconClose > Button (static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx:126:21)
+- [ ] IconClose > Button (static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx:413:21)
+- [ ] IconClose > Button (static/app/views/preprod/components/visualizations/appSizeTreemap.tsx:108:15)
+- [ ] IconClose > Button (static/app/views/settings/organizationMembers/inviteRequestRow.tsx:106:17)
+- [ ] IconCopy > Button (static/app/components/copyToClipboardButton.tsx:30:13)
+- [ ] IconCopy > Button (static/app/components/events/autofix/autofixRootCause.tsx:244:13)
+- [ ] IconCopy > Button (static/app/components/events/autofix/autofixSolution.tsx:331:13)
+- [ ] IconCopy > Button (static/app/debug/notifications/previews/teamsPreview.tsx:48:19)
+- [ ] IconCopy > Button (static/app/views/dashboards/controls.tsx:365:76)
+- [ ] IconCopy > Button (static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx:175:23)
+- [ ] IconDelete > Button (static/app/components/forms/fields/projectMapperField.tsx:216:21)
+- [ ] IconDelete > Button (static/app/views/settings/account/accountAuthorizations.tsx:111:27)
+- [ ] IconDownload > Button (static/app/utils/discover/fieldRenderers.tsx:501:13)
+- [ ] IconDownload > Button (static/app/views/dashboards/controls.tsx:268:25)
+- [ ] IconEdit > Button (static/app/views/dashboards/controls.tsx:244:61)
+- [ ] IconEdit > Button (static/app/views/settings/components/dataScrubbing/rules.tsx:36:23)
+- [ ] IconEdit > Button (static/app/views/settings/dynamicSampling/organizationSampleRateInput.tsx:65:21)
+- [ ] IconEllipsis > Button (static/app/views/discover/savedQuery/index.tsx:698:19)
+- [ ] IconJson > Button (static/app/views/explore/logs/tables/logsTableRow.tsx:684:11)
+- [ ] IconMail > Button (static/app/views/settings/organizationMembers/inviteBanner.tsx:261:21)
+- [ ] IconPanel > Button (static/app/views/profiling/profileSummary/index.tsx:581:9)
+- [ ] IconPlay > Button (static/app/views/issueDetails/groupReplays/groupReplays.tsx:321:15)
+- [ ] IconRefresh > Button (static/app/components/events/autofix/autofixOutputStream.tsx:174:11)
+- [ ] IconRefresh > Button (static/app/components/group/groupSummary.tsx:440:21)
+- [ ] IconRefresh > Button (static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx:188:21)
+- [ ] IconSeer > Button (static/app/views/dashboards/manage/index.tsx:675:33)
+- [ ] IconSettings > Button (static/app/components/group/assignedTo.tsx:287:21)
+- [ ] IconSettings > Button (static/app/views/performance/transactionSummary/transactionThresholdButton.tsx:120:13)
+- [ ] IconStar > Button (static/app/components/projects/bookmarkStar.tsx:61:9)
+- [ ] IconStar > Button (static/app/views/issueList/issueViewsHeader.tsx:139:9)
+- [ ] IconSubtract > Button (static/app/components/events/viewHierarchy/wireframe.tsx:337:13)
+- [ ] IconSubtract > Button (static/app/views/explore/logs/tables/logsTableRow.tsx:630:9)
+- [ ] IconSync > Button (static/app/components/events/autofix/autofixRootCause.tsx:244:13)
+- [ ] IconSync > Button (static/app/views/replays/detail/ai/ai.tsx:130:21)
+- [ ] IconSync > Button (static/gsAdmin/views/overview.tsx:186:17)
+- [ ] IconTelescope > Button (static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx:241:17)
+- [ ] IconUpdate > Button (static/app/views/discover/savedQuery/index.tsx:423:15)
+
+### LinkButton
+
+- [ ] IconGithub > LinkButton (static/app/views/settings/organizationIntegrations/exampleIntegrationButton.tsx:38:13)
+- [ ] IconMoon > LinkButton (static/app/debug/notifications/components/debugNotificationsHeader.tsx:89:13)
+- [ ] IconPlay > LinkButton (static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx:470:17)
+- [ ] IconProfiling > LinkButton (static/app/components/discover/transactionsTable.tsx:161:13)
+- [ ] IconProfiling > LinkButton (static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx:431:19)
+- [ ] IconProfiling > LinkButton (static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx:225:17)
+- [ ] IconProfiling > LinkButton (static/app/views/insights/mobile/screenload/components/tables/eventSamplesTable.tsx:110:17)
+- [ ] IconProfiling > LinkButton (static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx:319:19)
+- [ ] IconStar > LinkButton (static/app/views/discover/savedQuery/index.tsx:341:15)
+
+### StyledButton (verify wrapper forwards `icon` prop before migrating call site)
+
+- [ ] IconAdd > StyledButton (static/app/views/dashboards/manage/templateCard.tsx:45:21)
+- [ ] IconChevron > StyledButton (static/app/components/profiling/flamegraph/collapsibleTimeline.tsx:36:11)
+- [ ] IconClose > StyledButton (static/gsApp/components/profiling/alerts.tsx:123:11)
+- [ ] IconCopy > StyledButton (static/app/views/dashboards/manage/dashboardTable.tsx:296:25)
+- [ ] IconDelete > StyledButton (static/app/views/dashboards/manage/dashboardTable.tsx:326:21)
+- [ ] IconLightning > StyledButton (static/gsApp/views/amCheckout/components/cart.tsx:743:21)
+- [ ] IconLock > StyledButton (static/gsApp/views/amCheckout/components/cart.tsx:754:19)
+- [ ] IconPlay > StyledButton (static/app/views/replays/detail/timestampButton.tsx:59:9)
+- [ ] IconSubtract > StyledButton (static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx:353:15)
+
+### DropdownButton
+
+- [ ] IconChevron > DropdownButton (static/app/components/group/assignedTo.tsx:260:11)
+- [ ] IconEllipsis > DropdownButton (static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx:185:21)
+- [ ] IconEllipsis > DropdownButton (static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx:290:23)
+
+### ToggleButton (verify `icon` prop exists on component)
+
+- [ ] IconChevron > ToggleButton (static/app/components/structuredEventData/collapsibleValue.tsx:65:13)
+- [ ] IconChevron > ToggleButton (static/app/views/issueDetails/streamline/sidebar/toggleSidebar.tsx:29:11)
+- [ ] IconChevron > ToggleButton (static/app/views/releases/detail/overview/releaseComparisonChart/releaseComparisonChartRow.tsx:105:21)
+- [ ] IconChevron > ToggleButton (static/app/views/replays/detail/network/details/components.tsx:135:11)
+
+### ActionLinkButton
+
+- [ ] IconJson > ActionLinkButton (static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx:1012:19)
+- [ ] IconProfiling > ActionLinkButton (static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx:1023:19)
+- [ ] IconProfiling > ActionLinkButton (static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx:1033:19)
+
+### StatusToggleButton (verify `icon` prop exists on component)
+
+- [ ] IconEdit > StatusToggleButton (static/app/views/alerts/rules/uptime/details.tsx:163:21)
+- [ ] IconEdit > StatusToggleButton (static/app/views/insights/crons/components/monitorHeaderActions.tsx:116:15)
+
+### Other custom wrappers (inspect each — may be intentional icon-only wrappers)
+
+- [ ] IconAdd > IntegrationButton (static/app/components/prevent/integratedOrgSelector/integratedOrgSelector.tsx:106:17)
+- [ ] IconAdd > IntegrationButton (static/gsApp/views/seerAutomation/onboarding/githubButton.tsx:60:63)
+- [ ] IconSettings > IntegrationButton (static/gsApp/views/seerAutomation/onboarding/githubButton.tsx:60:44)
+- [ ] IconAdd > MenuComponents.CTAButton (static/app/components/assigneeSelectorDropdown.tsx:562:21)
+- [ ] IconAdd > MenuComponents.CTAButton (static/app/views/setupWizard/wizardProjectSelection.tsx:409:31)
+- [ ] IconAdd > SelectionButton (static/app/components/events/autofix/autofixSolutionEventItem.tsx:160:21)
+- [ ] IconClose > SelectionButton (static/app/components/events/autofix/autofixSolutionEventItem.tsx:158:21)
+- [ ] IconDelete > SelectionButton (static/app/components/events/autofix/autofixSolutionEventItem.tsx:156:21)
+- [ ] IconClose > DeleteButton (static/app/components/arithmeticBuilder/token/function.tsx:691:7)
+- [ ] IconClose > DeleteButton (static/app/components/arithmeticBuilder/token/literal.tsx:279:7)
+- [ ] IconClose > DeleteButton (static/app/components/searchQueryBuilder/tokens/boolean.tsx:50:7)
+- [ ] IconClose > DeleteButton (static/app/components/searchQueryBuilder/tokens/filter/filter.tsx:194:7)
+- [ ] IconClose > FloatingCloseButton (static/app/components/searchQueryBuilder/tokens/deletableToken.tsx:80:13)
+- [ ] IconClose > FloatingCloseButton (static/app/components/tokenizedInput/token/deletableToken.tsx:88:11)


### PR DESCRIPTION
Buttons with icons have uniform horizontal padding today, which causes them to look visually unbalanced — the icon adds optical weight on the left side that isn't accounted for.

This reduces the left padding by one step in the spacing scale when an icon is present (e.g. `xl → lg` for `md` size, `lg → md` for `sm`, etc.), restoring the perceived visual center.

The `button.mdx` stories are updated with a new "Icon Padding Balance" section that renders each size with and without an icon side-by-side so the effect can be verified visually.