### PR TITLE
ref(grouping): Cache more message parameterizations

### DIFF
--- a/src/sentry/grouping/context.py
+++ b/src/sentry/grouping/context.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Self
 
 from sentry.grouping.parameterization import experimental_parameterizer
 from sentry.grouping.parameterization import parameterizer as default_parameterizer
-from sentry.grouping.utils import get_canonical_message_from_event
+from sentry.grouping.utils import get_all_messages_from_event
 from sentry.options.rollout import in_rollout_group
 
 if TYPE_CHECKING:
@@ -43,27 +43,27 @@ class GroupingContext:
         self.config = strategy_config
         self.event = event
 
-        # Store the event's message, in both raw and parameterized form, as well as the
-        # parameterizer. This will save us having to recheck which parameterizer to use, and save us
-        # from having to reparameterize the message if it's used in multiple places during grouping
-        # (in the error value component and a custom fingerprint, for example).
-        event_message = get_canonical_message_from_event(event)
-        parameterizer = (
+        # Store the event's messages, in both raw and parameterized form, as well as the
+        # parameterizer. This will save us from having to reparameterize a message if it's used in
+        # multiple places during grouping (in app and system variants, for example, or the error
+        # value component and a custom fingerprint). Also, in case we try to normalize a message we
+        # haven't handled here (which we shouldn't, but just in case), it will save us having to
+        # recheck which parameterizer to use.
+        self.parameterizer = (
             experimental_parameterizer
             if in_rollout_group("grouping.experimental_parameterization", event.project_id)
             else default_parameterizer
         )
-        self.parameterizer = parameterizer
-        # "Canonical" because it's the message which is used for the `{{ message }}` variable and
-        # for message-based grouping. (When grouping is based on error message, in case of an error
-        # chain we use all messages.)
-        self.canonical_event_message = event_message
-        self.canonical_message_parameterized = parameterizer.parameterize(event_message)
+        self.message_parameterization_map = {
+            message: self.parameterizer.parameterize(message)
+            for message in get_all_messages_from_event(event)
+        }
 
         # Track use of the cached values for metrics purposes. Any use past the first one signifies
-        # a reuse of the value, thus proving caching worthwhile.
+        # a reuse of the value, thus proving caching worthwhile. (We track via raw message rather
+        # than parameterized value in case two messages parameterize the same way.)
+        self.messages_seen: set[str] = set()
         self.cached_parameterizer_used = False
-        self.cached_param_result_used = False
 
         self._push_context_layer()
 

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -118,3 +118,19 @@ def get_canonical_message_from_event(event: Event) -> str:
         or get_path(event.data, "exception", "values", -1, "value")
         or ""
     )
