### PR TITLE
feat(dashboards): text widget add to dashboard flow

### DIFF
--- a/static/app/components/modals/textWidgetViewerModal.tsx
+++ b/static/app/components/modals/textWidgetViewerModal.tsx
@@ -70,7 +70,7 @@ function TextWidgetViewerModal(props: Props) {
         <Heading as="h3">{widget.title}</Heading>
       </Header>
       <Body>
-        <Flex maxHeight={`${HALF_CONTAINER_HEIGHT}px`}>
+        <Flex maxHeight={`${HALF_CONTAINER_HEIGHT}px`} overflowY="auto">
           <WidgetCardChartContainer
             selection={selection}
             widget={widget}

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -858,6 +858,136 @@ describe('add to dashboard modal', () => {
     });
   });
 
+  describe('text widgets', () => {
+    let textWidget: Widget;
+
+    beforeEach(() => {
+      textWidget = {
+        title: 'My Note',
+        description: 'this is a text widget description',
+        displayType: DisplayType.TEXT,
+        interval: '5m',
+        widgetType: undefined,
+        queries: [],
+      };
+    });
+
+    it('renders without making an events-stats request', async () => {
+      render(
+        <AddToDashboardModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widgets={[textWidget]}
+          selection={defaultSelection}
+          location={LocationFixture()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Dashboard')).toBeEnabled();
+      });
+
+      expect(eventsStatsMock).not.toHaveBeenCalled();
+    });
+
+    it('adds a text widget to an existing dashboard without modifying queries', async () => {
+      const dashboardDetailGetMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/',
+        body: {id: '1', widgets: []},
+      });
+      const dashboardDetailPutMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/',
+        method: 'PUT',
+        body: {},
+      });
+
+      render(
+        <AddToDashboardModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widgets={[textWidget]}
+          selection={defaultSelection}
+          location={LocationFixture()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Dashboard')).toBeEnabled();
+      });
+      await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
+      await userEvent.click(screen.getByText('Add + Stay on this Page'));
+
+      expect(dashboardDetailGetMock).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(dashboardDetailPutMock).toHaveBeenCalledWith(
+          '/organizations/org-slug/dashboards/1/',
+          expect.objectContaining({
+            data: expect.objectContaining({
+              widgets: [
+                expect.objectContaining({
+                  title: 'My Note',
+                  description: 'this is a text widget description',
+                  displayType: DisplayType.TEXT,
+                  queries: [],
+                  layout: expect.any(Object),
+                }),
+              ],
+            }),
+          })
+        );
+      });
+    });
+
+    it('navigates to new dashboard with text widget in location state', async () => {
+      const {router} = render(
+        <AddToDashboardModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={initialData.organization}
+          widgets={[textWidget]}
+          selection={defaultSelection}
+          actions={['add-and-open-dashboard']}
+          location={LocationFixture()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Dashboard')).toBeEnabled();
+      });
+      await selectEvent.select(
+        screen.getByText('Select Dashboard'),
+        '+ Create New Dashboard'
+      );
+      await userEvent.click(screen.getByText('Add + Open Dashboard'));
+
+      expect(router.location.pathname).toBe('/organizations/org-slug/dashboards/new/');
+      expect(router.location.state?.widgets).toHaveLength(1);
+      expect(router.location.state?.widgets[0]).toMatchObject({
+        title: 'My Note',
+        displayType: DisplayType.TEXT,
+        queries: [],
+      });
+      expect(router.location.state?.widgets[0]?.layout).toMatchObject({
+        x: expect.any(Number),
+        y: expect.any(Number),
+        w: expect.any(Number),
+        h: expect.any(Number),
+        minH: expect.any(Number),
+      });
+    });
+  });
+
   describe('multiple widgets', () => {
     let multipleWidgets: [Widget, Widget];
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -49,6 +49,7 @@ import type {
 } from 'sentry/views/dashboards/types';
 import {
   DEFAULT_WIDGET_NAME,
+  DisplayType,
   MAX_WIDGETS,
   WidgetType,
 } from 'sentry/views/dashboards/types';
@@ -61,7 +62,10 @@ import {
   usesTimeSeriesData,
 } from 'sentry/views/dashboards/utils';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
-import {NEW_DASHBOARD_ID} from 'sentry/views/dashboards/widgetBuilder/utils';
+import {
+  addWidgetBuilderSessionStorageParams,
+  NEW_DASHBOARD_ID,
+} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {convertWidgetToQueryParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
@@ -214,6 +218,8 @@ function AddToDashboardModal({
 
     const widgetAsQueryParams = convertWidgetToQueryParams(widget);
 
+    addWidgetBuilderSessionStorageParams(widget);
+
     navigate(
       normalizeUrl({
         pathname,
@@ -242,6 +248,13 @@ function AddToDashboardModal({
 
   function normalizeWidgets(widgetsToNormalize: Widget[]): Widget[] {
     return widgetsToNormalize.map(w => {
+      if (w.displayType === DisplayType.TEXT) {
+        return {
+          ...w,
+          title: hasMultipleWidgets ? (w.title ?? DEFAULT_WIDGET_NAME) : newWidgetTitle,
+        };
+      }
+
       let newOrderBy = orderBy ?? w.queries[0]!.orderby;
       if (!(usesTimeSeriesData(w.displayType) && w.queries[0]!.columns.length)) {
         newOrderBy = ''; // Clear orderby if its not a top n visualization.
@@ -469,7 +482,16 @@ function AddToDashboardModal({
               organization={organization}
               eventView={eventViewFromWidget(
                 newWidgetTitle,
-                widget.queries[0]!,
+                widget.displayType === DisplayType.TEXT
+                  ? {
+                      name: '',
+                      fields: [],
+                      aggregates: [],
+                      columns: [],
+                      orderby: '',
+                      conditions: '',
+                    }
+                  : widget.queries[0]!,
                 selection
               )}
               location={location}

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -801,6 +801,8 @@ class DashboardDetail extends Component<Props, State> {
       };
     }
 
+    this.cleanupWidgetBuilderSessionStorage();
+
     navigate(
       getDashboardLocation({
         organization,
@@ -812,8 +814,6 @@ class DashboardDetail extends Component<Props, State> {
         state: navigationState,
       }
     );
-
-    this.cleanupWidgetBuilderSessionStorage();
   };
 
   handleChangeWidgetBuilderView = (openWidgetTemplates: boolean) => {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -69,7 +69,11 @@ import {
 } from 'sentry/views/dashboards/utils';
 import {WidgetQueryQueueProvider} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import WidgetBuilderV2 from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
-import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
+import {SESSION_STORAGE_CONTENT_KEY_MAP} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {
+  addWidgetBuilderSessionStorageParams,
+  DataSet,
+} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {convertWidgetToQueryParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import {getDefaultWidget} from 'sentry/views/dashboards/widgetBuilder/utils/getDefaultWidget';
 import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
@@ -675,6 +679,9 @@ class DashboardDetail extends Component<Props, State> {
     const path = defined(dashboardId)
       ? `/organizations/${organization.slug}/dashboard/${dashboardId}/widget-builder/widget/${widgetIndex}/edit/`
       : `/organizations/${organization.slug}/dashboards/new/widget-builder/widget/${widgetIndex}/edit/`;
+
+    addWidgetBuilderSessionStorageParams(widget);
+
     navigate(
       normalizeUrl({
         pathname: path,
@@ -757,6 +764,15 @@ class DashboardDetail extends Component<Props, State> {
     );
   };
 
+  // clean up session storage from non-url params in the widget builder
+  cleanupWidgetBuilderSessionStorage = () => {
+    for (const param of Object.keys(SESSION_STORAGE_CONTENT_KEY_MAP) as Array<
+      keyof typeof SESSION_STORAGE_CONTENT_KEY_MAP
+    >) {
+      sessionStorage.removeItem(SESSION_STORAGE_CONTENT_KEY_MAP[param]);
+    }
+  };
+
   handleCloseWidgetBuilder = (newWidgets?: Widget[]) => {
     const {organization, navigate, location, params, dashboard} = this.props;
     const {dashboardState, modifiedDashboard} = this.state;
@@ -796,6 +812,8 @@ class DashboardDetail extends Component<Props, State> {
         state: navigationState,
       }
     );
+
+    this.cleanupWidgetBuilderSessionStorage();
   };
 
   handleChangeWidgetBuilderView = (openWidgetTemplates: boolean) => {

--- a/static/app/views/dashboards/widgetBuilder/components/descriptionField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/descriptionField.tsx
@@ -12,9 +12,6 @@ import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/us
 
 interface WidgetBuilderDescriptionFieldProps {
   autosize?: boolean;
-  builderStateAction?:
-    | typeof BuilderStateAction.SET_DESCRIPTION
-    | typeof BuilderStateAction.SET_TEXT_CONTENT;
   placeholder?: string;
   rows?: number;
 }
@@ -23,13 +20,16 @@ export function WidgetBuilderDescriptionField({
   rows = 4,
   placeholder = t('Description'),
   autosize = true,
-  builderStateAction = BuilderStateAction.SET_DESCRIPTION,
 }: WidgetBuilderDescriptionFieldProps) {
   const organization = useOrganization();
   const {state, dispatch} = useWidgetBuilderContext();
   const isEditing = useIsEditingWidget();
   const source = useDashboardWidgetSource();
   const isTextWidget = state.displayType === DisplayType.TEXT;
+  const textValue = isTextWidget ? state.textContent : state.description;
+  const builderStateAction = isTextWidget
+    ? BuilderStateAction.SET_TEXT_CONTENT
+    : BuilderStateAction.SET_DESCRIPTION;
 
   return (
     <TextArea
@@ -38,7 +38,7 @@ export function WidgetBuilderDescriptionField({
       aria-label={placeholder}
       autosize={autosize}
       rows={rows}
-      value={isTextWidget ? state.textContent : state.description}
+      value={textValue}
       onChange={e => {
         dispatch({type: builderStateAction, payload: e.target.value}, {updateUrl: false});
       }}

--- a/static/app/views/dashboards/widgetBuilder/components/descriptionField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/descriptionField.tsx
@@ -1,0 +1,65 @@
+import {TextArea} from '@sentry/scraps/textarea';
+
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {DisplayType} from 'sentry/views/dashboards/types';
+import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {useDashboardWidgetSource} from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
+import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+
+interface WidgetBuilderDescriptionFieldProps {
+  autosize?: boolean;
+  builderStateAction?:
+    | typeof BuilderStateAction.SET_DESCRIPTION
+    | typeof BuilderStateAction.SET_TEXT_CONTENT;
+  placeholder?: string;
+  rows?: number;
+}
+
+export function WidgetBuilderDescriptionField({
+  rows = 4,
+  placeholder = t('Description'),
+  autosize = true,
+  builderStateAction = BuilderStateAction.SET_DESCRIPTION,
+}: WidgetBuilderDescriptionFieldProps) {
+  const organization = useOrganization();
+  const {state, dispatch} = useWidgetBuilderContext();
+  const isEditing = useIsEditingWidget();
+  const source = useDashboardWidgetSource();
+  const isTextWidget = state.displayType === DisplayType.TEXT;
+
+  return (
+    <TextArea
+      autoComplete="off"
+      placeholder={placeholder}
+      aria-label={placeholder}
+      autosize={autosize}
+      rows={rows}
+      value={isTextWidget ? state.textContent : state.description}
+      onChange={e => {
+        dispatch({type: builderStateAction, payload: e.target.value}, {updateUrl: false});
+      }}
+      onBlur={e => {
+        dispatch(
+          {
+            type: builderStateAction,
+            payload: e.target.value,
+          },
+          {updateUrl: true}
+        );
+        trackAnalytics('dashboards_views.widget_builder.change', {
+          from: source,
+          widget_type: state.dataset ?? '',
+          builder_version: WidgetBuilderVersion.SLIDEOUT,
+          field: 'description',
+          value: '',
+          new_widget: !isEditing,
+          organization,
+        });
+      }}
+    />
+  );
+}

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -53,4 +53,23 @@ describe('WidgetBuilder', () => {
       await screen.findByText('Title is required during creation.')
     ).toBeInTheDocument();
   });
+
+  it('does not show the add description button for text widgets', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderNameAndDescription />
+      </WidgetBuilderProvider>,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+            query: {displayType: 'text'},
+          },
+        },
+      }
+    );
+
+    expect(await screen.findByPlaceholderText('Name')).toBeInTheDocument();
+    expect(screen.queryByTestId('add-description')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -2,14 +2,15 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {TextArea} from '@sentry/scraps/textarea';
 
 import TextField from 'sentry/components/forms/fields/textField';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {DisplayType} from 'sentry/views/dashboards/types';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
+import {WidgetBuilderDescriptionField} from 'sentry/views/dashboards/widgetBuilder/components/descriptionField';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {useDashboardWidgetSource} from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
@@ -29,6 +30,7 @@ export function WidgetBuilderNameAndDescription({
   const [isDescSelected, setIsDescSelected] = useState(state.description ? true : false);
   const isEditing = useIsEditingWidget();
   const source = useDashboardWidgetSource();
+  const isTextWidget = state.displayType === DisplayType.TEXT;
 
   return (
     <Fragment>
@@ -73,7 +75,7 @@ export function WidgetBuilderNameAndDescription({
         error={error?.title}
         inline={false}
       />
-      {!isDescSelected && (
+      {!isTextWidget && !isDescSelected && (
         <Button
           priority="link"
           aria-label={t('Add Description')}
@@ -85,40 +87,7 @@ export function WidgetBuilderNameAndDescription({
           {t('+ Add Description')}
         </Button>
       )}
-      {isDescSelected && (
-        <TextArea
-          autoComplete="off"
-          placeholder={t('Description')}
-          aria-label={t('Description')}
-          autosize
-          rows={4}
-          value={state.description}
-          onChange={e => {
-            dispatch(
-              {type: BuilderStateAction.SET_DESCRIPTION, payload: e.target.value},
-              {updateUrl: false}
-            );
-          }}
-          onBlur={e => {
-            dispatch(
-              {
-                type: BuilderStateAction.SET_DESCRIPTION,
-                payload: e.target.value,
-              },
-              {updateUrl: true}
-            );
-            trackAnalytics('dashboards_views.widget_builder.change', {
-              from: source,
-              widget_type: state.dataset ?? '',
-              builder_version: WidgetBuilderVersion.SLIDEOUT,
-              field: 'description',
-              value: '',
-              new_widget: !isEditing,
-              organization,
-            });
-          }}
-        />
-      )}
+      {!isTextWidget && isDescSelected && <WidgetBuilderDescriptionField rows={4} />}
     </Fragment>
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -43,6 +45,38 @@ describe('TypeSelector', () => {
     );
 
     expect(await screen.findByText('Please select a type')).toBeInTheDocument();
+  });
+
+  it('shows text widget option when dashboards-text-widgets feature is enabled', async () => {
+    mockUseNavigate.mockReturnValue(jest.fn());
+
+    render(
+      <WidgetBuilderProvider>
+        <TypeSelector />
+      </WidgetBuilderProvider>,
+      {
+        organization: OrganizationFixture({features: ['dashboards-text-widgets']}),
+      }
+    );
+
+    await userEvent.click(await screen.findByText('Table'));
+    expect(screen.getByText('Text (Markdown)')).toBeInTheDocument();
+  });
+
+  it('does not show text widget option without dashboards-text-widgets feature', async () => {
+    mockUseNavigate.mockReturnValue(jest.fn());
+
+    render(
+      <WidgetBuilderProvider>
+        <TypeSelector />
+      </WidgetBuilderProvider>,
+      {
+        organization: OrganizationFixture({features: []}),
+      }
+    );
+
+    await userEvent.click(await screen.findByText('Table'));
+    expect(screen.queryByText('Text (Markdown)')).not.toBeInTheDocument();
   });
 
   it('resets the widget builder state when the display type is changed on an issue widget', async () => {

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -6,7 +6,7 @@ import {Select} from '@sentry/scraps/select';
 
 import {components} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {FieldGroup} from 'sentry/components/forms/fieldGroup';
-import {IconGraph, IconNumber, IconSettings, IconTable} from 'sentry/icons';
+import {IconGraph, IconMarkdown, IconNumber, IconSettings, IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
@@ -29,6 +29,7 @@ const typeIcons: Partial<Record<DisplayType, React.ReactNode>> = {
   [DisplayType.BIG_NUMBER]: <IconNumber key="number" />,
   [DisplayType.DETAILS]: <IconSettings key="details" />,
   [DisplayType.CATEGORICAL_BAR]: <IconGraph key="categorical_bar" type="bar" />,
+  [DisplayType.TEXT]: <IconMarkdown key="text" />,
 };
 
 interface WidgetBuilderTypeSelectorProps {
@@ -47,6 +48,7 @@ export function WidgetBuilderTypeSelector({
   const organization = useOrganization();
 
   const hasDetailsWidget = organization.features.includes('dashboards-details-widget');
+  const hasTextWidget = organization.features.includes('dashboards-text-widgets');
   // Use an array to define display type order explicitly.
   // Object key ordering in JS is technically specified but easy to break accidentally.
   const displayTypeOrder: Array<{label: string; type: DisplayType}> = [
@@ -56,6 +58,7 @@ export function WidgetBuilderTypeSelector({
     {type: DisplayType.LINE, label: t('Line')},
     {type: DisplayType.TABLE, label: t('Table')},
     {type: DisplayType.BIG_NUMBER, label: t('Big Number')},
+    ...(hasTextWidget ? [{type: DisplayType.TEXT, label: t('Text (Markdown)')}] : []),
     ...(hasDetailsWidget ? [{type: DisplayType.DETAILS, label: t('Details')}] : []),
   ];
 
@@ -108,7 +111,8 @@ export function WidgetBuilderTypeSelector({
             leadingItems: typeIcons[type],
             label,
             value: type,
-            disabled: !config.supportedDisplayTypes.includes(type),
+            disabled:
+              type !== DisplayType.TEXT && !config.supportedDisplayTypes.includes(type),
           }))}
           clearable={false}
           onChange={(newValue: any) => {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -648,6 +648,107 @@ describe('WidgetBuilderSlideout', () => {
     });
   });
 
+  it('should show the markdown content field for text widgets', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid={false}
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={jest.fn()}
+          setIsPreviewDraggable={jest.fn()}
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/dashboards/',
+            query: {
+              displayType: DisplayType.TEXT,
+            },
+          },
+        },
+      }
+    );
+
+    expect(
+      await screen.findByPlaceholderText('Write your markdown here...')
+    ).toBeInTheDocument();
+  });
+
+  it('should not show the dataset selector for text widgets', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid={false}
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={jest.fn()}
+          setIsPreviewDraggable={jest.fn()}
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/dashboards/',
+            query: {
+              displayType: DisplayType.TEXT,
+            },
+          },
+        },
+      }
+    );
+
+    expect(
+      await screen.findByPlaceholderText('Write your markdown here...')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Errors'})).not.toBeInTheDocument();
+  });
+
+  it('should not show the sort by step for text widgets', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid={false}
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={jest.fn()}
+          setIsPreviewDraggable={jest.fn()}
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/dashboards/',
+            query: {
+              displayType: DisplayType.TEXT,
+            },
+          },
+        },
+      }
+    );
+
+    expect(
+      await screen.findByPlaceholderText('Write your markdown here...')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Sort by')).not.toBeInTheDocument();
+  });
+
   it('should not show the group by selector if the widget is an issue and a chart display type', async () => {
     render(
       <WidgetBuilderProvider>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -64,7 +64,6 @@ import {useDashboardWidgetSource} from 'sentry/views/dashboards/widgetBuilder/ho
 import {useDisableTransactionWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useDisableTransactionWidget';
 import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {useSegmentSpanWidgetState} from 'sentry/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState';
-import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 import {convertWidgetToBuilderState} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
@@ -411,7 +410,6 @@ export function WidgetBuilderSlideout({
                           rows={12}
                           placeholder={t('Write your markdown here...')}
                           autosize={false}
-                          builderStateAction={BuilderStateAction.SET_TEXT_CONTENT}
                         />
                       </Section>
                     )}

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -42,6 +42,7 @@ import {
 import {AxisRangeSection} from 'sentry/views/dashboards/widgetBuilder/components/axisRangeSection';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import {WidgetBuilderDatasetSelector} from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
+import {WidgetBuilderDescriptionField} from 'sentry/views/dashboards/widgetBuilder/components/descriptionField';
 import {WidgetBuilderFilterBar} from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import {WidgetBuilderGroupBySelector} from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
 import {WidgetBuilderNameAndDescription} from 'sentry/views/dashboards/widgetBuilder/components/nameAndDescFields';
@@ -63,6 +64,7 @@ import {useDashboardWidgetSource} from 'sentry/views/dashboards/widgetBuilder/ho
 import {useDisableTransactionWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useDisableTransactionWidget';
 import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {useSegmentSpanWidgetState} from 'sentry/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 import {convertWidgetToBuilderState} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
@@ -138,17 +140,20 @@ export function WidgetBuilderSlideout({
       : t('Custom Widget Builder');
   const isTimeSeriesWidget = usesTimeSeriesData(state.displayType);
   const isCategoricalBarWidget = state.displayType === DisplayType.CATEGORICAL_BAR;
+  const isTextWidget = state.displayType === DisplayType.TEXT;
 
-  const showVisualizeSection = state.displayType !== DisplayType.DETAILS;
-  const showQueryFilterBuilder = !(
-    state.dataset === WidgetType.ISSUE && usesTimeSeriesData(state.displayType)
-  );
+  const showVisualizeSection = state.displayType !== DisplayType.DETAILS && !isTextWidget;
+  const showQueryFilterBuilder =
+    !isTextWidget &&
+    !(state.dataset === WidgetType.ISSUE && usesTimeSeriesData(state.displayType));
 
   // Group By is used by time-series chart widgets to break down data by a field.
   // - Time-series widgets: show Group By to allow breaking down by fields
   // - Issue widgets: don't support Group By (issues have their own grouping)
   // - Categorical Bar widgets: group by is not supported yet, but may be in the future
-  const showGroupBySelector = isTimeSeriesWidget && !(state.dataset === WidgetType.ISSUE);
+  // - Text widgets: don't support Group By (no data visualization)
+  const showGroupBySelector =
+    isTimeSeriesWidget && !(state.dataset === WidgetType.ISSUE) && !isTextWidget;
 
   // X-Axis selector is only for Categorical Bar widgets, other chart widgets
   // always use time as the X-axis
@@ -160,10 +165,17 @@ export function WidgetBuilderSlideout({
   // - Table: Always show to control row ordering
   // - Line, Area, Bar (Time Series): Show to control which top N groups are displayed
   // - Bar (Categorical): Show to control category ordering (like tables)
+  // - Text: don't need Sort By (no data)
   const showSortByStep =
-    isCategoricalBarWidget ||
-    (isTimeSeriesWidget && state.fields && state.fields.length > 0) ||
-    state.displayType === DisplayType.TABLE;
+    (isCategoricalBarWidget ||
+      (isTimeSeriesWidget && state.fields && state.fields.length > 0) ||
+      state.displayType === DisplayType.TABLE) &&
+    !isTextWidget;
+
+  // Dataset Selector is used by widgets to know which dataset to query.
+  // - Text: doesn't need a dataset because it does not query any data
+  // - Other widgets: need to select a dataset to query the appropriate data
+  const showDatasetSelector = !isTextWidget;
 
   const observer = useMemo(
     () =>
@@ -383,14 +395,26 @@ export function WidgetBuilderSlideout({
                       />
                     </Section>
                   </DisableTransactionWidget>
-                  <Section>
-                    <WidgetBuilderDatasetSelector />
-                  </Section>
+                  {showDatasetSelector && (
+                    <Section>
+                      <WidgetBuilderDatasetSelector />
+                    </Section>
+                  )}
                   <DisableTransactionWidget>
                     <Section>
                       <WidgetBuilderTypeSelector error={error} setError={setError} />
                       {isTimeSeriesWidget && <AxisRangeSection />}
                     </Section>
+                    {isTextWidget && (
+                      <Section>
+                        <WidgetBuilderDescriptionField
+                          rows={12}
+                          placeholder={t('Write your markdown here...')}
+                          autosize={false}
+                          builderStateAction={BuilderStateAction.SET_TEXT_CONTENT}
+                        />
+                      </Section>
+                    )}
                     <div ref={observeForDraggablePreview}>
                       {isSmallScreen && (
                         <Section>
@@ -411,19 +435,16 @@ export function WidgetBuilderSlideout({
                         />
                       </Section>
                     )}
-
                     {showXAxisSelector && (
                       <Section>
                         <WidgetBuilderXAxisSelector />
                       </Section>
                     )}
-
                     {showVisualizeSection && (
                       <Section>
                         <Visualize error={error} setError={setError} />
                       </Section>
                     )}
-
                     {showQueryFilterBuilder && (
                       <Section>
                         <WidgetBuilderQueryFilterBuilder

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -65,7 +65,7 @@ export const MAX_NUM_Y_AXES = 3;
 
 export const stateParamsNotInUrl: Array<keyof WidgetBuilderStateParams> = ['textContent'];
 
-const SESSION_STORAGE_CONTENT_KEY_MAP = {
+export const SESSION_STORAGE_CONTENT_KEY_MAP = {
   textContent: 'dashboard:widget-builder:text-content',
 };
 

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -1,6 +1,7 @@
 import {t} from 'sentry/locale';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {WidgetType} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
+import {SESSION_STORAGE_CONTENT_KEY_MAP} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
 // Used in the widget builder to limit the number of lines plotted in the chart
 export const DEFAULT_RESULTS_LIMIT = 5;
@@ -47,4 +48,15 @@ export function getResultsLimit(numQueries: number, numYAxes: number) {
   }
 
   return Math.floor(RESULTS_LIMIT / (numQueries * numYAxes));
+}
+
+// for the widget builder params that are not in the url
+// we need to store them in session storage
+export function addWidgetBuilderSessionStorageParams(widget: Widget): void {
+  if (widget.displayType === DisplayType.TEXT) {
+    sessionStorage.setItem(
+      SESSION_STORAGE_CONTENT_KEY_MAP.textContent,
+      JSON.stringify(widget.description ?? '')
+    );
+  }
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -290,7 +290,7 @@ describe('convertBuilderStateToWidget', () => {
       title: 'Test Widget',
       description: 'Test text content',
       displayType: DisplayType.TEXT,
-      interval: '',
+      interval: '1h',
       queries: [],
       widgetType: undefined,
       limit: undefined,

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -37,7 +37,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       title: state.title ?? '',
       description: state.textContent,
       displayType: state.displayType,
-      interval: '',
+      interval: '1h', // TODO: allow this field to be blank
       queries: [],
       widgetType: undefined,
       limit: undefined,


### PR DESCRIPTION
This PR ensures that text widgets can be added to other dashboards as well (i'm not sure how much use this will be but feature parity 🤩). Main things here is that the text content session key gets populated when the user decides to open in the widget builder on a different dashboard, AND we have a special case for text widget eventView creation because the text widget doesn't have any queries and most of the UI from this modal is needed for text widgets.

Closes [DAIN-1322](https://linear.app/getsentry/issue/DAIN-1322/implement-add-to-dashboard-flow-for-text-widgets)