### PR TITLE
feat(metrics): Add last seen, times seen, and attributes to metric dropdown

### DIFF
--- a/static/app/views/explore/hooks/useMetricOptions.spec.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.spec.tsx
@@ -63,7 +63,12 @@ describe('useMetricOptions', () => {
       match: [
         MockApiClient.matchQuery({
           dataset: DiscoverDatasets.TRACEMETRICS,
-          field: ['metric.name', 'metric.type', 'count(metric.name)'],
+          field: [
+            'metric.name',
+            'metric.type',
+            'count(metric.name)',
+            'max(timestamp_precise)',
+          ],
           referrer: 'api.explore.metric-options',
         }),
       ],
@@ -112,7 +117,12 @@ describe('useMetricOptions', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           dataset: 'tracemetrics',
-          field: ['metric.name', 'metric.type', 'count(metric.name)'],
+          field: [
+            'metric.name',
+            'metric.type',
+            'count(metric.name)',
+            'max(timestamp_precise)',
+          ],
           referrer: 'api.explore.metric-options',
           statsPeriod: '3d',
         }),

--- a/static/app/views/explore/hooks/useMetricOptions.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.tsx
@@ -41,6 +41,7 @@ function metricOptionsQueryKey({
     TraceMetricKnownFieldKey.METRIC_NAME,
     TraceMetricKnownFieldKey.METRIC_TYPE,
     `count(${TraceMetricKnownFieldKey.METRIC_NAME})`,
+    `max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`,
   ];
   if (hasMetricUnitsUI) {
     queryFields.push(TraceMetricKnownFieldKey.METRIC_UNIT);

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -41,6 +41,15 @@ describe('MetricSelector', () => {
         referrer: 'api.explore.metric-options',
       }),
     ]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [
+        {key: 'device.name', type: 'string'},
+        {key: 'release', type: 'string'},
+      ],
+    });
   });
 
   afterEach(() => {
@@ -458,6 +467,24 @@ describe('MetricSelector', () => {
 
       expect(await screen.findByText('Type:')).toBeInTheDocument();
       expect((await screen.findAllByText('bar')).length).toBeGreaterThan(0);
+    });
+
+    it('shows attributes section in side panel', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization: {
+          ...organization,
+          features: [
+            ...organization.features,
+            'tracemetrics-attributes-dropdown-side-panel',
+          ],
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await screen.findByRole('listbox');
+
+      expect(await screen.findByText('device.name')).toBeInTheDocument();
+      expect(await screen.findByText('release')).toBeInTheDocument();
     });
 
     it('side panel updates when hovering over a different metric option', async () => {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -429,7 +429,7 @@ describe('MetricSelector', () => {
       await userEvent.click(screen.getByRole('button', {name: 'bar'}));
       await screen.findByRole('option', {name: 'bar'});
 
-      expect(screen.queryByText('Type:')).not.toBeInTheDocument();
+      expect(screen.queryByText('Type')).not.toBeInTheDocument();
     });
 
     it('renders side panel with tracemetrics-attributes-dropdown-side-panel feature', async () => {
@@ -446,7 +446,7 @@ describe('MetricSelector', () => {
       await userEvent.click(screen.getByRole('button', {name: 'bar'}));
       await userEvent.hover(await screen.findByRole('option', {name: 'bar'}));
 
-      expect(await screen.findByText('Type:')).toBeInTheDocument();
+      expect(await screen.findByText('Type')).toBeInTheDocument();
       expect(await screen.findByText('Last seen')).toBeInTheDocument();
       expect(await screen.findByText('Times seen')).toBeInTheDocument();
     });
@@ -465,7 +465,7 @@ describe('MetricSelector', () => {
       await userEvent.click(screen.getByRole('button', {name: 'bar'}));
       await screen.findByRole('listbox');
 
-      expect(await screen.findByText('Type:')).toBeInTheDocument();
+      expect(await screen.findByText('Type')).toBeInTheDocument();
       expect((await screen.findAllByText('bar')).length).toBeGreaterThan(0);
     });
 

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -435,8 +435,11 @@ describe('MetricSelector', () => {
       });
 
       await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      await userEvent.hover(await screen.findByRole('option', {name: 'bar'}));
 
       expect(await screen.findByText('Type:')).toBeInTheDocument();
+      expect(await screen.findByText('Last seen')).toBeInTheDocument();
+      expect(await screen.findByText('Times seen')).toBeInTheDocument();
     });
 
     it('side panel defaults to current metric when no option is hovered', async () => {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -483,80 +483,6 @@ export function MetricSelector({
   );
 }
 
-function MetricAttributesSection({
-  metricName,
-  metricType,
-}: {
-  metricName: string;
-  metricType: string;
-}) {
-  const traceMetricFilter = createTraceMetricFilter({name: metricName, type: metricType});
-
-  const {attributes: stringAttrs, isLoading: stringLoading} =
-    useTraceMetricItemAttributes(
-      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
-      'string'
-    );
-  const {attributes: numberAttrs, isLoading: numberLoading} =
-    useTraceMetricItemAttributes(
-      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
-      'number'
-    );
-  const {attributes: booleanAttrs, isLoading: booleanLoading} =
-    useTraceMetricItemAttributes(
-      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
-      'boolean'
-    );
-
-  const isLoading = stringLoading || numberLoading || booleanLoading;
-
-  const attributeKeys = useMemo(() => {
-    const keys = new Set([
-      ...Object.keys(stringAttrs ?? {}),
-      ...Object.keys(numberAttrs ?? {}),
-      ...Object.keys(booleanAttrs ?? {}),
-    ]);
-    return [...keys]
-      .filter(key => !HiddenTraceMetricGroupByFields.includes(key))
-      .sort((a, b) => prettifyTagKey(a).localeCompare(prettifyTagKey(b)));
-  }, [stringAttrs, numberAttrs, booleanAttrs]);
-
-  if (isLoading) {
-    return (
-      <Stack gap="xs">
-        <Text size="md">{t('Attributes')}:</Text>
-        <Flex gap="xs">
-          <LoadingIndicator size={16} />
-        </Flex>
-      </Stack>
-    );
-  }
-
-  if (attributeKeys.length === 0) {
-    return (
-      <Stack gap="xs">
-        <Text size="md">{t('Attributes')}:</Text>
-        <Flex gap="xs">
-          <Text size="md">{t('No attributes found')}</Text>
-        </Flex>
-      </Stack>
-    );
-  }
-
-  return (
-    <Stack gap="xs">
-      <Text size="md">{t('Attributes')}:</Text>
-      <Flex wrap="wrap" gap="xs">
-        {attributeKeys.map(key => (
-          <Tag key={key} variant="muted">
-            {prettifyTagKey(key)}
-          </Tag>
-        ))}
-      </Flex>
-    </Stack>
-  );
-}
-
 function MetricDetailPanel({
   metric,
   hasMetricUnitsUI,
@@ -617,4 +543,76 @@ function MetricDetailPanel({
 
 function makeMetricSelectValue(metric: TraceMetric): string {
   return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
+}
+
+function MetricAttributesSection({
+  metricName,
+  metricType,
+}: {
+  metricName: string;
+  metricType: string;
+}) {
+  const traceMetricFilter = createTraceMetricFilter({name: metricName, type: metricType});
+
+  const {attributes: stringAttrs, isLoading: stringLoading} =
+    useTraceMetricItemAttributes(
+      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
+      'string'
+    );
+  const {attributes: numberAttrs, isLoading: numberLoading} =
+    useTraceMetricItemAttributes(
+      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
+      'number'
+    );
+  const {attributes: booleanAttrs, isLoading: booleanLoading} =
+    useTraceMetricItemAttributes(
+      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
+      'boolean'
+    );
+
+  const attributeKeys = useMemo(() => {
+    const keys = new Set([
+      ...Object.keys(stringAttrs ?? {}),
+      ...Object.keys(numberAttrs ?? {}),
+      ...Object.keys(booleanAttrs ?? {}),
+    ]);
+    return [...keys]
+      .filter(key => !HiddenTraceMetricGroupByFields.includes(key))
+      .sort((a, b) => prettifyTagKey(a).localeCompare(prettifyTagKey(b)));
+  }, [stringAttrs, numberAttrs, booleanAttrs]);
+
+  if (stringLoading || numberLoading || booleanLoading) {
+    return (
+      <Stack gap="xs">
+        <Text size="md">{t('Attributes')}:</Text>
+        <Flex gap="xs">
+          <LoadingIndicator size={16} />
+        </Flex>
+      </Stack>
+    );
+  }
+
+  if (attributeKeys.length === 0) {
+    return (
+      <Stack gap="xs">
+        <Text size="md">{t('Attributes')}:</Text>
+        <Flex gap="xs">
+          <Text size="md">{t('No attributes found')}</Text>
+        </Flex>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="xs">
+      <Text size="md">{t('Attributes')}:</Text>
+      <Flex wrap="wrap" gap="xs">
+        {attributeKeys.map(key => (
+          <Tag key={key} variant="muted">
+            {prettifyTagKey(key)}
+          </Tag>
+        ))}
+      </Flex>
+    </Stack>
+  );
 }

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -487,7 +487,9 @@ function MetricDetailPanel({
 
   return (
     <Stack gap="md">
-      <Text bold>{metric.metricName}</Text>
+      <Text bold wordBreak="break-all">
+        {metric.metricName}
+      </Text>
       <Flex gap="xs" align="center">
         <Text variant="muted" size="sm">
           {t('Type:')}

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -10,6 +10,7 @@ import {MenuListItem, type MenuListItemProps} from '@sentry/scraps/menuListItem'
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
+import {DateTime} from 'sentry/components/dateTime';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
@@ -64,6 +65,8 @@ interface MetricSelectOption {
   metricName: string;
   metricType: TraceMetricTypeValue;
   value: string;
+  count?: number;
+  lastSeen?: number;
   metricUnit?: string;
   trailingItems?: MenuListItemProps['trailingItems'];
 }
@@ -170,6 +173,12 @@ export function MetricSelector({
         metricUnit: hasMetricUnitsUI
           ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
           : undefined,
+        count: option[`count(${TraceMetricKnownFieldKey.METRIC_NAME})`] as number,
+        lastSeen:
+          option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`] === undefined
+            ? undefined
+            : Number(option[`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]) /
+              1_000_000,
         trailingItems: () => (
           <MetricOptionTrailingItems
             hasMetricUnitsUI={hasMetricUnitsUI}
@@ -491,19 +500,35 @@ function MetricDetailPanel({
         {metric.metricName}
       </Text>
       <Flex gap="xs" align="center">
-        <Text variant="muted" size="sm">
-          {t('Type:')}
+        <Text variant="muted" size="md">
+          {t('Type')}
         </Text>
         <MetricTypeBadge metricType={metric.metricType} />
       </Flex>
       {hasDisplayMetricUnit(hasMetricUnitsUI, metric.metricUnit) ? (
         <Flex gap="xs" align="center">
-          <Text variant="muted" size="sm">
-            {t('Unit:')}
+          <Text variant="muted" size="md">
+            {t('Unit')}
           </Text>
           <Tag variant="promotion">{metric.metricUnit}</Tag>
         </Flex>
       ) : null}
+      {metric.lastSeen ? (
+        <Flex gap="xs" align="center">
+          <Text variant="muted" size="md">
+            {t('Last seen')}
+          </Text>
+          <DateTime date={metric.lastSeen} timeZone />
+        </Flex>
+      ) : null}
+      {metric.count === undefined ? null : (
+        <Flex gap="xs" align="center">
+          <Text variant="muted" size="md">
+            {t('Times seen')}
+          </Text>
+          <Text size="md">{metric.count.toLocaleString()}</Text>
+        </Flex>
+      )}
     </Stack>
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -16,11 +16,14 @@ import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconCheckmark, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {prettifyTagKey} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useOverlay} from 'sentry/utils/useOverlay';
 import {usePrevious} from 'sentry/utils/usePrevious';
+import {useTraceMetricItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
+import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {canUseMetricsSidePanelUI} from 'sentry/views/explore/metrics/metricsFlags';
@@ -29,6 +32,7 @@ import {
   TraceMetricKnownFieldKey,
   type TraceMetricTypeValue,
 } from 'sentry/views/explore/metrics/types';
+import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 
 export const NONE_UNIT = 'none';
 
@@ -479,6 +483,80 @@ export function MetricSelector({
   );
 }
 
+function MetricAttributesSection({
+  metricName,
+  metricType,
+}: {
+  metricName: string;
+  metricType: string;
+}) {
+  const traceMetricFilter = createTraceMetricFilter({name: metricName, type: metricType});
+
+  const {attributes: stringAttrs, isLoading: stringLoading} =
+    useTraceMetricItemAttributes(
+      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
+      'string'
+    );
+  const {attributes: numberAttrs, isLoading: numberLoading} =
+    useTraceMetricItemAttributes(
+      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
+      'number'
+    );
+  const {attributes: booleanAttrs, isLoading: booleanLoading} =
+    useTraceMetricItemAttributes(
+      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
+      'boolean'
+    );
+
+  const isLoading = stringLoading || numberLoading || booleanLoading;
+
+  const attributeKeys = useMemo(() => {
+    const keys = new Set([
+      ...Object.keys(stringAttrs ?? {}),
+      ...Object.keys(numberAttrs ?? {}),
+      ...Object.keys(booleanAttrs ?? {}),
+    ]);
+    return [...keys]
+      .filter(key => !HiddenTraceMetricGroupByFields.includes(key))
+      .sort((a, b) => prettifyTagKey(a).localeCompare(prettifyTagKey(b)));
+  }, [stringAttrs, numberAttrs, booleanAttrs]);
+
+  if (isLoading) {
+    return (
+      <Stack gap="xs">
+        <Text size="md">{t('Attributes')}:</Text>
+        <Flex gap="xs">
+          <LoadingIndicator size={16} />
+        </Flex>
+      </Stack>
+    );
+  }
+
+  if (attributeKeys.length === 0) {
+    return (
+      <Stack gap="xs">
+        <Text size="md">{t('Attributes')}:</Text>
+        <Flex gap="xs">
+          <Text size="md">{t('No attributes found')}</Text>
+        </Flex>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="xs">
+      <Text size="md">{t('Attributes')}:</Text>
+      <Flex wrap="wrap" gap="xs">
+        {attributeKeys.map(key => (
+          <Tag key={key} variant="muted">
+            {prettifyTagKey(key)}
+          </Tag>
+        ))}
+      </Flex>
+    </Stack>
+  );
+}
+
 function MetricDetailPanel({
   metric,
   hasMetricUnitsUI,
@@ -529,6 +607,10 @@ function MetricDetailPanel({
           <Text size="md">{metric.count.toLocaleString()}</Text>
         </Flex>
       )}
+      <MetricAttributesSection
+        metricName={metric.metricName}
+        metricType={metric.metricType}
+      />
     </Stack>
   );
 }

--- a/tests/js/fixtures/tracemetrics.ts
+++ b/tests/js/fixtures/tracemetrics.ts
@@ -270,11 +270,13 @@ export function createTraceMetricFixtures(
     TraceMetricKnownFieldKey.METRIC_VALUE,
     TraceMetricKnownFieldKey.TIMESTAMP,
     TraceMetricKnownFieldKey.TRACE,
+    `count(${TraceMetricKnownFieldKey.METRIC_NAME})`,
+    `max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`,
   ];
 
   const baseFieldKeys = options.baseFields || defaultBaseFields;
 
-  const metricData: Array<Partial<Record<TraceMetricKnownFieldKey, string | number>>> = [
+  const metricData: Array<Partial<Record<string, string | number>>> = [
     {
       [TraceMetricKnownFieldKey.ID]: '1',
       [TraceMetricKnownFieldKey.PROJECT_ID]: project.id,
@@ -288,6 +290,8 @@ export function createTraceMetricFixtures(
       [TraceMetricKnownFieldKey.RELEASE]: '1.0.0',
       [TraceMetricKnownFieldKey.SDK_NAME]: 'sentry.python',
       [TraceMetricKnownFieldKey.SDK_VERSION]: '1.0.0',
+      [`count(${TraceMetricKnownFieldKey.METRIC_NAME})`]: 100,
+      [`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]: 1736507580000000000,
     },
     {
       [TraceMetricKnownFieldKey.ID]: '2',
@@ -302,6 +306,8 @@ export function createTraceMetricFixtures(
       [TraceMetricKnownFieldKey.RELEASE]: '1.0.0',
       [TraceMetricKnownFieldKey.SDK_NAME]: 'sentry.python',
       [TraceMetricKnownFieldKey.SDK_VERSION]: '1.0.0',
+      [`count(${TraceMetricKnownFieldKey.METRIC_NAME})`]: 50,
+      [`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]: 1736507580000000000,
     },
     {
       [TraceMetricKnownFieldKey.ID]: '3',
@@ -316,6 +322,8 @@ export function createTraceMetricFixtures(
       [TraceMetricKnownFieldKey.RELEASE]: '1.0.0',
       [TraceMetricKnownFieldKey.SDK_NAME]: 'sentry.python',
       [TraceMetricKnownFieldKey.SDK_VERSION]: '1.0.0',
+      [`count(${TraceMetricKnownFieldKey.METRIC_NAME})`]: 200,
+      [`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]: 1736507580000000000,
     },
     {
       [TraceMetricKnownFieldKey.ID]: '4',
@@ -330,6 +338,8 @@ export function createTraceMetricFixtures(
       [TraceMetricKnownFieldKey.RELEASE]: '1.0.1',
       [TraceMetricKnownFieldKey.SDK_NAME]: 'sentry.python',
       [TraceMetricKnownFieldKey.SDK_VERSION]: '1.0.0',
+      [`count(${TraceMetricKnownFieldKey.METRIC_NAME})`]: 75,
+      [`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]: 1736507580000000000,
     },
     {
       [TraceMetricKnownFieldKey.ID]: '5',
@@ -344,6 +354,8 @@ export function createTraceMetricFixtures(
       [TraceMetricKnownFieldKey.RELEASE]: '1.0.1',
       [TraceMetricKnownFieldKey.SDK_NAME]: 'sentry.python',
       [TraceMetricKnownFieldKey.SDK_VERSION]: '1.0.0',
+      [`count(${TraceMetricKnownFieldKey.METRIC_NAME})`]: 30,
+      [`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]: 1736507580000000000,
     },
     {
       [TraceMetricKnownFieldKey.ID]: '6',
@@ -358,6 +370,8 @@ export function createTraceMetricFixtures(
       [TraceMetricKnownFieldKey.RELEASE]: '1.0.1',
       [TraceMetricKnownFieldKey.SDK_NAME]: 'sentry.python',
       [TraceMetricKnownFieldKey.SDK_VERSION]: '1.0.0',
+      [`count(${TraceMetricKnownFieldKey.METRIC_NAME})`]: 150,
+      [`max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`]: 1736507580000000000,
     },
   ];
 


### PR DESCRIPTION
Adds additional metadata to the metric selector side panel to give users more context about a metric at a glance.

**Last seen** (`max(timestamp_precise)`) and **times seen** (`count(metric.name)`) are now requested alongside the existing metric options query and displayed in the detail panel. The `timestamp_precise` value is stored in nanoseconds and is converted to milliseconds for display.

**Attributes** are loaded lazily by fetching string, number, and boolean attributes filtered to the selected metric. This is gated behind the `tracemetrics-attributes-dropdown-side-panel` feature flag. Hidden/internal fields are filtered out before display.

Also fixes long metric names overflowing the panel by adding `wordBreak="break-all"`.

Closes LOGS-597, LOGS-598, and LOGS-596

Example side panel:
<img width="274" height="299" alt="Screenshot 2026-03-17 at 14 26 02" src="https://github.com/user-attachments/assets/15acca7b-5473-42aa-9ae5-bddc32bb94b1" />
