### PR TITLE
ref(tracemetrics): Migrate metric selector to React Aria primitives

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -254,20 +254,6 @@ describe('MetricSelector', () => {
       ).toHaveFocus();
     });
 
-    it('ArrowUp from search moves focus to last option', async () => {
-      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
-        organization,
-      });
-      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
-      await userEvent.keyboard('{ArrowUp}');
-
-      expect(
-        await screen.findByRole('option', {
-          name: SORTED_METRIC_NAMES[SORTED_METRIC_NAMES.length - 1]!,
-        })
-      ).toHaveFocus();
-    });
-
     it('ArrowDown twice selects second option with Enter', async () => {
       const onChange = jest.fn();
       render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
@@ -324,22 +310,6 @@ describe('MetricSelector', () => {
       await userEvent.keyboard('{ArrowDown}');
       await userEvent.keyboard('{Enter}');
       expect(onChange).toHaveBeenCalledTimes(1);
-    });
-
-    it('ArrowUp does not go below index 0', async () => {
-      const onChange = jest.fn();
-      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
-        organization,
-      });
-
-      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
-      await screen.findByRole('option', {name: SORTED_METRIC_NAMES[0]!});
-      await userEvent.keyboard('{ArrowUp}');
-      await userEvent.keyboard('{Enter}');
-
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({name: SORTED_METRIC_NAMES[0]})
-      );
     });
   });
 

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -105,6 +105,18 @@ describe('MetricSelector', () => {
       expect(await screen.findByRole('listbox')).toBeInTheDocument();
     });
 
