### PR TITLE
fix(gitlab): Use dialog-complete flow for OAuth popup installation

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -620,11 +620,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
                 "scopes": scopes,
                 "data": oauth_data,
             },
-            "post_install_data": {
-                "redirect_url_format": absolute_uri(
-                    f"/settings/{{org_slug}}/integrations/{self.key}/"
-                ),
-            },
+            "post_install_data": {},
         }
 
     def setup(self):

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -116,11 +116,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         assert req_params["client_id"] == ["client_id"]
         assert req_params["client_secret"] == ["client_secret"]
 
-        assert resp.status_code == 302
-        assert (
-            resp["Location"]
-            == f"http://testserver/settings/{self.organization.slug}/integrations/gitlab/"
-        )
+        assert resp.status_code == 200
 
     @responses.activate
     @patch("sentry.integrations.gitlab.integration.sha1_text")
@@ -585,12 +581,7 @@ class GitlabIntegrationInstanceTest(IntegrationTestCase):
         assert req_params["client_id"] == ["client_id"]
         assert req_params["client_secret"] == ["client_secret"]
 
-        assert resp.status_code == 302
-
-        assert (
-            resp["Location"]
-            == f"http://testserver/settings/{self.organization.slug}/integrations/gitlab/"
-        )
+        assert resp.status_code == 200
 
     @responses.activate
     @patch("sentry.integrations.gitlab.integration.sha1_text")


### PR DESCRIPTION
## Summary

GitLab's `build_integration` returned a `redirect_url_format` in `post_install_data`, causing the OAuth popup window to navigate to `/settings/{org}/integrations/gitlab/` instead of closing and signaling success to the opener.

The integration pipeline checks for `redirect_url_format` and calls `_get_redirect_response()` when present, bypassing `_dialog_success()` which renders `dialog-complete.html`. That template is what calls `window.opener.postMessage()` and `window.close()` -- the mechanism the `AddIntegration` frontend component relies on to detect a successful installation.

GitHub does not set `redirect_url_format`, which is why it works correctly in popup contexts. This change aligns GitLab with GitHub's behavior.

## Test plan
- [ ] Install GitLab integration via the popup dialog (Settings > Integrations > GitLab) -- popup should close and the parent page should update
- [ ] Install GitLab integration via the SCM connect onboarding step -- popup should close and the connected view should appear