### PR TITLE
feat(eventstore): Implement `get_event_by_id` as EAP query

### DIFF
--- a/src/sentry/services/eventstore/snuba/backend.py
+++ b/src/sentry/services/eventstore/snuba/backend.py
@@ -524,7 +524,7 @@ class SnubaEventStorage(EventStorage):
                 eap_group_id = eap_result.get("group_id") if eap_result else None
                 control_group_id = result["data"][0]["group_id"]
 
-                EAPOccurrencesComparator.check_and_choose(
+                chosen_group_id = EAPOccurrencesComparator.check_and_choose(
                     control_data=control_group_id,
                     experimental_data=eap_group_id,
                     callsite=callsite,
@@ -538,6 +538,7 @@ class SnubaEventStorage(EventStorage):
                         "dataset": dataset.value,
                     },
                 )
+                event.group_id = chosen_group_id
 
         # Set passed group_id if not a transaction
         if event.get_event_type() == "transaction" and not skip_transaction_groupevent and group_id:

--- a/src/sentry/services/eventstore/snuba/backend.py
+++ b/src/sentry/services/eventstore/snuba/backend.py
@@ -25,10 +25,17 @@ from snuba_sdk import (
 )
 
 from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
+from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.types import SnubaParams
 from sentry.services.eventstore.base import EventStorage, Filter
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
+from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
+from sentry.snuba.referrer import Referrer
 from sentry.utils import snuba
 from sentry.utils.snuba import DATASETS, _prepare_start_end, bulk_snuba_queries, raw_snql_query
 from sentry.utils.validators import normalize_event_id
@@ -468,7 +475,7 @@ class SnubaEventStorage(EventStorage):
                     end=event.datetime + timedelta(seconds=1),
                     filter_keys=filter_keys,
                     limit=1,
-                    referrer="eventstore.backend.get_event_by_id_nodestore",
+                    referrer=Referrer.EVENTSTORE_GET_EVENT_BY_ID_NODESTORE.value,
                     tenant_ids=tenant_ids,
                     **raw_query_kwargs,
                 )
@@ -498,12 +505,105 @@ class SnubaEventStorage(EventStorage):
             # Inject the snuba data here to make sure any snuba columns are available
             event._snuba_data = result["data"][0]
 
+            callsite = "eventstore.backend.get_event_by_id"
+            if EAPOccurrencesComparator.should_check_experiment(callsite):
+                eap_occurrence_category = (
+                    OccurrenceCategory.ISSUE_PLATFORM
+                    if event.get_event_type() in ("transaction", "generic")
+                    else OccurrenceCategory.ERROR
+                )
+                eap_result = self._get_event_by_id_eap(
+                    project_id=project_id,
+                    event_id=event_id,
+                    event_datetime=event.datetime,
+                    organization_id=tenant_ids["organization_id"],
+                    occurrence_category=eap_occurrence_category,
+                    group_id=group_id,
+                )
+
+                eap_group_id = eap_result.get("group_id") if eap_result else None
+                control_group_id = result["data"][0]["group_id"]
+
+                EAPOccurrencesComparator.check_and_choose(
+                    control_data=control_group_id,
+                    experimental_data=eap_group_id,
+                    callsite=callsite,
+                    is_experimental_data_a_null_result=eap_result is None,
+                    reasonable_match_comparator=lambda snuba, eap: snuba == eap,
+                    debug_context={
+                        "project_id": project_id,
+                        "event_id": event_id,
+                        "group_id": group_id,
+                        "event_type": event.get_event_type(),
+                        "dataset": dataset.value,
+                    },
+                )
+
         # Set passed group_id if not a transaction
         if event.get_event_type() == "transaction" and not skip_transaction_groupevent and group_id:
             logger.warning("eventstore.passed-group-id-for-transaction")
             return event.for_group(Group.objects.get(id=group_id))
 
         return event
+
+    def _get_event_by_id_eap(
+        self,
+        project_id: int,
+        event_id: str,
+        event_datetime: datetime,
+        organization_id: int,
+        occurrence_category: OccurrenceCategory,
+        group_id: int | None = None,
+    ) -> dict[str, Any] | None:
+        try:
+            organization = Organization.objects.get_from_cache(id=organization_id)
+            project = Project.objects.get_from_cache(id=project_id)
+        except (Organization.DoesNotExist, Project.DoesNotExist):
+            return None
+
+        snuba_params = SnubaParams(
+            start=event_datetime,
+            end=event_datetime + timedelta(seconds=1),
+            organization=organization,
+            projects=[project],
+            environments=[],
+        )
+
+        query_string = f"id:{event_id}"
+        if group_id is not None:
+            query_string += f" group_id:{group_id}"
+
+        try:
+            result = Occurrences.run_table_query(
+                params=snuba_params,
+                query_string=query_string,
+                selected_columns=[
+                    "id",
+                    "group_id",
+                    "project_id",
+                    "timestamp",
+                    "issue_occurrence_id",
+                ],
+                orderby=None,
+                offset=0,
+                limit=1,
+                referrer=Referrer.EVENTSTORE_GET_EVENT_BY_ID_NODESTORE.value,
+                config=SearchResolverConfig(),
+                occurrence_category=occurrence_category,
+            )
+            if result["data"]:
+                return result["data"][0]
+            return None
+        except Exception:
+            logger.exception(
+                "EAP query failed for get_event_by_id",
+                extra={
+                    "project_id": project_id,
+                    "event_id": event_id,
+                    "group_id": group_id,
+                },
+            )
+            return None
 
     def _get_dataset_for_event(self, event: Event | GroupEvent) -> Dataset:
         if getattr(event, "occurrence", None) or event.get_event_type() == "generic":

