### PR TITLE
fix(spans): Unlink distributed payload keys individually to avoid cross-slot errors

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -198,8 +198,8 @@ class SpansBuffer:
                 if payload_keys:
                     mk_key = self._get_payload_key_index(key)
                     p.delete(mk_key)
-                    for batch in itertools.batched(payload_keys, 100):
-                        p.unlink(*batch)
+                    for distributed_key in payload_keys:
+                        p.unlink(distributed_key)
                 self._distributed_payload_keys_map.pop(key, None)
             p.execute()
 
@@ -968,10 +968,8 @@ class SpansBuffer:
                     if flushed_segment.distributed_payload_keys:
                         mk_key = self._get_payload_key_index(segment_key)
                         p.delete(mk_key)
-                        for distributed_key_batch in itertools.batched(
-                            flushed_segment.distributed_payload_keys, 100
-                        ):
-                            p.unlink(*distributed_key_batch)
+                        for distributed_key in flushed_segment.distributed_payload_keys:
+                            p.unlink(distributed_key)
 
                 for queue_key, keys in queue_removals.items():
                     for key_batch in itertools.batched(keys, 100):


### PR DESCRIPTION
Each distributed payload key has a unique hash tag {project:trace:span_id}, so batching multiple keys into a single UNLINK command causes `ClusterCrossSlotError`. Unlink them one at a time within the pipeline instead.

Refs STREAM-799