### PR TITLE
feat(dashboards): Clarify pre-built dashboard UI

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -33,7 +33,7 @@ import {checkUserHasEditAccess} from './utils/checkUserHasEditAccess';
 import {UNSAVED_FILTERS_MESSAGE} from './detail';
 import {exportDashboard} from './exportDashboard';
 import type {DashboardDetails, DashboardListItem, DashboardPermissions} from './types';
-import {DashboardState, MAX_WIDGETS} from './types';
+import {DashboardState, MAX_WIDGETS, PREBUILT_DASHBOARD_LABEL} from './types';
 
 type Props = {
   dashboard: DashboardDetails;
@@ -221,7 +221,22 @@ export function Controls({
       return null;
     }
     if (isPrebuiltDashboard) {
-      return null;
+      return (
+        <Button
+          data-test-id="dashboard-edit"
+          aria-label={t('edit-dashboard')}
+          icon={<IconEdit />}
+          disabled
+          tooltipProps={{
+            title: tct(
+              'This is a [label] dashboard and cannot be edited. Duplicate it to make changes.',
+              {label: PREBUILT_DASHBOARD_LABEL}
+            ),
+          }}
+          priority="default"
+          size="sm"
+        />
+      );
     }
     const isDisabled = !hasFeature || hasUnsavedFilters || !hasEditAccess || isSaving;
     const toolTipMessage = isSaving

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -29,6 +29,7 @@ import type {
   DashboardListItem,
   DashboardPermissions,
 } from 'sentry/views/dashboards/types';
+import {PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 
 interface EditAccessSelectorProps {
   dashboard: DashboardDetails | DashboardListItem;
@@ -374,7 +375,7 @@ export function EditAccessSelector({
   );
 
   const tooltipTitle = disabled
-    ? t('Prebuilt dashboards cannot be edited')
+    ? tct('[label] dashboards cannot be edited', {label: PREBUILT_DASHBOARD_LABEL})
     : t('Only the creator of this dashboard can manage editor access');
 
   return (

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -123,9 +123,7 @@ function DashboardGrid({
           ? tct('[label] dashboards cannot be duplicated', {
               label: PREBUILT_DASHBOARD_LABEL,
             })
-          : hasReachedDashboardLimit
-            ? limitMessage
-            : undefined,
+          : limitMessage,
         tooltipOptions: {
           isHoverable: true,
         },

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -14,7 +14,7 @@ import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import Placeholder from 'sentry/components/placeholder';
 import TimeSince from 'sentry/components/timeSince';
 import {IconEllipsis} from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -28,6 +28,7 @@ import {
   MINIMUM_DASHBOARD_CARD_WIDTH,
 } from 'sentry/views/dashboards/manage/settings';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import {PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 
 import {DashboardCard} from './dashboardCard';
 import {GridPreview} from './gridPreview';
@@ -119,7 +120,9 @@ function DashboardGrid({
         },
         disabled: disableDuplicate,
         tooltip: shouldDisablePrebuiltControls
-          ? t('Prebuilt dashboards cannot be duplicated')
+          ? tct('[label] dashboards cannot be duplicated', {
+              label: PREBUILT_DASHBOARD_LABEL,
+            })
           : limitMessage,
         tooltipOptions: {
           isHoverable: true,
@@ -138,7 +141,7 @@ function DashboardGrid({
         },
         disabled: disableDelete,
         tooltip: shouldDisablePrebuiltControls
-          ? t('Prebuilt dashboards cannot be deleted')
+          ? tct('[label] dashboards cannot be deleted', {label: PREBUILT_DASHBOARD_LABEL})
           : undefined,
       },
     ];

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -123,7 +123,9 @@ function DashboardGrid({
           ? tct('[label] dashboards cannot be duplicated', {
               label: PREBUILT_DASHBOARD_LABEL,
             })
-          : limitMessage,
+          : hasReachedDashboardLimit
+            ? limitMessage
+            : undefined,
         tooltipOptions: {
           isHoverable: true,
         },

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -25,7 +25,7 @@ import GridEditable, {
 import SortLink from 'sentry/components/tables/gridEditable/sortLink';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCopy, IconDelete, IconStar} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -41,6 +41,7 @@ import type {
   DashboardListItem,
   DashboardPermissions,
 } from 'sentry/views/dashboards/types';
+import {PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 
 type Props = {
   api: Client;
@@ -305,7 +306,9 @@ function DashboardTable({
                     title:
                       defined(dataRow.prebuiltId) &&
                       !organization.features.includes('dashboards-prebuilt-controls')
-                        ? t('Prebuilt dashboards cannot be duplicated')
+                        ? tct('[label] dashboards cannot be duplicated', {
+                            label: PREBUILT_DASHBOARD_LABEL,
+                          })
                         : limitMessage,
                   }}
                 />
@@ -330,7 +333,9 @@ function DashboardTable({
               }
               tooltipProps={{
                 title: defined(dataRow.prebuiltId)
-                  ? t('Prebuilt dashboards cannot be deleted')
+                  ? tct('[label] dashboards cannot be deleted', {
+                      label: PREBUILT_DASHBOARD_LABEL,
+                    })
                   : undefined,
               }}
             />

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -309,9 +309,7 @@ function DashboardTable({
                         ? tct('[label] dashboards cannot be duplicated', {
                             label: PREBUILT_DASHBOARD_LABEL,
                           })
-                        : hasReachedDashboardLimit
-                          ? limitMessage
-                          : undefined,
+                        : limitMessage,
                   }}
                 />
               )}

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -309,7 +309,9 @@ function DashboardTable({
                         ? tct('[label] dashboards cannot be duplicated', {
                             label: PREBUILT_DASHBOARD_LABEL,
                           })
-                        : limitMessage,
+                        : hasReachedDashboardLimit
+                          ? limitMessage
+                          : undefined,
                   }}
                 />
               )}

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -54,7 +54,7 @@ import OwnedDashboardsTable, {
   OWNED_CURSOR_KEY,
 } from 'sentry/views/dashboards/manage/tableView/ownedDashboardsTable';
 import type {DashboardsLayout} from 'sentry/views/dashboards/manage/types';
-import {DashboardFilter} from 'sentry/views/dashboards/types';
+import {DashboardFilter, PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 import type {DashboardDetails, DashboardListItem} from 'sentry/views/dashboards/types';
 import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import RouteError from 'sentry/views/routeError';
@@ -590,7 +590,7 @@ function ManageDashboards() {
       renderDisabled={renderNoAccess}
     >
       <SentryDocumentTitle
-        title={isOnlyPrebuilt ? t('Sentry Built') : t('All Dashboards')}
+        title={isOnlyPrebuilt ? PREBUILT_DASHBOARD_LABEL : t('All Dashboards')}
         orgSlug={organization.slug}
       >
         <ErrorBoundary>
@@ -604,7 +604,7 @@ function ManageDashboards() {
                 <Layout.Header unified>
                   <Layout.HeaderContent unified>
                     <Layout.Title>
-                      {isOnlyPrebuilt ? t('Sentry Built') : t('All Dashboards')}
+                      {isOnlyPrebuilt ? PREBUILT_DASHBOARD_LABEL : t('All Dashboards')}
                       <PageHeadingQuestionTooltip
                         docsUrl="https://docs.sentry.io/product/dashboards/"
                         title={

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -34,6 +34,7 @@ export const DEFAULT_CATEGORICAL_BAR_LIMIT = 20;
 export const MAX_CATEGORICAL_BAR_LIMIT = 25;
 
 export const DEFAULT_WIDGET_NAME = t('Custom Widget');
+export const PREBUILT_DASHBOARD_LABEL = t('Sentry Built');
 
 export enum DisplayType {
   AREA = 'area',

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
@@ -12,7 +12,7 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
 import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
 import {DEFAULT_PREBUILT_SORT} from 'sentry/views/dashboards/manage/settings';
-import {DashboardFilter} from 'sentry/views/dashboards/types';
+import {DashboardFilter, PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {isPrimaryNavigationLinkActive} from 'sentry/views/navigation/primary/components';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
@@ -66,7 +66,7 @@ export function DashboardsSecondaryNavigation() {
                   isActive={isOnDashboardsList && isOnlyPrebuilt}
                   analyticsItemName="dashboards_sentry_built"
                 >
-                  {t('Sentry Built')}
+                  {PREBUILT_DASHBOARD_LABEL}
                 </SecondaryNavigation.Link>
               </SecondaryNavigation.ListItem>
             ) : null}


### PR DESCRIPTION
Show a disabled Edit button with a tooltip on pre-built dashboards instead of hiding it entirely. Previously it was unclear why the dashboard couldn't be edited or why it existed in its current form.

The tooltip reads: "This is a Sentry Built dashboard and cannot be edited. Duplicate it to make changes." — guiding users toward the duplication flow.

Also consolidates the user-facing "Sentry Built" label into a shared `PREBUILT_DASHBOARD_LABEL` constant and updates all "Prebuilt dashboards cannot be..." tooltips (edit, duplicate, delete) across the manage page table, grid, and edit access selector to use the consistent "Sentry Built" terminology that matches the sidebar navigation.

Refs LINEAR-DAIN-1260