### PR TITLE
fix(models): Break infinite recursion in GroupHash repr

### DIFF
--- a/src/sentry/models/grouphash.py
+++ b/src/sentry/models/grouphash.py
@@ -102,7 +102,7 @@ class GroupHash(Model):
         except AttributeError:
             return None
 
-    __repr__ = sane_repr("group_id", "hash", "metadata")
+    __repr__ = sane_repr("group_id", "hash")
     __str__ = __repr__
 
     def get_associated_fingerprint(self) -> list[str] | None:

--- a/src/sentry/models/grouphashmetadata.py
+++ b/src/sentry/models/grouphashmetadata.py
@@ -135,7 +135,7 @@ class GroupHashMetadata(Model):
     def hash(self) -> str:
         return self.grouphash.hash
 
-    __repr__ = sane_repr("grouphash_id", "group_id", "hash", "seer_matched_grouphash")
+    __repr__ = sane_repr("grouphash_id", "group_id", "hash", "seer_matched_grouphash_id")
     __str__ = __repr__
 
     def get_best_guess_schema_version(self) -> str:


### PR DESCRIPTION
Break a mutual recursion between GroupHash.__repr__ and GroupHashMetadata.__repr__ that causes a RecursionError and a storm of database queries.

The cycle: GroupHashMetadata.__repr__ accesses `seer_matched_grouphash` (lazy-loads a GroupHash), whose __repr__ accesses `metadata` (lazy-loads a GroupHashMetadata via reverse OneToOneField), whose __repr__ accesses `seer_matched_grouphash`... and so on until Python hits the recursion limit. This is triggered by the Sentry SDK's Django caching integration calling `str()` on cached model instances to measure their size.

Two changes to break the cycle from both sides:
- `GroupHashMetadata`: use `seer_matched_grouphash_id` (raw FK column) instead of `seer_matched_grouphash` (related object) in `sane_repr` — avoids the lazy load entirely
- `GroupHash`: remove `metadata` from `sane_repr` — it triggered a reverse OneToOneField query on every repr call