--- a/tests/sentry/services/eventstore/snuba/test_backend.py
+++ b/tests/sentry/services/eventstore/snuba/test_backend.py
@@ -1,5 +1,7 @@
+from datetime import timedelta
 from unittest import mock
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 from snuba_sdk import Column, Condition, Op
 
@@ -8,7 +10,13 @@ from sentry.services.eventstore.base import Filter
 from sentry.services.eventstore.models import Event
 from sentry.services.eventstore.snuba.backend import SnubaEventStorage
 from sentry.snuba.dataset import Dataset
-from sentry.testutils.cases import PerformanceIssueTestCase, SnubaTestCase, TestCase
+from sentry.snuba.occurrences_rpc import OccurrenceCategory
+from sentry.testutils.cases import (
+    OccurrenceTestCase,
+    PerformanceIssueTestCase,
+    SnubaTestCase,
+    TestCase,
+)
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils import snuba
 from sentry.utils.samples import load_data
@@ -707,3 +715,179 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
 
         assert prev_ids is None
         assert next_ids == (str(event_c.project_id), event_c.event_id)
+
+
+class EAPEventStorageTest(TestCase, SnubaTestCase, OccurrenceTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.eventstore = SnubaEventStorage()
+        self.now = before_now(minutes=1)
+
+    def test_get_event_by_id_eap_returns_correct_group_id(self) -> None:
+        group = self.create_group(project=self.project)
+        event_id = uuid4().hex
+
+        trace_item = self.create_eap_occurrence(
+            group_id=group.id,
+            event_id=event_id,
+            timestamp=self.now,
+        )
+        self.store_eap_items([trace_item])
+
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=event_id,
+            event_datetime=self.now,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ERROR,
+        )
+
+        assert result is not None
+        assert result["group_id"] == group.id
+        assert result["project_id"] == self.project.id
+        assert result["id"] == event_id
+
+    def test_get_event_by_id_eap_returns_none_for_nonexistent_event(self) -> None:
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=uuid4().hex,
+            event_datetime=self.now,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ERROR,
+        )
+        assert result is None
+
+    def test_get_event_by_id_eap_filters_by_group_id(self) -> None:
+        group1 = self.create_group(project=self.project)
+        group2 = self.create_group(project=self.project)
+        event_id = uuid4().hex
+
+        trace_item = self.create_eap_occurrence(
+            group_id=group1.id,
+            event_id=event_id,
+            timestamp=self.now,
+        )
+        self.store_eap_items([trace_item])
+
+        # Querying with the correct group_id returns the event
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=event_id,
+            event_datetime=self.now,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ERROR,
+            group_id=group1.id,
+        )
+        assert result is not None
+        assert result["group_id"] == group1.id
+
+        # Querying with the wrong group_id returns nothing
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=event_id,
+            event_datetime=self.now,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ERROR,
+            group_id=group2.id,
+        )
+        assert result is None
+
+    def test_get_event_by_id_eap_occurrence_category_filtering(self) -> None:
+        group = self.create_group(project=self.project)
+        error_event_id = uuid4().hex
+        ip_event_id = uuid4().hex
+        occurrence_id = uuid4().hex
+
+        error_item = self.create_eap_occurrence(
+            group_id=group.id,
+            event_id=error_event_id,
+            timestamp=self.now,
+        )
+        ip_item = self.create_eap_occurrence(
+            group_id=group.id,
+            event_id=ip_event_id,
+            timestamp=self.now,
+            issue_occurrence_id=occurrence_id,
+        )
+        self.store_eap_items([error_item, ip_item])
+
+        # ERROR category returns only the error item
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=error_event_id,
+            event_datetime=self.now,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ERROR,
+        )
+        assert result is not None
+        assert result["id"] == error_event_id
+        assert result["group_id"] == group.id
+        assert result["project_id"] == self.project.id
+        assert result["timestamp"] is not None
+
+        # ERROR category does not return the issue platform item
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=ip_event_id,
+            event_datetime=self.now,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ERROR,
+        )
+        assert result is None
+
+        # ISSUE_PLATFORM category returns only the issue platform item
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=ip_event_id,
+            event_datetime=self.now,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ISSUE_PLATFORM,
+        )
+        assert result is not None
+        assert result["id"] == ip_event_id
+        assert result["group_id"] == group.id
+        assert result["project_id"] == self.project.id
+        assert result["timestamp"] is not None
+        assert result["issue_occurrence_id"] == occurrence_id
+
+        # ISSUE_PLATFORM category does not return the error item
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=error_event_id,
+            event_datetime=self.now,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ISSUE_PLATFORM,
+        )
+        assert result is None
+
+    def test_get_event_by_id_eap_respects_time_window(self) -> None:
+        group = self.create_group(project=self.project)
+        event_id = uuid4().hex
+
+        trace_item = self.create_eap_occurrence(
+            group_id=group.id,
+            event_id=event_id,
+            timestamp=self.now,
+        )
+        self.store_eap_items([trace_item])
+
+        # Querying with a time window that includes the event returns it
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=event_id,
+            event_datetime=self.now,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ERROR,
+        )
+        assert result is not None
+
+        # Querying with a time window that excludes the event returns None
+        wrong_time = self.now - timedelta(hours=2)
+        result = self.eventstore._get_event_by_id_eap(
+            project_id=self.project.id,
+            event_id=event_id,
+            event_datetime=wrong_time,
+            organization_id=self.organization.id,
+            occurrence_category=OccurrenceCategory.ERROR,
+        )
+        assert result is None


### PR DESCRIPTION
Implements double reads of occurrences from EAP for `get_event_by_id` in `src/sentry/services/eventstore/snuba/backend.py`.