### PR TITLE
feat(preprod): Add git metadata and artifact IDs as tags for size analysis issues

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _artifact_to_tags(artifact: PreprodArtifact, *, include_git: bool = True) -> dict[str, str]:
+def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
     from sentry.preprod.models import PreprodArtifact as PreprodArtifactModel
 
     tags: dict[str, str] = {}
@@ -57,21 +57,6 @@ def _artifact_to_tags(artifact: PreprodArtifact, *, include_git: bool = True) ->
         tags["artifact_type"] = PreprodArtifactModel.ArtifactType(artifact.artifact_type).to_str()
 
     tags["artifact_id"] = str(artifact.id)
-
-    commit_comparison = artifact.commit_comparison if include_git else None
-    if commit_comparison is not None:
-        if commit_comparison.head_sha:
-            tags["sha"] = commit_comparison.head_sha
-        if commit_comparison.head_ref:
-            tags["branch"] = commit_comparison.head_ref
-        if commit_comparison.pr_number is not None:
-            tags["pr_number"] = str(commit_comparison.pr_number)
-        if commit_comparison.head_repo_name:
-            tags["repo"] = commit_comparison.head_repo_name
-        if commit_comparison.base_sha:
-            tags["base_sha"] = commit_comparison.base_sha
-        if commit_comparison.base_ref:
-            tags["base_branch"] = commit_comparison.base_ref
 
     return tags
 
