### PR TITLE
fix(dif): Allow ProGuard reupload clones in assemble

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -2,18 +2,22 @@ import logging
 import posixpath
 import re
 import uuid
-from collections.abc import Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, TypedDict, TypeGuard
 
 import jsonschema
 import orjson
 from django.db import IntegrityError, router
-from django.db.models import Exists, Q
+from django.db.models import Case, Exists, IntegerField, Q, QuerySet, Value, When
 from django.http import Http404, HttpResponse, StreamingHttpResponse
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
+
+if TYPE_CHECKING:
+    from django_stubs_ext import WithAnnotations
 
 from sentry import ratelimits
 from sentry.api.api_owners import ApiOwner
@@ -29,10 +33,14 @@ from sentry.auth.system import is_system_auth
 from sentry.constants import DEBUG_FILES_ROLE_DEFAULT, KNOWN_DIF_FORMATS
 from sentry.debug_files.debug_files import maybe_renew_debug_files
 from sentry.debug_files.upload import find_missing_chunks
+from sentry.lang.native.sources import record_last_upload
 from sentry.models.debugfile import (
     ProguardArtifactRelease,
     ProjectDebugFile,
+    build_proguard_reupload_dif_meta,
+    create_dif_from_id,
     create_files_from_dif_zip,
+    get_debug_id_from_dif_request,
 )
 from sentry.models.files.file import File
 from sentry.models.organizationmember import OrganizationMember
@@ -444,7 +452,14 @@ def batch_assemble(project, files):
         # `ProjectDebugFile` will be created, and we need to prevent a race
         # condition.
         state, detail = get_assemble_status(AssembleTask.DIF, project.id, checksum)
-        if state == ChunkFileState.OK:
+        requested_debug_id = _get_requested_debug_id(files[checksum])
+        cached_debug_id = detail.get("uuid") if isinstance(detail, Mapping) else None
+
+        if state == ChunkFileState.OK and not _is_proguard_reupload_clone_request(
+            file=files[checksum],
+            requested_debug_id=requested_debug_id,
+            selected_debug_id=cached_debug_id,
+        ):
             file_response[checksum] = {
                 "state": state,
                 "detail": None,
@@ -452,29 +467,46 @@ def batch_assemble(project, files):
                 "dif": detail,
             }
             checksums_with_status.add(checksum)
-        elif state is not None:
+        elif state is not None and state != ChunkFileState.OK:
             file_response[checksum] = {"state": state, "detail": detail, "missingChunks": []}
             checksums_with_status.add(checksum)
 
     checksums_to_check -= checksums_with_status
 
-    # 2. Check if this project already owns the `ProjectDebugFile` for each file.
-    debug_files = ProjectDebugFile.objects.filter(
-        project_id=project.id,
-        checksum__in=checksums_to_check,
-    ).select_related("file")
+    # 2. Check if this project already owns the `ProjectDebugFile` for each file,
+    # also create ProGuard reupload clones if applicable.
+    requested_debug_ids_by_checksum = {
+        checksum: _get_requested_debug_id(files[checksum]) for checksum in checksums_to_check
+    }
+    existing_debug_files = _find_existing_debug_files(
+        project=project,
+        checksums=checksums_to_check,
+        requested_debug_ids_by_checksum=requested_debug_ids_by_checksum,
+    )
 
-    checksums_with_debug_files = set()
-    for debug_file in debug_files:
+    for debug_file in existing_debug_files:
+        checksums_to_check.discard(debug_file.checksum)
+        requested_debug_id = requested_debug_ids_by_checksum[debug_file.checksum]
+
+        if _is_proguard_reupload_clone_request(
+            requested_debug_id=requested_debug_id,
+            file=files[debug_file.checksum],
+            selected_debug_id=debug_file.debug_id,
+        ):
+            file_response[debug_file.checksum] = _clone_proguard_debug_file_for_reupload(
+                project=project,
+                debug_file=debug_file,
+                requested_debug_id=requested_debug_id,
+                is_proguard_clone_source=bool(debug_file.proguard_clone_source_match),
+            )
+            continue
+
         file_response[debug_file.checksum] = {
             "state": ChunkFileState.OK,
             "detail": None,
             "missingChunks": [],
             "dif": serialize(debug_file),
         }
-        checksums_with_debug_files.add(debug_file.checksum)
-
-    checksums_to_check -= checksums_with_debug_files
 
     # 3. Compute all the chunks that have to be checked for existence.
     chunks_to_check = {}
