### PR TITLE
feat(explore) Adding count_unique, last_seen columns to occurrences dataset

### DIFF
--- a/src/sentry/search/eap/aggregate_utils.py
+++ b/src/sentry/search/eap/aggregate_utils.py
@@ -9,7 +9,9 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap import constants
-from sentry.search.eap.columns import ResolvedArguments
+from sentry.search.eap.columns import (
+    ResolvedArguments,
+)
 from sentry.search.eap.normalizer import unquote_literal
 
 
@@ -122,4 +124,4 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
                 value=attr_value,
             )
         )
-    return (aggregate_key, trace_filter)
+    return aggregate_key, trace_filter

--- a/src/sentry/search/eap/common_aggregates.py
+++ b/src/sentry/search/eap/common_aggregates.py
@@ -1,0 +1,37 @@
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Function
+
+from sentry.search.eap import constants
+from sentry.search.eap.aggregate_utils import count_processor
+from sentry.search.eap.columns import AggregateDefinition, AttributeArgumentDefinition
+
+COUNT_UNIQUE_ATTRIBUTE_TYPES = frozenset(
+    {
+        "string",
+        "duration",
+        "number",
+        "integer",
+        "percentage",
+        "currency",
+        *constants.SIZE_TYPE,
+        *constants.DURATION_TYPE,
+    }
+)
+
+
+def count_unique_aggregate_definition(
+    *,
+    default_arg: str | None = None,
+) -> AggregateDefinition:
+    """Shared count_unique aggregate for EAP datasets (spans, occurrences, ourlogs)."""
+    return AggregateDefinition(
+        internal_function=Function.FUNCTION_UNIQ,
+        default_search_type="integer",
+        infer_search_type_from_arguments=False,
+        processor=count_processor,
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types=set(COUNT_UNIQUE_ATTRIBUTE_TYPES),
+                default_arg=default_arg,
+            )
+        ],
+    )

--- a/src/sentry/search/eap/common_formulas.py
+++ b/src/sentry/search/eap/common_formulas.py
@@ -16,7 +16,7 @@ from sentry.search.eap.columns import ResolvedArguments, ResolverSettings
 def make_eps(
     count_key: AttributeKey,
 ) -> Callable[[ResolvedArguments, ResolverSettings], Column.BinaryFormula]:
-    """Return an eps formula resolver that counts *count_key* rows per second."""
+    """Return an eps formula resolver that counts 'count_key' rows per second."""
 
     def eps(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
         extrapolation_mode = settings["extrapolation_mode"]
@@ -48,7 +48,7 @@ def make_eps(
 def make_epm(
     count_key: AttributeKey,
 ) -> Callable[[ResolvedArguments, ResolverSettings], Column.BinaryFormula]:
-    """Return an epm formula resolver that counts *count_key* rows per minute."""
+    """Return an epm formula resolver that counts 'count_key' rows per minute."""
 
     def epm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
         extrapolation_mode = settings["extrapolation_mode"]

--- a/src/sentry/search/eap/occurrences/aggregates.py
+++ b/src/sentry/search/eap/occurrences/aggregates.py
@@ -1,7 +1,10 @@
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Function
 
 from sentry.search.eap import constants
-from sentry.search.eap.aggregate_utils import count_processor, resolve_key_eq_value_filter
+from sentry.search.eap.aggregate_utils import (
+    count_processor,
+    resolve_key_eq_value_filter,
+)
 from sentry.search.eap.columns import (
     AggregateDefinition,
     AttributeArgumentDefinition,
@@ -9,6 +12,7 @@ from sentry.search.eap.columns import (
     ValueArgumentDefinition,
     count_argument_resolver_optimized,
 )
+from sentry.search.eap.common_aggregates import count_unique_aggregate_definition
 from sentry.search.eap.validator import literal_validator, number_validator
 
 OCCURRENCE_GROUP_ID_KEY = AttributeKey(
@@ -125,6 +129,24 @@ OCCURRENCE_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
+            )
+        ],
+    ),
+    "count_unique": count_unique_aggregate_definition(default_arg="group_id"),
+    "last_seen": AggregateDefinition(
+        internal_function=Function.FUNCTION_MAX,
+        default_search_type="date",
+        infer_search_type_from_arguments=False,
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+                default_arg="timestamp",
             )
         ],
     ),

--- a/src/sentry/search/eap/occurrences/aggregates.py
+++ b/src/sentry/search/eap/occurrences/aggregates.py
@@ -143,6 +143,7 @@ OCCURRENCE_AGGREGATE_DEFINITIONS = {
                     "duration",
                     "number",
                     "integer",
+                    "string",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },

