### PR TITLE
fix(workflows): Don't crash when no action filter are provided

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -338,7 +338,7 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
 
             # TODO -- can we bulk create: actions, dcga's and the workflow dcg?
             # Create actions and action filters, then associate them to the workflow
-            for action_filter in validated_value["action_filters"]:
+            for action_filter in validated_value.get("action_filters", []):
                 actions, condition_group = self._split_action_and_condition_group(action_filter)
                 new_condition_group = condition_group_validator.create(condition_group)
 

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -156,6 +156,26 @@ class TestWorkflowValidatorCreate(TestCase):
         assert workflow.organization_id == self.organization.id
         assert workflow.created_by_id == self.user.id
 
+    def test_create__without_action_filters(self) -> None:
+        data_without_action_filters = {
+            "name": "test",
+            "enabled": True,
+            "config": {
+                "frequency": 30,
+            },
+            "triggers": {
+                "logicType": "any",
+                "conditions": [],
+            },
+        }
+        validator = WorkflowValidator(data=data_without_action_filters, context=self.context)
+        assert validator.is_valid() is True
+        workflow = validator.create(validator.validated_data)
+
+        # workflow is created successfully
+        assert workflow.id is not None
+        assert workflow.workflowdataconditiongroup_set.count() == 0
+
     def test_create__owner_user_id(self) -> None:
         self.valid_data["owner"] = f"user:{self.user.id}"
         validator = WorkflowValidator(data=self.valid_data, context=self.context)


### PR DESCRIPTION
We don't require action filters; we shouldn't fail when none are provided.