### PR TITLE
feat(dashboards): Add missing referrers to Referrer enum

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -25,10 +25,16 @@ class Referrer(StrEnum):
         "api.auth-token.events.metrics-enhanced.primary"
     )
     API_AUTH_TOKEN_EVENTS = "api.auth-token.events"
+
+    # ** Dashboards **
+
+    API_DASHBOARDS_RELEASE_SELECTOR = "api.dashboards-release-selector"
+    API_DASHBOARDS_DETAILS_WIDGET_DOMAIN_STATUS = "api.dashboards.details-widget.domain-status"
     API_DASHBOARDS_BIGNUMBERWIDGET_METRICS_ENHANCED_PRIMARY = (
         "api.dashboards.bignumberwidget.metrics-enhanced.primary"
     )
     API_DASHBOARDS_BIGNUMBERWIDGET = "api.dashboards.bignumberwidget"
+    API_DASHBOARDS_BIGNUMBERWIDGET_ROW = "api.dashboards.bignumberwidget.row"
     API_DASHBOARDS_TABLEWIDGET_METRICS_ENHANCED_PRIMARY = (
         "api.dashboards.tablewidget.metrics-enhanced.primary"
     )
@@ -36,6 +42,7 @@ class Referrer(StrEnum):
         "api.dashboards.tablewidget.metrics-enhanced.secondary"
     )
     API_DASHBOARDS_TABLEWIDGET = "api.dashboards.tablewidget"
+    API_DASHBOARDS_TABLEWIDGET_ROW = "api.dashboards.tablewidget.row"
     API_DASHBOARDS_TOP_EVENTS = "api.dashboards.top-events"
     API_DASHBOARDS_WIDGET_AREA_CHART_FIND_TOPN = "api.dashboards.widget.area-chart.find-topn"
     API_DASHBOARDS_WIDGET_AREA_CHART_METRICS_ENHANCED = (
@@ -48,6 +55,7 @@ class Referrer(StrEnum):
         "api.dashboards.widget.area-chart.find-topn.metrics-enhanced.primary"
     )
     API_DASHBOARDS_WIDGET_AREA_CHART = "api.dashboards.widget.area-chart"
+    API_DASHBOARDS_WIDGET_AREA_CHART_ROW = "api.dashboards.widget.area-chart.row"
     API_DASHBOARDS_WIDGET_BAR_CHART_FIND_TOPN = "api.dashboards.widget.bar-chart.find-topn"
     API_DASHBOARDS_WIDGET_BAR_CHART_METRICS_ENHANCED = (
         "api.dashboards.widget.bar-chart.metrics-enhanced"
@@ -59,6 +67,7 @@ class Referrer(StrEnum):
         "api.dashboards.widget.bar-chart.find-topn.metrics-enhanced.primary"
     )
     API_DASHBOARDS_WIDGET_BAR_CHART = "api.dashboards.widget.bar-chart"
+    API_DASHBOARDS_WIDGET_BAR_CHART_ROW = "api.dashboards.widget.bar-chart.row"
     API_DASHBOARDS_WIDGET_LINE_CHART_FIND_TOPN = "api.dashboards.widget.line-chart.find-topn"
     API_DASHBOARDS_WIDGET_LINE_CHART_METRICS_ENHANCED = (
         "api.dashboards.widget.line-chart.metrics-enhanced"
@@ -70,6 +79,7 @@ class Referrer(StrEnum):
         "api.dashboards.widget.line-chart.find-topn.metrics-enhanced.primary"
     )
     API_DASHBOARDS_WIDGET_LINE_CHART = "api.dashboards.widget.line-chart"
+    API_DASHBOARDS_WIDGET_LINE_CHART_ROW = "api.dashboards.widget.line-chart.row"
 
     API_DISCOVER_TOTAL_COUNT_FIELD = "api.discover.total-events-field"
     API_SPANS_TOTAL_COUNT_FIELD = "api.spans.total-events-field"


### PR DESCRIPTION
Add dashboard referrers used in the frontend that were missing from the
backend `Referrer` enum, causing validation warnings in Snuba queries.

**Added referrers:**
- `api.dashboards-release-selector` — release selector dropdown (`useReleases.tsx`)
- `api.dashboards.details-widget.domain-status` — HTTP domain status in details widget
- `api.dashboards.bignumberwidget.row` — row-click explore URL for big number widgets
- `api.dashboards.tablewidget.row` — row-click explore URL for table widgets
- `api.dashboards.widget.area-chart.row` — row-click explore URL for area charts
- `api.dashboards.widget.bar-chart.row` — row-click explore URL for bar charts
- `api.dashboards.widget.line-chart.row` — row-click explore URL for line charts

The `.row` variants are dynamically constructed in `getWidgetExploreUrl.tsx` via
`` `${getReferrer(widget.displayType)}.row` `` when clicking table/chart rows.

Also added a `# ** Dashboards **` section header to group dashboard referrers,
matching the style used by Insights and Explore sections.

Refs DAIN-606