### PR TITLE
fix(uptime): Add default 2xx status assertion to auto-detected monitors

### DIFF
--- a/src/sentry/uptime/autodetect/tasks.py
+++ b/src/sentry/uptime/autodetect/tasks.py
@@ -29,7 +29,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     get_auto_monitored_detectors_for_project,
     is_url_auto_monitored_for_project,
 )
-from sentry.uptime.types import UptimeMonitorMode
+from sentry.uptime.types import DEFAULT_2XX_STATUS_ASSERTION, UptimeMonitorMode
 from sentry.uptime.utils import get_cluster
 from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
@@ -255,6 +255,7 @@ def monitor_url_for_project(project: Project, url: str) -> Detector:
         timeout_ms=ONBOARDING_SUBSCRIPTION_TIMEOUT_MS,
         name=f"Uptime Monitoring for {url}",
         mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
+        assertion=DEFAULT_2XX_STATUS_ASSERTION,
     )
 
 

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -32,6 +32,19 @@ DEFAULT_DOWNTIME_THRESHOLD = 3
 Default number of consecutive failed checks required to mark monitor as down.
 """
 
+DEFAULT_2XX_STATUS_ASSERTION: dict[str, Any] = {
+    "root": {
+        "op": "and",
+        "children": [
+            {"op": "status_code_check", "operator": {"cmp": "greater_than"}, "value": 199},
+            {"op": "status_code_check", "operator": {"cmp": "less_than"}, "value": 300},
+        ],
+    }
+}
+"""
+Default assertion that checks for a 2xx status code response.
+"""
+
 RegionScheduleMode = Literal["round_robin"]
 """
 Defines how we'll schedule checks based on other active regions.

--- a/tests/sentry/uptime/autodetect/test_tasks.py
+++ b/tests/sentry/uptime/autodetect/test_tasks.py
@@ -39,7 +39,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     get_auto_monitored_detectors_for_project,
     is_url_auto_monitored_for_project,
 )
-from sentry.uptime.types import UptimeMonitorMode
+from sentry.uptime.types import DEFAULT_2XX_STATUS_ASSERTION, UptimeMonitorMode
 from sentry.uptime.utils import get_cluster
 from sentry.workflow_engine.models import Detector
 
@@ -362,6 +362,8 @@ class TestMonitorUrlForProject(UptimeTestCase):
         detector = monitor_url_for_project(self.project, url)
         assert is_url_auto_monitored_for_project(self.project, url)
         assert detector.name == f"Uptime Monitoring for {url}"
+        uptime_subscription = get_uptime_subscription(detector)
+        assert uptime_subscription.assertion == DEFAULT_2XX_STATUS_ASSERTION
 
     def test_existing(self) -> None:
         url = make_unique_test_url()


### PR DESCRIPTION
Auto-detected uptime monitors were being created without the default
status code assertion, unlike manually created monitors where the
frontend ensures it. Pass DEFAULT_2XX_STATUS_ASSERTION when creating
auto-detected monitors so all new subscriptions check for 2xx responses.