### PR TITLE
feat(seer): Add links to provider integration pages from scm treeview

### DIFF
--- a/static/app/components/repositories/scmIntegrationTree/providerConfigLink.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/providerConfigLink.tsx
@@ -4,9 +4,9 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Integration} from 'sentry/types/integrations';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
 
-function getProviderConfigUrl(integration: Integration): string | null {
+function getProviderConfigUrl(integration: OrganizationIntegration): string | null {
   const {externalId, provider, domainName, accountType} = integration;
   if (!externalId) {
     return null;
@@ -35,7 +35,11 @@ function getProviderConfigUrl(integration: Integration): string | null {
   return null;
 }
 
-export function ProviderConfigLink({integration}: {integration: Integration}) {
+export function ProviderConfigLink({
+  integration,
+}: {
+  integration: OrganizationIntegration;
+}) {
   const externalConfigUrl = getProviderConfigUrl(integration);
 
   if (!externalConfigUrl) {

--- a/static/app/components/repositories/scmIntegrationTree/providerConfigLink.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/providerConfigLink.tsx
@@ -22,12 +22,14 @@ function getProviderConfigUrl(integration: OrganizationIntegration): string | nu
 
   if (provider.key === 'github_enterprise') {
     if (domainName) {
+      // GHE externalId format is "<host>:<numeric_installation_id>"
+      const installationId = externalId.split(':').at(-1);
       const host = domainName.split('/')[0];
       if (accountType === 'Organization') {
         const orgName = domainName.replace(`${host}/`, '');
-        return `https://${host}/organizations/${orgName}/settings/installations/${externalId}`;
+        return `https://${host}/organizations/${orgName}/settings/installations/${installationId}`;
       }
-      return `https://${host}/settings/installations/${externalId}`;
+      return `https://${host}/settings/installations/${installationId}`;
     }
     return null;
   }

--- a/static/app/components/repositories/scmIntegrationTree/providerConfigLink.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/providerConfigLink.tsx
@@ -1,0 +1,53 @@
+import {Flex} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconOpen} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Integration} from 'sentry/types/integrations';
+
+function getProviderConfigUrl(integration: Integration): string | null {
+  const {externalId, provider, domainName, accountType} = integration;
+  if (!externalId) {
+    return null;
+  }
+
+  if (provider.key === 'github') {
+    if (accountType === 'Organization' && domainName) {
+      const orgName = domainName.replace(/^github\.com\//, '');
+      return `https://github.com/organizations/${orgName}/settings/installations/${externalId}`;
+    }
+    return `https://github.com/settings/installations/${externalId}`;
+  }
+
+  if (provider.key === 'github_enterprise') {
+    if (domainName) {
+      const host = domainName.split('/')[0];
+      if (accountType === 'Organization') {
+        const orgName = domainName.replace(`${host}/`, '');
+        return `https://${host}/organizations/${orgName}/settings/installations/${externalId}`;
+      }
+      return `https://${host}/settings/installations/${externalId}`;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+export function ProviderConfigLink({integration}: {integration: Integration}) {
+  const externalConfigUrl = getProviderConfigUrl(integration);
+
+  if (!externalConfigUrl) {
+    return null;
+  }
+  return (
+    <Flex align="center" gap="xs">
+      <Tooltip title={t('External installation settings')} skipWrapper>
+        <ExternalLink href={externalConfigUrl} onClick={e => e.stopPropagation()}>
+          {integration.provider.name} <IconOpen size="xs" />
+        </ExternalLink>
+      </Tooltip>
+    </Flex>
+  );
+}

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
@@ -5,9 +5,9 @@ import type {
   TreeNode,
 } from 'sentry/components/repositories/scmIntegrationTree/types';
 import type {
-  Integration,
   IntegrationProvider,
   IntegrationRepository,
+  OrganizationIntegration,
 } from 'sentry/types/integrations';
 
 type Props = {
@@ -18,7 +18,7 @@ type Props = {
   repoFilter: RepoFilter;
   reposByIntegrationId: Record<string, IntegrationRepository[]>;
   reposPendingByIntegrationId: Record<string, boolean>;
-  scmIntegrations: Integration[];
+  scmIntegrations: OrganizationIntegration[];
   scmProviders: IntegrationProvider[];
   search: string;
   togglingRepos: Set<string>;

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -12,6 +12,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
+import {ProviderConfigLink} from 'sentry/components/repositories/scmIntegrationTree/providerConfigLink';
 import type {TreeNode} from 'sentry/components/repositories/scmIntegrationTree/types';
 import {IconAdd, IconChevron, IconClose, IconDelete, IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -171,13 +172,16 @@ export function ScmIntegrationTreeRow({
                   )}
                 </Text>
               </Flex>
-              {node.isReposPending ? (
-                <LoadingReposMessage />
-              ) : (
-                <Badge variant="muted">
-                  {t('%s/%s repos connected', node.connectedRepoCount, node.repoCount)}
-                </Badge>
-              )}
+              <Flex align="center" gap="sm">
+                {node.isReposPending ? (
+                  <LoadingReposMessage />
+                ) : (
+                  <Badge variant="muted">
+                    {t('%s/%s repos connected', node.connectedRepoCount, node.repoCount)}
+                  </Badge>
+                )}
+                <ProviderConfigLink integration={node.integration} />
+              </Flex>
             </Flex>
           </Flex>
         </RowButton>

--- a/static/app/components/repositories/scmIntegrationTree/types.ts
+++ b/static/app/components/repositories/scmIntegrationTree/types.ts
@@ -2,6 +2,7 @@ import type {
   Integration,
   IntegrationProvider,
   IntegrationRepository,
+  OrganizationIntegration,
 } from 'sentry/types/integrations';
 
 export type ProviderNode = {
@@ -13,7 +14,7 @@ export type ProviderNode = {
 
 export type IntegrationNode = {
   connectedRepoCount: number;
-  integration: Integration;
+  integration: OrganizationIntegration;
   isExpanded: boolean;
   isReposPending: boolean;
   repoCount: number;

--- a/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
+++ b/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
@@ -2,9 +2,9 @@ import {useEffect, useMemo} from 'react';
 
 import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import type {
-  Integration,
   IntegrationProvider,
   IntegrationRepository,
+  OrganizationIntegration,
   Repository,
 } from 'sentry/types/integrations';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
@@ -20,7 +20,7 @@ type ScmIntegrationTreeData = {
   reposByIntegrationId: Record<string, IntegrationRepository[]>;
   reposPendingByIntegrationId: Record<string, boolean>;
   reposQueryKey: unknown;
-  scmIntegrations: Integration[];
+  scmIntegrations: OrganizationIntegration[];
   scmProviders: IntegrationProvider[];
 };
 
@@ -53,10 +53,13 @@ export function useScmIntegrationTreeData(): ScmIntegrationTreeData {
 
   // 2. Fetch installed integrations and filter to SCM providers
   const integrationsQuery = useQuery(
-    apiOptions.as<Integration[]>()('/organizations/$organizationIdOrSlug/integrations/', {
-      path: {organizationIdOrSlug: organization.slug},
-      staleTime: 0,
-    })
+    apiOptions.as<OrganizationIntegration[]>()(
+      '/organizations/$organizationIdOrSlug/integrations/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        staleTime: 0,
+      }
+    )
   );
 
   const scmIntegrations = useMemo(

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -431,6 +431,7 @@ export interface Integration extends CommonIntegration {
       uninstallationUrl?: string;
     };
   };
+  externalId?: string;
   scopes?: string[];
 }
 

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -431,7 +431,6 @@ export interface Integration extends CommonIntegration {
       uninstallationUrl?: string;
     };
   };
-  externalId?: string;
   scopes?: string[];
 }
 


### PR DESCRIPTION
This add links to GitHub and GitHub enterprise integration/addon pages when the sentry org is integrated with a github org.

These links allow users to quickly get into the settings page on GitHub and configure which repos are allowed to be shared with sentry.

<img width="969" height="298" alt="Screenshot 2026-03-17 at 11 21 30 AM" src="https://github.com/user-attachments/assets/13cf76e0-8156-4828-89df-ef6aba7491e6" />