+    it('opens dropdown when trigger receives ArrowDown', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+      const trigger = screen.getByRole('button', {name: 'bar'});
+      trigger.focus();
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    });
+
     it('closes on Escape', async () => {
       render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
         organization,
@@ -230,6 +242,18 @@ describe('MetricSelector', () => {
       expect(onChange).toHaveBeenCalled();
     });
 
+    it('ArrowDown from search moves focus to first option', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await userEvent.keyboard('{ArrowDown}');
+
+      expect(
+        await screen.findByRole('option', {name: SORTED_METRIC_NAMES[0]!})
+      ).toHaveFocus();
+    });
+
     it('ArrowDown twice selects second option with Enter', async () => {
       const onChange = jest.fn();
       render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
@@ -247,7 +271,7 @@ describe('MetricSelector', () => {
       );
     });
 
-    it('clamps focusedIndex when displayed options shrink', async () => {
+    it('keeps keyboard selection valid when displayed options shrink', async () => {
       const onChange = jest.fn();
       render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
         organization,
@@ -279,11 +303,11 @@ describe('MetricSelector', () => {
       const searchInput = screen.getByPlaceholderText('Search metrics\u2026');
       await userEvent.type(searchInput, 'b');
 
-      // After list shrinks, a single ArrowUp then Enter should select a valid option
+      // After list shrinks, keyboard selection should still pick a valid option.
       await waitFor(() => {
         expect(screen.getAllByRole('option').length).toBeLessThanOrEqual(2);
       });
-      await userEvent.keyboard('{ArrowUp}');
+      await userEvent.keyboard('{ArrowDown}');
       await userEvent.keyboard('{Enter}');
       expect(onChange).toHaveBeenCalled();
     });

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -254,6 +254,20 @@ describe('MetricSelector', () => {
       ).toHaveFocus();
     });
 
+    it('ArrowUp from search moves focus to last option', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization,
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await userEvent.keyboard('{ArrowUp}');
+
+      expect(
+        await screen.findByRole('option', {
+          name: SORTED_METRIC_NAMES[SORTED_METRIC_NAMES.length - 1]!,
+        })
+      ).toHaveFocus();
+    });
+
     it('ArrowDown twice selects second option with Enter', async () => {
       const onChange = jest.fn();
       render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -239,7 +239,7 @@ describe('MetricSelector', () => {
       await userEvent.keyboard('{ArrowDown}');
       await userEvent.keyboard('{Enter}');
 
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
 
     it('ArrowDown from search moves focus to first option', async () => {
@@ -309,7 +309,7 @@ describe('MetricSelector', () => {
       });
       await userEvent.keyboard('{ArrowDown}');
       await userEvent.keyboard('{Enter}');
-      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
 
     it('ArrowUp does not go below index 0', async () => {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -582,16 +582,10 @@ function MetricListBoxOption({
     listState,
     ref
   );
-  const optionPropsMerged = mergeProps(optionProps, {
-    onMouseEnter: () => {
-      listState.selectionManager.setFocused(true);
-      listState.selectionManager.setFocusedKey(item.key);
-    },
-  });
 
   return (
     <MenuListItem
-      {...optionPropsMerged}
+      {...optionProps}
       as="li"
       data-index={dataIndex}
       ref={mergeRefs(ref, measureRef)}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -360,8 +360,8 @@ export function MetricSelector({
   });
 
   // The search input sits outside the listbox, so useListBox's shouldFocusWrap
-  // never sees these keystrokes. We manually bridge focus from the search field
-  // into the list here; once focus is inside the list, shouldFocusWrap takes over.
+  // never sees these keystrokes. Bridge ArrowDown from the search field into the
+  // list; once focus is inside the list, shouldFocusWrap takes over.
   const {keyboardProps: searchKeyboardProps} = useKeyboard({
     onKeyDown: e => {
       if (e.key === 'ArrowDown') {
@@ -372,16 +372,6 @@ export function MetricSelector({
           listState.selectionManager.setFocusedKey(firstKey);
         }
         overlayRef.current?.querySelector<HTMLLIElement>('li[role="option"]')?.focus();
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        const lastKey = listState.collection.getLastKey();
-        if (lastKey) {
-          listState.selectionManager.setFocused(true);
-          listState.selectionManager.setFocusedKey(lastKey);
-        }
-        const options =
-          overlayRef.current?.querySelectorAll<HTMLLIElement>('li[role="option"]');
-        options?.[options.length - 1]?.focus();
       }
 
       if (e.key === 'Enter') {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -1,9 +1,15 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useId, useMemo, useRef, useState} from 'react';
 import {FocusScope} from '@react-aria/focus';
+import {useKeyboard} from '@react-aria/interactions';
+import {useListBox, useOption} from '@react-aria/listbox';
+import {mergeProps, mergeRefs} from '@react-aria/utils';
+import {Item} from '@react-stately/collections';
+import {useListState, type ListState} from '@react-stately/list';
+import type {Node} from '@react-types/shared';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Tag} from '@sentry/scraps/badge';
-import {LeadWrap} from '@sentry/scraps/compactSelect';
+import {LeadWrap, ListWrap} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {MenuListItem, type MenuListItemProps} from '@sentry/scraps/menuListItem';
@@ -30,6 +36,16 @@ import {
 } from 'sentry/views/explore/metrics/types';
 
 export const NONE_UNIT = 'none';
+
+function nextFrameCallback(cb: () => void) {
+  if ('requestAnimationFrame' in window) {
+    window.requestAnimationFrame(() => cb());
+  } else {
+    setTimeout(() => {
+      cb();
+    }, 1);
+  }
+}
 
 function hasDisplayMetricUnit(
   hasMetricUnitsUI: boolean,
@@ -75,34 +91,71 @@ export function MetricSelector({
   onChange: (traceMetric: TraceMetric) => void;
   traceMetric: TraceMetric;
 }) {
+  const triggerId = useId();
+
   const organization = useOrganization();
+  const hasMetricUnitsUI = useHasMetricUnitsUI();
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const listElementRef = useRef<HTMLUListElement>(null);
+  const scrollElementRef = useRef<HTMLDivElement>(null);
+
   const [searchInputValue, setSearchInputValue] = useState('');
   const debouncedSearch = useDebouncedValue(searchInputValue, DEFAULT_DEBOUNCE_DURATION);
-  const [focusedIndex, setFocusedIndex] = useState(-1);
   const {data: metricOptionsData, isFetching} = useMetricOptions({
     search: debouncedSearch,
   });
-  const hasMetricUnitsUI = useHasMetricUnitsUI();
-  const scrollElementRef = useRef<HTMLDivElement>(null);
 
   const {
     isOpen,
     state: overlayState,
     triggerProps,
     overlayProps,
+    triggerRef,
+    overlayRef,
+    update: updateOverlay,
   } = useOverlay({
     type: 'listbox',
     position: 'bottom-start',
     offset: 6,
     isDismissable: true,
     shouldApplyMinWidth: true,
-    // Reset search and keyboard focus when the overlay closes so it
-    // starts fresh the next time the user opens it.
+    disableTrigger: isFetching && !traceMetric.name,
     onOpenChange: open => {
-      if (!open) {
+      nextFrameCallback(() => {
+        if (open) {
+          updateOverlay?.();
+          if (searchRef.current) {
+            searchRef.current.focus();
+            return;
+          }
+
+          const firstSelectedOption = overlayRef.current?.querySelector<HTMLLIElement>(
+            'li[role="option"][aria-selected="true"]'
+          );
+          if (firstSelectedOption) {
+            firstSelectedOption.focus();
+            return;
+          }
+
+          overlayRef.current?.querySelector<HTMLLIElement>('li[role="option"]')?.focus();
+          return;
+        }
+
         setSearchInputValue('');
-        setFocusedIndex(-1);
-      }
+        if (
+          document.activeElement === document.body ||
+          wrapperRef.current?.contains(document.activeElement)
+        ) {
+          nextFrameCallback(() => {
+            const triggerElement =
+              triggerRef.current ??
+              wrapperRef.current?.querySelector<HTMLButtonElement>('button');
+            triggerElement?.focus();
+          });
+        }
+      });
     },
   });
 
@@ -205,15 +258,6 @@ export function MetricSelector({
     [isFetching, previousOptions, metricOptions]
   );
 
-  // Clamp the focused index when the list shrinks (e.g. after a search
-  // filters out options) so it doesn't point past the end of the list.
-  useEffect(() => {
-    if (displayedOptions.length === 0 || focusedIndex < displayedOptions.length) {
-      return;
-    }
-    setFocusedIndex(Math.max(displayedOptions.length - 1, -1));
-  }, [displayedOptions.length, focusedIndex]);
-
   // Find the option with the longest label to render as a hidden element.
   // This reserves enough width for the overlay so it doesn't resize as
   // the user scrolls through the virtualized list.
@@ -227,18 +271,6 @@ export function MetricSelector({
     [displayedOptions]
   );
 
-  const virtualizer = useVirtualizer({
-    count: displayedOptions.length,
-    getScrollElement: () => scrollElementRef.current,
-    estimateSize: () => 42,
-    overscan: 20,
-  });
-
-  const highlightedOption =
-    focusedIndex >= 0 && focusedIndex < displayedOptions.length
-      ? displayedOptions[focusedIndex]
-      : null;
-
   const handleSelect = useCallback(
     (option: MetricSelectOption) => {
       onChange({
@@ -251,54 +283,118 @@ export function MetricSelector({
     [onChange, hasMetricUnitsUI, overlayState]
   );
 
+  const displayedOptionsMap = useMemo(
+    () => new Map(displayedOptions.map(option => [option.value, option])),
+    [displayedOptions]
+  );
+
+  const listState = useListState<MetricSelectOption>({
+    items: displayedOptions,
+    selectionMode: 'single',
+    selectedKeys: traceMetric.name ? [traceMetricSelectValue] : [],
+    allowDuplicateSelectionEvents: true,
+    onSelectionChange: selection => {
+      if (selection === 'all') {
+        return;
+      }
+      const selectedKey = Array.from(selection)[0];
+      if (!selectedKey) {
+        return;
+      }
+      const selectedOption = displayedOptionsMap.get(String(selectedKey));
+      if (selectedOption) {
+        handleSelect(selectedOption);
+      }
+    },
+    children: (item: MetricSelectOption) => <Item key={item.value}>{item.label}</Item>,
+  });
+
+  const {listBoxProps} = useListBox(
+    {
+      shouldFocusWrap: true,
+      shouldFocusOnHover: true,
+      shouldSelectOnPressUp: true,
+      'aria-labelledby': triggerId,
+    },
+    listState,
+    listElementRef
+  );
+
+  const collectionItems = useMemo(
+    () => [...listState.collection],
+    [listState.collection]
+  );
+  const focusedKey = listState.selectionManager.focusedKey;
+
+  const virtualizer = useVirtualizer({
+    count: collectionItems.length,
+    getScrollElement: () => scrollElementRef.current,
+    estimateSize: () => 42,
+    overscan: 20,
+  });
+
+  const focusedIndex = useMemo(
+    () => collectionItems.findIndex(item => item.key === focusedKey),
+    [collectionItems, focusedKey]
+  );
+
+  useEffect(() => {
+    if (focusedIndex >= 0 && isOpen) {
+      virtualizer.scrollToIndex(focusedIndex, {align: 'auto'});
+    }
+  }, [focusedIndex, isOpen, virtualizer]);
+
+  const highlightedOption = focusedKey
+    ? (displayedOptionsMap.get(String(focusedKey)) ?? null)
+    : null;
+
+  const {keyboardProps: triggerKeyboardProps} = useKeyboard({
+    onKeyDown: e => {
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        overlayState.open();
+      } else {
+        e.continuePropagation();
+      }
+    },
+  });
+
+  const {keyboardProps: searchKeyboardProps} = useKeyboard({
+    onKeyDown: e => {
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        const firstKey = listState.collection.getFirstKey();
+        if (firstKey) {
+          listState.selectionManager.setFocused(true);
+          listState.selectionManager.setFocusedKey(firstKey);
+        }
+        overlayRef.current?.querySelector<HTMLLIElement>('li[role="option"]')?.focus();
+      }
+
+      if (e.key === 'Enter') {
+        e.preventDefault();
+      }
+
+      e.continuePropagation();
+    },
+  });
+
+  const mergedTriggerProps = mergeProps(triggerProps, triggerKeyboardProps, {
+    id: triggerId,
+  });
+
   const onSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchInputValue(e.target.value);
   }, []);
-
-  const onKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      switch (e.key) {
-        case 'ArrowDown': {
-          e.preventDefault();
-          if (displayedOptions.length === 0) {
-            break;
-          }
-          const next = Math.min(focusedIndex + 1, displayedOptions.length - 1);
-          setFocusedIndex(next);
-          virtualizer.scrollToIndex(next);
-          break;
-        }
-        case 'ArrowUp': {
-          e.preventDefault();
-          if (displayedOptions.length === 0) {
-            break;
-          }
-          const next = Math.max(focusedIndex - 1, 0);
-          setFocusedIndex(next);
-          virtualizer.scrollToIndex(next);
-          break;
-        }
-        case 'Enter':
-          e.preventDefault();
-          if (focusedIndex >= 0 && displayedOptions[focusedIndex]) {
-            handleSelect(displayedOptions[focusedIndex]);
-          }
-          break;
-        default:
-          break;
-      }
-    },
-    [displayedOptions, focusedIndex, handleSelect, virtualizer]
-  );
 
   const virtualItems = virtualizer.getVirtualItems();
 
   // Fall back to rendering all items when the virtualizer can't measure
   // the scroll container (e.g. in tests where the DOM has no layout).
   const itemsToRender =
-    virtualItems.length > 0 || displayedOptions.length === 0
+    virtualItems.length > 0 || collectionItems.length === 0
       ? virtualItems
-      : displayedOptions.map((_, index) => ({
+      : collectionItems.map((_, index) => ({
           index,
           key: index,
           start: 0,
@@ -308,9 +404,9 @@ export function MetricSelector({
         }));
 
   return (
-    <Container width="100%" position="relative">
+    <Container width="100%" position="relative" ref={wrapperRef}>
       <OverlayTrigger.Button
-        {...triggerProps}
+        {...mergedTriggerProps}
         style={{width: '100%', fontWeight: 'bold', textAlign: 'left'}}
         disabled={isFetching && !traceMetric.name}
       >
@@ -323,14 +419,13 @@ export function MetricSelector({
       >
         {isOpen ? (
           <Overlay style={{display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
-            <FocusScope contain restoreFocus autoFocus>
+            <FocusScope contain>
               <Flex direction={{xs: 'column', sm: 'row'}}>
                 <Stack
-                  minWidth="300px"
+                  minWidth="400px"
                   minHeight="0"
                   borderRight={{sm: 'primary'}}
                   borderBottom={{xs: 'primary', sm: undefined}}
-                  onKeyDown={onKeyDown}
                 >
                   <Flex align="center" justify="between" padding="sm lg">
                     <Text size="sm" bold wrap="nowrap">
@@ -357,12 +452,13 @@ export function MetricSelector({
                         value={searchInputValue}
                         onChange={onSearchChange}
                         size="xs"
+                        ref={searchRef}
+                        {...searchKeyboardProps}
                       />
                     </InputGroup>
                   </Container>
                   <Container
                     ref={scrollElementRef}
-                    role="listbox"
                     overflowY="auto"
                     flex="1"
                     minHeight="0"
@@ -392,7 +488,7 @@ export function MetricSelector({
                         />
                       </Container>
                     ) : null}
-                    {displayedOptions.length === 0 ? (
+                    {collectionItems.length === 0 ? (
                       <Flex align="center" justify="center" padding="xl">
                         <Text variant="muted" size="sm">
                           {t('No metrics found')}
@@ -413,41 +509,33 @@ export function MetricSelector({
                             transform: `translateY(${itemsToRender[0]?.start ?? 0}px)`,
                           }}
                         >
-                          {itemsToRender.map(virtualRow => {
-                            const option = displayedOptions[virtualRow.index];
-                            if (!option) return null;
+                          <ListWrap
+                            {...listBoxProps}
+                            style={{
+                              ...listBoxProps.style,
+                              padding: 0,
+                            }}
+                            ref={listElementRef}
+                          >
+                            {itemsToRender.map(virtualRow => {
+                              const item = collectionItems[virtualRow.index];
+                              if (item?.type !== 'item') {
+                                return null;
+                              }
 
-                            const isSelected = option.value === traceMetricSelectValue;
-                            const isFocused = virtualRow.index === focusedIndex;
-
-                            return (
-                              <div
-                                key={option.value}
-                                ref={virtualizer.measureElement}
-                                data-index={virtualRow.index}
-                                role="option"
-                                aria-label={option.label}
-                                aria-selected={isSelected}
-                                onClick={() => handleSelect(option)}
-                                onMouseEnter={() => setFocusedIndex(virtualRow.index)}
-                              >
-                                <MenuListItem
-                                  as="div"
+                              return (
+                                <MetricListBoxOption
+                                  key={item.key}
+                                  item={item}
+                                  listState={listState}
                                   size="md"
-                                  label={option.label}
-                                  isFocused={isFocused}
-                                  isSelected={isSelected}
-                                  priority={isSelected ? 'primary' : 'default'}
-                                  leadingItems={
-                                    <LeadWrap aria-hidden="true">
-                                      {isSelected ? <IconCheckmark size="sm" /> : null}
-                                    </LeadWrap>
-                                  }
-                                  trailingItems={option.trailingItems}
+                                  dataIndex={virtualRow.index}
+                                  measureRef={virtualizer.measureElement}
+                                  onSelect={handleSelect}
                                 />
-                              </div>
-                            );
-                          })}
+                              );
+                            })}
+                          </ListWrap>
                         </Container>
                       </Container>
                     )}
@@ -467,6 +555,66 @@ export function MetricSelector({
         ) : null}
       </PositionWrapper>
     </Container>
+  );
+}
+
+interface MetricListBoxOptionProps {
+  dataIndex: number;
+  item: Node<MetricSelectOption>;
+  listState: ListState<MetricSelectOption>;
+  onSelect: (option: MetricSelectOption) => void;
+  size: MenuListItemProps['size'];
+  measureRef?: React.Ref<HTMLLIElement>;
+}
+
+function MetricListBoxOption({
+  item,
+  listState,
+  onSelect,
+  size,
+  dataIndex,
+  measureRef,
+}: MetricListBoxOptionProps) {
+  const ref = useRef<HTMLLIElement>(null);
+  const option = item.value!;
+  const {optionProps, isFocused, isSelected, isDisabled, isPressed} = useOption(
+    {key: item.key, 'aria-label': option.label},
+    listState,
+    ref
+  );
+  const optionPropsMerged = mergeProps(optionProps, {
+    onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        onSelect(option);
+      }
+    },
+    onMouseEnter: () => {
+      listState.selectionManager.setFocused(true);
+      listState.selectionManager.setFocusedKey(item.key);
+    },
+  });
+
+  return (
+    <MenuListItem
+      {...optionPropsMerged}
+      as="li"
+      data-index={dataIndex}
+      ref={mergeRefs(ref, measureRef)}
+      size={size}
+      label={option.label}
+      isFocused={listState.selectionManager.isFocused && isFocused}
+      isSelected={isSelected}
+      isPressed={isPressed}
+      disabled={isDisabled}
+      priority={isSelected ? 'primary' : 'default'}
+      leadingItems={
+        <LeadWrap aria-hidden="true">
+          {isSelected ? <IconCheckmark size="sm" /> : null}
+        </LeadWrap>
+      }
+      trailingItems={option.trailingItems}
+    />
   );
 }
 

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -531,7 +531,6 @@ export function MetricSelector({
                                   size="md"
                                   dataIndex={virtualRow.index}
                                   measureRef={virtualizer.measureElement}
-                                  onSelect={handleSelect}
                                 />
                               );
                             })}
@@ -562,7 +561,6 @@ interface MetricListBoxOptionProps {
   dataIndex: number;
   item: Node<MetricSelectOption>;
   listState: ListState<MetricSelectOption>;
-  onSelect: (option: MetricSelectOption) => void;
   size: MenuListItemProps['size'];
   measureRef?: React.Ref<HTMLLIElement>;
 }
@@ -570,7 +568,6 @@ interface MetricListBoxOptionProps {
 function MetricListBoxOption({
   item,
   listState,
-  onSelect,
   size,
   dataIndex,
   measureRef,
@@ -583,12 +580,6 @@ function MetricListBoxOption({
     ref
   );
   const optionPropsMerged = mergeProps(optionProps, {
-    onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        onSelect(option);
-      }
-    },
     onMouseEnter: () => {
       listState.selectionManager.setFocused(true);
       listState.selectionManager.setFocusedKey(item.key);

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -531,7 +531,6 @@ export function MetricSelector({
                                   key={item.key}
                                   item={item}
                                   listState={listState}
-                                  onSelect={handleSelect}
                                   size="md"
                                   dataIndex={virtualRow.index}
                                   measureRef={virtualizer.measureElement}
@@ -565,7 +564,6 @@ interface MetricListBoxOptionProps {
   dataIndex: number;
   item: Node<MetricSelectOption>;
   listState: ListState<MetricSelectOption>;
-  onSelect: (option: MetricSelectOption) => void;
   size: MenuListItemProps['size'];
   measureRef?: React.Ref<HTMLLIElement>;
 }
@@ -573,7 +571,6 @@ interface MetricListBoxOptionProps {
 function MetricListBoxOption({
   item,
   listState,
-  onSelect,
   size,
   dataIndex,
   measureRef,
@@ -586,13 +583,6 @@ function MetricListBoxOption({
     ref
   );
   const optionPropsMerged = mergeProps(optionProps, {
-    onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
-      if (e.key !== 'Enter' || !listState.selectionManager.isSelected(item.key)) {
-        return;
-      }
-      e.preventDefault();
-      onSelect(option);
-    },
     onMouseEnter: () => {
       listState.selectionManager.setFocused(true);
       listState.selectionManager.setFocusedKey(item.key);

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -313,7 +313,6 @@ export function MetricSelector({
   const {listBoxProps} = useListBox(
     {
       shouldFocusWrap: true,
-      shouldFocusOnHover: true,
       shouldSelectOnPressUp: true,
       'aria-labelledby': triggerId,
     },
@@ -532,6 +531,7 @@ export function MetricSelector({
                                   key={item.key}
                                   item={item}
                                   listState={listState}
+                                  onSelect={handleSelect}
                                   size="md"
                                   dataIndex={virtualRow.index}
                                   measureRef={virtualizer.measureElement}
@@ -565,6 +565,7 @@ interface MetricListBoxOptionProps {
   dataIndex: number;
   item: Node<MetricSelectOption>;
   listState: ListState<MetricSelectOption>;
+  onSelect: (option: MetricSelectOption) => void;
   size: MenuListItemProps['size'];
   measureRef?: React.Ref<HTMLLIElement>;
 }
@@ -572,6 +573,7 @@ interface MetricListBoxOptionProps {
 function MetricListBoxOption({
   item,
   listState,
+  onSelect,
   size,
   dataIndex,
   measureRef,
@@ -583,10 +585,23 @@ function MetricListBoxOption({
     listState,
     ref
   );
+  const optionPropsMerged = mergeProps(optionProps, {
+    onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
+      if (e.key !== 'Enter' || !listState.selectionManager.isSelected(item.key)) {
+        return;
+      }
+      e.preventDefault();
+      onSelect(option);
+    },
+    onMouseEnter: () => {
+      listState.selectionManager.setFocused(true);
+      listState.selectionManager.setFocusedKey(item.key);
+    },
+  });
 
   return (
     <MenuListItem
-      {...optionProps}
+      {...optionPropsMerged}
       as="li"
       data-index={dataIndex}
       ref={mergeRefs(ref, measureRef)}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -359,9 +359,12 @@ export function MetricSelector({
     },
   });
 
+  // The search input sits outside the listbox, so useListBox's shouldFocusWrap
+  // never sees these keystrokes. We manually bridge focus from the search field
+  // into the list here; once focus is inside the list, shouldFocusWrap takes over.
   const {keyboardProps: searchKeyboardProps} = useKeyboard({
     onKeyDown: e => {
-      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      if (e.key === 'ArrowDown') {
         e.preventDefault();
         const firstKey = listState.collection.getFirstKey();
         if (firstKey) {
@@ -369,6 +372,16 @@ export function MetricSelector({
           listState.selectionManager.setFocusedKey(firstKey);
         }
         overlayRef.current?.querySelector<HTMLLIElement>('li[role="option"]')?.focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const lastKey = listState.collection.getLastKey();
+        if (lastKey) {
+          listState.selectionManager.setFocused(true);
+          listState.selectionManager.setFocusedKey(lastKey);
+        }
+        const options =
+          overlayRef.current?.querySelectorAll<HTMLLIElement>('li[role="option"]');
+        options?.[options.length - 1]?.focus();
       }
 
       if (e.key === 'Enter') {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -293,6 +293,7 @@ export function MetricSelector({
     selectionMode: 'single',
     selectedKeys: traceMetric.name ? [traceMetricSelectValue] : [],
     allowDuplicateSelectionEvents: true,
+    disallowEmptySelection: true,
     onSelectionChange: selection => {
       if (selection === 'all') {
         return;


### PR DESCRIPTION
Replaces the hand-rolled keyboard navigation and selection logic in the trace metrics `MetricSelector` with React Aria's `useListBox`/`useOption` primitives and `@react-stately/list` for state management.

The previous implementation manually tracked a `focusedIndex`, handled arrow key navigation, and clamped the index when the filtered list shrank. This was fragile and didn't provide proper ARIA attributes on options. React Aria gives us correct `role`, `aria-selected`, focus management, and keyboard interaction out of the box.

Key changes:
- `useListBox` + `useOption` manage the listbox role and option focus
- `useListState` handles selection state, replacing manual index tracking
- `useKeyboard` on the trigger opens the dropdown on ArrowDown/ArrowUp
- `useKeyboard` on the search input moves focus into the list on arrow keys
- Extracted `MetricListBoxOption` component for each virtualized option
- Focus management on open/close is handled explicitly via `onOpenChange`
- Removed the manual `focusedIndex` clamping effect

|||
|-|-|
|With panel|<img width="1016" height="508" alt="Screenshot 2026-03-17 at 09 44 48" src="https://github.com/user-attachments/assets/d8b82b51-cc71-44ee-9fdf-1ad566ceb71f" />|
|Without panel|<img width="740" height="512" alt="Screenshot 2026-03-17 at 09 45 03" src="https://github.com/user-attachments/assets/123e3856-f742-42bb-8ec1-8d3ebed8ca0e" />|



