### PR TITLE
fix(admin): Clean up sample rate display when rates match

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -754,6 +754,30 @@ describe('CustomerOverview', () => {
     await screen.findByText('54% instead of 60% (~6%)');
   });
 
+  it('renders decimal sample rates preserving trailing zeros', async () => {
+    const organization = OrganizationFixture({
+      features: ['dynamic-sampling'],
+      desiredSampleRate: 0.6,
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sampling/effective-sample-rate/`,
+      body: {effectiveSampleRate: 0.501},
+    });
+
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+    await screen.findByText('50.10% instead of 60% (~9.90%)');
+  });
+
   it('renders n/a when effective sample rate is missing', async () => {
     const organization = OrganizationFixture({
       features: ['dynamic-sampling'],

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -730,6 +730,37 @@ describe('CustomerOverview', () => {
     });
   });
 
+  it('renders matching rate without comparison when floating-point diff is near zero', async () => {
+    const organization = OrganizationFixture({
+      features: ['dynamic-sampling'],
+      desiredSampleRate: 0.6,
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+    });
+
+    // Simulates floating-point imprecision: 0.600001 * 100 !== 0.6 * 100
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sampling/effective-sample-rate/`,
+      body: {effectiveSampleRate: 0.600001},
+    });
+
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    await waitFor(() => {
+      const term = screen.getByText('Sample Rate (24h):');
+      const definition = term.nextElementSibling;
+      expect(definition).toHaveTextContent('60%');
+      expect(definition).not.toHaveTextContent('instead of');
+    });
+  });
+
   it('renders effective sample rate with desired comparison string', async () => {
     const organization = OrganizationFixture({
       features: ['dynamic-sampling'],

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -751,7 +751,7 @@ describe('CustomerOverview', () => {
         organization={organization}
       />
     );
-    await screen.findByText('54.00% instead of 60.00% (~6.00%)');
+    await screen.findByText('54% instead of 60% (~6%)');
   });
 
   it('renders n/a when effective sample rate is missing', async () => {

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -696,7 +696,37 @@ describe('CustomerOverview', () => {
     await waitFor(() => {
       const term = screen.getByText('Sample Rate (24h):');
       const definition = term.nextElementSibling;
-      expect(definition).toHaveTextContent('75.00%');
+      expect(definition).toHaveTextContent('75%');
+    });
+  });
+
+  it('renders matching sample rate without comparison string', async () => {
+    const organization = OrganizationFixture({
+      features: ['dynamic-sampling'],
+      desiredSampleRate: 1.0,
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sampling/effective-sample-rate/`,
+      body: {effectiveSampleRate: 1.0},
+    });
+
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    await waitFor(() => {
+      const term = screen.getByText('Sample Rate (24h):');
+      const definition = term.nextElementSibling;
+      expect(definition).toHaveTextContent('100%');
+      expect(definition).not.toHaveTextContent('instead of');
     });
   });
 

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -696,7 +696,7 @@ describe('CustomerOverview', () => {
     await waitFor(() => {
       const term = screen.getByText('Sample Rate (24h):');
       const definition = term.nextElementSibling;
-      expect(definition).toHaveTextContent('75%');
+      expect(definition).toHaveTextContent('75.00%');
     });
   });
 
@@ -725,7 +725,7 @@ describe('CustomerOverview', () => {
     await waitFor(() => {
       const term = screen.getByText('Sample Rate (24h):');
       const definition = term.nextElementSibling;
-      expect(definition).toHaveTextContent('100%');
+      expect(definition).toHaveTextContent('100.00%');
       expect(definition).not.toHaveTextContent('instead of');
     });
   });
@@ -756,7 +756,7 @@ describe('CustomerOverview', () => {
     await waitFor(() => {
       const term = screen.getByText('Sample Rate (24h):');
       const definition = term.nextElementSibling;
-      expect(definition).toHaveTextContent('60%');
+      expect(definition).toHaveTextContent('60.00%');
       expect(definition).not.toHaveTextContent('instead of');
     });
   });
@@ -782,7 +782,7 @@ describe('CustomerOverview', () => {
         organization={organization}
       />
     );
-    await screen.findByText('54% instead of 60% (~6%)');
+    await screen.findByText('54.00% instead of 60.00% (~6.00%)');
   });
 
   it('renders decimal sample rates preserving trailing zeros', async () => {
@@ -806,7 +806,7 @@ describe('CustomerOverview', () => {
         organization={organization}
       />
     );
-    await screen.findByText('50.10% instead of 60% (~9.90%)');
+    await screen.findByText('50.10% instead of 60.00% (~9.90%)');
   });
 
   it('renders n/a when effective sample rate is missing', async () => {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -441,7 +441,7 @@ function DynamicSampling({organization}: {organization: Organization}) {
       ? Math.abs(effectiveSampleRate - desiredSampleRate)
       : null;
 
-  const formatRate = (rate: number) => `${rate.toFixed(2).replace(/\.00$/, '')}%`;
+  const formatRate = (rate: number) => `${rate.toFixed(2)}%`;
 
   const getSampleRateValue = (): string => {
     if (effectiveSampleRate && desiredSampleRate) {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -443,8 +443,6 @@ function DynamicSampling({organization}: {organization: Organization}) {
 
   const formatRate = (rate: number) => `${rate.toFixed(2).replace(/\.00$/, '')}%`;
 
-  const ratesMatch = effectiveSampleRate && desiredSampleRate && diffSampleRate === 0;
-
   return (
     <ThresholdLabel
       positive={
@@ -453,7 +451,8 @@ function DynamicSampling({organization}: {organization: Organization}) {
           : false
       }
     >
-      {ratesMatch
+      {/* When rates match, show just the rate instead of "X% instead of X% (~0%)" */}
+      {effectiveSampleRate && desiredSampleRate && diffSampleRate === 0
         ? formatRate(effectiveSampleRate)
         : effectiveSampleRate && desiredSampleRate
           ? `${formatRate(effectiveSampleRate)} instead of ${formatRate(desiredSampleRate)} (~${formatRate(diffSampleRate!)})`

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -441,8 +441,7 @@ function DynamicSampling({organization}: {organization: Organization}) {
       ? Math.abs(effectiveSampleRate - desiredSampleRate)
       : null;
 
-  const formatRate = (rate: number) =>
-    rate % 1 === 0 ? `${rate}%` : `${rate.toFixed(2)}%`;
+  const formatRate = (rate: number) => `${rate.toFixed(2).replace(/\.00$/, '')}%`;
 
   const ratesMatch = effectiveSampleRate && desiredSampleRate && diffSampleRate === 0;
 

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -452,7 +452,9 @@ function DynamicSampling({organization}: {organization: Organization}) {
       }
     >
       {/* When rates match, show just the rate instead of "X% instead of X% (~0%)" */}
-      {effectiveSampleRate && desiredSampleRate && diffSampleRate === 0
+      {effectiveSampleRate &&
+      desiredSampleRate &&
+      formatRate(effectiveSampleRate) === formatRate(desiredSampleRate)
         ? formatRate(effectiveSampleRate)
         : effectiveSampleRate && desiredSampleRate
           ? `${formatRate(effectiveSampleRate)} instead of ${formatRate(desiredSampleRate)} (~${formatRate(diffSampleRate!)})`

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -445,6 +445,7 @@ function DynamicSampling({organization}: {organization: Organization}) {
 
   const getSampleRateValue = (): string => {
     if (effectiveSampleRate && desiredSampleRate) {
+      // When rates match, show just the rate instead of "X% instead of X% (~0%)"
       if (formatRate(effectiveSampleRate) === formatRate(desiredSampleRate)) {
         return formatRate(effectiveSampleRate);
       }

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -457,9 +457,9 @@ function DynamicSampling({organization}: {organization: Organization}) {
       {ratesMatch
         ? formatRate(effectiveSampleRate)
         : effectiveSampleRate && desiredSampleRate
-          ? `${effectiveSampleRate.toFixed(2)}% instead of ${desiredSampleRate.toFixed(2)}% (~${diffSampleRate?.toFixed(2)}%)`
+          ? `${formatRate(effectiveSampleRate)} instead of ${formatRate(desiredSampleRate)} (~${formatRate(diffSampleRate!)})`
           : desiredSampleRate
-            ? `${desiredSampleRate.toFixed(2)}%`
+            ? formatRate(desiredSampleRate)
             : 'n/a'}
     </ThresholdLabel>
   );

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -443,6 +443,19 @@ function DynamicSampling({organization}: {organization: Organization}) {
 
   const formatRate = (rate: number) => `${rate.toFixed(2).replace(/\.00$/, '')}%`;
 
+  const getSampleRateValue = (): string => {
+    if (effectiveSampleRate && desiredSampleRate) {
+      if (formatRate(effectiveSampleRate) === formatRate(desiredSampleRate)) {
+        return formatRate(effectiveSampleRate);
+      }
+      return `${formatRate(effectiveSampleRate)} instead of ${formatRate(desiredSampleRate)} (~${formatRate(diffSampleRate!)})`;
+    }
+    if (desiredSampleRate) {
+      return formatRate(desiredSampleRate);
+    }
+    return 'n/a';
+  };
+
   return (
     <ThresholdLabel
       positive={
@@ -451,16 +464,7 @@ function DynamicSampling({organization}: {organization: Organization}) {
           : false
       }
     >
-      {/* When rates match, show just the rate instead of "X% instead of X% (~0%)" */}
-      {effectiveSampleRate &&
-      desiredSampleRate &&
-      formatRate(effectiveSampleRate) === formatRate(desiredSampleRate)
-        ? formatRate(effectiveSampleRate)
-        : effectiveSampleRate && desiredSampleRate
-          ? `${formatRate(effectiveSampleRate)} instead of ${formatRate(desiredSampleRate)} (~${formatRate(diffSampleRate!)})`
-          : desiredSampleRate
-            ? formatRate(desiredSampleRate)
-            : 'n/a'}
+      {getSampleRateValue()}
     </ThresholdLabel>
   );
 }

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -441,6 +441,11 @@ function DynamicSampling({organization}: {organization: Organization}) {
       ? Math.abs(effectiveSampleRate - desiredSampleRate)
       : null;
 
+  const formatRate = (rate: number) =>
+    rate % 1 === 0 ? `${rate}%` : `${rate.toFixed(2)}%`;
+
+  const ratesMatch = effectiveSampleRate && desiredSampleRate && diffSampleRate === 0;
+
   return (
     <ThresholdLabel
       positive={
@@ -449,11 +454,13 @@ function DynamicSampling({organization}: {organization: Organization}) {
           : false
       }
     >
-      {effectiveSampleRate && desiredSampleRate
-        ? `${effectiveSampleRate.toFixed(2)}% instead of ${desiredSampleRate.toFixed(2)}% (~${diffSampleRate?.toFixed(2)}%)`
-        : desiredSampleRate
-          ? `${desiredSampleRate.toFixed(2)}%`
-          : 'n/a'}
+      {ratesMatch
+        ? formatRate(effectiveSampleRate)
+        : effectiveSampleRate && desiredSampleRate
+          ? `${effectiveSampleRate.toFixed(2)}% instead of ${desiredSampleRate.toFixed(2)}% (~${diffSampleRate?.toFixed(2)}%)`
+          : desiredSampleRate
+            ? `${desiredSampleRate.toFixed(2)}%`
+            : 'n/a'}
     </ThresholdLabel>
   );
 }


### PR DESCRIPTION
When effective and desired sample rates match, the admin "Sample Rate (24h)" field
showed a redundant string like `100.00% instead of 100.00% (~0.00%)`. Now it shows
the rate cleanly (e.g. `100.00%`). All rates consistently display two decimal places.

- Extract `formatRate` helper and `getSampleRateValue` for cleaner display logic
- Compare formatted strings to handle floating-point imprecision (e.g. `0.600001 ≈ 0.6`)
- Add tests for matching rates, mismatched rates, decimal rates, and missing data

Closes https://linear.app/getsentry/issue/TET-2088/add-special-handling-for-100percent-ds-sample-rate-in-admin