### PR TITLE
feat(tests): Update S015 rule to prevent hardcoding future years

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -45,11 +45,11 @@ Notes:
 - Tests should ALWAYS be procedural with NO branching logic. It is very rare
   that you will need an if statement as part of a backend test.
 
-## Date-stable tests (this year only)
+## Date-stable tests (current or future year)
 
-Do not use the **current UTC calendar year** as a hardcoded test “now” at **module or class** scope (or in `freeze_time(datetime(...))`)—that date drifts into Snuba retention. Use **`before_now(...)`** (or `now - timedelta`) for relative time. Fixed timestamps in **function bodies** (fixtures, assertions) are fine.
+Do not use the **current or future UTC calendar year** as a hardcoded test “now” at **module or class** scope (or in `freeze_time(datetime(...))`)—that date drifts into Snuba retention. Use **`before_now(...)`** (or `now - timedelta`) for relative time, or an older fixed year for intentional historical fixtures. Fixed timestamps in **function bodies** (fixtures, assertions) are fine.
 
-Flake8 **S015** flags only literals equal to the current UTC year in those scopes.
+Flake8 **S015** flags literals with year greater than or equal to the current UTC year in those scopes.
 
 ## Use Factories Instead of Directly Calling `Model.objects.create`
 

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -245,7 +245,7 @@ def test(monkeypatch) -> None: pass
 
 def test_S015_current_or_future_year() -> None:
     cy = datetime.now(timezone.utc).year
-    msg = _s015_msg(cy)
+    msg = _s015_msg()
     # Current year at module scope is flagged
     assert _run(
         f"from datetime import datetime, timezone\n\n"

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -243,14 +243,22 @@ def test(monkeypatch) -> None: pass
     assert _run(src) == expected
 
 
-def test_S015_current_year_only() -> None:
+def test_S015_current_or_future_year() -> None:
     cy = datetime.now(timezone.utc).year
     msg = _s015_msg(cy)
+    # Current year at module scope is flagged
     assert _run(
         f"from datetime import datetime, timezone\n\n"
         f"X = datetime({cy}, 1, 1, tzinfo=timezone.utc)\n",
         filename="tests/x.py",
     ) == [f"t.py:3:0: {msg}"]
+    # Future year at module scope is flagged
+    assert _run(
+        f"from datetime import datetime, timezone\n\n"
+        f"X = datetime({cy + 1}, 1, 1, tzinfo=timezone.utc)\n",
+        filename="tests/x.py",
+    ) == [f"t.py:3:0: {msg}"]
+    # Older year at module scope is allowed
     assert (
         _run(
             "from datetime import datetime, timezone\n\n"
@@ -259,6 +267,7 @@ def test_S015_current_year_only() -> None:
         )
         == []
     )
+    # Datetime inside function body is allowed
     assert (
         _run(
             f"def f():\n    x = datetime({cy}, 1, 1)\n",
@@ -266,9 +275,27 @@ def test_S015_current_year_only() -> None:
         )
         == []
     )
+    # freeze_time with current year is flagged
     assert _run(
         f"from freezegun import freeze_time\nfrom datetime import datetime, timezone\n\n"
         f"@freeze_time(datetime({cy}, 1, 1, tzinfo=timezone.utc))\n"
         f"def t():\n    pass\n",
         filename="tests/x.py",
     ) == [f"t.py:4:1: {msg}"]
+    # freeze_time with future year is flagged
+    assert _run(
+        f"from freezegun import freeze_time\nfrom datetime import datetime, timezone\n\n"
+        f"@freeze_time(datetime({cy + 1}, 1, 1, tzinfo=timezone.utc))\n"
+        f"def t():\n    pass\n",
+        filename="tests/x.py",
+    ) == [f"t.py:4:1: {msg}"]
+    # freeze_time with older year is allowed
+    assert (
+        _run(
+            "from freezegun import freeze_time\nfrom datetime import datetime, timezone\n\n"
+            "@freeze_time(datetime(2020, 1, 1, tzinfo=timezone.utc))\n"
+            "def t():\n    pass\n",
+            filename="tests/x.py",
+        )
+        == []
+    )

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -44,7 +44,7 @@ S014_msg = "S014 Use `unittest.mock` instead"
 
 # --- S015: do not hardcode current or future UTC year as test "now" ---
 # Flag year >= current UTC year at lint time. Module/class scope + freeze_time(datetime(...)).
-def _s015_msg(year: int) -> str:
+def _s015_msg() -> str:
     return (
         "S015 Do not hardcode datetime with current or future UTC year at module/class "
         "scope or in freeze_time(...); use before_now(...), now-timedelta, or an older fixed year"
@@ -248,7 +248,7 @@ class SentryCheck:
 
     def run(self) -> Generator[tuple[int, int, str, type[Any]]]:
         cy = datetime.now(timezone.utc).year
-        visitor = SentryVisitor(self.filename, cy, _s015_msg(cy))
+        visitor = SentryVisitor(self.filename, cy, _s015_msg())
         visitor.visit(self.tree)
 
         for e in visitor.errors:

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -42,12 +42,12 @@ S013_msg = "S013 Use `django.contrib.postgres.fields.array.ArrayField` instead"
 S014_msg = "S014 Use `unittest.mock` instead"
 
 
-# --- S015: do not hardcode this UTC calendar year as test "now" ---
-# Only year == current UTC year at lint time. Module/class scope + freeze_time(datetime(...)).
+# --- S015: do not hardcode current or future UTC year as test "now" ---
+# Flag year >= current UTC year at lint time. Module/class scope + freeze_time(datetime(...)).
 def _s015_msg(year: int) -> str:
     return (
-        f"S015 Do not hardcode datetime(..., {year}, ...) (current UTC year) at module/class "
-        "scope or in freeze_time(...); use before_now(...), now-timedelta, or another year"
+        "S015 Do not hardcode datetime with current or future UTC year at module/class "
+        "scope or in freeze_time(...); use before_now(...), now-timedelta, or an older fixed year"
     )
 
 
@@ -207,7 +207,7 @@ class SentryVisitor(ast.NodeVisitor):
             and isinstance(node.value, ast.Call)
         ):
             y = _wall_clock_year_from_datetime_call(node.value)
-            if y is not None and y == self._s015_year:
+            if y is not None and y >= self._s015_year:
                 self.errors.append((node.lineno, node.col_offset, self._s015_msg))
         self.generic_visit(node)
 
@@ -220,7 +220,7 @@ class SentryVisitor(ast.NodeVisitor):
                 and isinstance(node.args[0], ast.Call)
             ):
                 y = _wall_clock_year_from_datetime_call(node.args[0])
-                if y is not None and y == self._s015_year:
+                if y is not None and y >= self._s015_year:
                     self.errors.append((node.lineno, node.col_offset, self._s015_msg))
         if (
             # override_settings(...)


### PR DESCRIPTION
Modified the S015 linting rule to flag any hardcoded datetime values with the current or future UTC year at module/class scope and in `freeze_time(...)`. Updated related tests to reflect this change, ensuring that only older years are allowed in specific contexts. This enhances the accuracy of date-stable tests and prevents potential issues with Snuba retention.