### PR TITLE
fix(dashboards): Preserve group-by when saving logs query as widget

### DIFF
--- a/static/app/views/discover/savedQuery/utils.tsx
+++ b/static/app/views/discover/savedQuery/utils.tsx
@@ -252,7 +252,7 @@ function extractAnalyticsQueryFields(payload: NewQuery): Partial<NewQuery> {
   };
 }
 
-export function displayModeToDisplayType(displayMode: DisplayModes): DisplayType {
+export function displayModeToDisplayType(displayMode: DisplayModes | undefined) {
   switch (displayMode) {
     case DisplayModes.DAILYTOP5:
     case DisplayModes.DAILY:

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -941,10 +941,10 @@ describe('constructAddQueryToDashboardLink', () => {
         axisRange: 'auto',
       });
     });
-    it('should preserve group by columns for logs widgets', () => {
+    it('should preserve group by columns and display type for logs widgets', () => {
       const eventView = new EventView({
         ...baseView,
-        display: DisplayType.BAR,
+        display: DisplayType.AREA,
         name: 'logs query',
         fields: [
           {field: 'sentry.severity_text'},
@@ -970,7 +970,7 @@ describe('constructAddQueryToDashboardLink', () => {
         field: ['sentry.severity_text', 'sentry.service'],
         title: 'logs query',
         dataset: WidgetType.LOGS,
-        displayType: DisplayType.BAR,
+        displayType: DisplayType.AREA,
         yAxis: ['count()'],
         limit: undefined,
         source: DashboardWidgetSource.LOGS,

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -941,6 +941,42 @@ describe('constructAddQueryToDashboardLink', () => {
         axisRange: 'auto',
       });
     });
+    it('should preserve group by columns for logs widgets', () => {
+      const eventView = new EventView({
+        ...baseView,
+        display: DisplayType.BAR,
+        name: 'logs query',
+        fields: [
+          {field: 'sentry.severity_text'},
+          {field: 'sentry.service'},
+          {field: 'count()'},
+        ],
+      });
+      const {query} = constructAddQueryToDashboardLink({
+        eventView,
+        organization,
+        location,
+        source: DashboardWidgetSource.LOGS,
+        yAxis: ['count()'],
+        widgetType: WidgetType.LOGS,
+      });
+      expect(query).toEqual({
+        start: undefined,
+        end: undefined,
+        description: '',
+        query: [''],
+        sort: [''],
+        legendAlias: [''],
+        field: ['sentry.severity_text', 'sentry.service'],
+        title: 'logs query',
+        dataset: WidgetType.LOGS,
+        displayType: DisplayType.BAR,
+        yAxis: ['count()'],
+        limit: undefined,
+        source: DashboardWidgetSource.LOGS,
+        axisRange: 'auto',
+      });
+    });
   });
 });
 

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -65,6 +65,27 @@ import type {FieldValue, TableColumn} from 'sentry/views/discover/table/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
+/**
+ * @returns whether `widgetType` is one that stores a {@link DisplayType} directly
+ * in `eventView.display`, rather than a {@link DisplayModes} value that needs conversion.
+ */
+function widgetTypeUsesDisplayTypeDirectly(widgetType: WidgetType | undefined) {
+  return (
+    widgetType === WidgetType.SPANS ||
+    widgetType === WidgetType.LOGS ||
+    widgetType === WidgetType.TRACEMETRICS
+  );
+}
+
+function resolveDisplayType(
+  widgetType: WidgetType | undefined,
+  eventViewDisplay: string | undefined
+) {
+  return widgetTypeUsesDisplayTypeDirectly(widgetType)
+    ? (eventViewDisplay as DisplayType)
+    : displayModeToDisplayType(eventViewDisplay as DisplayModes);
+}
+
 const TEMPLATE_TABLE_COLUMN: TableColumn<string> = {
   key: '',
   name: '',
@@ -650,12 +671,7 @@ export function handleAddQueryToDashboard({
   query?: NewQuery;
   yAxis?: string | string[];
 }) {
-  const displayType =
-    widgetType === WidgetType.SPANS ||
-    widgetType === WidgetType.LOGS ||
-    widgetType === WidgetType.TRACEMETRICS
-      ? (eventView.display as DisplayType)
-      : displayModeToDisplayType(eventView.display as DisplayModes);
+  const displayType = resolveDisplayType(widgetType, eventView.display);
   const defaultWidgetQuery = eventViewToWidgetQuery({
     eventView,
     displayType,
@@ -738,10 +754,7 @@ export function handleAddMultipleQueriesToDashboard({
   }
 
   const widgets = eventViews.map(eventView => {
-    const displayType =
-      widgetType === WidgetType.SPANS || widgetType === WidgetType.TRACEMETRICS
-        ? (eventView.display as DisplayType)
-        : displayModeToDisplayType(eventView.display as DisplayModes);
+    const displayType = resolveDisplayType(widgetType, eventView.display);
 
     const defaultWidgetQuery = eventViewToWidgetQuery({
       eventView,
@@ -842,12 +855,7 @@ export function constructAddQueryToDashboardLink({
   widgetType?: WidgetType;
   yAxis?: string | string[];
 }) {
-  const displayType =
-    widgetType === WidgetType.SPANS ||
-    widgetType === WidgetType.LOGS ||
-    widgetType === WidgetType.TRACEMETRICS
-      ? (eventView.display as DisplayType)
-      : displayModeToDisplayType(eventView.display as DisplayModes);
+  const displayType = resolveDisplayType(widgetType, eventView.display);
   const defaultWidgetQuery = eventViewToWidgetQuery({
     eventView,
     displayType,
@@ -874,9 +882,7 @@ export function constructAddQueryToDashboardLink({
         aggregates: [...(typeof yAxis === 'string' ? [yAxis] : (yAxis ?? ['count()']))],
         fields: eventView.getFields(),
         columns:
-          widgetType === WidgetType.SPANS ||
-          widgetType === WidgetType.LOGS ||
-          widgetType === WidgetType.TRACEMETRICS ||
+          widgetTypeUsesDisplayTypeDirectly(widgetType) ||
           displayType === DisplayType.TOP_N ||
           eventView.display === DisplayModes.DAILYTOP5
             ? eventView

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -651,7 +651,9 @@ export function handleAddQueryToDashboard({
   yAxis?: string | string[];
 }) {
   const displayType =
-    widgetType === WidgetType.SPANS || widgetType === WidgetType.TRACEMETRICS
+    widgetType === WidgetType.SPANS ||
+    widgetType === WidgetType.LOGS ||
+    widgetType === WidgetType.TRACEMETRICS
       ? (eventView.display as DisplayType)
       : displayModeToDisplayType(eventView.display as DisplayModes);
   const defaultWidgetQuery = eventViewToWidgetQuery({
@@ -871,6 +873,7 @@ export function constructAddQueryToDashboardLink({
         fields: eventView.getFields(),
         columns:
           widgetType === WidgetType.SPANS ||
+          widgetType === WidgetType.LOGS ||
           widgetType === WidgetType.TRACEMETRICS ||
           displayType === DisplayType.TOP_N ||
           eventView.display === DisplayModes.DAILYTOP5

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -843,7 +843,9 @@ export function constructAddQueryToDashboardLink({
   yAxis?: string | string[];
 }) {
   const displayType =
-    widgetType === WidgetType.SPANS
+    widgetType === WidgetType.SPANS ||
+    widgetType === WidgetType.LOGS ||
+    widgetType === WidgetType.TRACEMETRICS
       ? (eventView.display as DisplayType)
       : displayModeToDisplayType(eventView.display as DisplayModes);
   const defaultWidgetQuery = eventViewToWidgetQuery({


### PR DESCRIPTION
Preserve logs group-by fields when adding a query to a dashboard via "Add to Dashboard".

`constructAddQueryToDashboardLink` populates a widget's `columns` (which carry group-by information for time-series charts) only for `WidgetType.SPANS`, `WidgetType.TRACEMETRICS`, `DisplayType.TOP_N`, and `DisplayModes.DAILYTOP5`. `WidgetType.LOGS` was missing from this condition, so non-aggregate fields from the event view were silently dropped — the resulting widget had no group-by.

This adds `WidgetType.LOGS` to both the `columns` population condition in `constructAddQueryToDashboardLink` and the `displayType` derivation in `handleAddQueryToDashboard` (so `DisplayType.BAR` is preserved directly rather than being transformed through `displayModeToDisplayType`).

Fixes DAIN-1125.

Made with [Cursor](https://cursor.com)