### PR TITLE
feat(flagpole): Add experiment_mode field to Feature dataclass

### DIFF
--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -115,6 +115,9 @@ class Feature:
     created_at: str | None = None
     "The datetime when this feature was created."
 
+    experiment_mode: str | None = None
+    "The experiment mode for this feature. When set, the flag is treated as an experiment."
+
     def match(self, context: EvaluationContext) -> bool:
         if not self.enabled:
             return False
@@ -151,12 +154,17 @@ class Feature:
                 email=raw_owner.get("email"),
             )
 
+            raw_experiment_mode = config_dict.get("experiment_mode")
+
             feature = cls(
                 name=name,
                 owner=owner,
                 enabled=bool(config_dict.get("enabled", True)),
                 created_at=str(config_dict.get("created_at")),
                 segments=segments,
+                experiment_mode=str(raw_experiment_mode)
+                if raw_experiment_mode is not None
+                else None,
             )
         except Exception as exc:
             raise InvalidFeatureFlagConfiguration(

--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -67,6 +67,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import os
+from enum import StrEnum
 from typing import Any
 
 import jsonschema
@@ -75,6 +76,11 @@ import yaml
 
 from flagpole.conditions import ConditionBase, Segment
 from flagpole.evaluation_context import ContextBuilder, EvaluationContext
+
+
+class ExperimentMode(StrEnum):
+    SIMPLE = "simple"
+    """Simple experiment mode: flag on = active, flag off = control."""
 
 
 class InvalidFeatureFlagConfiguration(Exception):
@@ -115,7 +121,7 @@ class Feature:
     created_at: str | None = None
     "The datetime when this feature was created."
 
-    experiment_mode: str | None = None
+    experiment_mode: ExperimentMode | None = None
     "The experiment mode for this feature. When set, the flag is treated as an experiment."
 
     def match(self, context: EvaluationContext) -> bool:
@@ -162,7 +168,7 @@ class Feature:
                 enabled=bool(config_dict.get("enabled", True)),
                 created_at=str(config_dict.get("created_at")),
                 segments=segments,
-                experiment_mode=str(raw_experiment_mode)
+                experiment_mode=ExperimentMode(raw_experiment_mode)
                 if raw_experiment_mode is not None
                 else None,
             )
@@ -223,6 +229,7 @@ class Feature:
 
 
 __all__ = [
+    "ExperimentMode",
     "Feature",
     "OwnerInfo",
     "InvalidFeatureFlagConfiguration",

--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -216,7 +216,9 @@ class Feature:
     def to_dict(self) -> dict[str, Any]:
         dict_data = dataclasses.asdict(self)
         dict_data.pop("name")
-        return {self.name: {k: v for k, v in dict_data.items() if v is not None}}
+        if dict_data.get("experiment_mode") is None:
+            dict_data.pop("experiment_mode", None)
+        return {self.name: dict_data}
 
     def to_yaml_str(self) -> str:
         # Add an extra level of indentation by adding a top level dummy config.

--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -216,7 +216,7 @@ class Feature:
     def to_dict(self) -> dict[str, Any]:
         dict_data = dataclasses.asdict(self)
         dict_data.pop("name")
-        return {self.name: dict_data}
+        return {self.name: {k: v for k, v in dict_data.items() if v is not None}}
 
     def to_yaml_str(self) -> str:
         # Add an extra level of indentation by adding a top level dummy config.

--- a/src/flagpole/flagpole-schema.json
+++ b/src/flagpole/flagpole-schema.json
@@ -45,6 +45,12 @@
       "description": "The datetime when this feature was created.",
       "type": "string",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)?$"
+    },
+    "experiment_mode": {
+      "title": "Experiment Mode",
+      "description": "When set, the flag is treated as an experiment with exposure tracking.",
+      "type": ["string", "null"],
+      "enum": ["simple", null]
     }
   },
   "required": ["name", "owner", "segments", "created_at"],

--- a/tests/flagpole/test_flagpole_eval.py
+++ b/tests/flagpole/test_flagpole_eval.py
@@ -4,9 +4,8 @@ from unittest import mock
 
 import pytest
 import yaml
-from jsonschema import ValidationError
 
-from flagpole import Feature, OwnerInfo
+from flagpole import ExperimentMode, Feature, InvalidFeatureFlagConfiguration, OwnerInfo
 from flagpole.conditions import EqualsCondition, Segment
 from flagpole.evaluation_context import EvaluationContext
 from flagpole.flagpole_eval import evaluate_flag, get_arguments, read_feature
@@ -397,7 +396,7 @@ class TestExperimentMode:
 
         feature = Feature.from_feature_dictionary("test-experiment", config_dict)
 
