### PR TITLE
feat(spans): Add option to skip enrichment per project in process-segments consumer

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3351,6 +3351,12 @@ register(
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "spans.process-segments.skip-enrichment-projects",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "indexed-spans.agg-span-waterfall.enable",

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -69,6 +69,12 @@ def _process_segment(
     unprocessed_spans: list[SpanEvent], skip_produce: bool
 ) -> list[CompatibleSpan]:
     _verify_compatibility(unprocessed_spans)
+
+    if unprocessed_spans:
+        project_id = unprocessed_spans[0].get("project_id")
+        if project_id in options.get("spans.process-segments.skip-enrichment-projects"):
+            return [make_compatible(span) for span in unprocessed_spans]
+
     segment_span, spans = _enrich_spans(unprocessed_spans)
     if segment_span is None:
         return spans

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -356,6 +356,57 @@ def test_verify_compatibility():
 
 
 @exclude_experimental_detectors
+class TestSkipEnrichmentKillswitch(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project()
+
+    @mock.patch(
+        "sentry.spans.consumers.process_segments.message.TreeEnricher.enrich_spans",
+        wraps=None,
+    )
+    def test_skip_enrichment_by_project_id(self, mock_enrich: mock.MagicMock) -> None:
+        """Test that enrichment is skipped and spans are still returned when project_id matches killswitch."""
+        segment_span = build_mock_span(
+            project_id=self.project.id,
+            is_segment=True,
+        )
+        child_span = build_mock_span(
+            project_id=self.project.id,
+            parent_span_id=segment_span["span_id"],
+        )
+
+        with override_options(
+            {"spans.process-segments.skip-enrichment-projects": [self.project.id]}
+        ):
+            processed_spans = process_segment([child_span, segment_span])
+
+        mock_enrich.assert_not_called()
+        assert len(processed_spans) == 2
+
+    @mock.patch(
+        "sentry.spans.consumers.process_segments.message.TreeEnricher.enrich_spans",
+    )
+    def test_no_skip_enrichment_for_other_project(self, mock_enrich: mock.MagicMock) -> None:
+        """Test that enrichment is not skipped when project_id does not match the option."""
+        mock_enrich.return_value = (None, [])
+        segment_span = build_mock_span(
+            project_id=self.project.id,
+            is_segment=True,
+        )
+        child_span = build_mock_span(
+            project_id=self.project.id,
+            parent_span_id=segment_span["span_id"],
+        )
+
+        with override_options(
+            {"spans.process-segments.skip-enrichment-projects": [self.project.id + 1]}
+        ):
+            process_segment([child_span, segment_span])
+
+        mock_enrich.assert_called_once()
+
+
+@exclude_experimental_detectors
 class TestSegmentDropKillswitch(TestCase):
     def setUp(self) -> None:
         self.project = self.create_project()


### PR DESCRIPTION
Add a new option `spans.process-segments.skip-enrichment-projects` (a list of project IDs) to the process-segments consumer. When a segment's project ID appears in this list, the consumer skips all enrichment — tree building, exclusive time, breakdowns, segment name normalization, model creation, performance detection, and signals — and passes spans through to the output topic as-is via `make_compatible()`.

This is useful for testing how product behaves when enrichment is absent, without needing a separate code path or consumer deployment.