### PR TITLE
perf(docker): precompile all application source files

### DIFF
--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -78,6 +78,7 @@ RUN set -x \
 COPY . .
 RUN : \
     && python3 -m tools.fast_editable --path . \
+    && python3 -m compileall -q src/ \
     && sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
 
 COPY ./self-hosted/sentry.conf.py ./self-hosted/config.yml $SENTRY_CONF/


### PR DESCRIPTION
This needs to happen anyways during start up time when each of these modules gets loaded into the memory, so it's better to push this to build time, and save some CPU when the containers are started 