### PR TITLE
feat(supergroups): pass `project_id` when triggering supergroups embedding

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -242,6 +242,7 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
             trigger_supergroups_embedding(
                 organization_id=organization.id,
                 group_id=group_id,
+                project_id=group.project_id,
                 artifact_data=root_cause_artifact.data,
             )
         except Exception:

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -231,6 +231,7 @@ class SummarizeIssueRequest(TypedDict):
 class SupergroupsEmbeddingRequest(TypedDict):
     organization_id: int
     group_id: int
+    project_id: int
     artifact_data: dict[str, Any]
 
 
@@ -238,6 +239,7 @@ class SupergroupsListRequest(TypedDict):
     organization_id: int
     offset: NotRequired[int | None]
     limit: NotRequired[int | None]
+    project_ids: NotRequired[list[int] | None]
 
 
 class SupergroupsGetRequest(TypedDict):

--- a/src/sentry/seer/supergroups.py
+++ b/src/sentry/seer/supergroups.py
@@ -11,11 +11,13 @@ from sentry.seer.signed_seer_api import (
 def trigger_supergroups_embedding(
     organization_id: int,
     group_id: int,
+    project_id: int,
     artifact_data: dict,
 ) -> None:
     body = SupergroupsEmbeddingRequest(
         organization_id=organization_id,
         group_id=group_id,
+        project_id=project_id,
         artifact_data=artifact_data,
     )
     viewer_context = SeerViewerContext(organization_id=organization_id)

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -393,6 +393,7 @@ class TestAutofixOnCompletionHookSupergroups(TestCase):
         mock_trigger_sg.assert_called_once_with(
             organization_id=self.organization.id,
             group_id=self.group.id,
+            project_id=self.group.project_id,
             artifact_data=block.artifacts[0].data,
         )
 

--- a/tests/sentry/seer/test_supergroups.py
+++ b/tests/sentry/seer/test_supergroups.py
@@ -12,6 +12,7 @@ class TriggerSupergroupsEmbeddingTest(TestCase):
         trigger_supergroups_embedding(
             organization_id=1,
             group_id=123,
+            project_id=456,
             artifact_data={"one_line_description": "Null pointer in auth module"},
         )
 
@@ -23,4 +24,5 @@ class TriggerSupergroupsEmbeddingTest(TestCase):
         payload = call_args.args[0]
         assert payload["organization_id"] == 1
         assert payload["group_id"] == 123
+        assert payload["project_id"] == 456
         assert payload["artifact_data"] == {"one_line_description": "Null pointer in auth module"}


### PR DESCRIPTION
For adding `project_id` to the seer embeddings, the embeddings task will need the target group's `project_id`. This is where the `project_id` will come from.

More context here: https://github.com/getsentry/seer/pull/5286