### PR TITLE
fix(agents): Enable horizontal scroll in trace drawer on mobile

### DIFF
--- a/static/app/views/insights/pages/agents/components/drawer.tsx
+++ b/static/app/views/insights/pages/agents/components/drawer.tsx
@@ -1,4 +1,5 @@
 import {memo, useCallback, useEffect} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -122,6 +123,9 @@ export function useTraceViewDrawer({onClose}: UseTraceViewDrawerProps = {}) {
           onClose,
           shouldCloseOnInteractOutside: () => true,
           drawerWidth: `${DRAWER_WIDTH}px`,
+          drawerCss: css`
+            min-width: ${DRAWER_WIDTH}px;
+          `,
           resizable: true,
           traceSlug,
           timestamp,


### PR DESCRIPTION
Add `drawerCss` with `min-width` to the agents trace view drawer, matching the behavior already present in the conversations drawer.

On mobile, the global drawer goes fullscreen (100% width). Without a `min-width` on the drawer content, the two internal panels (AI Spans list at 400px + trace details at 500px) collapse and overflow is hidden. The conversations drawer already handles this by setting `min-width: 900px` via `drawerCss`, which allows the global drawer's `overscroll-behavior-x: auto` on mobile to kick in and enable horizontal scrolling.

Users may not realize they can scroll horizontally on mobile since scrollbars are hidden by default, but this improves
the experience for now. We can revisit the mobile UX separately.

https://github.com/user-attachments/assets/5adfe5be-1ca1-4739-8236-115e77350232

contributes to https://linear.app/getsentry/issue/TET-2058/user-feedback-mobile-website-breaks-when-clicking-tool-calls

