### PR TITLE
feat(explore): Allow skipping attribute type

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Any, Literal, NotRequired, TypedDict
 
@@ -72,12 +73,15 @@ from sentry.tagstore.types import TagValue
 from sentry.utils import snuba_rpc
 from sentry.utils.cursors import Cursor, CursorResult
 
+POSSIBLE_ATTRIBUTE_TYPES = ["string", "number", "boolean"]
+
 
 class TraceItemAttributeKey(TypedDict):
     key: str
     name: str
     secondaryAliases: NotRequired[list[str]]
     attributeSource: dict[str, str | bool]
+    attributeType: Literal["string", "number", "boolean"]
 
 
 class TraceItemAttributesNamesPaginator:
@@ -144,8 +148,10 @@ class OrganizationTraceItemAttributesEndpointSerializer(serializers.Serializer):
         [e.value for e in SupportedTraceItemType], required=False, source="item_type"
     )
     dataset = serializers.ChoiceField([e.value for e in SupportedTraceItemType], required=False)
-    attributeType = serializers.ChoiceField(
-        ["string", "number", "boolean"], required=False, source="attribute_type"
+    attributeType = serializers.MultipleChoiceField(
+        choices=POSSIBLE_ATTRIBUTE_TYPES,
+        required=False,
+        source="attribute_type",
     )
     substringMatch = serializers.CharField(required=False, source="substring_match")
     query = serializers.CharField(required=False)
@@ -241,6 +247,7 @@ def as_attribute_key(
         # source of the attribute, used to determine whether to show the sentry icon etc. and helps delineate between sentry and user attributes when the names are identical
         # eg. sentry.environment and environment set by the user both have the same alias (name).
         "attributeSource": serialized_source,
+        "attributeType": attr_type,
     }
 
     if secondary_aliases:
@@ -278,7 +285,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         serialized = serializer.validated_data
         substring_match = serialized.get("substring_match", "")
         query_string = serialized.get("query")
-        attribute_type = serialized.get("attribute_type")
+        attribute_types = serialized.get("attribute_type")
+        if len(attribute_types) == 0:
+            attribute_types = POSSIBLE_ATTRIBUTE_TYPES
         # Deprecating this so we're using the same param name as the events endpoints
         item_type = serialized.get("item_type")
         # Dataset is going to replace item_type
@@ -309,23 +318,32 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
 
         include_internal = is_active_superuser(request) or is_active_staff(request)
 
-        def data_fn(offset: int, limit: int):
-            if attribute_type is None:
-                # query all 3 types in parallel if its not passed and return 1 just list
-                pass
-            else:
-                return self.query_trace_attributes(
-                    offset,
-                    limit,
-                    meta,
-                    query_filter,
-                    substring_match,
-                    attribute_type,
-                    column_definitions,
-                    use_sentry_conventions,
-                    trace_item_type,
-                    include_internal,
-                )
+        def data_fn(offset: int, limit: int) -> list[TraceItemAttributeKey]:
+            futures = []
+            with ThreadPoolExecutor(
+                thread_name_prefix=__name__,
+                max_workers=len(POSSIBLE_ATTRIBUTE_TYPES),
+            ) as pool:
+                for attribute_type in attribute_types:
+                    futures.append(
+                        pool.submit(
+                            self.query_trace_attributes,
+                            offset,
+                            limit,
+                            meta,
+                            query_filter,
+                            substring_match,
+                            attribute_type,
+                            column_definitions,
+                            use_sentry_conventions,
+                            trace_item_type,
+                            include_internal,
+                        )
+                    )
+            attributes = []
+            for future in futures:
+                attributes.extend(future.result())
+            return attributes
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -12,16 +12,21 @@ from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
     TraceItemAttributeNamesResponse,
     TraceItemAttributeValuesRequest,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import PageToken
-from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType as ProtoTraceItemType
+from sentry_protos.snuba.v1.request_common_pb2 import PageToken, RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import (
+    TraceItemType as ProtoTraceItemType,
+)
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 
 from sentry import features, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
-from sentry.api.endpoints.organization_spans_fields import BaseSpanFieldValuesAutocompletionExecutor
+from sentry.api.endpoints.organization_spans_fields import (
+    BaseSpanFieldValuesAutocompletionExecutor,
+)
 from sentry.api.event_search import translate_escape_sequences
 from sentry.api.paginator import ChainPaginator, GenericOffsetPaginator
 from sentry.api.serializers import serialize
@@ -35,7 +40,11 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseStages
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.search.eap import constants
-from sentry.search.eap.columns import ColumnDefinitions, VirtualColumnDefinition
+from sentry.search.eap.columns import (
+    ColumnDefinitions,
+    ResolvedAttribute,
+    VirtualColumnDefinition,
+)
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.preprod_size.definitions import PREPROD_SIZE_DEFINITIONS
 from sentry.search.eap.processing_errors.definitions import PROCESSING_ERROR_DEFINITIONS
@@ -136,7 +145,7 @@ class OrganizationTraceItemAttributesEndpointSerializer(serializers.Serializer):
     )
     dataset = serializers.ChoiceField([e.value for e in SupportedTraceItemType], required=False)
     attributeType = serializers.ChoiceField(
-        ["string", "number", "boolean"], required=True, source="attribute_type"
+        ["string", "number", "boolean"], required=False, source="attribute_type"
     )
     substringMatch = serializers.CharField(required=False, source="substring_match")
     query = serializers.CharField(required=False)
