### PR TITLE
ref(settings): migrate account emails to new form system

### DIFF
--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -1,166 +1,117 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
+import {parseAsString, useQueryState} from 'nuqs';
+import {z} from 'zod';
+
+import {AutoSaveForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
-import {SelectField} from 'sentry/components/forms/fields/selectField';
-import {Form} from 'sentry/components/forms/form';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Pagination} from 'sentry/components/pagination';
 import {Panel} from 'sentry/components/panels/panel';
-import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {SearchBar} from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {UserEmail} from 'sentry/types/user';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {keepPreviousData, useApiQuery} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
-import {useParams} from 'sentry/utils/useParams';
-import {withOrganizations} from 'sentry/utils/withOrganizations';
-import type {FineTuneField} from 'sentry/views/settings/account/notifications/fields';
+import {fetchMutation, keepPreviousData, useApiQuery} from 'sentry/utils/queryClient';
 import {ACCOUNT_NOTIFICATION_FIELDS} from 'sentry/views/settings/account/notifications/fields';
 import {OrganizationSelectHeader} from 'sentry/views/settings/account/notifications/organizationSelectHeader';
-import {
-  getNotificationTypeFromPathname,
-  groupByOrganization,
-  isGroupedByProject,
-} from 'sentry/views/settings/account/notifications/utils';
+import {groupByOrganization} from 'sentry/views/settings/account/notifications/utils';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
-const PanelBodyLineItem = styled(PanelBody)`
-  font-size: 1rem;
-  &:not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
-  }
-`;
+type EmailSelectOption = {label: string; value: string};
 
 type ANBPProps = {
-  field: FineTuneField;
+  emailChoices: EmailSelectOption[];
+  emailsByProject: Record<string, any>;
   projects: Project[];
+  refetchEmailsByProject: () => void;
 };
 
