### PR TITLE
fix(aci): Show detector environment in disabled environment selector

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -266,7 +266,7 @@ function EnvironmentSelector({group, event, project}: EventDetailsHeaderProps) {
       <EnvironmentPageFilter
         disabled
         triggerProps={{
-          label: detectorEnvironment ?? eventEnvironment ?? t('All Envs'),
+          label: eventEnvironment ?? detectorEnvironment ?? t('All Envs'),
           title: t('This issue only occurs in a single environment'),
           style,
         }}

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -251,6 +251,8 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
 function EnvironmentSelector({group, event, project}: EventDetailsHeaderProps) {
   const issueTypeConfig = getConfigForIssueType(group, project);
   const isFixedEnvironment = issueTypeConfig.header.filterBar.fixedEnvironment;
+  const detectorEnvironment =
+    event?.occurrence?.evidenceData?.dataSources?.[0]?.queryObj?.snubaQuery?.environment;
   const eventEnvironment = event?.tags?.find(tag => tag.key === 'environment')?.value;
   const theme = useTheme();
   const style = {
@@ -261,7 +263,7 @@ function EnvironmentSelector({group, event, project}: EventDetailsHeaderProps) {
     <EnvironmentPageFilter
       disabled
       triggerProps={{
-        label: eventEnvironment ?? t('All Envs'),
+        label: detectorEnvironment ?? eventEnvironment ?? t('All Envs'),
         title: t('This issue only occurs in a single environment'),
         style,
       }}

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -251,26 +251,30 @@ export function EventDetailsHeader({group, event, project}: EventDetailsHeaderPr
 function EnvironmentSelector({group, event, project}: EventDetailsHeaderProps) {
   const issueTypeConfig = getConfigForIssueType(group, project);
   const isFixedEnvironment = issueTypeConfig.header.filterBar.fixedEnvironment;
-  const detectorEnvironment =
-    event?.occurrence?.evidenceData?.dataSources?.[0]?.queryObj?.snubaQuery?.environment;
-  const eventEnvironment = event?.tags?.find(tag => tag.key === 'environment')?.value;
+
   const theme = useTheme();
   const style = {
     padding: `${theme.space.md} ${theme.space.lg}`,
   };
 
-  return isFixedEnvironment ? (
-    <EnvironmentPageFilter
-      disabled
-      triggerProps={{
-        label: detectorEnvironment ?? eventEnvironment ?? t('All Envs'),
-        title: t('This issue only occurs in a single environment'),
-        style,
-      }}
-    />
-  ) : (
-    <EnvironmentPageFilter triggerProps={{style}} />
-  );
+  if (isFixedEnvironment) {
+    const detectorEnvironment =
+      event?.occurrence?.evidenceData?.dataSources?.[0]?.queryObj?.snubaQuery
+        ?.environment;
+    const eventEnvironment = event?.tags?.find(tag => tag.key === 'environment')?.value;
+    return (
+      <EnvironmentPageFilter
+        disabled
+        triggerProps={{
+          label: detectorEnvironment ?? eventEnvironment ?? t('All Envs'),
+          title: t('This issue only occurs in a single environment'),
+          style,
+        }}
+      />
+    );
+  }
+
+  return <EnvironmentPageFilter triggerProps={{style}} />;
 }
 
 const DetailsContainer = styled('div')<{hasFilterBar: boolean}>`


### PR DESCRIPTION
Use the snuba query environment from the detector's data when displaying the fixed environment label on issue details. This matches the environment used by the 'Open in Discover' link.

fixes ISWF-2243