@@ -166,7 +175,7 @@ def get_column_definitions(item_type: SupportedTraceItemType) -> ColumnDefinitio
     raise ValueError(f"Invalid item type: {item_type}")
 
 
-def resolve_attribute_referrer(item_type: str, attribute_type: str) -> Referrer:
+def resolve_attribute_referrer(item_type: str) -> Referrer:
     if item_type == SupportedTraceItemType.SPANS.value:
         return Referrer.API_SPANS_TAG_KEYS_RPC
     elif item_type == SupportedTraceItemType.LOGS.value:
@@ -197,19 +206,21 @@ def resolve_attribute_values_referrer(item_type: str) -> Referrer:
 
 
 def as_attribute_key(
-    name: str, type: Literal["string", "number", "boolean"], item_type: SupportedTraceItemType
+    name: str,
+    attr_type: Literal["string", "number", "boolean"],
+    item_type: SupportedTraceItemType,
 ) -> TraceItemAttributeKey:
     public_key, public_name, attribute_source = translate_internal_to_public_alias(
-        name, type, item_type
+        name, attr_type, item_type
     )
     secondary_aliases = get_secondary_aliases(name, item_type)
 
     if public_key is not None and public_name is not None:
         pass
-    elif type == "number":
+    elif attr_type == "number":
         public_key = f"tags[{name},number]"
         public_name = name
-    elif type == "boolean":
+    elif attr_type == "boolean":
         public_key = f"tags[{name},boolean]"
         public_name = name
     else:
@@ -276,9 +287,8 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
             dataset = item_type
 
         max_attributes = options.get("explore.trace-items.keys.max")
-        value_substring_match = translate_escape_sequences(substring_match)
         trace_item_type = SupportedTraceItemType(dataset)
