### PR TITLE
fix(performance): Add is_transaction filter to FailureRateWidget queries

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -43,6 +43,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
 
   const transactionSearch = new MutableSearch('');
   transactionSearch.addFilterValue('transaction', transactionName);
+  transactionSearch.addFilterValue('is_transaction', 'true');
 
   const {
     data: failureRateSeriesData,


### PR DESCRIPTION
The EAP FailureRateWidget was missing the `is_transaction:true` filter, which is required to approximate the old transaction queries on the spans dataset. (Without it we consider all spans, not just transaction root spans).