### PR TITLE
fix(types): Remove `end_timestamp` parameter from span buffer test

### DIFF
--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -1620,7 +1620,6 @@ def test_schema_examples(buffer: SpansBuffer, example: dict) -> None:
         segment_id=segment_id,
         project_id=example["project_id"],
         payload=payload,
-        end_timestamp=cast(float, example["end_timestamp"]),
         is_segment_span=bool(example.get("parent_span_id") is None or example.get("is_segment")),
     )
 


### PR DESCRIPTION
Two recent PRs, https://github.com/getsentry/sentry/pull/109788 and https://github.com/getsentry/sentry/pull/109318, seem to be in conflict and are causing mypy errors in master. The former PR removed `end_timestamp` from span named tuples, but the latter added a test including `end_timestamp`. This fixes that by removing it from the new test.