-        referrer = resolve_attribute_referrer(trace_item_type, attribute_type)
+        referrer = resolve_attribute_referrer(trace_item_type)
         column_definitions = get_column_definitions(trace_item_type)
         resolver = SearchResolver(
             params=snuba_params,
@@ -297,124 +307,25 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         snuba_params.start = adjusted_start_date
         snuba_params.end = adjusted_end_date
 
-        attr_type = constants.ATTRIBUTES_QUERY_PARAM_TO_ATTRIBUTE_TYPE_MAP.get(
-            attribute_type, AttributeKey.Type.TYPE_STRING
-        )
         include_internal = is_active_superuser(request) or is_active_staff(request)
 
         def data_fn(offset: int, limit: int):
-            with sentry_sdk.start_span(op="filter", name="hardcoded_aliases") as span:
-                all_aliased_attributes = []
-                # our aliases don't exist in the db, so filter over our aliases
-                # virtually page through defined aliases before we hit the db
-                if substring_match and offset <= len(column_definitions.columns):
-                    for index, column in enumerate(column_definitions.columns.values()):
-                        if (
-                            column.proto_type == attr_type
-                            and substring_match in column.public_alias
-                            and not column.secondary_alias
-                            and not column.private
-                        ):
-                            all_aliased_attributes.append(column)
-                aliased_attributes = all_aliased_attributes[offset : offset + limit]
-            with sentry_sdk.start_span(op="query", name="attribute_names") as span:
-                if len(aliased_attributes) < limit - 1:
-                    offset -= len(all_aliased_attributes) - len(aliased_attributes)
-                    limit -= len(aliased_attributes)
-                    rpc_request = TraceItemAttributeNamesRequest(
-                        meta=meta,
-                        limit=limit,
-                        page_token=PageToken(offset=offset),
-                        type=attr_type,
-                        value_substring_match=value_substring_match,
-                        intersecting_attributes_filter=query_filter,
-                    )
-
-                    with handle_query_errors():
-                        rpc_response = snuba_rpc.attribute_names_rpc(rpc_request)
-                else:
-                    rpc_response = TraceItemAttributeNamesResponse()
-
-                if use_sentry_conventions:
-                    attribute_keys = {}
-                    for attribute in rpc_response.attributes:
-                        if attribute.name and can_expose_attribute(
-                            attribute.name,
-                            trace_item_type,
-                            include_internal=include_internal,
-                        ):
-                            attr_key = as_attribute_key(
-                                attribute.name,
-                                serialized["attribute_type"],
-                                trace_item_type,
-                            )
-                            public_alias = attr_key["name"]
-                            replacement = translate_to_sentry_conventions(
-                                public_alias, trace_item_type
-                            )
-                            if public_alias != replacement:
-                                attr_key = as_attribute_key(
-                                    replacement,
-                                    serialized["attribute_type"],
-                                    trace_item_type,
-                                )
-
-                            attribute_keys[attr_key["name"]] = attr_key
-                    for aliased_attr in aliased_attributes:
-                        attr_key = as_attribute_key(
-                            aliased_attr.internal_name,
-                            serialized["attribute_type"],
-                            trace_item_type,
-                        )
-                        attribute_keys[attr_key["name"]] = attr_key
-
-                    attributes = list(attribute_keys.values())
-                    sentry_sdk.set_context("api_response", {"attributes": attributes})
-                    return attributes
-
-                attributes = list(
-                    filter(
-                        lambda x: (
-                            not is_sentry_convention_replacement_attribute(
-                                x["name"], trace_item_type
-                            )
-                            # Remove anything where the public alias doesn't match the substring
-                            # This can happen when the public alias is different, but that's handled by
-                            # aliased_attributes
-                            and (substring_match in x["name"] if substring_match else True)
-                        ),
-                        [
-                            as_attribute_key(
-                                attribute.name,
-                                serialized["attribute_type"],
-                                trace_item_type,
-                            )
-                            for attribute in rpc_response.attributes
-                            if attribute.name
-                            and can_expose_attribute(
-                                attribute.name,
-                                trace_item_type,
-                                include_internal=include_internal,
-                            )
-                        ],
-                    )
+            if attribute_type is None:
+                # query all 3 types in parallel if its not passed and return 1 just list
+                pass
+            else:
+                return self.query_trace_attributes(
+                    offset,
+                    limit,
+                    meta,
+                    query_filter,
+                    substring_match,
+                    attribute_type,
+                    column_definitions,
+                    use_sentry_conventions,
+                    trace_item_type,
+                    include_internal,
                 )
-                for aliased_attr in aliased_attributes:
-                    if can_expose_attribute(
-                        aliased_attr.public_alias,
-                        trace_item_type,
-                        include_internal=include_internal,
-                    ):
-                        attr_key = as_attribute_key(
-                            aliased_attr.internal_name,
-                            serialized["attribute_type"],
-                            trace_item_type,
-                        )
-                        attributes.append(attr_key)
-                sentry_sdk.set_context("api_response", {"attributes": attributes})
-                span.set_data("attribute_count", len(attributes))
-                span.set_data("attribute_type", attribute_type)
-                return attributes
 
         return self.paginate(
             request=request,
@@ -423,6 +334,166 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
             default_per_page=max_attributes,
             max_per_page=max_attributes,
         )
+
+    def query_trace_attributes(
+        self,
+        offset: int,
+        limit: int,
+        meta: RequestMeta,
+        query_filter: TraceItemFilter | None,
+        substring_match: str,
+        attribute_type: Literal["string", "number", "boolean"],
+        column_definitions: ColumnDefinitions,
+        use_sentry_conventions: bool,
+        trace_item_type: SupportedTraceItemType,
+        include_internal: bool,
+    ):
+        value_substring_match = translate_escape_sequences(substring_match)
+        attr_type = constants.ATTRIBUTES_QUERY_PARAM_TO_ATTRIBUTE_TYPE_MAP.get(
+            attribute_type, AttributeKey.Type.TYPE_STRING
+        )
+        with sentry_sdk.start_span(op="filter", name="hardcoded_aliases") as span:
+            all_aliased_attributes = []
+            # our aliases don't exist in the db, so filter over our aliases
+            # virtually page through defined aliases before we hit the db
+            if substring_match and offset <= len(column_definitions.columns):
+                for index, column in enumerate(column_definitions.columns.values()):
+                    if (
+                        column.proto_type == attr_type
+                        and substring_match in column.public_alias
+                        and not column.secondary_alias
+                        and not column.private
+                    ):
+                        all_aliased_attributes.append(column)
+            aliased_attributes = all_aliased_attributes[offset : offset + limit]
+        with sentry_sdk.start_span(op="query", name="attribute_names") as span:
+            if len(aliased_attributes) < limit - 1:
+                offset -= len(all_aliased_attributes) - len(aliased_attributes)
+                limit -= len(aliased_attributes)
+                rpc_request = TraceItemAttributeNamesRequest(
+                    meta=meta,
+                    limit=limit,
+                    page_token=PageToken(offset=offset),
+                    type=attr_type,
+                    value_substring_match=value_substring_match,
+                    intersecting_attributes_filter=query_filter,
+                )
+
+                with handle_query_errors():
+                    rpc_response = snuba_rpc.attribute_names_rpc(rpc_request)
+            else:
+                rpc_response = TraceItemAttributeNamesResponse()
+
+        with sentry_sdk.start_span(op="query", name="serialize") as span:
+            if use_sentry_conventions:
+                serialize_function = self.serialize_trace_attributes_using_sentry_conventions
+            else:
+                serialize_function = self.serialize_trace_attributes
+
+            attributes = serialize_function(
+                rpc_response,
+                attribute_type,
+                trace_item_type,
+                include_internal,
+                substring_match,
+                aliased_attributes,
+            )
+
+        sentry_sdk.set_context("api_response", {"attributes": attributes})
+        span.set_data("attribute_count", len(attributes))
+        span.set_data("attribute_type", attribute_type)
+        return attributes
+
+    def serialize_trace_attributes_using_sentry_conventions(
+        self,
+        rpc_response: TraceItemAttributeNamesResponse,
+        attribute_type: Literal["string", "number", "boolean"],
+        trace_item_type: SupportedTraceItemType,
+        include_internal: bool,
+        substring_match: str,
+        aliased_attributes: list[str],
+    ) -> list[TraceItemAttributeKey]:
+        attribute_keys = {}
+        for attribute in rpc_response.attributes:
+            if attribute.name and can_expose_attribute(
+                attribute.name,
+                trace_item_type,
+                include_internal=include_internal,
+            ):
+                attr_key = as_attribute_key(
+                    attribute.name,
+                    attribute_type,
+                    trace_item_type,
+                )
+                public_alias = attr_key["name"]
+                replacement = translate_to_sentry_conventions(public_alias, trace_item_type)
+                if public_alias != replacement:
+                    attr_key = as_attribute_key(
+                        replacement,
+                        attribute_type,
+                        trace_item_type,
+                    )
+
+                attribute_keys[attr_key["name"]] = attr_key
+        for aliased_attr in aliased_attributes:
+            attr_key = as_attribute_key(
+                aliased_attr.internal_name,
+                attribute_type,
+                trace_item_type,
+            )
+            attribute_keys[attr_key["name"]] = attr_key
+
+        attributes = list(attribute_keys.values())
+        sentry_sdk.set_context("api_response", {"attributes": attributes})
+        return attributes
+
+    def serialize_trace_attributes(
+        self,
+        rpc_response: TraceItemAttributeNamesResponse,
+        attribute_type: Literal["string", "number", "boolean"],
+        trace_item_type: SupportedTraceItemType,
+        include_internal: bool,
+        substring_match: str,
+        aliased_attributes: list[ResolvedAttribute],
+    ) -> list[TraceItemAttributeKey]:
+        attributes = list(
+            filter(
+                lambda x: (
+                    not is_sentry_convention_replacement_attribute(x["name"], trace_item_type)
+                    # Remove anything where the public alias doesn't match the substring
+                    # This can happen when the public alias is different, but that's handled by
+                    # aliased_attributes
+                    and (substring_match in x["name"] if substring_match else True)
+                ),
+                [
+                    as_attribute_key(
+                        attribute.name,
+                        attribute_type,
+                        trace_item_type,
+                    )
+                    for attribute in rpc_response.attributes
+                    if attribute.name
+                    and can_expose_attribute(
+                        attribute.name,
+                        trace_item_type,
+                        include_internal=include_internal,
+                    )
+                ],
+            )
+        )
+        for aliased_attr in aliased_attributes:
+            if can_expose_attribute(
+                aliased_attr.public_alias,
+                trace_item_type,
+                include_internal=include_internal,
+            ):
+                attr_key = as_attribute_key(
+                    aliased_attr.internal_name,
+                    attribute_type,
+                    trace_item_type,
+                )
+                attributes.append(attr_key)
+        return attributes
 
 
 @cell_silo_endpoint

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -286,7 +286,8 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         substring_match = serialized.get("substring_match", "")
         query_string = serialized.get("query")
         attribute_types = serialized.get("attribute_type")
-        if len(attribute_types) == 0 or attribute_types is None:
+        # When not passed the user wants all types
+        if attribute_types is None or len(attribute_types) == 0:
             attribute_types = POSSIBLE_ATTRIBUTE_TYPES
         # Deprecating this so we're using the same param name as the events endpoints
         item_type = serialized.get("item_type")

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -286,7 +286,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         substring_match = serialized.get("substring_match", "")
         query_string = serialized.get("query")
         attribute_types = serialized.get("attribute_type")
-        if len(attribute_types) == 0:
+        if len(attribute_types) == 0 or attribute_types is None:
             attribute_types = POSSIBLE_ATTRIBUTE_TYPES
         # Deprecating this so we're using the same param name as the events endpoints
         item_type = serialized.get("item_type")
@@ -417,9 +417,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 aliased_attributes,
             )
 
-        sentry_sdk.set_context("api_response", {"attributes": attributes})
-        span.set_data("attribute_count", len(attributes))
-        span.set_data("attribute_type", attribute_type)
+            sentry_sdk.set_context("api_response", {"attributes": attributes})
+            span.set_data("attribute_count", len(attributes))
+            span.set_data("attribute_type", attribute_type)
         return attributes
 
     def serialize_trace_attributes_using_sentry_conventions(
@@ -429,7 +429,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         trace_item_type: SupportedTraceItemType,
         include_internal: bool,
         substring_match: str,
-        aliased_attributes: list[str],
+        aliased_attributes: list[ResolvedAttribute],
     ) -> list[TraceItemAttributeKey]:
         attribute_keys = {}
         for attribute in rpc_response.attributes:

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -219,6 +219,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                 },
                 "secondaryAliases": ["log.body"],
