### PR TITLE
fix(dashboards): Use firstTransactionEvent for overview onboarding conditions

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs.tsx
@@ -64,7 +64,7 @@ export enum PrebuiltDashboardId {
 /** Boolean flags on Project that indicate whether telemetry data has been received. */
 type ProjectTelemetryFlag = Extract<
   keyof Project,
-  `hasInsights${string}` | 'hasSessions'
+  `hasInsights${string}` | 'hasSessions' | 'firstTransactionEvent'
 >;
 
 export type OnboardingConfig =

--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -303,7 +303,7 @@ export const BACKEND_OVERVIEW_PREBUILT_CONFIG: PrebuiltDashboard = {
   ],
   onboarding: {
     type: 'overview',
-    requiredProjectFlags: ['hasInsightsDb', 'hasInsightsHttp'],
+    requiredProjectFlags: ['firstTransactionEvent'],
     description: 'Get started with backend tracing',
   },
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -257,7 +257,7 @@ export const FRONTEND_OVERVIEW_PREBUILT_CONFIG: PrebuiltDashboard = {
   widgets: [...FIRST_ROW_WIDGETS, ...SECOND_ROW_WIDGETS, TRANSACTIONS_TABLE],
   onboarding: {
     type: 'overview',
-    requiredProjectFlags: ['hasInsightsVitals', 'hasInsightsAssets'],
+    requiredProjectFlags: ['firstTransactionEvent'],
     description: 'Get started with frontend tracing',
   },
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/laravelOverview/laravelOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/laravelOverview/laravelOverview.ts
@@ -181,7 +181,7 @@ export const LARAVEL_OVERVIEW_PREBUILT_CONFIG: PrebuiltDashboard = {
   ],
   onboarding: {
     type: 'overview',
-    requiredProjectFlags: ['hasInsightsDb', 'hasInsightsHttp'],
+    requiredProjectFlags: ['firstTransactionEvent'],
     description: 'Get started with Laravel tracing',
   },
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
@@ -269,7 +269,7 @@ export const NEXTJS_FRONTEND_OVERVIEW_PREBUILT_CONFIG: PrebuiltDashboard = {
   ],
   onboarding: {
     type: 'overview',
-    requiredProjectFlags: ['hasInsightsVitals', 'hasInsightsAssets'],
+    requiredProjectFlags: ['firstTransactionEvent'],
     description: 'Get started with Next.js tracing',
   },
 };


### PR DESCRIPTION
Replace span-specific project flags with `firstTransactionEvent` for the overview pre-built dashboard onboarding gate (frontend, backend, Next.js, Laravel overviews).

Previously, the onboarding screen was gated on flags like `hasInsightsVitals`, `hasInsightsAssets`, `hasInsightsDb`, and `hasInsightsHttp` — which only become true when specific span types are received. This was too restrictive: users who send custom spans with different span types would never see the dashboard content even if they had sent transactions.

Using `firstTransactionEvent` means the onboarding is hidden as soon as any transaction has been received, which is the right signal for these general overview dashboards.

Fixes DAIN-1362