### PR TITLE
fix(ACI): Parse and persist owner field

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -213,7 +213,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
                 if wdcg:
                     data["filterMatch"] = wdcg.condition_group.logic_type
 
-            request_data = format_request_data(cast(ProjectRulePostData, data))
+            request_data = format_request_data(cast(ProjectRulePostData, data), project)
             if not request_data.get("config", {}).get("frequency"):
                 request_data["config"] = workflow.config
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -11,7 +11,7 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
-
+from sentry.types.actor import parse_and_validate_actor
 from sentry import audit_log, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -747,6 +747,7 @@ class ProjectRulePostData(TypedDict):
 
 def format_request_data(
     data: ProjectRulePostData,
+    project: Project,
 ) -> WorkflowInput:
     workflow_payload: WorkflowInput = {
         "name": data.get("name", ""),
@@ -760,6 +761,13 @@ def format_request_data(
     fake_dcg = DataConditionGroup()
     # XXX: In order to avoid making bigger changes to translate_to_data_condition in issue_alert_conditions.py
     # we pass in a dummy DCG and then pop it off since we just need the formatted data
+
+    owner = data.get("owner")
+    if owner:
+        actor = parse_and_validate_actor(str(owner), project.organization_id)
+        if actor is not None:
+            workflow_payload["owner"] = actor.identifier
+    
 
     for condition in data.get("conditions", []):
         try:

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -756,18 +756,19 @@ def format_request_data(
         "environment": data.get("environment"),
         "config": {"frequency": data.get("frequency")},
     }
+    owner = data.get("owner", "")
+    if owner:
+        actor = parse_and_validate_actor(str(owner), project.organization_id)
+        if actor is not None:
+            workflow_payload["owner"] = actor.identifier
+    elif owner is None:  # user has expliticly passed None so as to clear the owner field
+        workflow_payload["owner"] = None
 
     triggers: DataConditionGroupInput = {"logicType": "any-short", "conditions": []}
     translated_filter_list: list[DataConditionInput] = []
     fake_dcg = DataConditionGroup()
     # XXX: In order to avoid making bigger changes to translate_to_data_condition in issue_alert_conditions.py
     # we pass in a dummy DCG and then pop it off since we just need the formatted data
-
-    owner = data.get("owner")
-    if owner:
-        actor = parse_and_validate_actor(str(owner), project.organization_id)
-        if actor is not None:
-            workflow_payload["owner"] = actor.identifier
 
     for condition in data.get("conditions", []):
         try:

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -11,7 +11,7 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry.types.actor import parse_and_validate_actor
+
 from sentry import audit_log, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -42,6 +42,7 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.processing.processor import is_condition_slow
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_created
+from sentry.types.actor import parse_and_validate_actor
 from sentry.workflow_engine.endpoints.validators.base.action import ActionInput
 from sentry.workflow_engine.endpoints.validators.base.data_condition import DataConditionInput
 from sentry.workflow_engine.endpoints.validators.base.data_condition_group import (
@@ -912,7 +913,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
-            request_data = format_request_data(cast(ProjectRulePostData, request.data))
+            request_data = format_request_data(cast(ProjectRulePostData, request.data), project)
             validator = WorkflowValidator(
                 data=request_data,
                 context={"organization": project.organization, "request": request},

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -761,7 +761,7 @@ def format_request_data(
         actor = parse_and_validate_actor(str(owner), project.organization_id)
         if actor is not None:
             workflow_payload["owner"] = actor.identifier
-    elif owner is None:  # user has expliticly passed None so as to clear the owner field
+    elif owner is None:  # user has explicitly passed None so as to clear the owner field
         workflow_payload["owner"] = None
 
     triggers: DataConditionGroupInput = {"logicType": "any-short", "conditions": []}

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -767,7 +767,6 @@ def format_request_data(
         actor = parse_and_validate_actor(str(owner), project.organization_id)
         if actor is not None:
             workflow_payload["owner"] = actor.identifier
-    
 
     for condition in data.get("conditions", []):
         try:

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -52,7 +52,7 @@ class WorkflowInput(TypedDict):
     environment: NotRequired[str | None]
     triggers: NotRequired[DataConditionGroupInput]
     actionFilters: NotRequired[list[ActionFilterInput]]
-    owner: NotRequired[str | int]
+    owner: NotRequired[str | int | None]
 
 
 class WorkflowValidator(CamelSnakeSerializer[Any]):

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -52,6 +52,7 @@ class WorkflowInput(TypedDict):
     environment: NotRequired[str | None]
     triggers: NotRequired[DataConditionGroupInput]
     actionFilters: NotRequired[list[ActionFilterInput]]
+    owner: NotRequired[str | int]
 
 
 class WorkflowValidator(CamelSnakeSerializer[Any]):

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -749,9 +749,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             )
         assert_serializer_results_match(response.data, workflow_response.data)
         assert workflow_response.data.get("owner") == f"team:{team.id}"
-        workflow = Workflow.objects.get(id=workflow_response.data["id"])
-        assert workflow.owner_team_id == team.id
-        assert workflow.owner_user_id is None
+        self.dual_written_workflow.refresh_from_db()
+        assert self.dual_written_workflow.owner_team_id == team.id
+        assert self.dual_written_workflow.owner_user_id is None
 
         payload = {
             "name": "hello world 2",
@@ -779,9 +779,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             )
         assert_serializer_results_match(response.data, workflow_response.data)
         assert workflow_response.data.get("owner") == f"user:{self.user.id}"
-        workflow = Workflow.objects.get(id=workflow_response.data["id"])
-        assert workflow.owner_team_id is None
-        assert workflow.owner_user_id == self.user.id
+        self.dual_written_workflow.refresh_from_db()
+        assert self.dual_written_workflow.owner_team_id is None
+        assert self.dual_written_workflow.owner_user_id == self.user.id
 
     def test_team_owner_not_member(self) -> None:
         self.organization.flags.allow_joinleave = False

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -671,11 +671,11 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         conditions = [{"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"}]
         payload = {
             "name": "hello world",
-            "owner": self.user.id,
             "actionMatch": "any",
             "filterMatch": "any",
             "actions": [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}],
             "conditions": conditions,
+            "owner": f"user:{self.user.id}",
         }
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
@@ -748,6 +748,10 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 **payload,
             )
         assert_serializer_results_match(response.data, workflow_response.data)
+        assert workflow_response.data.get("owner") == f"team:{team.id}"
+        workflow = Workflow.objects.get(id=workflow_response.data["id"])
+        assert workflow.owner_team_id == team.id
+        assert workflow.owner_user_id is None
 
         payload = {
             "name": "hello world 2",
@@ -774,6 +778,10 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 **payload,
             )
         assert_serializer_results_match(response.data, workflow_response.data)
+        assert workflow_response.data.get("owner") == f"user:{self.user.id}"
+        workflow = Workflow.objects.get(id=workflow_response.data["id"])
+        assert workflow.owner_team_id is None
+        assert workflow.owner_user_id == self.user.id
 
     def test_team_owner_not_member(self) -> None:
         self.organization.flags.allow_joinleave = False

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -699,7 +699,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         actions = [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}]
 
         # first set it up so that it does have an owner
-        payload = {
+        payload: dict[str, Any] = {
             "name": "hello world",
             "owner": f"user:{self.user.id}",
             "actionMatch": "any",

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -696,6 +696,23 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
 
     def test_no_owner(self) -> None:
         conditions = [{"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"}]
+        actions = [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}]
+
+        # first set it up so that it does have an owner
+        payload = {
+            "name": "hello world",
+            "owner": f"user:{self.user.id}",
+            "actionMatch": "any",
+            "filterMatch": "any",
+            "actions": actions,
+            "conditions": conditions,
+        }
+
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
+        )
+        assert response.data["owner"] == f"user:{self.user.id}"
+
         payload = {
             "name": "hello world",
             "owner": None,
@@ -708,6 +725,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
         )
         assert response.data["id"] == str(self.rule.id)
+        assert response.data["owner"] is None
         assert_rule_from_payload(self.rule, payload)
 
         with self.feature("organizations:workflow-engine-rule-serializers"):


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/110785 and https://github.com/getsentry/sentry/pull/110381/ to write and update the owner on a workflow if that data is passed to the legacy endpoint and we have the feature flag flipped so that we single write. 