### PR TITLE
feat(onboarding): Scaffold SCM onboarding steps with placeholder UI

### DIFF
--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -1,11 +1,26 @@
 import {createContext, useContext, useMemo} from 'react';
 
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 type OnboardingContextProps = {
+  setSelectedFeatures: (features?: ProductSolution[]) => void;
+  setSelectedIntegration: (integration?: Integration) => void;
   setSelectedPlatform: (selectedSDK?: OnboardingSelectedSDK) => void;
+  setSelectedRepositories: (repos?: Repository[]) => void;
+  selectedFeatures?: ProductSolution[];
+  selectedIntegration?: Integration;
   selectedPlatform?: OnboardingSelectedSDK;
+  selectedRepositories?: Repository[];
+};
+
+type OnboardingSessionState = {
+  selectedFeatures?: ProductSolution[];
+  selectedIntegration?: Integration;
+  selectedPlatform?: OnboardingSelectedSDK;
+  selectedRepositories?: Repository[];
 };
 
 /**
@@ -14,6 +29,12 @@ type OnboardingContextProps = {
 const OnboardingContext = createContext<OnboardingContextProps>({
   selectedPlatform: undefined,
   setSelectedPlatform: () => {},
+  selectedIntegration: undefined,
+  setSelectedIntegration: () => {},
+  selectedRepositories: undefined,
+  setSelectedRepositories: () => {},
+  selectedFeatures: undefined,
+  setSelectedFeatures: () => {},
 });
 
 type ProviderProps = {
@@ -26,7 +47,7 @@ type ProviderProps = {
 
 export function OnboardingContextProvider({children, value}: ProviderProps) {
   const [onboarding, setOnboarding, removeOnboarding] = useSessionStorage<
-    NonNullable<Pick<OnboardingContextProps, 'selectedPlatform'>> | undefined
+    OnboardingSessionState | undefined
   >(
     'onboarding',
     value?.selectedPlatform ? {selectedPlatform: value.selectedPlatform} : undefined
@@ -40,8 +61,20 @@ export function OnboardingContextProvider({children, value}: ProviderProps) {
         if (selectedPlatform === undefined) {
           removeOnboarding();
         } else {
-          setOnboarding({selectedPlatform});
+          setOnboarding({...onboarding, selectedPlatform});
         }
+      },
+      selectedIntegration: onboarding?.selectedIntegration,
+      setSelectedIntegration: (selectedIntegration?: Integration) => {
+        setOnboarding({...onboarding, selectedIntegration});
+      },
+      selectedRepositories: onboarding?.selectedRepositories,
+      setSelectedRepositories: (selectedRepositories?: Repository[]) => {
+        setOnboarding({...onboarding, selectedRepositories});
+      },
+      selectedFeatures: onboarding?.selectedFeatures,
+      setSelectedFeatures: (selectedFeatures?: ProductSolution[]) => {
+        setOnboarding({...onboarding, selectedFeatures});
       },
     }),
     [onboarding, setOnboarding, removeOnboarding]

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -57,9 +57,22 @@ export function OnboardingContextProvider({children, value}: ProviderProps) {
     () => ({
       selectedPlatform: onboarding?.selectedPlatform,
       setSelectedPlatform: (selectedPlatform?: OnboardingSelectedSDK) => {
-        // If platform is undefined, remove the item from session storage
         if (selectedPlatform === undefined) {
-          removeOnboarding();
+          // Clear platform but preserve other SCM state (integration, repos, features).
+          // Full reset only happens if no other state remains.
+          const nextState = {
+            ...onboarding,
+            selectedPlatform: undefined,
+          };
+          const hasOtherState =
+            nextState.selectedIntegration ||
+            nextState.selectedRepositories ||
+            nextState.selectedFeatures;
+          if (hasOtherState) {
+            setOnboarding(nextState);
+          } else {
+            removeOnboarding();
+          }
         } else {
           setOnboarding({...onboarding, selectedPlatform});
         }

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -549,6 +549,179 @@ describe('Onboarding', () => {
     ).not.toBeInTheDocument();
   });
 
+  describe('SCM onboarding flow', () => {
+    const scmOrganization = OrganizationFixture({
+      features: ['onboarding-scm'],
+    });
+
+    function renderOnboarding(step: string) {
+      return render(
+        <OnboardingContextProvider>
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          organization: scmOrganization,
+          initialRouterConfig: {
+            location: {
+              pathname: `/onboarding/${scmOrganization.slug}/${step}/`,
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+    }
+
+    it('navigates from welcome to scm-connect', async () => {
+      const {router} = renderOnboarding('welcome');
+
+      await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${scmOrganization.slug}/scm-connect/`
+        );
+      });
+    });
+
+    it('renders scm-connect step and advances to scm-platform-features', async () => {
+      const {router} = renderOnboarding('scm-connect');
+
+      expect(screen.getByText('Connect your repository')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${scmOrganization.slug}/scm-platform-features/`
+        );
+      });
+    });
+
+    it('renders scm-platform-features step and advances to scm-project-details', async () => {
+      const {router} = renderOnboarding('scm-platform-features');
+
+      expect(screen.getByText('Platform & features')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${scmOrganization.slug}/scm-project-details/`
+        );
+      });
+    });
+
+    it('renders scm-project-details step and advances to setup-docs when platform is set', async () => {
+      const nextJsProject = ProjectFixture({
+        platform: 'javascript-nextjs',
+        id: '2',
+        slug: 'javascript-nextjs',
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${scmOrganization.slug}/sdks/`,
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${scmOrganization.slug}/${nextJsProject.slug}/keys/`,
+        method: 'GET',
+        body: [ProjectKeysFixture()[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${scmOrganization.slug}/${nextJsProject.slug}/issues/`,
+        body: [],
+      });
+
+      jest
+        .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
+        .mockImplementation(() => ({
+          project: nextJsProject,
+          isProjectActive: false,
+        }));
+
+      const {router} = render(
+        <OnboardingContextProvider
+          value={{
+            selectedPlatform: {
+              key: nextJsProject.slug as PlatformKey,
+              type: 'framework',
+              language: 'javascript',
+              category: 'browser',
+              name: 'Next.js',
+              link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+            },
+          }}
+        >
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          organization: scmOrganization,
+          initialRouterConfig: {
+            location: {
+              pathname: `/onboarding/${scmOrganization.slug}/scm-project-details/`,
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+
+      expect(screen.getByText('Project details')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${scmOrganization.slug}/setup-docs/`
+        );
+      });
+    });
+
+    it('does not advance to setup-docs without a platform selected', async () => {
+      const {router} = renderOnboarding('scm-project-details');
+
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      // Should stay on the same step
+      expect(router.location.pathname).toBe(
+        `/onboarding/${scmOrganization.slug}/scm-project-details/`
+      );
+    });
+
+    it('navigates back from scm-connect to welcome', async () => {
+      const {router} = renderOnboarding('scm-connect');
+
+      await userEvent.click(screen.getByRole('button', {name: 'Back'}));
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${scmOrganization.slug}/welcome/`
+        );
+      });
+    });
+
+    it('redirects invalid step to welcome', () => {
+      const {router} = render(
+        <OnboardingContextProvider>
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          organization: scmOrganization,
+          initialRouterConfig: {
+            location: {
+              pathname: `/onboarding/${scmOrganization.slug}/select-platform/`,
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+
+      // select-platform doesn't exist in SCM flow, should redirect to welcome
+      expect(router.location.pathname).toBe(
+        `/onboarding/${scmOrganization.slug}/welcome/`
+      );
+    });
+  });
+
   it('loads doc on platform click', async () => {
     const organization = OrganizationFixture();
     const nextJsProject = ProjectFixture({

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -37,11 +37,14 @@ import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar
 import {NewWelcomeUI} from './components/newWelcome';
 import {Stepper} from './components/stepper';
 import {PlatformSelection} from './platformSelection';
+import {ScmConnect} from './scmConnect';
+import {ScmPlatformFeatures} from './scmPlatformFeatures';
+import {ScmProjectDetails} from './scmProjectDetails';
 import {SetupDocs} from './setupDocs';
 import {OnboardingStepId, type StepDescriptor, type StepProps} from './types';
 import {TargetedOnboardingWelcome} from './welcome';
 
-export const onboardingSteps: StepDescriptor[] = [
+const legacyOnboardingSteps: StepDescriptor[] = [
   {
     id: OnboardingStepId.WELCOME,
     title: t('Welcome'),
@@ -53,6 +56,40 @@ export const onboardingSteps: StepDescriptor[] = [
     title: t('Select platform'),
     Component: PlatformSelection,
     hasFooter: true,
+    cornerVariant: 'top-left',
+  },
+  {
+    id: OnboardingStepId.SETUP_DOCS,
+    title: t('Install the Sentry SDK'),
+    Component: SetupDocs,
+    hasFooter: true,
+    cornerVariant: 'top-left',
+  },
+];
+
+const scmOnboardingSteps: StepDescriptor[] = [
+  {
+    id: OnboardingStepId.WELCOME,
+    title: t('Welcome'),
+    Component: WelcomeVariable,
+    cornerVariant: 'top-right',
+  },
+  {
+    id: OnboardingStepId.SCM_CONNECT,
+    title: t('Connect repository'),
+    Component: ScmConnect,
+    cornerVariant: 'top-left',
+  },
+  {
+    id: OnboardingStepId.SCM_PLATFORM_FEATURES,
+    title: t('Platform & features'),
+    Component: ScmPlatformFeatures,
+    cornerVariant: 'top-left',
+  },
+  {
+    id: OnboardingStepId.SCM_PROJECT_DETAILS,
+    title: t('Project details'),
+    Component: ScmProjectDetails,
     cornerVariant: 'top-left',
   },
   {
@@ -126,6 +163,8 @@ export function OnboardingWithoutContext() {
   const selectedProjectSlug = onboardingContext.selectedPlatform?.key;
 
   const hasNewWelcomeUI = useHasNewWelcomeUI();
+  const hasScmOnboarding = organization.features.includes('onboarding-scm');
+  const onboardingSteps = hasScmOnboarding ? scmOnboardingSteps : legacyOnboardingSteps;
 
   const stepObj = onboardingSteps.find(({id}) => stepId === id);
   const stepIndex = onboardingSteps.findIndex(({id}) => stepId === id);
@@ -144,7 +183,7 @@ export function OnboardingWithoutContext() {
   useEffect(() => {
     if (
       normalizeUrl(location.pathname, {forceCustomerDomain: true}) ===
-        `/onboarding/${onboardingSteps[2]!.id}/` &&
+        `/onboarding/${OnboardingStepId.SETUP_DOCS}/` &&
       location.query?.platform &&
       onboardingContext.selectedPlatform === undefined
     ) {
@@ -155,7 +194,9 @@ export function OnboardingWithoutContext() {
       // if no platform found, we redirect the user to the platform select page
       if (!platform) {
         navigate(
-          normalizeUrl(`/onboarding/${organization.slug}/${onboardingSteps[1]!.id}/`)
+          normalizeUrl(
+            `/onboarding/${organization.slug}/${OnboardingStepId.SELECT_PLATFORM}/`
+          )
         );
         return;
       }
@@ -201,6 +242,7 @@ export function OnboardingWithoutContext() {
 
   const {handleGoBack} = useBackActions({
     stepIndex,
+    onboardingSteps,
     goToStep,
     recentCreatedProject,
     isRecentCreatedProjectActive: isProjectActive,
@@ -211,13 +253,17 @@ export function OnboardingWithoutContext() {
       const currentStepIndex = onboardingSteps.findIndex(s => s.id === step.id);
       const nextStep = onboardingSteps[currentStepIndex + 1]!;
 
-      if (nextStep.id === 'setup-docs' && !platform) {
+      if (
+        nextStep.id === OnboardingStepId.SETUP_DOCS &&
+        !platform &&
+        !onboardingContext.selectedPlatform
+      ) {
         return;
       }
 
       navigate(normalizeUrl(`/onboarding/${organization.slug}/${nextStep.id}/`));
     },
-    [organization.slug, navigate]
+    [organization.slug, navigate, onboardingSteps, onboardingContext.selectedPlatform]
   );
 
   const genSkipOnboardingLink = () => {

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -191,13 +191,12 @@ export function OnboardingWithoutContext() {
         p => p.id === location.query.platform
       );
 
-      // if no platform found, we redirect the user to the platform select page
+      // if no platform found, redirect to the appropriate platform selection step
       if (!platform) {
-        navigate(
-          normalizeUrl(
-            `/onboarding/${organization.slug}/${OnboardingStepId.SELECT_PLATFORM}/`
-          )
-        );
+        const fallbackStep = hasScmOnboarding
+          ? OnboardingStepId.SCM_PLATFORM_FEATURES
+          : OnboardingStepId.SELECT_PLATFORM;
+        navigate(normalizeUrl(`/onboarding/${organization.slug}/${fallbackStep}/`));
         return;
       }
 
@@ -215,7 +214,14 @@ export function OnboardingWithoutContext() {
         name: platform.name,
       });
     }
-  }, [location.query, navigate, onboardingContext, organization.slug, location.pathname]);
+  }, [
+    location.query,
+    navigate,
+    onboardingContext,
+    organization.slug,
+    location.pathname,
+    hasScmOnboarding,
+  ]);
 
   const shallProjectBeDeleted =
     stepObj?.id === 'setup-docs' && defined(isProjectActive) && !isProjectActive;

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -1,0 +1,18 @@
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+import type {StepProps} from './types';
+
+export function ScmConnect({onComplete}: StepProps) {
+  return (
+    <Flex direction="column" align="center" justify="center" gap="lg" flexGrow={1}>
+      <Heading as="h2">{t('Connect your repository')}</Heading>
+      <Button priority="primary" onClick={() => onComplete()}>
+        {t('Continue')}
+      </Button>
+    </Flex>
+  );
+}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,0 +1,18 @@
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+import type {StepProps} from './types';
+
+export function ScmPlatformFeatures({onComplete}: StepProps) {
+  return (
+    <Flex direction="column" align="center" justify="center" gap="lg" flexGrow={1}>
+      <Heading as="h2">{t('Platform & features')}</Heading>
+      <Button priority="primary" onClick={() => onComplete()}>
+        {t('Continue')}
+      </Button>
+    </Flex>
+  );
+}

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,0 +1,18 @@
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+import type {StepProps} from './types';
+
+export function ScmProjectDetails({onComplete}: StepProps) {
+  return (
+    <Flex direction="column" align="center" justify="center" gap="lg" flexGrow={1}>
+      <Heading as="h2">{t('Project details')}</Heading>
+      <Button priority="primary" onClick={() => onComplete()}>
+        {t('Continue')}
+      </Button>
+    </Flex>
+  );
+}

--- a/static/app/views/onboarding/types.ts
+++ b/static/app/views/onboarding/types.ts
@@ -20,6 +20,10 @@ export enum OnboardingStepId {
   WELCOME = 'welcome',
   SELECT_PLATFORM = 'select-platform',
   SETUP_DOCS = 'setup-docs',
+  // SCM-first onboarding flow
+  SCM_CONNECT = 'scm-connect',
+  SCM_PLATFORM_FEATURES = 'scm-platform-features',
+  SCM_PROJECT_DETAILS = 'scm-project-details',
 }
 
 export enum OnboardingWelcomeProductId {

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -11,7 +11,6 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {onboardingSteps} from 'sentry/views/onboarding/onboarding';
 import type {StepDescriptor} from 'sentry/views/onboarding/types';
 
 /**
@@ -20,11 +19,13 @@ import type {StepDescriptor} from 'sentry/views/onboarding/types';
  */
 export function useBackActions({
   stepIndex,
+  onboardingSteps,
   recentCreatedProject,
   isRecentCreatedProjectActive,
   goToStep,
 }: {
   goToStep: (step: StepDescriptor) => void;
+  onboardingSteps: StepDescriptor[];
   stepIndex: number;
   isRecentCreatedProjectActive?: boolean;
   recentCreatedProject?: Project;
@@ -155,7 +156,7 @@ export function useBackActions({
         browserBackButton: false,
       });
     },
-    [stepIndex, backStepActions]
+    [stepIndex, backStepActions, onboardingSteps]
   );
 
   return {handleGoBack};

