### PR TITLE
ref(grouping): More parameterization metric improvements

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -265,7 +265,13 @@ class Parameterizer:
         # pattern will fall back to the standard pattern.)
         use_experimental_regexes: bool = False,
     ):
-        self._experimental = use_experimental_regexes
+        self._experimental = (
+            use_experimental_regexes
+            # Only mark the parameterizer as experimental if there are actually any experiments
+            # running. If there aren't, then both parameterizers use the default regex patterns, so
+            # the "experimental" parameterizer isn't actually experimental.
+            and EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP != DEFAULT_PARAMETERIZATION_REGEXES_MAP
+        )
         self._parameterization_regex = self._make_regex_from_patterns(
             regex_pattern_keys or DEFAULT_PARAMETERIZATION_REGEXES_MAP.keys()
         )

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -316,11 +316,6 @@ class Parameterizer:
             parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
             metric_tags["changed"] = parameterized != input_str
 
-        metrics.incr(
-            "grouping.parameterizer_called",
-            tags={"changed": parameterized != input_str, "experimental": self._experimental},
-        )
-
         for key, value in matches_counter.items():
             # Track the kinds of replacements being made
             metrics.incr("grouping.value_parameterized", amount=value, tags={"key": key})

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -310,7 +310,8 @@ class Parameterizer:
                     return f"<{key}>"
             return ""
 
-        parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
+        with metrics.timer("grouping.parameterize", tags={"experimental": self._experimental}):
+            parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
 
         metrics.incr(
             "grouping.parameterizer_called",

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -310,8 +310,11 @@ class Parameterizer:
                     return f"<{key}>"
             return ""
 
-        with metrics.timer("grouping.parameterize", tags={"experimental": self._experimental}):
+        with metrics.timer(
+            "grouping.parameterize", tags={"experimental": self._experimental}
+        ) as metric_tags:
             parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
+            metric_tags["changed"] = parameterized != input_str
 
         metrics.incr(
             "grouping.parameterizer_called",


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/110612, making a few more improvements to our message parameterization metrics.

- Until recently, message parameterization was only ever the result of a call to `normalize_message_for_grouping`, so timing that function was a good proxy for timing parameterization itself. However, in https://github.com/getsentry/sentry/pull/110605 we changed it so that a) `normalize_message_for_grouping` no longer calls the parameterizer every time it runs (instead relying on a cached value), and b) the initial calculation of that cached value happens elsewhere. `normalize_message_for_grouping` still _can_ call the parameterizer, but it now only does so in cases where it has to parameterize something other than the event's primary message (in the case of error chains, for example). Thus timing it is no longer a good way to measure how fast parameterization runs. This fixes that by adding a timer to the parameterization itself.

- With that timing metric in place, we no longer need the `parameterizer_called` metric, because we can just use the timing metrics `.count` values to get the same information, so this removes it in favor of adding the `experimental` and `changed` tags to the timer.

- Right now, parameterization can be tagged as being experimental even if the experimental parameterizer isn't actually any different than the default one. This fixes that by checking the two regex sets against each other before setting the parameterizer's `_experimental` attribute.