### PR TITLE
fix(worklows): More accurate legacy model use tracking

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -105,7 +105,10 @@ from sentry.workflow_engine.models import (
     Workflow,
 )
 from sentry.workflow_engine.types import DetectorPriorityLevel
-from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
+from sentry.workflow_engine.utils.legacy_metric_tracking import (
+    report_used_legacy_models,
+    track_alert_endpoint_execution,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -277,6 +280,7 @@ class AlertRuleFetchMixin(Endpoint):
             response[ALERT_RULES_COUNT_HEADER] = detectors.count()
         else:
             alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
+            report_used_legacy_models()
             if not features.has("organizations:performance-view", organization):
                 alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
             response = self.paginate(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -625,6 +625,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
 
         # Legacy path below
         alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
+        report_used_legacy_models()
 
         issue_rules = Rule.objects.filter(
             status__in=[ObjectStatus.ACTIVE, ObjectStatus.DISABLED],

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -21,7 +21,10 @@ from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import ensure_aware
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
-from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
+from sentry.workflow_engine.utils.legacy_metric_tracking import (
+    report_used_legacy_models,
+    track_alert_endpoint_execution,
+)
 
 from .utils import parse_team_params
 
@@ -49,6 +52,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
         incidents = Incident.objects.fetch_for_organization(
             organization, self.get_projects(request, organization)
         )
+        report_used_legacy_models()
 
         envs = self.get_environments(request, organization)
         if envs:


### PR DESCRIPTION
These rely on serializers, but there are clear legacy model usage paths, and by tagging them directly we avoid counting 0 result calls as not using legacy models.
