### PR TITLE
chore(dashboards): Remove dashboards-prebuilt-controls feature flag (frontend)

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -87,10 +87,6 @@ export function Controls({
   const {teams: userTeams} = useUserTeams();
   const api = useApi();
   const navigate = useNavigate();
-  const hasPrebuiltControlsFeature = organization.features.includes(
-    'dashboards-prebuilt-controls'
-  );
-
   const {duplicatePrebuiltDashboard, isLoading: isLoadingDuplicatePrebuiltDashboard} =
     useDuplicatePrebuiltDashboard({
       onSuccess: (newDashboard: DashboardDetails) => {
@@ -99,10 +95,6 @@ export function Controls({
     });
 
   const isPrebuiltDashboard = defined(dashboard.prebuiltId);
-
-  if (isPrebuiltDashboard && !hasPrebuiltControlsFeature) {
-    return null;
-  }
 
   if ([DashboardState.EDIT, DashboardState.PENDING_DELETE].includes(dashboardState)) {
     return (

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -14,7 +14,7 @@ import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import Placeholder from 'sentry/components/placeholder';
 import TimeSince from 'sentry/components/timeSince';
 import {IconEllipsis} from 'sentry/icons';
-import {t, tct, tn} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -28,7 +28,6 @@ import {
   MINIMUM_DASHBOARD_CARD_WIDTH,
 } from 'sentry/views/dashboards/manage/settings';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
-import {PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 
 import {DashboardCard} from './dashboardCard';
 import {GridPreview} from './gridPreview';
@@ -91,19 +90,13 @@ function DashboardGrid({
   }
 
   function renderDropdownMenu(dashboard: DashboardListItem, dashboardLimitData: any) {
-    const shouldDisablePrebuiltControls =
-      defined(dashboard.prebuiltId) &&
-      !organization.features.includes('dashboards-prebuilt-controls');
     const {
       hasReachedDashboardLimit,
       isLoading: isLoadingDashboardsLimit,
       limitMessage,
     } = dashboardLimitData;
 
-    const disableDuplicate =
-      hasReachedDashboardLimit ||
-      isLoadingDashboardsLimit ||
-      shouldDisablePrebuiltControls;
+    const disableDuplicate = hasReachedDashboardLimit || isLoadingDashboardsLimit;
 
     const disableDelete = defined(dashboard.prebuiltId);
 
@@ -119,11 +112,7 @@ function DashboardGrid({
           });
         },
         disabled: disableDuplicate,
-        tooltip: shouldDisablePrebuiltControls
-          ? tct('[label] dashboards cannot be duplicated', {
-              label: PREBUILT_DASHBOARD_LABEL,
-            })
-          : limitMessage,
+        tooltip: limitMessage,
         tooltipOptions: {
           isHoverable: true,
         },
@@ -140,9 +129,6 @@ function DashboardGrid({
           });
         },
         disabled: disableDelete,
-        tooltip: shouldDisablePrebuiltControls
-          ? tct('[label] dashboards cannot be deleted', {label: PREBUILT_DASHBOARD_LABEL})
-          : undefined,
       },
     ];
 

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -296,20 +296,9 @@ function DashboardTable({
                   data-test-id="dashboard-duplicate"
                   icon={<IconCopy />}
                   size="sm"
-                  disabled={
-                    hasReachedDashboardLimit ||
-                    isLoadingDashboardsLimit ||
-                    (defined(dataRow.prebuiltId) &&
-                      !organization.features.includes('dashboards-prebuilt-controls'))
-                  }
+                  disabled={hasReachedDashboardLimit || isLoadingDashboardsLimit}
                   tooltipProps={{
-                    title:
-                      defined(dataRow.prebuiltId) &&
-                      !organization.features.includes('dashboards-prebuilt-controls')
-                        ? tct('[label] dashboards cannot be duplicated', {
-                            label: PREBUILT_DASHBOARD_LABEL,
-                          })
-                        : limitMessage,
+                    title: limitMessage,
                   }}
                 />
               )}


### PR DESCRIPTION
Removes all frontend checks for the `organizations:dashboards-prebuilt-controls` feature flag, making the prebuilt dashboard controls (duplicate and edit) permanently available.

The flag has been fully rolled out to all users, so these guards are no longer needed. The feature-enabled code paths are kept as-is; only the conditional checks and their disabled/fallback branches are removed.

Part of feature flag cleanup:
- Backend (flag declaration removal): getsentry/sentry#110891
- sentry-options-automator (flag definition removal): https://github.com/getsentry/sentry-options-automator/pull/6860