### PR TITLE
feat(ACI): Handle owner passed to workflow

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -829,11 +829,11 @@ OWNER_HELP_TEXT = """
 
             **User**
             ```json
-                "user:123456
+                "user:123456"
             ```
 
             **Team**
             ```json
-                "team:456789
+                "team:456789"
             ```
         """

--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -825,20 +825,15 @@ CONDITION_GROUP_HELP_TEXT = """
         """
 
 OWNER_HELP_TEXT = """
-            The user or team who owns the monitor.
+            The ID user or team who owns the monitor or alert prefaced by the string 'user' or 'team'.
 
             **User**
             ```json
-                "type": "user",
-                "id": "12345",
-                "name": "Jane Doe",
-                "email": "jane.doe@sentry.io"
+                "user:123456
             ```
 
             **Team**
             ```json
-                "type": "team",
-                "id": "123456789",
-                "name": "example-team"
+                "team:456789
             ```
         """

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -195,7 +195,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
             # Handle owner field update
             if "owner" in validated_data:
                 instance.owner_user_id, instance.owner_team_id = update_owner(
-                    validated_data.get("owner")
+                    validated_data.pop("owner")
                 )
 
             if "condition_group" in validated_data:
@@ -272,14 +272,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
                         condition_group=condition_group,
                     )
 
