### PR TITLE
bug(preprod): Fix overlay color selection

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -305,6 +305,7 @@ const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`
   mask-mode: luminance;
   -webkit-mask-image: url(${p => p.$maskUrl});
   -webkit-mask-size: 100% 100%;
+  -webkit-mask-mode: luminance;
 `;
 
 const OnionContainer = styled('div')`

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -305,7 +305,6 @@ const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`
   mask-mode: luminance;
   -webkit-mask-image: url(${p => p.$maskUrl});
   -webkit-mask-size: 100% 100%;
-  -webkit-mask-mode: luminance;
 `;
 
 const OnionContainer = styled('div')`

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -168,23 +168,24 @@ function OverlayControls({
   showOverlay: boolean;
 }) {
   const theme = useTheme();
-  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
 
   const overlayColors = theme.chart.getColorPalette(10);
 
   useEffect(() => {
-    if (!isPickerOpen) {
+    if (!isColorPickerOpen) {
       return undefined;
     }
+
     function handleMouseDown(e: MouseEvent) {
       if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
-        setIsPickerOpen(false);
+        setIsColorPickerOpen(false);
       }
     }
     document.addEventListener('mousedown', handleMouseDown);
     return () => document.removeEventListener('mousedown', handleMouseDown);
-  }, [isPickerOpen]);
+  }, [isColorPickerOpen]);
 
   return (
     <Flex align="center" gap="sm">
@@ -197,21 +198,21 @@ function OverlayControls({
       </Button>
       <ColorPickerWrapper ref={pickerRef}>
         <ColorTrigger
-          $color={overlayColor}
+          color={overlayColor}
           aria-label={t('Pick overlay color')}
-          onClick={() => setIsPickerOpen(open => !open)}
+          onClick={() => setIsColorPickerOpen(open => !open)}
         />
-        {isPickerOpen && (
+        {isColorPickerOpen && (
           <ColorPickerDropdown>
             <Flex gap="xs">
               {overlayColors.map(color => (
                 <ColorSwatch
                   key={color}
-                  $color={color}
-                  $selected={overlayColor === color}
+                  color={color}
+                  selected={overlayColor === color}
                   onClick={() => {
                     onOverlayColorChange(color);
-                    setIsPickerOpen(false);
+                    setIsColorPickerOpen(false);
                   }}
                   aria-label={t('Overlay color %s', color)}
                 />
@@ -241,13 +242,13 @@ const ColorPickerDropdown = styled('div')`
   z-index: ${p => p.theme.zIndex.dropdown};
 `;
 
-const ColorTrigger = styled('button')<{$color: string}>`
+const ColorTrigger = styled('button')<{color: string}>`
   width: 24px;
   height: 24px;
   border-radius: 50%;
   cursor: pointer;
   border: 2px solid ${p => p.theme.tokens.border.primary};
-  background-color: ${p => p.$color};
+  background-color: ${p => p.color};
   padding: 0;
 
   &:hover {
@@ -255,15 +256,15 @@ const ColorTrigger = styled('button')<{$color: string}>`
   }
 `;
 
-const ColorSwatch = styled('button')<{$color: string; $selected: boolean}>`
+const ColorSwatch = styled('button')<{color: string; selected: boolean}>`
   width: 20px;
   height: 20px;
   border-radius: 50%;
   cursor: pointer;
   border: 2px solid
-    ${p => (p.$selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
-  background-color: ${p => p.$color};
+    ${p => (p.selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
+  background-color: ${p => p.color};
   padding: 0;
-  outline: ${p => (p.$selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
+  outline: ${p => (p.selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
   outline-offset: 1px;
 `;

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -169,8 +169,22 @@ function OverlayControls({
 }) {
   const theme = useTheme();
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
 
   const overlayColors = theme.chart.getColorPalette(10);
+
+  useEffect(() => {
+    if (!isPickerOpen) {
+      return undefined;
+    }
+    function handleMouseDown(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setIsPickerOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [isPickerOpen]);
 
   return (
     <Flex align="center" gap="sm">
@@ -181,7 +195,7 @@ function OverlayControls({
       >
         {showOverlay ? t('Hide Overlay') : t('Show Overlay')}
       </Button>
-      <ColorPickerWrapper>
+      <ColorPickerWrapper ref={pickerRef}>
         <ColorTrigger
           $color={overlayColor}
           aria-label={t('Pick overlay color')}

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -5,7 +6,6 @@ import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -168,6 +168,7 @@ function OverlayControls({
   showOverlay: boolean;
 }) {
   const theme = useTheme();
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
 
   const overlayColors = theme.chart.getColorPalette(10);
 
@@ -180,28 +181,51 @@ function OverlayControls({
       >
         {showOverlay ? t('Hide Overlay') : t('Show Overlay')}
       </Button>
-      <Tooltip
-        isHoverable
-        maxWidth={400}
-        title={
-          <Flex gap="xs">
-            {overlayColors.map(color => (
-              <ColorSwatch
-                key={color}
-                $color={color}
-                $selected={overlayColor === color}
-                onClick={() => onOverlayColorChange(color)}
-                aria-label={t('Overlay color %s', color)}
-              />
-            ))}
-          </Flex>
-        }
-      >
-        <ColorTrigger $color={overlayColor} aria-label={t('Pick overlay color')} />
-      </Tooltip>
+      <ColorPickerWrapper>
+        <ColorTrigger
+          $color={overlayColor}
+          aria-label={t('Pick overlay color')}
+          onClick={() => setIsPickerOpen(open => !open)}
+        />
+        {isPickerOpen && (
+          <ColorPickerDropdown>
+            <Flex gap="xs">
+              {overlayColors.map(color => (
+                <ColorSwatch
+                  key={color}
+                  $color={color}
+                  $selected={overlayColor === color}
+                  onClick={() => {
+                    onOverlayColorChange(color);
+                    setIsPickerOpen(false);
+                  }}
+                  aria-label={t('Overlay color %s', color)}
+                />
+              ))}
+            </Flex>
+          </ColorPickerDropdown>
+        )}
+      </ColorPickerWrapper>
     </Flex>
   );
 }
+
+const ColorPickerWrapper = styled('div')`
+  position: relative;
+`;
+
+const ColorPickerDropdown = styled('div')`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: ${p => p.theme.space.xs};
+  padding: ${p => p.theme.space.sm};
+  background: ${p => p.theme.tokens.background.primary};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
+  z-index: ${p => p.theme.zIndex.dropdown};
+`;
 
 const ColorTrigger = styled('button')<{$color: string}>`
   width: 24px;


### PR DESCRIPTION
Fixes overlay color selection. The inherent issue is the overlay selection being in a tooltip prevented the clicking on the specific swatch buttons. This now leverages a more custom component to handle the overlay. Resolves EME-954.

<img width="788" height="1062" alt="Screenshot 2026-03-16 at 11 25 04 AM" src="https://github.com/user-attachments/assets/6dc1971b-25f2-45fe-bf33-9a40a58e5a88" />
