### PR TITLE
ref(marked): Switch DOMPurify to tag and attribute allowlist

### DIFF
--- a/static/app/utils/marked/marked.spec.tsx
+++ b/static/app/utils/marked/marked.spec.tsx
@@ -132,6 +132,88 @@ describe('marked', () => {
     );
   });
 
+  it('strips style tags', () => {
+    const result1 = sanitizedMarked('<style>body { color: red; }</style>hello');
+    expect(result1).not.toContain('<style');
+    expect(result1).not.toContain('color: red');
+
+    const result2 = sanitizedMarked('text<style>.x{background:url(evil)}</style>');
+    expect(result2).not.toContain('<style');
+    expect(result2).toContain('text');
+  });
+
+  it('strips form elements', () => {
+    const formHtml = sanitizedMarked(
+      '<form action="/evil"><input name="csrf"><button>click</button></form>'
+    );
+    expect(formHtml).not.toContain('<form');
+    expect(formHtml).not.toContain('<input');
+    expect(formHtml).not.toContain('<button');
+
+    expect(sanitizedMarked('<select><option>a</option></select>')).not.toContain(
+      '<select'
+    );
+    expect(sanitizedMarked('<textarea>injected</textarea>')).not.toContain('<textarea');
+  });
+
+  it('strips iframe, object, and embed tags', () => {
+    expect(sanitizedMarked('<iframe src="https://evil.com"></iframe>')).not.toContain(
+      '<iframe'
+    );
+    expect(sanitizedMarked('<object data="evil.swf"></object>')).not.toContain('<object');
+    expect(sanitizedMarked('<embed src="evil.swf">')).not.toContain('<embed');
+  });
+
+  it('strips style attributes', () => {
+    const result1 = sanitizedMarked('<p style="color:red">text</p>');
+    expect(result1).toContain('<p>text</p>');
+    expect(result1).not.toContain('style');
+
+    const result2 = sanitizedMarked('a <span style="background:url(evil)">x</span> b');
+    expect(result2).toContain('<span>x</span>');
+    expect(result2).not.toContain('style');
+  });
+
+  it('strips event handler attributes', () => {
+    const imgResult = sanitizedMarked('<img src="x" onerror="alert(1)">');
+    expect(imgResult).toContain('<img src="x">');
+    expect(imgResult).not.toContain('onerror');
+
+    const linkResult = sanitizedMarked(
+      'a <a href="https://ok.com" onclick="alert(1)">link</a> b'
+    );
+    expect(linkResult).toContain('<a href="https://ok.com">link</a>');
+    expect(linkResult).not.toContain('onclick');
+  });
+
+  it('preserves allowed markdown HTML', () => {
+    // Bold, italic, code, links, images, lists, tables, blockquotes, headings
+    expect(sanitizedMarked('**bold** *italic* `code`')).toBe(
+      '<p><strong>bold</strong> <em>italic</em> <code>code</code></p>\n'
+    );
+    expect(sanitizedMarked('- item 1\n- item 2')).toBe(
+      '<ul>\n<li>item 1</li>\n<li>item 2</li>\n</ul>\n'
+    );
+    expect(sanitizedMarked('> quote')).toBe(
+      '<blockquote>\n<p>quote</p>\n</blockquote>\n'
+    );
+    expect(sanitizedMarked('# heading')).toBe('<h1>heading</h1>\n');
+    expect(sanitizedMarked('---')).toBe('<hr>\n');
+  });
+
+  it('strips dangerous tags via asyncSanitizedMarked', async () => {
+    const styleResult = await asyncSanitizedMarked('<style>body{color:red}</style>hello');
+    expect(styleResult).not.toContain('<style');
+    expect(styleResult).toContain('hello');
+
+    const formResult = await asyncSanitizedMarked(
+      '<form><input><button>x</button></form>'
+    );
+    expect(formResult).not.toContain('<form');
+    expect(formResult).not.toContain('<input');
+    expect(formResult).not.toContain('<button');
+  });
+
   it('renders syntax highlighting via asyncSanitizedMarked', async () => {
     const markdown = '```javascript\nconst x = 1;\n```';
     expect(await asyncSanitizedMarked(markdown)).toBe(

--- a/static/app/utils/marked/marked.tsx
+++ b/static/app/utils/marked/marked.tsx
@@ -31,7 +31,8 @@ class SafeRenderer extends marked.Renderer {
 
     const out = super.link(tokens);
     return dompurify.sanitize(out, {
-      FORBID_ATTR: ['style'],
+      ALLOWED_TAGS,
+      ALLOWED_ATTR,
     });
   }
 
@@ -52,13 +53,53 @@ class NoParagraphRenderer extends SafeRenderer {
   }
 }
 
+/**
+ * Allowlist of HTML tags that markdown rendering can produce.
+ * Using an allowlist rather than a blocklist ensures unexpected tags
+ * (style, form, input, script, iframe, etc.) are stripped by default.
+ */
+const ALLOWED_TAGS = [
+  // Block elements
+  'p',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'blockquote',
+  'pre',
+  'ul',
+  'ol',
+  'li',
+  'hr',
+  'br',
+  'table',
+  'thead',
+  'tbody',
+  'tr',
+  'th',
+  'td',
+  // Inline elements
+  'a',
+  'img',
+  'code',
+  'em',
+  'strong',
+  'del',
+  'span',
+  'b',
+  'i',
+  'sub',
+  'sup',
+];
+
+const ALLOWED_ATTR = ['href', 'title', 'src', 'alt', 'class', 'id'];
+
 function postprocess(html: string) {
   return dompurify.sanitize(html, {
-    // Forbid style attributes to prevent CSS injection attacks
-    // This is the primary security fix to prevent arbitrary CSS injection
-    FORBID_ATTR: ['style'],
-    // Keep default tag allowlist but remove dangerous attributes
-    // This prevents CSS injection while preserving markdown functionality
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
   });
 }
 


### PR DESCRIPTION
Switch the markdown sanitizer from a blocklist approach (`FORBID_ATTR: ['style']`) to an explicit allowlist of tags and attributes that markdown rendering can legitimately produce.

Previously, DOMPurify's default tag set was used with only `style` attributes blocked. This meant unexpected HTML elements like `<style>`, `<form>`, `<input>`, `<iframe>`, `<embed>`, etc. could pass through. An allowlist is more secure by default — anything not explicitly permitted is stripped.

**Allowed tags**: p, h1-h6, blockquote, pre, ul, ol, li, hr, br, table/thead/tbody/tr/th/td, a, img, code, em, strong, del, span, b, i, sub, sup

**Allowed attributes**: href, title, src, alt, class, id


Agent transcript: https://claudescope.sentry.dev/share/bUvAJa0G-KyljfoIqcL3gs4b1SGew4vld8pk9wOI74M