### PR TITLE
fix(billing): Update ent trial copy

### DIFF
--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1168,6 +1168,52 @@ describe('Customer Details', () => {
     expect(screen.getByRole('option', {name: /Add Legacy Soft Cap/})).toBeInTheDocument();
   });
 
+  it('shows limited events help text for free plan enterprise trial', async () => {
+    setUpMocks(organization, {plan: 'am1_f', isFree: true});
+
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: `/customers/:orgId`,
+      },
+      organization,
+    });
+
+    await screen.findByRole('heading', {name: 'Customers'});
+
+    await userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Customers Actions',
+      })[0]!
+    );
+
+    expect(screen.getByText(/capped event limits/)).toBeInTheDocument();
+    expect(screen.queryByText(/unlimited events/)).not.toBeInTheDocument();
+  });
+
+  it('shows unlimited events help text for paid plan enterprise trial', async () => {
+    setUpMocks(organization, {plan: 'am3_business', isFree: false});
+
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: `/customers/:orgId`,
+      },
+      organization,
+    });
+
+    await screen.findByRole('heading', {name: 'Customers'});
+
+    await userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Customers Actions',
+      })[0]!
+    );
+
+    expect(screen.getByText(/unlimited events/)).toBeInTheDocument();
+    expect(screen.queryByText(/capped event limits/)).not.toBeInTheDocument();
+  });
+
   it('renders and hides generic confirmation modals', async () => {
     setUpMocks(organization);
 

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -568,7 +568,9 @@ export function CustomerDetails() {
           {
             key: 'startEnterpriseTrial',
             name: 'Start Enterprise Trial',
-            help: 'Start enterprise trial (e.g. SSO, unlimited events).',
+            help: subscription.isFree
+              ? 'Start enterprise trial with capped event limits (includes SSO).'
+              : 'Start enterprise trial with unlimited events (includes SSO).',
             disabled: subscription.isPartner || subscription.isEnterpriseTrial,
             disabledReason: subscription.isPartner
               ? 'This account is managed by a third-party.'


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/BIL-2187/conditionally-render-enterprise-trial-copy-in-start-enterprise-trial

### before
<img width="236" height="88" alt="Screenshot 2026-03-17 at 1 01 42 PM" src="https://github.com/user-attachments/assets/9b836243-fa90-44ed-b2cb-b4aa1b2efe9d" />

### after
<img width="236" height="88" alt="Screenshot 2026-03-17 at 1 00 46 PM" src="https://github.com/user-attachments/assets/1642a443-4b8d-48d9-b8fb-d452001015fc" />
<img width="236" height="88" alt="Screenshot 2026-03-17 at 1 00 30 PM" src="https://github.com/user-attachments/assets/af71ab69-8c7d-48ef-8ffc-2eb144ce9661" />
