### PR TITLE
feat(oauth): Add Authorization Server Metadata endpoint (RFC 8414)

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -98,6 +98,7 @@ def mcp_json(request):
 
     return HttpResponse(json.dumps(MCP_CONFIG), content_type="application/json")
 
+
 @all_silo_view
 @cache_control(max_age=3600, public=True)
 def oauth_authorization_server_metadata(request: HttpRequest) -> HttpResponse:
@@ -132,6 +133,8 @@ def oauth_authorization_server_metadata(request: HttpRequest) -> HttpResponse:
     }
 
     return HttpResponse(json.dumps(metadata), content_type="application/json")
+
+
 @all_silo_view
 @cache_control(max_age=3600, public=True)
 def not_found(request):

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -102,11 +102,31 @@ def mcp_json(request):
 @all_silo_view
 @cache_control(max_age=3600, public=True)
 def oauth_authorization_server_metadata(request: HttpRequest) -> HttpResponse:
-    """
-    OAuth 2.0 Authorization Server Metadata endpoint per RFC 8414.
+    """OAuth 2.0 Authorization Server Metadata endpoint (RFC 8414).
 
-    Returns JSON metadata document describing the authorization server's
-    configuration, supported grant types, PKCE methods, and endpoints.
+    Purpose
+    - Publishes Sentry's authorization server metadata so OAuth clients can
+      discover the issuer, endpoint URLs, supported grant types, PKCE methods,
+      client authentication methods, and available scopes without hardcoding
+      configuration.
+
+    Request
+    - `GET /.well-known/oauth-authorization-server`
+    - No authentication is required (RFC 8414 §3).
+
+    Response
+    - Success: 200 JSON metadata document including:
+      `issuer`, `authorization_endpoint`, `token_endpoint`,
+      `userinfo_endpoint`, `device_authorization_endpoint`,
+      `response_types_supported`, `grant_types_supported`,
+      `code_challenge_methods_supported`,
+      `token_endpoint_auth_methods_supported`, and `scopes_supported`.
+    - Cache headers: `Cache-Control: max-age=3600, public`.
+
+    Notes
+    - `issuer` is published as Sentry's canonical base URL.
+    - `response_types_supported` is limited to `code`.
+    - `code_challenge_methods_supported` is limited to `S256`.
     """
     # Build sorted scopes list for consistent output
     scopes = sorted(settings.SENTRY_SCOPES)

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -1,11 +1,13 @@
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
+from django.urls import reverse
 from django.views.decorators.cache import cache_control
 from django.views.generic.base import View as BaseView
 from rest_framework.request import Request
 
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.utils import json
+from sentry.utils.http import absolute_uri
 from sentry.web.client_config import get_client_config
 from sentry.web.frontend.base import all_silo_view
 
@@ -96,7 +98,40 @@ def mcp_json(request):
 
     return HttpResponse(json.dumps(MCP_CONFIG), content_type="application/json")
 
+@all_silo_view
+@cache_control(max_age=3600, public=True)
+def oauth_authorization_server_metadata(request: HttpRequest) -> HttpResponse:
+    """
+    OAuth 2.0 Authorization Server Metadata endpoint per RFC 8414.
 
+    Returns JSON metadata document describing the authorization server's
+    configuration, supported grant types, PKCE methods, and endpoints.
+    """
+    # Build sorted scopes list for consistent output
+    scopes = sorted(settings.SENTRY_SCOPES)
+
+    metadata = {
+        "issuer": absolute_uri(),
+        "authorization_endpoint": absolute_uri(reverse("sentry-oauth-authorize")),
+        "token_endpoint": absolute_uri(reverse("sentry-oauth-token")),
+        "userinfo_endpoint": absolute_uri(reverse("sentry-api-0-oauth-userinfo")),
+        "device_authorization_endpoint": absolute_uri(reverse("sentry-oauth-device-code")),
+        "response_types_supported": ["code"],
+        "grant_types_supported": [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+        ],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_basic",
+            "client_secret_post",
+            "none",
+        ],
+        "scopes_supported": scopes,
+    }
+
+    return HttpResponse(json.dumps(metadata), content_type="application/json")
 @all_silo_view
 @cache_control(max_age=3600, public=True)
 def not_found(request):

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -9,7 +9,7 @@ from sentry.conf.types.sentry_config import SentryMode
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.web.client_config import get_client_config
-from sentry.web.frontend.base import all_silo_view
+from sentry.web.frontend.base import all_silo_view, control_silo_view
 
 # Paths to pages should not be added here, otherwise crawlers will
 # not be able to access the metadata with the 'none' directive
@@ -99,7 +99,7 @@ def mcp_json(request):
     return HttpResponse(json.dumps(MCP_CONFIG), content_type="application/json")
 
 
-@all_silo_view
+@control_silo_view
 @cache_control(max_age=3600, public=True)
 def oauth_authorization_server_metadata(request: HttpRequest) -> HttpResponse:
     """OAuth 2.0 Authorization Server Metadata endpoint (RFC 8414).

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1261,6 +1261,11 @@ urlpatterns += [
         api.mcp_json,
         name="sentry-mcp-json",
     ),
