### PR TITLE
chore(occ-eap): Misspell referer [sic]

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -323,8 +323,9 @@ def _extract_http(
 
         headers = request.get("headers", []) or []
         for header_name, header_value in [h for h in headers if h is not None]:
+            # Referer [sic] is spelled wrong in the HTTP standard.
             if header_name == "Referer" or header_name == "Referrer":
-                out["http_referrer"] = header_value
+                out["http_referer"] = header_value
 
     return out
 

--- a/src/sentry/search/eap/occurrences/attributes.py
+++ b/src/sentry/search/eap/occurrences/attributes.py
@@ -204,7 +204,7 @@ OCCURRENCE_ATTRIBUTE_DEFINITIONS = {
             ),
             ResolvedAttribute(
                 public_alias="http.referer",
-                internal_name="http_referrer",
+                internal_name="http_referer",
                 search_type="string",
             ),
             # Exception data

--- a/tests/sentry/eventstream/test_item_helpers.py
+++ b/tests/sentry/eventstream/test_item_helpers.py
@@ -230,7 +230,7 @@ class ItemHelpersTest(TestCase):
         assert out == {
             "http_url": "sentry.io",
             "http_method": "GET",
-            "http_referrer": "bestswetoolsofalltime.com",
+            "http_referer": "bestswetoolsofalltime.com",
         }
 
     def test_extract_modules(


### PR DESCRIPTION
It's misspelled in the HTTP standard; let's stay standardized (even if that means spelling things wrong)