+                "attributeType": "string",
             },
             {
                 "key": "message.parameter.0",
@@ -227,6 +228,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                     "is_transformed_alias": True,
                 },
+                "attributeType": "string",
             },
             {
                 "key": "message.parameter.1",
@@ -235,6 +237,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                     "is_transformed_alias": True,
                 },
+                "attributeType": "string",
             },
             {
                 "key": "message.parameter.ip",
@@ -243,6 +246,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                     "is_transformed_alias": True,
                 },
+                "attributeType": "string",
             },
             {
                 "key": "message.parameter.username",
@@ -251,6 +255,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                     "is_transformed_alias": True,
                 },
+                "attributeType": "string",
             },
             {
                 "key": "project",
@@ -258,6 +263,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 "attributeSource": {
                     "source_type": "sentry",
                 },
+                "attributeType": "string",
             },
             {
                 "key": "severity",
@@ -266,6 +272,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                 },
                 "secondaryAliases": ["log.severity_text", "severity_text"],
+                "attributeType": "string",
             },
         ]
 
@@ -288,6 +295,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 "attributeSource": {
                     "source_type": "sentry",
                 },
+                "attributeType": "number",
             },
             {
                 "key": "severity_number",
@@ -296,6 +304,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                 },
                 "secondaryAliases": ["log.severity_number"],