+
+
+def get_all_messages_from_event(event: Event) -> set[str]:
+    """
+    Get all messages contained in the event. Looks at log messages and exceptions, including
+    exception chains.
+    """
+    exceptions = get_path(event.data, "exception", "values", filter=True) or []
+    messages = {
+        get_canonical_message_from_event(event),  # This will grab a log message if available
+        *(exc.get("value") for exc in exceptions),
+    }
+    messages.discard("")  # In case `get_canonical_message_from_event` came up empty
+    messages.discard(None)  # In case any of the `get` calls came up empty
+
+    return messages

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -61,20 +61,29 @@ def normalize_message_for_grouping(
     Replace values from a event's message with placeholders (in order to improve grouping). If
     `trim_message` is True, trim the message to at most 2 lines.
     """
-    if message == context.canonical_event_message:
-        parameterized = context.canonical_message_parameterized
+    # Since we very often use event messages multiple times during grouping (in some combo of app
+    # and system variants, message components, and fingerprints), and always use them at least once,
+    # we prepopulate a parameterized message cache when we initialize the context. Thus we always
+    # expect to find the message here.
+    if message in context.message_parameterization_map:
+        parameterized = context.message_parameterization_map[message]
 
-        # Before we mark the value as having been used, check if it's already marked that way. If
-        # so, that means our use of the value here is at least the second use, thus proving the
-        # caching worthwhile.
-        if context.cached_param_result_used:
+        # Before we mark the message as having been seen, check if it's already marked that way. If
+        # so, that means our use of the parameterized value here is at least the second use, thus
+        # proving the caching worthwhile.
+        if message in context.messages_seen:
             # This represents a saved call to `parameterizer.parameterize`
             metrics.incr("grouping.cached_param_result_used")
 
-        context.cached_param_result_used = True
-    else:
+        context.messages_seen.add(message)
+
+    else:  # Fallback - should no longer land here
         parameterized = context.parameterizer.parameterize(message)
 
+        # TODO: Now that we're caching parameterizations for all event messages (and therefore
+        # shouldn't ever land in this branch), we could probably get rid of this metric, as well as
+        # `context.cached_parameterizer_used`.
+        #
         # Before we mark the parameterizer as having been used, check if it's already marked that
         # way. If so, that means our use of it here is at least the second use, thus proving the
         # caching worthwhile.

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -15,6 +15,7 @@ from sentry.grouping.variants import ComponentVariant, CustomFingerprintVariant
 from sentry.models.project import Project
 from sentry.services.eventstore.models import Event
 from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.pytest.mocking import count_matching_calls
 
 standard_cases = [
     ("email", "test@email.com", "<email>"),
@@ -266,16 +267,101 @@ def test_parameterized_message_stored_on_context(default_project: Project) -> No
         context = mock_get_variants.call_args.args[1]
 
         assert isinstance(context, GroupingContext)
-        assert context.canonical_event_message == "Dog number 1, #1 dog"
-        assert context.canonical_message_parameterized == "Dog number <int>, #<int> dog"
+        assert len(context.message_parameterization_map) == 1
+        assert (
+            context.message_parameterization_map["Dog number 1, #1 dog"]
+            == "Dog number <int>, #<int> dog"
+        )
+
+
+@django_db_all
+def test_parameterized_error_message_stored_on_context(default_project: Project) -> None:
+    with patch(
+        "sentry.grouping.api._get_variants_from_strategies", wraps=_get_variants_from_strategies
+    ) as mock_get_variants:
+        event = Event(
+            default_project.id,
+            "11211231",
+            data={
+                "exception": {
+                    "values": [
+                        {
+                            "type": "FailedToFetchError",
+                            "value": "That's ball number 6 that Charlie hasn't brought back!",
+                        }
+                    ]
+                },
+            },
+        )
+        event.get_grouping_variants()
+
+        context = mock_get_variants.call_args.args[1]
+
+        assert isinstance(context, GroupingContext)
+        assert len(context.message_parameterization_map) == 1
+        assert (
+            context.message_parameterization_map[
+                "That's ball number 6 that Charlie hasn't brought back!"
+            ]
+            == "That's ball number <int> that Charlie hasn't brought back!"
+        )
+
+
+@django_db_all
+def test_parameterized_chained_error_messages_stored_on_context(default_project: Project) -> None:
+    with patch(
+        "sentry.grouping.api._get_variants_from_strategies", wraps=_get_variants_from_strategies
+    ) as mock_get_variants:
+        event = Event(
+            default_project.id,
+            "11211231",
+            data={
+                "exception": {
+                    "values": [
+                        {
+                            "type": "DogSourcingError",
+                            "value": "Adopt don't shop!",
+                        },
+                        {
+                            "type": "FailedToFetchError",
+                            "value": "That's ball number 6 that Charlie hasn't brought back!",
+                        },
+                        {
+                            "type": "DestroyedShoeError",
+                            "value": "Oh, no! Maisey ate Dad's slippers!",
+                        },
+                    ]
+                },
+            },
+        )
+        event.get_grouping_variants()
+
+        context = mock_get_variants.call_args.args[1]
+
+        assert isinstance(context, GroupingContext)
+        assert len(context.message_parameterization_map) == 3
+        assert context.message_parameterization_map["Adopt don't shop!"] == "Adopt don't shop!"
+        assert (
+            context.message_parameterization_map[
+                "That's ball number 6 that Charlie hasn't brought back!"
+            ]
+            == "That's ball number <int> that Charlie hasn't brought back!"
+        )
+        assert (
+            context.message_parameterization_map["Oh, no! Maisey ate Dad's slippers!"]
+            == "Oh, no! Maisey ate Dad's slippers!"
+        )
 
 
 @django_db_all
 def test_stored_parameterized_message_used(default_project: Project) -> None:
-    with patch(
-        "sentry.grouping.parameterization.parameterizer.parameterize",
-        wraps=parameterizer.parameterize,
-    ) as parameterize_spy:
+    with (
+        patch("sentry.grouping.utils.metrics.incr") as mock_metrics_incr,
+        patch(
+            "sentry.grouping.parameterization.parameterizer.parameterize",
+            wraps=parameterizer.parameterize,
+        ) as parameterize_spy,
+    ):
         event = Event(
             default_project.id,
             "11211231",
@@ -300,3 +386,4 @@ def test_stored_parameterized_message_used(default_project: Project) -> None:
         # Even though the parameterized message was used in two places, the parameterizer only ran
         # once, meaning the stored value must have been used
         assert parameterize_spy.call_count == 1
+        assert count_matching_calls(mock_metrics_incr, "grouping.cached_param_result_used") == 1


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/110605, we added caching for the results of parameterizing event messages during grouping, to save work in cases where we use the message in multiple places, such as when an event with an error message also uses the `{{ message }}` variable in a custom fingerprint. In the PR description there, it says, "Other messages in the event, such as error messages from chained errors, aren't included because they're only used in one place."

While this isn't a lie, it is a little misleading. It's true that such messages are only used in one _place_, but in fact they're actually each used more than one _time_. More specifically, they're each used twice, once when computing the `app` variant and once when computing the `system` variant. Thus they, too, could benefit from having their parameterizations cached.

This PR does just that, by switching the existing caching to use a dictionary rather than a pair of named attributes (so that more than one parameterization can be stored), and then using it for all messages, not just the "canonical" one. In addition to adding tests testing that messages other than the canonical one get stored on the context, it also adds an assertion to the existing `test_stored_parameterized_message_used` test showing that the `cached_param_result_used` metric only fires once (the second time the value is used).