### PR TITLE
feat(autofix): Handle when autofix generates no artfacts

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -152,6 +152,12 @@ describe('RootCauseCard', () => {
     );
 
     expect(screen.getByText('Root Cause')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Seer failed to generate a root cause. This one is on us. Try running it again.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
   });
 
   it('handles empty five_whys with placeholder', () => {
@@ -224,6 +230,12 @@ describe('SolutionCard', () => {
     );
 
     expect(screen.getByText('Implementation Plan')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Seer failed to generate an implementation plan. This one is on us. Try running it again.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
   });
 });
 
@@ -302,7 +314,12 @@ describe('CodeChangesCard', () => {
     );
 
     expect(screen.getByText('Code Changes')).toBeInTheDocument();
-    expect(screen.getByText('0 files changed in 0 repos')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Seer failed to generate a code change. This one is on us. Try running it again.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
   });
 });
 

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -58,6 +58,16 @@ function makePR(overrides: Partial<RepoPRState> = {}): RepoPRState {
   };
 }
 
+const mockAutofix = {
+  runState: null,
+  isLoading: false,
+  isPolling: false,
+  startStep: jest.fn(),
+  createPR: jest.fn(),
+  reset: jest.fn(),
+  triggerCodingAgentHandoff: jest.fn(),
+};
+
 function makeRootCauseArtifact(data: RootCauseArtifact | null) {
   return {
     key: 'root-cause',
@@ -83,7 +93,10 @@ describe('RootCauseCard', () => {
     });
 
     render(
-      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+      <RootCauseCard
+        autofix={mockAutofix}
+        section={makeSection('root_cause', 'completed', [artifact])}
+      />
     );
 
     expect(screen.getByText('Root Cause')).toBeInTheDocument();
@@ -97,7 +110,10 @@ describe('RootCauseCard', () => {
     });
 
     render(
-      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+      <RootCauseCard
+        autofix={mockAutofix}
+        section={makeSection('root_cause', 'completed', [artifact])}
+      />
     );
 
     expect(screen.getByText('Why did this happen?')).toBeInTheDocument();
@@ -114,7 +130,10 @@ describe('RootCauseCard', () => {
     });
 
     render(
-      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+      <RootCauseCard
+        autofix={mockAutofix}
+        section={makeSection('root_cause', 'completed', [artifact])}
+      />
     );
 
     expect(screen.getByText('Reproduction Steps')).toBeInTheDocument();
@@ -126,7 +145,10 @@ describe('RootCauseCard', () => {
     const artifact = makeRootCauseArtifact(null);
 
     render(
-      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+      <RootCauseCard
+        autofix={mockAutofix}
+        section={makeSection('root_cause', 'completed', [artifact])}
+      />
     );
 
     expect(screen.getByText('Root Cause')).toBeInTheDocument();
@@ -139,7 +161,10 @@ describe('RootCauseCard', () => {
     });
 
     render(
-      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+      <RootCauseCard
+        autofix={mockAutofix}
+        section={makeSection('root_cause', 'completed', [artifact])}
+      />
     );
 
     expect(screen.getByText('Root Cause')).toBeInTheDocument();
@@ -154,7 +179,12 @@ describe('SolutionCard', () => {
       steps: [{title: 'Step 1', description: 'Add guard'}],
     });
 
-    render(<SolutionCard section={makeSection('solution', 'completed', [artifact])} />);
+    render(
+      <SolutionCard
+        autofix={mockAutofix}
+        section={makeSection('solution', 'completed', [artifact])}
+      />
+    );
 
     expect(screen.getByText('Implementation Plan')).toBeInTheDocument();
     expect(screen.getByText('Add null check before accessing user')).toBeInTheDocument();
@@ -169,7 +199,12 @@ describe('SolutionCard', () => {
       ],
     });
 
-    render(<SolutionCard section={makeSection('solution', 'completed', [artifact])} />);
+    render(
+      <SolutionCard
+        autofix={mockAutofix}
+        section={makeSection('solution', 'completed', [artifact])}
+      />
+    );
 
     expect(screen.getByText('Steps to Resolve')).toBeInTheDocument();
     expect(screen.getByText('Add validation')).toBeInTheDocument();
@@ -181,7 +216,12 @@ describe('SolutionCard', () => {
   it('renders card shell when artifact data is null', () => {
     const artifact = makeSolutionArtifact(null);
 
-    render(<SolutionCard section={makeSection('solution', 'completed', [artifact])} />);
+    render(
+      <SolutionCard
+        autofix={mockAutofix}
+        section={makeSection('solution', 'completed', [artifact])}
+      />
+    );
 
     expect(screen.getByText('Implementation Plan')).toBeInTheDocument();
   });
@@ -191,6 +231,7 @@ describe('CodeChangesCard', () => {
   it('renders single file in single repo', () => {
     render(
       <CodeChangesCard
+        autofix={mockAutofix}
         section={makeSection('code_changes', 'completed', [
           [makePatch('org/repo', 'src/app.py')],
         ])}
@@ -204,6 +245,7 @@ describe('CodeChangesCard', () => {
   it('renders multiple files in single repo', () => {
     render(
       <CodeChangesCard
+        autofix={mockAutofix}
         section={makeSection('code_changes', 'completed', [
           [
             makePatch('org/repo', 'src/app.py'),
@@ -220,6 +262,7 @@ describe('CodeChangesCard', () => {
   it('renders multiple files in multiple repos', () => {
     render(
       <CodeChangesCard
+        autofix={mockAutofix}
         section={makeSection('code_changes', 'completed', [
           [
             makePatch('org/repo-a', 'src/app.py'),
@@ -236,6 +279,7 @@ describe('CodeChangesCard', () => {
   it('renders repository name labels', () => {
     render(
       <CodeChangesCard
+        autofix={mockAutofix}
         section={makeSection('code_changes', 'completed', [
           [
             makePatch('org/repo-a', 'src/app.py'),
@@ -250,7 +294,12 @@ describe('CodeChangesCard', () => {
   });
 
   it('renders card shell when no code changes artifact found', () => {
-    render(<CodeChangesCard section={makeSection('code_changes', 'completed', [])} />);
+    render(
+      <CodeChangesCard
+        autofix={mockAutofix}
+        section={makeSection('code_changes', 'completed', [])}
+      />
+    );
 
     expect(screen.getByText('Code Changes')).toBeInTheDocument();
     expect(screen.getByText('0 files changed in 0 repos')).toBeInTheDocument();
@@ -261,6 +310,7 @@ describe('PullRequestsCard', () => {
   it('renders PR link buttons with correct text and href', () => {
     render(
       <PullRequestsCard
+        autofix={mockAutofix}
         section={makeSection('pull_request', 'completed', [[makePR()]])}
       />
     );
@@ -275,6 +325,7 @@ describe('PullRequestsCard', () => {
   it('renders multiple PR buttons', () => {
     render(
       <PullRequestsCard
+        autofix={mockAutofix}
         section={makeSection('pull_request', 'completed', [
           [
             makePR({repo_name: 'org/repo-a', pr_number: 10, pr_url: 'https://pr/10'}),
@@ -295,6 +346,7 @@ describe('PullRequestsCard', () => {
   it('skips PRs with missing pr_url or pr_number', () => {
     render(
       <PullRequestsCard
+        autofix={mockAutofix}
         section={makeSection('pull_request', 'completed', [
           [
             makePR({repo_name: 'org/repo-a', pr_url: null}),
@@ -324,7 +376,10 @@ describe('ArtifactCard expand/collapse', () => {
     });
 
     render(
-      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+      <RootCauseCard
+        autofix={mockAutofix}
+        section={makeSection('root_cause', 'completed', [artifact])}
+      />
     );
 
     expect(screen.getByText('Visible why')).toBeInTheDocument();
@@ -337,7 +392,10 @@ describe('ArtifactCard expand/collapse', () => {
     });
 
     render(
-      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+      <RootCauseCard
+        autofix={mockAutofix}
+        section={makeSection('root_cause', 'completed', [artifact])}
+      />
     );
 
     await userEvent.click(screen.getByRole('button', {name: 'Root Cause'}));
@@ -353,7 +411,10 @@ describe('ArtifactCard expand/collapse', () => {
     });
 
     render(
-      <RootCauseCard section={makeSection('root_cause', 'completed', [artifact])} />
+      <RootCauseCard
+        autofix={mockAutofix}
+        section={makeSection('root_cause', 'completed', [artifact])}
+      />
     );
 
     expect(screen.getByText('Bug')).toBeVisible();

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -197,25 +197,27 @@ export function CodeChangesCard({autofix, section}: AutofixCardProps) {
         <LoadingDetails messages={section.messages} />
       ) : (
         <Fragment>
-          <Text>{summary}</Text>
           {patchesForRepos.size ? (
-            [...patchesForRepos.entries()].map(([repo, patches]) => (
-              <ArtifactDetails key={repo}>
-                <Flex gap="lg">
-                  <Text bold>{t('Repository:')}</Text>
-                  <Text>{repo}</Text>
-                </Flex>
-                {patches.map((patch, index) => (
-                  <FileDiffViewer
-                    key={index}
-                    patch={patch.patch}
-                    showBorder
-                    collapsible
-                    defaultExpanded={artifact && artifact.length <= 1}
-                  />
-                ))}
-              </ArtifactDetails>
-            ))
+            <Fragment>
+              <Text>{summary}</Text>
+              {[...patchesForRepos.entries()].map(([repo, patches]) => (
+                <ArtifactDetails key={repo}>
+                  <Flex gap="lg">
+                    <Text bold>{t('Repository:')}</Text>
+                    <Text>{repo}</Text>
+                  </Flex>
+                  {patches.map((patch, index) => (
+                    <FileDiffViewer
+                      key={index}
+                      patch={patch.patch}
+                      showBorder
+                      collapsible
+                      defaultExpanded={artifact && artifact.length <= 1}
+                    />
+                  ))}
+                </ArtifactDetails>
+              ))}
+            </Fragment>
           ) : (
             <ArtifactDetails>
               <Text>

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -11,8 +11,10 @@ import {
   isRootCauseArtifact,
   isSolutionArtifact,
   type AutofixSection,
+  type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import Placeholder from 'sentry/components/placeholder';
+import {IconRefresh} from 'sentry/icons';
 import {IconBug} from 'sentry/icons/iconBug';
 import {IconCode} from 'sentry/icons/iconCode';
 import {IconList} from 'sentry/icons/iconList';
@@ -23,95 +25,132 @@ import {FileDiffViewer} from 'sentry/views/seerExplorer/fileDiffViewer';
 import {type ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
 interface AutofixCardProps {
+  autofix: ReturnType<typeof useExplorerAutofix>;
   section: AutofixSection;
 }
 
-export function RootCauseCard({section}: AutofixCardProps) {
+export function RootCauseCard({autofix, section}: AutofixCardProps) {
   const artifact = useMemo(
     () => section.artifacts.findLast(isRootCauseArtifact),
     [section.artifacts]
   );
 
+  const {runState, startStep} = autofix;
+  const runId = runState?.run_id;
+
   return (
     <ArtifactCard icon={<IconBug />} title={t('Root Cause')}>
-      {
-        section.status === 'processing' ? (
-          <LoadingDetails messages={section.messages} />
-        ) : artifact?.data ? (
-          <Fragment>
-            <Text>{artifact.data.one_line_description}</Text>
-            {artifact.data.five_whys?.length ? (
-              <Fragment>
+      {section.status === 'processing' ? (
+        <LoadingDetails messages={section.messages} />
+      ) : artifact?.data ? (
+        <Fragment>
+          <Text>{artifact.data.one_line_description}</Text>
+          {artifact.data.five_whys?.length ? (
+            <Fragment>
+              <ArtifactDetails>
+                <Text bold>{t('Why did this happen?')}</Text>
+                <Container as="ul" margin="0">
+                  {artifact.data.five_whys.map((why, index) => (
+                    <li key={index}>
+                      <Text>{why}</Text>
+                    </li>
+                  ))}
+                </Container>
+              </ArtifactDetails>
+              {artifact.data.reproduction_steps?.length ? (
                 <ArtifactDetails>
-                  <Text bold>{t('Why did this happen?')}</Text>
-                  <Container as="ul" margin="0">
-                    {artifact.data.five_whys.map((why, index) => (
+                  <Text bold>{t('Reproduction Steps')}</Text>
+                  <Container as="ol" margin="0">
+                    {artifact.data?.reproduction_steps.map((step, index) => (
                       <li key={index}>
-                        <Text>{why}</Text>
+                        <Text>{step}</Text>
                       </li>
                     ))}
                   </Container>
                 </ArtifactDetails>
-                {artifact.data.reproduction_steps?.length ? (
-                  <ArtifactDetails>
-                    <Text bold>{t('Reproduction Steps')}</Text>
-                    <Container as="ol" margin="0">
-                      {artifact.data?.reproduction_steps.map((step, index) => (
-                        <li key={index}>
-                          <Text>{step}</Text>
-                        </li>
-                      ))}
-                    </Container>
-                  </ArtifactDetails>
-                ) : null}
-              </Fragment>
-            ) : null}
-          </Fragment>
-        ) : null /* TODO: need an empty state when the artifact doesn't exist */
-      }
+              ) : null}
+            </Fragment>
+          ) : null}
+        </Fragment>
+      ) : (
+        <ArtifactDetails>
+          <Text>
+            {t(
+              'Seer failed to generate a root cause. This one is on us. Try running it again.'
+            )}
+          </Text>
+          <div>
+            <Button
+              priority="primary"
+              icon={<IconRefresh />}
+              onClick={() => startStep('root_cause', runId)}
+            >
+              {t('Re-run')}
+            </Button>
+          </div>
+        </ArtifactDetails>
+      )}
     </ArtifactCard>
   );
 }
 
-export function SolutionCard({section}: AutofixCardProps) {
+export function SolutionCard({autofix, section}: AutofixCardProps) {
   const artifact = useMemo(
     () => section.artifacts.findLast(isSolutionArtifact),
     [section.artifacts]
   );
 
+  const {runState, startStep} = autofix;
+  const runId = runState?.run_id;
+
   return (
     <ArtifactCard icon={<IconList />} title={t('Implementation Plan')}>
-      {
-        section.status === 'processing' ? (
-          <LoadingDetails messages={section.messages} />
-        ) : artifact?.data ? (
-          <Fragment>
-            <Text>{artifact.data.one_line_summary}</Text>
-            {artifact.data.steps ? (
-              <ArtifactDetails>
-                <Text bold>{t('Steps to Resolve')}</Text>
-                <Container as="ol" margin="0">
-                  {artifact.data.steps.map((step, index) => (
-                    <li key={index}>
-                      <Flex direction="column">
-                        <Text>{step.title}</Text>
-                        <Text size="sm" variant="muted">
-                          {step.description}
-                        </Text>
-                      </Flex>
-                    </li>
-                  ))}
-                </Container>
-              </ArtifactDetails>
-            ) : null}
-          </Fragment>
-        ) : null /* TODO: need an empty state when the artifact doesn't exist */
-      }
+      {section.status === 'processing' ? (
+        <LoadingDetails messages={section.messages} />
+      ) : artifact?.data ? (
+        <Fragment>
+          <Text>{artifact.data.one_line_summary}</Text>
+          {artifact.data.steps ? (
+            <ArtifactDetails>
+              <Text bold>{t('Steps to Resolve')}</Text>
+              <Container as="ol" margin="0">
+                {artifact.data.steps.map((step, index) => (
+                  <li key={index}>
+                    <Flex direction="column">
+                      <Text>{step.title}</Text>
+                      <Text size="sm" variant="muted">
+                        {step.description}
+                      </Text>
+                    </Flex>
+                  </li>
+                ))}
+              </Container>
+            </ArtifactDetails>
+          ) : null}
+        </Fragment>
+      ) : (
+        <ArtifactDetails>
+          <Text>
+            {t(
+              'Seer failed to generate an implementation plan. This one is on us. Try running it again.'
+            )}
+          </Text>
+          <div>
+            <Button
+              priority="primary"
+              icon={<IconRefresh />}
+              onClick={() => startStep('solution', runId)}
+            >
+              {t('Re-run')}
+            </Button>
+          </div>
+        </ArtifactDetails>
+      )}
     </ArtifactCard>
   );
 }
 
-export function CodeChangesCard({section}: AutofixCardProps) {
+export function CodeChangesCard({autofix, section}: AutofixCardProps) {
   const artifact = useMemo(
     () => section.artifacts.findLast(isCodeChangesArtifact),
     [section.artifacts]
@@ -149,6 +188,9 @@ export function CodeChangesCard({section}: AutofixCardProps) {
     return t('%s files changed in %s repos', filesChanged.size, reposChanged);
   }, [patchesForRepos]);
 
+  const {runState, startStep} = autofix;
+  const runId = runState?.run_id;
+
   return (
     <ArtifactCard icon={<IconCode />} title={t('Code Changes')}>
       {section.status === 'processing' ? (
@@ -156,27 +198,42 @@ export function CodeChangesCard({section}: AutofixCardProps) {
       ) : (
         <Fragment>
           <Text>{summary}</Text>
-          {
-            patchesForRepos.size
-              ? [...patchesForRepos.entries()].map(([repo, patches]) => (
-                  <ArtifactDetails key={repo}>
-                    <Flex gap="lg">
-                      <Text bold>{t('Repository:')}</Text>
-                      <Text>{repo}</Text>
-                    </Flex>
-                    {patches.map((patch, index) => (
-                      <FileDiffViewer
-                        key={index}
-                        patch={patch.patch}
-                        showBorder
-                        collapsible
-                        defaultExpanded={artifact && artifact.length <= 1}
-                      />
-                    ))}
-                  </ArtifactDetails>
-                ))
-              : null /* TODO: need an empty state when no changes were made */
-          }
+          {patchesForRepos.size ? (
+            [...patchesForRepos.entries()].map(([repo, patches]) => (
+              <ArtifactDetails key={repo}>
+                <Flex gap="lg">
+                  <Text bold>{t('Repository:')}</Text>
+                  <Text>{repo}</Text>
+                </Flex>
+                {patches.map((patch, index) => (
+                  <FileDiffViewer
+                    key={index}
+                    patch={patch.patch}
+                    showBorder
+                    collapsible
+                    defaultExpanded={artifact && artifact.length <= 1}
+                  />
+                ))}
+              </ArtifactDetails>
+            ))
+          ) : (
+            <ArtifactDetails>
+              <Text>
+                {t(
+                  'Seer failed to generate a code change. This one is on us. Try running it again.'
+                )}
+              </Text>
+              <div>
+                <Button
+                  priority="primary"
+                  icon={<IconRefresh />}
+                  onClick={() => startStep('code_changes', runId)}
+                >
+                  {t('Re-run')}
+                </Button>
+              </div>
+            </ArtifactDetails>
+          )}
         </Fragment>
       )}
     </ArtifactCard>

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -47,7 +47,7 @@ export function SeerDrawerContent({aiConfig, autofix}: SeerDrawerContentProps) {
 
   return (
     <Flex direction="column" gap="lg">
-      <SeerDrawerArtifacts sections={sections} />
+      <SeerDrawerArtifacts autofix={autofix} sections={sections} />
       {autofix.runState?.status === 'completed' && (
         <SeerDrawerNextStep autofix={autofix} sections={sections} />
       )}
@@ -56,27 +56,32 @@ export function SeerDrawerContent({aiConfig, autofix}: SeerDrawerContentProps) {
 }
 
 interface SeerDrawerArtifactsProps {
+  autofix: ReturnType<typeof useExplorerAutofix>;
   sections: AutofixSection[];
 }
 
-function SeerDrawerArtifacts({sections}: SeerDrawerArtifactsProps) {
+function SeerDrawerArtifacts({autofix, sections}: SeerDrawerArtifactsProps) {
   return (
     <Fragment>
       {sections.map(section => {
         if (isRootCauseSection(section)) {
-          return <RootCauseCard key={section.step} section={section} />;
+          return <RootCauseCard key={section.step} autofix={autofix} section={section} />;
         }
 
         if (isSolutionSection(section)) {
-          return <SolutionCard key={section.step} section={section} />;
+          return <SolutionCard key={section.step} autofix={autofix} section={section} />;
         }
 
         if (isCodeChangesSection(section)) {
-          return <CodeChangesCard key={section.step} section={section} />;
+          return (
+            <CodeChangesCard key={section.step} autofix={autofix} section={section} />
+          );
         }
 
         if (isPullRequestSection(section)) {
-          return <PullRequestsCard key={section.step} section={section} />;
+          return (
+            <PullRequestsCard key={section.step} autofix={autofix} section={section} />
+          );
         }
 
         // TODO: maybe send a log?

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -1,9 +1,11 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
 import type {
   AutofixSection,
   useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import type {ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
 import {SeerDrawerNextStep} from './nextStep';
 
@@ -41,41 +43,39 @@ function defaultArtifacts(step: string): AutofixSection['artifacts'] {
           data: {one_line_summary: 'summary', steps: [{title: 't', description: 'd'}]},
         },
       ];
-    case 'code_changes':
-      return [
-        [
-          {
-            repo_name: 'repo',
-            diff: 'diff content',
-            patch: {
-              added: 1,
-              removed: 0,
-              path: 'file.py',
-              source_file: 'file.py',
-              target_file: 'file.py',
-              type: 'M',
-              hunks: [
+    case 'code_changes': {
+      const codeChange: ExplorerFilePatch = {
+        repo_name: 'repo',
+        diff: 'diff content',
+        patch: {
+          added: 1,
+          removed: 0,
+          path: 'file.py',
+          source_file: 'file.py',
+          target_file: 'file.py',
+          type: DiffFileType.MODIFIED,
+          hunks: [
+            {
+              section_header: '@@ -1,1 +1,2 @@',
+              source_start: 1,
+              source_length: 1,
+              target_start: 1,
+              target_length: 2,
+              lines: [
                 {
-                  section_header: '@@ -1,1 +1,2 @@',
-                  source_start: 1,
-                  source_length: 1,
-                  target_start: 1,
-                  target_length: 2,
-                  lines: [
-                    {
-                      diff_line_no: 1,
-                      line_type: '+',
-                      source_line_no: null,
-                      target_line_no: 1,
-                      value: 'new line',
-                    },
-                  ],
+                  diff_line_no: 1,
+                  line_type: DiffLineType.ADDED,
+                  source_line_no: null,
+                  target_line_no: 1,
+                  value: 'new line',
                 },
               ],
             },
-          },
-        ],
-      ];
+          ],
+        },
+      };
+      return [[codeChange]];
+    }
     default:
       return [];
   }

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -23,10 +23,71 @@ function makeAutofix(
   } as ReturnType<typeof useExplorerAutofix>;
 }
 
-function makeSection(step: string): AutofixSection {
+function defaultArtifacts(step: string): AutofixSection['artifacts'] {
+  switch (step) {
+    case 'root_cause':
+      return [
+        {
+          key: 'root_cause',
+          reason: 'test',
+          data: {one_line_description: 'desc', five_whys: ['why']},
+        },
+      ];
+    case 'solution':
+      return [
+        {
+          key: 'solution',
+          reason: 'test',
+          data: {one_line_summary: 'summary', steps: [{title: 't', description: 'd'}]},
+        },
+      ];
+    case 'code_changes':
+      return [
+        [
+          {
+            repo_name: 'repo',
+            diff: 'diff content',
+            patch: {
+              added: 1,
+              removed: 0,
+              path: 'file.py',
+              source_file: 'file.py',
+              target_file: 'file.py',
+              type: 'M',
+              hunks: [
+                {
+                  section_header: '@@ -1,1 +1,2 @@',
+                  source_start: 1,
+                  source_length: 1,
+                  target_start: 1,
+                  target_length: 2,
+                  lines: [
+                    {
+                      diff_line_no: 1,
+                      line_type: '+',
+                      source_line_no: null,
+                      target_line_no: 1,
+                      value: 'new line',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      ];
+    default:
+      return [];
+  }
+}
+
+function makeSection(
+  step: string,
+  artifacts?: AutofixSection['artifacts']
+): AutofixSection {
   return {
     step,
-    artifacts: [],
+    artifacts: artifacts ?? defaultArtifacts(step),
     messages: [],
     status: 'completed',
   };
@@ -46,6 +107,17 @@ describe('SeerDrawerNextStep', () => {
   });
 
   describe('RootCauseNextStep', () => {
+    it('returns null when section has no artifacts', () => {
+      const autofix = makeAutofix();
+      const {container} = render(
+        <SeerDrawerNextStep
+          sections={[makeSection('root_cause', [])]}
+          autofix={autofix}
+        />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
     it('renders prompt and yes button', () => {
       const autofix = makeAutofix();
       render(
@@ -113,6 +185,14 @@ describe('SeerDrawerNextStep', () => {
   });
 
   describe('SolutionNextStep', () => {
+    it('returns null when section has no artifacts', () => {
+      const autofix = makeAutofix();
+      const {container} = render(
+        <SeerDrawerNextStep sections={[makeSection('solution', [])]} autofix={autofix} />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
     it('renders prompt and yes button', () => {
       const autofix = makeAutofix();
       render(
@@ -182,6 +262,17 @@ describe('SeerDrawerNextStep', () => {
   });
 
   describe('CodeChangesNextStep', () => {
+    it('returns null when section has no artifacts', () => {
+      const autofix = makeAutofix();
+      const {container} = render(
+        <SeerDrawerNextStep
+          sections={[makeSection('code_changes', [])]}
+          autofix={autofix}
+        />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
     it('renders prompt and yes button', () => {
       const autofix = makeAutofix();
       render(

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState, type ReactNode} from 'react';
+import {useCallback, useMemo, useState, type ReactNode} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
@@ -6,8 +6,11 @@ import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 
 import {
+  isCodeChangesArtifact,
   isCodeChangesSection,
+  isRootCauseArtifact,
   isRootCauseSection,
+  isSolutionArtifact,
   isSolutionSection,
   type AutofixSection,
   type useExplorerAutofix,
@@ -22,22 +25,22 @@ interface SeerDrawerNextStepProps {
 
 export function SeerDrawerNextStep({sections, autofix}: SeerDrawerNextStepProps) {
   const runId = autofix.runState?.run_id;
-  const lastSection = sections[sections.length - 1];
+  const section = sections[sections.length - 1];
 
-  if (!defined(runId) || !defined(lastSection)) {
+  if (!defined(runId) || !defined(section)) {
     return null;
   }
 
-  if (isRootCauseSection(lastSection)) {
-    return <RootCauseNextStep autofix={autofix} runId={runId} />;
+  if (isRootCauseSection(section)) {
+    return <RootCauseNextStep autofix={autofix} runId={runId} section={section} />;
   }
 
-  if (isSolutionSection(lastSection)) {
-    return <SolutionNextStep autofix={autofix} runId={runId} />;
+  if (isSolutionSection(section)) {
+    return <SolutionNextStep autofix={autofix} runId={runId} section={section} />;
   }
 
-  if (isCodeChangesSection(lastSection)) {
-    return <CodeChangesNextStep autofix={autofix} runId={runId} />;
+  if (isCodeChangesSection(section)) {
+    return <CodeChangesNextStep autofix={autofix} runId={runId} section={section} />;
   }
 
   return null;
@@ -46,9 +49,10 @@ export function SeerDrawerNextStep({sections, autofix}: SeerDrawerNextStepProps)
 interface NextStepProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
   runId: number;
+  section: AutofixSection;
 }
 
-function RootCauseNextStep({autofix, runId}: NextStepProps) {
+function RootCauseNextStep({autofix, runId, section}: NextStepProps) {
   const {startStep} = autofix;
 
   const handleYesClick = useCallback(() => {
@@ -61,6 +65,15 @@ function RootCauseNextStep({autofix, runId}: NextStepProps) {
     },
     [startStep, runId]
   );
+
+  const artifact = useMemo(
+    () => section.artifacts.findLast(isRootCauseArtifact),
+    [section.artifacts]
+  );
+
+  if (!defined(artifact)) {
+    return null;
+  }
 
   return (
     <NextStepTemplate
@@ -77,7 +90,7 @@ function RootCauseNextStep({autofix, runId}: NextStepProps) {
   );
 }
 
-function SolutionNextStep({autofix, runId}: NextStepProps) {
+function SolutionNextStep({autofix, runId, section}: NextStepProps) {
   const {startStep} = autofix;
 
   const handleYesClick = useCallback(() => {
@@ -90,6 +103,15 @@ function SolutionNextStep({autofix, runId}: NextStepProps) {
     },
     [startStep, runId]
   );
+
+  const artifact = useMemo(
+    () => section.artifacts.findLast(isSolutionArtifact),
+    [section.artifacts]
+  );
+
+  if (!defined(artifact)) {
+    return null;
+  }
 
   return (
     <NextStepTemplate
@@ -108,7 +130,7 @@ function SolutionNextStep({autofix, runId}: NextStepProps) {
   );
 }
 
-function CodeChangesNextStep({autofix, runId}: NextStepProps) {
+function CodeChangesNextStep({autofix, runId, section}: NextStepProps) {
   const {createPR, startStep} = autofix;
 
   const handleYesClick = useCallback(() => {
@@ -121,6 +143,15 @@ function CodeChangesNextStep({autofix, runId}: NextStepProps) {
     },
     [startStep, runId]
   );
+
+  const artifact = useMemo(
+    () => section.artifacts.findLast(isCodeChangesArtifact),
+    [section.artifacts]
+  );
+
+  if (!defined(artifact)) {
+    return null;
+  }
 
   return (
     <NextStepTemplate


### PR DESCRIPTION
This adds a re-try step to allow users to retry a step when the previous attempt didn't produce an artifact.

| Root Cause | Implementation Plan | Code Changes |
| -----------| ----------------------| -------------|
| <img width="1296" height="286" alt="image" src="https://github.com/user-attachments/assets/fc609223-4f65-4553-a2c5-07962d362685" /> | <img width="1296" height="284" alt="image" src="https://github.com/user-attachments/assets/b1ffee50-a842-4e7d-8502-0df2c3df21f6" /> | <img width="1296" height="286" alt="image" src="https://github.com/user-attachments/assets/bc220402-95d2-4989-8d57-ec2b297e0c0e" /> |