### PR TITLE
test(occurrences on eap): Update test harness to store occurrence trace items in EAP synchronously

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1208,10 +1208,21 @@ class SnubaTestCase(BaseTestCase):
         extra_event_data: dict[str, Any] | None = None,
     ) -> list[Event]:
         """
-        Store occurrences in both legacy Snuba and EAP via the production dual-write path.
+        Store events (occurrence trace items) in both legacy Snuba and EAP.
+
+        EAP items are captured from the eventstream serialization path in production
+        and inserted synchronously via store_eap_items() to ensure consistency
+        in tests.
         """
+        captured_items: list[TraceItem] = []
+
         events: list[Event] = []
-        with self.options({"eventstream.eap_forwarding_rate": 1.0}):
+        with (
+            self.options({"eventstream.eap_forwarding_rate": 1.0}),
+            mock.patch.object(
+                SnubaEventStream, "_send_item", side_effect=lambda item: captured_items.append(item)
+            ),
+        ):
             for _ in range(count):
                 data: dict[str, Any] = {
                     "message": message or f"error in {fingerprint}",
@@ -1229,6 +1240,10 @@ class SnubaTestCase(BaseTestCase):
                     assert_no_errors=False,
                 )
                 events.append(event)
+
+        if captured_items:
+            self.store_eap_items(captured_items)
+
         return events
 
     def store_eap_items(self, items: Sequence[TraceItem]) -> None:


### PR DESCRIPTION
We're seeing some flakes in tests related to EAP:
- [test_eap_and_snuba_past_counts_match_multiple_groups](https://github.com/getsentry/sentry/issues/110873)
- [test_eap_hourly_count_excludes_old_events](https://github.com/getsentry/sentry/issues/110755)
- [test_eap_and_snuba_past_counts_match_single_group](https://github.com/getsentry/sentry/issues/110753)

I _think_ these flakes are due to our reliance in the test harness on ingesting events into EAP via the production write path, which is asynchronous.