### PR TITLE
ref(seer): Update Seer UI headers to 'Seer Autofix'

### DIFF
--- a/static/app/components/events/autofix/drawer/drawerNavigator.tsx
+++ b/static/app/components/events/autofix/drawer/drawerNavigator.tsx
@@ -44,7 +44,7 @@ export function SeerDrawerNavigator({
       <Flex align="center" gap="md">
         <IconSeer animation={undefined} size="md" />
         <Heading as="h3" size="xl">
-          {t('Seer')}
+          {t('Seer Autofix')}
         </Heading>
         <QuestionTooltip
           isHoverable

--- a/static/app/components/events/autofix/v3/header.tsx
+++ b/static/app/components/events/autofix/v3/header.tsx
@@ -18,7 +18,7 @@ export function SeerDrawerHeader({onCopyMarkdown, onReset}: SeerDrawerHeaderProp
     <DrawerHeader>
       <Flex justify="between" width="100%">
         <Flex align="center" gap="xs">
-          <Text>{t('Autofix')}</Text>
+          <Text>{t('Seer Autofix')}</Text>
           <Button
             size="xs"
             icon={<IconCopy />}

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -218,7 +218,7 @@ describe('SeerDrawer', () => {
       screen.queryByTestId('ai-setup-loading-indicator')
     );
 
-    expect(screen.getByRole('heading', {name: 'Seer'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Seer Autofix'})).toBeInTheDocument();
 
     // Verify the Start Root Cause Analysis button is available
     const startButton = screen.getByRole('button', {name: 'Start Root Cause Analysis'});
@@ -498,7 +498,7 @@ describe('SeerDrawer', () => {
       screen.queryByTestId('ai-setup-loading-indicator')
     );
 
-    expect(screen.getByRole('heading', {name: 'Seer'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Seer Autofix'})).toBeInTheDocument();
 
     // Since "Install the GitHub Integration" text isn't found, let's check for
     // the "Set Up the GitHub Integration" text which is what the component is actually showing

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -148,7 +148,7 @@ export function SeerSection({
     <HeaderContainer>{t('Resources')}</HeaderContainer>
   ) : (
     <HeaderContainer>
-      {t('Seer')}
+      {t('Seer Autofix')}
       <IconSeer />
     </HeaderContainer>
   );

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
@@ -102,7 +102,7 @@ describe('StreamlinedSidebar', () => {
       organization,
     });
 
-    expect(await screen.findByText('Seer')).toBeInTheDocument();
+    expect(await screen.findByText('Seer Autofix')).toBeInTheDocument();
 
     expect(await screen.findByText('First seen')).toBeInTheDocument();
     expect(screen.getByText('Last seen')).toBeInTheDocument();

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -103,7 +103,7 @@ export function SeerAutomationSettings() {
                   },
                   {
                     name: 'autoOpenPrs',
-                    label: t('Allow Root Cause Analysis to create PRs by Default'),
+                    label: t('Allow Autofix to create PRs by Default'),
                     help: (
                       <Stack gap="sm">
                         {t(


### PR DESCRIPTION
- Update sidebar section header from 'Seer' to 'Seer Autofix'
- Update drawer headers to 'Seer Autofix' (both v3 and explorer versions)
- Update settings label from 'Allow Root Cause Analysis to create PRs by Default' to 'Allow Autofix to create PRs by Default'