-            owner = validated_data.get("owner")
-            owner_user_id = None
-            owner_team_id = None
-            if owner:
-                if owner.is_user:
-                    owner_user_id = owner.id
-                elif owner.is_team:
-                    owner_team_id = owner.id
+            owner_user_id, owner_team_id = update_owner(validated_data.get("owner"))
 
             detector = Detector(
                 project_id=self.context["project"].id,

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -28,6 +28,7 @@ from sentry.workflow_engine.endpoints.validators.utils import (
     get_unknown_detector_type_error,
     log_alerting_quota_hit,
     toggle_detector,
+    update_owner,
 )
 from sentry.workflow_engine.models import (
     DataConditionGroup,
@@ -193,18 +194,9 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
 
             # Handle owner field update
             if "owner" in validated_data:
-                owner = validated_data.get("owner")
-                if owner:
-                    if owner.is_user:
-                        instance.owner_user_id = owner.id
-                        instance.owner_team_id = None
-                    elif owner.is_team:
-                        instance.owner_user_id = None
-                        instance.owner_team_id = owner.id
-                else:
-                    # Clear owner if None is passed
-                    instance.owner_user_id = None
-                    instance.owner_team_id = None
+                instance.owner_user_id, instance.owner_team_id = update_owner(
+                    validated_data.get("owner")
+                )
 
             if "condition_group" in validated_data:
                 condition_group = validated_data.pop("condition_group")

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -23,6 +23,7 @@ from sentry.workflow_engine.endpoints.validators.base import (
 from sentry.workflow_engine.endpoints.validators.utils import (
     log_alerting_quota_hit,
     remove_items_by_api_input,
+    update_owner,
     validate_json_schema,
 )
 from sentry.workflow_engine.models import (
@@ -253,21 +254,13 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
 
             # Handle owner field update
             if "owner" in validated_data:
-                owner = validated_data.pop("owner")
-                if owner:
-                    if owner.is_user:
-                        instance.owner_user_id = owner.id
-                        instance.owner_team_id = None
-                    elif owner.is_team:
-                        instance.owner_user_id = None
-                        instance.owner_team_id = owner.id
-                else:
-                    # Clear owner if None is passed
-                    instance.owner_user_id = None
-                    instance.owner_team_id = None
+                instance.owner_user_id, instance.owner_team_id = update_owner(
+                    validated_data.get("owner")
+                )
 
             # Update the workflow
             instance.update(**validated_data)
+            instance.save()
             return instance
 
     def _validate_workflow_limits(self) -> None:

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -255,7 +255,7 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
             # Handle owner field update
             if "owner" in validated_data:
                 instance.owner_user_id, instance.owner_team_id = update_owner(
-                    validated_data.get("owner")
+                    validated_data.pop("owner")
                 )
 
             # Update the workflow
@@ -306,6 +306,8 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
                     owner_user_id = owner.id
                 elif owner.is_team:
                     owner_team_id = owner.id
+
+            owner_user_id, owner_team_id = update_owner(validated_value.get("owner"))
 
             workflow = Workflow.objects.create(
                 name=validated_value["name"],

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -4,6 +4,7 @@ from django.db import router, transaction
 from rest_framework import serializers
 
 from sentry import audit_log, features, options
+from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.api.serializers.rest_framework.environment import EnvironmentField
 from sentry.db import models
@@ -11,6 +12,7 @@ from sentry.models.organization import Organization
 from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.validators.api_docs_help_text import (
     ACTION_FILTERS_HELP_TEXT,
+    OWNER_HELP_TEXT,
     WORKFLOW_CONFIG_HELP_TEXT,
     WORKFLOW_TRIGGERS_HELP_TEXT,
 )
@@ -59,6 +61,11 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
     action_filters = serializers.ListField(
         required=False,
         help_text=ACTION_FILTERS_HELP_TEXT,
+    )
+    owner = OwnerActorField(
+        required=False,
+        allow_null=True,
+        help_text=OWNER_HELP_TEXT,
     )
 
     def _split_action_and_condition_group(
@@ -244,6 +251,21 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
             if action_filters is not None:
                 self.update_action_filters(action_filters)
 
+            # Handle owner field update
+            if "owner" in validated_data:
+                owner = validated_data.pop("owner")
+                if owner:
+                    if owner.is_user:
+                        instance.owner_user_id = owner.id
+                        instance.owner_team_id = None
+                    elif owner.is_team:
+                        instance.owner_user_id = None
+                        instance.owner_team_id = owner.id
+                else:
+                    # Clear owner if None is passed
+                    instance.owner_user_id = None
+                    instance.owner_team_id = None
+
             # Update the workflow
             instance.update(**validated_data)
             return instance
@@ -283,6 +305,15 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
 
             environment = validated_value.get("environment")
 
+            owner = validated_value.get("owner")
+            owner_user_id = None
+            owner_team_id = None
+            if owner:
+                if owner.is_user:
+                    owner_user_id = owner.id
+                elif owner.is_team:
+                    owner_team_id = owner.id
+
             workflow = Workflow.objects.create(
                 name=validated_value["name"],
                 enabled=validated_value["enabled"],
@@ -291,6 +322,8 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
                 environment_id=environment.id if environment else None,
                 when_condition_group=when_condition_group,
                 created_by_id=self.context["request"].user.id,
+                owner_user_id=owner_user_id,
+                owner_team_id=owner_team_id,
             )
 
             # TODO -- can we bulk create: actions, dcga's and the workflow dcg?

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -5,6 +5,7 @@ from django.forms import ValidationError
 from jsonschema import ValidationError as JsonValidationError
 from jsonschema import validate
 
+from sentry.api.fields.actor import OwnerActorField
 from sentry.issues import grouptype
 from sentry.models.organization import Organization
 from sentry.users.models.user import User
@@ -13,6 +14,22 @@ from sentry.utils import metrics
 from sentry.workflow_engine.models.detector import Detector
 
 logger = logging.getLogger(__name__)
+
+
+def update_owner(owner: OwnerActorField) -> tuple[int | None, int | None]:
+    if owner:
+        if owner.is_user:
+            owner_user_id = owner.id
+            owner_team_id = None
+        elif owner.is_team:
+            owner_user_id = None
+            owner_team_id = owner.id
+    else:
+        # Clear owner if None is passed
+        owner_user_id = None
+        owner_team_id = None
+
+    return owner_user_id, owner_team_id
 
 
 def log_alerting_quota_hit(

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -5,9 +5,9 @@ from django.forms import ValidationError
 from jsonschema import ValidationError as JsonValidationError
 from jsonschema import validate
 
-from sentry.api.fields.actor import OwnerActorField
 from sentry.issues import grouptype
 from sentry.models.organization import Organization
+from sentry.types.actor import Actor
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.utils import metrics
@@ -16,7 +16,7 @@ from sentry.workflow_engine.models.detector import Detector
 logger = logging.getLogger(__name__)
 
 
-def update_owner(owner: OwnerActorField | None) -> tuple[int | None, int | None]:
+def update_owner(owner: Actor | None) -> tuple[int | None, int | None]:
     if owner:
         if owner.is_user:
             owner_user_id = owner.id

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -16,7 +16,7 @@ from sentry.workflow_engine.models.detector import Detector
 logger = logging.getLogger(__name__)
 
 
-def update_owner(owner: OwnerActorField) -> tuple[int | None, int | None]:
+def update_owner(owner: OwnerActorField | None) -> tuple[int | None, int | None]:
     if owner:
         if owner.is_user:
             owner_user_id = owner.id

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -4,6 +4,7 @@ import pytest
 from rest_framework.exceptions import ErrorDetail
 from rest_framework.serializers import ValidationError
 
+from sentry.auth.access import SystemAccess
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.serializers.workflow_serializer import (
@@ -153,6 +154,96 @@ class TestWorkflowValidatorCreate(TestCase):
         assert workflow.config == self.valid_data["config"]
         assert workflow.organization_id == self.organization.id
         assert workflow.created_by_id == self.user.id
+
+    def test_create__owner_user_id(self) -> None:
+        self.valid_data["owner"] = f"user:{self.user.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is True
+
+        workflow = validator.create(validator.validated_data)
+        assert workflow.owner_user_id == self.user.id
+
+    def test_create__owner_team_id(self) -> None:
+        self.valid_data["owner"] = f"team:{self.team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is True
+
+        workflow = validator.create(validator.validated_data)
+        assert workflow.owner_team_id == self.team.id
+
+    def test_owner_perms(self) -> None:
+        other_user = self.create_user()
+        self.valid_data["owner"] = f"user:{other_user.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is False
+        assert str(validator.errors["owner"][0]) == "User is not a member of this organization"
+
+        other_team = self.create_team(self.create_organization())
+        self.valid_data["owner"] = f"team:{other_team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is False
+        assert str(validator.errors["owner"][0]) == "Team is not a member of this organization"
+
+    def test_team_owner(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        self.valid_data["owner"] = f"team:{team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is True
+        workflow = validator.create(validator.validated_data)
+        assert workflow.owner_team_id == team.id
+        assert workflow.owner_user_id is None
+
+    def test_team_owner_not_member(self) -> None:
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        team = self.create_team(organization=self.organization)
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+
+        context = {
+            "organization": self.organization,
+            "request": self.make_request(user=member_user),
+        }
+        self.valid_data["owner"] = f"team:{team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=context)
+        assert validator.is_valid() is False
+        assert str(validator.errors["owner"][0]) == "You can only assign teams you are a member of"
+
+    def test_team_owner_not_member_with_team_admin_scope(self) -> None:
+        team = self.create_team(organization=self.organization)
+
+        context = {
+            "organization": self.organization,
+            "request": self.make_request(user=self.user),
+            "access": SystemAccess(),
+        }
+        self.valid_data["owner"] = f"team:{team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=context)
+        assert validator.is_valid() is True
+        workflow = validator.create(validator.validated_data)
+        assert workflow.owner_team_id == team.id
+        assert workflow.owner_user_id is None
+
+    def test_user_owner_another_member(self) -> None:
+        other_user = self.create_user()
+        self.create_member(
+            user=other_user,
+            organization=self.organization,
+            role="member",
+        )
+
+        self.valid_data["owner"] = f"user:{other_user.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is True
+        workflow = validator.create(validator.validated_data)
+        assert workflow.owner_user_id == other_user.id
+        assert workflow.owner_team_id is None
 
     def test_create__validate_triggers_empty(self) -> None:
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
@@ -732,3 +823,118 @@ class TestWorkflowValidatorUpdate(TestCase):
         workflow_condition_group = self.workflow.workflowdataconditiongroup_set.first()
         assert workflow_condition_group is not None
         assert workflow_condition_group.condition_group.dataconditiongroupaction_set.count() == 0
+
+    def test_update_owner_type(self, mock_action_validator: mock.MagicMock) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        context = {**self.context, "request": self.make_request(user=self.user)}
+
+        self.valid_data["owner"] = f"team:{team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=context)
+        assert validator.is_valid() is True
+        workflow = validator.update(self.workflow, validator.validated_data)
+        assert workflow.owner_team_id == team.id
+        assert workflow.owner_user_id is None
+
+        self.valid_data["owner"] = f"user:{self.user.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=context)
+        assert validator.is_valid() is True
+        workflow = validator.update(self.workflow, validator.validated_data)
+        assert workflow.owner_user_id == self.user.id
+        assert workflow.owner_team_id is None
+
+    def test_team_owner_not_member(self, mock_action_validator: mock.MagicMock) -> None:
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        team = self.create_team(organization=self.organization)
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+
+        context = {**self.context, "request": self.make_request(user=member_user)}
+        self.valid_data["owner"] = f"team:{team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=context)
+        assert validator.is_valid() is False
+        assert str(validator.errors["owner"][0]) == "You can only assign teams you are a member of"
+
+    def test_team_owner_not_member_with_team_admin_scope(
+        self, mock_action_validator: mock.MagicMock
+    ) -> None:
+        team = self.create_team(organization=self.organization)
+
+        context = {**self.context, "access": SystemAccess()}
+        self.valid_data["owner"] = f"team:{team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=context)
+        assert validator.is_valid() is True
+        workflow = validator.update(self.workflow, validator.validated_data)
+        assert workflow.owner_team_id == team.id
+        assert workflow.owner_user_id is None
+
+    def test_reassign_owner_from_own_team_to_any_team(
+        self, mock_action_validator: mock.MagicMock
+    ) -> None:
+        from sentry.types.actor import Actor
+
+        member_team = self.create_team(organization=self.organization)
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[member_team],
+        )
+        target_team = self.create_team(organization=self.organization)
+
+        self.workflow.owner_team_id = member_team.id
+        self.workflow.save()
+
+        current_owner = Actor.from_id(user_id=None, team_id=member_team.id)
+        context = {
+            **self.context,
+            "request": self.make_request(user=member_user),
+            "current_owner": current_owner,
+        }
+        self.valid_data["owner"] = f"team:{target_team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=context)
+        assert validator.is_valid() is True
+        workflow = validator.update(self.workflow, validator.validated_data)
+        assert workflow.owner_team_id == target_team.id
+
+    def test_cannot_reassign_owner_from_other_team(
+        self, mock_action_validator: mock.MagicMock
+    ) -> None:
+        from sentry.types.actor import Actor
+
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        other_team = self.create_team(organization=self.organization)
+        member_team = self.create_team(organization=self.organization)
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[member_team],
+        )
+        target_team = self.create_team(organization=self.organization)
+
+        self.workflow.owner_team_id = other_team.id
+        self.workflow.save()
+
+        current_owner = Actor.from_id(user_id=None, team_id=other_team.id)
+        context = {
+            **self.context,
+            "request": self.make_request(user=member_user),
+            "current_owner": current_owner,
+        }
+        self.valid_data["owner"] = f"team:{target_team.id}"
+        validator = WorkflowValidator(data=self.valid_data, context=context)
+        assert validator.is_valid() is False
+        assert str(validator.errors["owner"][0]) == "You can only assign teams you are a member of"
+        self.workflow.refresh_from_db()
+        assert self.workflow.owner_team_id == other_team.id

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -7,6 +7,7 @@ from rest_framework.serializers import ValidationError
 from sentry.auth.access import SystemAccess
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestCase
+from sentry.types.actor import Actor
 from sentry.workflow_engine.endpoints.serializers.workflow_serializer import (
     TriggerSerializerResponse,
     WorkflowSerializer,
@@ -869,8 +870,6 @@ class TestWorkflowValidatorUpdate(TestCase):
     def test_reassign_owner_from_own_team_to_any_team(
         self, mock_action_validator: mock.MagicMock
     ) -> None:
-        from sentry.types.actor import Actor
-
         member_team = self.create_team(organization=self.organization)
         member_user = self.create_user()
         self.create_member(

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -898,8 +898,6 @@ class TestWorkflowValidatorUpdate(TestCase):
     def test_cannot_reassign_owner_from_other_team(
         self, mock_action_validator: mock.MagicMock
     ) -> None:
-        from sentry.types.actor import Actor
-
         self.organization.flags.allow_joinleave = False
         self.organization.save()
 

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -163,13 +163,14 @@ class TestWorkflowValidatorCreate(TestCase):
         workflow = validator.create(validator.validated_data)
         assert workflow.owner_user_id == self.user.id
 
-    def test_create__owner_team_id(self) -> None:
-        self.valid_data["owner"] = f"team:{self.team.id}"
+    def test_team_owner(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        self.valid_data["owner"] = f"team:{team.id}"
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid() is True
-
         workflow = validator.create(validator.validated_data)
-        assert workflow.owner_team_id == self.team.id
+        assert workflow.owner_team_id == team.id
+        assert workflow.owner_user_id is None
 
     def test_owner_perms(self) -> None:
         other_user = self.create_user()
@@ -183,15 +184,6 @@ class TestWorkflowValidatorCreate(TestCase):
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid() is False
         assert str(validator.errors["owner"][0]) == "Team is not a member of this organization"
-
-    def test_team_owner(self) -> None:
-        team = self.create_team(organization=self.organization, members=[self.user])
-        self.valid_data["owner"] = f"team:{team.id}"
-        validator = WorkflowValidator(data=self.valid_data, context=self.context)
-        assert validator.is_valid() is True
-        workflow = validator.create(validator.validated_data)
-        assert workflow.owner_team_id == team.id
-        assert workflow.owner_user_id is None
 
     def test_team_owner_not_member(self) -> None:
         self.organization.flags.allow_joinleave = False

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -160,8 +160,8 @@ class TestWorkflowValidatorCreate(TestCase):
         self.valid_data["owner"] = f"user:{self.user.id}"
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid() is True
-
         workflow = validator.create(validator.validated_data)
+        workflow.refresh_from_db()
         assert workflow.owner_user_id == self.user.id
 
     def test_team_owner(self) -> None:
@@ -170,6 +170,7 @@ class TestWorkflowValidatorCreate(TestCase):
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid() is True
         workflow = validator.create(validator.validated_data)
+        workflow.refresh_from_db()
         assert workflow.owner_team_id == team.id
         assert workflow.owner_user_id is None
 
@@ -825,12 +826,14 @@ class TestWorkflowValidatorUpdate(TestCase):
         validator = WorkflowValidator(data=self.valid_data, context=context)
         assert validator.is_valid() is True
         workflow = validator.update(self.workflow, validator.validated_data)
+        workflow.refresh_from_db()
         assert workflow.owner_team_id == team.id
         assert workflow.owner_user_id is None
 
         self.valid_data["owner"] = f"user:{self.user.id}"
         validator = WorkflowValidator(data=self.valid_data, context=context)
         assert validator.is_valid() is True
+        workflow.refresh_from_db()
         workflow = validator.update(self.workflow, validator.validated_data)
         assert workflow.owner_user_id == self.user.id
         assert workflow.owner_team_id is None


### PR DESCRIPTION
The `Workflow` model inherits the `OwnerModel` but the `WorkflowValidator` doesn't actually do anything if passed `owner`. This PR adds handling to the validator for the `owner` field so that it's saved and updated if passed. Thankfully the `OwnerActorField` handles all the validation needed. Tests are copied from the existing behavior in issue alert rules for creating and updating. API docs are updated (and fixed) to indicate that there can be an owner for detectors and workflows (externally, monitors and alerts). 