### PR TITLE
fix: return string IDs in ownership rule API response

### DIFF
--- a/src/sentry/issues/ownership/grammar.py
+++ b/src/sentry/issues/ownership/grammar.py
@@ -527,7 +527,7 @@ def add_owner_ids_to_schema(rules: list[dict[str, Any]], owners_id: dict[str, in
     for rule in rules:
         for rule_owner in rule["owners"]:
             if rule_owner["identifier"] in owners_id.keys():
-                rule_owner["id"] = owners_id[rule_owner["identifier"]]
+                rule_owner["id"] = str(owners_id[rule_owner["identifier"]])
 
 
 def create_schema_from_issue_owners(

--- a/tests/sentry/issues/endpoints/test_project_ownership.py
+++ b/tests/sentry/issues/endpoints/test_project_ownership.py
@@ -169,8 +169,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
                 {
                     "matcher": {"type": "path", "pattern": "*.js"},
                     "owners": [
-                        {"type": "user", "identifier": "admin@localhost", "id": self.user.id},
-                        {"type": "team", "identifier": "tiger-team", "id": self.team.id},
+                        {"type": "user", "identifier": "admin@localhost", "id": str(self.user.id)},
+                        {"type": "team", "identifier": "tiger-team", "id": str(self.team.id)},
                     ],
                 }
             ],
@@ -186,8 +186,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
                 {
                     "matcher": {"type": "path", "pattern": "*.js"},
                     "owners": [
-                        {"type": "user", "id": self.user.id, "name": "admin@localhost"},
-                        {"type": "team", "id": self.team.id, "name": "tiger-team"},
+                        {"type": "user", "id": str(self.user.id), "name": "admin@localhost"},
+                        {"type": "team", "id": str(self.team.id), "name": "tiger-team"},
                     ],
                 }
             ],
@@ -200,8 +200,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             {
                 "matcher": {"type": "path", "pattern": "*.js"},
                 "owners": [
-                    {"type": "user", "identifier": "admin@localhost", "id": self.user.id},
-                    {"type": "team", "identifier": "tiger-team", "id": self.team.id},
+                    {"type": "user", "identifier": "admin@localhost", "id": str(self.user.id)},
+                    {"type": "team", "identifier": "tiger-team", "id": str(self.team.id)},
                 ],
             }
         ]
@@ -258,7 +258,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             "rules": [
                 {
                     "matcher": {"type": "path", "pattern": "*.js"},
-                    "owners": [{"type": "team", "name": "tiger-team", "id": self.team.id}],
+                    "owners": [{"type": "team", "name": "tiger-team", "id": str(self.team.id)}],
                 }
             ],
         }


### PR DESCRIPTION
The ownership rule API returns integer IDs for team/user owners in the schema response, but Sentry's API design rules require returning strings for numeric IDs. This inconsistency causes issues when frontend components perform strict type checking on owner IDs.

**Root cause:** In `grammar.py`, `convert_schema_to_rules_v2()` assigns `owners_id[...]` directly (which is an int) instead of casting to `str()`.

**Fix:** Added `str()` cast on the owner ID assignment in `grammar.py` and updated corresponding test assertions.

Refs: #110591

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.