### PR TITLE
refactor(billing): graduate expose-category-size-analysis flag

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -502,22 +502,7 @@ describe('OrganizationStats', () => {
     expect(screen.queryByRole('option', {name: 'Issue Scans'})).not.toBeInTheDocument();
   });
 
-  it('shows size analysis when expose category feature flag is enabled', async () => {
-    const newOrg = OrganizationFixture({
-      features: ['expose-category-size-analysis'],
-    });
-
-    render(<OrganizationStats />, {
-      organization: newOrg,
-    });
-
-    await userEvent.click(await screen.findByText('Category'));
-    expect(
-      screen.getByRole('option', {name: 'Size Analysis Builds'})
-    ).toBeInTheDocument();
-  });
-
-  it('does not show size analysis when expose category feature flag is disabled', async () => {
+  it('always shows size analysis (GA)', async () => {
     const newOrg = OrganizationFixture({
       features: [],
     });
@@ -528,8 +513,8 @@ describe('OrganizationStats', () => {
 
     await userEvent.click(await screen.findByText('Category'));
     expect(
-      screen.queryByRole('option', {name: 'Size Analysis Builds'})
-    ).not.toBeInTheDocument();
+      screen.getByRole('option', {name: 'Size Analysis Builds'})
+    ).toBeInTheDocument();
   });
 
   it('shows installable build when expose category feature flag is enabled', async () => {

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -287,9 +287,6 @@ export class OrganizationStatsInner extends Component<OrganizationStatsProps> {
       if (opt.value === DataCategory.PROFILES) {
         return !hasProfilingStats;
       }
-      if (opt.value === DataCategory.SIZE_ANALYSIS) {
-        return organization.features.includes('expose-category-size-analysis');
-      }
       if (opt.value === DataCategory.INSTALLABLE_BUILD) {
         return organization.features.includes('expose-category-installable-build');
       }

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -437,6 +437,7 @@ describe('NotificationSettingsByType', () => {
     expect(screen.queryByText('UI Profile Hours', {exact: true})).not.toBeInTheDocument();
     expect(screen.queryByText('Spans')).not.toBeInTheDocument();
     expect(screen.getByText('Seer Budget')).toBeInTheDocument();
+    expect(screen.getByText('Size Analysis Builds')).toBeInTheDocument();
   });
 
   it('spend notifications on org with am3 without spend visibility notifications', async () => {

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -229,6 +229,11 @@ export function NotificationSettingsByType({notificationType}: Props) {
       organization.features?.includes('am2-tier')
     );
 
+    // at least one org exists with am1 tier plan
+    const hasOrgWithAm1 = organizations.some(organization =>
+      organization.features?.includes('am1-tier')
+    );
+
     // Check if any organization has the continuous-profiling-billing feature flag
     const hasOrgWithContinuousProfilingBilling = organizations.some(organization =>
       organization.features?.includes('continuous-profiling-billing')
@@ -252,7 +257,7 @@ export function NotificationSettingsByType({notificationType}: Props) {
       (hasOrgWithAm2 || hasOrgWithAm3) && hasOrgWithContinuousProfilingBilling;
     const includeSeer = hasSeerBilling;
     const includeLogs = hasLogsBilling;
-    const includeSizeAnalysis = hasOrgWithAm3 || hasOrgWithAm2;
+    const includeSizeAnalysis = hasOrgWithAm3 || hasOrgWithAm2 || hasOrgWithAm1;
 
     return fields.filter(field => {
       if (field.name === 'quotaSpans' && !includeSpans) {

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -246,17 +246,13 @@ export function NotificationSettingsByType({notificationType}: Props) {
       organization.features?.includes('seer-user-billing-launch')
     );
 
-    const hasSizeAnalysisBilling = organizations.some(organization =>
-      organization.features?.includes('expose-category-size-analysis')
-    );
-
     const excludeTransactions = hasOrgWithAm3 && !hasOrgWithoutAm3;
     const includeSpans = hasOrgWithAm3;
     const includeProfileDuration =
       (hasOrgWithAm2 || hasOrgWithAm3) && hasOrgWithContinuousProfilingBilling;
     const includeSeer = hasSeerBilling;
     const includeLogs = hasLogsBilling;
-    const includeSizeAnalysis = hasSizeAnalysisBilling;
+    const includeSizeAnalysis = hasOrgWithAm3 || hasOrgWithAm2;
 
     return fields.filter(field => {
       if (field.name === 'quotaSpans' && !includeSpans) {

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -16,11 +16,10 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
-import {DataCategory, DataCategoryExact} from 'sentry/types/core';
+import {DataCategory} from 'sentry/types/core';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 import {CustomerOverview} from 'admin/components/customers/customerOverview';
-import * as constants from 'getsentry/constants';
 import {AddOnCategory, PlanTier} from 'getsentry/types';
 
 describe('CustomerOverview', () => {
@@ -396,9 +395,10 @@ describe('CustomerOverview', () => {
     expect(screen.queryByText('Transactions:')).not.toBeInTheDocument();
   });
 
-  it('renders admin-only product trials when feature flag is enabled', () => {
+  it('renders SIZE_ANALYSIS admin-only product trials (GA, no feature flag required)', () => {
+    // SIZE_ANALYSIS is now GA: adminOnlyProductTrialFeature is true, no feature flag check needed
     const organization = OrganizationFixture({
-      features: ['expose-category-size-analysis'],
+      features: [], // No feature flags needed
     });
     const subscription = SubscriptionFixture({
       organization,
@@ -415,84 +415,11 @@ describe('CustomerOverview', () => {
     );
 
     expect(screen.getByText('Product Trials')).toBeInTheDocument();
-    // SIZE_ANALYSIS should appear because org has the feature flag
+    // SIZE_ANALYSIS always appears (graduated)
     expect(screen.getByText('Size Analysis Builds:')).toBeInTheDocument();
-  });
-
-  it('does not render admin-only product trials when feature flag is disabled', () => {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_f',
-      planTier: PlanTier.AM3,
-    });
-
-    render(
-      <CustomerOverview
-        customer={subscription}
-        onAction={jest.fn()}
-        organization={organization}
-      />
-    );
-
-    expect(screen.getByText('Product Trials')).toBeInTheDocument();
-    // SIZE_ANALYSIS should NOT appear because org lacks the feature flag
-    expect(screen.queryByText('Size Analysis Builds:')).not.toBeInTheDocument();
     // Regular product trials should still appear
     expect(screen.getByText('Spans:')).toBeInTheDocument();
     expect(screen.getByText('Replays:')).toBeInTheDocument();
-  });
-
-  it('renders admin-only product trials when feature flag is graduated (true)', () => {
-    // Mock BILLED_DATA_CATEGORY_INFO to simulate a graduated flag (adminOnlyProductTrialFeature: true)
-    const originalBilledDataCategoryInfo = constants.BILLED_DATA_CATEGORY_INFO;
-
-    try {
-      const mockedBilledDataCategoryInfo = {
-        ...originalBilledDataCategoryInfo,
-        [DataCategoryExact.SIZE_ANALYSIS]: {
-          ...originalBilledDataCategoryInfo[DataCategoryExact.SIZE_ANALYSIS],
-          adminOnlyProductTrialFeature: true, // Graduated - no feature flag check needed
-        },
-      };
-
-      // Override the module export for this test
-      Object.defineProperty(constants, 'BILLED_DATA_CATEGORY_INFO', {
-        value: mockedBilledDataCategoryInfo,
-        configurable: true,
-      });
-
-      // Organization has NO feature flags - but graduated flag should still show
-      const organization = OrganizationFixture({
-        features: [], // No feature flags!
-      });
-      const subscription = SubscriptionFixture({
-        organization,
-        plan: 'am3_f',
-        planTier: PlanTier.AM3,
-      });
-
-      render(
-        <CustomerOverview
-          customer={subscription}
-          onAction={jest.fn()}
-          organization={organization}
-        />
-      );
-
-      expect(screen.getByText('Product Trials')).toBeInTheDocument();
-      // SIZE_ANALYSIS should appear because the flag is graduated (true), not requiring feature flag
-      expect(screen.getByText('Size Analysis Builds:')).toBeInTheDocument();
-      // Regular product trials should still appear
-      expect(screen.getByText('Spans:')).toBeInTheDocument();
-      expect(screen.getByText('Replays:')).toBeInTheDocument();
-    } finally {
-      // Restore the original - always runs even if assertions fail
-      Object.defineProperty(constants, 'BILLED_DATA_CATEGORY_INFO', {
-        value: originalBilledDataCategoryInfo,
-        configurable: true,
-      });
-    }
   });
 
   it('renders product trials based on current subscription state', () => {
@@ -566,6 +493,7 @@ describe('CustomerOverview', () => {
       DataCategory.PROFILE_DURATION,
       DataCategory.PROFILE_DURATION_UI,
       DataCategory.LOG_BYTE,
+      DataCategory.SIZE_ANALYSIS,
       AddOnCategory.LEGACY_SEER,
     ];
 

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -208,7 +208,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SIZE_ANALYSIS],
     freeEventsMultiple: 1,
     shortenedUnitName: t('build'),
-    adminOnlyProductTrialFeature: 'expose-category-size-analysis',
+    adminOnlyProductTrialFeature: true,
   },
   [DataCategoryExact.INSTALLABLE_BUILD]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.INSTALLABLE_BUILD],


### PR DESCRIPTION
## Summary

SIZE_ANALYSIS (Emerge builds) is now fully launched to all AM customers. This PR removes the `organizations:expose-category-size-analysis` feature flag gate from the frontend.

- **`static/gsApp/constants.tsx`**: Mark `adminOnlyProductTrialFeature` as `true` (graduated) for `SIZE_ANALYSIS` — admin product trials are now always available without a feature flag check
- **`static/app/views/organizationStats/index.tsx`**: Remove feature flag check — SIZE_ANALYSIS category is now always shown in the org stats category dropdown
- **`static/app/views/settings/account/notifications/notificationSettingsByType.tsx`**: Remove feature flag check — SIZE_ANALYSIS notification settings are shown for all AM2/AM3 orgs
- **`static/gsAdmin/components/customers/customerOverview.spec.tsx`**: Consolidate three flag-conditional specs into one that verifies SIZE_ANALYSIS always appears; remove unused `DataCategoryExact` and `constants` imports

## Test plan

- [ ] Pre-commit hooks pass (eslint, prettier — all clean)
- [ ] Deleted specs that verified flag-gated hiding behavior (no longer applicable)
- [ ] Single consolidated spec verifies SIZE_ANALYSIS always appears without a feature flag
- [ ] Companion PRs:
  - `getsentry/getsentry` — remove backend flag check in `should_expose_category()`, deregister flag
  - `getsentry/sentry-options-automator` — remove flagpole segment