### PR TITLE
ref(rr6): Convert RedirectToProjectModal to hooks

### DIFF
--- a/static/app/components/modals/redirectToProject.spec.tsx
+++ b/static/app/components/modals/redirectToProject.spec.tsx
@@ -1,32 +1,19 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, renderGlobalModal} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {RedirectToProjectModal} from 'sentry/components/modals/redirectToProject';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 
-jest.unmock('sentry/utils/recreateRoute');
+jest.mock('sentry/utils/recreateRoute', () => jest.fn(() => '/org-slug/new-slug/'));
 
 describe('RedirectToProjectModal', () => {
   it('has timer to redirect to new slug after mounting', () => {
     jest.useFakeTimers();
-    const {routerProps} = initializeOrg({
-      router: {
-        routes: [
-          {path: '/', childRoutes: []},
-          {name: 'Organizations', path: ':orgId/', childRoutes: []},
-          {name: 'Projects', path: ':projectId/', childRoutes: []},
-        ],
-        params: {orgId: 'org-slug', projectId: 'project-slug'},
-      },
-    });
 
     renderGlobalModal();
 
     act(() =>
-      openModal(modalProps => (
-        <RedirectToProjectModal {...modalProps} {...routerProps} slug="new-slug" />
-      ))
+      openModal(modalProps => <RedirectToProjectModal {...modalProps} slug="new-slug" />)
     );
 
     act(() => jest.advanceTimersByTime(4900));

--- a/static/app/components/modals/redirectToProject.tsx
+++ b/static/app/components/modals/redirectToProject.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
@@ -6,90 +6,69 @@ import {Text} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {t, tct} from 'sentry/locale';
-import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
-// eslint-disable-next-line no-restricted-imports
-import {withSentryRouter} from 'sentry/utils/withSentryRouter';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
+import {useRoutes} from 'sentry/utils/useRoutes';
 
-type Props = ModalRenderProps &
-  WithRouterProps & {
-    slug: string;
-  };
-
-type State = {
-  timer: number;
-};
-
-class RedirectToProjectModal extends Component<Props, State> {
-  state: State = {
-    timer: 5,
-  };
-
-  componentDidMount() {
-    this.redirectInterval = window.setInterval(() => {
-      if (this.state.timer <= 1) {
-        testableWindowLocation.assign(this.newPath);
-        return;
-      }
-
-      this.setState(state => ({
-        timer: state.timer - 1,
-      }));
-    }, 1000);
-  }
-
-  componentWillUnmount() {
-    if (this.redirectInterval) {
-      window.clearInterval(this.redirectInterval);
-    }
-  }
-
-  redirectInterval: number | null = null;
-
-  get newPath() {
-    const {params, slug} = this.props;
-
-    return recreateRoute('', {
-      ...this.props,
-      params: {
-        ...params,
-        projectId: slug,
-      },
-    });
-  }
-
-  render() {
-    const {slug, Header, Body} = this.props;
-    return (
-      <Fragment>
-        <Header>{t('Redirecting to New Project...')}</Header>
-
-        <Body>
-          <Flex direction="column" gap="lg">
-            <Flex direction="column" gap="sm">
-              <Text>{t('The project slug has been changed.')}</Text>
-              <Text variant="muted">
-                {tct(
-                  'You will be redirected to the new project [project] in [timer] seconds...',
-                  {
-                    project: <strong>{slug}</strong>,
-                    timer: `${this.state.timer}`,
-                  }
-                )}
-              </Text>
-            </Flex>
-            <Flex justify="end">
-              <LinkButton priority="primary" href={this.newPath}>
-                {t('Continue to %s', slug)}
-              </LinkButton>
-            </Flex>
-          </Flex>
-        </Body>
-      </Fragment>
-    );
-  }
+interface Props extends ModalRenderProps {
+  slug: string;
 }
 
-export default withSentryRouter(RedirectToProjectModal);
+function RedirectToProjectModal({slug, Header, Body}: Props) {
+  const routes = useRoutes();
+  const params = useParams();
+  const location = useLocation();
+
+  const [timer, setTimer] = useState(5);
+
+  const newPath = recreateRoute('', {
+    routes,
+    location,
+    params: {...params, projectId: slug},
+  });
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setTimer(value => value - 1), 1000);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (timer <= 0) {
+      testableWindowLocation.assign(newPath);
+    }
+  }, [timer, newPath]);
+
+  return (
+    <Fragment>
+      <Header>{t('Redirecting to New Project...')}</Header>
+
+      <Body>
+        <Flex direction="column" gap="lg">
+          <Flex direction="column" gap="sm">
+            <Text>{t('The project slug has been changed.')}</Text>
+            <Text variant="muted">
+              {tct(
+                'You will be redirected to the new project [project] in [timer] seconds...',
+                {
+                  project: <strong>{slug}</strong>,
+                  timer,
+                }
+              )}
+            </Text>
+          </Flex>
+          <Flex justify="end">
+            <LinkButton priority="primary" href={newPath}>
+              {t('Continue to %s', slug)}
+            </LinkButton>
+          </Flex>
+        </Flex>
+      </Body>
+    </Fragment>
+  );
+}
+
+export default RedirectToProjectModal;
 export {RedirectToProjectModal};


### PR DESCRIPTION
Replace class component + withSentryRouter with function component
using useRoutes, useParams, and useLocation hooks directly.

Co-Authored-By: Claude <noreply@anthropic.com>