### PR TITLE
feat(insights): Add banner to Mobile Overview page linking to Mobile Vitals Dashboard

### DIFF
--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
+import {Link} from '@sentry/scraps/link';
+
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
@@ -9,6 +12,7 @@ import {
 } from 'sentry/components/pageFilters/date/datePageFilter';
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {t} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
@@ -27,6 +31,8 @@ import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 import {InsightsEnvironmentSelector} from 'sentry/views/insights/common/components/enviornmentSelector';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
@@ -36,6 +42,7 @@ import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
+import {useHasPlatformizedInsights} from 'sentry/views/insights/common/utils/useHasPlatformizedInsights';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {Am1MobileOverviewPage} from 'sentry/views/insights/pages/mobile/am1OverviewPage';
@@ -66,6 +73,30 @@ import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets
 import {LegacyOnboarding} from 'sentry/views/performance/onboarding';
 import {ProjectPerformanceType} from 'sentry/views/performance/utils';
 
+function MobileVitalsBanner() {
+  const organization = useOrganization();
+  const {dashboard, isLoading} = useGetPrebuiltDashboard(
+    PrebuiltDashboardId.MOBILE_VITALS
+  );
+
+  if (isLoading || !dashboard?.id) {
+    return null;
+  }
+
+  return (
+    <ModuleLayout.Full>
+      <Alert variant="info" showIcon>
+        {t(
+          'This page is no longer being updated. For more detailed mobile performance metrics, visit the '
+        )}
+        <Link to={`/organizations/${organization.slug}/dashboards/${dashboard.id}/`}>
+          {t('Mobile Vitals Dashboard')}
+        </Link>
+      </Alert>
+    </ModuleLayout.Full>
+  );
+}
+
 interface EAPMobileOverviewPageProps {
   datePageFilterProps: DatePageFilterProps;
 }
@@ -73,6 +104,7 @@ interface EAPMobileOverviewPageProps {
 function EAPMobileOverviewPage({datePageFilterProps}: EAPMobileOverviewPageProps) {
   useOverviewPageTrackPageload();
 
+  const hasPlatformizedInsights = useHasPlatformizedInsights();
   const organization = useOrganization();
   const location = useLocation();
   const {projects} = useProjects();
@@ -247,6 +279,7 @@ function EAPMobileOverviewPage({datePageFilterProps}: EAPMobileOverviewPageProps
               </ToolRibbon>
             </ModuleLayout.Full>
             <PageAlert />
+            {hasPlatformizedInsights && <MobileVitalsBanner />}
             <ModuleLayout.Full>
               {showOnboarding ? (
                 <LegacyOnboarding

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -12,7 +12,7 @@ import {
 } from 'sentry/components/pageFilters/date/datePageFilter';
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {t} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
@@ -86,12 +86,16 @@ function MobileVitalsBanner() {
   return (
     <ModuleLayout.Full>
       <Alert variant="info" showIcon>
-        {t(
-          'This page is no longer being updated. For more detailed mobile performance metrics, visit the '
+        {tct(
+          'This page is no longer being updated. For more detailed mobile performance metrics, visit the [link:Mobile Vitals Dashboard].',
+          {
+            link: (
+              <Link
+                to={`/organizations/${organization.slug}/dashboards/${dashboard.id}/`}
+              />
+            ),
+          }
         )}
-        <Link to={`/organizations/${organization.slug}/dashboards/${dashboard.id}/`}>
-          {t('Mobile Vitals Dashboard')}
-        </Link>
       </Alert>
     </ModuleLayout.Full>
   );


### PR DESCRIPTION
Add an info banner to the EAP Mobile Overview page that directs users to the prebuilt Mobile Vitals Dashboard. The Mobile Overview page is no longer being updated, so this guides users toward the newer, more detailed Mobile Vitals experience.

<img width="2444" height="624" alt="image" src="https://github.com/user-attachments/assets/e22323b0-0f36-4d83-99ad-f719c08b225d" />


The banner uses `useGetPrebuiltDashboard` to resolve the actual dashboard ID and links directly to the dashboards view. It only renders when the org has platformized insights enabled (`useHasPlatformizedInsights`).

Refs DAIN-1352