### PR TITLE
fix(self-hosted): Migration inconsistency

### DIFF
--- a/src/sentry/monitors/migrations/0008_fix_processing_error_keys.py
+++ b/src/sentry/monitors/migrations/0008_fix_processing_error_keys.py
@@ -168,7 +168,7 @@ def fix_processing_error_keys(apps: StateApps, schema_editor: BaseDatabaseSchema
     pipeline = redis.pipeline()
 
     # step 1: fix all monitors
-    for monitor in RangeQuerySetWrapper(Monitor.objects.all()):
+    for monitor in RangeQuerySetWrapper(Monitor.objects.only("id").all()):
         monitor_identifier = build_monitor_identifier(monitor)
         processing_errors = fetch_processing_errors(monitor_identifier)
         for error_id in processing_errors:
@@ -182,7 +182,7 @@ def fix_processing_error_keys(apps: StateApps, schema_editor: BaseDatabaseSchema
         pipeline.execute()
 
     # step 2: fix all projects
-    for project in RangeQuerySetWrapper(Project.objects.all()):
+    for project in RangeQuerySetWrapper(Project.objects.only("id").all()):
         project_identifier = build_project_identifier(str(project.id))
         processing_errors = fetch_processing_errors(project_identifier)
         for error_id in processing_errors:
@@ -213,7 +213,7 @@ class Migration(CheckedMigration):
 
     dependencies = [
         ("monitors", "0007_monitors_json_field"),
-        ("sentry", "1040_drop_fk_projecttemplate"),
+        ("sentry", "0964_add_commitcomparison_table"),
     ]
 
     operations = [

--- a/src/sentry/monitors/migrations/0008_fix_processing_error_keys.py
+++ b/src/sentry/monitors/migrations/0008_fix_processing_error_keys.py
@@ -17,7 +17,6 @@ from django.utils.text import slugify
 
 from sentry.new_migrations.migrations import CheckedMigration
 from sentry.utils import json, redis
-from sentry.utils.query import RangeQuerySetWrapper
 
 MAX_ERRORS_PER_SET = 10
 MONITOR_ERRORS_LIFETIME = timedelta(days=7)
@@ -121,8 +120,8 @@ def _get_cluster() -> Any:
     return redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
 
 
-def build_monitor_identifier(monitor: Any) -> str:
-    return f"monitor:{monitor.id}"
+def build_monitor_identifier(monitor_id: int) -> str:
+    return f"monitor:{monitor_id}"
 
 
 def build_error_identifier(uuid: uuid.UUID) -> str:
@@ -168,8 +167,8 @@ def fix_processing_error_keys(apps: StateApps, schema_editor: BaseDatabaseSchema
     pipeline = redis.pipeline()
 
     # step 1: fix all monitors
-    for monitor in RangeQuerySetWrapper(Monitor.objects.only("id").all()):
-        monitor_identifier = build_monitor_identifier(monitor)
+    for monitor_id in Monitor.objects.values_list("id", flat=True).iterator():
+        monitor_identifier = build_monitor_identifier(monitor_id)
         processing_errors = fetch_processing_errors(monitor_identifier)
         for error_id in processing_errors:
             processing_error = processing_errors[error_id]
@@ -182,8 +181,8 @@ def fix_processing_error_keys(apps: StateApps, schema_editor: BaseDatabaseSchema
         pipeline.execute()
 
     # step 2: fix all projects
-    for project in RangeQuerySetWrapper(Project.objects.only("id").all()):
-        project_identifier = build_project_identifier(str(project.id))
+    for project_id in Project.objects.values_list("id", flat=True).iterator():
+        project_identifier = build_project_identifier(str(project_id))
         processing_errors = fetch_processing_errors(project_identifier)
         for error_id in processing_errors:
             processing_error = processing_errors[error_id]


### PR DESCRIPTION
follow up to https://github.com/getsentry/sentry/pull/110374

For self-hosted users, 0008 migration is already applied. 1040 was added last month, so the migration order cannot be done in the order that is expected in the dependency graph. This reverts the migration dependency, and fixes clean migrations so that 0008 no longer uses `sentry_project.template_id` which was breaking for clean installs of getsentry

fixes https://github.com/getsentry/self-hosted/issues/4222