-        assert feature.experiment_mode == "simple"
+        assert feature.experiment_mode == ExperimentMode.SIMPLE
 
     def test_feature_without_experiment_mode(self):
         config_dict = {
@@ -427,18 +426,17 @@ class TestExperimentMode:
 
         assert feature_regular.match(context) == feature_experiment.match(context)
 
-    def test_validate_invalid_experiment_mode(self):
-        feature = Feature(
-            name="test-feature",
-            owner=OwnerInfo(team="growth"),
-            enabled=True,
-            created_at="2026-03-13",
-            segments=[],
-            experiment_mode="invalid",
-        )
+    def test_invalid_experiment_mode_raises_on_parse(self):
+        config_dict = {
+            "enabled": True,
+            "owner": {"team": "growth"},
+            "created_at": "2026-03-13",
+            "experiment_mode": "invalid",
+            "segments": [{"name": "all-orgs", "rollout": 50, "conditions": []}],
+        }
 
-        with pytest.raises(ValidationError):
-            feature.validate()
+        with pytest.raises(InvalidFeatureFlagConfiguration):
+            Feature.from_feature_dictionary("test-feature", config_dict)
 
     def test_validate_valid_experiment_mode(self):
         feature = Feature(
@@ -447,7 +445,7 @@ class TestExperimentMode:
             enabled=True,
             created_at="2026-03-13",
             segments=[],
-            experiment_mode="simple",
+            experiment_mode=ExperimentMode.SIMPLE,
         )
 
         assert feature.validate() is True

--- a/tests/flagpole/test_flagpole_eval.py
+++ b/tests/flagpole/test_flagpole_eval.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 import yaml
+from jsonschema import ValidationError
 
 from flagpole import Feature, OwnerInfo
 from flagpole.conditions import EqualsCondition, Segment
@@ -380,3 +381,85 @@ class TestEvaluateFlag:
         assert rollout == 75
         assert segment
         assert segment.name == "partial-rollout-segment"
+
+
+class TestExperimentMode:
+    """Test experiment_mode field on Feature dataclass."""
+
+    def test_feature_with_experiment_mode_simple(self):
+        config_dict = {
+            "enabled": True,
+            "owner": {"team": "growth"},
+            "created_at": "2026-03-13",
+            "experiment_mode": "simple",
+            "segments": [{"name": "all-orgs", "rollout": 50, "conditions": []}],
+        }
+
+        feature = Feature.from_feature_dictionary("test-experiment", config_dict)
+
+        assert feature.experiment_mode == "simple"
+
+    def test_feature_without_experiment_mode(self):
+        config_dict = {
+            "enabled": True,
+            "owner": {"team": "growth"},
+            "created_at": "2026-03-13",
+            "segments": [{"name": "all-orgs", "rollout": 100, "conditions": []}],
+        }
+
+        feature = Feature.from_feature_dictionary("test-feature", config_dict)
+
+        assert feature.experiment_mode is None
+
+    def test_experiment_mode_does_not_affect_match(self):
+        config_dict = {
+            "enabled": True,
+            "owner": {"team": "growth"},
+            "created_at": "2026-03-13",
+            "segments": [{"name": "all-orgs", "rollout": 100, "conditions": []}],
+        }
+        config_with_experiment = {**config_dict, "experiment_mode": "simple"}
+
+        feature_regular = Feature.from_feature_dictionary("regular", config_dict)
+        feature_experiment = Feature.from_feature_dictionary("experiment", config_with_experiment)
+
+        context = EvaluationContext({"user_id": 123})
+
+        assert feature_regular.match(context) == feature_experiment.match(context)
+
+    def test_validate_invalid_experiment_mode(self):
+        feature = Feature(
+            name="test-feature",
+            owner=OwnerInfo(team="growth"),
+            enabled=True,
+            created_at="2026-03-13",
+            segments=[],
+            experiment_mode="invalid",
+        )
+
+        with pytest.raises(ValidationError):
+            feature.validate()
+
+    def test_validate_valid_experiment_mode(self):
+        feature = Feature(
+            name="test-feature",
+            owner=OwnerInfo(team="growth"),
+            enabled=True,
+            created_at="2026-03-13",
+            segments=[],
+            experiment_mode="simple",
+        )
+
+        assert feature.validate() is True
+
+    def test_validate_none_experiment_mode(self):
+        feature = Feature(
+            name="test-feature",
+            owner=OwnerInfo(team="growth"),
+            enabled=True,
+            created_at="2026-03-13",
+            segments=[],
+            experiment_mode=None,
+        )
+
+        assert feature.validate() is True


### PR DESCRIPTION
Add an optional `experiment_mode` field to flagpole flags. When present, the flag is treated as an experiment with additional behavior

`experiment_mode` only affects how the result is interpreted downstream, it doesn't affect segment matching.

For now the only supported value is `"simple"` (control vs active). We may support multivariant modes later as needed.

<!-- Describe your PR here. -->