### PR TITLE
ref(trace): Remove useIsEAPTraceEnabled hook and non-EAP code paths

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
@@ -48,21 +48,7 @@ describe('EventTraceView', () => {
     });
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: `/organizations/${organization.slug}/events-trace-meta/${traceId}/`,
-      body: {
-        errors: 1,
-        performance_issues: 1,
-        projects: 1,
-        transactions: 1,
-        transaction_child_count_map: new Array(size)
-          .fill(0)
-          .map((_, i) => [{'transaction.id': i.toString(), count: 1}]),
-        span_count: 0,
-        span_count_map: {},
-      },
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-trace/${traceId}/`,
+      url: `/organizations/${organization.slug}/trace/${traceId}/`,
       body: {
         transactions: Array.from({length: size}, (_, i) =>
           makeTransaction({
@@ -123,19 +109,7 @@ describe('EventTraceView', () => {
     });
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: `/organizations/${organization.slug}/events-trace-meta/${traceId}/`,
-      body: {
-        errors: 0,
-        performance_issues: 0,
-        projects: 0,
-        transactions: 0,
-        transaction_child_count_map: [{'transaction.id': '1', count: 1}],
-        span_count: 0,
-        span_count_map: {},
-      },
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-trace/${traceId}/`,
+      url: `/organizations/${organization.slug}/trace/${traceId}/`,
       body: {
         transactions: [],
         orphan_errors: [],

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -72,7 +72,7 @@ function EventTraceViewInner({event, organization, traceId}: EventTraceViewInner
     timestamp,
     traceSlug: traceId,
     limit: 10000,
-    targetEventId: event.id,
+    targetEventId: event.eventID,
   });
   const params = useTraceQueryParams({
     timestamp,

--- a/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
@@ -81,7 +81,7 @@ function SpanEvidenceTraceViewImpl({
     timestamp,
     traceSlug: traceId,
     limit: 10000,
-    targetEventId: event.id,
+    targetEventId: event.eventID,
   });
   const tree = useIssuesTraceTree({trace, replay: null});
 

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -206,6 +206,11 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/trace/${TRACE_ID}/`,
+    body: [],
+  });
+
+  MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/events-trace/${TRACE_ID}/`,
     body: trace
       ? {transactions: [trace], orphan_errors: []}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -20,7 +20,10 @@ import {IssueCategory, IssueType} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import GroupEventDetails from 'sentry/views/issueDetails/groupEventDetails/groupEventDetails';
-import type {TraceFullDetailed} from 'sentry/views/performance/newTraceDetails/traceApi/types';
+import {
+  makeEAPOccurrence,
+  makeEAPSpan,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
 
 const TRACE_ID = '797cda4e24844bdc90e0efe741616047';
 
@@ -105,62 +108,13 @@ const makeDefaultMockData = (
   };
 };
 
-const mockedTrace = (project: Project) => {
-  return {
-    event_id: '8806ea4691c24fc7b1c77ecd78df574f',
-    span_id: 'b0e6f15b45c36b12',
-    transaction: 'MainActivity.add_attachment',
-    'transaction.duration': 1000,
-    'transaction.op': 'navigation',
-    project_id: parseInt(project.id, 10),
-    project_slug: project.slug,
-    parent_span_id: null,
-    parent_event_id: null,
-    generation: 0,
-    errors: [
-      {
-        event_id: 'c6971a73454646338bc3ec80c70f8891',
-        issue_id: 104,
-        span: 'b0e6f15b45c36b12',
-        project_id: parseInt(project.id, 10),
-        project_slug: project.slug,
-        title: 'ApplicationNotResponding: ANR for at least 5000 ms.',
-        message: 'ANR for at least 5000 ms.',
-        level: 'error',
-        issue: '',
-      },
-    ],
-    performance_issues: [
-      {
-        event_id: '8806ea4691c24fc7b1c77ecd78df574f',
-        issue_id: 110,
-        issue_short_id: 'SENTRY-ANDROID-1R',
-        span: ['b0e6f15b45c36b12'],
-        suspect_spans: ['89930aab9a0314d4'],
-        project_id: parseInt(project.id, 10),
-        project_slug: project.slug,
-        title: 'File IO on Main Thread',
-        message: 'File IO on Main Thread',
-        level: 'info',
-        culprit: 'MainActivity.add_attachment',
-        type: 1008,
-        end: 1678290375.15056,
-        start: 1678290374.150562,
-      },
-    ],
-    timestamp: 1678290375.150561,
-    start_timestamp: 1678290374.150561,
-    children: [],
-  } as Partial<TraceFullDetailed>;
-};
-
 const mockGroupApis = (
   organization: Organization,
   project: Project,
   group: Group,
   event: Event,
   replayId?: string,
-  trace?: Partial<TraceFullDetailed>
+  trace?: Array<ReturnType<typeof makeEAPSpan>>
 ) => {
   MockApiClient.addMockResponse({
     url: '/organizations/org-slug/issues/1/events/',
@@ -207,43 +161,7 @@ const mockGroupApis = (
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/trace/${TRACE_ID}/`,
-    body: trace?.performance_issues?.length
-      ? [
-          {
-            event_id: trace.event_id ?? '',
-            event_type: 'span',
-            op: trace['transaction.op'] ?? 'navigation',
-            name: trace.transaction ?? '',
-            transaction: trace.transaction ?? '',
-            start_timestamp: trace.start_timestamp ?? 0,
-            end_timestamp: trace.timestamp ?? 0,
-            is_transaction: true,
-            project_id: trace.project_id ?? parseInt(project.id, 10),
-            project_slug: trace.project_slug ?? project.slug,
-            parent_span_id: null,
-            children: [],
-            errors: [],
-            duration: (trace.timestamp ?? 0) - (trace.start_timestamp ?? 0),
-            profile_id: '',
-            profiler_id: '',
-            sdk_name: '',
-            occurrences: trace.performance_issues.map(issue => ({
-              event_id: issue.event_id,
-              event_type: 'occurrence',
-              issue_id: issue.issue_id,
-              issue_type: issue.type,
-              description: issue.title,
-              culprit: issue.culprit,
-              project_id: issue.project_id,
-              project_slug: issue.project_slug,
-              level: issue.level,
-              start_timestamp: issue.start,
-              transaction: trace.transaction ?? '',
-              short_id: issue.issue_short_id,
-            })),
-          },
-        ]
-      : [],
+    body: trace ?? [],
   });
 
   MockApiClient.addMockResponse({
@@ -580,7 +498,17 @@ describe('groupEventDetails', () => {
         props.group,
         props.event,
         undefined,
-        mockedTrace(props.project)
+        [
+          makeEAPSpan({
+            is_transaction: true,
+            occurrences: [
+              makeEAPOccurrence({
+                description: 'File IO on Main Thread',
+                issue_type: 1008,
+              }),
+            ],
+          }),
+        ]
       );
 
       render(<GroupEventDetails />, {
@@ -607,7 +535,17 @@ describe('groupEventDetails', () => {
         props.group,
         props.event,
         undefined,
-        mockedTrace(props.project)
+        [
+          makeEAPSpan({
+            is_transaction: true,
+            occurrences: [
+              makeEAPOccurrence({
+                description: 'File IO on Main Thread',
+                issue_type: 1008,
+              }),
+            ],
+          }),
+        ]
       );
 
       render(<GroupEventDetails />, {
@@ -632,7 +570,17 @@ describe('groupEventDetails', () => {
         props.group,
         props.event,
         undefined,
-        mockedTrace(props.project)
+        [
+          makeEAPSpan({
+            is_transaction: true,
+            occurrences: [
+              makeEAPOccurrence({
+                description: 'File IO on Main Thread',
+                issue_type: 1008,
+              }),
+            ],
+          }),
+        ]
       );
 
       render(<GroupEventDetails />, {
@@ -657,7 +605,17 @@ describe('groupEventDetails', () => {
         props.group,
         props.event,
         undefined,
-        mockedTrace(props.project)
+        [
+          makeEAPSpan({
+            is_transaction: true,
+            occurrences: [
+              makeEAPOccurrence({
+                description: 'File IO on Main Thread',
+                issue_type: 1008,
+              }),
+            ],
+          }),
+        ]
       );
 
       render(<GroupEventDetails />, {
@@ -676,17 +634,13 @@ describe('groupEventDetails', () => {
 
     it('does not render root cause section if related perf issues do not exist', async () => {
       const props = makeDefaultMockData();
-      const trace = mockedTrace(props.project);
       mockGroupApis(
         props.organization,
         props.project,
         props.group,
         props.event,
         undefined,
-        {
-          ...trace,
-          performance_issues: [],
-        }
+        [makeEAPSpan({is_transaction: true})]
       );
 
       render(<GroupEventDetails />, {

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -207,21 +207,43 @@ const mockGroupApis = (
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/trace/${TRACE_ID}/`,
-    body: [],
-  });
-
-  MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/events-trace/${TRACE_ID}/`,
-    body: trace
-      ? {transactions: [trace], orphan_errors: []}
-      : {transactions: [], orphan_errors: []},
-  });
-
-  MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/events-trace-light/${TRACE_ID}/`,
-    body: trace
-      ? {transactions: [trace], orphan_errors: []}
-      : {transactions: [], orphan_errors: []},
+    body: trace?.performance_issues?.length
+      ? [
+          {
+            event_id: trace.event_id ?? '',
+            event_type: 'span',
+            op: trace['transaction.op'] ?? 'navigation',
+            name: trace.transaction ?? '',
+            transaction: trace.transaction ?? '',
+            start_timestamp: trace.start_timestamp ?? 0,
+            end_timestamp: trace.timestamp ?? 0,
+            is_transaction: true,
+            project_id: trace.project_id ?? parseInt(project.id, 10),
+            project_slug: trace.project_slug ?? project.slug,
+            parent_span_id: null,
+            children: [],
+            errors: [],
+            duration: (trace.timestamp ?? 0) - (trace.start_timestamp ?? 0),
+            profile_id: '',
+            profiler_id: '',
+            sdk_name: '',
+            occurrences: trace.performance_issues.map(issue => ({
+              event_id: issue.event_id,
+              event_type: 'occurrence',
+              issue_id: issue.issue_id,
+              issue_type: issue.type,
+              description: issue.title,
+              culprit: issue.culprit,
+              project_id: issue.project_id,
+              project_slug: issue.project_slug,
+              level: issue.level,
+              start_timestamp: issue.start,
+              transaction: trace.transaction ?? '',
+              short_id: issue.issue_short_id,
+            })),
+          },
+        ]
+      : [],
   });
 
   MockApiClient.addMockResponse({

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -76,7 +76,7 @@ function mockTracePreferences(preferences: Partial<StoredTracePreferences>) {
 
 function mockTraceResponse(resp?: Partial<ResponseType>) {
   MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/events-trace/trace-id/',
+    url: '/organizations/org-slug/trace/trace-id/',
     method: 'GET',
     asyncDelay: 1,
     ...(resp ?? {body: {}}),
@@ -94,18 +94,18 @@ function mockPerformanceSubscriptionDetailsResponse(resp?: Partial<ResponseType>
 
 function mockTraceMetaResponse(resp?: Partial<ResponseType>) {
   MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/events-trace-meta/trace-id/',
+    url: '/organizations/org-slug/trace-meta/trace-id/',
     method: 'GET',
     asyncDelay: 1,
     ...(resp ?? {
       body: {
         errors: 0,
+        logs: 0,
         performance_issues: 0,
-        projects: 0,
-        transactions: 0,
         transaction_child_count_map: [],
         span_count: 200,
         span_count_map: {},
+        uptime_checks: 0,
       },
     }),
   });

--- a/static/app/views/performance/newTraceDetails/traceApi/types.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/types.tsx
@@ -86,16 +86,6 @@ export type TraceSplitResults<U extends TraceFull | TraceFullDetailed | EventLit
   transactions: U[];
 };
 
-export type TraceMeta = {
-  errors: number;
-  performance_issues: number;
-  projects: number;
-  span_count: number;
-  span_count_map: Record<string, number>;
-  transaction_child_count_map: Record<string, number>;
-  transactions: number;
-};
-
 export type EAPTraceMeta = {
   errors: number;
   logs: number;

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
@@ -5,14 +5,6 @@ import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary'
 
 import {useTrace} from './useTrace';
 
-jest.mock('sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled', () => ({
-  useIsEAPTraceEnabled: jest.fn(),
-}));
-
-const {useIsEAPTraceEnabled} = jest.requireMock(
-  'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled'
-);
-
 const organization = OrganizationFixture();
 const queryClient = makeTestQueryClient();
 
@@ -38,9 +30,6 @@ describe('useTrace', () => {
     ])('does NOT call EAP endpoint with errorId when URL has %s', async search => {
       // Set up mocked URL before hook runs
       window.history.pushState({}, '', `/some-path${search}`);
-
-      // Set up EAP enabled
-      useIsEAPTraceEnabled.mockReturnValue(true);
 
       const eapTraceMock = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/trace/test-trace-id/`,
@@ -72,64 +61,29 @@ describe('useTrace', () => {
 
     it.each([
       {
-        search: `?targetId=${validUUid}`, // EAP endpoint
-        mockEapEnabled: true,
-        endpoint: 'trace',
+        search: `?targetId=${validUUid}`,
         expectedParamKey: 'errorId',
       },
       {
-        search: `?eventId=${validUUid}`, // EAP endpoint
-        mockEapEnabled: true,
-        endpoint: 'trace',
+        search: `?eventId=${validUUid}`,
         expectedParamKey: 'errorId',
       },
       {
-        search: `?node=error-${validUUid}`, // EAP endpoint
-        mockEapEnabled: true,
-        endpoint: 'trace',
+        search: `?node=error-${validUUid}`,
         expectedParamKey: 'errorId',
       },
       {
-        search: `?node=txn-${validUUid}`, // EAP endpoint
-        mockEapEnabled: true,
-        endpoint: 'trace',
+        search: `?node=txn-${validUUid}`,
         expectedParamKey: 'errorId',
-      },
-      {
-        search: `?targetId=${validUUid}`, // non-EAP endpoint
-        mockEapEnabled: false,
-        endpoint: 'events-trace',
-        expectedParamKey: 'targetId',
-      },
-      {
-        search: `?eventId=${validUUid}`, // non-EAP endpoint
-        mockEapEnabled: false,
-        endpoint: 'events-trace',
-        expectedParamKey: 'targetId',
-      },
-      {
-        search: `?node=error-${validUUid}`, // non-EAP endpoint
-        mockEapEnabled: false,
-        endpoint: 'events-trace',
-        expectedParamKey: 'targetId',
-      },
-      {
-        search: `?node=txn-${validUUid}`, // non-EAP endpoint
-        mockEapEnabled: false,
-        endpoint: 'events-trace',
-        expectedParamKey: 'targetId',
       },
     ])(
       'calls tracing endpoint with query param options %s',
-      async ({search, mockEapEnabled, endpoint, expectedParamKey}) => {
+      async ({search, expectedParamKey}) => {
         // Mock URL before hook runs
         window.history.pushState({}, '', `/some-path${search}`);
 
-        // Mock EAP toggle
-        useIsEAPTraceEnabled.mockReturnValue(mockEapEnabled);
-
         const eapTraceMock = MockApiClient.addMockResponse({
-          url: `/organizations/${organization.slug}/${endpoint}/trace-test-id/`,
+          url: `/organizations/${organization.slug}/trace/trace-test-id/`,
           method: 'GET',
           body: [],
         });
@@ -145,7 +99,7 @@ describe('useTrace', () => {
         });
 
         expect(eapTraceMock).toHaveBeenCalledWith(
-          `/organizations/${organization.slug}/${endpoint}/trace-test-id/`,
+          `/organizations/${organization.slug}/trace/trace-test-id/`,
           expect.objectContaining({
             query: expect.objectContaining({
               [expectedParamKey]: validUUid,

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -12,7 +12,6 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import {useIsEAPTraceEnabled} from 'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled';
 
 import type {TraceFullDetailed, TraceSplitResults} from './types';
 
@@ -26,10 +25,9 @@ type TraceQueryParamOptions = {
 };
 
 function getTargetIdParams(
-  traceType: 'eap' | 'non-eap',
   options: TraceQueryParamOptions,
   normalizedParams: ReturnType<typeof normalizeDateTimeParams>
-): {targetId?: string} | {errorId?: string} {
+): {errorId?: string} {
   // Node params occur in the format `${event-type}-${eventId}`, where the most relevant event is the last one in the array.
   // If not an array, it is a string with the same format.
   const nodeParams = normalizedParams.node;
@@ -51,11 +49,7 @@ function getTargetIdParams(
     return {};
   }
 
-  if (traceType === 'eap') {
-    return isValidEventUUID(targetId) ? {errorId: targetId} : {};
-  }
-
-  return {targetId};
+  return isValidEventUUID(targetId) ? {errorId: targetId} : {};
 }
 
 type TraceQueryParams = {
@@ -65,10 +59,9 @@ type TraceQueryParams = {
   pageStart?: string;
   statsPeriod?: string;
   timestamp?: string;
-} & ({targetId?: string} | {errorId?: string});
+} & {errorId?: string};
 
 export function getTraceQueryParams(
-  traceType: 'eap' | 'non-eap',
   query: Location['query'],
   filters?: Partial<PageFilters>,
   options: TraceQueryParamOptions = {}
@@ -102,7 +95,7 @@ export function getTraceQueryParams(
     delete timeRangeParams.statsPeriod;
   }
 
-  const targetEventParams = getTargetIdParams(traceType, options, normalizedParams);
+  const targetEventParams = getTargetIdParams(options, normalizedParams);
 
   const queryParams = {
     ...timeRangeParams,
@@ -239,50 +232,25 @@ export function useTrace(
   const organization = useOrganization();
   const query = qs.parse(location.search);
 
-  const isEAPEnabled = useIsEAPTraceEnabled();
   const hasValidTrace = Boolean(options.traceSlug && organization.slug);
 
   const queryParams = useMemo(() => {
-    return getTraceQueryParams(
-      isEAPEnabled ? 'eap' : 'non-eap',
-      query,
-      filters.selection,
-      {
-        limit: options.limit,
-        timestamp: options.timestamp,
-        targetId: options.targetEventId,
-      }
-    );
+    return getTraceQueryParams(query, filters.selection, {
+      limit: options.limit,
+      timestamp: options.timestamp,
+      targetId: options.targetEventId,
+    });
 
     // Only re-run this if the view query param changes, otherwise if we pass location.search
     // as a dependency, the query will re-run every time we perform actions on the trace view; like
     // clicking on a span, that updates the url.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    options.limit,
-    options.timestamp,
-    options.targetEventId,
-    isEAPEnabled,
-    filters.selection,
-  ]);
+  }, [options.limit, options.timestamp, options.targetEventId, filters.selection]);
 
   const isDemoMode = Boolean(queryParams.demo);
   const demoTrace = useDemoTrace(queryParams.demo, organization);
 
-  const traceQuery = useApiQuery<TraceSplitResults<TraceTree.Transaction>>(
-    [
-      getApiUrl(`/organizations/$organizationIdOrSlug/events-trace/$traceId/`, {
-        path: {organizationIdOrSlug: organization.slug, traceId: options.traceSlug ?? ''},
-      }),
-      {query: queryParams},
-    ],
-    {
-      staleTime: Infinity,
-      enabled: hasValidTrace && !isDemoMode && !isEAPEnabled,
-    }
-  );
-
-  const eapTraceQuery = useApiQuery<TraceTree.EAPTrace>(
+  const traceQuery = useApiQuery<TraceTree.EAPTrace>(
     [
       getApiUrl(`/organizations/$organizationIdOrSlug/trace/$traceId/`, {
         path: {organizationIdOrSlug: organization.slug, traceId: options.traceSlug ?? ''},
@@ -298,11 +266,11 @@ export function useTrace(
     {
       staleTime: Infinity,
       retry: false,
-      enabled: hasValidTrace && !isDemoMode && isEAPEnabled,
+      enabled: hasValidTrace && !isDemoMode,
     }
   );
 
-  return isDemoMode ? demoTrace : isEAPEnabled ? eapTraceQuery : traceQuery;
+  return isDemoMode ? demoTrace : traceQuery;
 }
 
 const isValidEventUUID = (id: string): boolean => {

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -103,7 +103,7 @@ describe('useTraceMeta', () => {
           '1': 1,
           '2': 2,
         },
-        uptime_checks: 0,
+        uptime_checks: 1,
       },
       errors: [],
       status: 'success',

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -2,14 +2,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
 
 import {useTraceMeta} from './useTraceMeta';
-
-jest.mock('sentry/utils/useSyncedLocalStorageState', () => ({
-  useSyncedLocalStorageState: jest.fn(),
-}));
 
 const organization = OrganizationFixture();
 
@@ -30,99 +25,10 @@ const mockedReplayTraces: ReplayTrace[] = [
 
 describe('useTraceMeta', () => {
   beforeEach(() => {
-    jest.mocked(useSyncedLocalStorageState).mockReturnValue(['non-eap', jest.fn()]);
     jest.clearAllMocks();
   });
 
   it('Returns merged meta results', async () => {
-    MockApiClient.addMockResponse({
-      method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug1/',
-      body: {
-        errors: 1,
-        performance_issues: 1,
-        projects: 1,
-        transactions: 1,
-        transaction_child_count_map: [{'transaction.id': '1', count: 1}],
-        span_count: 1,
-        span_count_map: {
-          op1: 1,
-        },
-      },
-    });
-    MockApiClient.addMockResponse({
-      method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug2/',
-      body: {
-        errors: 1,
-        performance_issues: 1,
-        projects: 1,
-        transactions: 1,
-        transaction_child_count_map: [{'transaction.id': '2', count: 2}],
-        span_count: 2,
-        span_count_map: {
-          op1: 1,
-          op2: 1,
-        },
-      },
-    });
-    MockApiClient.addMockResponse({
-      method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug3/',
-      body: {
-        errors: 1,
-        performance_issues: 1,
-        projects: 1,
-        transactions: 1,
-        transaction_child_count_map: [],
-        span_count: 1,
-        span_count_map: {
-          op3: 1,
-        },
-      },
-    });
-
-    const {result} = renderHookWithProviders(() => useTraceMeta(mockedReplayTraces), {
-      organization,
-    });
-
-    expect(result.current).toEqual({
-      data: undefined,
-      errors: [],
-      status: 'pending',
-    });
-
-    await waitFor(() => expect(result.current.status === 'success').toBe(true));
-
-    expect(result.current).toEqual({
-      data: {
-        errors: 3,
-        performance_issues: 3,
-        projects: 1,
-        transactions: 3,
-        transaction_child_count_map: {
-          '1': 1,
-          '2': 2,
-        },
-        span_count: 4,
-        span_count_map: {
-          op1: 2,
-          op2: 1,
-          op3: 1,
-        },
-      },
-      errors: [],
-      status: 'success',
-    });
-  });
-
-  it('EAP - Returns merged meta results', async () => {
-    const org = OrganizationFixture({
-      features: ['trace-spans-format'],
-    });
-
-    jest.mocked(useSyncedLocalStorageState).mockReturnValue(['eap', jest.fn()]);
-
     MockApiClient.addMockResponse({
       method: 'GET',
       url: '/organizations/org-slug/trace-meta/slug1/',
@@ -145,7 +51,7 @@ describe('useTraceMeta', () => {
         errors: 1,
         logs: 1,
         performance_issues: 1,
-        span_count: 1,
+        span_count: 2,
         span_count_map: {
           op1: 1,
           op2: 1,
@@ -166,12 +72,12 @@ describe('useTraceMeta', () => {
           op3: 1,
         },
         uptime_checks: 1,
-        transaction_child_count_map: [{'transaction.id': '3', count: 1}],
+        transaction_child_count_map: [],
       },
     });
 
     const {result} = renderHookWithProviders(() => useTraceMeta(mockedReplayTraces), {
-      organization: org,
+      organization,
     });
 
     expect(result.current).toEqual({
@@ -187,7 +93,7 @@ describe('useTraceMeta', () => {
         errors: 3,
         logs: 3,
         performance_issues: 3,
-        span_count: 3,
+        span_count: 4,
         span_count_map: {
           op1: 2,
           op2: 1,
@@ -196,7 +102,6 @@ describe('useTraceMeta', () => {
         transaction_child_count_map: {
           '1': 1,
           '2': 2,
-          '3': 1,
         },
         uptime_checks: 0,
       },
@@ -208,17 +113,17 @@ describe('useTraceMeta', () => {
   it('Collects errors from rejected api calls', async () => {
     const mockRequest1 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      url: '/organizations/org-slug/trace-meta/slug1/',
       statusCode: 400,
     });
     const mockRequest2 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug2/',
+      url: '/organizations/org-slug/trace-meta/slug2/',
       statusCode: 400,
     });
     const mockRequest3 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug3/',
+      url: '/organizations/org-slug/trace-meta/slug3/',
       statusCode: 400,
     });
 
@@ -237,12 +142,12 @@ describe('useTraceMeta', () => {
     expect(result.current).toEqual({
       data: {
         errors: 0,
+        logs: 0,
         performance_issues: 0,
-        projects: 0,
-        transactions: 0,
-        transaction_child_count_map: {},
         span_count: 0,
         span_count_map: {},
+        transaction_child_count_map: {},
+        uptime_checks: 0,
       },
       errors: [expect.any(Error), expect.any(Error), expect.any(Error)],
       status: 'error',
@@ -256,37 +161,37 @@ describe('useTraceMeta', () => {
   it('Accumulates metaResults and collects errors from rejected api calls', async () => {
     const mockRequest1 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug1/',
+      url: '/organizations/org-slug/trace-meta/slug1/',
       statusCode: 400,
     });
     const mockRequest2 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug2/',
+      url: '/organizations/org-slug/trace-meta/slug2/',
       body: {
         errors: 1,
+        logs: 1,
         performance_issues: 1,
-        projects: 1,
-        transactions: 1,
-        transaction_child_count_map: [],
         span_count: 1,
         span_count_map: {
           op1: 1,
         },
+        uptime_checks: 0,
+        transaction_child_count_map: [],
       },
     });
     const mockRequest3 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace-meta/slug3/',
+      url: '/organizations/org-slug/trace-meta/slug3/',
       body: {
         errors: 1,
+        logs: 1,
         performance_issues: 1,
-        projects: 1,
-        transactions: 1,
-        transaction_child_count_map: [],
         span_count: 1,
         span_count_map: {
           op2: 1,
         },
+        uptime_checks: 0,
+        transaction_child_count_map: [],
       },
     });
 
@@ -305,15 +210,15 @@ describe('useTraceMeta', () => {
     expect(result.current).toEqual({
       data: {
         errors: 2,
+        logs: 2,
         performance_issues: 2,
-        projects: 1,
-        transactions: 2,
-        transaction_child_count_map: {},
         span_count: 2,
         span_count_map: {
           op1: 1,
           op2: 1,
         },
+        transaction_child_count_map: {},
+        uptime_checks: 0,
       },
       errors: [expect.any(Error)],
       status: 'success',

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -104,6 +104,7 @@ async function fetchTraceMetaInBatches(
         }
 
         acc.span_count += result.value.span_count;
+        acc.uptime_checks += result.value.uptime_checks;
         Object.entries(result.value.span_count_map).forEach(([span_op, count]: any) => {
           acc.span_count_map[span_op] = (acc.span_count_map[span_op] ?? 0) + count;
         });

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -12,10 +12,9 @@ import type {QueryStatus} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useIsEAPTraceEnabled} from 'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled';
 import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
 
-import type {EAPTraceMeta, TraceMeta} from './types';
+import type {EAPTraceMeta} from './types';
 
 type TraceMetaQueryParams =
   | {
@@ -45,16 +44,12 @@ function getMetaQueryParams(
 }
 
 async function fetchSingleTraceMetaNew(
-  type: 'non-eap' | 'eap',
   api: Client,
   organization: Organization,
   replayTrace: ReplayTrace,
   queryParams: any
 ) {
-  const url =
-    type === 'eap'
-      ? `/organizations/${organization.slug}/trace-meta/${replayTrace.traceSlug}/`
-      : `/organizations/${organization.slug}/events-trace-meta/${replayTrace.traceSlug}/`;
+  const url = `/organizations/${organization.slug}/trace-meta/${replayTrace.traceSlug}/`;
 
   const data = await api.requestPromise(url, {
     method: 'GET',
@@ -64,7 +59,6 @@ async function fetchSingleTraceMetaNew(
 }
 
 async function fetchTraceMetaInBatches(
-  type: 'non-eap' | 'eap',
   api: Client,
   organization: Organization,
   replayTraces: ReplayTrace[],
@@ -72,35 +66,24 @@ async function fetchTraceMetaInBatches(
   filters: Partial<PageFilters> = {}
 ) {
   const clonedTraceIds = [...replayTraces];
-  const meta: TraceMeta | EAPTraceMeta =
-    type === 'eap'
-      ? {
-          errors: 0,
-          logs: 0,
-          performance_issues: 0,
-          span_count: 0,
-          span_count_map: {},
-          transaction_child_count_map: {},
-          uptime_checks: 0,
-        }
-      : {
-          errors: 0,
-          performance_issues: 0,
-          projects: 0,
-          transactions: 0,
-          transaction_child_count_map: {},
-          span_count: 0,
-          span_count_map: {},
-        };
+  const meta: EAPTraceMeta = {
+    errors: 0,
+    logs: 0,
+    performance_issues: 0,
+    span_count: 0,
+    span_count_map: {},
+    transaction_child_count_map: {},
+    uptime_checks: 0,
+  };
 
   const apiErrors: Error[] = [];
 
   while (clonedTraceIds.length > 0) {
     const batch = clonedTraceIds.splice(0, 3);
-    const results = await Promise.allSettled<TraceMeta | EAPTraceMeta>(
+    const results = await Promise.allSettled<EAPTraceMeta>(
       batch.map(replayTrace => {
         const queryParams = getMetaQueryParams(replayTrace, normalizedParams, filters);
-        return fetchSingleTraceMetaNew(type, api, organization, replayTrace, queryParams);
+        return fetchSingleTraceMetaNew(api, organization, replayTrace, queryParams);
       })
     );
 
@@ -108,16 +91,7 @@ async function fetchTraceMetaInBatches(
       if (result.status === 'fulfilled') {
         acc.errors += result.value.errors;
         acc.performance_issues += result.value.performance_issues;
-
-        if ('projects' in acc && 'projects' in result.value) {
-          acc.projects = Math.max(acc.projects, result.value.projects);
-        }
-        if ('transactions' in acc && 'transactions' in result.value) {
-          acc.transactions += result.value.transactions;
-        }
-        if ('logs' in acc && 'logs' in result.value) {
-          acc.logs += result.value.logs;
-        }
+        acc.logs += result.value.logs;
 
         // Turn the transaction_child_count_map array into a map of transaction id to child count
         // for more efficient lookups.
@@ -144,7 +118,7 @@ async function fetchTraceMetaInBatches(
 }
 
 export type TraceMetaQueryResults = {
-  data: TraceMeta | EAPTraceMeta | undefined;
+  data: EAPTraceMeta | undefined;
   errors: Error[];
   status: QueryStatus;
 };
@@ -153,7 +127,6 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
   const api = useApi();
   const filters = usePageFilters();
   const organization = useOrganization();
-  const isEAP = useIsEAPTraceEnabled();
 
   const normalizedParams = useMemo(() => {
     const query = qs.parse(location.search);
@@ -169,7 +142,7 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
   const query = useQuery<
     {
       apiErrors: Error[];
-      meta: TraceMeta | EAPTraceMeta;
+      meta: EAPTraceMeta;
     },
     Error
   >({
@@ -177,7 +150,6 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
     queryKey: ['traceData', replayTraces.map(trace => trace.traceSlug)],
     queryFn: () =>
       fetchTraceMetaInBatches(
-        isEAP ? 'eap' : 'non-eap',
         api,
         organization,
         replayTraces,
@@ -205,29 +177,19 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
   // The trace meta query has to reflect this by returning a single transaction and project.
   const demoResults = useMemo(() => {
     return {
-      data: isEAP
-        ? {
-            errors: 0,
-            logs: 0,
-            performance_issues: 0,
-            span_count: 0,
-            span_count_map: {},
-            transaction_child_count_map: {},
-            uptime_checks: 0,
-          }
-        : {
-            errors: 0,
-            performance_issues: 0,
-            projects: 1,
-            transactions: 1,
-            transaction_child_count_map: {},
-            span_count: 0,
-            span_count_map: {},
-          },
-      errors: [],
+      data: {
+        errors: 0,
+        logs: 0,
+        performance_issues: 0,
+        span_count: 0,
+        span_count_map: {},
+        transaction_child_count_map: {},
+        uptime_checks: 0,
+      } as EAPTraceMeta,
+      errors: [] as Error[],
       status: 'success' as QueryStatus,
     };
-  }, [isEAP]);
+  }, []);
 
   return mode === 'demo' ? demoResults : results;
 }

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -29,12 +29,12 @@ const baseProps: Partial<TraceMetadataHeaderProps> = {
   metaResults: {
     data: {
       errors: 1,
+      logs: 0,
       performance_issues: 1,
-      projects: 1,
-      transactions: 1,
       transaction_child_count_map: {span1: 1},
       span_count: 1,
       span_count_map: {},
+      uptime_checks: 0,
     },
     errors: [],
     status: 'success',

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
@@ -41,30 +41,44 @@ describe('incremental trace fetch', () => {
     MockApiClient.addMockResponse({
       method: 'GET',
       url: '/organizations/org-slug/trace/slug1/?include_uptime=1&limit=10000&timestamp=1',
-      body: {
-        transactions: [
-          makeTransaction({
-            transaction: 'txn 3',
-            start_timestamp: 0,
-            children: [makeTransaction({start_timestamp: 1, transaction: 'txn 4'})],
-          }),
-        ],
-        orphan_errors: [],
-      },
+      body: makeEAPTrace([
+        makeEAPSpan({
+          event_id: 'a',
+          start_timestamp: 0,
+          end_timestamp: 1,
+          op: 'txn 3',
+          children: [
+            makeEAPSpan({
+              event_id: 'b',
+              start_timestamp: 1,
+              parent_span_id: 'a',
+              end_timestamp: 2,
+              op: 'txn 4',
+            }),
+          ],
+        }),
+      ]),
     });
     MockApiClient.addMockResponse({
       method: 'GET',
       url: '/organizations/org-slug/trace/slug2/?include_uptime=1&limit=10000&timestamp=2',
-      body: {
-        transactions: [
-          makeTransaction({
-            transaction: 'txn 5',
-            start_timestamp: 0,
-            children: [makeTransaction({start_timestamp: 1, transaction: 'txn 6'})],
-          }),
-        ],
-        orphan_errors: [],
-      },
+      body: makeEAPTrace([
+        makeEAPSpan({
+          event_id: 'c',
+          start_timestamp: 0,
+          end_timestamp: 1,
+          op: 'txn 5',
+          children: [
+            makeEAPSpan({
+              event_id: 'd',
+              start_timestamp: 1,
+              parent_span_id: 'c',
+              end_timestamp: 2,
+              op: 'txn 6',
+            }),
+          ],
+        }),
+      ]),
     });
 
     tree.build();

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
@@ -129,30 +129,44 @@ describe('incremental trace fetch', () => {
     const mockedResponse2 = MockApiClient.addMockResponse({
       method: 'GET',
       url: '/organizations/org-slug/trace/slug2/?include_uptime=1&limit=10000&timestamp=2',
-      body: {
-        transactions: [
-          makeTransaction({
-            transaction: 'txn 5',
-            start_timestamp: 0,
-            children: [makeTransaction({start_timestamp: 1, transaction: 'txn 6'})],
-          }),
-        ],
-        orphan_errors: [],
-      },
+      body: makeEAPTrace([
+        makeEAPSpan({
+          event_id: 'e',
+          start_timestamp: 0,
+          end_timestamp: 1,
+          op: 'txn 5',
+          children: [
+            makeEAPSpan({
+              event_id: 'f',
+              start_timestamp: 1,
+              parent_span_id: 'e',
+              end_timestamp: 2,
+              op: 'txn 6',
+            }),
+          ],
+        }),
+      ]),
     });
     const mockedResponse3 = MockApiClient.addMockResponse({
       method: 'GET',
       url: '/organizations/org-slug/trace/slug3/?include_uptime=1&limit=10000&timestamp=3',
-      body: {
-        transactions: [
-          makeTransaction({
-            transaction: 'txn 7',
-            start_timestamp: 0,
-            children: [makeTransaction({start_timestamp: 1, transaction: 'txn 8'})],
-          }),
-        ],
-        orphan_errors: [],
-      },
+      body: makeEAPTrace([
+        makeEAPSpan({
+          event_id: 'g',
+          start_timestamp: 0,
+          end_timestamp: 1,
+          op: 'txn 7',
+          children: [
+            makeEAPSpan({
+              event_id: 'h',
+              start_timestamp: 1,
+              parent_span_id: 'g',
+              end_timestamp: 2,
+              op: 'txn 8',
+            }),
+          ],
+        }),
+      ]),
     });
 
     tree.build();

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
@@ -40,7 +40,7 @@ describe('incremental trace fetch', () => {
     // Mock the API calls
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug1/?include_uptime=1&limit=10000&timestamp=1',
+      url: '/organizations/org-slug/trace/slug1/?include_uptime=1&limit=10000&timestamp=1',
       body: {
         transactions: [
           makeTransaction({
@@ -54,7 +54,7 @@ describe('incremental trace fetch', () => {
     });
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug2/?include_uptime=1&limit=10000&timestamp=2',
+      url: '/organizations/org-slug/trace/slug2/?include_uptime=1&limit=10000&timestamp=2',
       body: {
         transactions: [
           makeTransaction({
@@ -77,7 +77,7 @@ describe('incremental trace fetch', () => {
       organization,
       rerender: () => {},
       urlParams: {} as Location['query'],
-      type: 'non-eap',
+
       meta: null,
     });
 
@@ -109,12 +109,12 @@ describe('incremental trace fetch', () => {
     // Mock the API calls
     const mockedResponse1 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug1/?include_uptime=1&limit=10000&timestamp=1',
+      url: '/organizations/org-slug/trace/slug1/?include_uptime=1&limit=10000&timestamp=1',
       statusCode: 400,
     });
     const mockedResponse2 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug2/?include_uptime=1&limit=10000&timestamp=2',
+      url: '/organizations/org-slug/trace/slug2/?include_uptime=1&limit=10000&timestamp=2',
       body: {
         transactions: [
           makeTransaction({
@@ -128,7 +128,7 @@ describe('incremental trace fetch', () => {
     });
     const mockedResponse3 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug3/?include_uptime=1&limit=10000&timestamp=3',
+      url: '/organizations/org-slug/trace/slug3/?include_uptime=1&limit=10000&timestamp=3',
       body: {
         transactions: [
           makeTransaction({
@@ -151,7 +151,7 @@ describe('incremental trace fetch', () => {
       organization,
       rerender: () => {},
       urlParams: {} as Location['query'],
-      type: 'non-eap',
+
       meta: null,
     });
 
@@ -238,7 +238,7 @@ describe('incremental trace fetch', () => {
       organization,
       rerender: () => {},
       urlParams: {} as Location['query'],
-      type: 'eap',
+
       meta: null,
     });
 
@@ -318,7 +318,7 @@ describe('incremental trace fetch', () => {
       organization,
       rerender: () => {},
       urlParams: {} as Location['query'],
-      type: 'eap',
+
       meta: null,
     });
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -551,11 +551,11 @@ describe('TraceTree', () => {
               // we have no data for child transaction
             },
             errors: 0,
+            logs: 0,
             performance_issues: 0,
-            projects: 0,
-            transactions: 0,
             span_count: 0,
             span_count_map: {},
+            uptime_checks: 0,
           },
           replay: null,
           organization,

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -347,13 +347,10 @@ function fetchTrace(
     orgSlug: string;
     query: string;
     traceId: string;
-  },
-  type: 'eap' | 'non-eap'
+  }
 ): Promise<TraceSplitResults<TraceTree.Transaction> | TraceTree.EAPTrace> {
   return api.requestPromise(
-    type === 'eap'
-      ? `/organizations/${params.orgSlug}/trace/${params.traceId}/?${params.query}`
-      : `/organizations/${params.orgSlug}/events-trace/${params.traceId}/?${params.query}`
+    `/organizations/${params.orgSlug}/trace/${params.traceId}/?${params.query}`
   );
 }
 
@@ -1403,7 +1400,6 @@ export class TraceTree extends TraceTreeEventDispatcher {
     organization: Organization;
     replayTraces: ReplayTrace[];
     rerender: () => void;
-    type: 'eap' | 'non-eap';
     urlParams: Location['query'];
     preferences?: Pick<TracePreferencesState, 'autogroup' | 'missing_instrumentation'>;
   }): () => void {
@@ -1420,19 +1416,15 @@ export class TraceTree extends TraceTreeEventDispatcher {
         const batch = clonedTraceIds.splice(0, 3);
         const results = await Promise.allSettled(
           batch.map(batchTraceData => {
-            return fetchTrace(
-              api,
-              {
-                orgSlug: organization.slug,
-                query: qs.stringify(
-                  getTraceQueryParams(options.type, urlParams, filters.selection, {
-                    timestamp: batchTraceData.timestamp,
-                  })
-                ),
-                traceId: batchTraceData.traceSlug,
-              },
-              options.type
-            );
+            return fetchTrace(api, {
+              orgSlug: organization.slug,
+              query: qs.stringify(
+                getTraceQueryParams(urlParams, filters.selection, {
+                  timestamp: batchTraceData.timestamp,
+                })
+              ),
+              traceId: batchTraceData.traceSlug,
+            });
           })
         );
 

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -40,7 +40,6 @@ import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/tr
 import {TraceOpenInExploreButton} from 'sentry/views/performance/newTraceDetails/traceOpenInExploreButton';
 import {traceGridCssVariables} from 'sentry/views/performance/newTraceDetails/traceWaterfallStyles';
 import {useDividerResizeSync} from 'sentry/views/performance/newTraceDetails/useDividerResizeSync';
-import {useIsEAPTraceEnabled} from 'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled';
 import {useTraceSpaceListeners} from 'sentry/views/performance/newTraceDetails/useTraceSpaceListeners';
 import {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
 import {useTraceWaterfallScroll} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallScroll';
@@ -96,8 +95,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   const {projects} = useProjects();
   const organization = useOrganization();
 
-  const isEAP = useIsEAPTraceEnabled();
-
   const traceDispatch = useTraceStateDispatch();
   const traceStateEmitter = useTraceStateEmitter();
 
@@ -139,7 +136,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     }
 
     const cleanup = props.tree.fetchAdditionalTraces({
-      type: isEAP ? 'eap' : 'non-eap',
       api,
       filters,
       replayTraces: props.replayTraces,

--- a/static/app/views/performance/newTraceDetails/useIsEAPTraceEnabled.tsx
+++ b/static/app/views/performance/newTraceDetails/useIsEAPTraceEnabled.tsx
@@ -1,7 +1,0 @@
-import {useOrganization} from 'sentry/utils/useOrganization';
-
-export function useIsEAPTraceEnabled() {
-  const organization = useOrganization();
-
-  return organization.features.includes('trace-spans-format');
-}

--- a/static/app/views/performance/onboarding.spec.tsx
+++ b/static/app/views/performance/onboarding.spec.tsx
@@ -102,10 +102,6 @@ describe('Testing new onboarding ui', () => {
     expect(
       await screen.findByText("Waiting for this project's first trace")
     ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('button', {name: 'Take me to an example'})
-    ).toBeInTheDocument();
   });
 
   it('when the first trace is received, display a busy button "Take me to my trace"', async () => {

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -433,7 +433,6 @@ export function Onboarding({organization, project}: OnboardingProps) {
   });
   const received = !!firstIssue;
 
-  const isEAPTraceEnabled = organization.features.includes('trace-spans-format');
   const tracesQuery = useTraces({
     enabled: received,
     limit: 1,
@@ -641,16 +640,7 @@ export function Onboarding({organization, project}: OnboardingProps) {
                       >
                         {t('Take me to my trace')}
                       </Button>
-                    ) : isEAPTraceEnabled ? null : (
-                      <SampleButton
-                        triggerText={t('Take me to an example')}
-                        loadingMessage={t('Processing sample trace...')}
-                        errorMessage={t('Failed to create sample trace')}
-                        organization={organization}
-                        project={project}
-                        api={api}
-                      />
-                    )}
+                    ) : null}
                   </GuidedSteps.ButtonWrapper>
                 </Fragment>
               ) : (


### PR DESCRIPTION
## Summary
- Remove the `useIsEAPTraceEnabled` hook that checked the `trace-spans-format` feature flag — EAP is now the only trace code path
- Remove the `TraceMeta` type and simplify `useTraceMeta` to always use EAP endpoints (`/trace-meta/`) and EAP response shape
- Remove the `traceType` parameter from `getTraceQueryParams`, `getTargetIdParams`, `fetchTrace`, and `fetchAdditionalTraces` — always use EAP endpoints (`/trace/`)
- Remove the non-EAP `events-trace/` query from `useTrace`
- Remove the `SampleButton` conditional in `onboarding.tsx` that was gated behind the flag

From original [PR](https://github.com/getsentry/sentry/pull/110623):
> - All relevant AM plans are now ingesting spans
> - SH is ingesting spans see [internal slack link](https://sentry.slack.com/archives/C03FS3KJZ0R/p1772742481919559?thread_ts=1772723941.771909&cid=C03FS3KJZ0R) so we should be safe to just always assume EAP is available here