@@ -246,10 +231,20 @@ class PreprodSizeAnalysisDetectorHandler(
             tags["regression_kind"] = measurement.replace("_size", "")
             for key, value in _artifact_to_tags(metadata["head_artifact"]).items():
                 tags[f"head.{key}"] = value
-            for key, value in _artifact_to_tags(
-                metadata["base_artifact"], include_git=False
-            ).items():
+            for key, value in _artifact_to_tags(metadata["base_artifact"]).items():
                 tags[f"base.{key}"] = value
+
+            commit_comparison = metadata["head_artifact"].commit_comparison
+            if commit_comparison is not None:
+                tags["git.sha"] = commit_comparison.head_sha
+                tags["git.branch"] = commit_comparison.head_ref
+                tags["git.repo"] = commit_comparison.head_repo_name
+                if commit_comparison.base_sha:
+                    tags["git.base_sha"] = commit_comparison.base_sha
+                if commit_comparison.base_ref:
+                    tags["git.base_branch"] = commit_comparison.base_ref
+                if commit_comparison.pr_number is not None:
+                    tags["git.pr_number"] = str(commit_comparison.pr_number)
 
         occurrence = DetectorOccurrence(
             issue_title=issue_title,

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -236,13 +236,16 @@ class PreprodSizeAnalysisDetectorHandler(
 
             commit_comparison = metadata["head_artifact"].commit_comparison
             if commit_comparison is not None:
-                tags["git.sha"] = commit_comparison.head_sha
-                tags["git.branch"] = commit_comparison.head_ref
-                tags["git.repo"] = commit_comparison.head_repo_name
-                if commit_comparison.base_sha:
-                    tags["git.base_sha"] = commit_comparison.base_sha
-                if commit_comparison.base_ref:
-                    tags["git.base_branch"] = commit_comparison.base_ref
+                if (head_sha := commit_comparison.head_sha) is not None:
+                    tags["git.sha"] = head_sha
+                if (head_ref := commit_comparison.head_ref) is not None:
+                    tags["git.branch"] = head_ref
+                if (head_repo := commit_comparison.head_repo_name) is not None:
+                    tags["git.repo"] = head_repo
+                if (base_sha := commit_comparison.base_sha) is not None:
+                    tags["git.base_sha"] = base_sha
+                if (base_ref := commit_comparison.base_ref) is not None:
+                    tags["git.base_branch"] = base_ref
                 if commit_comparison.pr_number is not None:
                     tags["git.pr_number"] = str(commit_comparison.pr_number)
 

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
+def _artifact_to_tags(artifact: PreprodArtifact, *, include_git: bool = True) -> dict[str, str]:
     from sentry.preprod.models import PreprodArtifact as PreprodArtifactModel
 
     tags: dict[str, str] = {}
@@ -58,17 +58,20 @@ def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
 
     tags["artifact_id"] = str(artifact.id)
 
-    commit_comparison = artifact.commit_comparison
+    commit_comparison = artifact.commit_comparison if include_git else None
     if commit_comparison is not None:
-        tags["sha"] = commit_comparison.head_sha
-        tags["branch"] = commit_comparison.head_ref
-        tags["repo"] = commit_comparison.head_repo_name
+        if commit_comparison.head_sha:
+            tags["sha"] = commit_comparison.head_sha
+        if commit_comparison.head_ref:
+            tags["branch"] = commit_comparison.head_ref
+        if commit_comparison.pr_number is not None:
+            tags["pr_number"] = str(commit_comparison.pr_number)
+        if commit_comparison.head_repo_name:
+            tags["repo"] = commit_comparison.head_repo_name
         if commit_comparison.base_sha:
             tags["base_sha"] = commit_comparison.base_sha
         if commit_comparison.base_ref:
             tags["base_branch"] = commit_comparison.base_ref
-        if commit_comparison.pr_number is not None:
-            tags["pr_number"] = str(commit_comparison.pr_number)
 
     return tags
 
@@ -243,7 +246,9 @@ class PreprodSizeAnalysisDetectorHandler(
             tags["regression_kind"] = measurement.replace("_size", "")
             for key, value in _artifact_to_tags(metadata["head_artifact"]).items():
                 tags[f"head.{key}"] = value
-            for key, value in _artifact_to_tags(metadata["base_artifact"]).items():
+            for key, value in _artifact_to_tags(
+                metadata["base_artifact"], include_git=False
+            ).items():
                 tags[f"base.{key}"] = value
 
         occurrence = DetectorOccurrence(

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -69,8 +69,6 @@ def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
             tags["base_branch"] = commit_comparison.base_ref
         if commit_comparison.pr_number is not None:
             tags["pr_number"] = str(commit_comparison.pr_number)
-        if commit_comparison.provider:
-            tags["provider"] = commit_comparison.provider
 
     return tags
 

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -55,6 +55,23 @@ def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
         tags["build_configuration"] = artifact.build_configuration.name
     if artifact.artifact_type is not None:
         tags["artifact_type"] = PreprodArtifactModel.ArtifactType(artifact.artifact_type).to_str()
+
+    tags["artifact_id"] = str(artifact.id)
+
+    commit_comparison = artifact.commit_comparison
+    if commit_comparison is not None:
+        tags["sha"] = commit_comparison.head_sha
+        tags["branch"] = commit_comparison.head_ref
+        tags["repo"] = commit_comparison.head_repo_name
+        if commit_comparison.base_sha:
+            tags["base_sha"] = commit_comparison.base_sha
+        if commit_comparison.base_ref:
+            tags["base_branch"] = commit_comparison.base_ref
+        if commit_comparison.pr_number is not None:
+            tags["pr_number"] = str(commit_comparison.pr_number)
+        if commit_comparison.provider:
+            tags["provider"] = commit_comparison.provider
+
     return tags
 
 

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -98,14 +98,22 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
+        ).select_related(
+            "preprod_artifact",
+            "preprod_artifact__mobile_app_info",
+            "preprod_artifact__commit_comparison",
+        )
         base_size_metrics = list(base_size_metrics_qs)
 
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[artifact_id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
+        ).select_related(
+            "preprod_artifact",
+            "preprod_artifact__mobile_app_info",
+            "preprod_artifact__commit_comparison",
+        )
         head_size_metrics = list(head_size_metrics_qs)
 
         validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)
@@ -155,14 +163,22 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[head_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
+        ).select_related(
+            "preprod_artifact",
+            "preprod_artifact__mobile_app_info",
+            "preprod_artifact__commit_comparison",
+        )
         head_size_metrics = list(head_size_metrics_qs)
 
         base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[artifact_id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
+        ).select_related(
+            "preprod_artifact",
+            "preprod_artifact__mobile_app_info",
+            "preprod_artifact__commit_comparison",
+        )
         base_size_metrics = list(base_size_metrics_qs)
 
         validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -98,11 +98,7 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related(
-            "preprod_artifact",
-            "preprod_artifact__mobile_app_info",
-            "preprod_artifact__commit_comparison",
-        )
+        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         base_size_metrics = list(base_size_metrics_qs)
 
         head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
@@ -174,11 +170,7 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[artifact_id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-        ).select_related(
-            "preprod_artifact",
-            "preprod_artifact__mobile_app_info",
-            "preprod_artifact__commit_comparison",
-        )
+        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         base_size_metrics = list(base_size_metrics_qs)
 
         validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)
@@ -338,7 +330,6 @@ def manual_size_analysis_comparison(
         )
         .select_related("preprod_artifact")
         .select_related("preprod_artifact__mobile_app_info")
-        .select_related("preprod_artifact__commit_comparison")
     )
     base_size_metrics = list(base_size_metrics_qs)
 

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -326,6 +326,7 @@ def manual_size_analysis_comparison(
         )
         .select_related("preprod_artifact")
         .select_related("preprod_artifact__mobile_app_info")
+        .select_related("preprod_artifact__commit_comparison")
     )
     head_size_metrics = list(head_size_metrics_qs)
 