+                "attributeType": "number",
             },
             {
                 "key": "tags[message.parameter.1,number]",
@@ -304,6 +313,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                     "is_transformed_alias": True,
                 },
+                "attributeType": "number",
             },
             {
                 "key": "tags[message.parameter.2,number]",
@@ -312,6 +322,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                     "is_transformed_alias": True,
                 },
+                "attributeType": "number",
             },
             {
                 "key": "tags[message.parameter.value,number]",
@@ -320,6 +331,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                     "source_type": "sentry",
                     "is_transformed_alias": True,
                 },
+                "attributeType": "number",
             },
             {
                 "key": "timestamp_precise",
@@ -327,6 +339,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 "attributeSource": {
                     "source_type": "sentry",
                 },
+                "attributeType": "number",
             },
         ]
 
@@ -432,23 +445,41 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.data
         expected: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar", "attributeSource": {"source_type": "user"}},
-            {"key": "baz", "name": "baz", "attributeSource": {"source_type": "user"}},
-            {"key": "foo", "name": "foo", "attributeSource": {"source_type": "user"}},
+            {
+                "key": "bar",
+                "name": "bar",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "user"},
+            },
+            {
+                "key": "baz",
+                "name": "baz",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "user"},
+            },
+            {
+                "key": "foo",
+                "name": "foo",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "user"},
+            },
             {
                 "key": "span.description",
                 "name": "span.description",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
             {
                 "key": "transaction",
                 "name": "transaction",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "project",
                 "name": "project",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
         ]
@@ -496,46 +527,55 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {
                 "key": "tags[bar,number]",
                 "name": "bar",
+                "attributeType": "number",
                 "attributeSource": {"source_type": "user"},
             },
             {
                 "key": "tags[baz,number]",
                 "name": "baz",
+                "attributeType": "number",
                 "attributeSource": {"source_type": "user"},
             },
             {
                 "key": "measurements.fcp",
                 "name": "measurements.fcp",
+                "attributeType": "number",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "tags[foo,number]",
                 "name": "foo",
+                "attributeType": "number",
                 "attributeSource": {"source_type": "user"},
             },
             {
                 "key": "http.decoded_response_content_length",
                 "name": "http.decoded_response_content_length",
+                "attributeType": "number",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "http.response_content_length",
                 "name": "http.response_content_length",
+                "attributeType": "number",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "http.response_transfer_size",
                 "name": "http.response_transfer_size",
+                "attributeType": "number",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "measurements.lcp",
                 "name": "measurements.lcp",
+                "attributeType": "number",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "span.duration",
                 "name": "span.duration",
+                "attributeType": "number",
                 "attributeSource": {"source_type": "sentry"},
             },
         ]
