### PR TITLE
fix(spans): Remove invalid end_timestamp kwarg from Span in test

### DIFF
--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -1620,7 +1620,6 @@ def test_schema_examples(buffer: SpansBuffer, example: dict) -> None:
         segment_id=segment_id,
         project_id=example["project_id"],
         payload=payload,
-        end_timestamp=cast(float, example["end_timestamp"]),
         is_segment_span=bool(example.get("parent_span_id") is None or example.get("is_segment")),
     )
 


### PR DESCRIPTION
The `Span` NamedTuple in `src/sentry/spans/buffer.py` does not have an `end_timestamp` field, causing a mypy `[call-arg]` error in `tests/sentry/spans/test_buffer.py`. Removes the unsupported keyword argument.