### PR TITLE
ref(dashboards): Use VisualizationWidget in fullscreen widget viewer

### DIFF
--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -631,8 +631,6 @@ function DataWidgetViewerModal(props: Props) {
                 widget={primaryWidget}
                 tableItemLimit={widget.limit}
                 onZoom={onZoom}
-                legendSelection={widgetLegendState.getWidgetSelectionState(widget)}
-                onLegendSelectionChange={selected => onLegendSelectChanged({selected})}
                 showConfidenceWarning={
                   widget.widgetType === WidgetType.SPANS ||
                   widget.widgetType === WidgetType.TRACEMETRICS ||

--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -90,6 +90,7 @@ import {
   getWidgetTableRowExploreUrlFunction,
 } from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {getWidgetMetricsUrl} from 'sentry/views/dashboards/utils/getWidgetMetricsUrl';
+import {widgetCanUseTimeSeriesVisualization} from 'sentry/views/dashboards/utils/widgetCanUseTimeSeriesVisualization';
 import {
   SESSION_DURATION_ALERT,
   WidgetDescription,
@@ -101,6 +102,7 @@ import {
 import type {GenericWidgetQueriesResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {IssueWidgetQueries} from 'sentry/views/dashboards/widgetCard/issueWidgetQueries';
 import ReleaseWidgetQueries from 'sentry/views/dashboards/widgetCard/releaseWidgetQueries';
+import {VisualizationWidget} from 'sentry/views/dashboards/widgetCard/visualizationWidget';
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import {WidgetQueries} from 'sentry/views/dashboards/widgetCard/widgetQueries';
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
@@ -622,27 +624,45 @@ function DataWidgetViewerModal(props: Props) {
                 : HALF_CONTAINER_HEIGHT
             }
           >
-            <MemoizedWidgetCardChartContainer
-              api={api}
-              selection={modalSelection}
-              dashboardFilters={dashboardFilters}
-              // Top N charts rely on the orderby of the table
-              widget={primaryWidget}
-              tableItemLimit={widget.limit}
-              onZoom={onZoom}
-              onLegendSelectChanged={onLegendSelectChanged}
-              legendOptions={{
-                selected: widgetLegendState.getWidgetSelectionState(widget),
-              }}
-              noPadding
-              widgetLegendState={widgetLegendState}
-              showConfidenceWarning={
-                widget.widgetType === WidgetType.SPANS ||
-                widget.widgetType === WidgetType.TRACEMETRICS ||
-                widget.widgetType === WidgetType.LOGS
-              }
-              widgetInterval={widgetInterval}
-            />
+            {widgetCanUseTimeSeriesVisualization(primaryWidget) ? (
+              <VisualizationWidget
+                selection={modalSelection}
+                dashboardFilters={dashboardFilters}
+                widget={primaryWidget}
+                tableItemLimit={widget.limit}
+                onZoom={onZoom}
+                legendSelection={widgetLegendState.getWidgetSelectionState(widget)}
+                onLegendSelectionChange={selected => onLegendSelectChanged({selected})}
+                showConfidenceWarning={
+                  widget.widgetType === WidgetType.SPANS ||
+                  widget.widgetType === WidgetType.TRACEMETRICS ||
+                  widget.widgetType === WidgetType.LOGS
+                }
+                widgetInterval={widgetInterval}
+              />
+            ) : (
+              <MemoizedWidgetCardChartContainer
+                api={api}
+                selection={modalSelection}
+                dashboardFilters={dashboardFilters}
+                // Top N charts rely on the orderby of the table
+                widget={primaryWidget}
+                tableItemLimit={widget.limit}
+                onZoom={onZoom}
+                onLegendSelectChanged={onLegendSelectChanged}
+                legendOptions={{
+                  selected: widgetLegendState.getWidgetSelectionState(widget),
+                }}
+                noPadding
+                widgetLegendState={widgetLegendState}
+                showConfidenceWarning={
+                  widget.widgetType === WidgetType.SPANS ||
+                  widget.widgetType === WidgetType.TRACEMETRICS ||
+                  widget.widgetType === WidgetType.LOGS
+                }
+                widgetInterval={widgetInterval}
+              />
+            )}
           </Container>
         )}
         {widget.queries.length > 1 && (

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -9,7 +9,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconWarning} from 'sentry/icons';
 import type {PageFilters} from 'sentry/types/core';
-import type {Series} from 'sentry/types/echarts';
+import type {EChartDataZoomHandler, Series} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
@@ -32,6 +32,7 @@ import {getChartType} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {transformWidgetSeriesToTimeSeries} from 'sentry/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries';
 import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
+  LegendSelection,
   TabularColumn,
   TimeSeries,
   TimeSeriesGroupBy,
@@ -58,6 +59,7 @@ interface VisualizationWidgetProps {
   selection: PageFilters;
   widget: Widget;
   dashboardFilters?: DashboardFilters;
+  legendSelection?: LegendSelection;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: {
     pageLinks?: string;
@@ -67,8 +69,10 @@ interface VisualizationWidgetProps {
     timeseriesResultsUnits?: Record<string, DataUnit>;
     totalIssuesCount?: string;
   }) => void;
+  onLegendSelectionChange?: (selection: LegendSelection) => void;
   onWidgetTableResizeColumn?: (columns: TabularColumn[]) => void;
   onWidgetTableSort?: (sort: Sort) => void;
+  onZoom?: EChartDataZoomHandler;
   renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   showConfidenceWarning?: boolean;
   showReleaseAs?: LoadableChartWidgetProps['showReleaseAs'];
@@ -87,6 +91,9 @@ export function VisualizationWidget({
   renderErrorMessage,
   showReleaseAs = 'bubble',
   showConfidenceWarning,
+  onZoom,
+  legendSelection,
+  onLegendSelectionChange,
 }: VisualizationWidgetProps) {
   const {releases: releasesWithDate} = useReleaseStats(selection, {
     enabled: showReleaseAs !== 'none',
@@ -138,6 +145,9 @@ export function VisualizationWidget({
             dataScanned={dataScanned}
             isSampled={isSampled}
             sampleCount={sampleCount}
+            onZoom={onZoom}
+            legendSelection={legendSelection}
+            onLegendSelectionChange={onLegendSelectionChange}
           />
         );
       }}
@@ -156,6 +166,9 @@ interface VisualizationWidgetContentProps {
   dataScanned?: 'full' | 'partial';
   errorMessage?: string;
   isSampled?: boolean | null;
+  legendSelection?: LegendSelection;
+  onLegendSelectionChange?: (selection: LegendSelection) => void;
+  onZoom?: EChartDataZoomHandler;
   renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   sampleCount?: number;
   showConfidenceWarning?: boolean;
@@ -181,6 +194,9 @@ function VisualizationWidgetContent({
   dataScanned,
   isSampled,
   sampleCount,
+  onZoom,
+  legendSelection,
+  onLegendSelectionChange,
 }: VisualizationWidgetContentProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -420,6 +436,9 @@ function VisualizationWidgetContent({
             showReleaseAs={showReleaseAs}
             showLegend="never"
             axisRange={widget.axisRange}
+            onZoom={onZoom}
+            legendSelection={legendSelection}
+            onLegendSelectionChange={onLegendSelectionChange}
           />
         </Container>
         <Container {...timeseriesContainerPadding}>{confidenceFooter}</Container>
@@ -440,6 +459,9 @@ function VisualizationWidgetContent({
           releases={releases}
           showReleaseAs={showReleaseAs}
           axisRange={widget.axisRange}
+          onZoom={onZoom}
+          legendSelection={legendSelection}
+          onLegendSelectionChange={onLegendSelectionChange}
         />
       </Container>
       <Container {...timeseriesContainerPadding}>{confidenceFooter}</Container>


### PR DESCRIPTION
Use `VisualizationWidget` (backed by `TimeSeriesWidgetVisualization`) in
the fullscreen data widget viewer modal for time series widgets (LINE,
AREA, BAR), aligning it with the dashboard card rendering path.

Previously the modal always used `WidgetCardChartContainer` which renders
via the older ECharts chart components in `chart.tsx`. This is a step
toward eventually removing the time series rendering code from
`WidgetCardChartContainer`/`chart.tsx`.

To support this, `VisualizationWidget` gains three new props that are
forwarded to `TimeSeriesWidgetVisualization`:
- `onZoom` — zoom callback for the modal's custom zoom-to-selection behavior
- `legendSelection` — controlled legend selection state
- `onLegendSelectionChange` — legend toggle callback

Non-time-series widgets (TABLE, BIG_NUMBER, TEXT, etc.) still fall back
to `WidgetCardChartContainer`.

Refs DAIN-1258