### PR TITLE
feat(explore): Add drag-and-drop reordering to Visualize toolbar

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -1,4 +1,6 @@
 import type {ReactNode} from 'react';
+import {useSortable} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -8,6 +10,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconAdd} from 'sentry/icons';
 import {IconDelete} from 'sentry/icons/iconDelete';
+import {IconGrabbable} from 'sentry/icons/iconGrabbable';
 import {t} from 'sentry/locale';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {getFieldDefinition} from 'sentry/utils/fields';
@@ -39,6 +42,7 @@ interface ToolbarVisualizeDropdownProps {
   onChangeAggregate: (option: SelectOption<SelectKey>) => void;
   onChangeArgument: (index: number, option: SelectOption<SelectKey>) => void;
   parsedFunction: ParsedFunction | null;
+  dragColumnId?: number;
   label?: ReactNode;
   loading?: boolean;
   onClose?: () => void;
@@ -47,6 +51,7 @@ interface ToolbarVisualizeDropdownProps {
 }
 
 export function ToolbarVisualizeDropdown({
+  dragColumnId,
   aggregateOptions,
   fieldOptions,
   onChangeAggregate,
@@ -58,13 +63,31 @@ export function ToolbarVisualizeDropdown({
   label,
   loading,
 }: ToolbarVisualizeDropdownProps) {
+  const {attributes, listeners, setNodeRef, transform} = useSortable({
+    id: dragColumnId ?? 0,
+    transition: null,
+  });
+
   const aggregateFunc = parsedFunction?.name;
   const aggregateDefinition = aggregateFunc
     ? getFieldDefinition(aggregateFunc, 'span')
     : undefined;
 
   return (
-    <ToolbarRow>
+    <ToolbarRow
+      ref={setNodeRef}
+      style={{transform: CSS.Transform.toString(transform)}}
+      {...attributes}
+    >
+      {dragColumnId === undefined ? null : (
+        <Button
+          aria-label={t('Drag to reorder')}
+          priority="transparent"
+          size="zero"
+          icon={<IconGrabbable size="sm" />}
+          {...listeners}
+        />
+      )}
       {label}
       <AggregateCompactSelect
         search

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -1,4 +1,6 @@
 import {useCallback, useMemo, type ReactNode} from 'react';
+import {useSortable} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
@@ -7,6 +9,7 @@ import {ArithmeticBuilder} from 'sentry/components/arithmeticBuilder';
 import type {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import type {FunctionArgument} from 'sentry/components/arithmeticBuilder/types';
 import {IconDelete} from 'sentry/icons/iconDelete';
+import {IconGrabbable} from 'sentry/icons/iconGrabbable';
 import {t} from 'sentry/locale';
 import {EQUATION_PREFIX, stripEquationPrefix} from 'sentry/utils/discover/fields';
 import {
@@ -22,11 +25,13 @@ import {Visualize} from 'sentry/views/explore/queryParams/visualize';
 interface VisualizeEquationProps {
   onReplace: (visualize: Visualize) => void;
   visualize: Visualize;
+  dragColumnId?: number;
   label?: ReactNode;
   onDelete?: () => void;
 }
 
 export function VisualizeEquation({
+  dragColumnId,
   onDelete,
   onReplace,
   visualize,
@@ -81,8 +86,26 @@ export function VisualizeEquation({
     booleanAttributes: booleanTags,
   });
 
+  const {attributes, listeners, setNodeRef, transform} = useSortable({
+    id: dragColumnId ?? 0,
+    transition: null,
+  });
+
   return (
-    <ToolbarRow>
+    <ToolbarRow
+      ref={setNodeRef}
+      style={{transform: CSS.Transform.toString(transform)}}
+      {...attributes}
+    >
+      {dragColumnId === undefined ? null : (
+        <Button
+          aria-label={t('Drag to reorder')}
+          priority="transparent"
+          size="zero"
+          icon={<IconGrabbable size="sm" />}
+          {...listeners}
+        />
+      )}
       {label}
       <Flex flex={1}>
         <ArithmeticBuilder

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -20,6 +20,7 @@ import {
   ToolbarVisualizeHeader,
 } from 'sentry/views/explore/components/toolbar/toolbarVisualize';
 import {VisualizeEquation as VisualizeEquationInput} from 'sentry/views/explore/components/toolbar/toolbarVisualize/visualizeEquation';
+import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {
   DEFAULT_VISUALIZATION,
@@ -98,54 +99,70 @@ export function ToolbarVisualize({
     [setVisualizes, visualizes]
   );
 
+  const setVisualizesWithOp = useCallback(
+    (columns: Visualize[]) => {
+      setVisualizes(columns.map(v => v.serialize()));
+    },
+    [setVisualizes]
+  );
+
   return (
-    <ToolbarSection data-test-id="section-visualizes">
-      <ToolbarVisualizeHeader />
-      {visualizes.map((visualize, group) => {
-        const label = (
-          <VisualizeLabel
-            index={group}
-            visualize={visualize}
-            onClick={() => toggleVisibility(group)}
-          />
-        );
-        const onDelete = visualizes.length > 1 ? () => handleOnDelete(group) : undefined;
+    <DragNDropContext columns={[...visualizes]} setColumns={setVisualizesWithOp}>
+      {({editableColumns}) => (
+        <ToolbarSection data-test-id="section-visualizes">
+          <ToolbarVisualizeHeader />
+          {editableColumns.map((column, i) => {
+            const visualize = column.column;
+            const dragColumnId = editableColumns.length > 1 ? column.id : undefined;
+            const label = (
+              <VisualizeLabel
+                index={i}
+                visualize={visualize}
+                onClick={() => toggleVisibility(i)}
+              />
+            );
+            const onDelete =
+              editableColumns.length > 1 ? () => handleOnDelete(i) : undefined;
 
-        if (isVisualizeEquation(visualize)) {
-          return (
-            <VisualizeEquationInput
-              key={group}
-              onDelete={onDelete}
-              onReplace={newVisualize => replaceOverlay(group, newVisualize)}
-              visualize={visualize}
-              label={label}
+            if (isVisualizeEquation(visualize)) {
+              return (
+                <VisualizeEquationInput
+                  key={column.id}
+                  dragColumnId={dragColumnId}
+                  onDelete={onDelete}
+                  onReplace={newVisualize => replaceOverlay(i, newVisualize)}
+                  visualize={visualize}
+                  label={label}
+                />
+              );
+            }
+
+            return (
+              <ToolbarVisualizeItem
+                key={column.id}
+                dragColumnId={dragColumnId}
+                onDelete={onDelete}
+                onReplace={newVisualize => replaceOverlay(i, newVisualize)}
+                visualize={visualize}
+                label={label}
+              />
+            );
+          })}
+          <ToolbarFooter>
+            <ToolbarVisualizeAddChart
+              add={addChart}
+              disabled={visualizes.length >= MAX_VISUALIZES}
             />
-          );
-        }
-
-        return (
-          <ToolbarVisualizeItem
-            key={group}
-            onDelete={onDelete}
-            onReplace={newVisualize => replaceOverlay(group, newVisualize)}
-            visualize={visualize}
-            label={label}
-          />
-        );
-      })}
-      <ToolbarFooter>
-        <ToolbarVisualizeAddChart
-          add={addChart}
-          disabled={visualizes.length >= MAX_VISUALIZES}
-        />
-        {allowEquations && (
-          <ToolbarVisualizeAddEquation
-            add={addEquation}
-            disabled={visualizes.length >= MAX_VISUALIZES}
-          />
-        )}
-      </ToolbarFooter>
-    </ToolbarSection>
+            {allowEquations && (
+              <ToolbarVisualizeAddEquation
+                add={addEquation}
+                disabled={visualizes.length >= MAX_VISUALIZES}
+              />
+            )}
+          </ToolbarFooter>
+        </ToolbarSection>
+      )}
+    </DragNDropContext>
   );
 }
 
@@ -153,10 +170,12 @@ interface VisualizeDropdownProps {
   label: ReactNode;
   onReplace: (visualize: Visualize) => void;
   visualize: Visualize;
+  dragColumnId?: number;
   onDelete?: () => void;
 }
 
 function ToolbarVisualizeItem({
+  dragColumnId,
   label,
   onDelete,
   onReplace,
@@ -232,6 +251,7 @@ function ToolbarVisualizeItem({
 
   return (
     <ToolbarVisualizeDropdown
+      dragColumnId={dragColumnId}
       aggregateOptions={aggregateOptions}
       fieldOptions={fieldOptions}
       onChangeAggregate={onChangeAggregate}


### PR DESCRIPTION
Add drag-and-drop reordering to the Visualize toolbar in Explore > Traces, matching the pattern already used in the Group By toolbar.

When 2+ visualize items (charts or equations) are present, each toolbar row shows a grabbable drag handle. Reordering the rows updates the URL state, which automatically reorders the chart panels below since both derive from the same query params.

Uses the existing `DragNDropContext` wrapper and `useSortable` hook with `transition: null` (to avoid the drop animation glitch fixed in #110676). No new dependencies.

<img width="967" height="452" alt="Screenshot of Explore > Traces with an equation and a chart in Visualize, with drag-n-drop button indicators" src="https://github.com/user-attachments/assets/03780d77-a182-4581-abac-efa4ddce9f35" />


Fixes EXP-843

Made with [Cursor](https://cursor.com)