### PR TITLE
ref(options): Remove ai-agent-monitoring.custom-model-mapping option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1359,14 +1359,6 @@ register(
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Custom model costs mapping for AI Agent Monitoring. Used to map alternative model ids to existing model ids.
-# {"alternative_model_id": "gpt-4o", "existing_model_id": "openai/gpt-4o"}
-register(
-    "ai-agent-monitoring.custom-model-mapping",
-    default=[],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # ## sentry.killswitches
 #
 # The following options are documented in sentry.killswitches in more detail

--- a/src/sentry/tasks/ai_agent_monitoring.py
+++ b/src/sentry/tasks/ai_agent_monitoring.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from django.conf import settings
 
-from sentry import options
 from sentry.http import safe_urlopen
 from sentry.relay.config.ai_model_costs import (
     AI_MODEL_COSTS_CACHE_KEY,
@@ -144,17 +143,6 @@ def fetch_ai_model_costs() -> None:
         )
         # re-raise to fail the task
         raise
-
-    # Custom model mapping for models pricing - often times the same models are named differently
-    # in different hosting providers. This allows us to map the alternative model id to the existing model id.
-    for model_mapping in options.get("ai-agent-monitoring.custom-model-mapping"):
-        alternative_model_id = model_mapping.get("alternative_model_id")
-        existing_model_id = model_mapping.get("existing_model_id")
-
-        if existing_model_id not in models_dict or alternative_model_id in models_dict:
-            continue
-
-        models_dict[alternative_model_id] = models_dict[existing_model_id]
 
     # Add glob versions of model names for flexible matching
     _add_glob_model_names(models_dict)

--- a/tests/sentry/tasks/test_ai_agent_monitoring.py
+++ b/tests/sentry/tasks/test_ai_agent_monitoring.py
@@ -8,7 +8,6 @@ from sentry.tasks.ai_agent_monitoring import (
     fetch_ai_model_costs,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.utils.cache import cache
 
 
@@ -450,57 +449,6 @@ class FetchAIModelCostsTest(TestCase):
         """Test retrieving from empty cache"""
         cached_data = _get_ai_model_costs_from_cache()
         assert cached_data is None
-
-    @override_options(
-        {
-            "ai-agent-monitoring.custom-model-mapping": [
-                {
-                    "alternative_model_id": "gemini-pro-alternative",
-                    "existing_model_id": "gemini-2.5-pro",
-                },
-                {
-                    "alternative_model_id": "nonexistent-mapping",
-                    "existing_model_id": "model-that-does-not-exist",
-                },
-            ]
-        }
-    )
-    @responses.activate
-    def test_fetch_ai_model_costs_custom_model_mapping(self) -> None:
-        self._mock_openrouter_api_response(MOCK_OPENROUTER_API_RESPONSE)
-        self._mock_models_dev_api_response(MOCK_MODELS_DEV_API_RESPONSE)
-
-        fetch_ai_model_costs()
-
-        # Verify the data was cached correctly
-        cached_data = _get_ai_model_costs_from_cache()
-        assert cached_data is not None
-        models = cached_data.get("models")
-        assert models is not None
-
-        # Original models should exist
-        assert "gemini-2.5-pro" in models
-
-        # Alternative model IDs should be mapped to existing models
-        assert "gemini-pro-alternative" in models
-
-        # Verify that the alternative models have the same pricing as the existing models
-        gemini_model = models["gemini-2.5-pro"]
-        gemini_alt_model = models["gemini-pro-alternative"]
-        assert gemini_model.get("inputPerToken") == gemini_alt_model.get("inputPerToken")
-        assert gemini_model.get("outputPerToken") == gemini_alt_model.get("outputPerToken")
-        assert gemini_model.get("outputReasoningPerToken") == gemini_alt_model.get(
-            "outputReasoningPerToken"
-        )
-        assert gemini_model.get("inputCachedPerToken") == gemini_alt_model.get(
-            "inputCachedPerToken"
-        )
-        assert gemini_model.get("inputCacheWritePerToken") == gemini_alt_model.get(
-            "inputCacheWritePerToken"
-        )
-
-        # Non-existent mapping should not create a new model
-        assert "nonexistent-mapping" not in models
 
     @responses.activate
     def test_fetch_ai_model_costs_with_normalized_and_prefix_glob_names(self) -> None:


### PR DESCRIPTION
Remove the `ai-agent-monitoring.custom-model-mapping` option, its usage in the AI model costs fetch task, and the associated test.

This option allowed mapping alternative model IDs to existing ones for AI agent monitoring model pricing but is no longer needed.