### PR TITLE
feat(autofix): Support coding agents in redesigns

### DIFF
--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -12,6 +12,7 @@ import {DateTime} from 'sentry/components/dateTime';
 import {
   CodingAgentProvider,
   CodingAgentStatus,
+  getCodingAgentName,
   getResultButtonLabel,
   type CodingAgentState,
   type SeerRepoDefinition,
@@ -67,19 +68,6 @@ export function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) 
     return status === CodingAgentStatus.PENDING || status === CodingAgentStatus.RUNNING;
   };
 
-  const getProviderName = (provider: CodingAgentProvider) => {
-    switch (provider) {
-      case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
-        return t('Cursor Cloud Agent');
-      case CodingAgentProvider.GITHUB_COPILOT_AGENT:
-        return t('GitHub Copilot');
-      case CodingAgentProvider.CLAUDE_CODE_AGENT:
-        return t('Claude Agent');
-      default:
-        return t('Coding Agent');
-    }
-  };
-
   const hasButtons = Boolean(
     codingAgentState.agent_url || codingAgentState.results?.some(result => result.pr_url)
   );
@@ -99,7 +87,7 @@ export function CodingAgentCard({codingAgentState, repo}: CodingAgentCardProps) 
                     ) : (
                       <IconCode size="md" variant="accent" />
                     )}
-                    {getProviderName(codingAgentState.provider)}
+                    {getCodingAgentName(codingAgentState.provider)}
                   </HeaderText>
                 </HeaderWrapper>
 

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -405,3 +405,16 @@ export interface ProjectSeerPreferences {
 }
 
 export const AUTOFIX_TTL_IN_DAYS = 30;
+
+export function getCodingAgentName(provider: string | undefined): string {
+  switch (provider) {
+    case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
+      return t('Cursor Cloud Agent');
+    case CodingAgentProvider.CLAUDE_CODE_AGENT:
+      return t('Claude Agent');
+    case CodingAgentProvider.GITHUB_COPILOT_AGENT:
+      return t('GitHub Copilot');
+    default:
+      return t('Coding Agent');
+  }
+}

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -1,4 +1,8 @@
+import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
 import {
+  isCodeChangesArtifact,
+  isCodingAgentsArtifact,
+  isPullRequestsArtifact,
   isRootCauseArtifact,
   isSolutionArtifact,
   type RootCauseArtifact,
@@ -110,5 +114,122 @@ describe('isSolutionArtifact', () => {
         })
       )
     ).toBe(true);
