### PR TITLE
feat(experiments): Populate org serializer experiments dict from flagpole

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -515,7 +515,7 @@ class _DetailedOrganizationSerializerResponseOptional(OrganizationSerializerResp
 
 @extend_schema_serializer(exclude_fields=["availableRoles"])
 class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResponseOptional):
-    experiments: Any
+    experiments: dict[str, str]
     isDefault: bool
     defaultRole: str  # TODO: replace with enum/literal
     availableRoles: list[Any]  # TODO: deprecated, use orgRoleList
@@ -637,9 +637,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
 
         context: DetailedOrganizationSerializerResponse = {
             **base,
-            # TODO(epurkhiser): This can be removed once we confirm the
-            # frontend does not use it
-            "experiments": {},
+            "experiments": features.get_experiment_assignments(obj, actor=user),
             "isDefault": obj.is_default,
             "defaultRole": obj.default_role,
             "availableRoles": [{"id": r.id, "name": r.name} for r in roles.get_all()],  # Deprecated

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -65,3 +65,4 @@ all = default_manager.all
 add_handler = default_manager.add_handler
 add_entity_handler = default_manager.add_entity_handler
 has_for_batch = default_manager.has_for_batch
+get_experiment_assignments = default_manager.get_experiment_assignments

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -71,6 +71,13 @@ class FeatureHandler:
     ) -> dict[str, bool] | None:
         raise NotImplementedError
 
+    def get_experiment_assignments(
+        self,
+        organization: Organization,
+        actor: User | RpcUser | AnonymousUser | None = None,
+    ) -> dict[str, str]:
+        return {}
+
 
 class BatchFeatureHandler(FeatureHandler):
     """

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -413,6 +413,27 @@ class FeatureManager(RegisteredFeatureManager):
                 return None
         return None
 
+    def get_experiment_assignments(
+        self,
+        organization: Organization,
+        actor: User | RpcUser | AnonymousUser | None = None,
+    ) -> dict[str, str]:
+        """
+        Get experiment assignments for an organization.
+
+        Returns a dict mapping experiment name (without scope prefix) to
+        assignment ("active" or "control") for all flags with experiment_mode set.
+
+        Delegates to the entity handler (FlagpoleFeatureHandler in getsentry).
+        """
+        try:
+            if self._entity_handler:
+                return self._entity_handler.get_experiment_assignments(organization, actor)
+        except Exception:
+            if in_random_rollout("features.error.capture_rate"):
+                logger.exception("Failed to get experiment assignments")
+        return {}
+
     @staticmethod
     def _shim_feature_strategy(
         entity_feature_strategy: bool | FeatureHandlerStrategy,

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -240,6 +240,35 @@ class DetailedOrganizationSerializerTest(TestCase):
 
         assert result["replayAccessMembers"] == []
 
+    def test_experiments_field_defaults_to_empty_dict(self) -> None:
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+        acc = access.from_user(user, organization)
+
+        serializer = DetailedOrganizationSerializer()
+        result = serialize(organization, user, serializer, access=acc)
+
+        assert result["experiments"] == {}
+
+    def test_experiments_field_populated_from_entity_handler(self) -> None:
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+        acc = access.from_user(user, organization)
+
+        handler = mock.Mock(spec=features.FeatureHandler)
+        handler.get_experiment_assignments.return_value = {"experiment-test": "active"}
+        handler.batch_has.return_value = None
+        handler.has.return_value = None
+
+        features.default_manager.add_entity_handler(handler)
+        try:
+            serializer = DetailedOrganizationSerializer()
+            result = serialize(organization, user, serializer, access=acc)
+
+            assert result["experiments"] == {"experiment-test": "active"}
+        finally:
+            features.default_manager._entity_handler = None
+
 
 class DetailedOrganizationSerializerWithProjectsAndTeamsTest(TestCase):
     def test_detailed_org_projs_teams(self) -> None:

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -447,3 +447,39 @@ class FeatureManagerTest(TestCase):
 
         assert list(manager.all().keys()) == ["feat:org", "feat:project", "feat:system"]
         assert list(manager.all(OrganizationFeature).keys()) == ["feat:org"]
+
+    def test_get_experiment_assignments_delegates_to_entity_handler(self) -> None:
+        test_org = self.create_organization()
+
+        handler = mock.Mock(spec=features.FeatureHandler)
+        handler.get_experiment_assignments.return_value = {"experiment-test": "active"}
+
+        manager = features.FeatureManager()
+        manager.add_entity_handler(handler)
+
+        result = manager.get_experiment_assignments(test_org, actor=None)
+
+        assert result == {"experiment-test": "active"}
+        handler.get_experiment_assignments.assert_called_once_with(test_org, None)
+
+    def test_get_experiment_assignments_returns_empty_without_entity_handler(self) -> None:
+        test_org = self.create_organization()
+
+        manager = features.FeatureManager()
+        result = manager.get_experiment_assignments(test_org)
+
+        assert result == {}
+
+    def test_get_experiment_assignments_handles_exception(self) -> None:
+        test_org = self.create_organization()
+
+        handler = mock.Mock(spec=features.FeatureHandler)
+        handler.get_experiment_assignments.side_effect = Exception("boom")
+
+        manager = features.FeatureManager()
+        manager.add_entity_handler(handler)
+
+        with override_options({"features.error.capture_rate": 1.0}):
+            result = manager.get_experiment_assignments(test_org)
+
+        assert result == {}


### PR DESCRIPTION
Add `get_experiment_assignments()` to the feature system, which returns experiment assignments for an org by evaluating all flagpole flags with `experiment_mode` set. The org serializer now calls this instead of returning an empty dict.

The actual implementation lives in getsentry's FlagpoleFeatureHandler, which will be implemented in a follow-up pr.