### PR TITLE
fix(digests): Migrate digests serialization from pickle to JSON

### DIFF
--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -219,10 +219,13 @@ class RedisBackend(Backend):
                 else:
                     raise
 
+            valid_entries = [
+                (key, value, timestamp) for key, value, timestamp in response if value is not None
+            ]
+            decoded = self.codec.decode_many([value for _, value, _ in valid_entries])
             records = [
-                Record(key.decode(), self.codec.decode(value), float(timestamp))
-                for key, value, timestamp in response
-                if value is not None
+                Record(key.decode(), notification, float(timestamp))
+                for (key, _, timestamp), notification in zip(valid_entries, decoded)
             ]
 
             # If the record value is `None`, this means the record data was

--- a/src/sentry/digests/codecs.py
+++ b/src/sentry/digests/codecs.py
@@ -4,6 +4,7 @@ import pickle
 import zlib
 from typing import Any, Literal, TypedDict
 
+from sentry import options
 from sentry.digests.types import IdentifierKey, Notification
 from sentry.utils.codecs import BytesCodec, JSONCodec, ZstdCodec
 
@@ -32,7 +33,7 @@ class NotificationPayload(TypedDict):
     event_id: str
     group_id: int | None
     timestamp: float
-    rules: list[int]
+    rule_ids: list[int]
     notification_uuid: str | None
     identifier_key: str
 
@@ -47,8 +48,6 @@ class Codec:
 
 class CompressedPickleCodec(Codec):
     def encode(self, value: Notification) -> bytes:
-        from sentry import options
-
         if not options.get("digests.encode-json-zstd"):
             return zlib.compress(pickle.dumps(value, protocol=5))
 
@@ -59,7 +58,7 @@ class CompressedPickleCodec(Codec):
             "event_id": event.event_id,
             "group_id": event.group_id,
             "timestamp": event.datetime.timestamp(),
-            "rules": list(value.rules),
+            "rule_ids": list(value.rules),
             "notification_uuid": value.notification_uuid,
             "identifier_key": str(value.identifier_key),
         }
@@ -81,7 +80,7 @@ class CompressedPickleCodec(Codec):
             )
             return Notification(
                 event=event,
-                rules=raw["rules"],
+                rules=raw["rule_ids"],
                 notification_uuid=raw["notification_uuid"],
                 identifier_key=IdentifierKey(raw["identifier_key"]),
             )

--- a/src/sentry/digests/codecs.py
+++ b/src/sentry/digests/codecs.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import pickle
 import zlib
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal
+
+from pydantic import BaseModel
 
 from sentry import options
 from sentry.digests.types import IdentifierKey, Notification
-from sentry.utils.codecs import BytesCodec, JSONCodec, ZstdCodec
+from sentry.utils.codecs import BytesCodec, ZstdCodec
 
-_json_zstd = JSONCodec() | BytesCodec() | ZstdCodec()
+_bytes_zstd = BytesCodec() | ZstdCodec()
 
 # All zstd frames start with a 4-byte little-endian magic number 0xFD2FB528
 # (RFC 8878 §3.1.1). Used to distinguish JSON+zstd payloads from legacy
@@ -18,17 +20,17 @@ _json_zstd = JSONCodec() | BytesCodec() | ZstdCodec()
 _ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
 
 
-class NotificationPayload(TypedDict):
+class NotificationPayload(BaseModel):
     """Schema for the JSON+zstd serialized notification payload.
 
-    ``_v`` should be bumped when making a breaking schema change.
+    ``version`` should be bumped when making a breaking schema change.
     It can be used if needed in decode to dispatch on the right deserialization logic.
 
-    Fields added as ``NotRequired`` don't need a version
-    bump since the reader can check for their presence.
+    Fields added as optional don't need a version bump since the reader can
+    check for their presence.
     """
 
-    _v: Literal[1]
+    version: Literal[1]
     project_id: int
     event_id: str
     group_id: int | None
@@ -52,17 +54,17 @@ class CompressedPickleCodec(Codec):
             return zlib.compress(pickle.dumps(value, protocol=5))
 
         event = value.event
-        payload: NotificationPayload = {
-            "_v": 1,
-            "project_id": event.project_id,
-            "event_id": event.event_id,
-            "group_id": event.group_id,
-            "timestamp": event.datetime.timestamp(),
-            "rule_ids": list(value.rules),
-            "notification_uuid": value.notification_uuid,
-            "identifier_key": str(value.identifier_key),
-        }
-        return _json_zstd.encode(payload)
+        payload = NotificationPayload(
+            version=1,
+            project_id=event.project_id,
+            event_id=event.event_id,
+            group_id=event.group_id,
+            timestamp=event.datetime.timestamp(),
+            rule_ids=list(value.rules),
+            notification_uuid=value.notification_uuid,
+            identifier_key=str(value.identifier_key),
+        )
+        return _bytes_zstd.encode(payload.json())
 
     def decode(self, value: bytes) -> Notification:
         if value[:4] == _ZSTD_MAGIC:
@@ -71,18 +73,18 @@ class CompressedPickleCodec(Codec):
             # full model graph which isn't ready yet at that point.
             from sentry.services.eventstore.models import Event
 
-            raw: NotificationPayload = _json_zstd.decode(value)
+            raw = NotificationPayload.parse_raw(_bytes_zstd.decode(value))
             event = Event(
-                project_id=raw["project_id"],
-                event_id=raw["event_id"],
-                group_id=raw["group_id"],
-                data={"timestamp": raw["timestamp"]},
+                project_id=raw.project_id,
+                event_id=raw.event_id,
+                group_id=raw.group_id,
+                data={"timestamp": raw.timestamp},
             )
             return Notification(
                 event=event,
-                rules=raw["rule_ids"],
-                notification_uuid=raw["notification_uuid"],
-                identifier_key=IdentifierKey(raw["identifier_key"]),
+                rules=raw.rule_ids,
+                notification_uuid=raw.notification_uuid,
+                identifier_key=IdentifierKey(raw.identifier_key),
             )
         # Legacy: pickle + zlib
         return pickle.loads(zlib.decompress(value))

