### PR TITLE
feat(performance): Add Apdex chart to EAP transaction summary sidebar

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -383,6 +383,7 @@ export enum SpanFunction {
   COUNT_SCORES = 'count_scores',
   OPPORTUNITY_SCORE = 'opportunity_score',
   FAILURE_RATE = 'failure_rate',
+  APDEX = 'apdex',
 }
 
 export const COUNTER_AGGREGATES = [
@@ -421,7 +422,8 @@ type ConditionalAggregate =
   | SpanFunction.COUNT_OP
   | SpanFunction.FAILURE_RATE_IF
   | SpanFunction.TRACE_STATUS_RATE
-  | SpanFunction.TIME_SPENT_PERCENTAGE;
+  | SpanFunction.TIME_SPENT_PERCENTAGE
+  | SpanFunction.APDEX;
 
 export const SPAN_FUNCTIONS = [
   SpanFunction.EPM,

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -6,6 +6,7 @@ import {Stack} from '@sentry/scraps/layout';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
+import {formatFloat} from 'sentry/utils/number/formatFloat';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -15,6 +16,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
+import {useTransactionSummaryContext} from 'sentry/views/performance/transactionSummary/transactionSummaryContext';
 
 type Props = {
   hasWebVitals: boolean;
@@ -27,8 +29,93 @@ export function EAPSidebarCharts({transactionName, hasWebVitals}: Props) {
   return (
     <Stack gap="md">
       {hasWebVitals && <Widget Title={t('Web Vitals')} />}
+      <ApdexWidget transactionName={transactionName} />
       <FailureRateWidget transactionName={transactionName} />
     </Stack>
+  );
+}
+
+type ApdexWidgetProps = {
+  transactionName: string;
+};
+
+function ApdexWidget({transactionName}: ApdexWidgetProps) {
+  const organization = useOrganization();
+  const theme = useTheme();
+  const {selection} = usePageFilters();
+  const {transactionThreshold} = useTransactionSummaryContext();
+
+  const threshold = transactionThreshold ?? 300;
+  const apdexField = `apdex(span.duration, ${threshold})` as const;
+
+  const transactionSearch = new MutableSearch('');
+  transactionSearch.addFilterValue('transaction', transactionName);
+
+  const {
+    data: apdexSeriesData,
+    isPending: isApdexSeriesPending,
+    isError: isApdexSeriesError,
+  } = useFetchSpanTimeSeries(
+    {
+      query: transactionSearch.copy(),
+      yAxis: [apdexField],
+    },
+    REFERRER
+  );
+
+  const {
+    data: apdexValue,
+    isPending: isApdexValuePending,
+    isError: isApdexValueError,
+  } = useSpans(
+    {
+      search: transactionSearch.copy(),
+      fields: [apdexField],
+      pageFilters: selection,
+    },
+    REFERRER
+  );
+
+  const getApdexBadge = () => {
+    if (isApdexValuePending || isApdexValueError) {
+      return null;
+    }
+
+    return (
+      <Tag key="apdex-value">{formatFloat(apdexValue[0]?.[apdexField] ?? 0, 4)}</Tag>
+    );
+  };
+
+  if (isApdexSeriesPending || isApdexSeriesError) {
+    return (
+      <Widget
+        Title={t('Apdex')}
+        TitleBadges={getApdexBadge()}
+        Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
+      />
+    );
+  }
+
+  const plottables = apdexSeriesData.timeSeries.map(
+    ts => new Line(ts, {color: theme.chart.getColorPalette(1)[0]})
+  );
+
+  return (
+    <Widget
+      Title={<SideBarWidgetTitle>{t('Apdex')}</SideBarWidgetTitle>}
+      TitleBadges={getApdexBadge()}
+      Actions={
+        <Widget.WidgetToolbar>
+          <Widget.WidgetDescription
+            title={t('Apdex')}
+            description={getTermHelp(organization, PerformanceTerm.APDEX)}
+          />
+        </Widget.WidgetToolbar>
+      }
+      Visualization={<TimeSeriesWidgetVisualization plottables={plottables} />}
+      height={200}
+      borderless
+    />
   );
 }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -17,6 +17,7 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 import {useTransactionSummaryContext} from 'sentry/views/performance/transactionSummary/transactionSummaryContext';
+import {TransactionThresholdMetric} from 'sentry/views/performance/transactionSummary/transactionThresholdModal';
 
 type Props = {
   hasWebVitals: boolean;
@@ -43,10 +44,15 @@ function ApdexWidget({transactionName}: ApdexWidgetProps) {
   const organization = useOrganization();
   const theme = useTheme();
   const {selection} = usePageFilters();
-  const {transactionThreshold} = useTransactionSummaryContext();
+  const {transactionThreshold, transactionThresholdMetric} =
+    useTransactionSummaryContext();
 
   const threshold = transactionThreshold ?? 300;
-  const apdexField = `apdex(span.duration,${threshold})` as const;
+  const apdexDurationField =
+    transactionThresholdMetric === TransactionThresholdMetric.LARGEST_CONTENTFUL_PAINT
+      ? 'measurements.lcp'
+      : 'span.duration';
+  const apdexField = `apdex(${apdexDurationField},${threshold})` as const;
 
   const transactionSearch = new MutableSearch('');
   transactionSearch.addFilterValue('transaction', transactionName);

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -82,7 +82,9 @@ function ApdexWidget({transactionName}: ApdexWidgetProps) {
     }
 
     return (
-      <Tag key="apdex-value">{formatFloat(apdexValue[0]?.[apdexField] ?? 0, 4)}</Tag>
+      <Tag key="apdex-value" variant="info">
+        {formatFloat(Number(apdexValue[0]?.[apdexField] ?? 0), 4)}
+      </Tag>
     );
   };
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -114,7 +114,9 @@ function ApdexWidget({transactionName}: ApdexWidgetProps) {
           />
         </Widget.WidgetToolbar>
       }
-      Visualization={<TimeSeriesWidgetVisualization plottables={plottables} />}
+      Visualization={
+        <TimeSeriesWidgetVisualization plottables={plottables} axisRange="dataMin" />
+      }
       height={200}
       borderless
     />

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -46,7 +46,7 @@ function ApdexWidget({transactionName}: ApdexWidgetProps) {
   const {transactionThreshold} = useTransactionSummaryContext();
 
   const threshold = transactionThreshold ?? 300;
-  const apdexField = `apdex(span.duration, ${threshold})` as const;
+  const apdexField = `apdex(span.duration,${threshold})` as const;
 
   const transactionSearch = new MutableSearch('');
   transactionSearch.addFilterValue('transaction', transactionName);


### PR DESCRIPTION
Add an `ApdexWidget` to the EAP sidebar charts to match the legacy sidebar which shows both Apdex and Failure Rate. Uses the explicit `apdex(<metric>, <threshold>)` form required by EAP, with the threshold from `TransactionSummaryContext` (defaulting to 300ms).