### PR TITLE
fix(suspect-commits): Skip commit age filtering for demo/sandbox orgs

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from django.utils.datastructures import OrderedSet
 
-from sentry import analytics
+from sentry import analytics, options
 from sentry.analytics.events.integration_commit_context_all_frames import (
     IntegrationsFailedToFetchCommitContextAllFrames,
     IntegrationsSuccessfullyFetchedCommitContextAllFrames,
@@ -83,23 +83,28 @@ def find_commit_context_for_event_all_frames(
         extra=extra,
     )
 
-    # We want the most recent commit that is within MAX_COMMIT_AGE_DAYS of group_first_seen
-    earliest_valid_date = group_first_seen - timedelta(days=MAX_COMMIT_AGE_DAYS)
-    selected_blame = None
-    selected_date = earliest_valid_date
-    has_too_old_blames = False
-    has_too_recent_blames = False
-    for blame in file_blames:
-        commit_date = blame.commit.committedDate
-        # Track outside-of-window commits for analytics
-        if commit_date < earliest_valid_date:
-            has_too_old_blames = True
-        elif commit_date > group_first_seen:
-            has_too_recent_blames = True
-        # Select best valid commit
-        if selected_date < commit_date < group_first_seen:
-            selected_blame = blame
-            selected_date = commit_date
+    if organization_id in options.get("demo-org-ids") and file_blames:
+        selected_blame = max(file_blames, key=lambda blame: blame.commit.committedDate)
+        has_too_old_blames = False
+        has_too_recent_blames = False
+    else:
+        # We want the most recent commit that is within MAX_COMMIT_AGE_DAYS of group_first_seen
+        earliest_valid_date = group_first_seen - timedelta(days=MAX_COMMIT_AGE_DAYS)
+        selected_blame = None
+        selected_date = earliest_valid_date
+        has_too_old_blames = False
+        has_too_recent_blames = False
+        for blame in file_blames:
+            commit_date = blame.commit.committedDate
+            # Track outside-of-window commits for analytics
+            if commit_date < earliest_valid_date:
+                has_too_old_blames = True
+            elif commit_date > group_first_seen:
+                has_too_recent_blames = True
+            # Select best valid commit
+            if selected_date < commit_date < group_first_seen:
+                selected_blame = blame
+                selected_date = commit_date
 
     selected_install, selected_provider = (
         integration_to_install_mapping[selected_blame.code_mapping.organization_integration_id]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3775,6 +3775,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "demo-org-ids",
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # option for sample size when fetching project tag keys
 register(
     "visibility.tag-key-sample-size",


### PR DESCRIPTION
# Goal

Makes sure that Suspect Commit comes up in demo/sandbox without needing to touch the erroring line every 2 months in every one of ~ 20 and counting individual demo apps by always picking the most recent blame commit regardless of its age.

# Implementation
doesn't seem like we have any existing constants for demo org ids/slugs
`demo-mode` is for very specific sandbox hacks (read-only org + `sandbox` pulls artifacts from `demo` org)

# Testing 
none

# Related
https://github.com/getsentry/sentry-options-automator/pull/6804

---

Continuation of #110493 (reopened from `getsentry` branch instead of fork).