### PR TITLE
ref(seer): change prompt to include fix in commit

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -327,7 +327,7 @@ def generate_autofix_handoff_prompt(
     parts = ["Please fix the following issue. Ensure that your fix is fully working."]
 
     if short_id:
-        parts.append(f"Include 'Fixes {short_id}' in the pull request description.")
+        parts.append(f"Include 'Fixes {short_id}' in the commit message.")
 
     if instruction and instruction.strip():
         parts.append(instruction.strip())

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -818,9 +818,7 @@ def get_coding_agent_prompt(
     base_prompt = "Please fix the following issue. Ensure that your fix is fully working."
 
     if short_id:
-        base_prompt = (
-            f"{base_prompt}\n\nInclude 'Fixes {short_id}' in the pull request description."
-        )
+        base_prompt = f"{base_prompt}\n\nInclude 'Fixes {short_id}' in the commit message."
 
     if instruction and instruction.strip():
         base_prompt = f"{base_prompt}\n\n{instruction.strip()}"

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -149,7 +149,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
 
         prompt = generate_autofix_handoff_prompt(state, short_id="AIML-2301")
 
-        assert "Include 'Fixes AIML-2301' in the pull request description" in prompt
+        assert "Include 'Fixes AIML-2301' in the commit message" in prompt
 
     def test_prompt_without_short_id(self):
         """Test that 'Fixes' is not in prompt when short_id is None."""
@@ -177,7 +177,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
             state, instruction="Focus on performance", short_id="PROJ-123"
         )
 
-        assert "Include 'Fixes PROJ-123' in the pull request description" in prompt
+        assert "Include 'Fixes PROJ-123' in the commit message" in prompt
         assert "Focus on performance" in prompt
 
 

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -188,7 +188,7 @@ class TestGetCodingAgentPrompt(TestCase):
         )
 
         assert "Fixes AIML-2301" in result
-        assert "Include 'Fixes AIML-2301' in the pull request description" in result
+        assert "Include 'Fixes AIML-2301' in the commit message" in result
         assert "Please fix the following issue" in result
         assert "This is the autofix prompt" in result
 


### PR DESCRIPTION
The prompt always said to include the short-id in the PR, but when a PR was not created it can be confusing for a coding agent handoff. Additionally, including in PR description vs in commit message resolves the issue differently at the moment (commit resolves issue on creation but PR resolves on merge). It makes more sense to stick to one format for consistency and a follow up PR will improve logic for resolving with commit messages.

Tests:
Fixed unit tests and ran locally