### PR TITLE
feat(supergroups): Add project filter to supergroups page

### DIFF
--- a/static/app/views/issueList/pages/supergroups.tsx
+++ b/static/app/views/issueList/pages/supergroups.tsx
@@ -106,7 +106,9 @@ function Supergroups() {
     }
   );
 
-  const supergroups = response?.data ?? [];
+  const supergroups = (response?.data ?? []).filter(
+    sg => sg.group_ids.length > 1
+  );
 
   const handleSupergroupClick = (supergroup: SupergroupDetail) => {
     openDrawer(() => <SupergroupDetailDrawer supergroup={supergroup} />, {

--- a/static/app/views/issueList/pages/supergroups.tsx
+++ b/static/app/views/issueList/pages/supergroups.tsx
@@ -1,7 +1,10 @@
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {inlineCodeStyles} from '@sentry/scraps/code';
+import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -13,6 +16,8 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Redirect} from 'sentry/components/redirect';
 import {IconFocus} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -26,9 +31,11 @@ interface ListSupergroupsResponse {
 
 function SupergroupCard({
   supergroup,
+  projects,
   onClick,
 }: {
   onClick: () => void;
+  projects: Project[];
   supergroup: SupergroupDetail;
 }) {
   return (
@@ -39,9 +46,23 @@ function SupergroupCard({
         </Text>
 
         <Stack gap="xs">
-          <Text size="xs" variant="muted">
-            {tn('%s issue', '%s issues', supergroup.group_ids.length)}
-          </Text>
+          <Flex align="center" gap="sm">
+            <Text size="xs" variant="muted">
+              {tn('%s issue', '%s issues', supergroup.group_ids.length)}
+            </Text>
+            {projects.length > 0 && (
+              <Flex align="center" gap="xs">
+                {projects.map(project => (
+                  <Flex key={project.id} align="center" gap="xs">
+                    <ProjectAvatar project={project} size={14} />
+                    <Text size="xs" variant="muted">
+                      {project.slug}
+                    </Text>
+                  </Flex>
+                ))}
+              </Flex>
+            )}
+          </Flex>
           {supergroup.error_type && (
             <Flex align="baseline" gap="xs">
               <Text size="xs" variant="muted" bold>
@@ -88,11 +109,12 @@ function Supergroups() {
   const organization = useOrganization();
   const hasTopIssuesUI = organization.features.includes('top-issues-ui');
   const {openDrawer} = useDrawer();
+  const [selectedProjectId, setSelectedProjectId] = useState<string>('');
 
   const {
     data: response,
-    isPending,
-    isError,
+    isPending: isSupergroupsPending,
+    isError: isSupergroupsError,
     refetch,
   } = useApiQuery<ListSupergroupsResponse>(
     [
@@ -106,9 +128,99 @@ function Supergroups() {
     }
   );
 
-  const supergroups = (response?.data ?? []).filter(
-    sg => sg.group_ids.length > 1
+  const supergroups = (response?.data ?? []).filter(sg => sg.group_ids.length > 1);
+
+  // Collect all group IDs from visible supergroups to fetch their issue details
+  const allGroupIds = useMemo(
+    () => [...new Set(supergroups.flatMap(sg => sg.group_ids))],
+    [supergroups]
   );
+
+  const {data: groups, isPending: isGroupsPending} = useApiQuery<Group[]>(
+    [
+      getApiUrl('/organizations/$organizationIdOrSlug/issues/', {
+        path: {organizationIdOrSlug: organization.slug},
+      }),
+      {
+        query: {
+          query: `issue.id:[${allGroupIds.join(',')}]`,
+          limit: allGroupIds.length.toString(),
+          project: '-1',
+        },
+      },
+    ],
+    {
+      staleTime: 60000,
+      enabled: allGroupIds.length > 0,
+    }
+  );
+
+  // Build a map of groupId -> project
+  const groupProjectMap = useMemo(() => {
+    const map = new Map<number, Project>();
+    if (groups) {
+      for (const group of groups) {
+        map.set(Number(group.id), group.project);
+      }
+    }
+    return map;
+  }, [groups]);
+
+  // Get unique projects for each supergroup
+  const supergroupProjectsMap = useMemo(() => {
+    const map = new Map<number, Project[]>();
+    for (const sg of supergroups) {
+      const seen = new Set<string>();
+      const projects: Project[] = [];
+      for (const gid of sg.group_ids) {
+        const project = groupProjectMap.get(gid);
+        if (project && !seen.has(project.id)) {
+          seen.add(project.id);
+          projects.push(project);
+        }
+      }
+      map.set(sg.id, projects);
+    }
+    return map;
+  }, [supergroups, groupProjectMap]);
+
+  // Get all unique projects across all supergroups for the filter dropdown
+  const allProjects = useMemo(() => {
+    const seen = new Map<string, Project>();
+    for (const projects of supergroupProjectsMap.values()) {
+      for (const project of projects) {
+        if (!seen.has(project.id)) {
+          seen.set(project.id, project);
+        }
+      }
+    }
+    return [...seen.values()].sort((a, b) => a.slug.localeCompare(b.slug));
+  }, [supergroupProjectsMap]);
+
+  const projectFilterOptions: Array<SelectOption<string>> = useMemo(
+    () => [
+      {value: '', label: t('All Projects')},
+      ...allProjects.map(project => ({
+        value: project.id,
+        label: project.slug,
+        leadingItems: <ProjectAvatar project={project} size={16} />,
+      })),
+    ],
+    [allProjects]
+  );
+
+  // Filter supergroups by selected project
+  const filteredSupergroups = useMemo(() => {
+    if (!selectedProjectId) {
+      return supergroups;
+    }
+    return supergroups.filter(sg => {
+      const projects = supergroupProjectsMap.get(sg.id) ?? [];
+      return projects.some(p => p.id === selectedProjectId);
+    });
+  }, [supergroups, selectedProjectId, supergroupProjectsMap]);
+
+  const isPending = isSupergroupsPending || (allGroupIds.length > 0 && isGroupsPending);
 
   const handleSupergroupClick = (supergroup: SupergroupDetail) => {
     openDrawer(() => <SupergroupDetailDrawer supergroup={supergroup} />, {
@@ -148,7 +260,7 @@ function Supergroups() {
         <Layout.Main width="full">
           {isPending ? (
             <LoadingIndicator />
-          ) : isError ? (
+          ) : isSupergroupsError ? (
             <LoadingError onRetry={refetch} />
           ) : supergroups.length === 0 ? (
             <Container padding="lg" border="primary" radius="md" background="primary">
@@ -158,18 +270,43 @@ function Supergroups() {
             </Container>
           ) : (
             <Stack gap="lg">
-              <Text size="sm" variant="muted">
-                {tn('%s supergroup', '%s supergroups', supergroups.length)}
-              </Text>
-              <Grid columns={{xs: '1fr', lg: '1fr 1fr'}} gap="lg">
-                {supergroups.map(sg => (
-                  <SupergroupCard
-                    key={sg.id}
-                    supergroup={sg}
-                    onClick={() => handleSupergroupClick(sg)}
+              <Flex align="center" gap="lg">
+                {allProjects.length > 1 && (
+                  <CompactSelect
+                    triggerLabel={
+                      selectedProjectId
+                        ? (allProjects.find(p => p.id === selectedProjectId)?.slug ??
+                          t('All Projects'))
+                        : t('All Projects')
+                    }
+                    triggerProps={{size: 'xs'}}
+                    options={projectFilterOptions}
+                    value={selectedProjectId}
+                    onChange={opt => setSelectedProjectId(opt.value)}
                   />
-                ))}
-              </Grid>
+                )}
+                <Text size="sm" variant="muted">
+                  {tn('%s supergroup', '%s supergroups', filteredSupergroups.length)}
+                </Text>
+              </Flex>
+              {filteredSupergroups.length === 0 ? (
+                <Container padding="lg" border="primary" radius="md" background="primary">
+                  <Text variant="muted" align="center" as="div">
+                    {t('No supergroups match the selected project')}
+                  </Text>
+                </Container>
+              ) : (
+                <Grid columns={{xs: '1fr', lg: '1fr 1fr'}} gap="lg">
+                  {filteredSupergroups.map(sg => (
+                    <SupergroupCard
+                      key={sg.id}
+                      supergroup={sg}
+                      projects={supergroupProjectsMap.get(sg.id) ?? []}
+                      onClick={() => handleSupergroupClick(sg)}
+                    />
+                  ))}
+                </Grid>
+              )}
             </Stack>
           )}
         </Layout.Main>


### PR DESCRIPTION
Fetch issue details for all displayed supergroups to resolve their projects. Show project avatars on each card and add a CompactSelect dropdown to filter supergroups by project.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
