### PR TITLE
Require org:write for OrganizationDataForwardingDetailsPermission

### DIFF
--- a/src/sentry/integrations/api/endpoints/data_forwarding_index.py
+++ b/src/sentry/integrations/api/endpoints/data_forwarding_index.py
@@ -26,7 +26,7 @@ from sentry.web.decorators import set_referrer_policy
 
 class OrganizationDataForwardingDetailsPermission(OrganizationPermission):
     scope_map = {
-        "GET": ["org:read"],
+        "GET": ["org:write"],
         "POST": ["org:write"],
     }
 

--- a/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
+++ b/tests/sentry/integrations/api/endpoints/test_data_forwarding.py
@@ -114,11 +114,46 @@ class DataForwardingIndexGetTest(DataForwardingIndexEndpointTest):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(my_forwarder.id)
 
-    def test_get_requires_read_permission(self) -> None:
+    def test_get_requires_org_write_permission(self) -> None:
         user_without_permission = self.create_user()
         self.login_as(user=user_without_permission)
 
         self.get_error_response(self.organization.slug, status_code=403)
+
+    def test_get_denied_for_member_role(self) -> None:
+        self.create_data_forwarder(
+            provider=DataForwarderProviderSlug.SEGMENT,
+            config={"write_key": "test_key"},
+        )
+
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],
+        )
+        self.login_as(user=member_user)
+
+        self.get_error_response(self.organization.slug, status_code=403)
+
+    def test_get_allowed_for_manager_role(self) -> None:
+        data_forwarder = self.create_data_forwarder(
+            provider=DataForwarderProviderSlug.SEGMENT,
+            config={"write_key": "test_key"},
+        )
+
+        manager_user = self.create_user()
+        self.create_member(
+            user=manager_user,
+            organization=self.organization,
+            role="manager",
+        )
+        self.login_as(user=manager_user)
+
+        response = self.get_success_response(self.organization.slug)
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(data_forwarder.id)
 
     def test_get_with_disabled_data_forwarder(self) -> None:
         data_forwarder = self.create_data_forwarder(


### PR DESCRIPTION
We currently allow org:read for OrganizationDataForwardingDetailsPermissin meaning any org member can read Data Forwarding settings which can include sensitive values. Going to gate this behind org:write for only managers and above. It's the same as we do for OrganizationAuditPermission. Team admins are still able to use the PUT, so no trouble there. 

I considered changing what we expose here, like letting members still see the forwarding but redacting the `config` in the serializer when you don't have a wide enough scope, but that's not particularly useful as a user workflow. Team admins can do what they need and manager+ can see the real config to troubleshoot.