### PR TITLE
ref(supergroups): Filter out supergroups with only one issue

### DIFF
--- a/static/app/views/issueList/pages/supergroups.tsx
+++ b/static/app/views/issueList/pages/supergroups.tsx
@@ -106,7 +106,7 @@ function Supergroups() {
     }
   );
 
-  const supergroups = response?.data ?? [];
+  const supergroups = (response?.data ?? []).filter(sg => sg.group_ids.length > 1);
 
   const handleSupergroupClick = (supergroup: SupergroupDetail) => {
     openDrawer(() => <SupergroupDetailDrawer supergroup={supergroup} />, {


### PR DESCRIPTION
In general, supergroups with one issue are not great to show, so we can filter them out in the frontend for now. Plan is to filter these singletons supergroups out in seer as a followup.