### PR TITLE
feat(occ-eap): Update tagstore to query attrs instead of tags

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -157,6 +157,10 @@ def _extract_from_event(event: Event | GroupEvent) -> Mapping[str, float | int]:
     return out
 
 
+def format_attr_key(key: str) -> str:
+    return f"attr[{key}]"
+
+
 def _extract_tags_and_contexts(
     event_data: Mapping[str, Any],
 ) -> Mapping[str, str | float | int | bool | None]:
@@ -167,9 +171,8 @@ def _extract_tags_and_contexts(
         "dist": event_data.get("dist"),
     }
 
-    # From a user's perspective, "attributes" are tags + contexts.
+    # From a user's perspective, "attributes" are tags + contexts (+ flags, from ctx).
     # Yes, it's confusing with the general EAP attributes.
-    format_attr_key = lambda key: f"attr[{key}]"
 
     attr_keys = set()
     tags = event_data.get("tags")

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -28,6 +28,7 @@ from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderB
 from sentry import features, options
 from sentry.api.paginator import SequencePaginator
 from sentry.api.utils import default_start_end_dates, handle_query_errors
+from sentry.eventstream.item_helpers import format_attr_key
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -186,7 +187,7 @@ class SnubaTagStorage(TagStorage):
         """
         tag_key should be unformatted (i.e. "foo" rather than "tags[foo]")
         """
-        attr_name = f"tags[{tag_key}]"
+        attr_name = format_attr_key(tag_key)
         if limit is None or limit > 100:
             # EAP imposes a limit of 100 buckets max
             limit = 100


### PR DESCRIPTION
We changed the name, we need to change this to match.