### PR TITLE
chore(np): Changes data and target serialization to use Pydantic models

### DIFF
--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -1,9 +1,7 @@
 import logging
 from collections import defaultdict
 from collections.abc import Mapping
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, Final, get_type_hints
+from typing import Any, Final
 
 import sentry_sdk
 
@@ -15,7 +13,7 @@ from sentry.notifications.platform.metrics import (
 from sentry.notifications.platform.provider import NotificationProvider
 from sentry.notifications.platform.registry import provider_registry, template_registry
 from sentry.notifications.platform.rollout import NotificationRolloutService
-from sentry.notifications.platform.target import NotificationTargetDto
+from sentry.notifications.platform.target import deserialize_target, serialize_target
 from sentry.notifications.platform.types import (
     NotificationData,
     NotificationProviderKey,
@@ -29,6 +27,7 @@ from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import notifications_tasks
+from sentry.utils import json
 from sentry.utils.registry import NoRegistrationExistsError
 
 logger = logging.getLogger(__name__)
@@ -118,11 +117,11 @@ class NotificationService[T: NotificationData]:
         targets = self._get_targets(strategy=strategy, targets=targets)
 
         for target in targets:
-            serialized_target = NotificationTargetDto(target=target)
-            serialized_data = NotificationDataDto(notification_data=self.data).to_dict()
+            serialized_data = serialize_notification_data(self.data)
+            serialized_target = serialize_target(target)
             notify_target_async.delay(
                 data=serialized_data,
-                nested_target=serialized_target.to_dict(),
+                nested_target=serialized_target,
             )
 
     def notify_sync(
@@ -191,15 +190,13 @@ def notify_target_async(
             using this method directly to prevent unwanted noise associated with your notifications.
     """
     try:
-        notification_data_dto = NotificationDataDto.from_dict(data)
+        notification_data = deserialize_notification_data(data)
     except (NotificationServiceError, NoRegistrationExistsError) as e:
         logger.warning(
             "notifications.platform.notify_target_async.deserialize_error",
             extra={"error": e, "data": data, "nested_target": nested_target},
         )
         return
-
-    notification_data = notification_data_dto.notification_data
 
     lifecycle_metric = NotificationEventLifecycleMetric(
         interaction_type=NotificationInteractionType.NOTIFY_TARGET_ASYNC,
@@ -208,10 +205,9 @@ def notify_target_async(
 
     with lifecycle_metric.capture() as lifecycle:
         # Step 1: Deserialize the target from nested structure
-        serialized_target = NotificationTargetDto.from_dict(nested_target)
-        target = serialized_target.target
+        target = deserialize_target(nested_target)
         lifecycle_metric.notification_provider = target.provider_key
-        lifecycle.add_extras({"source": notification_data.source, "target": target.to_dict()})
+        lifecycle.add_extras({"source": notification_data.source, "target": target.dict()})
 
         # Step 2: Get the provider, and validate the target against it
         provider = provider_registry.get(target.provider_key)
@@ -234,37 +230,14 @@ def notify_target_async(
             lifecycle.record_failure(failure_reason=e, create_issue=True)
 
 
-@dataclass
-class NotificationDataDto:
-    """
-    A wrapper class that handles serialization/deserialization of NotificationData.
-    """
+def serialize_notification_data(data: NotificationData) -> dict[str, Any]:
+    return {"source": data.source, "data": json.loads(data.json())}
 
-    notification_data: NotificationData
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "source": self.notification_data.source,
-            "data": self.notification_data.__dict__,
-        }
+def deserialize_notification_data(raw: dict[str, Any]) -> NotificationData:
+    source = raw.get("source")
+    if source is None:
+        raise NotificationServiceError("Source is required")
 
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "NotificationDataDto":
-        source = data.get("source")
-        if source is None:
-            raise NotificationServiceError("Source is required")
-
-        notification_data_cls = template_registry.get(source).get_data_class()
-        notification_fields = data.get("data", {}).copy()
-
-        # We're using type hints to know which fields need special conversion
-        type_hints = get_type_hints(notification_data_cls)
-
-        for field_name, value in notification_fields.items():
-            if field_name in type_hints:
-                expected_type = type_hints[field_name]
-                if expected_type == datetime and isinstance(value, str):
-                    notification_fields[field_name] = datetime.fromisoformat(value)
-
-        notification_data = notification_data_cls(**notification_fields)
-        return cls(notification_data=notification_data)
+    notification_data_cls = template_registry.get(source).get_data_class()
+    return notification_data_cls.parse_obj(raw.get("data", {}))

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -27,7 +27,6 @@ from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import notifications_tasks
-from sentry.utils import json
 from sentry.utils.registry import NoRegistrationExistsError
 
 logger = logging.getLogger(__name__)
@@ -232,7 +231,7 @@ def notify_target_async(
 
 
 def serialize_notification_data(data: NotificationData) -> dict[str, Any]:
-    return {"source": data.source, "data": json.loads(data.json())}
+    return {"source": data.source, "data": data.dict()}
 
 
 def deserialize_notification_data(raw: dict[str, Any]) -> NotificationData:

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any, Final
 
 import sentry_sdk
+from pydantic import ValidationError
 
 from sentry.models.organization import Organization
 from sentry.notifications.platform.metrics import (
@@ -191,7 +192,7 @@ def notify_target_async(
     """
     try:
         notification_data = deserialize_notification_data(data)
-    except (NotificationServiceError, NoRegistrationExistsError) as e:
+    except (NotificationServiceError, NoRegistrationExistsError, ValidationError) as e:
         logger.warning(
             "notifications.platform.notify_target_async.deserialize_error",
             extra={"error": e, "data": data, "nested_target": nested_target},

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -109,6 +109,7 @@ class NotificationService[T: NotificationData]:
         *,
         strategy: NotificationStrategy | None = None,
         targets: list[NotificationTarget] | None = None,
+        **kwargs: Any,
     ) -> None:
         """
         Send a notification directly to a target via task, if you care about using the result of the notification, use notify_sync instead.

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -108,7 +108,7 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         return ButtonElement(
             text=AUTOFIX_CONFIG[data.stopping_point]["label"],
             style="primary",
-            value=data.stopping_point.value,
+            value=data.stopping_point,
             action_id=encode_action_id(
                 action=SlackAction.SEER_AUTOFIX_START.value,
                 organization_id=data.organization_id,

--- a/src/sentry/notifications/platform/target.py
+++ b/src/sentry/notifications/platform/target.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import StrEnum
 from functools import cached_property
-from typing import Any, Self
+from typing import Any
 
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.services.integration.model import (
@@ -12,7 +12,6 @@ from sentry.integrations.services.integration.service import integration_service
 from sentry.notifications.platform.types import (
     NotificationProviderKey,
     NotificationTarget,
-    NotificationTargetResourceType,
 )
 
 
@@ -32,43 +31,15 @@ class NotificationTargetType(StrEnum):
     INTEGRATION = "integration"
 
 
-@dataclass(kw_only=True, frozen=True)
 class GenericNotificationTarget(NotificationTarget):
     """
     A designated recipient for a notification. This could be a user, a team, or a channel.
     Accepts the renderable object type that matches the connected provider.
     """
 
-    is_prepared: bool = field(init=False, default=False)
-    provider_key: NotificationProviderKey
-    resource_type: NotificationTargetResourceType
-    resource_id: str
-    """
-    The identifier that a provider can use to access or send to the given resource.
-    For example, an email address, a slack channel ID, a discord user ID, etc.
-    """
-    specific_data: dict[str, Any] | None = field(default=None)
-    """
-    Arbitrary data that is specific to the target; for example, a link to a user's notification settings.
-
-    When possible, consider whether this is really necessary as it produces inconsistencies across recipients, which may be lead to confusion.
-    If all targets use the same payload, please add this to the NotificationTemplate instead.
-    """
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "provider_key": self.provider_key,
-            "resource_type": self.resource_type,
-            "resource_id": self.resource_id,
-            "specific_data": self.specific_data,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Self:
-        return cls(**data)
+    pass
 
 
-@dataclass(kw_only=True, frozen=True)
 class IntegrationNotificationTarget(GenericNotificationTarget):
     """
     Adds necessary properties and methods to designate a target within an integration.
@@ -77,18 +48,6 @@ class IntegrationNotificationTarget(GenericNotificationTarget):
 
     integration_id: int
     organization_id: int
-
-    def to_dict(self) -> dict[str, Any]:
-        base_data = super().to_dict()
-        return {
-            **base_data,
-            "integration_id": self.integration_id,
-            "organization_id": self.organization_id,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Self:
-        return cls(**data)
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -124,39 +83,17 @@ class PreparedIntegrationNotificationTarget[IntegrationInstallationT: Integratio
         )
 
 
-@dataclass
-class NotificationTargetDto:
-    """
-    A wrapper class that handles serialization/deserialization of NotificationTargets.
-    """
+def serialize_target(target: NotificationTarget) -> dict[str, Any]:
+    if isinstance(target, IntegrationNotificationTarget):
+        return {"type": NotificationTargetType.INTEGRATION, "target": target.dict()}
+    return {"type": NotificationTargetType.GENERIC, "target": target.dict()}
 
-    target: NotificationTarget
 
-    @property
-    def notification_type(self) -> NotificationTargetType:
-        if isinstance(self.target, IntegrationNotificationTarget):
-            return NotificationTargetType.INTEGRATION
-        elif isinstance(self.target, GenericNotificationTarget):
-            return NotificationTargetType.GENERIC
-        else:
-            raise NotificationTargetError(f"Unknown target type: {type(self.target)}")
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "type": self.notification_type,
-            "target": self.target.to_dict(),
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "NotificationTargetDto":
-        target_type = data["type"]
-        target_data = data["target"]
-
-        if target_type == NotificationTargetType.GENERIC:
-            target = GenericNotificationTarget.from_dict(target_data)
-        elif target_type == NotificationTargetType.INTEGRATION:
-            target = IntegrationNotificationTarget.from_dict(target_data)
-        else:
-            raise NotificationTargetError(f"Unknown target type: {target_type}")
-
-        return cls(target=target)
+def deserialize_target(data: dict[str, Any]) -> NotificationTarget:
+    target_type = data["type"]
+    target_data = data["target"]
+    if target_type == NotificationTargetType.INTEGRATION:
+        return IntegrationNotificationTarget.parse_obj(target_data)
+    elif target_type == NotificationTargetType.GENERIC:
+        return GenericNotificationTarget.parse_obj(target_data)
+    raise NotificationTargetError(f"Unknown target type: {target_type}")

--- a/src/sentry/notifications/platform/templates/data_export.py
+++ b/src/sentry/notifications/platform/templates/data_export.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any
 
 import orjson
 from django.utils import timezone
@@ -24,7 +24,7 @@ def format_date(date: datetime) -> str:
 
 
 class DataExportSuccess(NotificationData):
-    source: Literal[NotificationSource.DATA_EXPORT_SUCCESS] = NotificationSource.DATA_EXPORT_SUCCESS
+    source: NotificationSource = NotificationSource.DATA_EXPORT_SUCCESS
     export_url: str
     expiration_date: datetime
 
@@ -55,7 +55,7 @@ class DataExportSuccessTemplate(NotificationTemplate[DataExportSuccess]):
 
 
 class DataExportFailure(NotificationData):
-    source: Literal[NotificationSource.DATA_EXPORT_FAILURE] = NotificationSource.DATA_EXPORT_FAILURE
+    source: NotificationSource = NotificationSource.DATA_EXPORT_FAILURE
     error_message: str
     error_payload: dict[str, Any]
     creation_date: datetime

--- a/src/sentry/notifications/platform/templates/data_export.py
+++ b/src/sentry/notifications/platform/templates/data_export.py
@@ -1,6 +1,5 @@
-from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 import orjson
 from django.utils import timezone
@@ -24,14 +23,13 @@ def format_date(date: datetime) -> str:
     return date.strftime("%I:%M %p on %B %d, %Y (%Z)")
 
 
-@dataclass(frozen=True)
 class DataExportSuccess(NotificationData):
-    source = NotificationSource.DATA_EXPORT_SUCCESS
+    source: Literal[NotificationSource.DATA_EXPORT_SUCCESS] = NotificationSource.DATA_EXPORT_SUCCESS
     export_url: str
     expiration_date: datetime
 
 
-@template_registry.register(DataExportSuccess.source)
+@template_registry.register(NotificationSource.DATA_EXPORT_SUCCESS)
 class DataExportSuccessTemplate(NotificationTemplate[DataExportSuccess]):
     category = NotificationCategory.DATA_EXPORT
     example_data = DataExportSuccess(
@@ -56,15 +54,14 @@ class DataExportSuccessTemplate(NotificationTemplate[DataExportSuccess]):
         )
 
 
-@dataclass(frozen=True)
 class DataExportFailure(NotificationData):
-    source = NotificationSource.DATA_EXPORT_FAILURE
+    source: Literal[NotificationSource.DATA_EXPORT_FAILURE] = NotificationSource.DATA_EXPORT_FAILURE
     error_message: str
     error_payload: dict[str, Any]
     creation_date: datetime
 
 
-@template_registry.register(DataExportFailure.source)
+@template_registry.register(NotificationSource.DATA_EXPORT_FAILURE)
 class DataExportFailureTemplate(NotificationTemplate[DataExportFailure]):
     category = NotificationCategory.DATA_EXPORT
     example_data = DataExportFailure(

--- a/src/sentry/notifications/platform/templates/repository.py
+++ b/src/sentry/notifications/platform/templates/repository.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from typing import Literal
 
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
@@ -13,15 +13,16 @@ from sentry.notifications.platform.types import (
 )
 
 
-@dataclass(frozen=True)
 class UnableToDeleteRepository(NotificationData):
-    source = NotificationSource.UNABLE_TO_DELETE_REPOSITORY
+    source: Literal[NotificationSource.UNABLE_TO_DELETE_REPOSITORY] = (
+        NotificationSource.UNABLE_TO_DELETE_REPOSITORY
+    )
     repository_name: str
     provider_name: str
     error_message: str
 
 
-@template_registry.register(UnableToDeleteRepository.source)
+@template_registry.register(NotificationSource.UNABLE_TO_DELETE_REPOSITORY)
 class UnableToDeleteRepositoryTemplate(NotificationTemplate[UnableToDeleteRepository]):
     category = NotificationCategory.REPOSITORY
     example_data = UnableToDeleteRepository(

--- a/src/sentry/notifications/platform/templates/repository.py
+++ b/src/sentry/notifications/platform/templates/repository.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
     CodeTextBlock,
@@ -14,9 +12,7 @@ from sentry.notifications.platform.types import (
 
 
 class UnableToDeleteRepository(NotificationData):
-    source: Literal[NotificationSource.UNABLE_TO_DELETE_REPOSITORY] = (
-        NotificationSource.UNABLE_TO_DELETE_REPOSITORY
-    )
+    source: NotificationSource = NotificationSource.UNABLE_TO_DELETE_REPOSITORY
     repository_name: str
     provider_name: str
     error_message: str

--- a/src/sentry/notifications/platform/templates/sample.py
+++ b/src/sentry/notifications/platform/templates/sample.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Literal
-
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
     BoldTextBlock,
@@ -22,7 +20,7 @@ from sentry.notifications.platform.types import (
 
 
 class ErrorAlertData(NotificationData):
-    source: Literal[NotificationSource.ERROR_ALERT] = NotificationSource.ERROR_ALERT
+    source: NotificationSource = NotificationSource.ERROR_ALERT
     error_type: str
     error_message: str
     project_name: str
@@ -115,7 +113,7 @@ class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
 
 
 class DeploymentData(NotificationData):
-    source: Literal[NotificationSource.DEPLOYMENT] = NotificationSource.DEPLOYMENT
+    source: NotificationSource = NotificationSource.DEPLOYMENT
     project_name: str
     version: str
     environment: str
@@ -184,9 +182,7 @@ class DeploymentNotificationTemplate(NotificationTemplate[DeploymentData]):
 
 
 class SlowLoadMetricAlertData(NotificationData):
-    source: Literal[NotificationSource.SLOW_LOAD_METRIC_ALERT] = (
-        NotificationSource.SLOW_LOAD_METRIC_ALERT
-    )
+    source: NotificationSource = NotificationSource.SLOW_LOAD_METRIC_ALERT
     alert_type: str
     severity: str
     project_name: str
@@ -244,9 +240,7 @@ class SlowLoadMetricAlertNotificationTemplate(NotificationTemplate[SlowLoadMetri
 
 
 class PerformanceAlertData(NotificationData):
-    source: Literal[NotificationSource.PERFORMANCE_MONITORING] = (
-        NotificationSource.PERFORMANCE_MONITORING
-    )
+    source: NotificationSource = NotificationSource.PERFORMANCE_MONITORING
     metric_name: str
     threshold: str
     current_value: str
@@ -312,7 +306,7 @@ class PerformanceAlertNotificationTemplate(NotificationTemplate[PerformanceAlert
 
 
 class TeamUpdateData(NotificationData):
-    source: Literal[NotificationSource.TEAM_COMMUNICATION] = NotificationSource.TEAM_COMMUNICATION
+    source: NotificationSource = NotificationSource.TEAM_COMMUNICATION
     team_name: str
     update_type: str
     message: str

--- a/src/sentry/notifications/platform/templates/sample.py
+++ b/src/sentry/notifications/platform/templates/sample.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from typing import Literal
 
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
@@ -21,9 +21,8 @@ from sentry.notifications.platform.types import (
 )
 
 
-@dataclass(frozen=True)
 class ErrorAlertData(NotificationData):
-    source = NotificationSource.ERROR_ALERT
+    source: Literal[NotificationSource.ERROR_ALERT] = NotificationSource.ERROR_ALERT
     error_type: str
     error_message: str
     project_name: str
@@ -35,7 +34,7 @@ class ErrorAlertData(NotificationData):
     assign_url: str
 
 
-@template_registry.register(ErrorAlertData.source)
+@template_registry.register(NotificationSource.ERROR_ALERT)
 class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
     category = NotificationCategory.DEBUG
     example_data = ErrorAlertData(
@@ -115,9 +114,8 @@ class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
         )
 
 
-@dataclass(frozen=True)
 class DeploymentData(NotificationData):
-    source = NotificationSource.DEPLOYMENT
+    source: Literal[NotificationSource.DEPLOYMENT] = NotificationSource.DEPLOYMENT
     project_name: str
     version: str
     environment: str
@@ -128,7 +126,7 @@ class DeploymentData(NotificationData):
     rollback_url: str
 
 
-@template_registry.register(DeploymentData.source)
+@template_registry.register(NotificationSource.DEPLOYMENT)
 class DeploymentNotificationTemplate(NotificationTemplate[DeploymentData]):
     category = NotificationCategory.DEBUG
 
@@ -185,9 +183,10 @@ class DeploymentNotificationTemplate(NotificationTemplate[DeploymentData]):
         )
 
 
-@dataclass(frozen=True)
 class SlowLoadMetricAlertData(NotificationData):
-    source = NotificationSource.SLOW_LOAD_METRIC_ALERT
+    source: Literal[NotificationSource.SLOW_LOAD_METRIC_ALERT] = (
+        NotificationSource.SLOW_LOAD_METRIC_ALERT
+    )
     alert_type: str
     severity: str
     project_name: str
@@ -200,7 +199,7 @@ class SlowLoadMetricAlertData(NotificationData):
     chart_url: str
 
 
-@template_registry.register(SlowLoadMetricAlertData.source)
+@template_registry.register(NotificationSource.SLOW_LOAD_METRIC_ALERT)
 class SlowLoadMetricAlertNotificationTemplate(NotificationTemplate[SlowLoadMetricAlertData]):
     category = NotificationCategory.DEBUG
     example_data = SlowLoadMetricAlertData(
@@ -244,9 +243,10 @@ class SlowLoadMetricAlertNotificationTemplate(NotificationTemplate[SlowLoadMetri
         )
 
 
-@dataclass(frozen=True)
 class PerformanceAlertData(NotificationData):
-    source = NotificationSource.PERFORMANCE_MONITORING
+    source: Literal[NotificationSource.PERFORMANCE_MONITORING] = (
+        NotificationSource.PERFORMANCE_MONITORING
+    )
     metric_name: str
     threshold: str
     current_value: str
@@ -255,7 +255,7 @@ class PerformanceAlertData(NotificationData):
     investigation_url: str
 
 
-@template_registry.register(PerformanceAlertData.source)
+@template_registry.register(NotificationSource.PERFORMANCE_MONITORING)
 class PerformanceAlertNotificationTemplate(NotificationTemplate[PerformanceAlertData]):
     category = NotificationCategory.DEBUG
     example_data = PerformanceAlertData(
@@ -311,9 +311,8 @@ class PerformanceAlertNotificationTemplate(NotificationTemplate[PerformanceAlert
         )
 
 
-@dataclass(frozen=True)
 class TeamUpdateData(NotificationData):
-    source = NotificationSource.TEAM_COMMUNICATION
+    source: Literal[NotificationSource.TEAM_COMMUNICATION] = NotificationSource.TEAM_COMMUNICATION
     team_name: str
     update_type: str
     message: str
@@ -321,7 +320,7 @@ class TeamUpdateData(NotificationData):
     timestamp: str
 
 
-@template_registry.register(TeamUpdateData.source)
+@template_registry.register(NotificationSource.TEAM_COMMUNICATION)
 class TeamUpdateNotificationTemplate(NotificationTemplate[TeamUpdateData]):
     category = NotificationCategory.DEBUG
     example_data = TeamUpdateData(

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import TypedDict
+from typing import Literal, TypedDict
+
+from pydantic import Field
 
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT
 from sentry.notifications.platform.registry import template_registry
@@ -30,14 +31,13 @@ def _get_next_stopping_point(current: AutofixStoppingPoint) -> AutofixStoppingPo
     return _RANK_TO_STOPPING_POINT.get(current_rank + 1)
 
 
-@dataclass(frozen=True)
 class SeerAutofixError(NotificationData):
     error_message: str
-    source: NotificationSource = NotificationSource.SEER_AUTOFIX_ERROR
+    source: Literal[NotificationSource.SEER_AUTOFIX_ERROR] = NotificationSource.SEER_AUTOFIX_ERROR
     error_title: str = "Seer had some trouble..."
 
 
-@template_registry.register(SeerAutofixError.source)
+@template_registry.register(NotificationSource.SEER_AUTOFIX_ERROR)
 class SeerAutofixErrorTemplate(NotificationTemplate[SeerAutofixError]):
     category = NotificationCategory.SEER
     example_data = SeerAutofixError(
@@ -64,7 +64,6 @@ class SeerAutofixPullRequest(TypedDict):
     pr_url: str
 
 
-@dataclass(frozen=True)
 class SeerAutofixUpdate(NotificationData):
     run_id: int
     organization_id: int
@@ -72,11 +71,11 @@ class SeerAutofixUpdate(NotificationData):
     group_id: int
     current_point: AutofixStoppingPoint
     group_link: str
-    steps: list[str] = field(default_factory=list)
-    changes: list[SeerAutofixCodeChange] = field(default_factory=list)
-    pull_requests: list[SeerAutofixPullRequest] = field(default_factory=list)
+    steps: list[str] = Field(default_factory=list)
+    changes: list[SeerAutofixCodeChange] = Field(default_factory=list)
+    pull_requests: list[SeerAutofixPullRequest] = Field(default_factory=list)
     summary: str | None = None
-    source: NotificationSource = NotificationSource.SEER_AUTOFIX_UPDATE
+    source: Literal[NotificationSource.SEER_AUTOFIX_UPDATE] = NotificationSource.SEER_AUTOFIX_UPDATE
 
     @property
     def has_next_trigger(self) -> bool:
@@ -95,7 +94,7 @@ class SeerAutofixUpdate(NotificationData):
                 return False
 
 
-@template_registry.register(SeerAutofixUpdate.source)
+@template_registry.register(NotificationSource.SEER_AUTOFIX_UPDATE)
 class SeerAutofixUpdateTemplate(NotificationTemplate[SeerAutofixUpdate]):
     category = NotificationCategory.SEER
     example_data = SeerAutofixUpdate(
@@ -134,7 +133,6 @@ class SeerAutofixUpdateTemplate(NotificationTemplate[SeerAutofixUpdate]):
         return NotificationRenderedTemplate(subject="Seer Autofix Update", body=[])
 
 
-@dataclass(frozen=True)
 class SeerAutofixTrigger(NotificationData):
     """
     Note: This data is only used to render the trigger itself for an autofix run,
@@ -146,7 +144,9 @@ class SeerAutofixTrigger(NotificationData):
     project_id: int
     group_id: int
     run_id: int | None = None
-    source: NotificationSource = NotificationSource.SEER_AUTOFIX_TRIGGER
+    source: Literal[NotificationSource.SEER_AUTOFIX_TRIGGER] = (
+        NotificationSource.SEER_AUTOFIX_TRIGGER
+    )
     stopping_point: AutofixStoppingPoint = AutofixStoppingPoint.ROOT_CAUSE
 
     @staticmethod

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, TypedDict
+from typing import TypedDict
 
 from pydantic import Field
 
@@ -33,7 +33,7 @@ def _get_next_stopping_point(current: AutofixStoppingPoint) -> AutofixStoppingPo
 
 class SeerAutofixError(NotificationData):
     error_message: str
-    source: Literal[NotificationSource.SEER_AUTOFIX_ERROR] = NotificationSource.SEER_AUTOFIX_ERROR
+    source: NotificationSource = NotificationSource.SEER_AUTOFIX_ERROR
     error_title: str = "Seer had some trouble..."
 
 
@@ -75,7 +75,7 @@ class SeerAutofixUpdate(NotificationData):
     changes: list[SeerAutofixCodeChange] = Field(default_factory=list)
     pull_requests: list[SeerAutofixPullRequest] = Field(default_factory=list)
     summary: str | None = None
-    source: Literal[NotificationSource.SEER_AUTOFIX_UPDATE] = NotificationSource.SEER_AUTOFIX_UPDATE
+    source: NotificationSource = NotificationSource.SEER_AUTOFIX_UPDATE
 
     @property
     def has_next_trigger(self) -> bool:
@@ -144,9 +144,7 @@ class SeerAutofixTrigger(NotificationData):
     project_id: int
     group_id: int
     run_id: int | None = None
-    source: Literal[NotificationSource.SEER_AUTOFIX_TRIGGER] = (
-        NotificationSource.SEER_AUTOFIX_TRIGGER
-    )
+    source: NotificationSource = NotificationSource.SEER_AUTOFIX_TRIGGER
     stopping_point: AutofixStoppingPoint = AutofixStoppingPoint.ROOT_CAUSE
 
     @staticmethod

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import abc
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Literal, Protocol, Self
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel
 
 from sentry.integrations.types import ExternalProviderEnum
 
@@ -106,21 +108,18 @@ class NotificationTargetResourceType(StrEnum):
     DIRECT_MESSAGE = "direct_message"
 
 
-class NotificationTarget(Protocol):
+class NotificationTarget(BaseModel):
     """
-    All targets of the notification platform must adhere to this protocol.
+    All targets of the notification platform must adhere to this base class.
     """
 
-    is_prepared: bool
+    class Config:
+        frozen = True
+
     provider_key: NotificationProviderKey
     resource_type: NotificationTargetResourceType
     resource_id: str
-    specific_data: dict[str, Any] | None
-
-    def to_dict(self) -> dict[str, Any]: ...
-
-    @classmethod
-    def from_dict(self, data: dict[str, Any]) -> Self: ...
+    specific_data: dict[str, Any] | None = None
 
 
 class NotificationStrategy(Protocol):
@@ -131,10 +130,13 @@ class NotificationStrategy(Protocol):
     def get_targets(self) -> list[NotificationTarget]: ...
 
 
-class NotificationData(Protocol):
+class NotificationData(BaseModel):
     """
-    All data passing through the notification platform must adhere to this protocol.
+    All data passing through the notification platform must adhere to this base class.
     """
+
+    class Config:
+        frozen = True
 
     source: NotificationSource
     """

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -115,6 +115,7 @@ class NotificationTarget(BaseModel):
 
     class Config:
         frozen = True
+        use_enum_values = True
 
     provider_key: NotificationProviderKey
     resource_type: NotificationTargetResourceType
@@ -137,6 +138,7 @@ class NotificationData(BaseModel):
 
     class Config:
         frozen = True
+        use_enum_values = True
 
     source: NotificationSource
     """

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -30,6 +30,7 @@ from sentry.shared_integrations.exceptions import IntegrationConfigurationError,
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 from sentry.taskworker.retry import Retry
+from sentry.utils.registry import NoRegistrationExistsError
 
 if TYPE_CHECKING:
     from sentry.integrations.slack.integration import SlackIntegration
@@ -117,7 +118,7 @@ def process_thread_update(
     ).capture() as lifecycle:
         try:
             notification_data = deserialize_notification_data(serialized_data)
-        except (NotificationServiceError, ValidationError) as e:
+        except (NotificationServiceError, NoRegistrationExistsError, ValidationError) as e:
             lifecycle.record_failure(failure_reason=e)
             return
 

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -11,9 +11,10 @@ from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.platform.registry import provider_registry, template_registry
 from sentry.notifications.platform.service import (
-    NotificationDataDto,
     NotificationService,
     NotificationServiceError,
+    deserialize_notification_data,
+    serialize_notification_data,
 )
 from sentry.notifications.platform.slack.provider import SlackRenderable
 from sentry.notifications.platform.slack.renderers.seer import SeerSlackRenderer
@@ -115,7 +116,7 @@ def process_thread_update(
         organization_id=organization_id,
     ).capture() as lifecycle:
         try:
-            data_dto = NotificationDataDto.from_dict(serialized_data)
+            notification_data = deserialize_notification_data(serialized_data)
         except (NotificationServiceError, NoRegistrationExistsError) as e:
             lifecycle.record_failure(failure_reason=e)
             return
@@ -133,7 +134,7 @@ def process_thread_update(
     send_thread_update(
         install=SlackIntegration(model=integration, organization_id=organization_id),
         thread=thread,
-        data=data_dto.notification_data,
+        data=notification_data,
         ephemeral_user_id=ephemeral_user_id,
     )
 
@@ -152,7 +153,7 @@ def schedule_all_thread_updates(
         integration_id=integration_id,
         organization_id=organization_id,
     ).capture() as lifecycle:
-        serialized_data = NotificationDataDto(notification_data=data).to_dict()
+        serialized_data = serialize_notification_data(data)
         lifecycle.add_extra("thread_count", len(threads))
         for thread in threads:
             process_thread_update.apply_async(

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
+from pydantic import ValidationError
 from slack_sdk.models.blocks.blocks import Block
 
 from sentry.constants import ObjectStatus
@@ -29,7 +30,6 @@ from sentry.shared_integrations.exceptions import IntegrationConfigurationError,
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 from sentry.taskworker.retry import Retry
-from sentry.utils.registry import NoRegistrationExistsError
 
 if TYPE_CHECKING:
     from sentry.integrations.slack.integration import SlackIntegration
@@ -117,7 +117,7 @@ def process_thread_update(
     ).capture() as lifecycle:
         try:
             notification_data = deserialize_notification_data(serialized_data)
-        except (NotificationServiceError, NoRegistrationExistsError) as e:
+        except (NotificationServiceError, ValidationError) as e:
             lifecycle.record_failure(failure_reason=e)
             return
 

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from typing import Literal
 
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
@@ -18,13 +18,12 @@ from sentry.notifications.platform.types import (
 )
 
 
-@dataclass(kw_only=True, frozen=True)
 class MockNotification(NotificationData):
-    source = NotificationSource.TEST
+    source: Literal[NotificationSource.TEST] = NotificationSource.TEST
     message: str
 
 
-@template_registry.register(MockNotification.source)
+@template_registry.register(NotificationSource.TEST)
 class MockNotificationTemplate(NotificationTemplate[MockNotification]):
     category = NotificationCategory.DEBUG
     example_data = MockNotification(message="This is a mock notification")

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
     NotificationBodyFormattingBlockType,
@@ -19,7 +17,7 @@ from sentry.notifications.platform.types import (
 
 
 class MockNotification(NotificationData):
-    source: Literal[NotificationSource.TEST] = NotificationSource.TEST
+    source: NotificationSource = NotificationSource.TEST
     message: str
 
 

--- a/tests/sentry/notifications/platform/test_service.py
+++ b/tests/sentry/notifications/platform/test_service.py
@@ -7,9 +7,10 @@ from django.utils import timezone
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.notifications.platform.email.provider import EmailNotificationProvider
 from sentry.notifications.platform.service import (
-    NotificationDataDto,
     NotificationService,
     NotificationServiceError,
+    deserialize_notification_data,
+    serialize_notification_data,
 )
 from sentry.notifications.platform.target import (
     GenericNotificationTarget,
@@ -179,8 +180,8 @@ class NotificationServiceTest(TestCase):
         assert_count_of_metric(mock_record, EventLifecycleOutcome.SUCCESS, 2)
 
 
-class NotificationDataDtoTest(TestCase):
-    def test_from_dict_raises_error_without_source(self) -> None:
+class NotificationDataSerializationTest(TestCase):
+    def test_deserialize_raises_error_without_source(self) -> None:
         serialized = {
             "data": {
                 "message": "test",
@@ -188,31 +189,30 @@ class NotificationDataDtoTest(TestCase):
         }
 
         with pytest.raises(NotificationServiceError, match="Source is required"):
-            NotificationDataDto.from_dict(serialized)
+            deserialize_notification_data(serialized)
 
     def test_roundtrip_serialization(self) -> None:
         original_notification = MockNotification(message="roundtrip test")
-        dto = NotificationDataDto(notification_data=original_notification)
 
-        serialized = dto.to_dict()
-        reconstructed_dto = NotificationDataDto.from_dict(serialized)
+        serialized = serialize_notification_data(original_notification)
+        reconstructed = deserialize_notification_data(serialized)
 
-        assert isinstance(reconstructed_dto.notification_data, MockNotification)
-        assert reconstructed_dto.notification_data.source == original_notification.source
-        assert reconstructed_dto.notification_data.message == original_notification.message
+        assert isinstance(reconstructed, MockNotification)
+        assert reconstructed.source == original_notification.source
+        assert reconstructed.message == original_notification.message
 
-    def test_from_dict_with_complex_data_types(self) -> None:
+    def test_roundtrip_with_complex_data_types(self) -> None:
         now = timezone.now()
         data = DataExportFailure(
             error_message="Export failed",
             error_payload={"export_type": "Issues", "project": [123]},
             creation_date=now,
         )
-        serialized = NotificationDataDto(notification_data=data).to_dict()
-        dto = NotificationDataDto.from_dict(serialized)
+        serialized = serialize_notification_data(data)
+        reconstructed = deserialize_notification_data(serialized)
 
-        assert dto.notification_data.source == "data-export-failure"
-        assert isinstance(dto.notification_data, DataExportFailure)
-        assert dto.notification_data.error_message == "Export failed"
-        assert dto.notification_data.error_payload == {"export_type": "Issues", "project": [123]}
-        assert dto.notification_data.creation_date == now
+        assert reconstructed.source == "data-export-failure"
+        assert isinstance(reconstructed, DataExportFailure)
+        assert reconstructed.error_message == "Export failed"
+        assert reconstructed.error_payload == {"export_type": "Issues", "project": [123]}
+        assert reconstructed.creation_date == now

--- a/tests/sentry/seer/entrypoints/slack/test_slack.py
+++ b/tests/sentry/seer/entrypoints/slack/test_slack.py
@@ -2,7 +2,7 @@ from unittest.mock import ANY, Mock, patch
 
 from fixtures.seer.webhooks import MOCK_RUN_ID, MOCK_SEER_WEBHOOKS
 from sentry.integrations.slack.message_builder.types import SlackAction
-from sentry.notifications.platform.service import NotificationDataDto
+from sentry.notifications.platform.service import serialize_notification_data
 from sentry.notifications.platform.slack.provider import SlackRenderable
 from sentry.notifications.platform.templates.seer import SeerAutofixUpdate
 from sentry.notifications.utils.actions import BlockKitMessageAction
@@ -266,7 +266,7 @@ class SlackEntrypointTest(TestCase):
     @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_message")
     def test_process_thread_update(self, mock_send_threaded_message):
         data = self._create_update(AutofixStoppingPoint.SOLUTION)
-        serialized_data = NotificationDataDto(notification_data=data).to_dict()
+        serialized_data = serialize_notification_data(data)
 
         process_thread_update(
             integration_id=self.integration.id,


### PR DESCRIPTION
Resolves ISWF-2257

Changes the serialization method for `NotificationData` and `NotificationTarget` classes to use Pydantic models, which guarantee that the model is JSON serializable. 

Previously, a developer would need to E2E test their notification data and render code to ensure cross-task serialization works as expected. This seems unnecessarily tedious, so I've converted the classes to use Pydantic models to enforce this instead, similar to our RPC services.
