### PR TITLE
fix(scoping): Pass X-Viewer-Context on supergroups list/get requests to Seer

### DIFF
--- a/src/sentry/seer/endpoints/organization_supergroup_details.py
+++ b/src/sentry/seer/endpoints/organization_supergroup_details.py
@@ -12,7 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.signed_seer_api import make_supergroups_get_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_supergroups_get_request
 
 logger = logging.getLogger(__name__)
 
@@ -36,10 +36,8 @@ class OrganizationSupergroupDetailsEndpoint(OrganizationEndpoint):
             return Response({"detail": "Feature not available"}, status=403)
 
         response = make_supergroups_get_request(
-            body={
-                "organization_id": organization.id,
-                "supergroup_id": supergroup_id,
-            },
+            {"organization_id": organization.id, "supergroup_id": supergroup_id},
+            SeerViewerContext(organization_id=organization.id, user_id=request.user.id),
             timeout=10,
         )
 

--- a/src/sentry/seer/endpoints/organization_supergroups.py
+++ b/src/sentry/seer/endpoints/organization_supergroups.py
@@ -12,7 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.signed_seer_api import make_supergroups_list_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_supergroups_list_request
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +36,8 @@ class OrganizationSupergroupsEndpoint(OrganizationEndpoint):
             return Response({"detail": "Feature not available"}, status=403)
 
         response = make_supergroups_list_request(
-            body={
-                "organization_id": organization.id,
-            },
+            {"organization_id": organization.id},
+            SeerViewerContext(organization_id=organization.id, user_id=request.user.id),
             timeout=10,
         )
 

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -346,6 +346,7 @@ def make_supergroups_embedding_request(
 
 def make_supergroups_list_request(
     body: SupergroupsListRequest,
+    viewer_context: SeerViewerContext,
     timeout: int | float | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
@@ -353,11 +354,13 @@ def make_supergroups_list_request(
         "/v0/issues/supergroups/list",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_supergroups_get_request(
     body: SupergroupsGetRequest,
+    viewer_context: SeerViewerContext,
     timeout: int | float | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
@@ -365,6 +368,7 @@ def make_supergroups_get_request(
         "/v0/issues/supergroups/get",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 


### PR DESCRIPTION
## Summary
- Adds `viewer_context` parameter to `make_supergroups_list_request` and `make_supergroups_get_request`
- Passes `SeerViewerContext(organization_id, user_id)` from the supergroups list and detail endpoints

These endpoints were the only supergroups call sites not sending the `X-Viewer-Context` header to Seer, causing `OrganizationScoped` validation errors (SEER-7P5).

## Test plan
- [x] Verified locally: Seer logs `ActorContext set from X-Viewer-Context` when header is present
- [ ] After deploy, SEER-7P5 event volume should drop to zero


Agent transcript: https://claudescope.sentry.dev/share/-Im9fOrNO5oHm22L3mTaH_pN_j6rK5n_QkFSPygYm5E