### PR TITLE
fix(dashboards): Use normalizeUrl when navigating after pre-built dashboard duplication

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -18,6 +18,7 @@ import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useQueryClient} from 'sentry/utils/queryClient';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -94,7 +95,11 @@ export function Controls({
   const {duplicatePrebuiltDashboard, isLoading: isLoadingDuplicatePrebuiltDashboard} =
     useDuplicatePrebuiltDashboard({
       onSuccess: (newDashboard: DashboardDetails) => {
-        navigate(`/organizations/${organization.slug}/dashboard/${newDashboard.id}/`);
+        navigate(
+          normalizeUrl(
+            `/organizations/${organization.slug}/dashboard/${newDashboard.id}/`
+          )
+        );
       },
     });
 


### PR DESCRIPTION
Wraps the navigation target with `normalizeUrl` whoops! Otherwise the sidebar doesn't correctly find the right secondary navigation.

Fixes DAIN-1336