-function AccountNotificationsByProject({projects, field}: ANBPProps) {
+function AccountNotificationsByProject({
+  projects,
+  emailChoices,
+  emailsByProject,
+  refetchEmailsByProject,
+}: ANBPProps) {
   const projectsByOrg = groupByOrganization(projects);
 
-  const {title: _title, description: _description, ...fieldConfig} = field;
-
-  // Display as select box in this view regardless of the type specified in the config
-  const data = Object.values(projectsByOrg).map(org => ({
-    name: org.organization.name,
-    projects: org.projects.map(project => ({
-      ...fieldConfig,
-      // `name` key refers to field name
-      // we use project.id because slugs are not unique across orgs
-      name: project.id,
-      label: (
-        <ProjectBadge
-          project={project}
-          avatarSize={20}
-          avatarProps={{consistentWidth: true}}
-          disableLink
-        />
-      ),
-    })),
-  }));
-
   return (
     <Fragment>
-      {data.map(({name, projects: projectFields}) => (
-        <div key={name}>
-          {projectFields.map(f => (
-            <PanelBodyLineItem key={f.name}>
-              <SelectField
-                defaultValue={f.defaultValue}
-                name={f.name}
-                options={f.options}
-                label={f.label}
-              />
-            </PanelBodyLineItem>
-          ))}
-        </div>
-      ))}
+      {Object.values(projectsByOrg).map(org =>
+        org.projects.map((project, i) => {
+          const schema = z.object({[project.id]: z.string()});
+          return (
+            <Fragment key={project.id}>
+              {i === 0 ? null : <Stack.Separator />}
+              <AutoSaveForm
+                name={project.id}
+                schema={schema}
+                initialValue={emailsByProject?.[project.id] ?? ''}
+                mutationOptions={{
+                  mutationFn: (data: Record<string, string>) =>
+                    fetchMutation({
+                      method: 'PUT',
+                      url: '/users/me/notifications/email/',
+                      data,
+                    }),
+                  onSuccess: () => refetchEmailsByProject(),
+                }}
+              >
+                {field => (
+                  <field.Layout.Row
+                    padding="xl"
+                    label={
+                      <ProjectBadge
+                        project={project}
+                        avatarSize={20}
+                        avatarProps={{consistentWidth: true}}
+                        disableLink
+                      />
+                    }
+                  >
+                    <field.Select
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      options={emailChoices}
+                    />
+                  </field.Layout.Row>
+                )}
+              </AutoSaveForm>
+            </Fragment>
+          );
+        })
+      )}
     </Fragment>
   );
 }
 
-type ANBOProps = {
-  field: FineTuneField;
-};
-
-function AccountNotificationsByOrganization({field}: ANBOProps) {
+export function AccountNotificationFineTuning() {
   const {organizations} = useLegacyStore(OrganizationsStore);
-
-  const {title: _title, description: _description, ...fieldConfig} = field;
-
-  // Display as select box in this view regardless of the type specified in the config
-  const data = organizations.map(org => ({
-    ...fieldConfig,
-    // `name` key refers to field name
-    // we use org.id to remain consistent project.id use (which is required because slugs are not unique across orgs)
-    name: org.id,
-    label: org.slug,
-  }));
-
-  return (
-    <Fragment>
-      {data.map(f => (
-        <PanelBodyLineItem key={f.name}>
-          <SelectField
-            defaultValue={f.defaultValue}
-            name={f.name}
-            options={f.options}
-            label={f.label}
-          />
-        </PanelBodyLineItem>
-      ))}
-    </Fragment>
-  );
-}
-
-interface AccountNotificationFineTuningProps {
-  organizations: Organization[];
-}
-
-function AccountNotificationFineTuning({
-  organizations,
-}: AccountNotificationFineTuningProps) {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const params = useParams<{fineTuneType: string}>();
-  const {fineTuneType: pathnameType} = params;
-  const fineTuneType = getNotificationTypeFromPathname(pathnameType);
   const config = useLegacyStore(ConfigStore);
+
+  const [orgIdParam, setOrgId] = useQueryState('organizationId', parseAsString);
+  const [cursor] = useQueryState('cursor', parseAsString);
+  const [query, setQuery] = useQueryState('query', parseAsString);
 
   // Get org id from:
   // - query param
   // - subdomain
   // - default to first org
   const organizationId =
-    (location?.query?.organizationId as string | undefined) ??
+    orgIdParam ??
     organizations.find(({slug}) => slug === config?.customerDomain?.subdomain)?.id ??
     (organizations.length === 1 ? organizations[0]?.id : undefined);
 
-  const {
-    data: notifications,
-    isPending: isPendingNotifications,
-    isError: isErrorNotifications,
-  } = useApiQuery<Record<string, any>>(
-    [getApiUrl('/users/$userId/notifications/', {path: {userId: 'me'}})],
-    {
-      staleTime: 0,
-    }
-  );
-  const projectsEnabled = isGroupedByProject(fineTuneType);
   const {
     data: projects,
     isPending: isPendingProjects,
@@ -172,20 +123,17 @@ function AccountNotificationFineTuning({
       {
         query: {
           organizationId,
-          cursor: location.query.cursor,
-          query: location.query.query,
+          cursor,
+          query,
         },
       },
     ],
     {
       staleTime: 0,
-      enabled: Boolean(projectsEnabled && organizationId),
+      enabled: Boolean(organizationId),
     }
   );
-  const isLoadingProjects = projectsEnabled ? isPendingProjects : false;
 
-  // Extra data specific to email notifications
-  const isEmail = fineTuneType === 'email';
   const {
     data: emails = [],
     isPending: isPendingEmails,
@@ -194,7 +142,6 @@ function AccountNotificationFineTuning({
     [getApiUrl('/users/$userId/emails/', {path: {userId: 'me'}})],
     {
       staleTime: 0,
-      enabled: isEmail,
     }
   );
   const {
@@ -206,72 +153,50 @@ function AccountNotificationFineTuning({
     [getApiUrl('/users/$userId/notifications/email/', {path: {userId: 'me'}})],
     {
       staleTime: 0,
-      enabled: isEmail,
       placeholderData: keepPreviousData,
     }
   );
 
-  const isProject = isGroupedByProject(fineTuneType) && organizations.length > 0;
-  const field = ACCOUNT_NOTIFICATION_FIELDS[fineTuneType]!;
+  const field = ACCOUNT_NOTIFICATION_FIELDS.email!;
 
-  if (
-    fineTuneType === 'quota' &&
-    organizations.some(org => org.features?.includes('spend-visibility-notifications'))
-  ) {
-    field.title = t('Spend Notifications');
-    field.description = t(
-      'Control the notifications you receive for organization spend.'
-    );
-  }
+  // Verified email addresses
+  const emailChoices: EmailSelectOption[] = emails
+    .filter(({isVerified}) => isVerified)
+    .sort((a, b) => {
+      if (a.isPrimary) {
+        return -1;
+      }
+      if (b.isPrimary) {
+        return 1;
+      }
+      return a.email < b.email ? -1 : 1;
+    })
+    .map(({email}) => ({value: email, label: email}));
 
-  if (isEmail) {
-    // Verified email addresses
-    const emailChoices: UserEmail[] = emails
-      .filter(({isVerified}) => isVerified)
-      .sort((a, b) => {
-        // Sort by primary -> email
-        if (a.isPrimary) {
-          return -1;
-        }
-        if (b.isPrimary) {
-          return 1;
-        }
-
-        return a.email < b.email ? -1 : 1;
-      });
-    field.options = emailChoices.map(({email}) => ({value: email, label: email}));
-  }
-
-  if (
-    isErrorProjects ||
-    isErrorNotifications ||
-    isErrorEmails ||
-    isErrorEmailsByProject
-  ) {
+  if (isErrorProjects || isErrorEmails || isErrorEmailsByProject) {
     return <LoadingError />;
   }
 
-  if (!notifications || (!emailsByProject && fineTuneType === 'email')) {
+  if (!emailsByProject) {
     return null;
   }
 
   const hasProjects = !!projects?.length;
   const mainContent =
-    isLoadingProjects ||
-    isPendingNotifications ||
-    (isEmail && (isPendingEmailsByProject || isPendingEmails)) ? (
+    isPendingProjects || isPendingEmailsByProject || isPendingEmails ? (
       <LoadingIndicator />
     ) : (
       <Fragment>
-        {isProject && hasProjects && (
-          <AccountNotificationsByProject projects={projects} field={field} />
-        )}
-
-        {isProject && !hasProjects && (
+        {hasProjects ? (
+          <AccountNotificationsByProject
+            projects={projects}
+            emailChoices={emailChoices}
+            emailsByProject={emailsByProject}
+            refetchEmailsByProject={refetchEmailsByProject}
+          />
+        ) : (
           <EmptyMessage>{t('No projects found')}</EmptyMessage>
         )}
-
-        {!isProject && <AccountNotificationsByOrganization field={field} />}
       </Fragment>
     );
 
@@ -280,80 +205,35 @@ function AccountNotificationFineTuning({
       <SettingsPageHeader title={field.title} />
       {field.description && <TextBlock>{field.description}</TextBlock>}
       <Panel>
-        <StyledPanelHeader hasButtons={isProject}>
-          {isProject ? (
-            <Fragment>
-              <OrganizationSelectHeader
-                organizations={organizations}
-                organizationId={organizationId}
-                handleOrgChange={(newOrgId: string) => {
-                  navigate(
-                    {
-                      ...location,
-                      query: {organizationId: newOrgId},
-                    },
-                    {replace: true}
-                  );
-                }}
-              />
-              <SearchBar
-                placeholder={t('Search Projects')}
-                query={location.query.query as string | undefined}
-                onSearch={value => {
-                  navigate(
-                    {
-                      ...location,
-                      query: {...location.query, query: value, cursor: undefined},
-                    },
-                    {replace: true}
-                  );
-                }}
-              />
-            </Fragment>
-          ) : (
-            <Heading>{t('Organizations')}</Heading>
-          )}
-        </StyledPanelHeader>
-        <PanelBody>
-          {/* Only email needs the form to change the email */}
+        <PanelHeader hasButtons>
+          <Flex wrap="wrap" gap="md" flex="1" align="center">
+            <OrganizationSelectHeader
+              organizations={organizations}
+              organizationId={organizationId}
+              handleOrgChange={(newOrgId: string) => {
+                void setOrgId(newOrgId);
+              }}
+            />
+            <SearchBar
+              placeholder={t('Search Projects')}
+              query={query ?? undefined}
+              onSearch={value => {
+                void setQuery(value || null);
+              }}
+            />
+          </Flex>
+        </PanelHeader>
+        <Stack gap="0">
           {organizationId ? (
-            fineTuneType === 'email' && emailsByProject && !isPendingEmailsByProject ? (
-              <Form
-                saveOnBlur
-                apiMethod="PUT"
-                apiEndpoint="/users/me/notifications/email/"
-                initialData={emailsByProject}
-                onSubmitSuccess={() => {
-                  refetchEmailsByProject();
-                }}
-              >
-                {mainContent}
-              </Form>
-            ) : (
-              mainContent
-            )
+            mainContent
           ) : (
             <EmptyStateWarning withIcon={false}>
               {t('Select an organization to continue')}
             </EmptyStateWarning>
           )}
-        </PanelBody>
+        </Stack>
       </Panel>
       {projects && <Pagination pageLinks={getProjectsResponseHeader?.('Link')} />}
     </div>
   );
 }
-
-const Heading = styled('div')`
-  flex: 1;
-`;
-
-const StyledPanelHeader = styled(PanelHeader)`
-  flex-wrap: wrap;
-  gap: ${p => p.theme.space.md};
-  & > form:last-child {
-    flex-grow: 1;
-  }
-`;
-
-export default withOrganizations(AccountNotificationFineTuning);

--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -158,6 +158,8 @@ export function AccountNotificationFineTuning() {
   );
 
   const field = ACCOUNT_NOTIFICATION_FIELDS.email!;
+  const isPending = isPendingProjects || isPendingEmailsByProject || isPendingEmails;
+  const isError = isErrorProjects || isErrorEmails || isErrorEmailsByProject;
 
   // Verified email addresses
   const emailChoices: EmailSelectOption[] = emails
@@ -173,32 +175,31 @@ export function AccountNotificationFineTuning() {
     })
     .map(({email}) => ({value: email, label: email}));
 
-  if (isErrorProjects || isErrorEmails || isErrorEmailsByProject) {
+  if (isError) {
     return <LoadingError />;
   }
 
-  if (!emailsByProject) {
+  if (!emailsByProject && !isPending) {
     return null;
   }
 
   const hasProjects = !!projects?.length;
-  const mainContent =
-    isPendingProjects || isPendingEmailsByProject || isPendingEmails ? (
-      <LoadingIndicator />
-    ) : (
-      <Fragment>
-        {hasProjects ? (
-          <AccountNotificationsByProject
-            projects={projects}
-            emailChoices={emailChoices}
-            emailsByProject={emailsByProject}
-            refetchEmailsByProject={refetchEmailsByProject}
-          />
-        ) : (
-          <EmptyMessage>{t('No projects found')}</EmptyMessage>
-        )}
-      </Fragment>
-    );
+  const mainContent = isPending ? (
+    <LoadingIndicator />
+  ) : (
+    <Fragment>
+      {hasProjects ? (
+        <AccountNotificationsByProject
+          projects={projects}
+          emailChoices={emailChoices}
+          emailsByProject={emailsByProject}
+          refetchEmailsByProject={refetchEmailsByProject}
+        />
+      ) : (
+        <EmptyMessage>{t('No projects found')}</EmptyMessage>
+      )}
+    </Fragment>
+  );
 
   return (
     <div>
@@ -223,7 +224,7 @@ export function AccountNotificationFineTuning() {
             />
           </Flex>
         </PanelHeader>
-        <Stack gap="0">
+        <Stack>
           {organizationId ? (
             mainContent
           ) : (

--- a/static/app/views/settings/account/accountNotificationFineTuningController.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuningController.tsx
@@ -1,16 +1,11 @@
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import type {Organization} from 'sentry/types/organization';
+import {OrganizationsStore} from 'sentry/stores/organizationsStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {useParams} from 'sentry/utils/useParams';
-import {withOrganizations} from 'sentry/utils/withOrganizations';
 import {NotificationSettingsByType} from 'sentry/views/settings/account/notifications/notificationSettingsByType';
 import {getNotificationTypeFromPathname} from 'sentry/views/settings/account/notifications/utils';
 
-import AccountNotificationFineTuning from './accountNotificationFineTuning';
-
-interface AccountNotificationFineTuningControllerProps {
-  organizations: Organization[];
-  organizationsLoading?: boolean;
-}
+import {AccountNotificationFineTuning} from './accountNotificationFineTuning';
 
 const accountNotifications = [
   'alerts',
@@ -23,15 +18,12 @@ const accountNotifications = [
   'brokenMonitors',
 ];
 
-function AccountNotificationFineTuningController({
-  organizationsLoading,
-  ...props
-}: AccountNotificationFineTuningControllerProps) {
-  const params = useParams<{fineTuneType: string}>();
-  const {fineTuneType: pathnameType} = params;
+export default function AccountNotificationFineTuningController() {
+  const {loaded} = useLegacyStore(OrganizationsStore);
+  const {fineTuneType: pathnameType} = useParams<{fineTuneType: string}>();
   const fineTuneType = getNotificationTypeFromPathname(pathnameType);
 
-  if (organizationsLoading) {
+  if (!loaded) {
     return <LoadingIndicator />;
   }
 
@@ -39,7 +31,5 @@ function AccountNotificationFineTuningController({
     return <NotificationSettingsByType notificationType={fineTuneType} />;
   }
 
-  return <AccountNotificationFineTuning {...props} />;
+  return <AccountNotificationFineTuning />;
 }
-
-export default withOrganizations(AccountNotificationFineTuningController);

--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -11,13 +11,13 @@ import type {SelectValue} from 'sentry/types/core';
 import {DataCategoryExact} from 'sentry/types/core';
 import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 
-export type FineTuneField = {
+interface FineTuneField {
   description: string;
   title: string;
   type: 'select';
   defaultValue?: string;
   options?: Array<SelectValue<string>>;
-};
+}
 
 // TODO: clean up unused fields
 export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {


### PR DESCRIPTION
Migrates the `/settings/account/notifications/email` pages to new form system.

- Replaces `styled` components with core layout components
- Replaces `useLocation` with `useQueryState`
- Removes dead code (`AccountNotificationsByOrganization` is not accessible)

Barely any visual diff, big code cleanup.

| Before | After |
|--------|--------|
| <img width="3024" height="1725" alt="email-before" src="https://github.com/user-attachments/assets/8d578e77-73fd-4280-88af-cca6aa77a1b2" /> | <img width="3024" height="1725" alt="email-after" src="https://github.com/user-attachments/assets/e36f9dfe-b137-4cb8-afaa-1161d69ec992" /> | 