### PR TITLE
fix(seer): Handle empty response in SCM integrations query

### DIFF
--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -50,16 +50,15 @@ function useScmIntegrations() {
   );
 
   // Filter to only SCM integrations
-  const scmIntegrations = data?.filter(integration =>
-    SCM_PROVIDER_KEYS.includes(integration.provider.key)
-  );
+  const scmIntegrations =
+    data?.filter(integration => SCM_PROVIDER_KEYS.includes(integration.provider.key)) ??
+    [];
 
-  const hasGithub = scmIntegrations?.some(integration =>
+  const hasGithub = scmIntegrations.some(integration =>
     ['github', 'github_enterprise'].includes(integration.provider.key)
   );
 
   const hasOnlyNonGithubScm =
-    scmIntegrations &&
     scmIntegrations.length > 0 &&
     !hasGithub &&
     scmIntegrations.every(integration =>


### PR DESCRIPTION
Handle empty response in primary nav Seer config reminder

When the integrations API returns a 204 with no body, `data` is `undefined`.
The previous code left `scmIntegrations` as `undefined | Integration[]`,
requiring optional chaining (`?.some`, `&&` length checks) throughout the
hook. This adds a `?? []` fallback so `scmIntegrations` is always an array,
simplifying downstream checks.

#inc-2083