@@ -337,6 +338,7 @@ def manual_size_analysis_comparison(
         )
         .select_related("preprod_artifact")
         .select_related("preprod_artifact__mobile_app_info")
+        .select_related("preprod_artifact__commit_comparison")
     )
     base_size_metrics = list(base_size_metrics_qs)
 

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -627,7 +627,6 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
             head_ref="feature/test-branch",
             base_ref="main",
             head_repo_name="owner/repo",
-            provider="github",
             pr_number=42,
         )
         head_artifact = self.create_preprod_artifact(
@@ -678,7 +677,6 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert event_data["tags"]["head.base_sha"] == "b" * 40
         assert event_data["tags"]["head.base_branch"] == "main"
         assert event_data["tags"]["head.pr_number"] == "42"
-        assert event_data["tags"]["head.provider"] == "github"
         assert "base.sha" not in event_data["tags"]
         assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
         assert occurrence.evidence_data["base_artifact_id"] == base_artifact.id

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -620,22 +620,33 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         return handler.evaluate(data_packet)
 
     def test_create_occurrence_install_size_with_metadata(self):
+        commit_comparison = self.create_commit_comparison(
+            organization=self.project.organization,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            head_ref="feature/test-branch",
+            base_ref="main",
+            head_repo_name="owner/repo",
+            provider="github",
+            pr_number=42,
+        )
         head_artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",
             artifact_type=PreprodArtifact.ArtifactType.APK,
+            commit_comparison=commit_comparison,
         )
         base_artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",
             artifact_type=PreprodArtifact.ArtifactType.APK,
         )
-        head_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
-            id=head_artifact.id
-        )
-        base_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
-            id=base_artifact.id
-        )
+        head_artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "commit_comparison"
+        ).get(id=head_artifact.id)
+        base_artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "commit_comparison"
+        ).get(id=base_artifact.id)
         metadata = {
             "platform": "android",
             "head_metric_id": 100,
@@ -659,29 +670,46 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert event_data["tags"]["head.app_id"] == "com.example.app"
         assert event_data["tags"]["base.app_id"] == "com.example.app"
         assert event_data["tags"]["head.artifact_type"] == "apk"
+        assert event_data["tags"]["head.artifact_id"] == str(head_artifact.id)
+        assert event_data["tags"]["base.artifact_id"] == str(base_artifact.id)
+        assert event_data["tags"]["head.sha"] == "a" * 40
+        assert event_data["tags"]["head.branch"] == "feature/test-branch"
+        assert event_data["tags"]["head.repo"] == "owner/repo"
+        assert event_data["tags"]["head.base_sha"] == "b" * 40
+        assert event_data["tags"]["head.base_branch"] == "main"
+        assert event_data["tags"]["head.pr_number"] == "42"
+        assert event_data["tags"]["head.provider"] == "github"
+        assert "base.sha" not in event_data["tags"]
         assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
         assert occurrence.evidence_data["base_artifact_id"] == base_artifact.id
         assert occurrence.evidence_data["head_size_metric_id"] == 100
         assert occurrence.evidence_data["base_size_metric_id"] == 200
 
     def test_create_occurrence_download_size_with_metadata(self):
+        commit_comparison = self.create_commit_comparison(
+            organization=self.project.organization,
+            head_sha="c" * 40,
+            head_ref="feature/download-test",
+            head_repo_name="owner/repo",
+        )
         head_artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",
             app_name="MyApp",
             artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=commit_comparison,
         )
         base_artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",
             artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
         )
