### PR TITLE
fix(workflow): Prevent IndexError when serializing workflows without WDCGs

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 from django.db.models import Max, Prefetch, Q, prefetch_related_objects
 from rest_framework import serializers
@@ -560,8 +560,20 @@ class WorkflowEngineRuleSerializer(Serializer):
             result[workflow]["action_match"] = (
                 workflow.when_condition_group.logic_type if workflow.when_condition_group else None
             )
+
+            # Check if workflow has at least one WorkflowDataConditionGroup
+            # prefetched_wdcgs is set by Prefetch(to_attr="prefetched_wdcgs") in _fetch_workflows
+            prefetched_wdcgs = cast("list[WorkflowDataConditionGroup]", workflow.prefetched_wdcgs)
+            if not prefetched_wdcgs:
+                # Workflow has no WorkflowDataConditionGroups - set defaults
+                result[workflow]["filter_match"] = None
+                result[workflow]["conditions"] = []
+                result[workflow]["filters"] = []
+                result[workflow]["actions"] = []
+                continue
+
             # pick first DCG for filter_match (rules only have 1)
-            workflow_dcg = workflow.prefetched_wdcgs[0]  # type: ignore[attr-defined]
+            workflow_dcg = prefetched_wdcgs[0]
             result[workflow]["filter_match"] = workflow_dcg.condition_group.logic_type
 
             # build up actions data
@@ -642,9 +654,14 @@ class WorkflowEngineRuleSerializer(Serializer):
                 serialized_actions.append(action_data)
 
             # Generate conditions and filters
-            conditions, filters = self._generate_rule_conditions_filters(
-                workflow, result[workflow]["projects"][0], workflow_dcg
-            )
+            projects = result[workflow]["projects"]
+            if projects:
+                conditions, filters = self._generate_rule_conditions_filters(
+                    workflow, projects[0], workflow_dcg
+                )
+            else:
+                conditions, filters = [], []
+
             for f in filters:
                 # IssueCategoryFilter stores numeric string choices and must stay as str
                 if (

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict, cast
+from typing import Any, TypedDict
 
 from django.db.models import Max, Prefetch, Q, prefetch_related_objects
 from rest_framework import serializers
@@ -563,7 +563,7 @@ class WorkflowEngineRuleSerializer(Serializer):
 
             # Check if workflow has at least one WorkflowDataConditionGroup
             # prefetched_wdcgs is set by Prefetch(to_attr="prefetched_wdcgs") in _fetch_workflows
-            prefetched_wdcgs = cast("list[WorkflowDataConditionGroup]", workflow.prefetched_wdcgs)
+            prefetched_wdcgs: list[WorkflowDataConditionGroup] = workflow.prefetched_wdcgs  # type: ignore[attr-defined]
             if not prefetched_wdcgs:
                 # Workflow has no WorkflowDataConditionGroups - set defaults
                 result[workflow]["filter_match"] = None
@@ -687,9 +687,9 @@ class WorkflowEngineRuleSerializer(Serializer):
                 if condition.type in UNSUPPORTED_CONDITIONS:
                     errors.append({"detail": f"Condition not supported: {condition.type}"})
 
-            for f in filter_conditions:
-                if f.type in UNSUPPORTED_CONDITIONS:
-                    errors.append({"detail": f"Filter not supported: {f.type}"})
+            for filter_condition in filter_conditions:
+                if filter_condition.type in UNSUPPORTED_CONDITIONS:
+                    errors.append({"detail": f"Filter not supported: {filter_condition.type}"})
 
             if len(errors):
                 result[workflow]["errors"] = errors

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -1024,3 +1024,13 @@ class WorkflowRuleSerializerTest(TestCase):
             serialized_workflow["errors"][0]["detail"]
             == "Could not fetch details from Test Application"
         )
+
+    def test_workflow_without_data_condition_groups(self) -> None:
+        workflow = self.create_workflow(organization=self.organization)
+
+        serialized = serialize(workflow, self.user, WorkflowEngineRuleSerializer())
+
+        assert serialized["filterMatch"] is None
+        assert serialized["conditions"] == []
+        assert serialized["filters"] == []
+        assert serialized["actions"] == []


### PR DESCRIPTION
I don't think we've run into this in practice, and it's likely rare, but if nothing else this prevents AI code reviewers from complaining about it.
