### PR TITLE
perf(seer): Pre-resolve stacktrace frames before sending to Seer

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -304,6 +304,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-context-engine-fe-override-ui-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code editing tools in Seer Explorer chat
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Send code mappings to Seer for autofix to avoid expensive git tree fetches
+    manager.add("organizations:autofix-send-code-mappings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Autofix to use Seer Explorer instead of legacy Celery pipeline
     manager.add("organizations:autofix-on-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Autofix to use Seer Explorer V2 designs

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -185,13 +185,7 @@ def _pre_resolve_stacktrace_frames(
 ) -> None:
     """
     Pre-resolve stacktrace frame repo_name and filename using Sentry's code mappings
-    and platform-specific frame munging before sending to Seer.
-
-    This uses the same logic as Sentry's convert_stacktrace_frame_path_to_source_path
-    (in sentry/issues/auto_source_code_config/code_mapping.py) including platform-specific
-    munging for Java, Cocoa, Flutter etc.
-
-    By pre-resolving frames, Seer can skip its expensive git tree fetch for large repos.
+    before sending to Seer, so Seer can skip its expensive git tree fetch for large repos.
     """
     if not code_mappings:
         return

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -17,6 +17,10 @@ from sentry.api.serializers import EventSerializer, serialize
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory, ObjectStatus
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.types import ExternalProviders
+from sentry.issues.auto_source_code_config.code_mapping import (
+    convert_stacktrace_frame_path_to_source_path,
+    get_sorted_code_mapping_configs,
+)
 from sentry.issues.grouptype import WebVitalsGroup
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.group import Group
@@ -45,6 +49,7 @@ from sentry.snuba.referrer import Referrer
 from sentry.tasks.autofix import check_autofix_status
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
+from sentry.utils.event_frames import EventFrame
 
 logger = logging.getLogger(__name__)
 
@@ -171,6 +176,79 @@ def _get_serialized_event(
 
     serialized_event = serialize(event, user, EventSerializer())
     return serialized_event, event
+
+
+def _pre_resolve_stacktrace_frames(
+    serialized_event: dict[str, Any],
+    project: Project,
+) -> None:
+    """
+    Pre-resolve stacktrace frame repo_name and filename using Sentry's code mappings
+    and platform-specific frame munging before sending to Seer.
+
+    This uses the same logic as Sentry's convert_stacktrace_frame_path_to_source_path
+    (in sentry/issues/auto_source_code_config/code_mapping.py) including platform-specific
+    munging for Java, Cocoa, Flutter etc.
+
+    By pre-resolving frames, Seer can skip its expensive git tree fetch for large repos.
+    """
+    code_mappings = get_sorted_code_mapping_configs(project)
+    if not code_mappings:
+        return
+
+    platform = serialized_event.get("platform")
+    sdk_name = serialized_event.get("sdk", {}).get("name") if serialized_event.get("sdk") else None
+
+    # Build a lookup: repo full_name -> list of code mappings for that repo
+    repo_mappings: dict[str, list] = {}
+    for cm in code_mappings:
+        repo = cm.repository
+        repo_name_sections = repo.name.split("/")
+        if len(repo_name_sections) > 1 and repo.provider:
+            full_name = repo.name
+            repo_mappings.setdefault(full_name, []).append(cm)
+
+    for entry in serialized_event.get("entries", []):
+        frames = None
+        if entry.get("type") == "exception":
+            for exception in entry.get("data", {}).get("values", []):
+                frames = (exception.get("stacktrace") or {}).get("frames")
+                if frames:
+                    _resolve_frames(frames, repo_mappings, platform, sdk_name)
+        elif entry.get("type") == "threads":
+            for thread in entry.get("data", {}).get("values", []):
+                frames = (thread.get("stacktrace") or {}).get("frames")
+                if frames:
+                    _resolve_frames(frames, repo_mappings, platform, sdk_name)
+
+
+def _resolve_frames(
+    frames: list[dict[str, Any]],
+    repo_mappings: dict[str, list],
+    platform: str | None,
+    sdk_name: str | None,
+) -> None:
+    """Resolve each frame's repo_name using code mappings with platform munging."""
+
+    for frame in frames:
+        if not frame.get("inApp"):
+            continue
+
+        event_frame = EventFrame.from_dict(frame)
+
+        for repo_full_name, mappings in repo_mappings.items():
+            resolved = False
+            for cm in mappings:
+                source_path = convert_stacktrace_frame_path_to_source_path(
+                    event_frame, cm, platform, sdk_name
+                )
+                if source_path:
+                    frame["repo_name"] = repo_full_name
+                    frame["filename"] = source_path
+                    resolved = True
+                    break
+            if resolved:
+                break
 
 
 def _get_trace_tree_for_event(
@@ -633,6 +711,14 @@ def trigger_autofix(
         return _respond_with_error("Cannot fix issues without an event.", 400)
 
     repos = get_autofix_repos_from_project_code_mappings(group.project)
+
+    # Pre-resolve stacktrace frame paths using code mappings so Seer can skip
+    # expensive git tree fetches for large repos.
+    if features.has("organizations:autofix-send-code-mappings", group.organization):
+        try:
+            _pre_resolve_stacktrace_frames(serialized_event, group.project)
+        except Exception:
+            logger.exception("Failed to pre-resolve stacktrace frames")
 
     # get trace tree of transactions and errors for this event
     try:

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -182,6 +182,7 @@ def _get_serialized_event(
 def _pre_resolve_stacktrace_frames(
     serialized_event: dict[str, Any],
     project: Project,
+    code_mappings: list[RepositoryProjectPathConfig] | None = None,
 ) -> None:
     """
     Pre-resolve stacktrace frame repo_name and filename using Sentry's code mappings
@@ -193,7 +194,8 @@ def _pre_resolve_stacktrace_frames(
 
     By pre-resolving frames, Seer can skip its expensive git tree fetch for large repos.
     """
-    code_mappings = get_sorted_code_mapping_configs(project)
+    if code_mappings is None:
+        code_mappings = get_sorted_code_mapping_configs(project)
     if not code_mappings:
         return
 
@@ -714,13 +716,16 @@ def trigger_autofix(
     if serialized_event is None:
         return _respond_with_error("Cannot fix issues without an event.", 400)
 
-    repos = get_autofix_repos_from_project_code_mappings(group.project)
+    code_mappings = get_sorted_code_mapping_configs(group.project)
+    repos = get_autofix_repos_from_project_code_mappings(group.project, code_mappings=code_mappings)
 
     # Pre-resolve stacktrace frame paths using code mappings so Seer can skip
     # expensive git tree fetches for large repos.
     if features.has("organizations:autofix-send-code-mappings", group.organization):
         try:
-            _pre_resolve_stacktrace_frames(serialized_event, group.project)
+            _pre_resolve_stacktrace_frames(
+                serialized_event, group.project, code_mappings=code_mappings
+            )
         except Exception:
             logger.exception("Failed to pre-resolve stacktrace frames")
 

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -201,18 +201,35 @@ def _pre_resolve_stacktrace_frames(
         if len(repo_name_sections) > 1 and repo.provider:
             ordered_mappings.append((repo.name, cm))
 
+    resolved = 0
+    total_in_app = 0
+
     for entry in serialized_event.get("entries", []):
         frames = None
         if entry.get("type") == "exception":
             for exception in entry.get("data", {}).get("values", []):
                 frames = (exception.get("stacktrace") or {}).get("frames")
                 if frames:
-                    _resolve_frames(frames, ordered_mappings, platform, sdk_name)
+                    r, t = _resolve_frames(frames, ordered_mappings, platform, sdk_name)
+                    resolved += r
+                    total_in_app += t
         elif entry.get("type") == "threads":
             for thread in entry.get("data", {}).get("values", []):
                 frames = (thread.get("stacktrace") or {}).get("frames")
                 if frames:
-                    _resolve_frames(frames, ordered_mappings, platform, sdk_name)
+                    r, t = _resolve_frames(frames, ordered_mappings, platform, sdk_name)
+                    resolved += r
+                    total_in_app += t
+
+    logger.info(
+        "autofix.pre_resolve_stacktrace_frames",
+        extra={
+            "resolved_frames": resolved,
+            "unresolved_frames": total_in_app - resolved,
+            "total_in_app_frames": total_in_app,
+            "platform": platform,
+        },
+    )
 
 
 def _resolve_frames(
@@ -220,12 +237,19 @@ def _resolve_frames(
     ordered_mappings: list[tuple[str, RepositoryProjectPathConfig]],
     platform: str | None,
     sdk_name: str | None,
-) -> None:
-    """Resolve each frame's repo_name using code mappings in global priority order."""
+) -> tuple[int, int]:
+    """Resolve each frame's repo_name using code mappings in global priority order.
+
+    Returns (resolved_count, total_in_app_count).
+    """
+    resolved = 0
+    total_in_app = 0
 
     for frame in frames:
         if not frame.get("inApp"):
             continue
+
+        total_in_app += 1
 
         # Serialized events use camelCase keys but EventFrame expects snake_case
         event_frame = EventFrame(
@@ -245,7 +269,10 @@ def _resolve_frames(
             if source_path:
                 frame["repo_name"] = repo_full_name
                 frame["filename"] = source_path
+                resolved += 1
                 break
+
+    return resolved, total_in_app
 
 
 def _get_trace_tree_for_event(

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -181,8 +181,7 @@ def _get_serialized_event(
 
 def _pre_resolve_stacktrace_frames(
     serialized_event: dict[str, Any],
-    project: Project,
-    code_mappings: list[RepositoryProjectPathConfig] | None = None,
+    code_mappings: list[RepositoryProjectPathConfig],
 ) -> None:
     """
     Pre-resolve stacktrace frame repo_name and filename using Sentry's code mappings
@@ -194,8 +193,6 @@ def _pre_resolve_stacktrace_frames(
 
     By pre-resolving frames, Seer can skip its expensive git tree fetch for large repos.
     """
-    if code_mappings is None:
-        code_mappings = get_sorted_code_mapping_configs(project)
     if not code_mappings:
         return
 
@@ -723,9 +720,7 @@ def trigger_autofix(
     # expensive git tree fetches for large repos.
     if features.has("organizations:autofix-send-code-mappings", group.organization):
         try:
-            _pre_resolve_stacktrace_frames(
-                serialized_event, group.project, code_mappings=code_mappings
-            )
+            _pre_resolve_stacktrace_frames(serialized_event, code_mappings)
         except Exception:
             logger.exception("Failed to pre-resolve stacktrace frames")
 

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -16,6 +16,7 @@ from sentry.api.endpoints.organization_trace import OrganizationTraceEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory, ObjectStatus
 from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.types import ExternalProviders
 from sentry.issues.auto_source_code_config.code_mapping import (
     convert_stacktrace_frame_path_to_source_path,
@@ -199,14 +200,13 @@ def _pre_resolve_stacktrace_frames(
     platform = serialized_event.get("platform")
     sdk_name = serialized_event.get("sdk", {}).get("name") if serialized_event.get("sdk") else None
 
-    # Build a lookup: repo full_name -> list of code mappings for that repo
-    repo_mappings: dict[str, list] = {}
+    # Build ordered list of (repo_full_name, code_mapping) preserving global priority
+    ordered_mappings: list[tuple[str, RepositoryProjectPathConfig]] = []
     for cm in code_mappings:
         repo = cm.repository
         repo_name_sections = repo.name.split("/")
         if len(repo_name_sections) > 1 and repo.provider:
-            full_name = repo.name
-            repo_mappings.setdefault(full_name, []).append(cm)
+            ordered_mappings.append((repo.name, cm))
 
     for entry in serialized_event.get("entries", []):
         frames = None
@@ -214,21 +214,21 @@ def _pre_resolve_stacktrace_frames(
             for exception in entry.get("data", {}).get("values", []):
                 frames = (exception.get("stacktrace") or {}).get("frames")
                 if frames:
-                    _resolve_frames(frames, repo_mappings, platform, sdk_name)
+                    _resolve_frames(frames, ordered_mappings, platform, sdk_name)
         elif entry.get("type") == "threads":
             for thread in entry.get("data", {}).get("values", []):
                 frames = (thread.get("stacktrace") or {}).get("frames")
                 if frames:
-                    _resolve_frames(frames, repo_mappings, platform, sdk_name)
+                    _resolve_frames(frames, ordered_mappings, platform, sdk_name)
 
 
 def _resolve_frames(
     frames: list[dict[str, Any]],
-    repo_mappings: dict[str, list],
+    ordered_mappings: list[tuple[str, RepositoryProjectPathConfig]],
     platform: str | None,
     sdk_name: str | None,
 ) -> None:
-    """Resolve each frame's repo_name using code mappings with platform munging."""
+    """Resolve each frame's repo_name using code mappings in global priority order."""
 
     for frame in frames:
         if not frame.get("inApp"):
@@ -245,18 +245,13 @@ def _resolve_frames(
             lineno=frame.get("lineNo"),
         )
 
-        for repo_full_name, mappings in repo_mappings.items():
-            resolved = False
-            for cm in mappings:
-                source_path = convert_stacktrace_frame_path_to_source_path(
-                    event_frame, cm, platform, sdk_name
-                )
-                if source_path:
-                    frame["repo_name"] = repo_full_name
-                    frame["filename"] = source_path
-                    resolved = True
-                    break
-            if resolved:
+        for repo_full_name, cm in ordered_mappings:
+            source_path = convert_stacktrace_frame_path_to_source_path(
+                event_frame, cm, platform, sdk_name
+            )
+            if source_path:
+                frame["repo_name"] = repo_full_name
+                frame["filename"] = source_path
                 break
 
 

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -234,7 +234,16 @@ def _resolve_frames(
         if not frame.get("inApp"):
             continue
 
-        event_frame = EventFrame.from_dict(frame)
+        # Serialized events use camelCase keys but EventFrame expects snake_case
+        event_frame = EventFrame(
+            filename=frame.get("filename"),
+            abs_path=frame.get("absPath"),
+            module=frame.get("module"),
+            package=frame.get("package"),
+            function=frame.get("function"),
+            in_app=frame.get("inApp"),
+            lineno=frame.get("lineNo"),
+        )
 
         for repo_full_name, mappings in repo_mappings.items():
             resolved = False

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -509,19 +509,19 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
 
         # We expect a repository name to be in the format of "owner/name" for now.
         if len(repo_name_sections) > 1 and repo.provider:
-            repo_key = (repo.provider, repo_name_sections[0], "/".join(repo_name_sections[1:]))
+            repo_dict = {
+                "organization_id": repo.organization_id,
+                "integration_id": (
+                    str(repo.integration_id) if repo.integration_id is not None else None
+                ),
+                "provider": repo.provider,
+                "owner": repo_name_sections[0],
+                "name": "/".join(repo_name_sections[1:]),
+                "external_id": repo.external_id,
+            }
+            repo_key = (repo_dict["provider"], repo_dict["owner"], repo_dict["name"])
 
-            if repo_key not in repos:
-                repos[repo_key] = {
-                    "organization_id": repo.organization_id,
-                    "integration_id": (
-                        str(repo.integration_id) if repo.integration_id is not None else None
-                    ),
-                    "provider": repo.provider,
-                    "owner": repo_name_sections[0],
-                    "name": "/".join(repo_name_sections[1:]),
-                    "external_id": repo.external_id,
-                }
+            repos[repo_key] = repo_dict
 
     return list(repos.values())
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -502,6 +502,10 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
 
     code_mappings = get_sorted_code_mapping_configs(project)
 
+    should_send_code_mappings = features.has(
+        "organizations:autofix-send-code-mappings", project.organization
+    )
+
     repos: dict[tuple, dict] = {}
     for code_mapping in code_mappings:
         repo: Repository = code_mapping.repository
@@ -509,19 +513,29 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
 
         # We expect a repository name to be in the format of "owner/name" for now.
         if len(repo_name_sections) > 1 and repo.provider:
-            repo_dict = {
-                "organization_id": repo.organization_id,
-                "integration_id": (
-                    str(repo.integration_id) if repo.integration_id is not None else None
-                ),
-                "provider": repo.provider,
-                "owner": repo_name_sections[0],
-                "name": "/".join(repo_name_sections[1:]),
-                "external_id": repo.external_id,
-            }
-            repo_key = (repo_dict["provider"], repo_dict["owner"], repo_dict["name"])
+            repo_key = (repo.provider, repo_name_sections[0], "/".join(repo_name_sections[1:]))
 
-            repos[repo_key] = repo_dict
+            if repo_key not in repos:
+                repos[repo_key] = {
+                    "organization_id": repo.organization_id,
+                    "integration_id": (
+                        str(repo.integration_id) if repo.integration_id is not None else None
+                    ),
+                    "provider": repo.provider,
+                    "owner": repo_name_sections[0],
+                    "name": "/".join(repo_name_sections[1:]),
+                    "external_id": repo.external_id,
+                }
+                if should_send_code_mappings:
+                    repos[repo_key]["code_mappings"] = []
+
+            if should_send_code_mappings:
+                repos[repo_key]["code_mappings"].append(
+                    {
+                        "stack_root": code_mapping.stack_root,
+                        "source_root": code_mapping.source_root,
+                    }
+                )
 
     return list(repos.values())
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -502,10 +502,6 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
 
     code_mappings = get_sorted_code_mapping_configs(project)
 
-    should_send_code_mappings = features.has(
-        "organizations:autofix-send-code-mappings", project.organization
-    )
-
     repos: dict[tuple, dict] = {}
     for code_mapping in code_mappings:
         repo: Repository = code_mapping.repository
@@ -526,16 +522,6 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
                     "name": "/".join(repo_name_sections[1:]),
                     "external_id": repo.external_id,
                 }
-                if should_send_code_mappings:
-                    repos[repo_key]["code_mappings"] = []
-
-            if should_send_code_mappings:
-                repos[repo_key]["code_mappings"].append(
-                    {
-                        "stack_root": code_mapping.stack_root,
-                        "source_root": code_mapping.source_root,
-                    }
-                )
 
     return list(repos.values())
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -13,6 +13,7 @@ from urllib3.util.retry import Retry
 
 from sentry import features, options, ratelimits
 from sentry.constants import DataCategory
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.issues.auto_source_code_config.code_mapping import (
     get_sorted_code_mapping_configs,
 )
@@ -495,12 +496,16 @@ def bulk_set_project_preferences(organization_id: int, preferences: list[dict]) 
         raise SeerApiError(response.data.decode("utf-8"), response.status)
 
 
-def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]:
+def get_autofix_repos_from_project_code_mappings(
+    project: Project,
+    code_mappings: list[RepositoryProjectPathConfig] | None = None,
+) -> list[dict]:
     if settings.SEER_AUTOFIX_FORCE_USE_REPOS:
         # This is for testing purposes only, for example in s4s we want to force the use of specific repo(s)
         return settings.SEER_AUTOFIX_FORCE_USE_REPOS
 
-    code_mappings = get_sorted_code_mapping_configs(project)
+    if code_mappings is None:
+        code_mappings = get_sorted_code_mapping_configs(project)
 
     repos: dict[tuple, dict] = {}
     for code_mapping in code_mappings:

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -47,68 +47,6 @@ class TestGetRepoFromCodeMappings(TestCase):
         ]
         assert repos == expected_repos
 
-    def test_includes_code_mappings_when_feature_flag_enabled(self) -> None:
-        project = self.create_project()
-        repo = self.create_repo(
-            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
-        )
-        self.create_code_mapping(
-            project=project, repo=repo, stack_root="src/", source_root="sentry/"
-        )
-        self.create_code_mapping(
-            project=project, repo=repo, stack_root="tests/", source_root="tests/sentry/"
-        )
-
-        with self.feature("organizations:autofix-send-code-mappings"):
-            repos = get_autofix_repos_from_project_code_mappings(project)
-
-        assert len(repos) == 1
-        assert sorted(repos[0]["code_mappings"], key=lambda m: m["stack_root"]) == [
-            {"stack_root": "src/", "source_root": "sentry/"},
-            {"stack_root": "tests/", "source_root": "tests/sentry/"},
-        ]
-
-    def test_no_code_mappings_without_feature_flag(self) -> None:
-        project = self.create_project()
-        repo = self.create_repo(
-            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
-        )
-        self.create_code_mapping(
-            project=project, repo=repo, stack_root="src/", source_root="sentry/"
-        )
-
-        repos = get_autofix_repos_from_project_code_mappings(project)
-
-        assert len(repos) == 1
-        assert "code_mappings" not in repos[0]
-
-    def test_code_mappings_multiple_repos(self) -> None:
-        project = self.create_project()
-        repo1 = self.create_repo(
-            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
-        )
-        repo2 = self.create_repo(
-            name="getsentry/seer", provider="github", external_id="456", integration_id=234
-        )
-        self.create_code_mapping(
-            project=project, repo=repo1, stack_root="src/", source_root="sentry/"
-        )
-        self.create_code_mapping(
-            project=project, repo=repo2, stack_root="ml/", source_root="src/seer/"
-        )
-
-        with self.feature("organizations:autofix-send-code-mappings"):
-            repos = get_autofix_repos_from_project_code_mappings(project)
-
-        assert len(repos) == 2
-        repos_by_name = {r["name"]: r for r in repos}
-        assert repos_by_name["sentry"]["code_mappings"] == [
-            {"stack_root": "src/", "source_root": "sentry/"},
-        ]
-        assert repos_by_name["seer"]["code_mappings"] == [
-            {"stack_root": "ml/", "source_root": "src/seer/"},
-        ]
-
 
 class TestGetAutofixStateFromPrId(TestCase):
     @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -47,6 +47,68 @@ class TestGetRepoFromCodeMappings(TestCase):
         ]
         assert repos == expected_repos
 
+    def test_includes_code_mappings_when_feature_flag_enabled(self) -> None:
+        project = self.create_project()
+        repo = self.create_repo(
+            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
+        )
+        self.create_code_mapping(
+            project=project, repo=repo, stack_root="src/", source_root="sentry/"
+        )
+        self.create_code_mapping(
+            project=project, repo=repo, stack_root="tests/", source_root="tests/sentry/"
+        )
+
+        with self.feature("organizations:autofix-send-code-mappings"):
+            repos = get_autofix_repos_from_project_code_mappings(project)
+
+        assert len(repos) == 1
+        assert sorted(repos[0]["code_mappings"], key=lambda m: m["stack_root"]) == [
+            {"stack_root": "src/", "source_root": "sentry/"},
+            {"stack_root": "tests/", "source_root": "tests/sentry/"},
+        ]
+
+    def test_no_code_mappings_without_feature_flag(self) -> None:
+        project = self.create_project()
+        repo = self.create_repo(
+            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
+        )
+        self.create_code_mapping(
+            project=project, repo=repo, stack_root="src/", source_root="sentry/"
+        )
+
+        repos = get_autofix_repos_from_project_code_mappings(project)
+
+        assert len(repos) == 1
+        assert "code_mappings" not in repos[0]
+
+    def test_code_mappings_multiple_repos(self) -> None:
+        project = self.create_project()
+        repo1 = self.create_repo(
+            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
+        )
+        repo2 = self.create_repo(
+            name="getsentry/seer", provider="github", external_id="456", integration_id=234
+        )
+        self.create_code_mapping(
+            project=project, repo=repo1, stack_root="src/", source_root="sentry/"
+        )
+        self.create_code_mapping(
+            project=project, repo=repo2, stack_root="ml/", source_root="src/seer/"
+        )
+
+        with self.feature("organizations:autofix-send-code-mappings"):
+            repos = get_autofix_repos_from_project_code_mappings(project)
+
+        assert len(repos) == 2
+        repos_by_name = {r["name"]: r for r in repos}
+        assert repos_by_name["sentry"]["code_mappings"] == [
+            {"stack_root": "src/", "source_root": "sentry/"},
+        ]
+        assert repos_by_name["seer"]["code_mappings"] == [
+            {"stack_root": "ml/", "source_root": "src/seer/"},
+        ]
+
 
 class TestGetAutofixStateFromPrId(TestCase):
     @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import Mock, patch
 
 import orjson
@@ -14,6 +15,7 @@ from sentry.seer.autofix.autofix import (
     _get_logs_for_event,
     _get_profile_from_trace_tree,
     _get_trace_tree_for_event,
+    _pre_resolve_stacktrace_frames,
     _respond_with_error,
     get_all_tags_overview,
     trigger_autofix,
@@ -1515,3 +1517,149 @@ class UpdateAutofixTest(TestCase):
 
         assert response.status_code == 200
         assert response.data == mock_response.json.return_value
+
+
+class TestPreResolveStacktraceFrames(TestCase):
+    def _make_serialized_event(self, frames, platform="python"):
+        return {
+            "platform": platform,
+            "entries": [
+                {
+                    "type": "exception",
+                    "data": {
+                        "values": [
+                            {
+                                "stacktrace": {
+                                    "frames": frames,
+                                }
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+
+    def test_resolves_frames_with_code_mapping(self):
+        project = self.create_project()
+        repo = self.create_repo(
+            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
+        )
+        self.create_code_mapping(
+            project=project, repo=repo, stack_root="src/", source_root="sentry/"
+        )
+
+        event = self._make_serialized_event(
+            [
+                {"filename": "src/utils.py", "inApp": True},
+                {"filename": "src/models.py", "inApp": True},
+                {"filename": "lib/external.py", "inApp": False},
+            ]
+        )
+
+        _pre_resolve_stacktrace_frames(event, project)
+
+        frames = event["entries"][0]["data"]["values"][0]["stacktrace"]["frames"]
+        assert frames[0]["repo_name"] == "getsentry/sentry"
+        assert frames[0]["filename"] == "sentry/utils.py"
+        assert frames[1]["repo_name"] == "getsentry/sentry"
+        assert frames[1]["filename"] == "sentry/models.py"
+        # Non in-app frames should not be resolved
+        assert "repo_name" not in frames[2]
+
+    def test_no_code_mappings_is_noop(self):
+        project = self.create_project()
+
+        event = self._make_serialized_event([{"filename": "src/utils.py", "inApp": True}])
+
+        _pre_resolve_stacktrace_frames(event, project)
+
+        frames = event["entries"][0]["data"]["values"][0]["stacktrace"]["frames"]
+        assert "repo_name" not in frames[0]
+
+    def test_unmatched_frames_left_unresolved(self):
+        project = self.create_project()
+        repo = self.create_repo(
+            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
+        )
+        self.create_code_mapping(
+            project=project, repo=repo, stack_root="src/", source_root="sentry/"
+        )
+
+        event = self._make_serialized_event(
+            [
+                {"filename": "src/utils.py", "inApp": True},
+                {"filename": "unknown/other.py", "inApp": True},
+            ]
+        )
+
+        _pre_resolve_stacktrace_frames(event, project)
+
+        frames = event["entries"][0]["data"]["values"][0]["stacktrace"]["frames"]
+        assert frames[0]["repo_name"] == "getsentry/sentry"
+        assert "repo_name" not in frames[1]
+
+    def test_multiple_repos(self):
+        project = self.create_project()
+        repo1 = self.create_repo(
+            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
+        )
+        repo2 = self.create_repo(
+            name="getsentry/seer", provider="github", external_id="456", integration_id=234
+        )
+        self.create_code_mapping(
+            project=project, repo=repo1, stack_root="src/", source_root="sentry/"
+        )
+        self.create_code_mapping(
+            project=project, repo=repo2, stack_root="ml/", source_root="src/seer/"
+        )
+
+        event = self._make_serialized_event(
+            [
+                {"filename": "src/utils.py", "inApp": True},
+                {"filename": "ml/models.py", "inApp": True},
+            ]
+        )
+
+        _pre_resolve_stacktrace_frames(event, project)
+
+        frames = event["entries"][0]["data"]["values"][0]["stacktrace"]["frames"]
+        assert frames[0]["repo_name"] == "getsentry/sentry"
+        assert frames[0]["filename"] == "sentry/utils.py"
+        assert frames[1]["repo_name"] == "getsentry/seer"
+        assert frames[1]["filename"] == "src/seer/models.py"
+
+    def test_resolves_thread_frames(self):
+        project = self.create_project()
+        repo = self.create_repo(
+            name="getsentry/sentry", provider="github", external_id="123", integration_id=234
+        )
+        self.create_code_mapping(
+            project=project, repo=repo, stack_root="src/", source_root="sentry/"
+        )
+
+        event = {
+            "platform": "python",
+            "entries": [
+                {
+                    "type": "threads",
+                    "data": {
+                        "values": [
+                            {
+                                "stacktrace": {
+                                    "frames": [
+                                        {"filename": "src/tasks.py", "inApp": True},
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+
+        _pre_resolve_stacktrace_frames(event, project)
+
+        entry: Any = event["entries"][0]
+        frames = entry["data"]["values"][0]["stacktrace"]["frames"]
+        assert frames[0]["repo_name"] == "getsentry/sentry"
+        assert frames[0]["filename"] == "sentry/tasks.py"

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -6,6 +6,7 @@ import orjson
 import pytest
 from django.contrib.auth.models import AnonymousUser
 
+from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
 from sentry.issues.grouptype import WebVitalsGroup
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.seer.autofix.autofix import (
@@ -1556,7 +1557,7 @@ class TestPreResolveStacktraceFrames(TestCase):
             ]
         )
 
-        _pre_resolve_stacktrace_frames(event, project)
+        _pre_resolve_stacktrace_frames(event, get_sorted_code_mapping_configs(project))
 
         frames = event["entries"][0]["data"]["values"][0]["stacktrace"]["frames"]
         assert frames[0]["repo_name"] == "getsentry/sentry"
@@ -1567,11 +1568,9 @@ class TestPreResolveStacktraceFrames(TestCase):
         assert "repo_name" not in frames[2]
 
     def test_no_code_mappings_is_noop(self):
-        project = self.create_project()
-
         event = self._make_serialized_event([{"filename": "src/utils.py", "inApp": True}])
 
-        _pre_resolve_stacktrace_frames(event, project)
+        _pre_resolve_stacktrace_frames(event, [])
 
         frames = event["entries"][0]["data"]["values"][0]["stacktrace"]["frames"]
         assert "repo_name" not in frames[0]
@@ -1592,7 +1591,7 @@ class TestPreResolveStacktraceFrames(TestCase):
             ]
         )
 
-        _pre_resolve_stacktrace_frames(event, project)
+        _pre_resolve_stacktrace_frames(event, get_sorted_code_mapping_configs(project))
 
         frames = event["entries"][0]["data"]["values"][0]["stacktrace"]["frames"]
         assert frames[0]["repo_name"] == "getsentry/sentry"
@@ -1620,7 +1619,7 @@ class TestPreResolveStacktraceFrames(TestCase):
             ]
         )
 
-        _pre_resolve_stacktrace_frames(event, project)
+        _pre_resolve_stacktrace_frames(event, get_sorted_code_mapping_configs(project))
 
         frames = event["entries"][0]["data"]["values"][0]["stacktrace"]["frames"]
         assert frames[0]["repo_name"] == "getsentry/sentry"
@@ -1657,7 +1656,7 @@ class TestPreResolveStacktraceFrames(TestCase):
             ],
         }
 
-        _pre_resolve_stacktrace_frames(event, project)
+        _pre_resolve_stacktrace_frames(event, get_sorted_code_mapping_configs(project))
 
         entry: Any = event["entries"][0]
         frames = entry["data"]["values"][0]["stacktrace"]["frames"]


### PR DESCRIPTION
Pre-resolve stacktrace frame paths in Sentry before sending to Seer for autofix,
using Sentry's existing code mapping + platform munging infrastructure.

**What it does:** For each in-app stacktrace frame, applies
`convert_stacktrace_frame_path_to_source_path` (which includes platform-specific
munging for Java, Cocoa, Flutter) and sets `repo_name` directly on the frame dict
in the serialized event before sending to Seer.

**Motivation:** Large monorepos cause autofix to timeout because
Seer's `_get_git_tree()` has to enumerate every file path via the GitHub API, which
can require hundreds of recursive API calls when the tree is truncated. Sentry already
has code mappings configured automatically / by users — by pre-resolving frames here, Seer can skip
the tree fetch entirely.

Gated behind the `organizations:autofix-send-code-mappings` feature flag.

**Companion Seer PR:** https://github.com/getsentry/seer/pull/5314 — adds an early-return
in `process_stacktrace_paths` to skip the git tree fetch when all frames already have
`repo_name` set. Without the Seer PR, frames would still be correctly attributed (Seer's
per-frame `repo_name is None` check skips pre-resolved frames), but the tree would still
be fetched unnecessarily. **Deploy the Seer PR first.**