+    re_path(
+        r"^\.well-known/oauth-authorization-server$",
+        api.oauth_authorization_server_metadata,
+        name="sentry-oauth-authorization-server-metadata",
+    ),
     # Force a 404 of favicon.ico.
     # This url is commonly requested by browsers, and without
     # blocking this, it was treated as a 200 OK for a react page view.

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -168,6 +168,7 @@ const patterns: RegExp[] = [
   new RegExp('^api/0/tempest-ips/$'),
   new RegExp('^api/0/secret-scanning/github/$'),
   new RegExp('^api/hooks/mailgun/inbound/'),
+  new RegExp('^\\.well-known/oauth-authorization-server$'),
   new RegExp('^oauth/authorize/$'),
   new RegExp('^oauth/token/$'),
   new RegExp('^oauth/userinfo/$'),

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -700,3 +700,64 @@ class McpJsonTest(TestCase):
         assert response.status_code == 200
         assert "max-age=3600" in response["Cache-Control"]
         assert "public" in response["Cache-Control"]
+
+
+class OAuthAuthorizationServerMetadataTest(TestCase):
+    @cached_property
+    def path(self) -> str:
+        return reverse("sentry-oauth-authorization-server-metadata")
+
+    def test_metadata_response(self) -> None:
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/json"
+
+        data = json.loads(response.content)
+
+        # RFC 8414 required fields
+        assert "issuer" in data
+        assert "authorization_endpoint" in data
+        assert "token_endpoint" in data
+
+        assert data["authorization_endpoint"].endswith("/oauth/authorize/")
+        assert data["token_endpoint"].endswith("/oauth/token/")
+        assert data["userinfo_endpoint"].endswith("/oauth/userinfo/")
+        assert data["device_authorization_endpoint"].endswith("/oauth/device/code/")
+
+        assert data["grant_types_supported"] == [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+        ]
+
+        # OAuth 2.1 only allows "code" response type
+        assert data["response_types_supported"] == ["code"]
+
+        # S256 only per security best practices
+        assert data["code_challenge_methods_supported"] == ["S256"]
+
+        assert data["token_endpoint_auth_methods_supported"] == [
+            "client_secret_basic",
+            "client_secret_post",
+            "none",
+        ]
+
+        assert "scopes_supported" in data
+        assert data["scopes_supported"] == sorted(data["scopes_supported"])
+        assert "openid" in data["scopes_supported"]
+        assert "org:read" in data["scopes_supported"]
+        assert "project:read" in data["scopes_supported"]
+
+    def test_cache_control(self) -> None:
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+        assert "max-age=3600" in response["Cache-Control"]
+        assert "public" in response["Cache-Control"]
+
+    def test_issuer_matches_server(self) -> None:
+        response = self.client.get(self.path)
+        data = json.loads(response.content)
+
+        assert data["issuer"] == "http://testserver"

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -18,6 +18,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test, create_test_regions
 from sentry.utils import json
+from sentry.utils.http import absolute_uri
 
 
 class RobotsTxtTest(TestCase):
@@ -705,7 +706,7 @@ class McpJsonTest(TestCase):
 class OAuthAuthorizationServerMetadataTest(TestCase):
     @cached_property
     def path(self) -> str:
-        return reverse("sentry-oauth-authorization-server-metadata")
+        return "/.well-known/oauth-authorization-server"
 
     def test_metadata_response(self) -> None:
         response = self.client.get(self.path)
@@ -720,10 +721,10 @@ class OAuthAuthorizationServerMetadataTest(TestCase):
         assert "authorization_endpoint" in data
         assert "token_endpoint" in data
 
-        assert data["authorization_endpoint"].endswith("/oauth/authorize/")
-        assert data["token_endpoint"].endswith("/oauth/token/")
-        assert data["userinfo_endpoint"].endswith("/oauth/userinfo/")
-        assert data["device_authorization_endpoint"].endswith("/oauth/device/code/")
+        assert data["authorization_endpoint"] == absolute_uri("/oauth/authorize/")
+        assert data["token_endpoint"] == absolute_uri("/oauth/token/")
+        assert data["userinfo_endpoint"] == absolute_uri("/oauth/userinfo/")
+        assert data["device_authorization_endpoint"] == absolute_uri("/oauth/device/code/")
 
         assert data["grant_types_supported"] == [
             "authorization_code",

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -706,6 +706,8 @@ class McpJsonTest(TestCase):
 class OAuthAuthorizationServerMetadataTest(TestCase):
     @cached_property
     def path(self) -> str:
+        # RFC 8414 fixes the discovery URL, so test the concrete well-known path
+        # and exact absolute endpoint values rather than Django route indirection.
         return "/.well-known/oauth-authorization-server"
 
     def test_metadata_response(self) -> None:

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -711,7 +711,8 @@ class OAuthAuthorizationServerMetadataTest(TestCase):
         return "/.well-known/oauth-authorization-server"
 
     def test_metadata_response(self) -> None:
-        response = self.client.get(self.path)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            response = self.client.get(self.path)
 
         assert response.status_code == 200
         assert response["Content-Type"] == "application/json"
@@ -753,14 +754,16 @@ class OAuthAuthorizationServerMetadataTest(TestCase):
         assert "project:read" in data["scopes_supported"]
 
     def test_cache_control(self) -> None:
-        response = self.client.get(self.path)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            response = self.client.get(self.path)
 
         assert response.status_code == 200
         assert "max-age=3600" in response["Cache-Control"]
         assert "public" in response["Cache-Control"]
 
     def test_issuer_matches_server(self) -> None:
-        response = self.client.get(self.path)
-        data = json.loads(response.content)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            response = self.client.get(self.path)
+            data = json.loads(response.content)
 
         assert data["issuer"] == "http://testserver"


### PR DESCRIPTION
Add /.well-known/oauth-authorization-server discovery metadata for Sentry's OAuth server.

This lets OAuth clients discover the authorize, token, userinfo, and device code endpoints without hardcoding them, and advertises the grant types, PKCE support, auth methods, and scopes that Sentry currently supports.

This also canonicalizes the published issuer to Sentry's base URL and resolves endpoint URLs from named routes so the metadata stays aligned with the actual OAuth endpoints.

This replaces #107017, which was closed before the follow-up metadata fix landed.

Refs #99002