### PR TITLE
ref(seer): Move seer settings routes into a getsentry hook

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -825,6 +825,7 @@ function buildRoutes(): RouteObject[] {
   };
 
   const orgSettingsChildren: SentryRouteObject[] = [
+    routeHook('routes:settings'),
     {
       index: true,
       name: t('General'),
@@ -1164,52 +1165,6 @@ function buildRoutes(): RouteObject[] {
               ),
             },
           ],
-        },
-      ],
-    },
-    {
-      path: 'seer/',
-      name: t('Seer'),
-      // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
-      component: make(() => import('getsentry/views/seerAutomation/index')),
-      children: [
-        {
-          path: 'trial/',
-          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
-          component: make(() => import('getsentry/views/seerAutomation/trial')),
-        },
-        {
-          index: true,
-          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
-          component: make(() => import('getsentry/views/seerAutomation/seerAutomation')),
-        },
-        {
-          path: 'scm/',
-          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
-          component: make(() => import('getsentry/views/seerAutomation/scm')),
-        },
-        {
-          path: 'projects/',
-          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
-          component: make(() => import('getsentry/views/seerAutomation/projects')),
-        },
-        {
-          path: 'repos/',
-          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
-          component: make(() => import('getsentry/views/seerAutomation/repos')),
-        },
-        {
-          path: 'repos/:repoId/',
-          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
-          component: make(() => import('getsentry/views/seerAutomation/repoDetails')),
-        },
-        {
-          path: 'onboarding/',
-          name: t('Setup Wizard'),
-          component: make(
-            // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
-            () => import('getsentry/views/seerAutomation/onboarding/onboarding')
-          ),
         },
       ],
     },

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -62,6 +62,7 @@ export type HookName = keyof Hooks;
 type RouteHooks = {
   'routes:legacy-organization-redirects': RouteObjectHook;
   'routes:root': RouteObjectHook;
+  'routes:settings': RouteObjectHook;
   'routes:subscription-settings': RouteObjectHook;
 };
 

--- a/static/gsApp/hooks/seerSettingsRoutes.ts
+++ b/static/gsApp/hooks/seerSettingsRoutes.ts
@@ -1,0 +1,42 @@
+import {t} from 'sentry/locale';
+import {makeLazyloadComponent as make} from 'sentry/makeLazyloadComponent';
+import type {SentryRouteObject} from 'sentry/router/types';
+
+export const seerSettingsRoutes = (): SentryRouteObject => ({
+  path: 'seer/',
+  name: t('Seer'),
+  component: make(() => import('getsentry/views/seerAutomation/index')),
+  children: [
+    {
+      path: 'trial/',
+      component: make(() => import('getsentry/views/seerAutomation/trial')),
+    },
+    {
+      index: true,
+      component: make(() => import('getsentry/views/seerAutomation/seerAutomation')),
+    },
+    {
+      path: 'scm/',
+      component: make(() => import('getsentry/views/seerAutomation/scm')),
+    },
+    {
+      path: 'projects/',
+      component: make(() => import('getsentry/views/seerAutomation/projects')),
+    },
+    {
+      path: 'repos/',
+      component: make(() => import('getsentry/views/seerAutomation/repos')),
+    },
+    {
+      path: 'repos/:repoId/',
+      component: make(() => import('getsentry/views/seerAutomation/repoDetails')),
+    },
+    {
+      path: 'onboarding/',
+      name: t('Setup Wizard'),
+      component: make(
+        () => import('getsentry/views/seerAutomation/onboarding/onboarding')
+      ),
+    },
+  ],
+});

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -61,6 +61,7 @@ import {getOrgRoles} from 'getsentry/hooks/organizationRoles';
 import OrgStatsBanner from 'getsentry/hooks/orgStatsBanner';
 import {OrgStatsProfilingBanner} from 'getsentry/hooks/orgStatsProfilingBanner';
 import {rootRoutes} from 'getsentry/hooks/rootRoutes';
+import {seerSettingsRoutes} from 'getsentry/hooks/seerSettingsRoutes';
 import {ComponentWrapper as EnhancedOrganizationStats} from 'getsentry/hooks/spendVisibility/enhancedIndex';
 import {SpikeProtectionProjectSettings} from 'getsentry/hooks/spendVisibility/spikeProtectionProjectSettings';
 import {subscriptionSettingsRoutes} from 'getsentry/hooks/subscriptionSettingsRoutes';
@@ -108,10 +109,12 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
    * Additional routes to be inserted into sentrys route tree
    */
   'routes:root': rootRoutes,
+  'routes:settings': seerSettingsRoutes,
   'routes:legacy-organization-redirects': legacyOrganizationRedirectRoutes,
 
   /**
-   *
+   * This has more than just subscriptions...
+   * and it uses it's own layout which makes it different from the other settings routes.
    */
   'routes:subscription-settings': subscriptionSettingsRoutes,
 


### PR DESCRIPTION
The seer settings routes were hardcoded in routes.tsx with boundary/element-types eslint suppressions. Move them into a getsentry hook (routes:settings) so they live in the right package without needing to suppress the boundary rules.

I added a new hook for these because the existing `routes:subscription-settings` hook adds its own wrapper that is unique and subscription specific. There are non-subscription related routes that render inside it, but the feedback button, for example, tags everything as 'billing' which seer probably shouldn't be part of. It's ripe for more refactoring imo.

Fixes CW-915