### PR TITLE
fix(repos): Filter null integrations in useScmIntegrationTreeData

### DIFF
--- a/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.spec.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.spec.tsx
@@ -1,3 +1,5 @@
+import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
+import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -7,44 +9,9 @@ import {useScmIntegrationTreeData} from './useScmIntegrationTreeData';
 describe('useScmIntegrationTreeData', () => {
   const organization = OrganizationFixture();
 
-  const githubProvider = {
-    key: 'github',
-    slug: 'github',
-    name: 'GitHub',
-    canAdd: true,
-    canDisable: false,
-    features: ['commits'],
-    metadata: {
-      aspects: {},
-      author: 'The Sentry Team',
-      description: '',
-      features: [{featureId: 1, featureGate: 'integrations-commits', description: ''}],
-      issue_url: '',
-      noun: 'Installation',
-      source_url: '',
-    },
-    setupDialog: {height: 600, url: '', width: 600},
-  };
+  const githubProvider = GitHubIntegrationProviderFixture();
 
-  const githubIntegration = {
-    id: '1',
-    name: 'GitHub',
-    provider: {
-      key: 'github',
-      slug: 'github',
-      name: 'GitHub',
-      canAdd: true,
-      canDisable: false,
-      features: [],
-      aspects: {},
-    },
-    domainName: 'github.com/test',
-    icon: null,
-    accountType: null,
-    gracePeriodEnd: null,
-    organizationIntegrationStatus: 'active',
-    status: 'active',
-  };
+  const githubIntegration = GitHubIntegrationFixture();
 
   beforeEach(() => {
     MockApiClient.addMockResponse({

--- a/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.spec.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.spec.tsx
@@ -1,0 +1,79 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useScmIntegrationTreeData} from './useScmIntegrationTreeData';
+
+describe('useScmIntegrationTreeData', () => {
+  const organization = OrganizationFixture();
+
+  const githubProvider = {
+    key: 'github',
+    slug: 'github',
+    name: 'GitHub',
+    canAdd: true,
+    canDisable: false,
+    features: ['commits'],
+    metadata: {
+      aspects: {},
+      author: 'The Sentry Team',
+      description: '',
+      features: [{featureId: 1, featureGate: 'integrations-commits', description: ''}],
+      issue_url: '',
+      noun: 'Installation',
+      source_url: '',
+    },
+    setupDialog: {height: 600, url: '', width: 600},
+  };
+
+  const githubIntegration = {
+    id: '1',
+    name: 'GitHub',
+    provider: {
+      key: 'github',
+      slug: 'github',
+      name: 'GitHub',
+      canAdd: true,
+      canDisable: false,
+      features: [],
+      aspects: {},
+    },
+    domainName: 'github.com/test',
+    icon: null,
+    accountType: null,
+    gracePeriodEnd: null,
+    organizationIntegrationStatus: 'active',
+    status: 'active',
+  };
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/`,
+      body: {providers: [githubProvider]},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: {results: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/1/repos/`,
+      body: {repos: [], searchable: false},
+    });
+  });
+
+  it('filters out null integration items from the API response', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [githubIntegration, null],
+    });
+
+    const {result} = renderHookWithProviders(useScmIntegrationTreeData, {
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.scmIntegrations).toHaveLength(1);
+    expect(result.current.scmIntegrations[0]!.id).toBe('1');
+  });
+});

--- a/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
+++ b/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
@@ -60,7 +60,10 @@ export function useScmIntegrationTreeData(): ScmIntegrationTreeData {
   );
 
   const scmIntegrations = useMemo(
-    () => (integrationsQuery.data ?? []).filter(i => scmProviderKeys.has(i.provider.key)),
+    () =>
+      (integrationsQuery.data ?? []).filter(
+        i => i !== null && scmProviderKeys.has(i.provider.key)
+      ),
     [integrationsQuery.data, scmProviderKeys]
   );
 


### PR DESCRIPTION
The `/integrations/` API can return `null` items in the response list when the backend serializer fails for an individual integration (the backend fix for that is in #110865). The `filter` call in `useScmIntegrationTreeData` was accessing `i.provider.key` without guarding against null items, causing a `TypeError` that crashed the `/settings/repos/` page behind an error boundary.

Add a `i !== null` guard before accessing `.provider.key`.

Related to https://github.com/getsentry/sentry/pull/110865

Fixes JAVASCRIPT-381Y