### PR TITLE
fix(ai-conversations): order spans by end timestamp

### DIFF
--- a/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
@@ -7,16 +7,20 @@ import {MessagesPanel} from './messagesPanel';
 function createMockNode(overrides: {
   id: string;
   attributes?: Record<string, string | number>;
+  endTimestamp?: number;
   startTimestamp?: number;
 }) {
-  const {id, attributes = {}, startTimestamp = 1000} = overrides;
+  const {id, attributes = {}, startTimestamp = 1000, endTimestamp} = overrides;
+  const end = endTimestamp ?? startTimestamp + 100;
   return {
     id,
     type: 'span' as const,
     op: 'gen_ai.generate',
     startTimestamp,
+    endTimestamp: end,
     value: {
       start_timestamp: startTimestamp,
+      end_timestamp: end,
     },
     attributes: {
       // Must be 'ai_client' for getIsAiGenerationSpan to return true
@@ -30,16 +34,20 @@ function createMockNode(overrides: {
 function createMockToolNode(overrides: {
   id: string;
   toolName: string;
+  endTimestamp?: number;
   startTimestamp?: number;
 }) {
-  const {id, toolName, startTimestamp = 1000} = overrides;
+  const {id, toolName, startTimestamp = 1000, endTimestamp} = overrides;
+  const end = endTimestamp ?? startTimestamp + 100;
   return {
     id,
     type: 'span' as const,
     op: 'gen_ai.execute_tool',
     startTimestamp,
+    endTimestamp: end,
     value: {
       start_timestamp: startTimestamp,
+      end_timestamp: end,
     },
     attributes: {
       [SpanFields.GEN_AI_OPERATION_TYPE]: 'tool',

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -229,7 +229,7 @@ export function useConversation(
       return node;
     });
 
-    transformedNodes.sort((a, b) => (a.startTimestamp ?? 0) - (b.startTimestamp ?? 0));
+    transformedNodes.sort((a, b) => (a.endTimestamp ?? 0) - (b.endTimestamp ?? 0));
 
     return {nodes: transformedNodes, nodeTraceMap: traceMap};
   }, [conversationQuery.data]);

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
@@ -15,16 +15,20 @@ import {
 function createMockNode(overrides: {
   id: string;
   attributes?: Record<string, string | number>;
+  endTimestamp?: number;
   startTimestamp?: number;
 }) {
-  const {id, attributes = {}, startTimestamp = 1000} = overrides;
+  const {id, attributes = {}, startTimestamp = 1000, endTimestamp} = overrides;
+  const end = endTimestamp ?? startTimestamp + 100;
   return {
     id,
     type: 'span' as const,
     op: 'gen_ai.generate',
     startTimestamp,
+    endTimestamp: end,
     value: {
       start_timestamp: startTimestamp,
+      end_timestamp: end,
     },
     attributes: {
       [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
@@ -37,16 +41,20 @@ function createMockNode(overrides: {
 function createMockToolNode(overrides: {
   id: string;
   toolName: string;
+  endTimestamp?: number;
   startTimestamp?: number;
 }) {
-  const {id, toolName, startTimestamp = 1000} = overrides;
+  const {id, toolName, startTimestamp = 1000, endTimestamp} = overrides;
+  const end = endTimestamp ?? startTimestamp + 100;
   return {
     id,
     type: 'span' as const,
     op: 'gen_ai.execute_tool',
     startTimestamp,
+    endTimestamp: end,
     value: {
       start_timestamp: startTimestamp,
+      end_timestamp: end,
     },
     attributes: {
       [SpanFields.GEN_AI_OPERATION_TYPE]: 'tool',
@@ -58,12 +66,16 @@ function createMockToolNode(overrides: {
 
 describe('conversationMessages utilities', () => {
   describe('getNodeTimestamp', () => {
-    it('returns start_timestamp from node value', () => {
-      const node = createMockNode({id: 'node-1', startTimestamp: 1500});
-      expect(getNodeTimestamp(node as any)).toBe(1500);
+    it('returns end_timestamp from node value', () => {
+      const node = createMockNode({
+        id: 'node-1',
+        startTimestamp: 1500,
+        endTimestamp: 1600,
+      });
+      expect(getNodeTimestamp(node as any)).toBe(1600);
     });
 
-    it('returns 0 when start_timestamp is not present', () => {
+    it('returns 0 when no timestamp is present', () => {
       const node = {id: 'node-1', value: {}} as any;
       expect(getNodeTimestamp(node)).toBe(0);
     });
@@ -469,7 +481,10 @@ describe('conversationMessages utilities', () => {
     it('creates user and assistant messages from turns', () => {
       const turns = [
         {
-          generation: {id: 'gen-1', value: {start_timestamp: 1000}} as any,
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
           userContent: 'Hello',
           assistantContent: 'Hi there',
           toolCalls: [],
@@ -494,14 +509,20 @@ describe('conversationMessages utilities', () => {
     it('deduplicates user messages by exact content', () => {
       const turns = [
         {
-          generation: {id: 'gen-1', value: {start_timestamp: 1000}} as any,
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
           userContent: 'Hello',
           assistantContent: 'Response 1',
           toolCalls: [],
           userEmail: undefined,
         },
         {
-          generation: {id: 'gen-2', value: {start_timestamp: 2000}} as any,
+          generation: {
+            id: 'gen-2',
+            value: {start_timestamp: 2000, end_timestamp: 2100},
+          } as any,
           userContent: 'Hello', // Exact same content
           assistantContent: 'Response 2',
           toolCalls: [],
@@ -522,14 +543,20 @@ describe('conversationMessages utilities', () => {
     it('does not deduplicate user messages with different whitespace or case', () => {
       const turns = [
         {
-          generation: {id: 'gen-1', value: {start_timestamp: 1000}} as any,
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
           userContent: 'Hello',
           assistantContent: 'Response 1',
           toolCalls: [],
           userEmail: undefined,
         },
         {
-          generation: {id: 'gen-2', value: {start_timestamp: 2000}} as any,
+          generation: {
+            id: 'gen-2',
+            value: {start_timestamp: 2000, end_timestamp: 2100},
+          } as any,
           userContent: '  HELLO  ', // Different due to whitespace and case
           assistantContent: 'Response 2',
           toolCalls: [],
@@ -546,14 +573,20 @@ describe('conversationMessages utilities', () => {
     it('deduplicates assistant messages by exact content', () => {
       const turns = [
         {
-          generation: {id: 'gen-1', value: {start_timestamp: 1000}} as any,
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
           userContent: 'Question 1',
           assistantContent: 'Same response',
           toolCalls: [],
           userEmail: undefined,
         },
         {
-          generation: {id: 'gen-2', value: {start_timestamp: 2000}} as any,
+          generation: {
+            id: 'gen-2',
+            value: {start_timestamp: 2000, end_timestamp: 2100},
+          } as any,
           userContent: 'Question 2',
           assistantContent: 'Same response', // Exact same content
           toolCalls: [],
@@ -570,7 +603,10 @@ describe('conversationMessages utilities', () => {
     it('attaches tool calls to assistant messages', () => {
       const turns = [
         {
-          generation: {id: 'gen-1', value: {start_timestamp: 1000}} as any,
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
           userContent: 'Question',
           assistantContent: 'Answer',
           toolCalls: [{name: 'search', nodeId: 'tool-1', hasError: false}],
@@ -588,14 +624,20 @@ describe('conversationMessages utilities', () => {
     it('sorts messages by timestamp', () => {
       const turns = [
         {
-          generation: {id: 'gen-1', value: {start_timestamp: 2000}} as any,
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 2000, end_timestamp: 2100},
+          } as any,
           userContent: 'Second',
           assistantContent: 'Second response',
           toolCalls: [],
           userEmail: undefined,
         },
         {
-          generation: {id: 'gen-2', value: {start_timestamp: 1000}} as any,
+          generation: {
+            id: 'gen-2',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
           userContent: 'First',
           assistantContent: 'First response',
           toolCalls: [],

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -168,6 +168,7 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
       seenAssistantContent.add(turn.assistantContent);
 
       // Duration: from start of generation span to end of last span (generation or tool)
+      const startTs = getNodeStartTimestamp(turn.generation);
       const genEnd = getNodeEndTimestamp(turn.generation);
       const toolSpanNodes = turn.toolSpanNodes ?? [];
       const lastToolEnd =
@@ -175,7 +176,7 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
           ? Math.max(...toolSpanNodes.map(getNodeEndTimestamp))
           : 0;
       const endTs = Math.max(genEnd, lastToolEnd);
-      const duration = endTs > timestamp ? endTs - timestamp : undefined;
+      const duration = endTs > startTs ? endTs - startTs : undefined;
 
       messages.push({
         id: `assistant-${turn.generation.id}`,
@@ -264,6 +265,10 @@ export function getNodeTimestamp(node: AITraceSpanNode): number {
     return node.value.timestamp;
   }
   return 0;
+}
+
+function getNodeStartTimestamp(node: AITraceSpanNode): number {
+  return 'start_timestamp' in node.value ? node.value.start_timestamp : 0;
 }
 
 function getNodeEndTimestamp(node: AITraceSpanNode): number {

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -257,7 +257,13 @@ export function parseAssistantContent(node: AITraceSpanNode): string | null {
 }
 
 export function getNodeTimestamp(node: AITraceSpanNode): number {
-  return 'start_timestamp' in node.value ? node.value.start_timestamp : 0;
+  if ('end_timestamp' in node.value && typeof node.value.end_timestamp === 'number') {
+    return node.value.end_timestamp;
+  }
+  if ('timestamp' in node.value && typeof node.value.timestamp === 'number') {
+    return node.value.timestamp;
+  }
+  return 0;
 }
 
 function getNodeEndTimestamp(node: AITraceSpanNode): number {


### PR DESCRIPTION
part of [TET-2067: Incorrect response order in harness output with timestamps](https://linear.app/getsentry/issue/TET-2067/incorrect-response-order-in-harness-output-with-timestamps)