### PR TITLE
fix(integrations): Handle None from IntegrationConfigSerializer in OrganizationIntegrationSerializer

### DIFF
--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -151,12 +151,15 @@ class OrganizationIntegrationSerializer(Serializer):
         # integration installation config object which very well may be making
         # API request for config options.
         integration: RpcIntegration = attrs.get("integration")  # type: ignore[assignment]
-        serialized_integration: MutableMapping[str, Any] = serialize(
+        serialized_integration: MutableMapping[str, Any] | None = serialize(
             objects=integration,
             user=user,
             serializer=IntegrationConfigSerializer(obj.organization_id, params=self.params),
             include_config=include_config,
         )
+
+        if serialized_integration is None:
+            raise Exception(f"Failed to serialize integration {integration.id}")
 
         dynamic_display_information = None
         config_data = None

--- a/tests/sentry/integrations/api/serializers/test_integration.py
+++ b/tests/sentry/integrations/api/serializers/test_integration.py
@@ -4,6 +4,7 @@ import pytest
 
 from sentry.api.serializers import serialize
 from sentry.integrations.api.serializers.models.integration import OrganizationIntegrationSerializer
+from sentry.integrations.services.integration import integration_service
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -13,13 +14,19 @@ class OrganizationIntegrationSerializerTest(TestCase):
     def setUp(self) -> None:
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
-        self.integration, self.org_integration = self.create_provider_integration_for(
+        self.integration, org_integration = self.create_provider_integration_for(
             self.organization,
             self.user,
             provider="example",
             name="Example",
             external_id="example:1",
         )
+        rpc_org_integration = integration_service.get_organization_integration(
+            integration_id=self.integration.id,
+            organization_id=self.organization.id,
+        )
+        assert rpc_org_integration is not None
+        self.org_integration = rpc_org_integration
 
     def test_serialize(self) -> None:
         result = serialize(self.org_integration, self.user, OrganizationIntegrationSerializer())

--- a/tests/sentry/integrations/api/serializers/test_integration.py
+++ b/tests/sentry/integrations/api/serializers/test_integration.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+import pytest
+
+from sentry.api.serializers import serialize
+from sentry.integrations.api.serializers.models.integration import OrganizationIntegrationSerializer
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class OrganizationIntegrationSerializerTest(TestCase):
+    def setUp(self) -> None:
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="example",
+            name="Example",
+            external_id="example:1",
+        )
+
+    def test_serialize(self) -> None:
+        result = serialize(self.org_integration, self.user, OrganizationIntegrationSerializer())
+        assert result["id"] == str(self.integration.id)
+        assert result["externalId"] == self.integration.external_id
+        assert result["organizationId"] == self.organization.id
+
+    def test_serialize_raises_when_integration_config_serializer_fails(self) -> None:
+        """When IntegrationConfigSerializer fails (returns None via _serialize), the
+        OrganizationIntegrationSerializer should raise a clear exception rather than an
+        AttributeError from calling .update() on None."""
+        serializer = OrganizationIntegrationSerializer()
+        attrs = serializer.get_attrs([self.org_integration], self.user)
+
+        with patch(
+            "sentry.integrations.api.serializers.models.integration.IntegrationConfigSerializer.serialize",
+            side_effect=Exception("boom"),
+        ):
+            with pytest.raises(Exception, match=r"Failed to serialize integration \d+"):
+                serializer.serialize(self.org_integration, attrs[self.org_integration], self.user)


### PR DESCRIPTION
When `IntegrationConfigSerializer.serialize()` throws an unexpected exception, the base `_serialize()` in `base.py` catches it, logs "Failed to serialize", and returns `None`. `OrganizationIntegrationSerializer.serialize()` then calls `.update()` on that `None`, producing a confusing `AttributeError: 'NoneType' object has no attribute 'update'` that hides the real failure.

The fix adds a `None` guard after the inner `serialize()` call. If it returns `None`, we raise an explicit exception so the outer `_serialize()` handles it cleanly — the original root cause is already logged by the inner serializer.

Fixes SENTRY-48E7