### PR TITLE
fix(issues): Apply issue.id filter to postgres queryset candidates

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -591,6 +591,7 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "issue.priority": QCallbackCondition(lambda priorities: Q(priority__in=priorities)),
             "issue.seer_actionability": QCallbackCondition(seer_actionability_filter),
             "issue.seer_last_run": ScalarCondition("seer_autofix_last_triggered"),
+            "issue.id": QCallbackCondition(lambda ids: Q(id__in=[int(id) for id in ids])),
         }
 
         if environments is not None:

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -591,7 +591,9 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "issue.priority": QCallbackCondition(lambda priorities: Q(priority__in=priorities)),
             "issue.seer_actionability": QCallbackCondition(seer_actionability_filter),
             "issue.seer_last_run": ScalarCondition("seer_autofix_last_triggered"),
-            "issue.id": QCallbackCondition(lambda ids: Q(id__in=[int(id) for id in ids])),
+            "issue.id": QCallbackCondition(
+                lambda ids: Q(id__in=[int(v) for v in (ids if isinstance(ids, list) else [ids])])
+            ),
         }
 
         if environments is not None:

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2635,6 +2635,13 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         # include the searched group. Without this, _preprocess_group_id_redirects
         # can intersect postgres candidates with the snuba group_id condition
         # and produce an empty IN clause that crashes ClickHouse.
+        # Single value syntax
+        results = self.make_query(
+            search_filter_query=f"issue.id:{self.group1.id}",
+        )
+        assert set(results) == {self.group1}
+
+        # List syntax
         results = self.make_query(
             search_filter_query=f"issue.id:[{self.group1.id}]",
         )

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2630,6 +2630,27 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         assert len(results) == 0
 
+    def test_issue_id_filter(self) -> None:
+        # issue.id must be applied to the postgres queryset so that candidates
+        # include the searched group. Without this, _preprocess_group_id_redirects
+        # can intersect postgres candidates with the snuba group_id condition
+        # and produce an empty IN clause that crashes ClickHouse.
+        results = self.make_query(
+            search_filter_query=f"issue.id:[{self.group1.id}]",
+        )
+        assert set(results) == {self.group1}
+
+        results = self.make_query(
+            search_filter_query=f"issue.id:[{self.group1.id},{self.group2.id}]",
+        )
+        assert set(results) == {self.group1, self.group2}
+
+        # Non-existent group should return empty results (not crash)
+        results = self.make_query(
+            search_filter_query="issue.id:[999999999]",
+        )
+        assert set(results) == set()
+
 
 class EventsSnubaSearchTest(TestCase, EventsSnubaSearchTestCases):
     pass


### PR DESCRIPTION
When searching by `issue.id`, the filter was only applied as a snuba condition but not to the postgres queryset that generates candidate group IDs. If the searched group wasn't among the postgres candidates, `_preprocess_group_id_redirects` would intersect the two `group_id` sets and produce an empty `IN` clause, crashing ClickHouse with:

```
DB::Exception: Element of set in IN, VALUES, or LIMIT, or aggregate function parameter,
or a table function argument is not a constant expression (result column not found): tuple()
```

Adding `issue.id` to the queryset conditions ensures the postgres candidates include the searched group, or returns empty early if the group doesn't exist — avoiding the snuba query entirely.

Ref #102879
Fixes SENTRY-4EQ8