### PR TITLE
ref(marked): Add 'align' to DOMPurify allowed attributes

### DIFF
--- a/static/app/utils/marked/marked.tsx
+++ b/static/app/utils/marked/marked.tsx
@@ -94,7 +94,7 @@ const ALLOWED_TAGS = [
   'sup',
 ];
 
-const ALLOWED_ATTR = ['href', 'title', 'src', 'alt', 'class', 'id'];
+const ALLOWED_ATTR = ['href', 'title', 'src', 'alt', 'class', 'id', 'align'];
 
 function postprocess(html: string) {
   return dompurify.sanitize(html, {


### PR DESCRIPTION
Adds 'align' to the list of allowed HTML attributes in DOMPurify's sanitization configuration.

This allows the marked renderer to preserve the align attribute when sanitizing HTML output, enabling proper alignment styling for table cells and other elements.


Agent transcript: https://claudescope.sentry.dev/share/l5X-eWw6sCiTey3337voKjKhLuyGimehKLGTipxa_l0