### PR TITLE
fix(dashboards): Resolve prebuilt dashboard placeholder IDs before duplication

### DIFF
--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.spec.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.spec.tsx
@@ -1,0 +1,129 @@
+import {DashboardFixture, DashboardListItemFixture} from 'sentry-fixture/dashboard';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {
+  useDuplicateDashboard,
+  useDuplicatePrebuiltDashboard,
+} from 'sentry/views/dashboards/hooks/useDuplicateDashboard';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+
+describe('useDuplicateDashboard', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('fetches and duplicates a non-prebuilt dashboard', async () => {
+    const fetchMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/42/`,
+      body: DashboardFixture([WidgetFixture()], {id: '42'}),
+    });
+    const createMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      method: 'POST',
+      body: DashboardFixture([WidgetFixture()], {id: '100'}),
+    });
+
+    const onSuccess = jest.fn();
+    const {result} = renderHookWithProviders(() => useDuplicateDashboard({onSuccess}), {
+      organization,
+    });
+
+    await act(async () => {
+      await result.current(DashboardListItemFixture({id: '42'}), 'grid');
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({id: '100'}));
+  });
+
+  it('resolves linked dashboard IDs before duplicating a prebuilt dashboard', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      method: 'GET',
+      body: [
+        DashboardFixture([], {
+          id: '55',
+          prebuiltId: PrebuiltDashboardId.WEB_VITALS_SUMMARY,
+        }),
+      ],
+    });
+    const createMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      method: 'POST',
+      body: DashboardFixture([], {id: '200'}),
+    });
+
+    const onSuccess = jest.fn();
+    const {result} = renderHookWithProviders(() => useDuplicateDashboard({onSuccess}), {
+      organization,
+    });
+
+    await act(async () => {
+      await result.current(
+        DashboardListItemFixture({
+          id: '-1',
+          prebuiltId: PrebuiltDashboardId.WEB_VITALS,
+        }),
+        'grid'
+      );
+    });
+
+    expect(createMock).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalled();
+  });
+});
+
+describe('useDuplicatePrebuiltDashboard', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('resolves and duplicates a prebuilt dashboard', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      method: 'GET',
+      body: [
+        DashboardFixture([], {
+          id: '55',
+          prebuiltId: PrebuiltDashboardId.WEB_VITALS_SUMMARY,
+        }),
+      ],
+    });
+    const createMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      method: 'POST',
+      body: DashboardFixture([], {id: '300'}),
+    });
+
+    const onSuccess = jest.fn();
+    const {result} = renderHookWithProviders(
+      () => useDuplicatePrebuiltDashboard({onSuccess}),
+      {organization}
+    );
+
+    await act(async () => {
+      await result.current.duplicatePrebuiltDashboard(PrebuiltDashboardId.WEB_VITALS);
+    });
+
+    expect(createMock).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({id: '300'}));
+  });
+
+  it('throws when no prebuiltId is provided', async () => {
+    const {result} = renderHookWithProviders(() => useDuplicatePrebuiltDashboard({}), {
+      organization,
+    });
+
+    await expect(result.current.duplicatePrebuiltDashboard(undefined)).rejects.toThrow(
+      'Prebuilt dashboard ID is required'
+    );
+  });
+});

--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
@@ -36,6 +36,7 @@ export function useDuplicateDashboard({onSuccess}: UseDuplicateDashboardProps) {
           : await fetchDashboard(api, organization.slug, dashboard.id);
 
         const newDashboard = cloneDashboard(dashboardDetail);
+        newDashboard.title = `${newDashboard.title} copy`;
         newDashboard.widgets.map(widget => (widget.id = undefined));
         const copiedDashboard = await createDashboard(
           api,

--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
@@ -4,6 +4,7 @@ import {createDashboard, fetchDashboard} from 'sentry/actionCreators/dashboards'
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useQueryClient} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {DashboardDetails, DashboardListItem} from 'sentry/views/dashboards/types';
@@ -12,6 +13,7 @@ import {
   PREBUILT_DASHBOARDS,
   type PrebuiltDashboardId,
 } from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {resolveLinkedDashboardIds} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
 interface UseDuplicateDashboardProps {
   onSuccess?: (copiedDashboard: DashboardDetails) => void;
@@ -19,13 +21,18 @@ interface UseDuplicateDashboardProps {
 
 export function useDuplicateDashboard({onSuccess}: UseDuplicateDashboardProps) {
   const api = useApi();
+  const queryClient = useQueryClient();
   const organization = useOrganization();
 
   const duplicateDashboard = useCallback(
     async (dashboard: DashboardListItem, viewType: 'table' | 'grid') => {
       try {
         const dashboardDetail = dashboard.prebuiltId
-          ? {id: '-1', ...PREBUILT_DASHBOARDS[dashboard.prebuiltId]}
+          ? await resolveLinkedDashboardIds({
+              queryClient,
+              orgSlug: organization.slug,
+              dashboard: toPrebuiltDashboardDetails(dashboard.prebuiltId),
+            })
           : await fetchDashboard(api, organization.slug, dashboard.id);
 
         const newDashboard = cloneDashboard(dashboardDetail);
@@ -46,7 +53,7 @@ export function useDuplicateDashboard({onSuccess}: UseDuplicateDashboardProps) {
         addErrorMessage(t('Error duplicating Dashboard'));
       }
     },
-    [api, organization, onSuccess]
+    [api, queryClient, organization, onSuccess]
   );
 
   return duplicateDashboard;
@@ -54,6 +61,7 @@ export function useDuplicateDashboard({onSuccess}: UseDuplicateDashboardProps) {
 
 export function useDuplicatePrebuiltDashboard({onSuccess}: UseDuplicateDashboardProps) {
   const api = useApi();
+  const queryClient = useQueryClient();
   const organization = useOrganization();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -64,9 +72,13 @@ export function useDuplicatePrebuiltDashboard({onSuccess}: UseDuplicateDashboard
           'Prebuilt dashboard ID is required to duplicate a prebuilt dashboard'
         );
       }
-      const prebuiltDashboard = {id: '-1', ...PREBUILT_DASHBOARDS[prebuiltId]};
       try {
-        const newDashboard = cloneDashboard(prebuiltDashboard);
+        const dashboardDetail = await resolveLinkedDashboardIds({
+          queryClient,
+          orgSlug: organization.slug,
+          dashboard: toPrebuiltDashboardDetails(prebuiltId),
+        });
+        const newDashboard = cloneDashboard(dashboardDetail);
         delete newDashboard.prebuiltId;
         newDashboard.title = `${newDashboard.title} copy`;
         newDashboard.widgets.map(widget => (widget.id = undefined));
@@ -84,8 +96,18 @@ export function useDuplicatePrebuiltDashboard({onSuccess}: UseDuplicateDashboard
         setIsLoading(false);
       }
     },
-    [api, organization, onSuccess]
+    [api, queryClient, organization, onSuccess]
   );
 
   return {duplicatePrebuiltDashboard, isLoading};
+}
+
+/**
+ * Prebuilt dashboard configs don't have an `id` since they aren't persisted.
+ * `cloneDashboard` and `createDashboard` require `DashboardDetails` (which includes `id`),
+ * so we attach a placeholder. Neither function actually uses the `id` value, so
+ * we should update those types.
+ */
+function toPrebuiltDashboardDetails(prebuiltId: PrebuiltDashboardId): DashboardDetails {
+  return {id: '-1', ...PREBUILT_DASHBOARDS[prebuiltId]};
 }

--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
@@ -74,6 +74,7 @@ export function useDuplicatePrebuiltDashboard({onSuccess}: UseDuplicateDashboard
         );
       }
       try {
+        setIsLoading(true);
         const dashboardDetail = await resolveLinkedDashboardIds({
           queryClient,
           orgSlug: organization.slug,
@@ -83,7 +84,6 @@ export function useDuplicatePrebuiltDashboard({onSuccess}: UseDuplicateDashboard
         delete newDashboard.prebuiltId;
         newDashboard.title = `${newDashboard.title} copy`;
         newDashboard.widgets.map(widget => (widget.id = undefined));
-        setIsLoading(true);
         const copiedDashboard = await createDashboard(
           api,
           organization.slug,

--- a/static/app/views/dashboards/manage/tableView/table.spec.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.spec.tsx
@@ -180,7 +180,7 @@ describe('DashboardTable', () => {
       expect.objectContaining({
         method: 'POST',
         data: expect.objectContaining({
-          title: 'Dashboard',
+          title: 'Dashboard copy',
           widgets: [],
         }),
       })

--- a/static/app/views/dashboards/utils/usePopulateLinkedDashboards.spec.tsx
+++ b/static/app/views/dashboards/utils/usePopulateLinkedDashboards.spec.tsx
@@ -1,0 +1,90 @@
+import {DashboardFixture} from 'sentry-fixture/dashboard';
+import {WidgetFixture} from 'sentry-fixture/widget';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
+
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {
+  getLinkedDashboardPrebuiltIds,
+  replacePlaceholderLinkedDashboardIds,
+} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
+
+describe('getLinkedDashboardPrebuiltIds', () => {
+  it('returns empty array when widget has no linked dashboards', () => {
+    expect(getLinkedDashboardPrebuiltIds(WidgetFixture())).toEqual([]);
+  });
+
+  it('extracts staticDashboardId values from linked dashboards', () => {
+    const widget = WidgetFixture({
+      queries: [
+        WidgetQueryFixture({
+          linkedDashboards: [
+            {
+              dashboardId: '-1',
+              field: 'transaction',
+              staticDashboardId: PrebuiltDashboardId.WEB_VITALS_SUMMARY,
+            },
+          ],
+        }),
+      ],
+    });
+    expect(getLinkedDashboardPrebuiltIds(widget)).toEqual([
+      PrebuiltDashboardId.WEB_VITALS_SUMMARY,
+    ]);
+  });
+
+  it('filters out linked dashboards without staticDashboardId', () => {
+    const widget = WidgetFixture({
+      queries: [
+        WidgetQueryFixture({
+          linkedDashboards: [{dashboardId: '42', field: 'transaction'}],
+        }),
+      ],
+    });
+    expect(getLinkedDashboardPrebuiltIds(widget)).toEqual([]);
+  });
+});
+
+describe('replacePlaceholderLinkedDashboardIds', () => {
+  it('replaces placeholder dashboardId with resolved id', () => {
+    const dashboard = DashboardFixture([
+      WidgetFixture({
+        queries: [
+          WidgetQueryFixture({
+            linkedDashboards: [
+              {
+                dashboardId: '-1',
+                field: 'transaction',
+                staticDashboardId: PrebuiltDashboardId.WEB_VITALS_SUMMARY,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+
+    const resolvedIdMap = new Map([[PrebuiltDashboardId.WEB_VITALS_SUMMARY, '99']]);
+    const result = replacePlaceholderLinkedDashboardIds(dashboard, resolvedIdMap);
+    expect(result.widgets[0]!.queries[0]!.linkedDashboards![0]!.dashboardId).toBe('99');
+  });
+
+  it('drops linked dashboard when no matching resolved dashboard is found', () => {
+    const dashboard = DashboardFixture([
+      WidgetFixture({
+        queries: [
+          WidgetQueryFixture({
+            linkedDashboards: [
+              {
+                dashboardId: '-1',
+                field: 'transaction',
+                staticDashboardId: PrebuiltDashboardId.WEB_VITALS_SUMMARY,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+
+    const result = replacePlaceholderLinkedDashboardIds(dashboard, new Map());
+    expect(result.widgets[0]!.queries[0]!.linkedDashboards).toEqual([]);
+  });
+});

--- a/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
+++ b/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
@@ -1,10 +1,12 @@
 import {useMemo} from 'react';
+import type {QueryClient} from '@tanstack/react-query';
 
 import {defined} from 'sentry/utils';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {fetchDataQuery, useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import type {DashboardDetails} from 'sentry/views/dashboards/types';
+import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
 import {
   PREBUILT_DASHBOARDS,
   PrebuiltDashboardId,
@@ -16,6 +18,42 @@ export const useGetPrebuiltDashboard = (prebuiltId?: PrebuiltDashboardId) => {
   return usePopulatePrebuiltIdsWithActualIds(prebuiltDashboard, prebuiltId);
 };
 
+/**
+ * Async resolver for use outside of React render (e.g., in duplication callbacks).
+ * Fetches real dashboard IDs for any linked dashboards that use placeholder '-1' IDs,
+ * then returns the dashboard with those placeholders replaced.
+ */
+export async function resolveLinkedDashboardIds({
+  queryClient,
+  orgSlug,
+  dashboard,
+}: {
+  dashboard: DashboardDetails;
+  orgSlug: string;
+  queryClient: QueryClient;
+}): Promise<DashboardDetails> {
+  const prebuiltIds = [
+    ...new Set(dashboard.widgets.flatMap(getLinkedDashboardPrebuiltIds)),
+  ];
+
+  // If no widgets reference other prebuilt dashboards, there are no placeholder
+  // IDs to resolve — skip the API call and return the dashboard as-is.
+  if (prebuiltIds.length === 0) {
+    return dashboard;
+  }
+
+  const queryKey = makeDashboardsQueryKey(orgSlug, prebuiltIds);
+
+  const [resolvedDashboards] = await queryClient.fetchQuery({
+    queryKey,
+    queryFn: fetchDataQuery<DashboardDetails[]>,
+    staleTime: Infinity,
+  });
+
+  const resolvedIdMap = buildResolvedIdMap(resolvedDashboards);
+  return replacePlaceholderLinkedDashboardIds(dashboard, resolvedIdMap);
+}
+
 const usePopulatePrebuiltIdsWithActualIds = (
   dashboard?: PrebuiltDashboard,
   prebuiltId?: PrebuiltDashboardId
@@ -25,32 +63,17 @@ const usePopulatePrebuiltIdsWithActualIds = (
   const widgets = useMemo(() => dashboard?.widgets ?? [], [dashboard]);
 
   const prebuiltIds = useMemo(
-    () =>
-      widgets
-        .flatMap(widget => {
-          return widget.queries
-            .flatMap(query => query.linkedDashboards ?? [])
-            .filter(defined);
-        })
-        .map(d => d.staticDashboardId)
-        .filter(defined),
+    () => widgets.flatMap(getLinkedDashboardPrebuiltIds),
     [widgets]
   );
 
   const hasLinkedDashboards = prebuiltIds.length > 0;
 
   const {data, isLoading} = useApiQuery<DashboardDetails[]>(
-    [
-      getApiUrl('/organizations/$organizationIdOrSlug/dashboards/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
-      {
-        query: {
-          prebuiltId: [...prebuiltIds.sort(), prebuiltId].filter(defined),
-          filter: 'showHidden',
-        },
-      },
-    ],
+    makeDashboardsQueryKey(
+      organization.slug,
+      [...prebuiltIds, prebuiltId].filter(defined)
+    ),
     {
       enabled: hasLinkedDashboards || Boolean(prebuiltId),
       staleTime: Infinity,
@@ -61,6 +84,7 @@ const usePopulatePrebuiltIdsWithActualIds = (
   return useMemo(() => {
     const populatedDashboard = {
       ...dashboard,
+      widgets,
       id: data?.find(d => d.prebuiltId === prebuiltId)?.id || undefined,
     };
 
@@ -72,25 +96,81 @@ const usePopulatePrebuiltIdsWithActualIds = (
       return {dashboard: populatedDashboard, isLoading};
     }
 
-    const populatedDashboardWithLinkedDashboards = {
-      ...populatedDashboard,
-      widgets: widgets.map(widget => ({
-        ...widget,
-        queries: widget.queries.map(query => ({
-          ...query,
-          linkedDashboards: query.linkedDashboards?.map(linkedDashboard => {
+    const resolvedIdMap = buildResolvedIdMap(data);
+    return {
+      dashboard: replacePlaceholderLinkedDashboardIds(populatedDashboard, resolvedIdMap),
+      isLoading,
+    };
+  }, [dashboard, widgets, data, hasLinkedDashboards, isLoading, prebuiltId]);
+};
+
+/**
+ * Extracts all `staticDashboardId` values from a single widget's linked dashboards.
+ */
+export function getLinkedDashboardPrebuiltIds(widget: Widget): PrebuiltDashboardId[] {
+  return widget.queries
+    .flatMap(query => query.linkedDashboards ?? [])
+    .filter(defined)
+    .map(d => d.staticDashboardId)
+    .filter(defined);
+}
+
+/**
+ * Replaces placeholder `dashboardId: '-1'` values in linked dashboards with real IDs
+ * from the provided map. Linked dashboards without a `staticDashboardId` (i.e. those
+ * that already have a real ID) are left unchanged.
+ */
+export function replacePlaceholderLinkedDashboardIds<T extends {widgets: Widget[]}>(
+  dashboard: T,
+  resolvedIdMap: Map<PrebuiltDashboardId, string>
+): T {
+  return {
+    ...dashboard,
+    widgets: dashboard.widgets.map(widget => ({
+      ...widget,
+      queries: widget.queries.map(query => ({
+        ...query,
+        linkedDashboards: query.linkedDashboards
+          ?.map(linkedDashboard => {
             if (!linkedDashboard.staticDashboardId) {
               return linkedDashboard;
             }
-            const dashboardId = data.find(
-              d => d.prebuiltId === linkedDashboard.staticDashboardId
-            )?.id;
-            return dashboardId ? {...linkedDashboard, dashboardId} : linkedDashboard;
-          }),
-        })),
+            const dashboardId = resolvedIdMap.get(linkedDashboard.staticDashboardId);
+            // Drop linked dashboards whose prebuilt target hasn't been materialized
+            // yet — sending the placeholder '-1' to the backend would fail.
+            return dashboardId ? {...linkedDashboard, dashboardId} : null;
+          })
+          .filter(defined),
       })),
-    };
+    })),
+  };
+}
 
-    return {dashboard: populatedDashboardWithLinkedDashboards, isLoading};
-  }, [dashboard, widgets, data, hasLinkedDashboards, isLoading, prebuiltId]);
-};
+function buildResolvedIdMap(
+  dashboards: DashboardDetails[]
+): Map<PrebuiltDashboardId, string> {
+  const map = new Map<PrebuiltDashboardId, string>();
+  for (const d of dashboards) {
+    if (d.prebuiltId) {
+      map.set(d.prebuiltId, d.id);
+    }
+  }
+  return map;
+}
+
+function makeDashboardsQueryKey(
+  orgSlug: string,
+  prebuiltIds: PrebuiltDashboardId[]
+): ApiQueryKey {
+  return [
+    getApiUrl('/organizations/$organizationIdOrSlug/dashboards/', {
+      path: {organizationIdOrSlug: orgSlug},
+    }),
+    {
+      query: {
+        prebuiltId: prebuiltIds.sort(),
+        filter: 'showHidden',
+      },
+    },
+  ];
+}


### PR DESCRIPTION
Prebuilt dashboards reference other prebuilt dashboards via `linkedDashboards` with placeholder `dashboardId: '-1'`. During duplication from list/grid views, these placeholders were sent directly to the backend, causing failures.

Extracts shared pure utilities (`getLinkedDashboardPrebuiltIds`, `replacePlaceholderLinkedDashboardIds`) from the existing `usePopulateLinkedDashboards` hook and adds an async resolver (`resolveLinkedDashboardIds`) that fetches real IDs via TanStack `queryClient.fetchQuery` before cloning. Unresolved linked dashboards are dropped to avoid sending invalid `-1` IDs.

The resolver shares a `makeDashboardsQueryKey` helper with the existing hook to keep query key construction consistent.

This creates a bit of duplication with the code that resolves prebuilt IDs for _displaying_ the pre-built dashboard, but that whole layer will need a re-look anyway. I filed a separate ticket for that: https://linear.app/getsentry/issue/DAIN-1341/consolidate-dashboards-data-fetching-code

DAIN-1300