--- a/static/app/views/onboarding/useConfigureSdk.spec.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.spec.tsx
@@ -68,6 +68,9 @@ describe('useConfigureSdk', () => {
 
     mockUseOnboardingContext.mockReturnValue({
       setSelectedPlatform: jest.fn(),
+      setSelectedIntegration: jest.fn(),
+      setSelectedRepositories: jest.fn(),
+      setSelectedFeatures: jest.fn(),
     });
 
     createProjectInstance = mockCreateProjectHook();


### PR DESCRIPTION
Scaffold the frontend onboarding step array for the SCM-first onboarding flow behind the `organizations:onboarding-scm` feature flag. When enabled, the onboarding shows 5 steps instead of the legacy 3, with placeholder components for each new step that just render a heading and Continue button.

The feature flag was registered in #110570. This PR adds the frontend wiring:

- Three new `OnboardingStepId` enum values (`SCM_CONNECT`, `SCM_PLATFORM_FEATURES`, `SCM_PROJECT_DETAILS`)
- Conditional step array selection based on the feature flag
- Placeholder step components (`ScmConnect`, `ScmPlatformFeatures`, `ScmProjectDetails`)
- Extended `OnboardingContext` with `selectedIntegration`, `selectedRepositories`, and `selectedFeatures` state (session storage backed)
- Updated `useBackActions` to accept `onboardingSteps` as a parameter instead of importing the now-conditional module-level constant
- Fixed `goNextStep` to allow navigation to SETUP_DOCS when platform is set via context (needed for the SCM flow where platform selection happens in an earlier step)
- Replaced fragile index-based step lookups (`onboardingSteps[2]`) with `OnboardingStepId` enum references

With the flag off, behavior is unchanged (existing tests all pass).

Refs VDY-18