### PR TITLE
ref(uptime): clean up invoke_checker_validator mocks in tests

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3197,29 +3197,22 @@ class MonitorIngestTestCase(MonitorTestCase):
 class UptimeTestCaseMixin:
     def setUp(self):
         super().setUp()
-        self.mock_resolve_hostname_ctx = mock.patch(
+        patcher = mock.patch(
             "sentry.uptime.rdap.query.resolve_hostname", return_value="192.168.0.1"
         )
-        self.mock_resolve_rdap_provider_ctx = mock.patch(
-            "sentry.uptime.rdap.query.resolve_rdap_provider",
-            return_value="https://fake.com/",
-        )
-        self.mock_requests_get_ctx = mock.patch("sentry.uptime.rdap.query.requests.get")
-        self.mock_invoke_checker_validator_ctx = mock.patch(
-            "sentry.uptime.checker_api.invoke_checker_validator", return_value=None
-        )
-        self.mock_resolve_hostname = self.mock_resolve_hostname_ctx.__enter__()
-        self.mock_resolve_rdap_provider = self.mock_resolve_rdap_provider_ctx.__enter__()
-        self.mock_requests_get = self.mock_requests_get_ctx.__enter__()
-        self.mock_requests_get.return_value.json.return_value = {"entities": [{"handle": "hi"}]}
-        self.mock_invoke_checker_validator = self.mock_invoke_checker_validator_ctx.__enter__()
+        self.mock_resolve_hostname = patcher.start()
+        self.addCleanup(patcher.stop)
 
-    def tearDown(self):
-        super().tearDown()
-        self.mock_resolve_hostname_ctx.__exit__(None, None, None)
-        self.mock_resolve_rdap_provider_ctx.__exit__(None, None, None)
-        self.mock_requests_get_ctx.__exit__(None, None, None)
-        self.mock_invoke_checker_validator_ctx.__exit__(None, None, None)
+        patcher = mock.patch(
+            "sentry.uptime.rdap.query.resolve_rdap_provider", return_value="https://fake.com/"
+        )
+        self.mock_resolve_rdap_provider = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch("sentry.uptime.rdap.query.requests.get")
+        self.mock_requests_get = patcher.start()
+        self.mock_requests_get.return_value.json.return_value = {"entities": [{"handle": "hi"}]}
+        self.addCleanup(patcher.stop)
 
     def create_uptime_result(
         self,

--- a/tests/sentry/uptime/endpoints/__init__.py
+++ b/tests/sentry/uptime/endpoints/__init__.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from sentry.testutils.cases import APITestCase
 
 
@@ -7,11 +5,3 @@ class UptimeAlertBaseEndpointTest(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
-        self.mock_invoke_checker_validator_ctx = mock.patch(
-            "sentry.uptime.checker_api.invoke_checker_validator", return_value=None
-        )
-        self.mock_invoke_checker_validator = self.mock_invoke_checker_validator_ctx.__enter__()
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        self.mock_invoke_checker_validator_ctx.__exit__(None, None, None)

--- a/tests/sentry/uptime/endpoints/test_detector.py
+++ b/tests/sentry/uptime/endpoints/test_detector.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from django.utils import timezone
 from rest_framework import status
 
@@ -49,10 +47,6 @@ class UptimeDetectorBaseTest(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
-        self.mock_invoke_checker_validator_ctx = mock.patch(
-            "sentry.uptime.checker_api.invoke_checker_validator", return_value=None
-        )
-        self.mock_invoke_checker_validator = self.mock_invoke_checker_validator_ctx.__enter__()
         self.environment = self.create_environment(
             organization_id=self.organization.id, name="production"
         )
@@ -74,10 +68,6 @@ class UptimeDetectorBaseTest(APITestCase):
             uptime_subscription=self.uptime_subscription,
             name="Test Detector",
         )
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        self.mock_invoke_checker_validator_ctx.__exit__(None, None, None)
 
 
 class OrganizationDetectorDetailsPutTest(UptimeDetectorBaseTest):
@@ -310,14 +300,6 @@ class OrganizationDetectorIndexPostTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.mock_invoke_checker_validator_ctx = mock.patch(
-            "sentry.uptime.checker_api.invoke_checker_validator", return_value=None
-        )
-        self.mock_invoke_checker_validator = self.mock_invoke_checker_validator_ctx.__enter__()
-
-    def tearDown(self):
-        super().tearDown()
-        self.mock_invoke_checker_validator_ctx.__exit__(None, None, None)
 
     def test_create_detector_validation_error(self):
         invalid_data = _get_valid_data(

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
@@ -36,12 +36,11 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
         assert "timeoutMs" in response.data
         assert response.data["timeoutMs"][0].code == "required"
 
-    def test_bad_checker_validation(self) -> None:
-        mock_response = mock.Mock()
-        mock_response.status_code = 400
-        mock_response.json.return_value = {"error": True}
-        self.mock_invoke_checker_validator.return_value = mock_response
-
+    @mock.patch("sentry.uptime.checker_api.invoke_checker_validator")
+    def test_bad_checker_validation(self, mock_validator: mock.MagicMock) -> None:
+        mock_validator.return_value = mock.Mock(
+            status_code=400, **{"json.return_value": {"error": True}}
+        )
         response = self.get_error_response(
             self.organization.slug,
             name="test",

--- a/tests/sentry/uptime/endpoints/test_validators.py
+++ b/tests/sentry/uptime/endpoints/test_validators.py
@@ -78,13 +78,6 @@ class UptimeMonitorDataSourceValidatorTest(TestCase):
             "project": self.project,
             "request": self.make_request(),
         }
-        self.mock_invoke_checker_validator_ctx = mock.patch(
-            "sentry.uptime.checker_api.invoke_checker_validator", return_value=None
-        )
-        self.mock_invoke_checker_validator = self.mock_invoke_checker_validator_ctx.__enter__()
-
-    def tearDown(self):
-        self.mock_invoke_checker_validator_ctx.__exit__(None, None, None)
 
     def test_simple(self):
         validator = UptimeMonitorDataSourceValidator(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -52,10 +52,6 @@ class OrganizationDetectorIndexBaseTest(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
-        self.mock_invoke_checker_validator_ctx = mock.patch(
-            "sentry.uptime.checker_api.invoke_checker_validator", return_value=None
-        )
-        self.mock_invoke_checker_validator = self.mock_invoke_checker_validator_ctx.__enter__()
         self.environment = Environment.objects.create(
             organization_id=self.organization.id, name="production"
         )
@@ -69,10 +65,6 @@ class OrganizationDetectorIndexBaseTest(APITestCase):
         self.issue_stream_detector = self.create_detector(
             type=IssueStreamGroupType.slug, project=self.project, name="Issue Stream"
         )
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        self.mock_invoke_checker_validator_ctx.__exit__(None, None, None)
 
 
 @cell_silo_test


### PR DESCRIPTION
Remove unnecessary `invoke_checker_validator` mocks added when the
uptime-runtime-assertions flag was removed. The mock was added broadly
as a precaution but most test classes don't exercise code paths that
call the function at all.

Also fix `test_success` and `test_alerts_write_permission` which were
accidentally broken by the blanket base class mock — those tests should
exercise the full path through `invoke_checker_validator`, using
`responses` to intercept the actual HTTP call to `validate_check`.

Replace manual `__enter__`/`__exit__` context manager pattern with
`patcher.start()`/`addCleanup(patcher.stop)` where mocks remain.