### PR TITLE
fix: Avoid KeyError when reading SDK metadata

### DIFF
--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -381,7 +381,7 @@ def get_sdk_versions():
 def get_sdk_urls():
     try:
         rv = dict(settings.SDK_URLS)
-        rv.update((key, info["main_docs_url"]) for (key, info) in get_sdk_index().items())
+        rv.update((key, info.get("main_docs_url", "")) for (key, info) in get_sdk_index().items())
         return rv
     except Exception:
         logger.exception("sentry-release-registry.sdk-urls")


### PR DESCRIPTION
SDK packages can be published without docs. We shouldn't fail when that happens.

Fixes SENTRY-5M6Z
