### PR TITLE
ref(dashboards): Use PREBUILT_DASHBOARD_LABEL for owner tooltip

### DIFF
--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -231,7 +231,7 @@ function DashboardTable({
         </Flex>
       ) : (
         <Flex justify="between" align="center" gap="3xl">
-          <Tooltip title="Sentry">
+          <Tooltip title={PREBUILT_DASHBOARD_LABEL}>
             <ActivityAvatar type="system" size={26} />
           </Tooltip>
         </Flex>

--- a/static/app/views/dashboards/manage/tableView/table.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.tsx
@@ -19,6 +19,7 @@ import {useDeleteDashboard} from 'sentry/views/dashboards/hooks/useDeleteDashboa
 import {useDuplicateDashboard} from 'sentry/views/dashboards/hooks/useDuplicateDashboard';
 import {useResetDashboardLists} from 'sentry/views/dashboards/hooks/useResetDashboardLists';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import {PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 
 export interface DashboardTableProps {
   cursorKey: string;
@@ -136,7 +137,7 @@ export function DashboardTable({
             </SavedEntityTable.Cell>
             <SavedEntityTable.Cell data-column="created-by">
               {dashboard.createdBy === null ? (
-                <Tooltip title="Sentry">
+                <Tooltip title={PREBUILT_DASHBOARD_LABEL}>
                   <ActivityAvatar type="system" size={20} />
                 </Tooltip>
               ) : dashboard.createdBy ? (


### PR DESCRIPTION
Updates the owner avatar tooltip on the dashboards list page from "Sentry" to "Sentry Built" for prebuilt dashboards, using the shared `PREBUILT_DASHBOARD_LABEL` constant for consistency with the sidebar navigation, page titles, and action tooltips.

Applies to both the legacy table view (`dashboardTable.tsx`) and the new table view (`tableView/table.tsx`).

Refs LINEAR-DAIN-1259