### PR TITLE
fix(tasks) Add shim for CompressionType to instrumented_task

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -7,7 +7,9 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 import sentry_sdk
+from django.conf import settings
 from django.db.models import Model
+from taskbroker_client.constants import CompressionType as TaskbrokerCompressionType
 
 from sentry.silo.base import SiloMode
 from sentry.taskworker.constants import CompressionType
@@ -113,6 +115,9 @@ def instrumented_task(
     silo_mode : SiloMode | None
         The silo that the task will run in. This should be the silo that the task was called from.
     """
+    if compression_type and settings.TASKWORKER_USE_LIBRARY:
+        # TODO(tasks) this shim is temporary and will be removed alongside TASKWORKER_USE_LIBRARY
+        compression_type = TaskbrokerCompressionType(compression_type.value)  # type: ignore[assignment]
 
     def wrapped(func: Callable[P, R]) -> Task[P, R]:
         task = namespace.register(

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -2,15 +2,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import override_settings
+from taskbroker_client.constants import CompressionType as TaskbrokerCompressionType
+from taskbroker_client.registry import TaskRegistry as TaskbrokerTaskRegistry
+from taskbroker_client.task import Task as TaskbrokerTask
 
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.tasks.base import instrumented_task, retry
+from sentry.taskworker.adapters import SentryMetricsBackend, SentryRouter, make_producer
 from sentry.taskworker.constants import CompressionType
 from sentry.taskworker.namespaces import exampletasks, test_tasks
 from sentry.taskworker.registry import TaskRegistry
 from sentry.taskworker.retry import Retry, RetryTaskError
 from sentry.taskworker.state import CurrentTaskState
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @instrumented_task(
@@ -254,6 +259,43 @@ def test_instrumented_task_parameters() -> None:
     assert decorated.retry
     assert decorated.retry._times == 3
     assert decorated.retry._allowed_exception_types == (RuntimeError,)
+
+
+@django_db_all
+def test_instrumented_task_compression_type_translation() -> None:
+    """
+    instrumented_task should convert CompressionType to the taskbroker_client enum
+    when the setting is active.
+    """
+    with override_settings(TASKWORKER_USE_LIBRARY=True):
+        registry = TaskbrokerTaskRegistry(
+            application="sentry",
+            metrics=SentryMetricsBackend(),
+            router=SentryRouter(),
+            producer_factory=make_producer,
+        )
+        namespace = registry.create_namespace("registertest")
+
+        @instrumented_task(
+            name="hello_task",
+            namespace=namespace,  # type: ignore[arg-type]
+            retry=Retry(times=3, on=(RuntimeError,)),
+            processing_deadline_duration=60,
+            compression_type=CompressionType.ZSTD,
+        )
+        def hello_task():
+            pass
+
+    decorated = namespace.get("hello_task")
+    assert isinstance(decorated, TaskbrokerTask)
+    assert decorated
+    assert decorated.compression_type == TaskbrokerCompressionType.ZSTD
+    assert decorated.retry
+    assert decorated.retry._times == 3
+    assert decorated.retry._allowed_exception_types == (RuntimeError,)
+
+    payload = decorated.create_activation(args=("hello", "world"), kwargs={})
+    assert payload.parameters[0] != "{"
 
 
 @patch("sentry.tasks.base.current_task")


### PR DESCRIPTION
Tasks are defined using sentry.taskworker, but we are in the process of converting to taskbroker-client. The taskbroker-client library uses its internal constant values. To maintain compression behavior, we need to shim the enum values.

Refs STREAM-610