-        head_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
-            id=head_artifact.id
-        )
-        base_artifact = PreprodArtifact.objects.select_related("mobile_app_info").get(
-            id=base_artifact.id
-        )
+        head_artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "commit_comparison"
+        ).get(id=head_artifact.id)
+        base_artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "commit_comparison"
+        ).get(id=base_artifact.id)
         metadata = {
             "platform": "apple",
             "head_metric_id": 101,
@@ -703,7 +731,49 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert event_data["platform"] == "apple"
         assert event_data["tags"]["regression_kind"] == "download"
         assert event_data["tags"]["head.app_name"] == "MyApp"
+        assert event_data["tags"]["head.artifact_id"] == str(head_artifact.id)
+        assert event_data["tags"]["head.sha"] == "c" * 40
+        assert event_data["tags"]["head.branch"] == "feature/download-test"
+        assert event_data["tags"]["head.repo"] == "owner/repo"
         assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
+
+    def test_create_occurrence_with_metadata_no_commit_comparison(self):
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            app_id="com.example.app",
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            app_id="com.example.app",
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+        )
+        head_artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "commit_comparison"
+        ).get(id=head_artifact.id)
+        base_artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "commit_comparison"
+        ).get(id=base_artifact.id)
+        metadata = {
+            "platform": "android",
+            "head_metric_id": 100,
+            "base_metric_id": 200,
+            "head_artifact_id": head_artifact.id,
+            "base_artifact_id": base_artifact.id,
+            "head_artifact": head_artifact,
+            "base_artifact": base_artifact,
+        }
+        result = self._evaluate_with_metadata("install_size", metadata)
+
+        assert None in result
+        event_data = result[None].event_data
+        assert event_data is not None
+
+        assert event_data["tags"]["head.artifact_id"] == str(head_artifact.id)
+        assert event_data["tags"]["base.artifact_id"] == str(base_artifact.id)
+        assert "head.sha" not in event_data["tags"]
+        assert "head.branch" not in event_data["tags"]
+        assert "head.repo" not in event_data["tags"]
 
     def test_create_occurrence_without_metadata(self):
         detector = self.create_detector(

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -671,13 +671,12 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert event_data["tags"]["head.artifact_type"] == "apk"
         assert event_data["tags"]["head.artifact_id"] == str(head_artifact.id)
         assert event_data["tags"]["base.artifact_id"] == str(base_artifact.id)
-        assert event_data["tags"]["head.sha"] == "a" * 40
-        assert event_data["tags"]["head.branch"] == "feature/test-branch"
-        assert event_data["tags"]["head.repo"] == "owner/repo"
-        assert event_data["tags"]["head.base_sha"] == "b" * 40
-        assert event_data["tags"]["head.base_branch"] == "main"
-        assert event_data["tags"]["head.pr_number"] == "42"
-        assert "base.sha" not in event_data["tags"]
+        assert event_data["tags"]["git.sha"] == "a" * 40
+        assert event_data["tags"]["git.branch"] == "feature/test-branch"
+        assert event_data["tags"]["git.repo"] == "owner/repo"
+        assert event_data["tags"]["git.base_sha"] == "b" * 40
+        assert event_data["tags"]["git.base_branch"] == "main"
+        assert event_data["tags"]["git.pr_number"] == "42"
         assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
         assert occurrence.evidence_data["base_artifact_id"] == base_artifact.id
         assert occurrence.evidence_data["head_size_metric_id"] == 100
@@ -730,9 +729,9 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert event_data["tags"]["regression_kind"] == "download"
         assert event_data["tags"]["head.app_name"] == "MyApp"
         assert event_data["tags"]["head.artifact_id"] == str(head_artifact.id)
-        assert event_data["tags"]["head.sha"] == "c" * 40
-        assert event_data["tags"]["head.branch"] == "feature/download-test"
-        assert event_data["tags"]["head.repo"] == "owner/repo"
+        assert event_data["tags"]["git.sha"] == "c" * 40
+        assert event_data["tags"]["git.branch"] == "feature/download-test"
+        assert event_data["tags"]["git.repo"] == "owner/repo"
         assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
 
     def test_create_occurrence_with_metadata_no_commit_comparison(self):
@@ -769,9 +768,9 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
 
         assert event_data["tags"]["head.artifact_id"] == str(head_artifact.id)
         assert event_data["tags"]["base.artifact_id"] == str(base_artifact.id)
-        assert "head.sha" not in event_data["tags"]
-        assert "head.branch" not in event_data["tags"]
-        assert "head.repo" not in event_data["tags"]
+        assert "git.sha" not in event_data["tags"]
+        assert "git.branch" not in event_data["tags"]
+        assert "git.repo" not in event_data["tags"]
 
     def test_create_occurrence_without_metadata(self):
         detector = self.create_detector(

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -269,4 +269,4 @@ class ArtifactToTagsTest(TestCase):
 
         tags = _artifact_to_tags(artifact)
 
-        assert tags == {"app_id": "com.example.app"}
+        assert tags == {"app_id": "com.example.app", "artifact_id": str(artifact.id)}


### PR DESCRIPTION
## Summary
- Extend `_artifact_to_tags()` to emit `artifact_id`, `commit_sha`, `branch`, `repo`, `base_sha`, `base_branch`, `pr_number` as tags on size analysis issue events
- Add `select_related("preprod_artifact__commit_comparison")` to 4 queryset calls in the comparison task to avoid N+1 queries
- Add tests for the new tags (with and without commit_comparison)

## Test plan
- [x] `pytest -svv --create-db tests/sentry/preprod/size_analysis/test_grouptype.py` — all 23 tests pass
- [x] `pre-commit run --files` on all modified files passes