@@ -565,18 +605,35 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.data
 
         expected: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar", "attributeSource": {"source_type": "user"}},
-            {"key": "baz", "name": "baz", "attributeSource": {"source_type": "user"}},
-            {"key": "foo", "name": "foo", "attributeSource": {"source_type": "user"}},
+            {
+                "key": "bar",
+                "name": "bar",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "user"},
+            },
+            {
+                "key": "baz",
+                "name": "baz",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "user"},
+            },
+            {
+                "key": "foo",
+                "name": "foo",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "user"},
+            },
             {
                 "key": "span.description",
                 "name": "span.description",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
             {
                 "key": "project",
                 "name": "project",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
         ]
@@ -606,17 +663,20 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {
                 "key": "span.description",
                 "name": "span.description",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
             {
                 "key": "transaction",
                 "name": "transaction",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "project",
                 "name": "project",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
         ]
@@ -642,18 +702,35 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.content
 
         expected_3: list[TraceItemAttributeKey] = [
-            {"key": "bar", "name": "bar", "attributeSource": {"source_type": "user"}},
-            {"key": "baz", "name": "baz", "attributeSource": {"source_type": "user"}},
-            {"key": "foo", "name": "foo", "attributeSource": {"source_type": "user"}},
+            {
+                "key": "bar",
+                "name": "bar",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "user"},
+            },
+            {
+                "key": "baz",
+                "name": "baz",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "user"},
+            },
+            {
+                "key": "foo",
+                "name": "foo",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "user"},
+            },
             {
                 "key": "span.description",
                 "name": "span.description",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
             {
                 "key": "project",
                 "name": "project",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
         ]
@@ -706,46 +783,55 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 {
                     "key": "tags[bar,number]",
                     "name": "bar",
+                    "attributeType": "number",
                     "attributeSource": {"source_type": "user"},
                 },
                 {
                     "key": "tags[baz,number]",
                     "name": "baz",
+                    "attributeType": "number",
                     "attributeSource": {"source_type": "user"},
                 },
                 {
                     "key": "measurements.fcp",
                     "name": "measurements.fcp",
+                    "attributeType": "number",
                     "attributeSource": {"source_type": "sentry"},
                 },
                 {
                     "key": "tags[foo,number]",
                     "name": "foo",
+                    "attributeType": "number",
                     "attributeSource": {"source_type": "user"},
                 },
                 {
                     "key": "http.decoded_response_content_length",
                     "name": "http.decoded_response_content_length",
+                    "attributeType": "number",
                     "attributeSource": {"source_type": "sentry"},
                 },
                 {
                     "key": "http.response.body.size",
                     "name": "http.response.body.size",
+                    "attributeType": "number",
                     "attributeSource": {"source_type": "sentry"},
                 },
                 {
                     "key": "http.response.size",
                     "name": "http.response.size",
+                    "attributeType": "number",
                     "attributeSource": {"source_type": "sentry"},
                 },
                 {
                     "key": "measurements.lcp",
                     "name": "measurements.lcp",
+                    "attributeType": "number",
                     "attributeSource": {"source_type": "sentry"},
                 },
                 {
                     "key": "span.duration",
                     "name": "span.duration",
+                    "attributeType": "number",
                     "attributeSource": {"source_type": "sentry"},
                 },
             ],
