### PR TITLE
fix(hybridcloud) Add circuit breaker for apigateway requests

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -126,10 +126,15 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
     circuit_breaker: CircuitBreaker | None = None
     # TODO(mark) remove rollout options
     if options.get("apigateway.proxy.circuit-breaker.enabled"):
-        circuit_breaker = CircuitBreaker(
-            f"apigateway.proxy.{cell.name}",
-            options.get("apigateway.proxy.circuit-breaker.config"),
-        )
+        try:
+            circuit_breaker = CircuitBreaker(
+                f"apigateway.proxy.{cell.name}",
+                options.get("apigateway.proxy.circuit-breaker.config"),
+            )
+        except Exception as e:
+            logger.warning("apigateway.invalid-breaker-config", extra={"message": str(e)})
+
+    if circuit_breaker is not None:
         if not circuit_breaker.should_allow_request():
             metrics.incr(
                 "apigateway.proxy.circuit_breaker.rejected",

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -123,6 +123,7 @@ def proxy_error_embed_request(
 def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpResponseBase:
     """Take a django request object and proxy it to a cell silo"""
 
+    metric_tags = {"region": cell.name, "url_name": url_name}
     circuit_breaker: CircuitBreaker | None = None
     # TODO(mark) remove rollout options
     if options.get("apigateway.proxy.circuit-breaker.enabled"):
@@ -136,10 +137,7 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
 
     if circuit_breaker is not None:
         if not circuit_breaker.should_allow_request():
-            metrics.incr(
-                "apigateway.proxy.circuit_breaker.rejected",
-                tags={"region": cell.name, "url_name": url_name},
-            )
+            metrics.incr("apigateway.proxy.circuit_breaker.rejected", tags=metric_tags)
             if options.get("apigateway.proxy.circuit-breaker.enforce"):
                 body = {
                     "error": "apigateway",
@@ -162,7 +160,6 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
     if not timeout:
         timeout = settings.GATEWAY_PROXY_TIMEOUT
     timeout = ENDPOINT_TIMEOUT_OVERRIDE.get(url_name, timeout)
-    metric_tags = {"region": cell.name, "url_name": url_name}
 
     # XXX: See sentry.testutils.pytest.sentry for more information
     if settings.APIGATEWAY_PROXY_SKIP_RELAY and request.path.startswith("/api/0/relays/"):
@@ -192,12 +189,18 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
                 allow_redirects=False,
             )
     except Timeout:
-        if circuit_breaker is not None:
-            circuit_breaker.record_error()
+        metrics.incr("apigateway.proxy.request_timeout", tags=metric_tags)
+        try:
+            if circuit_breaker is not None:
+                circuit_breaker.record_error()
+        except Exception:
+            logger.exception("Failed to record circuitbreaker failure")
+
         # remote silo timeout. Use DRF timeout instead
         raise RequestTimeout()
 
     if resp.status_code >= 500 and circuit_breaker is not None:
+        metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
         circuit_breaker.record_error()
 
     new_headers = clean_outbound_headers(resp.headers)

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin, urlparse
 from wsgiref.util import is_hop_by_hop
 
 from django.conf import settings
-from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 from requests import Response as ExternalResponse
 from requests import request as external_request
@@ -32,6 +32,7 @@ from sentry.types.region import (
     get_cell_for_organization,
 )
 from sentry.utils import metrics
+from sentry.utils.circuit_breaker2 import CircuitBreaker
 from sentry.utils.http import BodyWithLength
 
 logger = logging.getLogger(__name__)
@@ -119,8 +120,28 @@ def proxy_error_embed_request(
     return proxy_cell_request(request, cell, url_name)
 
 
-def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> StreamingHttpResponse:
+def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpResponseBase:
     """Take a django request object and proxy it to a cell silo"""
+
+    circuit_breaker: CircuitBreaker | None = None
+    # TODO(mark) remove rollout options
+    if options.get("apigateway.proxy.circuit-breaker.enabled"):
+        circuit_breaker = CircuitBreaker(
+            f"apigateway.proxy.{cell.name}",
+            options.get("apigateway.proxy.circuit-breaker.config"),
+        )
+        if not circuit_breaker.should_allow_request():
+            metrics.incr(
+                "apigateway.proxy.circuit_breaker.rejected",
+                tags={"region": cell.name, "url_name": url_name},
+            )
+            if options.get("apigateway.proxy.circuit-breaker.enforce"):
+                body = {
+                    "error": "apigateway",
+                    "detail": "Downstream service temporarily unavailable",
+                }
+                return JsonResponse(body, status=503)
+
     target_url = urljoin(cell.address, request.path)
 
     content_encoding = request.headers.get("Content-Encoding")
@@ -131,7 +152,11 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> Strea
     assert request.method is not None
     query_params = request.GET
 
-    timeout = ENDPOINT_TIMEOUT_OVERRIDE.get(url_name, settings.GATEWAY_PROXY_TIMEOUT)
+    # This option has a default of None, which is cast to 0
+    timeout = options.get("apigateway.proxy.timeout")
+    if not timeout:
+        timeout = settings.GATEWAY_PROXY_TIMEOUT
+    timeout = ENDPOINT_TIMEOUT_OVERRIDE.get(url_name, timeout)
     metric_tags = {"region": cell.name, "url_name": url_name}
 
     # XXX: See sentry.testutils.pytest.sentry for more information
@@ -162,8 +187,13 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> Strea
                 allow_redirects=False,
             )
     except Timeout:
+        if circuit_breaker is not None:
+            circuit_breaker.record_error()
         # remote silo timeout. Use DRF timeout instead
         raise RequestTimeout()
+
+    if resp.status_code >= 500 and circuit_breaker is not None:
+        circuit_breaker.record_error()
 
     new_headers = clean_outbound_headers(resp.headers)
     resp.headers.clear()

--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -1,5 +1,5 @@
 from sentry.options import FLAG_AUTOMATOR_MODIFIABLE, register
-from sentry.utils.types import Bool, Int, Sequence
+from sentry.utils.types import Bool, Dict, Int, Sequence
 
 register(
     "outbox_replication.sentry_organizationmember.replication_version",
@@ -159,5 +159,37 @@ register(
     "hybrid_cloud.authentication.disabled_user_shards",
     type=Sequence,
     default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+
+# API Gateway timeout and circuit breaker options
+register(
+    "apigateway.proxy.timeout",
+    type=Int,
+    default=None,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "apigateway.proxy.circuit-breaker.config",
+    type=Dict,
+    default={
+        "error_limit": 100,
+        "error_limit_window": 60,  # 1 min
+        "broken_state_duration": 30,  # 30 sec
+    },
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Short term rollout flags for the circuit breaker in apigateway.
+register(
+    "apigateway.proxy.circuit-breaker.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "apigateway.proxy.circuit-breaker.enforce",
+    type=Bool,
+    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -1,16 +1,21 @@
+from unittest.mock import MagicMock, patch
 from urllib.parse import urlencode
 
+import pytest
 import requests
 import responses
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import RequestFactory
+from requests.exceptions import Timeout
 
+from sentry.api.exceptions import RequestTimeout
 from sentry.hybridcloud.apigateway.proxy import proxy_request
 from sentry.silo.util import (
     INVALID_OUTBOUND_HEADERS,
     PROXY_APIGATEWAY_HEADER,
     PROXY_DIRECT_LOCATION_HEADER,
 )
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.apigateway import (
     ApiGatewayTestCase,
     verify_file_body,
@@ -261,3 +266,117 @@ class ProxyTestCase(ApiGatewayTestCase):
 
         resp = proxy_request(request, self.organization.slug, url_name)
         assert not any([header in resp for header in INVALID_OUTBOUND_HEADERS])
+
+
+CB_ENABLED = {
+    "apigateway.proxy.circuit-breaker.enabled": True,
+    "apigateway.proxy.circuit-breaker.enforce": True,
+}
+
+
+@control_silo_test(regions=[ApiGatewayTestCase.REGION])
+class ProxyCircuitBreakerTestCase(ApiGatewayTestCase):
+    def _make_breaker_mock(self, *, allow_request: bool) -> MagicMock:
+        mock_breaker = MagicMock()
+        mock_breaker.should_allow_request.return_value = allow_request
+        return mock_breaker
+
+    @responses.activate
+    @override_options(CB_ENABLED)
+    def test_open_circuit_returns_503(self) -> None:
+        with patch("sentry.hybridcloud.apigateway.proxy.CircuitBreaker") as mock_breaker_class:
+            mock_breaker_class.return_value = self._make_breaker_mock(allow_request=False)
+            request = RequestFactory().get("http://sentry.io/get")
+            resp = proxy_request(request, self.organization.slug, url_name)
+        assert resp.status_code == 503
+        assert json.loads(resp.content) == {
+            "error": "apigateway",
+            "detail": "Downstream service temporarily unavailable",
+        }
+
+    @responses.activate
+    @override_options(CB_ENABLED)
+    def test_circuit_breaker_keyed_per_cell(self) -> None:
+        with patch("sentry.hybridcloud.apigateway.proxy.CircuitBreaker") as mock_breaker_class:
+            mock_breaker_class.return_value = self._make_breaker_mock(allow_request=False)
+            request = RequestFactory().get("http://sentry.io/get")
+            proxy_request(request, self.organization.slug, url_name)
+        key_used = mock_breaker_class.call_args[0][0]
+        assert key_used == f"apigateway.proxy.{self.REGION.name}"
+
+    @responses.activate
+    def test_circuit_breaker_disabled_by_default(self) -> None:
+        with patch("sentry.hybridcloud.apigateway.proxy.CircuitBreaker") as mock_breaker_class:
+            request = RequestFactory().get("http://sentry.io/get")
+            proxy_request(request, self.organization.slug, url_name)
+        mock_breaker_class.assert_not_called()
+
+    @responses.activate
+    @override_options(
+        {
+            "apigateway.proxy.circuit-breaker.enabled": True,
+            "apigateway.proxy.circuit-breaker.enforce": False,
+        }
+    )
+    def test_open_circuit_not_enforced(self) -> None:
+        with patch("sentry.hybridcloud.apigateway.proxy.CircuitBreaker") as mock_breaker_class:
+            mock_breaker_class.return_value = self._make_breaker_mock(allow_request=False)
+            request = RequestFactory().get("http://sentry.io/get")
+            resp = proxy_request(request, self.organization.slug, url_name)
+        assert resp.status_code == 200
+
+    @responses.activate
+    @override_options(CB_ENABLED)
+    def test_timeout_records_error(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.REGION.address}/timeout",
+            body=Timeout(),
+        )
+        with patch("sentry.hybridcloud.apigateway.proxy.CircuitBreaker") as mock_breaker_class:
+            mock_breaker = self._make_breaker_mock(allow_request=True)
+            mock_breaker_class.return_value = mock_breaker
+            request = RequestFactory().get("http://sentry.io/timeout")
+            with pytest.raises(RequestTimeout):
+                proxy_request(request, self.organization.slug, url_name)
+        mock_breaker.record_error.assert_called_once()
+
+    @responses.activate
+    @override_options(CB_ENABLED)
+    def test_5xx_response_records_error(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.REGION.address}/server-error",
+            status=500,
+            body=json.dumps({"detail": "internal server error"}),
+            content_type="application/json",
+        )
+        with patch("sentry.hybridcloud.apigateway.proxy.CircuitBreaker") as mock_breaker_class:
+            mock_breaker = self._make_breaker_mock(allow_request=True)
+            mock_breaker_class.return_value = mock_breaker
+            request = RequestFactory().get("http://sentry.io/server-error")
+            resp = proxy_request(request, self.organization.slug, url_name)
+        assert resp.status_code == 500
+        mock_breaker.record_error.assert_called_once()
+
+    @responses.activate
+    @override_options(CB_ENABLED)
+    def test_4xx_response_does_not_record_error(self) -> None:
+        with patch("sentry.hybridcloud.apigateway.proxy.CircuitBreaker") as mock_breaker_class:
+            mock_breaker = self._make_breaker_mock(allow_request=True)
+            mock_breaker_class.return_value = mock_breaker
+            request = RequestFactory().get("http://sentry.io/error")
+            resp = proxy_request(request, self.organization.slug, url_name)
+        assert resp.status_code == 400
+        mock_breaker.record_error.assert_not_called()
+
+    @responses.activate
+    @override_options(CB_ENABLED)
+    def test_2xx_response_does_not_record_error(self) -> None:
+        with patch("sentry.hybridcloud.apigateway.proxy.CircuitBreaker") as mock_breaker_class:
+            mock_breaker = self._make_breaker_mock(allow_request=True)
+            mock_breaker_class.return_value = mock_breaker
+            request = RequestFactory().get("http://sentry.io/get")
+            resp = proxy_request(request, self.organization.slug, url_name)
+        assert resp.status_code == 200
+        mock_breaker.record_error.assert_not_called()

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -328,6 +328,13 @@ class ProxyCircuitBreakerTestCase(ApiGatewayTestCase):
         assert resp.status_code == 200
 
     @responses.activate
+    @override_options({"apigateway.proxy.circuit-breaker.config": "invalid-lol", **CB_ENABLED})
+    def test_handles_invalid_config(self) -> None:
+        request = RequestFactory().get("http://sentry.io/get")
+        res = proxy_request(request, self.organization.slug, url_name)
+        assert res.status_code == 200
+
+    @responses.activate
     @override_options(CB_ENABLED)
     def test_timeout_records_error(self) -> None:
         responses.add(

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 import responses
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import HttpResponse
 from django.test.client import RequestFactory
 from requests.exceptions import Timeout
 
@@ -288,6 +289,7 @@ class ProxyCircuitBreakerTestCase(ApiGatewayTestCase):
             mock_breaker_class.return_value = self._make_breaker_mock(allow_request=False)
             request = RequestFactory().get("http://sentry.io/get")
             resp = proxy_request(request, self.organization.slug, url_name)
+        assert isinstance(resp, HttpResponse)
         assert resp.status_code == 503
         assert json.loads(resp.content) == {
             "error": "apigateway",


### PR DESCRIPTION
We recently had an incident where we exhausted all of our control-web resources because requests to the downstream applications became slow, and exhausted all available webserver capacity.

These changes introduce a circuit breaker that will record failures from the proxied region requests. When enough errors are collected, the gateway will quickly return an error response. I've added two options that will allow controlled rollout of circuit breaker recording and enforcement. This will let me measure the impacts on redis and tweak the thresholds before enforcing the breaker limits.

In looking into how effective this would have been for the recent incident, I noticed that the proxy gateway timeout is undefined, and that we have very high tail latencies. These changes also introduce an option backed timeout that I plan to use to bring down tail latency without impacting failure rates significantly.

Refs [INFRENG-275](https://linear.app/getsentry/issue/INFRENG-275/investigate-circuit-breakers-for-apigateway-in-control-silo)
