### PR TITLE
feat(eslint): expand no-default-exports rule to files with other named exports

### DIFF
--- a/static/eslint/eslintPluginSentry/no-default-exports.spec.ts
+++ b/static/eslint/eslintPluginSentry/no-default-exports.spec.ts
@@ -20,6 +20,13 @@ ruleTester.run('no-default-exports', noDefaultExports, {
       filename: 'valid.tsx',
     },
     {
+      code: `
+export function MyComponentInner() { return <div />; }
+export default wrap(MyComponentInner);
+`,
+      filename: 'valid.tsx',
+    },
+    {
       code: `export const MyComponent = () => <div />;`,
       filename: 'valid.tsx',
     },
@@ -32,6 +39,18 @@ ruleTester.run('no-default-exports', noDefaultExports, {
     {
       code: 'function example() {}\nexport default example;',
       output: 'export function example() {}\n',
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+export function alsoExported() {}
+export default function defaultExported() {}
+`,
+      output: `
+export function alsoExported() {}
+export function defaultExported() {}
+`,
       errors: [{messageId: 'forbidden'}],
       filename: 'invalid.tsx',
     },

--- a/static/eslint/eslintPluginSentry/no-default-exports.ts
+++ b/static/eslint/eslintPluginSentry/no-default-exports.ts
@@ -108,13 +108,7 @@ export const noDefaultExports = ESLintUtils.RuleCreator.withoutDocs({
     const allowedFiles = allowedFilesLazy(parserServices.program);
     const currentFileName = ts.sys.resolvePath(context.filename);
 
-    if (
-      allowedFiles.has(currentFileName) ||
-      // TODO: Eventually, it'd be nice to fully ban all default exports...
-      context.sourceCode.ast.body.some(
-        statement => statement.type === AST_NODE_TYPES.ExportNamedDeclaration
-      )
-    ) {
+    if (allowedFiles.has(currentFileName)) {
       return {};
     }
 


### PR DESCRIPTION
Corresponding lint rule changes for #110853.

Note that the lint rule still doesn’t report on dynamic expressions like `export default memo(MyComponent)`. Those are trickier because consumers often take that default export under the name of the internal component (`import MyComponent from '...'`).