### PR TITLE
test(snapshots): Add visual snapshot tests for alert and badge

### DIFF
--- a/static/app/components/core/alert/alert.snapshots.tsx
+++ b/static/app/components/core/alert/alert.snapshots.tsx
@@ -1,0 +1,58 @@
+import {ThemeProvider} from '@emotion/react';
+
+import {Alert, type AlertProps} from '@sentry/scraps/alert';
+
+// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
+import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
+
+const themes = {light: lightTheme, dark: darkTheme};
+
+describe('Alert', () => {
+  describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
+    it.snapshot.each<AlertProps['variant']>([
+      'info',
+      'warning',
+      'success',
+      'danger',
+      'muted',
+    ])('variant-%s', variant => (
+      <ThemeProvider theme={themes[themeName]}>
+        <div style={{padding: 8, width: 400}}>
+          <Alert variant={variant}>This is a {variant} alert</Alert>
+        </div>
+      </ThemeProvider>
+    ));
+
+    it.snapshot.each<AlertProps['variant']>([
+      'info',
+      'warning',
+      'success',
+      'danger',
+      'muted',
+    ])('variant-%s-no-icon', variant => (
+      <ThemeProvider theme={themes[themeName]}>
+        <div style={{padding: 8, width: 400}}>
+          <Alert variant={variant} showIcon={false}>
+            This is a {variant} alert without icon
+          </Alert>
+        </div>
+      </ThemeProvider>
+    ));
+
+    it.snapshot.each<AlertProps['variant']>([
+      'info',
+      'warning',
+      'success',
+      'danger',
+      'muted',
+    ])('variant-%s-system', variant => (
+      <ThemeProvider theme={themes[themeName]}>
+        <div style={{padding: 8, width: 400}}>
+          <Alert variant={variant} system>
+            This is a system {variant} alert
+          </Alert>
+        </div>
+      </ThemeProvider>
+    ));
+  });
+});

--- a/static/app/components/core/badge/badge.snapshots.tsx
+++ b/static/app/components/core/badge/badge.snapshots.tsx
@@ -1,0 +1,33 @@
+import {ThemeProvider} from '@emotion/react';
+
+// eslint-disable-next-line @sentry/scraps/no-core-import -- SSR snapshot needs direct import to avoid barrel re-exports with heavy deps
+import {Badge, type BadgeProps} from 'sentry/components/core/badge/badge';
+// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
+import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
+
+const themes = {light: lightTheme, dark: darkTheme};
+
+describe('Badge', () => {
+  describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
+    it.snapshot.each<BadgeProps['variant']>([
+      'muted',
+      'internal',
+      'info',
+      'success',
+      'warning',
+      'danger',
+      'highlight',
+      'promotion',
+      'alpha',
+      'beta',
+      'new',
+      'experimental',
+    ])('variant-%s', variant => (
+      <ThemeProvider theme={themes[themeName]}>
+        <div style={{padding: 8}}>
+          <Badge variant={variant}>{variant}</Badge>
+        </div>
+      </ThemeProvider>
+    ));
+  });
+});


### PR DESCRIPTION
Add comprehensive visual snapshot tests for Alert and Badge components, matching the pattern established by Button snapshots.

**Alert snapshots** cover all 5 variants (info, warning, success, danger, muted) across light and dark themes, testing three prop variations: default with icon, without icon (showIcon=false), and system mode. This totals 30 snapshot tests.

**Badge snapshots** cover all 12 variants (muted, internal, info, success, warning, danger, highlight, promotion, alpha, beta, new, experimental) across both light and dark themes. This totals 24 snapshot tests.

The tests use Jest's snapshot framework with Playwright-based visual rendering, ensuring consistent styling across themes and component states.