@@ -542,6 +574,173 @@ def batch_assemble(project, files):
         file_response[checksum] = {"state": ChunkFileState.CREATED, "missingChunks": []}
 
     return file_response
+
+
+def _get_requested_debug_id(file) -> str | None:
+    """Returns the effective requested debug ID for one assemble payload.
+
+    This normalizes an explicit ``debug_id`` when present, or derives one from a
+    ProGuard-style request name such as ``/proguard/mapping-<uuid>.txt``.
+    """
+    return get_debug_id_from_dif_request(name=file.get("name"), debug_id=file.get("debug_id"))
+
+
+def _is_requested_proguard(file) -> bool:
+    """Returns whether one assemble payload should be treated as a ProGuard request.
+
+    This is true only when the request's effective debug ID comes from a
+    ProGuard-style filename, rather than merely from an explicit ``debug_id``.
+    """
+    name = file.get("name")
+    requested_debug_id = _get_requested_debug_id(file)
+    return (
+        requested_debug_id is not None
+        and get_debug_id_from_dif_request(name=name, debug_id=None) == requested_debug_id
+    )
+
+
+def _is_proguard_reupload_clone_request(
+    requested_debug_id: str | None,
+    file,
+    selected_debug_id: str | None,
+) -> TypeGuard[str]:
+    """Return whether the assemble request should clone a ProGuard debug file."""
+    return (
+        requested_debug_id is not None
+        and requested_debug_id != selected_debug_id
+        and _is_requested_proguard(file)
+    )
+
+
+class _DebugFileAnnotations(TypedDict):
+    requested_debug_id_match: int
+    proguard_clone_source_match: int
+
+
+def _find_existing_debug_files(
+    project: Project,
+    checksums: set[str],
+    requested_debug_ids_by_checksum: dict[str, str | None],
+) -> "QuerySet[WithAnnotations[ProjectDebugFile, _DebugFileAnnotations]]":
+    """Find up to one existing `ProjectDebugFile` row per requested checksum.
+
+    This query is used to determine whether assemble can be satisfied from rows
+    that already exist for the project, or whether the request must continue to
+    chunk lookup and async assembly.
+
+    It only considers `ProjectDebugFile` rows in the same project and for the
+    requested checksums. The result contains at most one row per checksum,
+    chosen by SQL ordering plus `distinct("checksum")`.
+
+    Two annotations are added and preserved on the returned rows:
+
+    - `requested_debug_id_match`: `1` when the row exactly matches the
+      effective requested debug ID for that checksum, else `0`.
+    - `proguard_clone_source_match`: `1` when the row points at a stored
+      ProGuard `project.dif` file that is safe to reuse as the source for a
+      ProGuard reupload clone, else `0`.
+
+    Rows are ordered so each checksum prefers:
+
+    1. an exact requested debug ID match,
+    2. otherwise a valid ProGuard clone source,
+    3. otherwise the newest remaining row.
+
+    If no result is returned for a given checksum, no `ProjectDebugFile` rows
+    with that checksum exist in the given project.
+
+    Downstream, `batch_assemble` uses that selected row to decide whether the
+    checksum is already satisfied, whether a ProGuard alias row should be
+    created, or whether the request still needs upload work.
+    """
+    return (
+        ProjectDebugFile.objects.filter(
+            project_id=project.id,
+            checksum__in=checksums,
+        )
+        .annotate(
+            requested_debug_id_match=_build_requested_debug_id_match_annotation(
+                requested_debug_ids_by_checksum.items()
+            ),
+            proguard_clone_source_match=_build_proguard_clone_source_annotation(checksums),
+        )
+        .select_related("file")
+        .order_by("checksum", "-requested_debug_id_match", "-proguard_clone_source_match", "-id")
+        .distinct("checksum")
+    )
+
+
+def _build_requested_debug_id_match_annotation(
+    requested_debug_ids: Iterable[tuple[str, str | None]],
+) -> Case:
+    """Builds a per-row match score for exact requested debug ID matches.
+
+    The annotation returns ``1`` when a row's ``checksum`` and ``debug_id`` match
+    the effective requested debug ID for that checksum, and ``0`` otherwise.
+    """
+    return Case(
+        *[
+            When(checksum=checksum, debug_id=debug_id, then=Value(1))
+            for checksum, debug_id in requested_debug_ids
+            if debug_id is not None
+        ],
+        default=Value(0),
+        output_field=IntegerField(),
+    )
+
+
+def _build_proguard_clone_source_annotation(checksums: Iterable[str]) -> Case:
+    """Builds a per-row match score for ProGuard clone-source selection.
+
+    The annotation returns ``1`` when a row belongs to one of the requested
+    checksums, points at a ``project.dif`` file, and its linked ``File`` has
+    headers exactly matching the stored ProGuard content type. It returns ``0``
+    for all other rows.
+    """
+    return Case(
+        When(
+            checksum__in=checksums,
+            file__type="project.dif",
+            file__headers={"Content-Type": DIF_MIMETYPES["proguard"]},
+            then=Value(1),
+        ),
+        default=Value(0),
+        output_field=IntegerField(),
+    )
+
+
+def _clone_proguard_debug_file_for_reupload(
+    project: Project,
+    debug_file: ProjectDebugFile,
+    requested_debug_id: str,
+    is_proguard_clone_source: bool,
+) -> dict[str, object]:
+    """Clone a ProGuard debug file row for a reupload and return a batch response.
+
+    ``is_proguard_clone_source`` must reflect the caller's annotation-based
+    selection result for whether ``debug_file`` is a valid ProGuard clone source.
+    If it is false, this returns an error response payload. Otherwise it creates
+    or reuses the ``ProjectDebugFile`` row for ``requested_debug_id`` and
+    returns an OK response payload.
+    """
+    if not is_proguard_clone_source:
+        return {
+            "state": ChunkFileState.ERROR,
+            "detail": "This file is not a ProGuard mapping.",
+            "missingChunks": [],
+        }
+
+    meta = build_proguard_reupload_dif_meta(debug_file, requested_debug_id)
+    dif, created = create_dif_from_id(project, meta, file=debug_file.file)
+    if created:
+        record_last_upload(project)
+
+    return {
+        "state": ChunkFileState.OK,
+        "detail": None,
+        "missingChunks": [],
+        "dif": serialize(dif),
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -386,6 +386,33 @@ def _analyze_progard_filename(filename: str | None) -> str | None:
         return None
 
 
+def get_debug_id_from_dif_request(name: str | None, debug_id: str | None) -> str | None:
+    """Returns the effective debug ID from assemble request metadata.
+
+    Most DIF uploads provide an explicit ``debug_id``. ProGuard mappings instead
+    encode it in the request ``name`` such as ``/proguard/mapping-<uuid>.txt``.
+    """
+    try:
+        normalized_id = normalize_debug_id(debug_id)
+    except SymbolicError:
+        normalized_id = None
+
+    return normalized_id or _analyze_progard_filename(name)
+
+
+def build_proguard_reupload_dif_meta(source_dif: ProjectDebugFile, debug_id: str) -> DifMeta:
+    """Builds trusted ProGuard metadata for cloning a row with a new debug ID."""
+    return DifMeta(
+        file_format="proguard",
+        arch=source_dif.cpu_name,
+        debug_id=debug_id,
+        code_id=source_dif.code_id,
+        path=source_dif.object_name,
+        name=source_dif.object_name,
+        data=source_dif.data,
+    )
+
+
 @cell_silo_model
 class ProguardArtifactRelease(Model):
     __relocation_scope__ = RelocationScope.Excluded

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -251,3 +251,106 @@ class DifAssembleEndpoint(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data[total_checksum]["state"] == ChunkFileState.ERROR
         assert "unsupported object file format" in response.data[total_checksum]["detail"]
+
+    def test_reuses_existing_proguard_file_with_new_debug_id(self) -> None:
+        file_contents = b"proguard mapping"
+        checksum = sha1(file_contents).hexdigest()
+        blob = FileBlob.from_file_with_organization(ContentFile(file_contents), self.organization)
+        chunks = [blob.checksum]
+
+        assemble_dif(
+            project_id=self.project.id,
+            name="/proguard/mapping-00000000-0000-0000-0000-000000000000.txt",
+            checksum=checksum,
+            chunks=chunks,
+        )
+
+        first_dif = ProjectDebugFile.objects.get(
+            project_id=self.project.id,
+            debug_id="00000000-0000-0000-0000-000000000000",
+        )
+
+        response = self.client.post(
+            self.url,
+            data={
+                checksum: {
+                    "name": "/proguard/mapping-11111111-1111-1111-1111-111111111111.txt",
+                    "chunks": chunks,
+                }
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data[checksum]["state"] == ChunkFileState.OK
+        assert response.data[checksum]["dif"]["uuid"] == "11111111-1111-1111-1111-111111111111"
+
+        second_dif = ProjectDebugFile.objects.get(
+            project_id=self.project.id,
+            debug_id="11111111-1111-1111-1111-111111111111",
+        )
+
+        assert first_dif.file_id == second_dif.file_id
+        assert File.objects.filter(type="project.dif", checksum=checksum).count() == 1
+
+    def test_reupload_proguard_with_same_debug_id_is_idempotent(self) -> None:
+        file_contents = b"proguard mapping"
+        checksum = sha1(file_contents).hexdigest()
+        blob = FileBlob.from_file_with_organization(ContentFile(file_contents), self.organization)
+        chunks = [blob.checksum]
+
+        assemble_dif(
+            project_id=self.project.id,
+            name="/proguard/mapping-00000000-0000-0000-0000-000000000000.txt",
+            checksum=checksum,
+            chunks=chunks,
+        )
+
+        response = self.client.post(
+            self.url,
+            data={
+                checksum: {
+                    "name": "/proguard/mapping-00000000-0000-0000-0000-000000000000.txt",
+                    "chunks": chunks,
+                }
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data[checksum]["state"] == ChunkFileState.OK
+        assert (
+            ProjectDebugFile.objects.filter(
+                project_id=self.project.id,
+                debug_id="00000000-0000-0000-0000-000000000000",
+            ).count()
+            == 1
+        )
+
+    def test_proguard_reupload_errors_for_non_proguard_file(self) -> None:
+        sym_file = self.load_fixture("crash.sym")
+        checksum = sha1(sym_file).hexdigest()
+        blob = FileBlob.from_file_with_organization(ContentFile(sym_file), self.organization)
+        chunks = [blob.checksum]
+
+        assemble_dif(
+            project_id=self.project.id,
+            name="crash.sym",
+            checksum=checksum,
+            chunks=chunks,
+        )
+
+        response = self.client.post(
+            self.url,
+            data={
+                checksum: {
+                    "name": "/proguard/mapping-11111111-1111-1111-1111-111111111111.txt",
+                    "chunks": chunks,
+                }
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data[checksum]["state"] == ChunkFileState.ERROR
+        assert response.data[checksum]["detail"] == "This file is not a ProGuard mapping."

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -17,6 +17,7 @@ from sentry.models.debugfile import (
     ProjectDebugFile,
     create_dif_from_id,
     detect_dif_from_path,
+    get_debug_id_from_dif_request,
 )
 from sentry.models.files.file import File
 from sentry.testutils.cases import APITestCase, TestCase
@@ -479,6 +480,30 @@ def test_proguard_file_not_detected(path: str, name: str | None) -> None:
         # Note that if the path or name does exist as a file on the filesystem,
         # this test will fail.
         detect_dif_from_path(path, name)
+
+
+def test_get_debug_id_from_dif_request_normalizes_debug_id() -> None:
+    assert (
+        get_debug_id_from_dif_request(
+            name=None,
+            debug_id="67E9247C814E392BA027DBDE6748FCBF",
+        )
+        == "67e9247c-814e-392b-a027-dbde6748fcbf"
+    )
+
+
+def test_get_debug_id_from_dif_request_invalid_debug_id_returns_none() -> None:
+    assert get_debug_id_from_dif_request(name=None, debug_id="not-a-debug-id") is None
+
+
+def test_get_debug_id_from_dif_request_reads_proguard_name() -> None:
+    assert (
+        get_debug_id_from_dif_request(
+            name="/proguard/mapping-00000000-0000-0000-0000-000000000000.txt",
+            debug_id=None,
+        )
+        == "00000000-0000-0000-0000-000000000000"
+    )
 
 
 def test_dartsymbolmap_file_detected() -> None:


### PR DESCRIPTION
Allow DIF assemble to create a second ProjectDebugFile row when a ProGuard mapping is reuploaded with the same checksum but a different requested debug ID.

Keep the normal assemble path unchanged for non-ProGuard requests, but select a ProGuard clone source per checksum and reuse the stored File when a reupload needs a new debug ID. Skip cached OK results for that case so the request reaches the clone logic.

Add helper and endpoint coverage for debug ID normalization, ProGuard clone creation, idempotent reupload, and non-ProGuard error handling.

Supersedes https://github.com/getsentry/sentry/pull/110442

Fixes #106947
Closes [INGEST-710](https://linear.app/getsentry/issue/INGEST-710/debug-files-with-identical-content-but-different-debug-ids-rejected-on)