### PR TITLE
fix(scm): Guard LoadingReposMessage so that a message always appears

### DIFF
--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
@@ -106,8 +106,6 @@ export function buildIntegrationTreeNodes({
           }
         }
       }
-
-      // nodes.push({type: 'add-config', provider});
     }
   }
 

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -378,7 +378,7 @@ function LoadingReposMessage() {
   return (
     <Flex align="center" gap="sm">
       <Text size="sm" variant="muted">
-        {messages[messageIndex]}
+        {messages[Math.min(messageIndex, messages.length - 1)]}
       </Text>
       <LoadingIndicator size={16} />
     </Flex>


### PR DESCRIPTION
Even if it takes a long time and there are no more new messages to pick from

<!-- Describe your PR here. -->