### PR TITLE
fix(scm): Prevent 1px text shift when toggling SCM integration row

### DIFF
--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -390,9 +390,13 @@ const RowContainer = styled('div')`
   top: 0;
   left: 0;
   width: 100%;
-  border-bottom: 1px solid ${p => p.theme.tokens.border.neutral.muted};
-  &:last-child {
-    border-bottom: 1px solid transparent;
+  &:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border-bottom: 1px solid ${p => p.theme.tokens.border.neutral.muted};
   }
 `;
 

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -392,7 +392,7 @@ const RowContainer = styled('div')`
   width: 100%;
   border-bottom: 1px solid ${p => p.theme.tokens.border.neutral.muted};
   &:last-child {
-    border-bottom: none;
+    border-bottom: 1px solid transparent;
   }
 `;
 


### PR DESCRIPTION
The RowContainer used border-bottom on rows and none on :last-child.
With box-sizing: border-box, the presence or absence of that 1px border
changed the content area height (56px vs 55px). Child elements using
height: 100% inherited this, so flex-centered text shifted by 1px
whenever a row's last-child status changed — which happens whenever the
integration row is expanded or collapsed.

Fix by drawing the separator via a position: absolute ::after pseudo-element
instead. Since the pseudo-element is outside the box model, the container's
content area is always the full 56px and height: 100% resolves consistently.
