### PR TITLE
fix(copilot): Use `state` field instead of `status` for task lifecycle

### DIFF
--- a/src/sentry/integrations/github_copilot/models.py
+++ b/src/sentry/integrations/github_copilot/models.py
@@ -72,7 +72,8 @@ class GithubCopilotTask(BaseModel):
     agent_collaborators: list[GithubCopilotAgentCollaborator] | None = None
     owner_id: int | None = None
     repo_id: int | None = None
-    status: str | None = None  # queued, in_progress, completed, failed, timed_out
+    status: str | None = None
+    state: str | None = None  # queued, in_progress, completed, failed, timed_out
     session_count: int | None = None
     artifacts: list[GithubCopilotArtifact] | None = None
     archived_at: str | None = None

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -558,8 +558,8 @@ def poll_github_copilot_agents(
                         pr_url=pr_url,
                     )
 
-                    # Status: queued, in_progress, completed, failed, timed_out
-                    is_task_done = task_status.status == "completed"
+                    # The Copilot API uses `state` (not `status`) for task lifecycle.
+                    is_task_done = task_status.state == "completed"
                     new_status = (
                         CodingAgentStatus.COMPLETED if is_task_done else CodingAgentStatus.RUNNING
                     )
@@ -575,19 +575,19 @@ def poll_github_copilot_agents(
                         extra={
                             "agent_id": agent_id,
                             "pr_url": pr_url,
-                            "task_status": task_status.status,
+                            "task_state": task_status.state,
                             "is_task_done": is_task_done,
                         },
                     )
 
-            elif task_status.status in ("failed", "timed_out"):
+            elif task_status.state in ("failed", "timed_out"):
                 update_coding_agent_state(
                     agent_id=agent_id,
                     status=CodingAgentStatus.FAILED,
                 )
                 logger.info(
                     "coding_agent.github_copilot.task_failed",
-                    extra={"agent_id": agent_id, "task_status": task_status.status},
+                    extra={"agent_id": agent_id, "task_state": task_status.state},
                 )
 
         except Exception:

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -51,13 +51,13 @@ class GithubCopilotAgentClientTest(TestCase):
         mock_response = Mock()
         mock_response.json = {
             "id": "task-123",
-            "status": "completed",
+            "state": "completed",
             "created_at": "2024-01-01T00:00:00Z",
-            "last_updated_at": "2024-01-01T01:00:00Z",
+            "updated_at": "2024-01-01T01:00:00Z",
             "artifacts": [
                 {
                     "provider": "github",
-                    "type": "pull_request",
+                    "type": "github_resource",
                     "data": {"id": 456, "type": "pull", "global_id": "PR_abc123"},
                 }
             ],
@@ -71,7 +71,7 @@ class GithubCopilotAgentClientTest(TestCase):
 
         assert isinstance(result, GithubCopilotTask)
         assert result.id == "task-123"
-        assert result.status == "completed"
+        assert result.state == "completed"
         assert result.artifacts is not None
         assert len(result.artifacts) == 1
         assert result.artifacts[0].data is not None
@@ -90,7 +90,7 @@ class GithubCopilotAgentClientTest(TestCase):
         mock_response = Mock()
         mock_response.json = {
             "id": "task-123",
-            "status": "running",
+            "state": "in_progress",
         }
         mock_response.status_code = 200
         mock_get.return_value = mock_response
@@ -100,7 +100,7 @@ class GithubCopilotAgentClientTest(TestCase):
         )
 
         assert result.id == "task-123"
-        assert result.status == "running"
+        assert result.state == "in_progress"
         assert result.artifacts is None
 
     def _make_launch_request(self, prompt: str = "Fix the bug") -> CodingAgentLaunchRequest:

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -513,7 +513,7 @@ class TestPollGithubCopilotAgents(TestCase):
         mock_client = MagicMock()
         mock_client.get_task_status.return_value = GithubCopilotTask(
             id="task-123",
-            status="completed",
+            state="completed",
             artifacts=[
                 GithubCopilotArtifact(
                     provider="github",
@@ -572,7 +572,7 @@ class TestPollGithubCopilotAgents(TestCase):
         mock_get_task_status = MagicMock(
             return_value=GithubCopilotTask(
                 id="task-123",
-                status="failed",
+                state="failed",
             )
         )
 
@@ -609,7 +609,7 @@ class TestPollGithubCopilotAgents(TestCase):
         mock_get_task_status = MagicMock(
             return_value=GithubCopilotTask(
                 id="task-123",
-                status="running",
+                state="in_progress",
                 artifacts=[
                     GithubCopilotArtifact(
                         provider="github",


### PR DESCRIPTION
The GitHub Copilot Tasks API returns task lifecycle values (`queued`, `in_progress`, `completed`, `failed`, `timed_out`) in the `state` field, while the `status` field is always an empty string. Our polling code was checking `task_status.status == "completed"` which was never true, so Copilot tasks would stay stuck in RUNNING state forever after completion — the PR URL and completion state were never synced back to Sentry.

Validated by hitting the live Copilot API: created a task, polled until completion, and confirmed that `state` carries the lifecycle values while `status` is always `""`. The partner API spec we were given listed `status` as the field, but the actual API uses `state`.

Changes:
- Add `state` field to `GithubCopilotTask` model (keep `status` for forward-compat)
- Switch polling logic to check `task_status.state` instead of `task_status.status`
- Update test mocks to match real API response shapes (`state`, `in_progress`, `github_resource`, `updated_at`)


Agent transcript: https://claudescope.sentry.dev/share/7RfoUCo3OmihUbUrznGRpJ0bE9LXTfcbFamSXhLirtc