--- a/src/sentry/search/eap/occurrences/aggregates.py
+++ b/src/sentry/search/eap/occurrences/aggregates.py
@@ -135,7 +135,7 @@ OCCURRENCE_AGGREGATE_DEFINITIONS = {
     "count_unique": count_unique_aggregate_definition(default_arg="group_id"),
     "last_seen": AggregateDefinition(
         internal_function=Function.FUNCTION_MAX,
-        default_search_type="date",
+        default_search_type="integer",
         infer_search_type_from_arguments=False,
         arguments=[
             AttributeArgumentDefinition(

--- a/src/sentry/search/eap/ourlogs/aggregates.py
+++ b/src/sentry/search/eap/ourlogs/aggregates.py
@@ -7,6 +7,7 @@ from sentry.search.eap.columns import (
     AttributeArgumentDefinition,
     count_argument_resolver_optimized,
 )
+from sentry.search.eap.common_aggregates import count_unique_aggregate_definition
 
 LOGS_ALWAYS_PRESENT_ATTRIBUTES = [
     AttributeKey(name="sentry.body", type=AttributeKey.Type.TYPE_STRING),
@@ -30,26 +31,7 @@ LOG_AGGREGATE_DEFINITIONS = {
         ],
         attribute_resolver=count_argument_resolver_optimized(LOGS_ALWAYS_PRESENT_ATTRIBUTES),
     ),
-    "count_unique": AggregateDefinition(
-        internal_function=Function.FUNCTION_UNIQ,
-        default_search_type="integer",
-        infer_search_type_from_arguments=False,
-        processor=count_processor,
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "string",
-                    "duration",
-                    "number",
-                    "integer",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-            )
-        ],
-    ),
+    "count_unique": count_unique_aggregate_definition(),
     "sum": AggregateDefinition(
         internal_function=Function.FUNCTION_SUM,
         default_search_type="number",

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -15,7 +15,10 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 
 from sentry.search.eap import constants
-from sentry.search.eap.aggregate_utils import count_processor, resolve_key_eq_value_filter
+from sentry.search.eap.aggregate_utils import (
+    count_processor,
+    resolve_key_eq_value_filter,
+)
 from sentry.search.eap.columns import (
     AggregateDefinition,
     AttributeArgumentDefinition,
@@ -24,6 +27,7 @@ from sentry.search.eap.columns import (
     ValueArgumentDefinition,
     count_argument_resolver_optimized,
 )
+from sentry.search.eap.common_aggregates import count_unique_aggregate_definition
 from sentry.search.eap.spans.utils import WEB_VITALS_MEASUREMENTS, transform_vital_score_to_ratio
 from sentry.search.eap.validator import literal_validator, number_validator
 
@@ -662,24 +666,5 @@ SPAN_AGGREGATE_DEFINITIONS = {
             )
         ],
     ),
-    "count_unique": AggregateDefinition(
-        internal_function=Function.FUNCTION_UNIQ,
-        default_search_type="integer",
-        infer_search_type_from_arguments=False,
-        processor=count_processor,
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "string",
-                    "duration",
-                    "number",
-                    "integer",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-            )
-        ],
-    ),
+    "count_unique": count_unique_aggregate_definition(),
 }

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -1,9 +1,11 @@
 import uuid
+from datetime import timedelta
 
 import pytest
 
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.testutils.cases import OccurrenceTestCase
+from sentry.testutils.helpers.datetime import before_now
 from tests.snuba.api.endpoints.test_organization_events import (
     OrganizationEventsEndpointTestBase,
 )
@@ -127,3 +129,126 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         meta = response.data["meta"]
         assert meta["fields"]["epm()"] == "rate"
         assert meta["units"]["epm()"] == "1/minute"