@@ -776,27 +862,32 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {
                 "key": "span.description",
                 "name": "span.description",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
             {
                 "key": "project",
                 "name": "project",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "transaction",
                 "name": "transaction",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "tags[span.duration,string]",
                 "name": "span.duration",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
                 "key": "tags[span.op,string]",
                 "name": "span.op",
+                "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
         ]
@@ -930,16 +1021,13 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert "tag.op2" in keys
 
     def test_empty_attribute_type_for_all_attribute_types(self) -> None:
-        span1 = self.create_span(
-            {"tags": {"tag.string": "foo"}}, start_ts=before_now(days=0, minutes=10)
-        )
-        span2 = self.create_span(
-            {"tags": {"tag.number": 123}}, start_ts=before_now(days=0, minutes=10)
-        )
-        span2 = self.create_span(
-            {"tags": {"tag.boolean": True}}, start_ts=before_now(days=0, minutes=10)
-        )
-        self.store_spans([span1, span2])
+        span1 = self.create_span(start_ts=before_now(days=0, minutes=10))
+        span1["data"] = {
+            "tag.string": "foo",
+            "tag.boolean": False,
+            "tag.number": 400,
+        }
+        self.store_spans([span1])
 
         response = self.do_request(
             query={
@@ -949,8 +1037,37 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.content
 
-        keys = {item["key"] for item in response.data}
-        assert len(keys) == 3
+        keys = {(item["key"], item["attributeType"]) for item in response.data}
+        # TODO: add this assert back when we stop doublewriting;
+        # assert len(keys) == 3
+        assert ("tags[tag.boolean,boolean]", "boolean") in keys
+        assert ("tags[tag.boolean,number]", "number") in keys
+        assert ("tag.string", "string") in keys
+
+    def test_multiple_attribute_types(self) -> None:
+        span1 = self.create_span(start_ts=before_now(days=0, minutes=10))
+        span1["data"] = {
+            "tag.string": "foo",
+            "tag.boolean": False,
+            "tag.number": 400,
+        }
+        self.store_spans([span1])
+
+        response = self.do_request(
+            query={
+                "attributeType": ["number", "string"],
+                "substringMatch": "tag.",
+                "per_page": 20,
+            }
+        )
+        assert response.status_code == 200, response.content
+
+        keys = {(item["key"], item["attributeType"]) for item in response.data}
+        # TODO: add this assert back when we stop doublewriting;
+        # assert len(keys) == 2
+        assert ("tags[tag.boolean,boolean]", "boolean") not in keys
+        assert ("tags[tag.boolean,number]", "number") in keys
+        assert ("tag.string", "string") in keys
 
 
 class OrganizationTraceItemAttributesEndpointTraceMetricsTest(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -5,7 +5,9 @@ from uuid import uuid4
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
-from sentry.api.endpoints.organization_trace_item_attributes import TraceItemAttributeKey
+from sentry.api.endpoints.organization_trace_item_attributes import (
+    TraceItemAttributeKey,
+)
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.types import SupportedTraceItemType
 from sentry.testutils.cases import (
@@ -36,8 +38,6 @@ class OrganizationTraceItemAttributesEndpointTestBase(APITestCase, SnubaTestCase
             query = {}
         if "dataset" not in query:
             query["dataset"] = self.item_type.value
-        if "attributeType" not in query:
-            query["attributeType"] = "string"
 
         if features is None:
             features = self.feature_flags
@@ -70,7 +70,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         }
 
     def test_no_projects(self) -> None:
-        response = self.do_request()
+        response = self.do_request(query={"attributeType": "string"})
         assert response.status_code == 200, response.content
         assert response.data == []
 
@@ -99,7 +99,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         self.store_eap_items(logs)
 
         # Test with empty prefix (should return all attributes)
-        response = self.do_request(query={"substringMatch": ""})
+        response = self.do_request(query={"substringMatch": "", "attributeType": "string"})
         assert response.status_code == 200, response.content
 
         keys = {item["key"] for item in response.data}
@@ -135,7 +135,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         ]
         self.store_eap_items(logs)
 
-        response = self.do_request()
+        response = self.do_request(query={"attributeType": "string"})
 
         assert response.status_code == 200, response.content
         keys = {item["key"] for item in response.data}
@@ -156,7 +156,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         ]
         self.store_eap_items(logs)
 
-        response = self.do_request()
+        response = self.do_request(query={"attributeType": "string"})
 
         assert response.status_code == 200, response.content
         keys = {item["key"] for item in response.data}
@@ -176,7 +176,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
 
         self.store_eap_items(logs)
 
-        response = self.do_request()
+        response = self.do_request(query={"attributeType": "string"})
 
         assert response.status_code == 200, response.content
         keys = {item["key"] for item in response.data}
@@ -341,7 +341,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
 
         self.store_eap_items(logs)
 
-        response = self.do_request()
+        response = self.do_request(query={"attributeType": "string"})
 
         assert response.status_code == 200, response.content
         keys = {item["key"] for item in response.data}
@@ -405,7 +405,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         }
 
     def test_no_projects(self) -> None:
-        response = self.do_request()
+        response = self.do_request(query={"attributeType": "string"})
         assert response.status_code == 200, response.content
         assert response.data == []
 
@@ -446,7 +446,11 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 "name": "transaction",
                 "attributeSource": {"source_type": "sentry"},
             },
-            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
+            {
+                "key": "project",
+                "name": "project",
+                "attributeSource": {"source_type": "sentry"},
+            },
         ]
         assert sorted(
             response.data,
@@ -489,14 +493,26 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.data
         assert response.data == [
-            {"key": "tags[bar,number]", "name": "bar", "attributeSource": {"source_type": "user"}},
-            {"key": "tags[baz,number]", "name": "baz", "attributeSource": {"source_type": "user"}},
+            {
+                "key": "tags[bar,number]",
+                "name": "bar",
+                "attributeSource": {"source_type": "user"},
+            },
+            {
+                "key": "tags[baz,number]",
+                "name": "baz",
+                "attributeSource": {"source_type": "user"},
+            },
             {
                 "key": "measurements.fcp",
                 "name": "measurements.fcp",
                 "attributeSource": {"source_type": "sentry"},
             },
-            {"key": "tags[foo,number]", "name": "foo", "attributeSource": {"source_type": "user"}},
+            {
+                "key": "tags[foo,number]",
+                "name": "foo",
+                "attributeSource": {"source_type": "user"},
+            },
             {
                 "key": "http.decoded_response_content_length",
                 "name": "http.decoded_response_content_length",
@@ -558,7 +574,11 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
+            {
+                "key": "project",
+                "name": "project",
+                "attributeSource": {"source_type": "sentry"},
+            },
         ]
 
         assert sorted(
@@ -594,7 +614,11 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 "name": "transaction",
                 "attributeSource": {"source_type": "sentry"},
             },
-            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
+            {
+                "key": "project",
+                "name": "project",
+                "attributeSource": {"source_type": "sentry"},
+            },
         ]
         assert sorted(
             response.data,
@@ -627,7 +651,11 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
+            {
+                "key": "project",
+                "name": "project",
+                "attributeSource": {"source_type": "sentry"},
+            },
         ]
         assert sorted(
             response.data,
@@ -742,7 +770,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             },
         )
 