+  });
+});
+
+describe('isCodeChangesArtifact', () => {
+  function makeValidFilePatch() {
+    return {
+      repo_name: 'org/repo',
+      diff: '--- a/file.py\n+++ b/file.py',
+      patch: {
+        path: 'file.py',
+        added: 1,
+        removed: 0,
+        hunks: [
+          {
+            lines: [
+              {
+                diff_line_no: 1,
+                line_type: DiffLineType.ADDED,
+                source_line_no: null,
+                target_line_no: 1,
+                value: '+hello',
+              },
+            ],
+            section_header: '@@ -1,3 +1,4 @@',
+            source_length: 3,
+            source_start: 1,
+            target_length: 4,
+            target_start: 1,
+          },
+        ],
+        source_file: 'a/file.py',
+        target_file: 'b/file.py',
+        type: DiffFileType.MODIFIED,
+      },
+    };
+  }
+
+  it('returns true for a valid file patch array', () => {
+    expect(isCodeChangesArtifact([makeValidFilePatch()])).toBe(true);
+  });
+
+  it('returns false for an empty array', () => {
+    expect(isCodeChangesArtifact([])).toBe(false);
+  });
+
+  it('returns false for non-array values', () => {
+    expect(isCodeChangesArtifact(null)).toBe(false);
+    expect(isCodeChangesArtifact('string')).toBe(false);
+    expect(isCodeChangesArtifact({repo_name: 'org/repo'})).toBe(false);
+  });
+
+  it('returns false when array contains invalid items', () => {
+    expect(isCodeChangesArtifact([{repo_name: 'org/repo'}])).toBe(false);
+  });
+});
+
+describe('isPullRequestsArtifact', () => {
+  function makeValidPR() {
+    return {
+      repo_name: 'org/repo',
+      branch_name: 'fix/bug',
+      commit_sha: 'abc123',
+      pr_creation_error: null,
+      pr_creation_status: 'completed',
+      pr_id: 1,
+      pr_number: 42,
+      pr_url: 'https://github.com/org/repo/pull/42',
+      title: 'Fix bug',
+    };
+  }
+
+  it('returns true for a valid PR state array', () => {
+    expect(isPullRequestsArtifact([makeValidPR()])).toBe(true);
+  });
+
+  it('returns false for an empty array', () => {
+    expect(isPullRequestsArtifact([])).toBe(false);
+  });
+
+  it('returns false for non-array values', () => {
+    expect(isPullRequestsArtifact(null)).toBe(false);
+    expect(isPullRequestsArtifact('string')).toBe(false);
+    expect(isPullRequestsArtifact({repo_name: 'org/repo'})).toBe(false);
+  });
+
+  it('returns false when array contains invalid items', () => {
+    expect(isPullRequestsArtifact([{not_a: 'pr'}])).toBe(false);
+  });
+});
+
+describe('isCodingAgentsArtifact', () => {
+  function makeValidCodingAgent() {
+    return {
+      id: 'agent-1',
+      name: 'My Agent',
+      provider: 'cursor_background_agent',
+      started_at: '2026-01-01T00:00:00Z',
+      status: 'running',
+    };
+  }
+
+  it('returns true for a valid coding agent array', () => {
+    expect(isCodingAgentsArtifact([makeValidCodingAgent()])).toBe(true);
+  });
+
+  it('returns false for an empty array', () => {
+    expect(isCodingAgentsArtifact([])).toBe(false);
+  });
+
+  it('returns false for non-array values', () => {
+    expect(isCodingAgentsArtifact(null)).toBe(false);
+    expect(isCodingAgentsArtifact('string')).toBe(false);
+    expect(isCodingAgentsArtifact({id: 'agent-1'})).toBe(false);
+  });
+
+  it('returns false when array contains invalid items', () => {
+    expect(isCodingAgentsArtifact([{not_an: 'agent'}])).toBe(false);
   });
 });

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -5,6 +5,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixCursorGithubAccessModal} from 'sentry/components/events/autofix/autofixCursorGithubAccessModal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {AutofixGithubCopilotPurchaseModal} from 'sentry/components/events/autofix/autofixGithubCopilotPurchaseModal';
+import {CodingAgentStatus} from 'sentry/components/events/autofix/types';
 import {
   needsGitHubAuth,
   type CodingAgentIntegration,
@@ -422,7 +423,8 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
       messages: [],
       status: codingAgents.some(
         codingAgent =>
-          codingAgent.status === 'pending' || codingAgent.status === 'running'
+          codingAgent.status === CodingAgentStatus.PENDING ||
+          codingAgent.status === CodingAgentStatus.RUNNING
       )
         ? 'processing'
         : 'completed',

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -26,6 +26,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {
   isArtifact,
+  isExplorerCodingAgentState,
   isExplorerFilePatch,
   isRepoPRState,
   type Artifact,
@@ -137,8 +138,14 @@ export function isCodeChangesArtifact(value: unknown): value is ExplorerFilePatc
   return isArrayOf(value, isExplorerFilePatch) && value.length > 0;
 }
 
-export function isPullRequestArtifact(value: unknown): value is RepoPRState[] {
+export function isPullRequestsArtifact(value: unknown): value is RepoPRState[] {
   return isArrayOf(value, isRepoPRState) && value.length > 0;
+}
+
+export function isCodingAgentsArtifact(
+  value: unknown
+): value is ExplorerCodingAgentState[] {
+  return isArrayOf(value, isExplorerCodingAgentState) && value.length > 0;
 }
 
 /**
@@ -393,13 +400,30 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
   finalizeSection();
 
   // If there are any PR states, append a synthetic "pull_request" section.
-  const artifact = Object.values(runState?.repo_pr_states ?? {});
-  if (artifact.length) {
+  const pullRequests = Object.values(runState?.repo_pr_states ?? {});
+  if (pullRequests.length) {
     sections.push({
       step: 'pull_request',
-      artifacts: [artifact],
+      artifacts: [pullRequests],
       messages: [],
-      status: artifact.some(pullRequest => pullRequest.pr_creation_status === 'creating')
+      status: pullRequests.some(
+        pullRequest => pullRequest.pr_creation_status === 'creating'
+      )
+        ? 'processing'
+        : 'completed',
+    });
+  }
+
+  const codingAgents = Object.values(runState?.coding_agents ?? {});
+  if (codingAgents.length) {
+    sections.push({
+      step: 'coding_agents',
+      artifacts: [codingAgents],
+      messages: [],
+      status: codingAgents.some(
+        codingAgent =>
+          codingAgent.status === 'pending' || codingAgent.status === 'running'
+      )
         ? 'processing'
         : 'completed',
     });
@@ -424,7 +448,15 @@ export function isPullRequestSection(section: AutofixSection): boolean {
   return section.step === 'pull_request';
 }
 
-export type AutofixArtifact = Artifact<unknown> | ExplorerFilePatch[] | RepoPRState[];
+export function isCodingAgentsSection(section: AutofixSection): boolean {
+  return section.step === 'coding_agents';
+}
+
+export type AutofixArtifact =
+  | Artifact<unknown>
+  | ExplorerFilePatch[]
+  | RepoPRState[]
+  | ExplorerCodingAgentState[];
 
 export function getOrderedAutofixArtifacts(
   runState: ExplorerAutofixState | null
@@ -441,7 +473,10 @@ export function getOrderedAutofixArtifacts(
         return section.artifacts.findLast(isCodeChangesArtifact) ?? null;
       }
       if (isPullRequestSection(section)) {
-        return section.artifacts.findLast(isPullRequestArtifact) ?? null;
+        return section.artifacts.findLast(isPullRequestsArtifact) ?? null;
+      }
+      if (isCodingAgentsSection(section)) {
+        return section.artifacts.findLast(isCodingAgentsArtifact) ?? null;
       }
       return null;
     })

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1,15 +1,21 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 import type {
   AutofixArtifact,
   AutofixSection,
   RootCauseArtifact,
   SolutionArtifact,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
-import type {ExplorerFilePatch, RepoPRState} from 'sentry/views/seerExplorer/types';
+import type {
+  ExplorerCodingAgentState,
+  ExplorerFilePatch,
+  RepoPRState,
+} from 'sentry/views/seerExplorer/types';
 
 import {
   CodeChangesCard,
+  CodingAgentCard,
   PullRequestsCard,
   RootCauseCard,
   SolutionCard,
@@ -334,7 +340,7 @@ describe('PullRequestsCard', () => {
 
     expect(screen.getByText('Pull Requests')).toBeInTheDocument();
     const button = screen.getByRole('button', {
-      name: 'View PR#42 in org/repo',
+      name: 'View org/repo#42',
     });
     expect(button).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
   });
@@ -352,12 +358,8 @@ describe('PullRequestsCard', () => {
       />
     );
 
-    expect(
-      screen.getByRole('button', {name: 'View PR#10 in org/repo-a'})
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'View PR#20 in org/repo-b'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'View org/repo-a#10'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'View org/repo-b#20'})).toBeInTheDocument();
   });
 
   it('skips PRs with missing pr_url or pr_number', () => {
@@ -378,7 +380,7 @@ describe('PullRequestsCard', () => {
       />
     );
 
-    expect(screen.getByRole('button', {name: /View PR#/})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: /View org\/valid#55/})).toHaveAttribute(
       'href',
       'https://pr/55'
     );
@@ -444,5 +446,147 @@ describe('ArtifactCard expand/collapse', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Root Cause'}));
     expect(screen.getByText('Bug')).toBeVisible();
     expect(screen.getByText('Toggle why')).toBeVisible();
+  });
+});
+
+function makeCodingAgent(
+  overrides: Partial<ExplorerCodingAgentState> = {}
+): ExplorerCodingAgentState {
+  return {
+    id: 'agent-1',
+    name: 'My Agent Task',
+    provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
+    started_at: '2026-01-01T00:00:00Z',
+    status: 'running',
+    ...overrides,
+  };
+}
+
+describe('CodingAgentCard', () => {
+  it('renders agent name based on Cursor provider', () => {
+    render(
+      <CodingAgentCard
+        autofix={mockAutofix}
+        section={makeSection('coding_agents', 'completed', [
+          [makeCodingAgent({provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT})],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Cursor Cloud Agent')).toBeInTheDocument();
+  });
+
+  it('renders agent name based on Claude provider', () => {
+    render(
+      <CodingAgentCard
+        autofix={mockAutofix}
+        section={makeSection('coding_agents', 'completed', [
+          [makeCodingAgent({provider: CodingAgentProvider.CLAUDE_CODE_AGENT})],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Claude Agent')).toBeInTheDocument();
+  });
+
+  it('renders agent name based on GitHub Copilot provider', () => {
+    render(
+      <CodingAgentCard
+        autofix={mockAutofix}
+        section={makeSection('coding_agents', 'completed', [
+          [makeCodingAgent({provider: CodingAgentProvider.GITHUB_COPILOT_AGENT})],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('GitHub Copilot')).toBeInTheDocument();
+  });
+
+  it('renders default agent name for unknown provider', () => {
+    render(
+      <CodingAgentCard
+        autofix={mockAutofix}
+        section={makeSection('coding_agents', 'completed', [
+          [makeCodingAgent({provider: 'unknown_provider' as any})],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Coding Agent')).toBeInTheDocument();
+  });
+
+  it('renders agent status tags', () => {
+    render(
+      <CodingAgentCard
+        autofix={mockAutofix}
+        section={makeSection('coding_agents', 'completed', [
+          [makeCodingAgent({status: 'running'})],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('running')).toBeInTheDocument();
+  });
+
+  it('renders "Open in" link when agent_url is present', () => {
+    render(
+      <CodingAgentCard
+        autofix={mockAutofix}
+        section={makeSection('coding_agents', 'completed', [
+          [
+            makeCodingAgent({
+              agent_url: 'https://cursor.com/agent/1',
+            }),
+          ],
+        ])}
+      />
+    );
+
+    const link = screen.getByRole('button', {name: /Open in/});
+    expect(link).toHaveAttribute('href', 'https://cursor.com/agent/1');
+  });
+
+  it('renders result PR links when results have pr_url', () => {
+    render(
+      <CodingAgentCard
+        autofix={mockAutofix}
+        section={makeSection('coding_agents', 'completed', [
+          [
+            makeCodingAgent({
+              results: [
+                {
+                  description: 'Fixed',
+                  repo_full_name: 'org/repo',
+                  repo_provider: 'github',
+                  pr_url: 'https://github.com/org/repo/pull/99',
+                },
+              ],
+            }),
+          ],
+        ])}
+      />
+    );
+
+    const link = screen.getByRole('button', {name: 'View Pull Request'});
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/99');
+  });
+
+  it('handles multiple coding agents', () => {
+    render(
+      <CodingAgentCard
+        autofix={mockAutofix}
+        section={makeSection('coding_agents', 'completed', [
+          [
+            makeCodingAgent({id: 'agent-1', name: 'Agent One', status: 'completed'}),
+            makeCodingAgent({id: 'agent-2', name: 'Agent Two', status: 'running'}),
+          ],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Agent One')).toBeInTheDocument();
+    expect(screen.getByText('Agent Two')).toBeInTheDocument();
+    expect(screen.getByText('completed')).toBeInTheDocument();
+    expect(screen.getByText('running')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -7,7 +7,7 @@ import {Container, Flex, type FlexProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
-  CodingAgentProvider,
+  getCodingAgentName,
   getResultButtonLabel,
 } from 'sentry/components/events/autofix/types';
 import {
@@ -303,18 +303,7 @@ export function CodingAgentCard({section}: AutofixCardProps) {
 
   const provider = artifact?.[0]?.provider;
 
-  const agentName = useMemo(() => {
-    switch (provider) {
-      case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
-        return t('Cursor Cloud Agent');
-      case CodingAgentProvider.CLAUDE_CODE_AGENT:
-        return t('Claude Agent');
-      case CodingAgentProvider.GITHUB_COPILOT_AGENT:
-        return t('GitHub Copilot');
-      default:
-        return t('Coding Agent');
-    }
-  }, [provider]);
+  const agentName = useMemo(() => getCodingAgentName(provider), [provider]);
 
   return (
     <ArtifactCard icon={<IconBot />} title={agentName}>

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -1,25 +1,34 @@
 import {Fragment, useEffect, useMemo, useRef, type ReactNode} from 'react';
 
+import {Tag} from '@sentry/scraps/badge';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container, Flex, type FlexProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
+  CodingAgentProvider,
+  getResultButtonLabel,
+} from 'sentry/components/events/autofix/types';
+import {
   isCodeChangesArtifact,
-  isPullRequestArtifact,
+  isCodingAgentsArtifact,
+  isPullRequestsArtifact,
   isRootCauseArtifact,
   isSolutionArtifact,
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import Placeholder from 'sentry/components/placeholder';
+import TimeSince from 'sentry/components/timeSince';
 import {IconRefresh} from 'sentry/icons';
+import {IconBot} from 'sentry/icons/iconBot';
 import {IconBug} from 'sentry/icons/iconBug';
 import {IconCode} from 'sentry/icons/iconCode';
 import {IconList} from 'sentry/icons/iconList';
+import {IconOpen} from 'sentry/icons/iconOpen';
 import {IconPullRequest} from 'sentry/icons/iconPullRequest';
-import {t, tn} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/fileDiffViewer';
 import {type ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
@@ -244,7 +253,7 @@ export function CodeChangesCard({autofix, section}: AutofixCardProps) {
 
 export function PullRequestsCard({section}: AutofixCardProps) {
   const artifact = useMemo(
-    () => section.artifacts.findLast(isPullRequestArtifact),
+    () => section.artifacts.findLast(isPullRequestsArtifact),
     [section.artifacts]
   );
 
@@ -271,7 +280,7 @@ export function PullRequestsCard({section}: AutofixCardProps) {
               href={pullRequest.pr_url}
               priority="primary"
             >
-              {t('View PR#%s in %s', pullRequest.pr_number, pullRequest.repo_name)}
+              {t('View %s#%s', pullRequest.repo_name, pullRequest.pr_number)}
             </LinkButton>
           );
         }
@@ -280,6 +289,82 @@ export function PullRequestsCard({section}: AutofixCardProps) {
           <Button key={pullRequest.repo_name} priority="primary" disabled>
             {t('Failed to create PR in %s', pullRequest.repo_name)}
           </Button>
+        );
+      })}
+    </ArtifactCard>
+  );
+}
+
+export function CodingAgentCard({section}: AutofixCardProps) {
+  const artifact = useMemo(
+    () => section.artifacts.findLast(isCodingAgentsArtifact),
+    [section.artifacts]
+  );
+
+  const provider = artifact?.[0]?.provider;
+
+  const agentName = useMemo(() => {
+    switch (provider) {
+      case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
+        return t('Cursor Cloud Agent');
+      case CodingAgentProvider.CLAUDE_CODE_AGENT:
+        return t('Claude Agent');
+      case CodingAgentProvider.GITHUB_COPILOT_AGENT:
+        return t('GitHub Copilot');
+      default:
+        return t('Coding Agent');
+    }
+  }, [provider]);
+
+  return (
+    <ArtifactCard icon={<IconBot />} title={agentName}>
+      {artifact?.map(codingAgent => {
+        const statusVariant =
+          codingAgent.status === 'pending'
+            ? ('muted' as const)
+            : codingAgent.status === 'running'
+              ? ('info' as const)
+              : codingAgent.status === 'failed'
+                ? ('danger' as const)
+                : ('success' as const);
+
+        return (
+          <ArtifactDetails key={codingAgent.id} direction="column" gap="md">
+            <Flex direction="row" justify="between">
+              <Flex direction="row" gap="md">
+                <Text>{codingAgent.name}</Text>
+                <Text variant="muted">
+                  {tct('Started [startedAt]', {
+                    startedAt: <TimeSince date={codingAgent.started_at} />,
+                  })}
+                </Text>
+              </Flex>
+              <Tag variant={statusVariant}>{codingAgent.status}</Tag>
+            </Flex>
+            <Flex direction="row" gap="md">
+              {codingAgent.agent_url ? (
+                <LinkButton href={codingAgent.agent_url} external icon={<IconOpen />}>
+                  {t('Open in %s', agentName)}
+                </LinkButton>
+              ) : null}
+              {codingAgent.results?.map(result => {
+                if (!result.pr_url) {
+                  return null;
+                }
+
+                return (
+                  <LinkButton
+                    key={result.pr_url}
+                    href={result.pr_url}
+                    external
+                    icon={<IconOpen />}
+                  >
+                    {getResultButtonLabel(result.pr_url)}
+                  </LinkButton>
+                );
+              })}
+            </Flex>
+          </ArtifactDetails>
         );
       })}
     </ArtifactCard>

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -7,6 +7,7 @@ import {Container, Flex, type FlexProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
+  CodingAgentStatus,
   getCodingAgentName,
   getResultButtonLabel,
 } from 'sentry/components/events/autofix/types';
@@ -309,11 +310,11 @@ export function CodingAgentCard({section}: AutofixCardProps) {
     <ArtifactCard icon={<IconBot />} title={agentName}>
       {artifact?.map(codingAgent => {
         const statusVariant =
-          codingAgent.status === 'pending'
+          codingAgent.status === CodingAgentStatus.PENDING
             ? ('muted' as const)
-            : codingAgent.status === 'running'
+            : codingAgent.status === CodingAgentStatus.RUNNING
               ? ('info' as const)
-              : codingAgent.status === 'failed'
+              : codingAgent.status === CodingAgentStatus.FAILED
                 ? ('danger' as const)
                 : ('success' as const);
 

--- a/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
@@ -1,17 +1,20 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 import type {
   RootCauseArtifact,
   SolutionArtifact,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import type {
   Artifact,
+  ExplorerCodingAgentState,
   ExplorerFilePatch,
   RepoPRState,
 } from 'sentry/views/seerExplorer/types';
 
 import {
   CodeChangesPreview,
+  CodingAgentPreview,
   PullRequestsPreview,
   RootCausePreview,
   SolutionPreview,
@@ -194,5 +197,104 @@ describe('PullRequestsPreview', () => {
 
     expect(screen.getByRole('link', {name: 'org/valid#55'})).toBeInTheDocument();
     expect(screen.queryByRole('link', {name: /repo#42/})).not.toBeInTheDocument();
+  });
+});
+
+function makeCodingAgent(
+  overrides: Partial<ExplorerCodingAgentState> = {}
+): ExplorerCodingAgentState {
+  return {
+    id: 'agent-1',
+    name: 'My Agent Task',
+    provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
+    started_at: '2026-01-01T00:00:00Z',
+    status: 'running',
+    ...overrides,
+  };
+}
+
+describe('CodingAgentPreview', () => {
+  it('renders provider-specific title for Cursor', () => {
+    render(
+      <CodingAgentPreview
+        artifact={[
+          makeCodingAgent({provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT}),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Cursor Cloud Agent')).toBeInTheDocument();
+  });
+
+  it('renders provider-specific title for Claude', () => {
+    render(
+      <CodingAgentPreview
+        artifact={[makeCodingAgent({provider: CodingAgentProvider.CLAUDE_CODE_AGENT})]}
+      />
+    );
+
+    expect(screen.getByText('Claude Agent')).toBeInTheDocument();
+  });
+
+  it('renders provider-specific title for GitHub Copilot', () => {
+    render(
+      <CodingAgentPreview
+        artifact={[makeCodingAgent({provider: CodingAgentProvider.GITHUB_COPILOT_AGENT})]}
+      />
+    );
+
+    expect(screen.getByText('GitHub Copilot')).toBeInTheDocument();
+  });
+
+  it('renders default title for unknown provider', () => {
+    render(
+      <CodingAgentPreview artifact={[makeCodingAgent({provider: 'unknown' as any})]} />
+    );
+
+    expect(screen.getByText('Coding Agent')).toBeInTheDocument();
+  });
+
+  it('renders agent name and status tag', () => {
+    render(
+      <CodingAgentPreview
+        artifact={[makeCodingAgent({name: 'Fix auth bug', status: 'completed'})]}
+      />
+    );
+
+    expect(screen.getByText('Fix auth bug')).toBeInTheDocument();
+    expect(screen.getByText('completed')).toBeInTheDocument();
+  });
+
+  it('renders "Open in Agent" link when agent_url present', () => {
+    render(
+      <CodingAgentPreview
+        artifact={[makeCodingAgent({agent_url: 'https://cursor.com/agent/1'})]}
+      />
+    );
+
+    const link = screen.getByRole('button', {name: 'Open in Agent'});
+    expect(link).toHaveAttribute('href', 'https://cursor.com/agent/1');
+  });
+
+  it('does not render "Open in Agent" link when agent_url is absent', () => {
+    render(<CodingAgentPreview artifact={[makeCodingAgent()]} />);
+
+    expect(screen.queryByRole('button', {name: 'Open in Agent'})).not.toBeInTheDocument();
+  });
+
+  it('handles multiple agents', () => {
+    render(
+      <CodingAgentPreview
+        artifact={[
+          makeCodingAgent({id: 'a1', name: 'Agent One', status: 'running'}),
+          makeCodingAgent({id: 'a2', name: 'Agent Two', status: 'completed'}),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Agent One')).toBeInTheDocument();
+    expect(screen.getByText('Agent Two')).toBeInTheDocument();
+    expect(screen.getByText('running')).toBeInTheDocument();
+    expect(screen.getByText('completed')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/v3/autofixPreviews.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.tsx
@@ -6,7 +6,10 @@ import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
-import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
+import {
+  CodingAgentStatus,
+  getCodingAgentName,
+} from 'sentry/components/events/autofix/types';
 import type {
   RootCauseArtifact,
   SolutionArtifact,
@@ -126,28 +129,17 @@ interface CodingAgentPreviewProps {
 export function CodingAgentPreview({artifact}: CodingAgentPreviewProps) {
   const provider = artifact[0]?.provider;
 
-  const title = useMemo(() => {
-    switch (provider) {
-      case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
-        return t('Cursor Cloud Agent');
-      case CodingAgentProvider.CLAUDE_CODE_AGENT:
-        return t('Claude Agent');
-      case CodingAgentProvider.GITHUB_COPILOT_AGENT:
-        return t('GitHub Copilot');
-      default:
-        return t('Coding Agent');
-    }
-  }, [provider]);
+  const agentName = useMemo(() => getCodingAgentName(provider), [provider]);
 
   return (
-    <ArtifactCard icon={<IconBot />} title={title}>
+    <ArtifactCard icon={<IconBot />} title={agentName}>
       {artifact.map(codingAgent => {
         const statusVariant =
-          codingAgent.status === 'pending'
+          codingAgent.status === CodingAgentStatus.PENDING
             ? ('muted' as const)
-            : codingAgent.status === 'running'
+            : codingAgent.status === CodingAgentStatus.RUNNING
               ? ('info' as const)
-              : codingAgent.status === 'failed'
+              : codingAgent.status === CodingAgentStatus.FAILED
                 ? ('danger' as const)
                 : ('success' as const);
 

--- a/static/app/components/events/autofix/v3/autofixPreviews.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.tsx
@@ -1,13 +1,18 @@
 import {useMemo, type ReactNode} from 'react';
 
+import {Tag} from '@sentry/scraps/badge';
+import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
+import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 import type {
   RootCauseArtifact,
   SolutionArtifact,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {IconOpen} from 'sentry/icons';
+import {IconBot} from 'sentry/icons/iconBot';
 import {IconBug} from 'sentry/icons/iconBug';
 import {IconCode} from 'sentry/icons/iconCode';
 import {IconList} from 'sentry/icons/iconList';
@@ -15,6 +20,7 @@ import {IconPullRequest} from 'sentry/icons/iconPullRequest';
 import {t, tn} from 'sentry/locale';
 import {
   type Artifact,
+  type ExplorerCodingAgentState,
   type ExplorerFilePatch,
   type RepoPRState,
 } from 'sentry/views/seerExplorer/types';
@@ -107,6 +113,62 @@ export function PullRequestsPreview({artifact}: PullRequestsPreviewProps) {
           <ExternalLink key={label} href={pullRequest.pr_url}>
             {label}
           </ExternalLink>
+        );
+      })}
+    </ArtifactCard>
+  );
+}
+
+interface CodingAgentPreviewProps {
+  artifact: ExplorerCodingAgentState[];
+}
+
+export function CodingAgentPreview({artifact}: CodingAgentPreviewProps) {
+  const provider = artifact[0]?.provider;
+
+  const title = useMemo(() => {
+    switch (provider) {
+      case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
+        return t('Cursor Cloud Agent');
+      case CodingAgentProvider.CLAUDE_CODE_AGENT:
+        return t('Claude Agent');
+      case CodingAgentProvider.GITHUB_COPILOT_AGENT:
+        return t('GitHub Copilot');
+      default:
+        return t('Coding Agent');
+    }
+  }, [provider]);
+
+  return (
+    <ArtifactCard icon={<IconBot />} title={title}>
+      {artifact.map(codingAgent => {
+        const statusVariant =
+          codingAgent.status === 'pending'
+            ? ('muted' as const)
+            : codingAgent.status === 'running'
+              ? ('info' as const)
+              : codingAgent.status === 'failed'
+                ? ('danger' as const)
+                : ('success' as const);
+
+        return (
+          <Flex key={codingAgent.id} direction="column" gap="md">
+            <Text>{codingAgent.name}</Text>
+            <Flex direction="row-reverse" align="center" justify="between">
+              <Tag variant={statusVariant}>{codingAgent.status}</Tag>
+              {codingAgent.agent_url ? (
+                <LinkButton
+                  priority="transparent"
+                  size="xs"
+                  icon={<IconOpen />}
+                  href={codingAgent.agent_url}
+                  external
+                >
+                  {t('Open in Agent')}
+                </LinkButton>
+              ) : null}
+            </Flex>
+          </Flex>
         );
       })}
     </ArtifactCard>

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -5,6 +5,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {
   getOrderedAutofixSections,
   isCodeChangesSection,
+  isCodingAgentsSection,
   isPullRequestSection,
   isRootCauseSection,
   isSolutionSection,
@@ -13,6 +14,7 @@ import {
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {
   CodeChangesCard,
+  CodingAgentCard,
   PullRequestsCard,
   RootCauseCard,
   SolutionCard,
@@ -81,6 +83,12 @@ function SeerDrawerArtifacts({autofix, sections}: SeerDrawerArtifactsProps) {
         if (isPullRequestSection(section)) {
           return (
             <PullRequestsCard key={section.step} autofix={autofix} section={section} />
+          );
+        }
+
+        if (isCodingAgentsSection(section)) {
+          return (
+            <CodingAgentCard key={section.step} autofix={autofix} section={section} />
           );
         }
 

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -18,6 +18,7 @@ function makeAutofix(
     createPR: jest.fn(),
     sendMessage: jest.fn(),
     reset: jest.fn(),
+    triggerCodingAgentHandoff: jest.fn(),
     isLoading: false,
     isReady: true,
     isStreaming: false,
@@ -185,6 +186,12 @@ describe('SeerDrawerNextStep', () => {
   });
 
   describe('SolutionNextStep', () => {
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/coding-agents/',
+        body: {integrations: []},
+      });
+    });
     it('returns null when section has no artifacts', () => {
       const autofix = makeAutofix();
       const {container} = render(

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -1,10 +1,15 @@
 import {useCallback, useMemo, useState, type ReactNode} from 'react';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, ButtonBar} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {
+  organizationIntegrationsCodingAgents,
+  type CodingAgentIntegration,
+} from 'sentry/components/events/autofix/useAutofix';
 import {
   isCodeChangesArtifact,
   isCodeChangesSection,
@@ -15,8 +20,12 @@ import {
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
+import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import {defined} from 'sentry/utils';
+import {useQuery} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface SeerDrawerNextStepProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
@@ -91,7 +100,29 @@ function RootCauseNextStep({autofix, runId, section}: NextStepProps) {
 }
 
 function SolutionNextStep({autofix, runId, section}: NextStepProps) {
-  const {startStep} = autofix;
+  const organization = useOrganization();
+  const {startStep, triggerCodingAgentHandoff} = autofix;
+
+  const {data: codingAgentResponse} = useQuery(
+    organizationIntegrationsCodingAgents(organization)
+  );
+  const codingAgentIntegrations = useMemo(
+    () => codingAgentResponse?.integrations,
+    [codingAgentResponse?.integrations]
+  );
+
+  const handleCodingAgentHandoff = useCallback(
+    (integration: CodingAgentIntegration) => {
+      // OAuth redirect for integrations without identity
+      if (integration.requires_identity && !integration.has_identity) {
+        const currentUrl = window.location.href;
+        window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
+        return;
+      }
+      triggerCodingAgentHandoff(runId, integration);
+    },
+    [triggerCodingAgentHandoff, runId]
+  );
 
   const handleYesClick = useCallback(() => {
     startStep('code_changes', runId);
@@ -126,6 +157,8 @@ function SolutionNextStep({autofix, runId, section}: NextStepProps) {
       rethinkPrompt={t('How can this implementation plan be improved?')}
       labelNevermind={t('Nevermind, write a code fix')}
       labelRethink={t('Rethink implementation plan')}
+      codingAgentIntegrations={codingAgentIntegrations}
+      onCodingAgentHandoff={handleCodingAgentHandoff}
     />
   );
 }
@@ -178,6 +211,8 @@ interface NextStepTemplateProps {
   placeholderPrompt: string;
   prompt: ReactNode;
   rethinkPrompt: ReactNode;
+  codingAgentIntegrations?: CodingAgentIntegration[];
+  onCodingAgentHandoff?: (integration: CodingAgentIntegration) => void;
 }
 
 function NextStepTemplate({
@@ -190,7 +225,29 @@ function NextStepTemplate({
   rethinkPrompt,
   labelNevermind,
   labelRethink,
+  codingAgentIntegrations,
+  onCodingAgentHandoff,
 }: NextStepTemplateProps) {
+  const codingAgentOptions = useMemo(() => {
+    return (codingAgentIntegrations ?? []).map(integration => {
+      const actionLabel =
+        integration.requires_identity && !integration.has_identity
+          ? t('Setup %s', integration.name)
+          : t('Send to %s', integration.name);
+
+      return {
+        key: `agent:${integration.id ?? integration.provider}`,
+        label: (
+          <Flex gap="md" align="center">
+            <PluginIcon pluginId={integration.provider} size={16} />
+            <span>{actionLabel}</span>
+          </Flex>
+        ),
+        onAction: () => onCodingAgentHandoff?.(integration),
+      };
+    });
+  }, [codingAgentIntegrations, onCodingAgentHandoff]);
+
   const [clickedNo, handleClickedNo] = useState(false);
   const [userContext, setUserContext] = useState('');
 
@@ -220,9 +277,27 @@ function NextStepTemplate({
       <Text>{prompt}</Text>
       <Flex gap="md">
         <Button onClick={() => handleClickedNo(true)}>{labelNo}</Button>
-        <Button priority="primary" onClick={onClickYes}>
-          {labelYes}
-        </Button>
+        <ButtonBar>
+          <Button priority="primary" onClick={onClickYes}>
+            {labelYes}
+          </Button>
+          {codingAgentOptions?.length ? (
+            <DropdownMenu
+              items={codingAgentOptions}
+              trigger={(triggerProps, isOpen) => (
+                <Button
+                  {...triggerProps}
+                  disabled={codingAgentOptions.length <= 0}
+                  // disabled={isLoading || (step === 'code_changes' && !enableSeerCoding)}
+                  priority="primary"
+                  icon={<IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />}
+                  aria-label={t('More code fix options')}
+                />
+              )}
+              position="bottom-end"
+            />
+          ) : null}
+        </ButtonBar>
       </Flex>
     </Flex>
   );

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -288,7 +288,6 @@ function NextStepTemplate({
                 <Button
                   {...triggerProps}
                   disabled={codingAgentOptions.length <= 0}
-                  // disabled={isLoading || (step === 'code_changes' && !enableSeerCoding)}
                   priority="primary"
                   icon={<IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />}
                   aria-label={t('More code fix options')}

--- a/static/app/components/events/autofix/v3/utils.spec.ts
+++ b/static/app/components/events/autofix/v3/utils.spec.ts
@@ -6,6 +6,7 @@ import type {
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import type {
   Artifact,
+  ExplorerCodingAgentState,
   ExplorerFilePatch,
   RepoPRState,
 } from 'sentry/views/seerExplorer/types';
@@ -238,6 +239,93 @@ describe('artifactToMarkdown', () => {
     it('returns null for empty array', () => {
       const prs: RepoPRState[] = [];
       expect(artifactToMarkdown(prs)).toBeNull();
+    });
+  });
+
+  describe('ExplorerCodingAgentState[]', () => {
+    function makeCodingAgent(
+      overrides?: Partial<ExplorerCodingAgentState>
+    ): ExplorerCodingAgentState {
+      return {
+        id: 'agent-1',
+        name: 'Fix null pointer',
+        provider: 'cursor_background_agent',
+        started_at: '2026-01-01T00:00:00Z',
+        status: 'running',
+        agent_url: 'https://cursor.com/agent/1',
+        ...overrides,
+      };
+    }
+
+    it('renders coding agents with name and link', () => {
+      const agents = [makeCodingAgent()];
+      expect(artifactToMarkdown(agents)).toBe(
+        [
+          '# Coding Agents',
+          '',
+          '## Cursor Cloud Agent',
+          '',
+          '[Fix null pointer](https://cursor.com/agent/1)',
+        ].join('\n')
+      );
+    });
+
+    it('renders multiple agents', () => {
+      const agents = [
+        makeCodingAgent(),
+        makeCodingAgent({
+          id: 'agent-2',
+          name: 'Implement feature',
+          provider: 'claude_code_agent',
+          agent_url: 'https://claude.ai/agent/2',
+        }),
+      ];
+      expect(artifactToMarkdown(agents)).toBe(
+        [
+          '# Coding Agents',
+          '',
+          '## Cursor Cloud Agent',
+          '',
+          '[Fix null pointer](https://cursor.com/agent/1)',
+          '## Claude Agent',
+          '',
+          '[Implement feature](https://claude.ai/agent/2)',
+        ].join('\n')
+      );
+    });
+
+    it('filters out agents missing agent_url', () => {
+      const agents = [
+        makeCodingAgent({agent_url: undefined}),
+        makeCodingAgent({id: 'agent-2', name: 'Valid agent'}),
+      ];
+      expect(artifactToMarkdown(agents)).toBe(
+        [
+          '# Coding Agents',
+          '',
+          '## Cursor Cloud Agent',
+          '',
+          '[Valid agent](https://cursor.com/agent/1)',
+        ].join('\n')
+      );
+    });
+
+    it('returns null for empty array', () => {
+      const agents: ExplorerCodingAgentState[] = [];
+      expect(artifactToMarkdown(agents)).toBeNull();
+    });
+
+    it('uses fallback name for unknown provider', () => {
+      const agents = [makeCodingAgent({provider: 'unknown_provider'})];
+      expect(artifactToMarkdown(agents)).toBe(
+        [
+          '# Coding Agents',
+          '',
+          '## Coding Agent',
+          '',
+          '[Fix null pointer](https://cursor.com/agent/1)',
+        ].join('\n')
+      );
     });
   });
 

--- a/static/app/components/events/autofix/v3/utils.ts
+++ b/static/app/components/events/autofix/v3/utils.ts
@@ -1,5 +1,7 @@
+import {getCodingAgentName} from 'sentry/components/events/autofix/types';
 import {
   isCodeChangesArtifact,
+  isCodingAgentsArtifact,
   isPullRequestsArtifact,
   isRootCauseArtifact,
   isSolutionArtifact,
@@ -10,6 +12,7 @@ import {
 import {defined} from 'sentry/utils';
 import {
   type Artifact,
+  type ExplorerCodingAgentState,
   type ExplorerFilePatch,
   type RepoPRState,
 } from 'sentry/views/seerExplorer/types';
@@ -29,6 +32,10 @@ export function artifactToMarkdown(artifact: AutofixArtifact): string | null {
 
   if (isPullRequestsArtifact(artifact)) {
     return repoPRStatesToMarkdown(artifact);
+  }
+
+  if (isCodingAgentsArtifact(artifact)) {
+    return codingAgentsToMarkdown(artifact);
   }
 
   return null; // unknown artifact
@@ -123,6 +130,33 @@ function repoPRStatesToMarkdown(artifact: RepoPRState[]): string | null {
         return `[${pullRequest.repo_name}#${pullRequest.pr_number}](${pullRequest.pr_url})`;
       })
       .filter(defined)
+  );
+
+  return parts.join('\n');
+}
+
+function codingAgentsToMarkdown(artifact: ExplorerCodingAgentState[]): string | null {
+  if (!artifact.length) {
+    return null;
+  }
+
+  const parts: string[] = ['# Coding Agents', ''];
+
+  parts.push(
+    ...artifact
+      .map(codingAgent => {
+        if (!codingAgent.agent_url) {
+          return null;
+        }
+
+        return [
+          `## ${getCodingAgentName(codingAgent.provider)}`,
+          '',
+          `[${codingAgent.name}](${codingAgent.agent_url})`,
+        ];
+      })
+      .filter(defined)
+      .flatMap(lines => lines)
   );
 
   return parts.join('\n');

--- a/static/app/components/events/autofix/v3/utils.ts
+++ b/static/app/components/events/autofix/v3/utils.ts
@@ -1,15 +1,14 @@
 import {
+  isCodeChangesArtifact,
+  isPullRequestsArtifact,
   isRootCauseArtifact,
   isSolutionArtifact,
   type AutofixArtifact,
   type RootCauseArtifact,
   type SolutionArtifact,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
-import {isArrayOf} from 'sentry/types/utils';
 import {defined} from 'sentry/utils';
 import {
-  isExplorerFilePatch,
-  isRepoPRState,
   type Artifact,
   type ExplorerFilePatch,
   type RepoPRState,
@@ -24,11 +23,11 @@ export function artifactToMarkdown(artifact: AutofixArtifact): string | null {
     return solutionArtifactToMarkdown(artifact);
   }
 
-  if (isArrayOf(artifact, isExplorerFilePatch) && artifact.length) {
+  if (isCodeChangesArtifact(artifact)) {
     return filePatchesToMarkdown(artifact);
   }
 
-  if (isArrayOf(artifact, isRepoPRState) && artifact.length) {
+  if (isPullRequestsArtifact(artifact)) {
     return repoPRStatesToMarkdown(artifact);
   }
 

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -10,6 +10,9 @@ import {Text} from '@sentry/scraps/text';
 
 import {
   getOrderedAutofixArtifacts,
+  isCodeChangesArtifact,
+  isCodingAgentsArtifact,
+  isPullRequestsArtifact,
   isRootCauseArtifact,
   isSolutionArtifact,
   useExplorerAutofix,
@@ -17,6 +20,7 @@ import {
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {
   CodeChangesPreview,
+  CodingAgentPreview,
   PullRequestsPreview,
   RootCausePreview,
   SolutionPreview,
@@ -28,14 +32,12 @@ import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-import {isArrayOf} from 'sentry/types/utils';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {SidebarFoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 import {Resources} from 'sentry/views/issueDetails/streamline/sidebar/resources';
 import {useOpenSeerDrawer} from 'sentry/views/issueDetails/streamline/sidebar/seerDrawer';
-import {isExplorerFilePatch, isRepoPRState} from 'sentry/views/seerExplorer/types';
 
 interface AutofixSectionProps {
   group: Group;
@@ -219,12 +221,16 @@ function AutofixPreviews({artifacts, event, group, project}: AutofixPreviewsProp
           return <SolutionPreview key="solution" artifact={artifact} />;
         }
 
-        if (isArrayOf(artifact, isExplorerFilePatch) && artifact.length) {
+        if (isCodeChangesArtifact(artifact)) {
           return <CodeChangesPreview key="code-changes" artifact={artifact} />;
         }
 
-        if (isArrayOf(artifact, isRepoPRState) && artifact.length) {
+        if (isPullRequestsArtifact(artifact)) {
           return <PullRequestsPreview key="pull-requests" artifact={artifact} />;
+        }
+
+        if (isCodingAgentsArtifact(artifact)) {
+          return <CodingAgentPreview key="coding-agent" artifact={artifact} />;
         }
 
         // TODO: maybe send a log?

--- a/static/app/views/seerExplorer/types.spec.ts
+++ b/static/app/views/seerExplorer/types.spec.ts
@@ -4,7 +4,13 @@ import {
   type FilePatch,
 } from 'sentry/components/events/autofix/types';
 
-import {isArtifact, isExplorerFilePatch, isRepoPRState, type RepoPRState} from './types';
+import {
+  isArtifact,
+  isExplorerCodingAgentState,
+  isExplorerFilePatch,
+  isRepoPRState,
+  type RepoPRState,
+} from './types';
 
 function makeValidFilePatch(): FilePatch {
   return {
@@ -148,5 +154,66 @@ describe('isArtifact', () => {
 
   it('returns false when data property is missing entirely', () => {
     expect(isArtifact({key: 'k', reason: 'r'})).toBe(false);
+  });
+});
+
+describe('isExplorerCodingAgentState', () => {
+  function makeValidCodingAgentState() {
+    return {
+      id: 'agent-1',
+      name: 'My Agent',
+      provider: 'cursor_background_agent',
+      started_at: '2026-01-01T00:00:00Z',
+      status: 'running',
+    };
+  }
+
+  it('returns true for a valid object with all required fields', () => {
+    expect(isExplorerCodingAgentState(makeValidCodingAgentState())).toBe(true);
+  });
+
+  it('returns true when optional fields are present', () => {
+    expect(
+      isExplorerCodingAgentState({
+        ...makeValidCodingAgentState(),
+        agent_url: 'https://cursor.com/agent/1',
+        results: [
+          {description: 'Fixed it', repo_full_name: 'org/repo', repo_provider: 'github'},
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for null/undefined/non-objects', () => {
+    expect(isExplorerCodingAgentState(null)).toBe(false);
+    expect(isExplorerCodingAgentState(undefined)).toBe(false);
+    expect(isExplorerCodingAgentState('string')).toBe(false);
+    expect(isExplorerCodingAgentState(42)).toBe(false);
+  });
+
+  it('returns false when required string fields are missing', () => {
+    const {id: _, ...noId} = makeValidCodingAgentState();
+    expect(isExplorerCodingAgentState(noId)).toBe(false);
+
+    const {name: __, ...noName} = makeValidCodingAgentState();
+    expect(isExplorerCodingAgentState(noName)).toBe(false);
+
+    const {provider: ___, ...noProvider} = makeValidCodingAgentState();
+    expect(isExplorerCodingAgentState(noProvider)).toBe(false);
+
+    const {started_at: ____, ...noStartedAt} = makeValidCodingAgentState();
+    expect(isExplorerCodingAgentState(noStartedAt)).toBe(false);
+
+    const {status: _____, ...noStatus} = makeValidCodingAgentState();
+    expect(isExplorerCodingAgentState(noStatus)).toBe(false);
+  });
+
+  it('returns false when required fields have wrong type', () => {
+    expect(isExplorerCodingAgentState({...makeValidCodingAgentState(), id: 123})).toBe(
+      false
+    );
+    expect(
+      isExplorerCodingAgentState({...makeValidCodingAgentState(), status: true})
+    ).toBe(false);
   });
 });

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -138,3 +138,19 @@ export interface ExplorerCodingAgentState {
   agent_url?: string;
   results?: CodingAgentResult[];
 }
+
+export function isExplorerCodingAgentState(
+  value: unknown
+): value is ExplorerCodingAgentState {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.id === 'string' &&
+    typeof obj.name === 'string' &&
+    typeof obj.provider === 'string' &&
+    typeof obj.started_at === 'string' &&
+    typeof obj.status === 'string'
+  );
+}


### PR DESCRIPTION
This brings support for coding agents into the redesigns. The UI may require some tweaks as this is just a priliminary pass.

| Trigger | Preview | Card |
| ------- | -------- | ----- |
| <img width="294" height="183" alt="Screenshot 2026-03-17 at 2 55 15 PM" src="https://github.com/user-attachments/assets/35246b1a-5eae-464b-a6e5-0097968cfb37" /> | <img width="554" height="702" alt="image" src="https://github.com/user-attachments/assets/60970722-f685-4290-a24b-ac1693ffb908" /> | <img width="1144" height="850" alt="image" src="https://github.com/user-attachments/assets/a2f66a57-168e-486c-80be-050cf25382be" /> |