+
+    def test_count_unique(self) -> None:
+        group = self.create_group(project=self.project)
+        self.store_eap_items(
+            [
+                self.create_eap_occurrence(
+                    group_id=group.id,
+                    project=self.project,
+                    level="error",
+                    attributes={"fingerprint": ["a"]},
+                ),
+                self.create_eap_occurrence(
+                    group_id=group.id,
+                    project=self.project,
+                    level="error",
+                    attributes={"fingerprint": ["b"]},
+                ),
+            ]
+        )
+        with self.options(
+            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+        ):
+            response = self.do_request(
+                {
+                    "field": ["count()", "count_unique(level)"],
+                    "statsPeriod": "1h",
+                    "project": [self.project.id],
+                    "dataset": "occurrences",
+                }
+            )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["count()"] == 2
+        assert data[0]["count_unique(level)"] == 1
+
+    def test_count_if(
+        self,
+    ) -> None:
+        group = self.create_group(project=self.project)
+        for _ in range(3):
+            self.store_eap_items(
+                [
+                    self.create_eap_occurrence(
+                        group_id=group.id,
+                        project=self.project,
+                        level="error",
+                        attributes={"fingerprint": ["x"]},
+                    )
+                ]
+            )
+        for _ in range(2):
+            self.store_eap_items(
+                [
+                    self.create_eap_occurrence(
+                        group_id=group.id,
+                        project=self.project,
+                        level="warning",
+                        attributes={"fingerprint": ["x"]},
+                    )
+                ]
+            )
+        with self.options(
+            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+        ):
+            response = self.do_request(
+                {
+                    "field": [
+                        "count()",
+                        "count_if(level,equals,error)",
+                        "count_if(level,notEquals,error)",
+                    ],
+                    "statsPeriod": "1h",
+                    "project": [self.project.id],
+                    "dataset": "occurrences",
+                }
+            )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["count()"] == 5
+        assert data[0]["count_if(level,equals,error)"] == 3
+        assert data[0]["count_if(level,notEquals,error)"] == 2
+
+    def test_last_seen_table(
+        self,
+    ) -> None:
+        group = self.create_group(project=self.project)
+        base = before_now(hours=1)
+        self.store_eap_items(
+            [
+                self.create_eap_occurrence(
+                    group_id=group.id,
+                    project=self.project,
+                    timestamp=base,
+                    attributes={"fingerprint": ["a"]},
+                ),
+                self.create_eap_occurrence(
+                    group_id=group.id,
+                    project=self.project,
+                    timestamp=base + timedelta(minutes=10),
+                    attributes={"fingerprint": ["a"]},
+                ),
+            ]
+        )
+        with self.options(
+            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+        ):
+            response = self.do_request(
+                {
+                    "field": ["last_seen()"],
+                    "statsPeriod": "2h",
+                    "project": [self.project.id],
+                    "dataset": "occurrences",
+                }
+            )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        # EAP returns last_seen as Unix timestamp in seconds (float).
+        expected_seconds = (base + timedelta(minutes=10)).timestamp()
+        assert abs(data[0]["last_seen()"] - expected_seconds) < 1

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -251,4 +251,4 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         assert len(data) == 1
         # EAP returns last_seen as Unix timestamp in seconds (float).
         expected_seconds = (base + timedelta(minutes=10)).timestamp()
-        assert abs(data[0]["last_seen()"] - expected_seconds) < 1
+        assert data[0]["last_seen()"] == pytest.approx(expected_seconds, abs=1)

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 
@@ -46,9 +47,16 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
             return self.client.get(self.url if url is None else url, data=data, format="json")
 
     def _store_occurrences_and_request_timeseries(
-        self, event_counts: list[int], y_axis: str, **occurrence_kwargs: Any
+        self,
+        event_counts: list[int],
+        y_axis: str,
+        *,
+        extra_occurrence_kwargs_fn: Callable[[int, int], dict[str, Any]] | None = None,
+        **occurrence_kwargs: Any,
     ):
-        """Create a group, build occurrences from event_counts (with group_id), store them, run timeseries request."""
+        """Create a group, build occurrences from event_counts (with group_id), store them, run timeseries request.
+        extra_occurrence_kwargs_fn: when set, occurrence attributes are a function of (hour, minute).
+        """
         group = self.create_group(project=self.project)
         occurrences = [
             self.create_eap_occurrence(
@@ -56,6 +64,7 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
                 project=self.project,
                 timestamp=self.start + timedelta(hours=hour, minutes=minute),
                 **occurrence_kwargs,
+                **(extra_occurrence_kwargs_fn(hour, minute) if extra_occurrence_kwargs_fn else {}),
             )
             for hour, count in enumerate(event_counts)
             for minute in range(count)
@@ -148,3 +157,28 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
     def test_epm_timeseries(self) -> None:
         """Rate aggregate epm() on /events-timeseries: events/min per bucket, meta rate/1/minute."""
         self._run_rate_timeseries_test("epm()", "1/minute", 60.0)
+
+    def test_count_unique_timeseries(self) -> None:
+        event_counts = [6, 0, 6, 3, 0, 3]
+        response = self._store_occurrences_and_request_timeseries(
+            event_counts,
+            "count_unique(title)",
+            extra_occurrence_kwargs_fn=lambda hour, minute: {
+                "title": f"foo-{minute}",
+                "attributes": {"fingerprint": ["g1"]},
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"]["dataset"] == "occurrences"
+        assert len(response.data["timeSeries"]) == 1
+        timeseries = response.data["timeSeries"][0]
+        assert timeseries["yAxis"] == "count_unique(title)"
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start, 3_600_000, event_counts, ignore_accuracy=True
+        )
+        assert timeseries["meta"] == {
+            "dataScanned": "full",
+            "valueType": "integer",
+            "valueUnit": None,
+            "interval": 3_600_000,
+        }


### PR DESCRIPTION
 Adds integration tests for the new occurrences EAP dataset on
    `/api/0/organizations/{org}/events/ ` and `/events-stats/ endpoints`,
 introduced in https://github.com/getsentry/sentry/pull/109727.

Add `count_unique()` and `last_seen()` columns for occurrences.