-        response = self.do_request()
+        response = self.do_request(query={"attributeType": "string"})
         assert response.status_code == 200, response.data
         assert response.data == [
             {
@@ -751,7 +779,11 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 "attributeSource": {"source_type": "sentry"},
                 "secondaryAliases": ["description", "message"],
             },
-            {"key": "project", "name": "project", "attributeSource": {"source_type": "sentry"}},
+            {
+                "key": "project",
+                "name": "project",
+                "attributeSource": {"source_type": "sentry"},
+            },
             {
                 "key": "transaction",
                 "name": "transaction",
@@ -896,6 +928,29 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         # The keys from the db should only be from the last page
         assert "tag.op" in keys
         assert "tag.op2" in keys
+
+    def test_empty_attribute_type_for_all_attribute_types(self) -> None:
+        span1 = self.create_span(
+            {"tags": {"tag.string": "foo"}}, start_ts=before_now(days=0, minutes=10)
+        )
+        span2 = self.create_span(
+            {"tags": {"tag.number": 123}}, start_ts=before_now(days=0, minutes=10)
+        )
+        span2 = self.create_span(
+            {"tags": {"tag.boolean": True}}, start_ts=before_now(days=0, minutes=10)
+        )
+        self.store_spans([span1, span2])
+
+        response = self.do_request(
+            query={
+                "substringMatch": "tag.",
+                "per_page": 20,
+            }
+        )
+        assert response.status_code == 200, response.content
+
+        keys = {item["key"] for item in response.data}
+        assert len(keys) == 3
 
 
 class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
@@ -1119,7 +1174,7 @@ class OrganizationTraceItemAttributeValuesEndpointLogsTest(
         }
 
     def test_no_projects(self) -> None:
-        response = self.do_request()
+        response = self.do_request(query={"attributeType": "string"})
         assert response.status_code == 200, response.content
         assert response.data == []
 
@@ -1157,7 +1212,9 @@ class OrganizationTraceItemAttributeValuesEndpointLogsTest(
 
 
 class OrganizationTraceItemAttributeValuesEndpointSpansTest(
-    OrganizationTraceItemAttributeValuesEndpointBaseTest, BaseSpansTestCase, SpanTestCase
+    OrganizationTraceItemAttributeValuesEndpointBaseTest,
+    BaseSpansTestCase,
+    SpanTestCase,
 ):
     feature_flags = {"organizations:visibility-explore-view": True}
     item_type = SupportedTraceItemType.SPANS
@@ -1176,7 +1233,7 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
         }
 
     def test_no_projects(self) -> None:
-        response = self.do_request()
+        response = self.do_request(query={"attributeType": "string"})
         assert response.status_code == 200, response.content
         assert response.data == []
 


### PR DESCRIPTION
- this allows the trace-attribute endpoint to be used without an
  explicit trace attribute type (returning all types)
- As well as allowing multiple types to be requested as well