### PR TITLE
ref(rr6): Remove useRouter from pageFilters actions

### DIFF
--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -5,6 +5,7 @@ import type {
   ToolboxComponentOption,
   XAXisComponentOption,
 } from 'echarts';
+import type {Location} from 'history';
 import moment, {type MomentInput} from 'moment-timezone';
 import * as qs from 'query-string';
 
@@ -18,10 +19,10 @@ import type {
   EChartFinishedHandler,
   EChartRestoreHandler,
 } from 'sentry/types/echarts';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import {getUtcDateString, getUtcToLocalDateObject} from 'sentry/utils/dates';
-// eslint-disable-next-line no-restricted-imports
-import {withSentryRouter} from 'sentry/utils/withSentryRouter';
+import {useLocation} from 'sentry/utils/useLocation';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 const getDate = (date: MomentInput) =>
   date ? moment.utc(date).format(moment.HTML5_FMT.DATETIME_LOCAL_SECONDS) : null;
@@ -52,6 +53,8 @@ export interface ZoomRenderProps extends Pick<Props, ZoomPropKeys> {
 
 type Props = {
   children: (props: ZoomRenderProps) => React.ReactNode;
+  location: Location;
+  navigate: ReactRouter3Navigate;
   disabled?: boolean;
   end?: DateString;
   onChartReady?: EChartChartReadyHandler;
@@ -60,7 +63,6 @@ type Props = {
   onRestore?: EChartRestoreHandler;
   onZoom?: (period: Period) => void;
   period?: string | null;
-  router?: InjectedRouter;
   saveOnZoom?: boolean;
   start?: DateString;
   usePageDate?: boolean;
@@ -135,7 +137,7 @@ class ChartZoom extends Component<Props> {
    * Saves a callback function to be called after chart animation is completed
    */
   setPeriod = ({period, start, end}: any, saveHistory = false) => {
-    const {router, onZoom, usePageDate, saveOnZoom} = this.props;
+    const {location, navigate, onZoom, usePageDate, saveOnZoom} = this.props;
     const startFormatted = getDate(start);
     const endFormatted = getDate(end);
 
@@ -156,20 +158,17 @@ class ChartZoom extends Component<Props> {
       end: endFormatted,
     });
 
-    if (usePageDate && router) {
+    if (usePageDate) {
       const newQuery = {
-        ...router.location.query,
+        ...location.query,
         pageStart: start ? getUtcDateString(start) : undefined,
         pageEnd: end ? getUtcDateString(end) : undefined,
         pageStatsPeriod: period ?? undefined,
       };
 
       // Only push new location if query params has changed because this will cause a heavy re-render
-      if (qs.stringify(newQuery) !== qs.stringify(router.location.query)) {
-        router.push({
-          pathname: router.location.pathname,
-          query: newQuery,
-        });
+      if (qs.stringify(newQuery) !== qs.stringify(location.query)) {
+        navigate({pathname: location.pathname, query: newQuery});
       }
     } else {
       updateDateTime(
@@ -180,7 +179,8 @@ class ChartZoom extends Component<Props> {
             : startFormatted,
           end: endFormatted ? getUtcToLocalDateObject(endFormatted) : endFormatted,
         },
-        router,
+        location,
+        navigate,
         {save: saveOnZoom}
       );
     }
@@ -317,7 +317,6 @@ class ChartZoom extends Component<Props> {
       children,
       xAxisIndex,
 
-      router: _router,
       onZoom: _onZoom,
       onRestore: _onRestore,
       onChartReady: _onChartReady,
@@ -377,6 +376,14 @@ class ChartZoom extends Component<Props> {
 }
 
 /**
+ * Wrapper that injects `navigate` and `location` hooks into ChartZoom.
  * @deprecated use useChartZoom instead
  */
-export default withSentryRouter(ChartZoom);
+function ChartZoomWithHooks(props: Omit<Props, 'navigate' | 'location'>) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  return <ChartZoom {...props} navigate={navigate} location={location} />;
+}
+
+// eslint-disable-next-line @sentry/no-default-exports
+export default ChartZoomWithHooks;

--- a/static/app/components/charts/useChartZoom.tsx
+++ b/static/app/components/charts/useChartZoom.tsx
@@ -14,7 +14,6 @@ import type {
 import {getUtcDateString} from 'sentry/utils/dates';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import {useRouter} from 'sentry/utils/useRouter';
 
 // TODO: replace usages of ChartZoom with useChartZoom
 
@@ -131,7 +130,6 @@ export function useChartZoom({
   const {handleChartReady} = useChartZoomCancel();
   const location = useLocation();
   const navigate = useNavigate();
-  const router = useRouter();
 
   /**
    * Sets the new period due to a zoom related action
@@ -181,12 +179,13 @@ export function useChartZoom({
             start: startFormatted,
             end: endFormatted,
           },
-          router,
+          location,
+          navigate,
           {save: saveOnZoom}
         );
       }
     },
-    [onZoom, navigate, location, router, saveOnZoom, usePageDate]
+    [onZoom, navigate, location, saveOnZoom, usePageDate]
   );
 
   const handleDataZoom = useCallback<EChartDataZoomHandler>(

--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -6,7 +6,8 @@ import moment from 'moment-timezone';
 
 import {DateTime} from 'sentry/components/dateTime';
 import {updateDateTime} from 'sentry/components/pageFilters/actions';
-import {useRouter} from 'sentry/utils/useRouter';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {useTimelineCursor, type CursorOffsets} from './timelineCursor';
 import {useTimelineZoom} from './timelineZoom';
@@ -227,7 +228,8 @@ export function GridLineOverlay({
   labelPosition = 'left-top',
   resetPaginationOnZoom,
 }: GridLineOverlayProps) {
-  const router = useRouter();
+  const location = useLocation();
+  const navigate = useNavigate();
   const {periodStart, timelineWidth, dateLabelFormat, rollupConfig, timezone} =
     timeWindowConfig;
   const {timelineUnderscanWidth} = rollupConfig;
@@ -257,10 +259,11 @@ export function GridLineOverlay({
           start: dateFromPosition(startX).startOf('minute').toDate(),
           end: dateFromPosition(endX).add(1, 'minute').startOf('minute').toDate(),
         },
-        router,
+        location,
+        navigate,
         {keepCursor: !resetPaginationOnZoom}
       ),
-    [dateFromPosition, resetPaginationOnZoom, router]
+    [dateFromPosition, resetPaginationOnZoom, location, navigate]
   );
 
   const {

--- a/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
+++ b/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
@@ -3,7 +3,8 @@ import moment from 'moment-timezone';
 
 import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import {getDuration} from 'sentry/utils/duration/getDuration';
-import {useRouter} from 'sentry/utils/useRouter';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {usePageFilterDates} from './useMonitorDates';
 
@@ -29,7 +30,8 @@ export interface DateNavigation {
 }
 
 export function useDateNavigation(): DateNavigation {
-  const router = useRouter();
+  const location = useLocation();
+  const navigate = useNavigate();
   const {since, until, now} = usePageFilterDates();
 
   const windowMs = until.getTime() - since.getTime();
@@ -38,8 +40,12 @@ export function useDateNavigation(): DateNavigation {
     const nextUntil = moment(until).subtract(windowMs, 'milliseconds');
     const nextSince = moment(nextUntil).subtract(windowMs, 'milliseconds');
 
-    updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, router);
-  }, [windowMs, router, until]);
+    updateDateTime(
+      {start: nextSince.toDate(), end: nextUntil.toDate()},
+      location,
+      navigate
+    );
+  }, [windowMs, location, navigate, until]);
 
   const navigateToNextPeriod = useCallback(() => {
     // Do not navigate past the current time
@@ -49,10 +55,15 @@ export function useDateNavigation(): DateNavigation {
     );
     const nextSince = moment(nextUntil).subtract(windowMs, 'milliseconds');
 
-    updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, router, {
-      keepCursor: true,
-    });
-  }, [until, windowMs, now, router]);
+    updateDateTime(
+      {start: nextSince.toDate(), end: nextUntil.toDate()},
+      location,
+      navigate,
+      {
+        keepCursor: true,
+      }
+    );
+  }, [until, windowMs, now, location, navigate]);
 
   return {
     endIsNow: until.getTime() === now.getTime(),

--- a/static/app/components/pageFilters/actions.spec.tsx
+++ b/static/app/components/pageFilters/actions.spec.tsx
@@ -39,10 +39,12 @@ describe('PageFilters ActionCreators', () => {
 
   describe('initializeUrlState', () => {
     let router: ReturnType<typeof RouterFixture>;
+    let navigate: jest.Mock;
     const key = `global-selection:${organization.slug}`;
 
     beforeEach(() => {
       router = RouterFixture();
+      navigate = jest.fn();
       localStorageWrapper.setItem(
         key,
         JSON.stringify({
@@ -63,8 +65,8 @@ describe('PageFilters ActionCreators', () => {
       );
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: projects,
         nonMemberProjects: [],
       });
@@ -79,13 +81,14 @@ describe('PageFilters ActionCreators', () => {
         }),
         true
       );
-      expect(router.replace).toHaveBeenCalledWith(
+      expect(navigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
             environment: [],
             project: ['1'],
           },
-        })
+        }),
+        {replace: true}
       );
     });
 
@@ -93,11 +96,11 @@ describe('PageFilters ActionCreators', () => {
       jest.spyOn(localStorageWrapper, 'getItem');
       initializeUrlState({
         organization,
-        queryParams: {},
+        location: router.location,
         skipLoadLastUsed: true,
         memberProjects: projects,
         nonMemberProjects: [],
-        router,
+        navigate,
       });
 
       expect(localStorageWrapper.getItem).not.toHaveBeenCalled();
@@ -115,9 +118,9 @@ describe('PageFilters ActionCreators', () => {
 
       initializeUrlState({
         organization,
-        queryParams: {},
+        location: router.location,
         shouldPersist: false,
-        router,
+        navigate,
         memberProjects: projects,
         nonMemberProjects: [],
       });
@@ -136,7 +139,7 @@ describe('PageFilters ActionCreators', () => {
 
       await act(async () => {
         // Filters shouldn't persist even when `save` is true
-        updateProjects([1], router, {save: true});
+        updateProjects([1], router.location, navigate, {save: true});
 
         // Page filter values are asynchronously persisted to local storage after a tick,
         // so we need to wait before checking for commits to local storage
@@ -150,12 +153,10 @@ describe('PageFilters ActionCreators', () => {
     it('does not change dates with no query params or defaultSelection', () => {
       initializeUrlState({
         organization,
-        queryParams: {
-          project: '1',
-        },
+        location: {...router.location, query: {project: '1'}},
         memberProjects: projects,
         nonMemberProjects: [],
-        router,
+        navigate,
       });
       expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -173,9 +174,7 @@ describe('PageFilters ActionCreators', () => {
     it('does changes to default dates with defaultSelection and no query params', () => {
       initializeUrlState({
         organization,
-        queryParams: {
-          project: '1',
-        },
+        location: {...router.location, query: {project: '1'}},
         memberProjects: projects,
         nonMemberProjects: [],
         defaultSelection: {
@@ -186,7 +185,7 @@ describe('PageFilters ActionCreators', () => {
             end: null,
           },
         },
-        router,
+        navigate,
       });
       expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -204,10 +203,7 @@ describe('PageFilters ActionCreators', () => {
     it('uses query params statsPeriod over defaults', () => {
       initializeUrlState({
         organization,
-        queryParams: {
-          statsPeriod: '1h',
-          project: '1',
-        },
+        location: {...router.location, query: {statsPeriod: '1h', project: '1'}},
         memberProjects: projects,
         nonMemberProjects: [],
         defaultSelection: {
@@ -218,27 +214,24 @@ describe('PageFilters ActionCreators', () => {
             end: null,
           },
         },
-        router,
+        navigate,
       });
-      expect(router.replace).toHaveBeenCalledWith(
+      // Navigate is not called because URL already has the correct query params
+      expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {
-            cursor: undefined,
-            project: ['1'],
-            environment: [],
-            statsPeriod: '1h',
-          },
-        })
+          datetime: expect.objectContaining({period: '1h'}),
+          projects: [1],
+        }),
+        true
       );
     });
 
     it('uses absolute dates over defaults', () => {
       initializeUrlState({
         organization,
-        queryParams: {
-          start: '2020-03-22T00:53:38',
-          end: '2020-04-21T00:53:38',
-          project: '1',
+        location: {
+          ...router.location,
+          query: {start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38', project: '1'},
         },
         memberProjects: projects,
         nonMemberProjects: [],
@@ -250,30 +243,28 @@ describe('PageFilters ActionCreators', () => {
             end: null,
           },
         },
-        router,
+        navigate,
       });
-      expect(router.replace).toHaveBeenCalledWith(
+      // Navigate is not called because URL already has the correct query params
+      expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {
-            cursor: undefined,
-            project: ['1'],
-            environment: [],
-            start: '2020-03-22T00:53:38',
-            end: '2020-04-21T00:53:38',
-          },
-        })
+          datetime: expect.objectContaining({
+            start: expect.any(Date),
+            end: expect.any(Date),
+          }),
+          projects: [1],
+        }),
+        true
       );
     });
 
     it('does not load from local storage when there are query params', () => {
       initializeUrlState({
         organization,
-        queryParams: {
-          project: '1',
-        },
+        location: {...router.location, query: {project: '1'}},
         memberProjects: projects,
         nonMemberProjects: [],
-        router,
+        navigate,
       });
 
       expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
@@ -289,25 +280,15 @@ describe('PageFilters ActionCreators', () => {
         },
         true
       );
-      expect(router.replace).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: {
-            environment: [],
-            project: ['1'],
-          },
-        })
-      );
     });
 
     it('does not invalidate all projects from query params', () => {
       initializeUrlState({
         organization,
-        queryParams: {
-          project: '-1',
-        },
+        location: {...router.location, query: {project: '-1'}},
         memberProjects: projects,
         nonMemberProjects: [],
-        router,
+        navigate,
       });
       expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
         {
@@ -343,14 +324,14 @@ describe('PageFilters ActionCreators', () => {
       // Initialize state with a page that shouldn't restore from local storage
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: projects,
         nonMemberProjects: [],
       });
 
       // Confirm that query params are not restored from local storage
-      expect(router.replace).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
 
       pageFilterStorageMock.mockRestore();
     });
@@ -359,8 +340,8 @@ describe('PageFilters ActionCreators', () => {
       const nonMemberProject = ProjectFixture({isMember: false});
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: [],
         nonMemberProjects: [nonMemberProject],
       });
@@ -378,8 +359,8 @@ describe('PageFilters ActionCreators', () => {
       const nonMemberProject2 = ProjectFixture({id: '11', isMember: false});
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: [],
         nonMemberProjects: [nonMemberProject1, nonMemberProject2],
       });
@@ -401,8 +382,8 @@ describe('PageFilters ActionCreators', () => {
       const nonMemberProject = ProjectFixture({isMember: false});
       initializeUrlState({
         organization: superuserOrg,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: [],
         nonMemberProjects: [nonMemberProject],
       });
@@ -419,8 +400,8 @@ describe('PageFilters ActionCreators', () => {
       const singleProject = ProjectFixture({id: '42', isMember: true});
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: [singleProject],
         nonMemberProjects: [],
       });
@@ -436,8 +417,8 @@ describe('PageFilters ActionCreators', () => {
     it('does not auto-select when there are multiple projects', () => {
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: projects,
         nonMemberProjects: [],
       });
@@ -469,21 +450,22 @@ describe('PageFilters ActionCreators', () => {
       // Initialize state with a page that uses pinned filters
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: projects,
         nonMemberProjects: [],
       });
 
       // Confirm that only environment is restored from local storage
-      expect(router.replace).toHaveBeenCalledWith(
+      expect(navigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
             environment: ['prod'],
             project: ['1'],
             statsPeriod: '7d',
           },
-        })
+        }),
+        {replace: true}
       );
 
       pageFilterStorageMock.mockRestore();
@@ -509,8 +491,8 @@ describe('PageFilters ActionCreators', () => {
 
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: projects,
         nonMemberProjects: [],
         storageNamespace,
@@ -531,14 +513,15 @@ describe('PageFilters ActionCreators', () => {
         }),
         true
       );
-      expect(router.replace).toHaveBeenCalledWith(
+      expect(navigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
             environment: [],
             project: ['1'],
             statsPeriod: '30d',
           },
-        })
+        }),
+        {replace: true}
       );
     });
 
@@ -574,8 +557,8 @@ describe('PageFilters ActionCreators', () => {
 
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: projects,
         nonMemberProjects: [],
         storageNamespace,
@@ -596,14 +579,15 @@ describe('PageFilters ActionCreators', () => {
         }),
         true
       );
-      expect(router.replace).toHaveBeenCalledWith(
+      expect(navigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
             environment: [],
             project: [],
             statsPeriod: '30d',
           },
-        })
+        }),
+        {replace: true}
       );
     });
 
@@ -620,8 +604,8 @@ describe('PageFilters ActionCreators', () => {
 
       initializeUrlState({
         organization,
-        queryParams: {},
-        router,
+        location: router.location,
+        navigate,
         memberProjects: projects,
         nonMemberProjects: [],
         storageNamespace: 'insights',
@@ -635,13 +619,14 @@ describe('PageFilters ActionCreators', () => {
         }),
         true
       );
-      expect(router.replace).toHaveBeenCalledWith(
+      expect(navigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
             environment: [],
             project: ['1'],
           },
-        })
+        }),
+        {replace: true}
       );
     });
   });
@@ -653,126 +638,118 @@ describe('PageFilters ActionCreators', () => {
     });
 
     it('updates history when queries are different', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {project: '2'},
-        },
-      });
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {project: '2'}},
+      }).location;
       // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
       // however react-router will treat it as a string if there is only one param
-      updateProjects([1], router);
+      updateProjects([1], location, nav);
 
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {project: ['1']},
-      });
+      expect(nav).toHaveBeenCalledWith(
+        {pathname: '/test/', query: {project: ['1']}},
+        {replace: false}
+      );
     });
     it('does not update history when queries are the same', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {project: '1'},
-        },
-      });
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {project: '1'}},
+      }).location;
       // this can be passed w/ `project` as an array (e.g. multiple projects
       // being selected) however react-router will treat it as a string if
       // there is only one param
-      updateProjects([1], router);
+      updateProjects([1], location, nav);
 
-      expect(router.push).not.toHaveBeenCalled();
+      expect(nav).not.toHaveBeenCalled();
     });
 
     it('updates history when queries are different with replace', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {project: '2'},
-        },
-      });
-      updateProjects([1], router, {replace: true});
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {project: '2'}},
+      }).location;
+      updateProjects([1], location, nav, {replace: true});
 
-      expect(router.replace).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {project: ['1']},
-      });
+      expect(nav).toHaveBeenCalledWith(
+        {pathname: '/test/', query: {project: ['1']}},
+        {replace: true}
+      );
     });
 
     it('does not update history when queries are the same with replace', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {project: '1'},
-        },
-      });
-      updateProjects([1], router, {replace: true});
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {project: '1'}},
+      }).location;
+      updateProjects([1], location, nav, {replace: true});
 
-      expect(router.replace).not.toHaveBeenCalled();
+      expect(nav).not.toHaveBeenCalled();
     });
 
     it('does not override an absolute date selection', () => {
-      const router = RouterFixture({
+      const nav = jest.fn();
+      const location = RouterFixture({
         location: {
           pathname: '/test/',
           query: {project: '1', start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},
         },
-      });
-      updateProjects([2], router, {replace: true});
+      }).location;
+      updateProjects([2], location, nav, {replace: true});
 
-      expect(router.replace).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {project: ['2'], start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},
-      });
+      expect(nav).toHaveBeenCalledWith(
+        {
+          pathname: '/test/',
+          query: {
+            project: ['2'],
+            start: '2020-03-22T00:53:38',
+            end: '2020-04-21T00:53:38',
+          },
+        },
+        {replace: true}
+      );
     });
   });
 
   describe('updateEnvironments()', () => {
     it('updates single', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {environment: 'test'},
-        },
-      });
-      updateEnvironments(['new-env'], router);
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {environment: 'test'}},
+      }).location;
+      updateEnvironments(['new-env'], location, nav);
 
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {environment: ['new-env']},
-      });
+      expect(nav).toHaveBeenCalledWith(
+        {pathname: '/test/', query: {environment: ['new-env']}},
+        {replace: false}
+      );
     });
 
     it('updates multiple', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {environment: 'test'},
-        },
-      });
-      updateEnvironments(['new-env', 'another-env'], router);
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {environment: 'test'}},
+      }).location;
+      updateEnvironments(['new-env', 'another-env'], location, nav);
 
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {environment: ['new-env', 'another-env']},
-      });
+      expect(nav).toHaveBeenCalledWith(
+        {pathname: '/test/', query: {environment: ['new-env', 'another-env']}},
+        {replace: false}
+      );
     });
 
     it('removes environment', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {environment: 'test'},
-        },
-      });
-      updateEnvironments(null, router);
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {},
-      });
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {environment: 'test'}},
+      }).location;
+      updateEnvironments(null, location, nav);
+      expect(nav).toHaveBeenCalledWith({pathname: '/test/', query: {}}, {replace: false});
     });
 
     it('does not override an absolute date selection', () => {
-      const router = RouterFixture({
+      const nav = jest.fn();
+      const location = RouterFixture({
         location: {
           pathname: '/test/',
           query: {
@@ -781,71 +758,68 @@ describe('PageFilters ActionCreators', () => {
             end: '2020-04-21T00:53:38',
           },
         },
-      });
-      updateEnvironments(['new-env'], router, {replace: true});
+      }).location;
+      updateEnvironments(['new-env'], location, nav, {replace: true});
 
-      expect(router.replace).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {
-          environment: ['new-env'],
-          start: '2020-03-22T00:53:38',
-          end: '2020-04-21T00:53:38',
+      expect(nav).toHaveBeenCalledWith(
+        {
+          pathname: '/test/',
+          query: {
+            environment: ['new-env'],
+            start: '2020-03-22T00:53:38',
+            end: '2020-04-21T00:53:38',
+          },
         },
-      });
+        {replace: true}
+      );
     });
   });
 
   describe('updateDateTime()', () => {
     it('updates statsPeriod when there is no existing stats period', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {},
-        },
-      });
-      updateDateTime({period: '24h'}, router);
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {}},
+      }).location;
+      updateDateTime({period: '24h'}, location, nav);
 
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {
-          statsPeriod: '24h',
-        },
-      });
+      expect(nav).toHaveBeenCalledWith(
+        {pathname: '/test/', query: {statsPeriod: '24h'}},
+        {replace: false}
+      );
     });
 
     it('updates statsPeriod when there is an existing stats period', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {statsPeriod: '14d'},
-        },
-      });
-      updateDateTime({period: '24h'}, router);
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {statsPeriod: '14d'}},
+      }).location;
+      updateDateTime({period: '24h'}, location, nav);
 
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {
-          statsPeriod: '24h',
-        },
-      });
+      expect(nav).toHaveBeenCalledWith(
+        {pathname: '/test/', query: {statsPeriod: '24h'}},
+        {replace: false}
+      );
     });
 
     it('changes to absolute date', () => {
-      const router = RouterFixture({
-        location: {
-          pathname: '/test/',
-          query: {statsPeriod: '24h'},
-        },
-      });
-      updateDateTime({start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'}, router);
+      const nav = jest.fn();
+      const location = RouterFixture({
+        location: {pathname: '/test/', query: {statsPeriod: '24h'}},
+      }).location;
+      updateDateTime(
+        {start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},
+        location,
+        nav
+      );
 
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {
-          start: '2020-03-22T00:53:38',
-          end: '2020-04-21T00:53:38',
+      expect(nav).toHaveBeenCalledWith(
+        {
+          pathname: '/test/',
+          query: {start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},
         },
-      });
+        {replace: false}
+      );
     });
   });
 });

--- a/static/app/components/pageFilters/actions.tsx
+++ b/static/app/components/pageFilters/actions.tsx
@@ -23,12 +23,12 @@ import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import type {DateString, PageFilters, PinnedPageFilter} from 'sentry/types/core';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Environment, MinimalProject, Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 
 type EnvironmentId = Environment['id'];
 
@@ -74,11 +74,6 @@ type PageFiltersUpdate = {
 type DateTimeUpdate = Pick<PageFiltersUpdate, 'start' | 'end' | 'period' | 'utc'>;
 
 /**
- * This can be null which will not perform any router side effects, and instead updates store.
- */
-type Router = InjectedRouter | null | undefined;
-
-/**
  * Reset values in the page filters store
  */
 export function resetPageFilters() {
@@ -108,11 +103,11 @@ function mergeDatetime(
 }
 
 export type InitializeUrlStateParams = {
+  location: Location;
   memberProjects: Project[];
+  navigate: ReactRouter3Navigate;
   nonMemberProjects: Project[];
   organization: Organization;
-  queryParams: Location['query'];
-  router: InjectedRouter;
   defaultSelection?: Partial<PageFilters>;
   forceProject?: MinimalProject | null;
   /**
@@ -155,8 +150,8 @@ export type InitializeUrlStateParams = {
 
 export function initializeUrlState({
   organization,
-  queryParams,
-  router,
+  location,
+  navigate,
   memberProjects,
   nonMemberProjects,
   skipLoadLastUsed,
@@ -171,6 +166,7 @@ export function initializeUrlState({
   storageNamespace,
 }: InitializeUrlStateParams) {
   const orgSlug = organization.slug;
+  const queryParams = location.query;
 
   const parsed = getStateFromQuery(queryParams, {
     allowAbsoluteDatetime: showAbsolute,
@@ -364,7 +360,7 @@ export function initializeUrlState({
       };
 
   if (!skipInitializeUrlParams) {
-    updateParams({project, environment, ...newDatetime}, router, {
+    updateParams({project, environment, ...newDatetime}, location, navigate, {
       replace: true,
       keepCursor: true,
     });
@@ -376,7 +372,7 @@ function isProjectsValid(projects: number[]) {
 }
 
 /**
- * Updates store and selection URL param if `router` is supplied
+ * Updates store and selection URL param if `location` and `navigate` is supplied
  *
  * This accepts `environments` from `options` to also update environments
  * simultaneously as environments are tied to a project, so if you change
@@ -384,7 +380,8 @@ function isProjectsValid(projects: number[]) {
  */
 export function updateProjects(
   projects: number[],
-  router?: Router,
+  location?: Location,
+  navigate?: ReactRouter3Navigate,
   options?: Options & {environments?: EnvironmentId[]}
 ) {
   if (!isProjectsValid(projects)) {
@@ -396,7 +393,12 @@ export function updateProjects(
   }
 
   PageFiltersStore.updateProjects(projects, options?.environments ?? null);
-  updateParams({project: projects, environment: options?.environments}, router, options);
+  updateParams(
+    {project: projects, environment: options?.environments},
+    location,
+    navigate,
+    options
+  );
   persistPageFilters('projects', options);
 
   if (options?.environments) {
@@ -405,39 +407,31 @@ export function updateProjects(
 }
 
 /**
- * Updates store and updates global environment selection URL param if `router` is supplied
- *
- * @param {String[]} environments List of environments
- * @param {Object} [router] Router object
- * @param {Object} [options] Options object
- * @param {String[]} [options.resetParams] List of parameters to remove when changing URL params
+ * Updates store and updates global environment selection URL param if `location` and `navigate` is supplied
  */
 export function updateEnvironments(
   environment: EnvironmentId[] | null,
-  router?: Router,
+  location?: Location,
+  navigate?: ReactRouter3Navigate,
   options?: Options
 ) {
   PageFiltersStore.updateEnvironments(environment);
-  updateParams({environment}, router, options);
+  updateParams({environment}, location, navigate, options);
   persistPageFilters('environments', options);
 }
 
 /**
- * Updates store and global datetime selection URL param if `router` is supplied
- *
- * @param {Object} datetime Object with start, end, range keys
- * @param {Object} [router] Router object
- * @param {Object} [options] Options object
- * @param {String[]} [options.resetParams] List of parameters to remove when changing URL params
+ * Updates store and global datetime selection URL param if `location` and `navigate` is supplied
  */
 export function updateDateTime(
   datetime: DateTimeUpdate,
-  router?: Router,
+  location?: Location,
+  navigate?: ReactRouter3Navigate,
   options?: Options
 ) {
   const {selection} = PageFiltersStore.getState();
   PageFiltersStore.updateDateTime({...selection.datetime, ...datetime});
-  updateParams(datetime, router, options);
+  updateParams(datetime, location, navigate, options);
   persistPageFilters('datetime', options);
 }
 
@@ -450,27 +444,27 @@ export function updatePersistence(shouldPersist: boolean) {
 
 /**
  * Updates router/URL with new query params
- *
- * @param obj New query params
- * @param [router] React router object
- * @param [options] Options object
  */
-function updateParams(obj: PageFiltersUpdate, router?: Router, options?: Options) {
+function updateParams(
+  obj: PageFiltersUpdate,
+  location?: Location,
+  navigate?: ReactRouter3Navigate,
+  options?: Options
+) {
   // Allow another component to handle routing
-  if (!router) {
+  if (!location || !navigate) {
     return;
   }
 
-  const newQuery = getNewQueryParams(obj, router.location.query, options);
+  const newQuery = getNewQueryParams(obj, location.query, options);
 
   // Only push new location if query params has changed because this will cause a heavy re-render
-  if (qs.stringify(newQuery) === qs.stringify(router.location.query)) {
+  if (qs.stringify(newQuery) === qs.stringify(location.query)) {
     return;
   }
 
-  const routerAction = options?.replace ? router.replace : router.push;
-
-  routerAction({pathname: router.location.pathname, query: newQuery});
+  const to = {pathname: location.pathname, query: newQuery};
+  navigate(to, {replace: !!options?.replace});
 }
 
 /**
@@ -510,10 +504,6 @@ async function persistPageFilters(filter: PinnedPageFilter | null, options?: Opt
  *
  * Preserves the old query params, except for `cursor` (can be overridden with
  * keepCursor option)
- *
- * @param obj New query params
- * @param currentQuery The current query parameters
- * @param [options] Options object
  */
 function getNewQueryParams(
   obj: PageFiltersUpdate,

--- a/static/app/components/pageFilters/container.spec.tsx
+++ b/static/app/components/pageFilters/container.spec.tsx
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {act, render, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -332,10 +332,7 @@ describe('PageFiltersContainer', () => {
 
   it('does not update local storage when disablePersistence is true', async () => {
     const spy = jest.spyOn(Storage.prototype, 'setItem');
-
-    const mockRouter = RouterFixture({
-      location: {pathname: '/organizations/org-slug/test/', query: {project: []}},
-    });
+    const navigate = jest.fn();
 
     render(<PageFiltersContainer disablePersistence />, {
       organization,
@@ -346,7 +343,15 @@ describe('PageFiltersContainer', () => {
     });
 
     await act(async () => {
-      globalActions.updateProjects([1], mockRouter, {save: true});
+      globalActions.updateProjects(
+        [1],
+        LocationFixture({
+          pathname: '/organizations/org-slug/test/',
+          query: {project: ''},
+        }),
+        navigate,
+        {save: true}
+      );
 
       // page filter values are asynchronously persisted to local storage after a tick,
       // so we need to wait before checking for commits to local storage

--- a/static/app/components/pageFilters/container.tsx
+++ b/static/app/components/pageFilters/container.tsx
@@ -18,17 +18,17 @@ import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useDefaultMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {useProjects} from 'sentry/utils/useProjects';
-import {useRouter} from 'sentry/utils/useRouter';
 import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/views/navigation/constants';
 
 import {getDatetimeFromState, getStateFromQuery} from './parse';
 
 type InitializeUrlStateProps = Omit<
   InitializeUrlStateParams,
-  'memberProjects' | 'nonMemberProjects' | 'queryParams' | 'router' | 'organization'
+  'memberProjects' | 'nonMemberProjects' | 'location' | 'navigate' | 'organization'
 >;
 
 interface Props extends InitializeUrlStateProps {
@@ -70,8 +70,8 @@ export function PageFiltersContainer({
     disablePersistence,
     storageNamespace,
   } = props;
-  const router = useRouter();
   const location = useLocation();
+  const navigate = useNavigate();
   const organization = useOrganization();
   const [hasInitialized, setHasInitialized] = useState(false);
 
@@ -97,8 +97,8 @@ export function PageFiltersContainer({
   const doInitialization = () => {
     initializeUrlState({
       organization,
-      queryParams: location.query,
-      router,
+      location,
+      navigate,
       skipLoadLastUsed,
       skipLoadLastUsedEnvironment,
       maxPickableDays,
@@ -181,8 +181,8 @@ export function PageFiltersContainer({
       environment: [],
       project: [],
     });
-    updateDateTime(newDateState, router);
-  }, [maxPickableDays, router, selection.datetime.utc, shouldResetDateTime]);
+    updateDateTime(newDateState, location, navigate);
+  }, [maxPickableDays, location, navigate, selection.datetime.utc, shouldResetDateTime]);
 
   // Update store persistence when `disablePersistence` changes
   useEffect(() => updatePersistence(!disablePersistence), [disablePersistence]);
@@ -225,7 +225,7 @@ export function PageFiltersContainer({
     // Do not pass router to these actionCreators, as we do not want to update
     // routes since these state changes are happening due to a change of routes
     if (!noProjectChange) {
-      updateProjects(newState.project || [], null, {
+      updateProjects(newState.project || [], undefined, undefined, {
         environments: newEnvironments,
         storageNamespace,
       });

--- a/static/app/components/pageFilters/date/datePageFilter.tsx
+++ b/static/app/components/pageFilters/date/datePageFilter.tsx
@@ -3,7 +3,8 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {TimeRangeSelectorProps} from 'sentry/components/timeRangeSelector';
 import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import {t} from 'sentry/locale';
-import {useRouter} from 'sentry/utils/useRouter';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 export interface DatePageFilterProps extends Partial<
   Partial<Omit<TimeRangeSelectorProps, 'start' | 'end' | 'utc' | 'relative' | 'menuBody'>>
@@ -23,7 +24,8 @@ export function DatePageFilter({
   resetParamsOnChange,
   ...selectProps
 }: DatePageFilterProps) {
-  const router = useRouter();
+  const location = useLocation();
+  const navigate = useNavigate();
   const {selection, isReady: pageFilterIsReady} = usePageFilters();
   const {start, end, period, utc} = selection.datetime;
 
@@ -41,7 +43,7 @@ export function DatePageFilter({
 
         onChange?.(timePeriodUpdate);
 
-        updateDateTime(newTimePeriod, router, {
+        updateDateTime(newTimePeriod, location, navigate, {
           save: true,
           resetParams: resetParamsOnChange,
         });

--- a/static/app/components/pageFilters/environment/environmentPageFilter.spec.tsx
+++ b/static/app/components/pageFilters/environment/environmentPageFilter.spec.tsx
@@ -1,6 +1,6 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {act, fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -106,9 +106,7 @@ describe('EnvironmentPageFilter', () => {
   });
 
   it('responds to page filter changes, async e.g. from back button nav', async () => {
-    const mockRouter = RouterFixture({
-      location: {pathname: '/organizations/org-slug/issues/', query: {}},
-    });
+    const navigate = jest.fn();
 
     render(<EnvironmentPageFilter />, {
       organization,
@@ -121,7 +119,13 @@ describe('EnvironmentPageFilter', () => {
     expect(await screen.findByRole('button', {name: 'All Envs'})).toBeInTheDocument();
 
     // Edit store value
-    act(() => updateEnvironments(['prod'], mockRouter));
+    act(() =>
+      updateEnvironments(
+        ['prod'],
+        LocationFixture({pathname: '/organizations/org-slug/issues/', query: {}}),
+        navigate
+      )
+    );
 
     // <EnvironmentPageFilter /> is updated
     expect(screen.getByRole('button', {name: 'prod'})).toBeInTheDocument();

--- a/static/app/components/pageFilters/environment/environmentPageFilter.tsx
+++ b/static/app/components/pageFilters/environment/environmentPageFilter.tsx
@@ -22,6 +22,8 @@ import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getRouteStringFromRoutes} from 'sentry/utils/getRouteStringFromRoutes';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useRouter} from 'sentry/utils/useRouter';
@@ -63,6 +65,8 @@ export function EnvironmentPageFilter({
   ...selectProps
 }: EnvironmentPageFilterProps) {
   const router = useRouter();
+  const location = useLocation();
+  const navigate = useNavigate();
   const organization = useOrganization();
 
   // Ref to break the circular dependency: options need toggleOption, but toggleOption
@@ -132,7 +136,7 @@ export function EnvironmentPageFilter({
       // Wait for the menu to close before calling onChange
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      updateEnvironments(newValue, router, {
+      updateEnvironments(newValue, location, navigate, {
         save: true,
         resetParams: resetParamsOnChange,
         storageNamespace,
@@ -142,6 +146,8 @@ export function EnvironmentPageFilter({
       envPageFilterValue,
       resetParamsOnChange,
       router,
+      location,
+      navigate,
       organization,
       onChange,
       storageNamespace,

--- a/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
@@ -1,6 +1,6 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
   act,
@@ -184,9 +184,7 @@ describe('ProjectPageFilter', () => {
   });
 
   it('responds to page filter changes, async e.g. from back button nav', async () => {
-    const mockRouter = RouterFixture({
-      location: {pathname: '/organizations/org-slug/issues/', query: {}},
-    });
+    const navigate = jest.fn();
 
     render(<ProjectPageFilter />, {
       organization,
@@ -199,7 +197,13 @@ describe('ProjectPageFilter', () => {
     expect(await screen.findByRole('button', {name: 'My Projects'})).toBeInTheDocument();
 
     // Edit store value
-    act(() => updateProjects([2], mockRouter));
+    act(() =>
+      updateProjects(
+        [2],
+        LocationFixture({pathname: '/organizations/org-slug/issues/', query: {}}),
+        navigate
+      )
+    );
 
     // <ProjectPageFilter /> is updated
 

--- a/static/app/components/pageFilters/project/projectPageFilter.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.tsx
@@ -29,9 +29,10 @@ import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getRouteStringFromRoutes} from 'sentry/utils/getRouteStringFromRoutes';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import {useRouter} from 'sentry/utils/useRouter';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
@@ -74,7 +75,8 @@ export function ProjectPageFilter({
   ...selectProps
 }: ProjectPageFilterProps) {
   // External context/state
-  const router = useRouter();
+  const location = useLocation();
+  const navigate = useNavigate();
   const routes = useRoutes();
   const organization = useOrganization();
   // Project data s
@@ -443,7 +445,8 @@ export function ProjectPageFilter({
         // so toURLSelection can distinguish "All Projects selected" from "nothing selected".
         value: newValue.includes(ALL_ACCESS_PROJECTS) ? newValue : resolvedValue,
       }),
-      router,
+      location,
+      navigate,
       {
         save: true,
         resetParams: resetParamsOnChange,

--- a/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
@@ -6,8 +6,9 @@ import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useRouter} from 'sentry/utils/useRouter';
 import {Tab} from 'sentry/views/explore/hooks/useTab';
 import type {Mode} from 'sentry/views/explore/queryParams/mode';
 
@@ -20,7 +21,8 @@ type Props = {
 };
 
 export function FloatingTrigger({chartIndex, params, setTab}: Props) {
-  const router = useRouter();
+  const location = useLocation();
+  const navigate = useNavigate();
   const organization = useOrganization();
   const {setChartSelection} = useChartSelection();
   const {selectionState, setSelectionState, clearSelection} = params;
@@ -50,12 +52,13 @@ export function FloatingTrigger({chartIndex, params, setTab}: Props) {
         start: getUtcDateString(startTimestamp),
         end: getUtcDateString(endTimestamp),
       },
-      router,
+      location,
+      navigate,
       {save: true}
     );
 
     clearSelection();
-  }, [clearSelection, selectionState, router, organization]);
+  }, [clearSelection, selectionState, location, navigate, organization]);
 
   const handleFindAttributeBreakdowns = useCallback(() => {
     if (!selectionState) return;

--- a/static/app/views/insights/common/utils/useDefaultToAllProjects.spec.tsx
+++ b/static/app/views/insights/common/utils/useDefaultToAllProjects.spec.tsx
@@ -35,7 +35,7 @@ describe('useDefaultToAllProjects', () => {
     const nonMemberProject = ProjectFixture({isMember: false});
     ProjectsStore.loadInitialData([nonMemberProject]);
     renderHook(useDefaultToAllProjects);
-    expect(updateProjects).toHaveBeenCalledWith([-1], undefined, {
+    expect(updateProjects).toHaveBeenCalledWith([-1], undefined, undefined, {
       save: true,
     });
   });

--- a/static/app/views/insights/common/utils/useDefaultToAllProjects.tsx
+++ b/static/app/views/insights/common/utils/useDefaultToAllProjects.tsx
@@ -19,7 +19,7 @@ export function useDefaultToAllProjects() {
 
   useEffect(() => {
     if (initiallyLoaded && selection.projects.length === 0 && myProjects.length === 0) {
-      updateProjects([ALL_ACCESS_PROJECTS], undefined, {
+      updateProjects([ALL_ACCESS_PROJECTS], undefined, undefined, {
         save: true,
       });
     }

--- a/static/app/views/organizationStats/usageTable.tsx
+++ b/static/app/views/organizationStats/usageTable.tsx
@@ -1,5 +1,6 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
+import type {Location} from 'history';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Grid} from '@sentry/scraps/layout';
@@ -14,10 +15,10 @@ import {PanelTable} from 'sentry/components/panels/panelTable';
 import {IconGraph, IconSettings, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {DataCategoryInfo} from 'sentry/types/core';
-import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import type {Project} from 'sentry/types/project';
-// eslint-disable-next-line no-restricted-imports
-import {withSentryRouter} from 'sentry/utils/withSentryRouter';
+import {useLocation} from 'sentry/utils/useLocation';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {formatUsageWithUnits, getFormatUsageOptions} from './utils';
 
@@ -26,13 +27,15 @@ const DOCS_URL = 'https://docs.sentry.io/product/accounts/membership/#restrictin
 type Props = {
   dataCategory: DataCategoryInfo;
   headers: React.ReactNode[];
+  location: Location;
+  navigate: ReactRouter3Navigate;
   usageStats: TableStat[];
   errors?: Record<string, Error>;
   isEmpty?: boolean;
   isError?: boolean;
   isLoading?: boolean;
   showStoredOutcome?: boolean;
-} & WithRouterProps;
+};
 
 export type TableStat = {
   accepted: number;
@@ -66,7 +69,7 @@ class UsageTable extends Component<Props> {
   };
 
   loadProject(projectId: number) {
-    updateProjects([projectId], this.props.router, {
+    updateProjects([projectId], this.props.location, this.props.navigate, {
       save: true,
       environments: [], // Clear environments when switching projects
     });
@@ -173,7 +176,17 @@ class UsageTable extends Component<Props> {
   }
 }
 
-export default withSentryRouter(UsageTable);
+/**
+ * Wrapper that injects `navigate` and `location` hooks into UsageTable.
+ */
+function UsageTableWithHooks(props: Omit<Props, 'navigate' | 'location'>) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  return <UsageTable {...props} navigate={navigate} location={location} />;
+}
+
+// eslint-disable-next-line @sentry/no-default-exports
+export default UsageTableWithHooks;
 
 const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: repeat(7, auto);

--- a/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
@@ -14,7 +14,7 @@ import type {Project} from 'sentry/types/project';
 import type {EventView} from 'sentry/utils/discover/eventView';
 import type {MetricDataSwitcherOutcome} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouter} from 'sentry/utils/useRouter';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import type {DiscoverQueryPageSource} from 'sentry/views/performance/utils';
 import {
   createUnnamedTransactionsDiscoverTarget,
@@ -57,7 +57,7 @@ export function MetricsDataSwitcherAlert(
   props: MetricEnhancedDataAlertProps
 ): React.ReactElement | null {
   const location = useLocation();
-  const router = useRouter();
+  const navigate = useNavigate();
 
   const isOnFallbackThresolds = props.organization.features.includes(
     'performance-mep-bannerless-ui'
@@ -90,8 +90,8 @@ export function MetricsDataSwitcherAlert(
   }, [location, props.projects]);
 
   const handleSwitchToCompatibleProjects = useCallback(() => {
-    updateProjects(props.compatibleProjects || [], router);
-  }, [props.compatibleProjects, router]);
+    updateProjects(props.compatibleProjects || [], location, navigate);
+  }, [props.compatibleProjects, location, navigate]);
 
   if (!props.shouldNotifyUnnamedTransactions && !props.shouldWarnIncompatibleSDK) {
     // Control showing generic sdk-alert here since stacking alerts is noisy.

--- a/static/app/views/projectDetail/projectDetail.spec.tsx
+++ b/static/app/views/projectDetail/projectDetail.spec.tsx
@@ -144,6 +144,7 @@ describe('ProjectDetail', () => {
     await waitFor(() => {
       expect(pageFilters.updateProjects).toHaveBeenCalledWith(
         [Number(project.id)],
+        undefined,
         undefined
       );
     });

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -140,7 +140,7 @@ export function ProjectDetail() {
     function syncProjectWithSlug() {
       if (projectId && projectId !== projectQueryParam) {
         // if someone visits /organizations/sentry/projects/javascript/ (without ?project=XXX) we need to update URL and globalSelection with the right project ID
-        updateProjects([Number(projectId)], undefined);
+        updateProjects([Number(projectId)], undefined, undefined);
         navigate(
           {pathname: location.pathname, query: {...location.query, project: projectId}},
           {replace: true}


### PR DESCRIPTION
Replace the `router` parameter with `location` + `navigate` in
updateDateTime, updateProjects, updateEnvironments, and
initializeUrlState. This removes the dependency on the legacy
InjectedRouter type from all page filter action functions.