### PR TITLE
ref(errors): Explicitly throw on empty group_id snuba query

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -974,7 +974,13 @@ class SnubaQueryParams:
         # just subtract the NOT IN groups from the IN groups.
         if in_groups is not None:
             in_groups.difference_update(out_groups)
-            triple = ["group_id", "IN", get_all_merged_group_ids(in_groups)]
+
+            # An "group_id IN ()" clause breaks clickhouse.
+            # Better to make the exception (& expectations) clear.
+            if len(in_groups) > 0:
+                triple = ["group_id", "IN", get_all_merged_group_ids(in_groups)]
+            else:
+                raise SnubaError("Found empty intersection of group_ids")
         elif len(out_groups) > 0:
             triple = ["group_id", "NOT IN", out_groups]
 


### PR DESCRIPTION
This breaks clickhouse. Let's raise a SnubaError that spells out the problem more clearly instead of letting things get that far.
