### PR TITLE
fix(insights): Fix agents trace table horizontal overflow and empty state layout

### DIFF
--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -98,10 +98,6 @@ export const Grid = styled('table')<{
       ? css`
           height: 100%;
           max-height: ${typeof p.height === 'number' ? p.height + 'px' : p.height};
-
-          &:has(> thead + tbody) {
-            grid-template-rows: auto 1fr;
-          }
         `
       : ''}
 

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -98,6 +98,10 @@ export const Grid = styled('table')<{
       ? css`
           height: 100%;
           max-height: ${typeof p.height === 'number' ? p.height + 'px' : p.height};
+
+          &:has(> thead + tbody) {
+            grid-template-rows: auto 1fr;
+          }
         `
       : ''}
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -1,4 +1,3 @@
-import {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, MAX_TABLE_LIMIT, WidgetType} from 'sentry/views/dashboards/types';
@@ -23,17 +22,7 @@ const DEFAULT_GLOBAL_FILTERS = [
   },
 ];
 
-export const DEFAULT_TRACES_TABLE_WIDTHS = [
-  110,
-  COL_WIDTH_UNDEFINED,
-  140,
-  110,
-  110,
-  110,
-  120,
-  110,
-  110,
-];
+export const DEFAULT_TRACES_TABLE_WIDTHS = [110, 600, 140, 110, 110, 110, 120, 110, 110];
 
 const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -1,3 +1,4 @@
+import {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, MAX_TABLE_LIMIT, WidgetType} from 'sentry/views/dashboards/types';
@@ -22,7 +23,17 @@ const DEFAULT_GLOBAL_FILTERS = [
   },
 ];
 
-export const DEFAULT_TRACES_TABLE_WIDTHS = [110, 600, 140, 110, 110, 110, 120, 110, 110];
+export const DEFAULT_TRACES_TABLE_WIDTHS = [
+  110,
+  COL_WIDTH_UNDEFINED,
+  140,
+  110,
+  110,
+  110,
+  120,
+  110,
+  110,
+];
 
 const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -991,7 +991,6 @@ const ChartWrapper = styled('div')<{autoHeightResize: boolean; noPadding?: boole
 const TableWrapper = styled('div')`
   margin-top: ${p => p.theme.space.lg};
   min-height: 0;
-  flex: 1;
   border-bottom-left-radius: ${p => p.theme.radius.md};
   border-bottom-right-radius: ${p => p.theme.radius.md};
 `;

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -991,6 +991,7 @@ const ChartWrapper = styled('div')<{autoHeightResize: boolean; noPadding?: boole
 const TableWrapper = styled('div')`
   margin-top: ${p => p.theme.space.lg};
   min-height: 0;
+  flex: 1;
   border-bottom-left-radius: ${p => p.theme.radius.md};
   border-bottom-right-radius: ${p => p.theme.radius.md};
 `;

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -252,18 +252,15 @@ export function TracesTable({
     agentsRequest.isLoading,
   ]);
 
-  const renderHeadCell = useCallback(
-    (column: GridColumnHeader<string>) => {
-      return (
-        <HeadCell align={rightAlignColumns.has(column.key) ? 'right' : 'left'}>
-          {column.name}
-          {column.key === 'timestamp' && <IconArrow direction="down" size="xs" />}
-          {column.key === 'agents' && !frameless && <CellExpander />}
-        </HeadCell>
-      );
-    },
-    [frameless]
-  );
+  const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
+    return (
+      <HeadCell align={rightAlignColumns.has(column.key) ? 'right' : 'left'}>
+        {column.name}
+        {column.key === 'timestamp' && <IconArrow direction="down" size="xs" />}
+        {column.key === 'agents' && <CellExpander />}
+      </HeadCell>
+    );
+  }, []);
 
   const renderBodyCell = useCallback(
     (column: GridColumnOrder<string>, dataRow: TableData) => {

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -252,15 +252,18 @@ export function TracesTable({
     agentsRequest.isLoading,
   ]);
 
-  const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
-    return (
-      <HeadCell align={rightAlignColumns.has(column.key) ? 'right' : 'left'}>
-        {column.name}
-        {column.key === 'timestamp' && <IconArrow direction="down" size="xs" />}
-        {column.key === 'agents' && <CellExpander />}
-      </HeadCell>
-    );
-  }, []);
+  const renderHeadCell = useCallback(
+    (column: GridColumnHeader<string>) => {
+      return (
+        <HeadCell align={rightAlignColumns.has(column.key) ? 'right' : 'left'}>
+          {column.name}
+          {column.key === 'timestamp' && <IconArrow direction="down" size="xs" />}
+          {column.key === 'agents' && !frameless && <CellExpander />}
+        </HeadCell>
+      );
+    },
+    [frameless]
+  );
 
   const renderBodyCell = useCallback(
     (column: GridColumnOrder<string>, dataRow: TableData) => {
@@ -279,7 +282,6 @@ export function TracesTable({
   const additionalGridProps = frameless
     ? {
         bodyStyle: FRAMELESS_STYLES,
-        fit: 'max-content' as const,
         resizable: true,
         scrollable: true,
         height: '100%',

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -252,18 +252,15 @@ export function TracesTable({
     agentsRequest.isLoading,
   ]);
 
-  const renderHeadCell = useCallback(
-    (column: GridColumnHeader<string>) => {
-      return (
-        <HeadCell align={rightAlignColumns.has(column.key) ? 'right' : 'left'}>
-          {column.name}
-          {column.key === 'timestamp' && <IconArrow direction="down" size="xs" />}
-          {column.key === 'agents' && !frameless && <CellExpander />}
-        </HeadCell>
-      );
-    },
-    [frameless]
-  );
+  const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
+    return (
+      <HeadCell align={rightAlignColumns.has(column.key) ? 'right' : 'left'}>
+        {column.name}
+        {column.key === 'timestamp' && <IconArrow direction="down" size="xs" />}
+        {column.key === 'agents' && <CellExpander />}
+      </HeadCell>
+    );
+  }, []);
 
   const renderBodyCell = useCallback(
     (column: GridColumnOrder<string>, dataRow: TableData) => {
@@ -282,6 +279,7 @@ export function TracesTable({
   const additionalGridProps = frameless
     ? {
         bodyStyle: FRAMELESS_STYLES,
+        fit: 'max-content' as const,
         resizable: true,
         scrollable: true,
         height: '100%',


### PR DESCRIPTION
When the platformized AI agents overview is enabled, the traces table had a horizontal scrollbar due to hardcoded column widths (the agents column was fixed at 600px).

This fixes the overflow by:
- Using `COL_WIDTH_UNDEFINED` for the agents column so it fills available space instead of a fixed 600px
- Removing `fit: max-content` which prevented the table from fitting its container

Additionally fixes the empty state ("No results") layout where the message appeared at the top of the widget instead of being vertically centered:
- `TableWrapper` now uses `flex: 1` to fill remaining vertical space in the widget card
- `Grid` now sets `grid-template-rows: auto 1fr` when `height` is set and both `thead`/`tbody` are present, keeping the header compact while the body fills remaining space



**Before**

https://github.com/user-attachments/assets/2553c168-a69b-406e-8d06-c10fa35e9ede



**After**

https://github.com/user-attachments/assets/f1c88a11-e2a3-4c48-8c1e-c4bdaa09d090



closes https://linear.app/getsentry/issue/TET-2081/agent-monitoring-dashboard-horizontal-scrollbar-on-table