### PR TITLE
feat(text): Add render prop pattern to Text component

### DIFF
--- a/static/app/components/core/text/heading.spec.tsx
+++ b/static/app/components/core/text/heading.spec.tsx
@@ -1,8 +1,9 @@
 import {createRef} from 'react';
+import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Heading} from './';
+import {Heading, type HeadingProps, type HeadingPropsWithRenderFunction} from './';
 
 describe('Heading', () => {
   it('renders with correct HTML element', () => {
@@ -47,5 +48,60 @@ describe('Heading', () => {
       </Heading>
     );
     expect(ref.current?.tagName).toBe('H6');
+  });
+
+  it('implements render prop', () => {
+    render(
+      <section>
+        <Heading variant="muted">{props => <h2 {...props}>Title</h2>}</Heading>
+      </section>
+    );
+
+    expect(screen.getByText('Title')?.tagName).toBe('H2');
+    expect(screen.getByText('Title').parentElement?.tagName).toBe('SECTION');
+
+    expect(screen.getByText('Title')).not.toHaveAttribute('variant', 'muted');
+  });
+
+  it('render prop guards against invalid attributes', () => {
+    render(
+      // @ts-expect-error - aria-activedescendant should be set on the child element
+      <Heading variant="muted" aria-activedescendant="what">
+        {/* @ts-expect-error - this should be a React.ElementType */}
+        {props => <h2 {...props}>Title</h2>}
+      </Heading>
+    );
+
+    expect(screen.getByText('Title')).not.toHaveAttribute('aria-activedescendant');
+  });
+
+  it('render prop type is correctly inferred', () => {
+    // Incompatible className type - should be string
+    function Child({className}: {className: 'invalid'}) {
+      return <h2 className={className}>Title</h2>;
+    }
+
+    render(
+      <Heading variant="muted">
+        {/* @ts-expect-error - className is incompatible */}
+        {props => <Child {...props} />}
+      </Heading>
+    );
+  });
+
+  describe('types', () => {
+    it('default signature requires as and limits children to React.ReactNode', () => {
+      const props: HeadingProps = {as: 'h1', children: 'Title'};
+      expectTypeOf(props.children).toEqualTypeOf<React.ReactNode>();
+    });
+
+    it('render prop signature limits children to (props: {className: string}) => React.ReactNode | undefined', () => {
+      const props: HeadingPropsWithRenderFunction = {
+        children: () => undefined,
+      };
+      expectTypeOf(props.children).toEqualTypeOf<
+        (props: {className: string}) => React.ReactNode | undefined
+      >();
+    });
   });
 });

--- a/static/app/components/core/text/heading.tsx
+++ b/static/app/components/core/text/heading.tsx
@@ -34,9 +34,40 @@ export type HeadingProps = BaseHeadingProps & {
   > &
   ExclusiveTextEllipsisProps;
 
+export type HeadingPropsWithRenderFunction = BaseHeadingProps &
+  ExclusiveTextEllipsisProps & {
+    children: (props: {className: string}) => React.ReactNode | undefined;
+    as?: never;
+    ref?: never;
+    size?: Responsive<HeadingSize>;
+    /**
+     * Deprecated in favor of the Heading component API.
+     * If you have an is an unsupported use-case, please contact design engineering for support.
+     * @deprecated
+     */
+    style?: React.CSSProperties;
+  } & Partial<
+    Record<
+      // HTMLAttributes extends from DOMAttributes which types children as React.ReactNode | undefined.
+      // Therefore, we need to exclude it from the map, or the children will produce a never type.
+      Exclude<
+        keyof React.DetailedHTMLProps<
+          React.HTMLAttributes<HTMLHeadingElement>,
+          HTMLHeadingElement
+        >,
+        'children'
+      >,
+      never
+    >
+  >;
+
 export const Heading = styled(
-  (props: HeadingProps) => {
-    const {children, as, ...rest} = props;
+  (props: HeadingProps | HeadingPropsWithRenderFunction) => {
+    if (typeof props.children === 'function') {
+      // When using render prop, only pass className to the child function
+      return props.children({className: (props as any).className});
+    }
+    const {children, as, ...rest} = props as HeadingProps;
     const HeadingComponent = as;
 
     return <HeadingComponent {...rest}>{children}</HeadingComponent>;
@@ -46,9 +77,14 @@ export const Heading = styled(
   }
 )`
   ${p =>
-    rc('font-size', p.size ?? getDefaultHeadingFontSize(p.as), p.theme, v => {
-      return getFontSize(v, p.theme);
-    })};
+    rc(
+      'font-size',
+      p.size ?? (p.as ? getDefaultHeadingFontSize(p.as) : undefined),
+      p.theme,
+      v => {
+        return getFontSize(v, p.theme);
+      }
+    )};
   ${p => rc('line-height', p.density, p.theme, v => getLineHeight(v, p.theme))};
   ${p => rc('text-align', p.align, p.theme)};
 

--- a/static/app/components/core/text/heading.tsx
+++ b/static/app/components/core/text/heading.tsx
@@ -40,12 +40,6 @@ export type HeadingPropsWithRenderFunction = BaseHeadingProps &
     as?: never;
     ref?: never;
     size?: Responsive<HeadingSize>;
-    /**
-     * Deprecated in favor of the Heading component API.
-     * If you have an is an unsupported use-case, please contact design engineering for support.
-     * @deprecated
-     */
-    style?: React.CSSProperties;
   } & Partial<
     Record<
       // HTMLAttributes extends from DOMAttributes which types children as React.ReactNode | undefined.

--- a/static/app/components/core/text/index.tsx
+++ b/static/app/components/core/text/index.tsx
@@ -1,4 +1,5 @@
-export type {TextProps} from './text';
+export type {TextProps, TextPropsWithRenderFunction} from './text';
 export {Text} from './text';
 export {Heading} from './heading';
+export type {HeadingProps, HeadingPropsWithRenderFunction} from './heading';
 export {Prose} from './prose';

--- a/static/app/components/core/text/styles.tsx
+++ b/static/app/components/core/text/styles.tsx
@@ -2,10 +2,16 @@ import type {Theme} from '@emotion/react';
 
 import type {HeadingSize, TextSize} from 'sentry/utils/theme';
 
-import type {HeadingProps} from './heading';
-import type {TextProps} from './text';
+import type {HeadingProps, HeadingPropsWithRenderFunction} from './heading';
+import type {TextProps, TextPropsWithRenderFunction} from './text';
 
-export function getTextDecoration(p: TextProps<any> | HeadingProps) {
+export function getTextDecoration(
+  p:
+    | TextProps<any>
+    | HeadingProps
+    | TextPropsWithRenderFunction
+    | HeadingPropsWithRenderFunction
+) {
   const decorations: string[] = [];
   if (p.strikethrough) {
     decorations.push('line-through');

--- a/static/app/components/core/text/text.spec.tsx
+++ b/static/app/components/core/text/text.spec.tsx
@@ -3,7 +3,11 @@ import {expectTypeOf} from 'expect-type';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Text, type TextProps} from '@sentry/scraps/text';
+import {
+  Text,
+  type TextProps,
+  type TextPropsWithRenderFunction,
+} from '@sentry/scraps/text';
 
 describe('Text', () => {
   it('Defaults to span', () => {
@@ -62,5 +66,60 @@ describe('Text', () => {
   it('does not allow color prop', () => {
     // @ts-expect-error: color is not a valid prop for Text
     render(<Text color="red">Hello World</Text>);
+  });
+
+  it('implements render prop', () => {
+    render(
+      <section>
+        <Text variant="muted">{props => <p {...props}>Hello</p>}</Text>
+      </section>
+    );
+
+    expect(screen.getByText('Hello')?.tagName).toBe('P');
+    expect(screen.getByText('Hello').parentElement?.tagName).toBe('SECTION');
+
+    expect(screen.getByText('Hello')).not.toHaveAttribute('variant', 'muted');
+  });
+
+  it('render prop guards against invalid attributes', () => {
+    render(
+      // @ts-expect-error - aria-activedescendant should be set on the child element
+      <Text variant="muted" aria-activedescendant="what">
+        {/* @ts-expect-error - this should be a React.ElementType */}
+        {props => <p {...props}>Hello</p>}
+      </Text>
+    );
+
+    expect(screen.getByText('Hello')).not.toHaveAttribute('aria-activedescendant');
+  });
+
+  it('render prop type is correctly inferred', () => {
+    // Incompatible className type - should be string
+    function Child({className}: {className: 'invalid'}) {
+      return <p className={className}>Hello</p>;
+    }
+
+    render(
+      <Text variant="muted">
+        {/* @ts-expect-error - className is incompatible */}
+        {props => <Child {...props} />}
+      </Text>
+    );
+  });
+
+  describe('types', () => {
+    it('default signature limits children to React.ReactNode', () => {
+      const props: TextProps<'span'> = {children: 'hello'};
+      expectTypeOf(props.children).toEqualTypeOf<React.ReactNode>();
+    });
+
+    it('render prop signature limits children to (props: {className: string}) => React.ReactNode | undefined', () => {
+      const props: TextPropsWithRenderFunction<'span'> = {
+        children: () => undefined,
+      };
+      expectTypeOf(props.children).toEqualTypeOf<
+        (props: {className: string}) => React.ReactNode | undefined
+      >();
+    });
   });
 });

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -155,9 +155,46 @@ type TextPrimitive = 'span' | 'p' | 'label' | 'div' | 'time' | 'legend';
 export type TextProps<T extends TextPrimitive> = TextAttributes<T> &
   ExclusiveTextEllipsisProps;
 
+export type TextPropsWithRenderFunction<T extends TextPrimitive = 'span'> =
+  BaseTextProps &
+    ExclusiveTextEllipsisProps & {
+      children: (props: {className: string}) => React.ReactNode | undefined;
+      as?: never;
+      color?: never;
+      dateTime?: never;
+      htmlFor?: never;
+      ref?: never;
+      size?: Responsive<TextSize>;
+      /**
+       * Deprecated in favor of the Text component API.
+       * If you have an is an unsupported use-case, please contact design engineering for support.
+       * @deprecated
+       */
+      style?: React.CSSProperties;
+    } & Partial<
+      Record<
+        // HTMLAttributes extends from DOMAttributes which types children as React.ReactNode | undefined.
+        // Therefore, we need to exclude it from the map, or the children will produce a never type.
+        Exclude<
+          keyof React.DetailedHTMLProps<
+            React.HTMLAttributes<HTMLElementTagNameMap[T]>,
+            HTMLElementTagNameMap[T]
+          >,
+          'children'
+        >,
+        never
+      >
+    >;
+
 export const Text = styled(
-  <T extends TextPrimitive = 'span'>(props: TextProps<T>) => {
-    const {children, ...rest} = props;
+  <T extends TextPrimitive = 'span'>(
+    props: TextProps<T> | TextPropsWithRenderFunction<T>
+  ) => {
+    if (typeof props.children === 'function') {
+      // When using render prop, only pass className to the child function
+      return props.children({className: (props as any).className});
+    }
+    const {children, ...rest} = props as TextProps<T>;
     const Component = props.as || 'span';
     return <Component {...(rest as any)}>{children}</Component>;
   },
@@ -225,5 +262,5 @@ export const Text = styled(
    * https://github.com/styled-components/styled-components/issues/1803
    */
 ` as unknown as <T extends TextPrimitive = 'span'>(
-  props: TextProps<T>
+  props: TextProps<T> | TextPropsWithRenderFunction<T>
 ) => React.ReactElement;

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -165,12 +165,6 @@ export type TextPropsWithRenderFunction<T extends TextPrimitive = 'span'> =
       htmlFor?: never;
       ref?: never;
       size?: Responsive<TextSize>;
-      /**
-       * Deprecated in favor of the Text component API.
-       * If you have an is an unsupported use-case, please contact design engineering for support.
-       * @deprecated
-       */
-      style?: React.CSSProperties;
     } & Partial<
       Record<
         // HTMLAttributes extends from DOMAttributes which types children as React.ReactNode | undefined.

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -1,4 +1,4 @@
-import type {ComponentProps, ReactElement, ReactNode} from 'react';
+import type {ReactElement, ReactNode} from 'react';
 import {Fragment, isValidElement} from 'react';
 import styled from '@emotion/styled';
 
@@ -8,10 +8,11 @@ import {Heading} from '@sentry/scraps/text';
 
 import {IconLink} from 'sentry/icons';
 import {useStory} from 'sentry/stories/view/useStory';
+import type {HeadingProps} from 'sentry/components/core/text/heading';
 import {slugify} from 'sentry/utils/slugify';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 
-export function StoryHeading(props: ComponentProps<typeof Heading>) {
+export function StoryHeading(props: HeadingProps) {
   const {story} = useStory();
 
   const storyTitle = (story.exports.frontmatter as any)?.title;

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -5,10 +5,10 @@ import styled from '@emotion/styled';
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
+import type {HeadingProps} from '@sentry/scraps/text';
 
 import {IconLink} from 'sentry/icons';
 import {useStory} from 'sentry/stories/view/useStory';
-import type {HeadingProps} from 'sentry/components/core/text/heading';
 import {slugify} from 'sentry/utils/slugify';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 


### PR DESCRIPTION
Extend Text and Heading components with render prop support, matching the APIs of Layout primitives