--- a/src/sentry/digests/codecs.py
+++ b/src/sentry/digests/codecs.py
@@ -74,6 +74,9 @@ class CompressedPickleCodec(Codec):
             from sentry.services.eventstore.models import Event
 
             raw = NotificationPayload.parse_raw(_bytes_zstd.decode(value))
+            # Partial Event: only project_id, event_id, group_id, and
+            # datetime are populated. Do not access other fields (e.g.
+            # tags, title, message) — they will silently return empty values.
             event = Event(
                 project_id=raw.project_id,
                 event_id=raw.event_id,

--- a/src/sentry/digests/codecs.py
+++ b/src/sentry/digests/codecs.py
@@ -1,6 +1,40 @@
+from __future__ import annotations
+
 import pickle
 import zlib
-from typing import Any
+from typing import Any, Literal, TypedDict
+
+from sentry.digests.types import IdentifierKey, Notification
+from sentry.utils.codecs import BytesCodec, JSONCodec, ZstdCodec
+
+_json_zstd = JSONCodec() | BytesCodec() | ZstdCodec()
+
+# All zstd frames start with a 4-byte little-endian magic number 0xFD2FB528
+# (RFC 8878 §3.1.1). Used to distinguish JSON+zstd payloads from legacy
+# pickle+zlib data on decode. No collision is possible: legacy data is
+# zlib-compressed (CMF byte 0x78 from Python's default 32KB window), and
+# 0x28B5 isn't a valid zlib header (fails the CMF/FLG checksum).
+_ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+
+
+class NotificationPayload(TypedDict):
+    """Schema for the JSON+zstd serialized notification payload.
+
+    ``_v`` should be bumped when making a breaking schema change.
+    It can be used if needed in decode to dispatch on the right deserialization logic.
+
+    Fields added as ``NotRequired`` don't need a version
+    bump since the reader can check for their presence.
+    """
+
+    _v: Literal[1]
+    project_id: int
+    event_id: str
+    group_id: int | None
+    timestamp: float
+    rules: list[int]
+    notification_uuid: str | None
+    identifier_key: str
 
 
 class Codec:
@@ -12,8 +46,44 @@ class Codec:
 
 
 class CompressedPickleCodec(Codec):
-    def encode(self, value: Any) -> bytes:
-        return zlib.compress(pickle.dumps(value, protocol=5))
+    def encode(self, value: Notification) -> bytes:
+        from sentry import options
 
-    def decode(self, value: bytes) -> Any:
+        if not options.get("digests.encode-json-zstd"):
+            return zlib.compress(pickle.dumps(value, protocol=5))
+
+        event = value.event
+        payload: NotificationPayload = {
+            "_v": 1,
+            "project_id": event.project_id,
+            "event_id": event.event_id,
+            "group_id": event.group_id,
+            "timestamp": event.datetime.timestamp(),
+            "rules": list(value.rules),
+            "notification_uuid": value.notification_uuid,
+            "identifier_key": str(value.identifier_key),
+        }
+        return _json_zstd.encode(payload)
+
+    def decode(self, value: bytes) -> Notification:
+        if value[:4] == _ZSTD_MAGIC:
+            # Deferred to avoid circular import: this module is loaded during
+            # app init (via digests backend config), but Event pulls in the
+            # full model graph which isn't ready yet at that point.
+            from sentry.services.eventstore.models import Event
+
+            raw: NotificationPayload = _json_zstd.decode(value)
+            event = Event(
+                project_id=raw["project_id"],
+                event_id=raw["event_id"],
+                group_id=raw["group_id"],
+                data={"timestamp": raw["timestamp"]},
+            )
+            return Notification(
+                event=event,
+                rules=raw["rules"],
+                notification_uuid=raw["notification_uuid"],
+                identifier_key=IdentifierKey(raw["identifier_key"]),
+            )
+        # Legacy: pickle + zlib
         return pickle.loads(zlib.decompress(value))

--- a/src/sentry/digests/codecs.py
+++ b/src/sentry/digests/codecs.py
@@ -48,11 +48,10 @@ class Codec:
         raise NotImplementedError
 
 
-class CompressedPickleCodec(Codec):
-    def encode(self, value: Notification) -> bytes:
-        if not options.get("digests.encode-json-zstd"):
-            return zlib.compress(pickle.dumps(value, protocol=5))
+class CompressedJsonCodec(Codec):
+    """Encodes notifications as JSON compressed with zstd."""
 
+    def encode(self, value: Notification) -> bytes:
         event = value.event
         payload = NotificationPayload(
             version=1,
@@ -67,27 +66,42 @@ class CompressedPickleCodec(Codec):
         return _bytes_zstd.encode(payload.json())
 
     def decode(self, value: bytes) -> Notification:
-        if value[:4] == _ZSTD_MAGIC:
-            # Deferred to avoid circular import: this module is loaded during
-            # app init (via digests backend config), but Event pulls in the
-            # full model graph which isn't ready yet at that point.
-            from sentry.services.eventstore.models import Event
+        # Deferred to avoid circular import: this module is loaded during
+        # app init (via digests backend config), but Event pulls in the
+        # full model graph which isn't ready yet at that point.
+        from sentry.services.eventstore.models import Event
 
-            raw = NotificationPayload.parse_raw(_bytes_zstd.decode(value))
-            # Partial Event: only project_id, event_id, group_id, and
-            # datetime are populated. Do not access other fields (e.g.
-            # tags, title, message) — they will silently return empty values.
-            event = Event(
-                project_id=raw.project_id,
-                event_id=raw.event_id,
-                group_id=raw.group_id,
-                data={"timestamp": raw.timestamp},
-            )
-            return Notification(
-                event=event,
-                rules=raw.rule_ids,
-                notification_uuid=raw.notification_uuid,
-                identifier_key=IdentifierKey(raw.identifier_key),
-            )
-        # Legacy: pickle + zlib
+        raw = NotificationPayload.parse_raw(_bytes_zstd.decode(value))
+        # Partial Event: only project_id, event_id, group_id, and
+        # datetime are populated. Do not access other fields (e.g.
+        # tags, title, message) — they will silently return empty values.
+        event = Event(
+            project_id=raw.project_id,
+            event_id=raw.event_id,
+            group_id=raw.group_id,
+            data={"timestamp": raw.timestamp},
+        )
+        return Notification(
+            event=event,
+            rules=raw.rule_ids,
+            notification_uuid=raw.notification_uuid,
+            identifier_key=IdentifierKey(raw.identifier_key),
+        )
+
+
+class CompressedPickleCodec(Codec):
+    """Transitional codec that encodes notifications as pickle+zlib or JSON+zstd
+    depending on config and decodes both formats."""
+
+    def __init__(self) -> None:
+        self._json_codec = CompressedJsonCodec()
+
+    def encode(self, value: Notification) -> bytes:
+        if not options.get("digests.encode-json-zstd"):
+            return zlib.compress(pickle.dumps(value, protocol=5))
+        return self._json_codec.encode(value)
+
+    def decode(self, value: bytes) -> Notification:
+        if value[:4] == _ZSTD_MAGIC:
+            return self._json_codec.decode(value)
         return pickle.loads(zlib.decompress(value))

--- a/src/sentry/digests/codecs.py
+++ b/src/sentry/digests/codecs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import pickle
 import zlib
 from typing import Any, Literal
@@ -9,6 +10,8 @@ from pydantic import BaseModel
 from sentry import options
 from sentry.digests.types import IdentifierKey, Notification
 from sentry.utils.codecs import BytesCodec, ZstdCodec
+
+logger = logging.getLogger("sentry.digests")
 
 _bytes_zstd = BytesCodec() | ZstdCodec()
 
@@ -66,21 +69,31 @@ class CompressedJsonCodec(Codec):
         return _bytes_zstd.encode(payload.json())
 
     def decode(self, value: bytes) -> Notification:
-        # Deferred to avoid circular import: this module is loaded during
-        # app init (via digests backend config), but Event pulls in the
-        # full model graph which isn't ready yet at that point.
+        # Deferred imports: this module is loaded during app init (via
+        # digests backend config), before the full model graph is ready.
+        from sentry import eventstore
         from sentry.services.eventstore.models import Event
 
         raw = NotificationPayload.parse_raw(_bytes_zstd.decode(value))
-        # Partial Event: only project_id, event_id, group_id, and
-        # datetime are populated. Do not access other fields (e.g.
-        # tags, title, message) — they will silently return empty values.
-        event = Event(
-            project_id=raw.project_id,
-            event_id=raw.event_id,
+
+        event = eventstore.backend.get_event_by_id(
+            raw.project_id,
+            raw.event_id,
             group_id=raw.group_id,
-            data={"timestamp": raw.timestamp},
+            skip_transaction_groupevent=True,
         )
+        if event is None:
+            logger.warning(
+                "digests.codec.event_not_found",
+                extra={"project_id": raw.project_id, "event_id": raw.event_id},
+            )
+            event = Event(
+                project_id=raw.project_id,
+                event_id=raw.event_id,
+                group_id=raw.group_id,
+                data={"timestamp": raw.timestamp},
+            )
+
         return Notification(
             event=event,
             rules=raw.rule_ids,

--- a/src/sentry/digests/codecs.py
+++ b/src/sentry/digests/codecs.py
@@ -50,6 +50,9 @@ class Codec:
     def decode(self, value: bytes) -> Any:
         raise NotImplementedError
 
+    def decode_many(self, values: list[bytes]) -> list[Any]:
+        return [self.decode(v) for v in values]
+
 
 class CompressedJsonCodec(Codec):
     """Encodes notifications as JSON compressed with zstd."""
@@ -69,37 +72,51 @@ class CompressedJsonCodec(Codec):
         return _bytes_zstd.encode(payload.json())
 
     def decode(self, value: bytes) -> Notification:
+        return self.decode_many([value])[0]
+
+    def decode_many(self, values: list[bytes]) -> list[Notification]:
         # Deferred imports: this module is loaded during app init (via
         # digests backend config), before the full model graph is ready.
         from sentry import eventstore
         from sentry.services.eventstore.models import Event
 
-        raw = NotificationPayload.parse_raw(_bytes_zstd.decode(value))
+        payloads = [NotificationPayload.parse_raw(_bytes_zstd.decode(v)) for v in values]
 
-        event = eventstore.backend.get_event_by_id(
-            raw.project_id,
-            raw.event_id,
-            group_id=raw.group_id,
-            skip_transaction_groupevent=True,
-        )
-        if event is None:
-            logger.warning(
-                "digests.codec.event_not_found",
-                extra={"project_id": raw.project_id, "event_id": raw.event_id},
-            )
-            event = Event(
+        # Build unfetched Event objects and batch-load node data in one
+        # multi-get call instead of N individual fetches.
+        events = [
+            Event(
                 project_id=raw.project_id,
                 event_id=raw.event_id,
                 group_id=raw.group_id,
-                data={"timestamp": raw.timestamp},
             )
+            for raw in payloads
+        ]
+        eventstore.backend.bind_nodes(events)
 
-        return Notification(
-            event=event,
-            rules=raw.rule_ids,
-            notification_uuid=raw.notification_uuid,
-            identifier_key=IdentifierKey(raw.identifier_key),
-        )
+        notifications: list[Notification] = []
+        for raw, event in zip(payloads, events):
+            if len(event.data) == 0:
+                logger.warning(
+                    "digests.codec.event_not_found",
+                    extra={"project_id": raw.project_id, "event_id": raw.event_id},
+                )
+                event = Event(
+                    project_id=raw.project_id,
+                    event_id=raw.event_id,
+                    group_id=raw.group_id,
+                    data={"timestamp": raw.timestamp},
+                )
+
+            notifications.append(
+                Notification(
+                    event=event,
+                    rules=raw.rule_ids,
+                    notification_uuid=raw.notification_uuid,
+                    identifier_key=IdentifierKey(raw.identifier_key),
+                )
+            )
+        return notifications
 
 
 class CompressedPickleCodec(Codec):
@@ -118,3 +135,22 @@ class CompressedPickleCodec(Codec):
         if value[:4] == _ZSTD_MAGIC:
             return self._json_codec.decode(value)
         return pickle.loads(zlib.decompress(value))
+
+    def decode_many(self, values: list[bytes]) -> list[Notification]:
+        json_indices: list[int] = []
+        json_values: list[bytes] = []
+        results: list[Notification | None] = [None] * len(values)
+
+        for i, value in enumerate(values):
+            if value[:4] == _ZSTD_MAGIC:
+                json_indices.append(i)
+                json_values.append(value)
+            else:
+                results[i] = pickle.loads(zlib.decompress(value))
+
+        if json_values:
+            decoded = self._json_codec.decode_many(json_values)
+            for i, notification in zip(json_indices, decoded):
+                results[i] = notification
+
+        return results  # type: ignore[return-value]

--- a/src/sentry/digests/types.py
+++ b/src/sentry/digests/types.py
@@ -18,6 +18,9 @@ class IdentifierKey(StrEnum):
 
 
 class Notification(NamedTuple):
+    # NOTE: `event` may be a partial Event, with only: (project_id, event_id, group_id, datetime).
+    # Don't use without understanding the implications.
+    # TODO: Use more specialized type once we've stopped pickle-ing.
     event: Event | GroupEvent
     rules: Sequence[int] = ()
     notification_uuid: str | None = None

--- a/src/sentry/digests/types.py
+++ b/src/sentry/digests/types.py
@@ -18,9 +18,6 @@ class IdentifierKey(StrEnum):
 
 
 class Notification(NamedTuple):
-    # NOTE: `event` may be a partial Event, with only: (project_id, event_id, group_id, datetime).
-    # Don't use without understanding the implications.
-    # TODO: Use more specialized type once we've stopped pickle-ing.
     event: Event | GroupEvent
     rules: Sequence[int] = ()
     notification_uuid: str | None = None

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -208,6 +208,8 @@ register(
 )
 
 # Digests
+# When true, digests will use JSON+zstd encoding instead of pickle+zlib.
+# Decoding should support both until no more pickle+zlib data is in the wild.
 register(
     "digests.encode-json-zstd",
     default=False,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -207,6 +207,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Digests
+register(
+    "digests.encode-json-zstd",
+    default=False,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # TOTP (Auth app)
 register(
     "totp.disallow-new-enrollment",

--- a/tests/sentry/digests/test_codecs.py
+++ b/tests/sentry/digests/test_codecs.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import pickle
+import zlib
+from collections.abc import Iterator
+from datetime import datetime, timezone
+
+import pytest
+
+from sentry.digests.codecs import CompressedPickleCodec
+from sentry.digests.types import IdentifierKey, Notification
+from sentry.services.eventstore.models import Event
+from sentry.testutils.helpers.options import override_options
+
+
+def _make_notification(
+    *,
+    project_id: int = 1,
+    event_id: str = "abc123",
+    group_id: int = 42,
+    timestamp: float = 1700000000.0,
+    rules: list[int] | None = None,
+    notification_uuid: str | None = "notif-uuid-1",
+    identifier_key: IdentifierKey = IdentifierKey.RULE,
+) -> Notification:
+    event = Event(
+        project_id=project_id,
+        event_id=event_id,
+        group_id=group_id,
+        data={"timestamp": timestamp},
+    )
+    return Notification(
+        event=event,
+        rules=rules if rules is not None else [1, 2],
+        notification_uuid=notification_uuid,
+        identifier_key=identifier_key,
+    )
+
+
+class TestCompressedPickleCodec:
+    codec: CompressedPickleCodec = CompressedPickleCodec()
+
+    @pytest.fixture(autouse=True)
+    def _enable_json_zstd(self) -> Iterator[None]:
+        with override_options({"digests.encode-json-zstd": True}):
+            yield
+
+    def test_round_trip(self) -> None:
+        original = _make_notification()
+        encoded = self.codec.encode(original)
+        decoded = self.codec.decode(encoded)
+
+        assert decoded.event.project_id == original.event.project_id
+        assert decoded.event.event_id == original.event.event_id
+        assert decoded.event.group_id == original.event.group_id
+        assert decoded.event.datetime == original.event.datetime
+        assert list(decoded.rules) == list(original.rules)
+        assert decoded.notification_uuid == original.notification_uuid
+        assert decoded.identifier_key == original.identifier_key
+
+    def test_round_trip_workflow_identifier_key(self) -> None:
+        original = _make_notification(identifier_key=IdentifierKey.WORKFLOW)
+        decoded = self.codec.decode(self.codec.encode(original))
+        assert decoded.identifier_key == IdentifierKey.WORKFLOW
+
+    def test_round_trip_none_notification_uuid(self) -> None:
+        original = _make_notification(notification_uuid=None)
+        decoded = self.codec.decode(self.codec.encode(original))
+        assert decoded.notification_uuid is None
+
+    def test_round_trip_empty_rules(self) -> None:
+        original = _make_notification(rules=[])
+        decoded = self.codec.decode(self.codec.encode(original))
+        assert list(decoded.rules) == []
+
+    def test_decoded_event_datetime(self) -> None:
+        ts = 1700000000.0
+        original = _make_notification(timestamp=ts)
+        decoded = self.codec.decode(self.codec.encode(original))
+        expected = datetime.fromtimestamp(ts, tz=timezone.utc)
+        assert decoded.event.datetime == expected
+
+    def test_decoded_event_group_setter(self) -> None:
+        """Verify the decoded Event supports the .group setter used by _bind_records."""
+        decoded = self.codec.decode(self.codec.encode(_make_notification()))
+
+        class FakeGroup:
+            id: int = 99
+
+        decoded.event.group = FakeGroup()
+        assert decoded.event.group_id == 99
+
+    def test_backward_compat_legacy_pickle_zlib(self) -> None:
+        """New codec can decode data written by the old pickle+zlib codec."""
+        original = _make_notification()
+        legacy_bytes = zlib.compress(pickle.dumps(original, protocol=5))
+        decoded = self.codec.decode(legacy_bytes)
+
+        assert decoded.event.project_id == original.event.project_id
+        assert decoded.event.event_id == original.event.event_id
+        assert decoded.event.group_id == original.event.group_id
+        assert list(decoded.rules) == list(original.rules)
+        assert decoded.notification_uuid == original.notification_uuid
+
+    def test_encoded_starts_with_zstd_magic(self) -> None:
+        encoded = self.codec.encode(_make_notification())
+        assert encoded[:4] == b"\x28\xb5\x2f\xfd"
+
+    def test_option_disabled_encodes_pickle(self) -> None:
+        """When the option is off, encode produces pickle+zlib (the legacy format)."""
+        with override_options({"digests.encode-json-zstd": False}):
+            encoded = self.codec.encode(_make_notification())
+        # zlib-compressed data starts with \x78
+        assert encoded[0:1] == b"\x78"
+        # Decoder can still read it
+        decoded = self.codec.decode(encoded)
+        assert decoded.event.event_id == "abc123"
+
+    def test_option_disabled_round_trip(self) -> None:
+        """Full round-trip works with the option disabled (pickle path)."""
+        original = _make_notification()
+        with override_options({"digests.encode-json-zstd": False}):
+            encoded = self.codec.encode(original)
+            decoded = self.codec.decode(encoded)
+        assert decoded.event.project_id == original.event.project_id
+        assert decoded.event.event_id == original.event.event_id
+        assert decoded.event.group_id == original.event.group_id
+        assert list(decoded.rules) == list(original.rules)
+
+    def test_cross_format_decode(self) -> None:
+        """Data written with option off can be read with option on, and vice versa."""
+        original = _make_notification()
+
+        # Write pickle, read with json-zstd enabled
+        with override_options({"digests.encode-json-zstd": False}):
+            pickle_encoded = self.codec.encode(original)
+        decoded = self.codec.decode(pickle_encoded)
+        assert decoded.event.event_id == original.event.event_id
+
+        # Write json-zstd, read with option off (decoder doesn't check the option)
+        zstd_encoded = self.codec.encode(original)
+        with override_options({"digests.encode-json-zstd": False}):
+            decoded = self.codec.decode(zstd_encoded)
+        assert decoded.event.event_id == original.event.event_id

--- a/tests/sentry/digests/test_codecs.py
+++ b/tests/sentry/digests/test_codecs.py
@@ -4,11 +4,13 @@ import pickle
 import zlib
 from collections.abc import Iterator
 from datetime import datetime, timezone
+from unittest.mock import Mock
 
 import pytest
 
 from sentry.digests.codecs import CompressedPickleCodec
 from sentry.digests.types import IdentifierKey, Notification
+from sentry.models.group import Group
 from sentry.services.eventstore.models import Event
 from sentry.testutils.helpers.options import override_options
 
@@ -84,10 +86,8 @@ class TestCompressedPickleCodec:
         """Verify the decoded Event supports the .group setter used by _bind_records."""
         decoded = self.codec.decode(self.codec.encode(_make_notification()))
 
-        class FakeGroup:
-            id: int = 99
-
-        decoded.event.group = FakeGroup()
+        group = Mock(spec=Group, id=99)
+        decoded.event.group = group
         assert decoded.event.group_id == 99
 
     def test_backward_compat_legacy_pickle_zlib(self) -> None:

--- a/tests/sentry/digests/test_codecs.py
+++ b/tests/sentry/digests/test_codecs.py
@@ -11,6 +11,7 @@ import pytest
 
 from sentry.digests.codecs import _ZSTD_MAGIC, CompressedJsonCodec, CompressedPickleCodec
 from sentry.digests.types import IdentifierKey, Notification
+from sentry.models.event import GroupEvent
 from sentry.models.group import Group
 from sentry.services.eventstore.models import Event
 from sentry.testutils.helpers.options import override_options
@@ -56,7 +57,7 @@ class TestCompressedJsonCodec:
     @pytest.fixture(autouse=True)
     def _mock_eventstore(self) -> Iterator[None]:
         """Stub eventstore so decode can fetch events without Snuba."""
-        self._events: dict[tuple[int, str], Event] = {}
+        self._events: dict[tuple[int, str], Event | GroupEvent] = {}
 
         def fake_get_event_by_id(project_id: int, event_id: str, **kwargs: object) -> Event | None:
             return self._events.get((project_id, event_id))
@@ -131,7 +132,7 @@ class TestCompressedPickleCodec:
 
     @pytest.fixture(autouse=True)
     def _mock_eventstore(self) -> Iterator[None]:
-        self._events: dict[tuple[int, str], Event] = {}
+        self._events: dict[tuple[int, str], Event | GroupEvent] = {}
 
         def fake_get_event_by_id(project_id: int, event_id: str, **kwargs: object) -> Event | None:
             return self._events.get((project_id, event_id))

--- a/tests/sentry/digests/test_codecs.py
+++ b/tests/sentry/digests/test_codecs.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from sentry.digests.codecs import CompressedPickleCodec
+from sentry.digests.codecs import _ZSTD_MAGIC, CompressedJsonCodec, CompressedPickleCodec
 from sentry.digests.types import IdentifierKey, Notification
 from sentry.models.group import Group
 from sentry.services.eventstore.models import Event
@@ -39,26 +39,23 @@ def _make_notification(
     )
 
 
-class TestCompressedPickleCodec:
-    codec: CompressedPickleCodec = CompressedPickleCodec()
+def _assert_notifications_equal(decoded: Notification, original: Notification) -> None:
+    assert decoded.event.project_id == original.event.project_id
+    assert decoded.event.event_id == original.event.event_id
+    assert decoded.event.group_id == original.event.group_id
+    assert decoded.event.datetime == original.event.datetime
+    assert list(decoded.rules) == list(original.rules)
+    assert decoded.notification_uuid == original.notification_uuid
+    assert decoded.identifier_key == original.identifier_key
 
-    @pytest.fixture(autouse=True)
-    def _enable_json_zstd(self) -> Iterator[None]:
-        with override_options({"digests.encode-json-zstd": True}):
-            yield
+
+class TestCompressedJsonCodec:
+    codec: CompressedJsonCodec = CompressedJsonCodec()
 
     def test_round_trip(self) -> None:
         original = _make_notification()
-        encoded = self.codec.encode(original)
-        decoded = self.codec.decode(encoded)
-
-        assert decoded.event.project_id == original.event.project_id
-        assert decoded.event.event_id == original.event.event_id
-        assert decoded.event.group_id == original.event.group_id
-        assert decoded.event.datetime == original.event.datetime
-        assert list(decoded.rules) == list(original.rules)
-        assert decoded.notification_uuid == original.notification_uuid
-        assert decoded.identifier_key == original.identifier_key
+        decoded = self.codec.decode(self.codec.encode(original))
+        _assert_notifications_equal(decoded, original)
 
     def test_round_trip_workflow_identifier_key(self) -> None:
         original = _make_notification(identifier_key=IdentifierKey.WORKFLOW)
@@ -90,8 +87,26 @@ class TestCompressedPickleCodec:
         decoded.event.group = group
         assert decoded.event.group_id == 99
 
+    def test_encoded_starts_with_zstd_magic(self) -> None:
+        encoded = self.codec.encode(_make_notification())
+        assert encoded[:4] == _ZSTD_MAGIC
+
+
+class TestCompressedPickleCodec:
+    codec: CompressedPickleCodec = CompressedPickleCodec()
+
+    @pytest.fixture(autouse=True)
+    def _enable_json_zstd(self) -> Iterator[None]:
+        with override_options({"digests.encode-json-zstd": True}):
+            yield
+
+    def test_round_trip(self) -> None:
+        original = _make_notification()
+        decoded = self.codec.decode(self.codec.encode(original))
+        _assert_notifications_equal(decoded, original)
+
     def test_backward_compat_legacy_pickle_zlib(self) -> None:
-        """New codec can decode data written by the old pickle+zlib codec."""
+        """Decoder can handle data written by the old pickle+zlib format."""
         original = _make_notification()
         legacy_bytes = zlib.compress(pickle.dumps(original, protocol=5))
         decoded = self.codec.decode(legacy_bytes)
@@ -102,17 +117,12 @@ class TestCompressedPickleCodec:
         assert list(decoded.rules) == list(original.rules)
         assert decoded.notification_uuid == original.notification_uuid
 
-    def test_encoded_starts_with_zstd_magic(self) -> None:
-        encoded = self.codec.encode(_make_notification())
-        assert encoded[:4] == b"\x28\xb5\x2f\xfd"
-
     def test_option_disabled_encodes_pickle(self) -> None:
         """When the option is off, encode produces pickle+zlib (the legacy format)."""
         with override_options({"digests.encode-json-zstd": False}):
             encoded = self.codec.encode(_make_notification())
         # zlib-compressed data starts with \x78
         assert encoded[0:1] == b"\x78"
-        # Decoder can still read it
         decoded = self.codec.decode(encoded)
         assert decoded.event.event_id == "abc123"
 
@@ -122,10 +132,7 @@ class TestCompressedPickleCodec:
         with override_options({"digests.encode-json-zstd": False}):
             encoded = self.codec.encode(original)
             decoded = self.codec.decode(encoded)
-        assert decoded.event.project_id == original.event.project_id
-        assert decoded.event.event_id == original.event.event_id
-        assert decoded.event.group_id == original.event.group_id
-        assert list(decoded.rules) == list(original.rules)
+        _assert_notifications_equal(decoded, original)
 
     def test_cross_format_decode(self) -> None:
         """Data written with option off can be read with option on, and vice versa."""
@@ -141,4 +148,13 @@ class TestCompressedPickleCodec:
         zstd_encoded = self.codec.encode(original)
         with override_options({"digests.encode-json-zstd": False}):
             decoded = self.codec.decode(zstd_encoded)
+        assert decoded.event.event_id == original.event.event_id
+
+    def test_delegates_to_json_codec(self) -> None:
+        original = _make_notification()
+        encoded = self.codec.encode(original)
+        assert encoded[:4] == _ZSTD_MAGIC
+        # CompressedJsonCodec can decode it directly
+        json_codec = CompressedJsonCodec()
+        decoded = json_codec.decode(encoded)
         assert decoded.event.event_id == original.event.event_id

--- a/tests/sentry/digests/test_codecs.py
+++ b/tests/sentry/digests/test_codecs.py
@@ -11,7 +11,6 @@ import pytest
 
 from sentry.digests.codecs import _ZSTD_MAGIC, CompressedJsonCodec, CompressedPickleCodec
 from sentry.digests.types import IdentifierKey, Notification
-from sentry.models.event import GroupEvent
 from sentry.models.group import Group
 from sentry.services.eventstore.models import Event
 from sentry.testutils.helpers.options import override_options
@@ -57,19 +56,19 @@ class TestCompressedJsonCodec:
     @pytest.fixture(autouse=True)
     def _mock_eventstore(self) -> Iterator[None]:
         """Stub eventstore so decode can fetch events without Snuba."""
-        self._events: dict[tuple[int, str], Event | GroupEvent] = {}
+        self._node_data: dict[tuple[int, str], dict[str, object]] = {}
 
-        def fake_get_event_by_id(project_id: int, event_id: str, **kwargs: object) -> Event | None:
-            return self._events.get((project_id, event_id))
+        def fake_bind_nodes(event_list: list[Event]) -> None:
+            for event in event_list:
+                data = self._node_data.get((event.project_id, event.event_id), {})
+                event.data.bind_data(data, ref=event.data.get_ref(event))
 
-        with mock.patch(
-            "sentry.eventstore.backend.get_event_by_id", side_effect=fake_get_event_by_id
-        ):
+        with mock.patch("sentry.eventstore.backend.bind_nodes", side_effect=fake_bind_nodes):
             yield
 
     def _register(self, notification: Notification) -> None:
         e = notification.event
-        self._events[(e.project_id, e.event_id)] = e
+        self._node_data[(e.project_id, e.event_id)] = dict(e.data)
 
     def test_round_trip(self) -> None:
         original = _make_notification()
@@ -126,20 +125,50 @@ class TestCompressedJsonCodec:
         assert decoded.event.group_id == original.event.group_id
         assert decoded.event.datetime == original.event.datetime
 
+    def test_decode_many_batch(self) -> None:
+        notifications = [_make_notification(event_id=f"event-{i}", group_id=i) for i in range(5)]
+        for n in notifications:
+            self._register(n)
+
+        encoded = [self.codec.encode(n) for n in notifications]
+        decoded = self.codec.decode_many(encoded)
+
+        assert len(decoded) == 5
+        for original, result in zip(notifications, decoded):
+            _assert_notifications_equal(result, original)
+
+    def test_decode_many_partial_missing(self) -> None:
+        """Events missing from nodestore get the timestamp fallback."""
+        found = _make_notification(event_id="found-1", group_id=1)
+        missing = _make_notification(event_id="missing-1", group_id=2)
+        self._register(found)
+        # Don't register missing
+
+        encoded = [self.codec.encode(found), self.codec.encode(missing)]
+        decoded = self.codec.decode_many(encoded)
+
+        assert len(decoded) == 2
+        _assert_notifications_equal(decoded[0], found)
+        assert decoded[1].event.event_id == "missing-1"
+        assert decoded[1].event.datetime == missing.event.datetime
+
+    def test_decode_many_empty(self) -> None:
+        assert self.codec.decode_many([]) == []
+
 
 class TestCompressedPickleCodec:
     codec: CompressedPickleCodec = CompressedPickleCodec()
 
     @pytest.fixture(autouse=True)
     def _mock_eventstore(self) -> Iterator[None]:
-        self._events: dict[tuple[int, str], Event | GroupEvent] = {}
+        self._node_data: dict[tuple[int, str], dict[str, object]] = {}
 
-        def fake_get_event_by_id(project_id: int, event_id: str, **kwargs: object) -> Event | None:
-            return self._events.get((project_id, event_id))
+        def fake_bind_nodes(event_list: list[Event]) -> None:
+            for event in event_list:
+                data = self._node_data.get((event.project_id, event.event_id), {})
+                event.data.bind_data(data, ref=event.data.get_ref(event))
 
-        with mock.patch(
-            "sentry.eventstore.backend.get_event_by_id", side_effect=fake_get_event_by_id
-        ):
+        with mock.patch("sentry.eventstore.backend.bind_nodes", side_effect=fake_bind_nodes):
             yield
 
     @pytest.fixture(autouse=True)
@@ -149,7 +178,7 @@ class TestCompressedPickleCodec:
 
     def _register(self, notification: Notification) -> None:
         e = notification.event
-        self._events[(e.project_id, e.event_id)] = e
+        self._node_data[(e.project_id, e.event_id)] = dict(e.data)
 
     def test_round_trip(self) -> None:
         original = _make_notification()
@@ -211,3 +240,33 @@ class TestCompressedPickleCodec:
         json_codec = CompressedJsonCodec()
         decoded = json_codec.decode(encoded)
         assert decoded.event.event_id == original.event.event_id
+
+    def test_decode_many_mixed_formats(self) -> None:
+        """decode_many handles a mix of pickle and JSON payloads, preserving order."""
+        n1 = _make_notification(event_id="json-1", group_id=1)
+        n2 = _make_notification(event_id="pickle-1", group_id=2)
+        n3 = _make_notification(event_id="json-2", group_id=3)
+        self._register(n1)
+        self._register(n3)
+
+        json_encoded_1 = self.codec.encode(n1)
+        with override_options({"digests.encode-json-zstd": False}):
+            pickle_encoded = self.codec.encode(n2)
+        json_encoded_2 = self.codec.encode(n3)
+
+        decoded = self.codec.decode_many([json_encoded_1, pickle_encoded, json_encoded_2])
+
+        assert len(decoded) == 3
+        assert decoded[0].event.event_id == "json-1"
+        assert decoded[1].event.event_id == "pickle-1"
+        assert decoded[2].event.event_id == "json-2"
+
+    def test_decode_many_all_pickle(self) -> None:
+        notifications = [_make_notification(event_id=f"pickle-{i}", group_id=i) for i in range(3)]
+        with override_options({"digests.encode-json-zstd": False}):
+            encoded = [self.codec.encode(n) for n in notifications]
+        decoded = self.codec.decode_many(encoded)
+
+        assert len(decoded) == 3
+        for original, result in zip(notifications, decoded):
+            assert result.event.event_id == original.event.event_id

--- a/tests/sentry/digests/test_codecs.py
+++ b/tests/sentry/digests/test_codecs.py
@@ -4,6 +4,7 @@ import pickle
 import zlib
 from collections.abc import Iterator
 from datetime import datetime, timezone
+from unittest import mock
 from unittest.mock import Mock
 
 import pytest
@@ -52,36 +53,60 @@ def _assert_notifications_equal(decoded: Notification, original: Notification) -
 class TestCompressedJsonCodec:
     codec: CompressedJsonCodec = CompressedJsonCodec()
 
+    @pytest.fixture(autouse=True)
+    def _mock_eventstore(self) -> Iterator[None]:
+        """Stub eventstore so decode can fetch events without Snuba."""
+        self._events: dict[tuple[int, str], Event] = {}
+
+        def fake_get_event_by_id(project_id: int, event_id: str, **kwargs: object) -> Event | None:
+            return self._events.get((project_id, event_id))
+
+        with mock.patch(
+            "sentry.eventstore.backend.get_event_by_id", side_effect=fake_get_event_by_id
+        ):
+            yield
+
+    def _register(self, notification: Notification) -> None:
+        e = notification.event
+        self._events[(e.project_id, e.event_id)] = e
+
     def test_round_trip(self) -> None:
         original = _make_notification()
+        self._register(original)
         decoded = self.codec.decode(self.codec.encode(original))
         _assert_notifications_equal(decoded, original)
 
     def test_round_trip_workflow_identifier_key(self) -> None:
         original = _make_notification(identifier_key=IdentifierKey.WORKFLOW)
+        self._register(original)
         decoded = self.codec.decode(self.codec.encode(original))
         assert decoded.identifier_key == IdentifierKey.WORKFLOW
 
     def test_round_trip_none_notification_uuid(self) -> None:
         original = _make_notification(notification_uuid=None)
+        self._register(original)
         decoded = self.codec.decode(self.codec.encode(original))
         assert decoded.notification_uuid is None
 
     def test_round_trip_empty_rules(self) -> None:
         original = _make_notification(rules=[])
+        self._register(original)
         decoded = self.codec.decode(self.codec.encode(original))
         assert list(decoded.rules) == []
 
     def test_decoded_event_datetime(self) -> None:
         ts = 1700000000.0
         original = _make_notification(timestamp=ts)
+        self._register(original)
         decoded = self.codec.decode(self.codec.encode(original))
         expected = datetime.fromtimestamp(ts, tz=timezone.utc)
         assert decoded.event.datetime == expected
 
     def test_decoded_event_group_setter(self) -> None:
         """Verify the decoded Event supports the .group setter used by _bind_records."""
-        decoded = self.codec.decode(self.codec.encode(_make_notification()))
+        original = _make_notification()
+        self._register(original)
+        decoded = self.codec.decode(self.codec.encode(original))
 
         group = Mock(spec=Group, id=99)
         decoded.event.group = group
@@ -91,17 +116,43 @@ class TestCompressedJsonCodec:
         encoded = self.codec.encode(_make_notification())
         assert encoded[:4] == _ZSTD_MAGIC
 
+    def test_event_not_found_falls_back_to_partial(self) -> None:
+        original = _make_notification()
+        # Don't register — eventstore returns None
+        decoded = self.codec.decode(self.codec.encode(original))
+        assert decoded.event.project_id == original.event.project_id
+        assert decoded.event.event_id == original.event.event_id
+        assert decoded.event.group_id == original.event.group_id
+        assert decoded.event.datetime == original.event.datetime
+
 
 class TestCompressedPickleCodec:
     codec: CompressedPickleCodec = CompressedPickleCodec()
+
+    @pytest.fixture(autouse=True)
+    def _mock_eventstore(self) -> Iterator[None]:
+        self._events: dict[tuple[int, str], Event] = {}
+
+        def fake_get_event_by_id(project_id: int, event_id: str, **kwargs: object) -> Event | None:
+            return self._events.get((project_id, event_id))
+
+        with mock.patch(
+            "sentry.eventstore.backend.get_event_by_id", side_effect=fake_get_event_by_id
+        ):
+            yield
 
     @pytest.fixture(autouse=True)
     def _enable_json_zstd(self) -> Iterator[None]:
         with override_options({"digests.encode-json-zstd": True}):
             yield
 
+    def _register(self, notification: Notification) -> None:
+        e = notification.event
+        self._events[(e.project_id, e.event_id)] = e
+
     def test_round_trip(self) -> None:
         original = _make_notification()
+        self._register(original)
         decoded = self.codec.decode(self.codec.encode(original))
         _assert_notifications_equal(decoded, original)
 
@@ -137,6 +188,7 @@ class TestCompressedPickleCodec:
     def test_cross_format_decode(self) -> None:
         """Data written with option off can be read with option on, and vice versa."""
         original = _make_notification()
+        self._register(original)
 
         # Write pickle, read with json-zstd enabled
         with override_options({"digests.encode-json-zstd": False}):
@@ -152,9 +204,9 @@ class TestCompressedPickleCodec:
 
     def test_delegates_to_json_codec(self) -> None:
         original = _make_notification()
+        self._register(original)
         encoded = self.codec.encode(original)
         assert encoded[:4] == _ZSTD_MAGIC
-        # CompressedJsonCodec can decode it directly
         json_codec = CompressedJsonCodec()
         decoded = json_codec.decode(encoded)
         assert decoded.event.event_id == original.event.event_id


### PR DESCRIPTION
We don't want to use pickle if we can avoid it, and the current scheme pulls in Group, Project, Org, and a variety of cached fields for them, making it rather easy to break unintentionally.


This moves to a minimal set of data, encoded as JSON and compressed using zstd. This allows us to easily recognize new data via the standard vstd header. The intention is to deploy it disabled, and once the code is fully available enable it for our various environments incrementally. Once we have confidence it works as intended and is stable, we'll default the flag to enabled, and remove the option of pickle use.


Updates ISWF-2246.
