### PR TITLE
fix(sdk-crash): Exclude React Native fetch instrumentation from SDK crash detection

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -228,6 +228,14 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                     module_pattern="*",
                     function_pattern="sentryWrapped",
                 ),
+                # The fetch instrumentation wraps globalThis.fetch as a pass-through.
+                # When a user's fetch call fails (e.g., "Failed to fetch" network errors),
+                # the SDK wrapper frame appears in the stack but is not the cause.
+                # https://github.com/getsentry/sentry-javascript/blob/090d08c284089acf886d675f06cd516b3f6e06be/packages/core/src/instrument/fetch.ts
+                FunctionAndModulePattern(
+                    module_pattern="@sentry/core/*/instrument/fetch*",
+                    function_pattern="fetch",
+                ),
             },
         )
         configs.append(react_native_config)

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_react_native.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_react_native.py
@@ -331,6 +331,83 @@ def test_sentry_wrapped_not_detected(
     assert mock_sdk_crash_reporter.report.call_count == 0
 
 
+@pytest.mark.parametrize(
+    ["function", "module", "filename", "detected"],
+    [
+        # fetch instrumentation pass-through (ESM build) — should be ignored
+        (
+            "fetch",
+            "@sentry/core/build/esm/instrument/fetch",
+            "node_modules/@sentry/core/build/esm/instrument/fetch.js",
+            False,
+        ),
+        # fetch instrumentation pass-through (CJS build) — should be ignored
+        (
+            "fetch",
+            "@sentry/core/build/cjs/instrument/fetch",
+            "node_modules/@sentry/core/build/cjs/instrument/fetch.js",
+            False,
+        ),
+        # Different function in the same module — should be detected
+        (
+            "instrumentFetch",
+            "@sentry/core/build/esm/instrument/fetch",
+            "node_modules/@sentry/core/build/esm/instrument/fetch.js",
+            True,
+        ),
+        # XHR instrumentation — should be detected (not covered by the ignore pattern)
+        (
+            "fetch",
+            "@sentry/core/build/esm/instrument/xhr",
+            "node_modules/@sentry/core/build/esm/instrument/xhr.js",
+            True,
+        ),
+    ],
+)
+@decorators
+def test_fetch_instrumentation_not_detected(
+    mock_sdk_crash_reporter,
+    mock_random,
+    store_event,
+    configs,
+    function: str,
+    module: str,
+    filename: str,
+    detected: bool,
+) -> None:
+    event_data = get_crash_event(
+        exception={
+            "values": [
+                get_exception(
+                    frames=[
+                        *get_frames(),
+                        {
+                            "function": function,
+                            "module": module,
+                            "filename": filename,
+                            "abs_path": f"app:///{filename}",
+                        },
+                    ],
+                ),
+            ]
+        }
+    )
+
+    event = store_event(data=event_data)
+
+    configs[1].organization_allowlist = [event.project.organization_id]
+
+    sdk_crash_detection.detect_sdk_crash(
+        event=event,
+        configs=configs,
+    )
+
+    if detected:
+        assert mock_sdk_crash_reporter.report.call_count == 1
+    else:
+        assert mock_sdk_crash_reporter.report.call_count == 0
+
+
 @decorators
 def test_sentry_wrapped_end_detected(
     mock_sdk_crash_reporter, mock_random, store_event, configs


### PR DESCRIPTION
## Summary
- Adds an ignore matcher for the Sentry JS SDK's fetch instrumentation wrapper in React Native SDK crash detection
- The fetch instrumentation wraps `globalThis.fetch` as a pass-through; when a user's fetch call fails (e.g., "Failed to fetch" network errors), the SDK wrapper frame appears in the stack but is not the cause
- Adds parametrized tests covering ESM/CJS builds, different function names, and different modules to ensure the pattern is precise

## Test plan
- [x] Verify `test_fetch_instrumentation_not_detected` parametrized tests pass