### PR TITLE
feat(snapshots): Make snapshots support group param

### DIFF
--- a/static/app/components/core/alert/alert.snapshots.tsx
+++ b/static/app/components/core/alert/alert.snapshots.tsx
@@ -8,20 +8,24 @@ import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 const themes = {light: lightTheme, dark: darkTheme};
 
 describe('Alert', () => {
-  describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
+  describe.each(['light', 'dark'] as const)('%s', themeName => {
     it.snapshot.each<AlertProps['variant']>([
       'info',
       'warning',
       'success',
       'danger',
       'muted',
-    ])('variant-%s', variant => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 400}}>
-          <Alert variant={variant}>This is a {variant} alert</Alert>
-        </div>
-      </ThemeProvider>
-    ));
+    ])(
+      '%s',
+      variant => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 400}}>
+            <Alert variant={variant}>This is a {variant} alert</Alert>
+          </div>
+        </ThemeProvider>
+      ),
+      variant => ({theme: themeName, variant: String(variant)})
+    );
 
     it.snapshot.each<AlertProps['variant']>([
       'info',
@@ -29,15 +33,19 @@ describe('Alert', () => {
       'success',
       'danger',
       'muted',
-    ])('variant-%s-no-icon', variant => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 400}}>
-          <Alert variant={variant} showIcon={false}>
-            This is a {variant} alert without icon
-          </Alert>
-        </div>
-      </ThemeProvider>
-    ));
+    ])(
+      '%s-no-icon',
+      variant => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 400}}>
+            <Alert variant={variant} showIcon={false}>
+              This is a {variant} alert without icon
+            </Alert>
+          </div>
+        </ThemeProvider>
+      ),
+      variant => ({theme: themeName, variant: String(variant), showIcon: 'false'})
+    );
 
     it.snapshot.each<AlertProps['variant']>([
       'info',
@@ -45,14 +53,18 @@ describe('Alert', () => {
       'success',
       'danger',
       'muted',
-    ])('variant-%s-system', variant => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 400}}>
-          <Alert variant={variant} system>
-            This is a system {variant} alert
-          </Alert>
-        </div>
-      </ThemeProvider>
-    ));
+    ])(
+      'system-%s',
+      variant => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 400}}>
+            <Alert variant={variant} system>
+              This is a system {variant} alert
+            </Alert>
+          </div>
+        </ThemeProvider>
+      ),
+      variant => ({theme: themeName, variant: String(variant), system: 'true'})
+    );
   });
 });

--- a/static/app/components/core/badge/badge.snapshots.tsx
+++ b/static/app/components/core/badge/badge.snapshots.tsx
@@ -8,7 +8,7 @@ import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 const themes = {light: lightTheme, dark: darkTheme};
 
 describe('Badge', () => {
-  describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
+  describe.each(['light', 'dark'] as const)('%s', themeName => {
     it.snapshot.each<BadgeProps['variant']>([
       'muted',
       'internal',
@@ -22,12 +22,16 @@ describe('Badge', () => {
       'beta',
       'new',
       'experimental',
-    ])('variant-%s', variant => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Badge variant={variant}>{variant}</Badge>
-        </div>
-      </ThemeProvider>
-    ));
+    ])(
+      '%s',
+      variant => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Badge variant={variant}>{variant}</Badge>
+          </div>
+        </ThemeProvider>
+      ),
+      variant => ({theme: themeName, variant: String(variant)})
+    );
   });
 });

--- a/static/app/components/core/button/button.snapshots.tsx
+++ b/static/app/components/core/button/button.snapshots.tsx
@@ -8,7 +8,7 @@ import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 const themes = {light: lightTheme, dark: darkTheme};
 
 describe('Button', () => {
-  describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
+  describe.each(['light', 'dark'] as const)('%s', themeName => {
     it.snapshot.each<ButtonProps['priority']>([
       'default',
       'primary',
@@ -16,16 +16,20 @@ describe('Button', () => {
       'warning',
       'link',
       'transparent',
-    ])('priority-%s', priority => (
-      <ThemeProvider theme={themes[themeName]}>
-        {/* Buttons need a bit of padding as rootElement.screenshot() clips to the
-          element's CSS border-box. For buttons, box-shadows/outlines/focus rings
-          extending outside #root get cut off. */}
+    ])(
+      '%s',
+      priority => (
+        <ThemeProvider theme={themes[themeName]}>
+          {/* Buttons need a bit of padding as rootElement.screenshot() clips to the
+            element's CSS border-box. For buttons, box-shadows/outlines/focus rings
+            extending outside #root get cut off. */}
 
-        <div style={{padding: 8}}>
-          <Button priority={priority}>{priority}</Button>
-        </div>
-      </ThemeProvider>
-    ));
+          <div style={{padding: 8}}>
+            <Button priority={priority}>{priority}</Button>
+          </div>
+        </ThemeProvider>
+      ),
+      priority => ({theme: themeName, priority: String(priority)})
+    );
   });
 });

--- a/static/app/components/core/text/text.snapshots.tsx
+++ b/static/app/components/core/text/text.snapshots.tsx
@@ -10,13 +10,17 @@ const themes = {light: lightTheme, dark: darkTheme};
 
 describe('Text', () => {
   describe.each(['light', 'dark'] as const)('%s', themeName => {
-    it.snapshot.each(['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const)('%s', size => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text size={size}>Text at size {size}</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot.each(['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const)(
+      'size-%s',
+      size => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text size={size}>Text at size {size}</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      size => ({theme: themeName, size})
+    );
 
     it.snapshot.each([
       'primary',
@@ -26,129 +30,185 @@ describe('Text', () => {
       'warning',
       'danger',
       'promotion',
-    ] as const)('%s', variant => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text variant={variant}>Text with {variant} variant</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    ] as const)(
+      'variant-%s',
+      variant => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text variant={variant}>Text with {variant} variant</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      variant => ({theme: themeName, variant})
+    );
 
-    it.snapshot('bold', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text bold>Bold text</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'bold',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text bold>Bold text</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('italic', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text italic>Italic text</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'italic',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text italic>Italic text</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('underline', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text underline>Underlined text</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'underline',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text underline>Underlined text</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('underline-dotted', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text underline="dotted">Dotted underlined text</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'underline-dotted',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text underline="dotted">Dotted underlined text</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('strikethrough', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text strikethrough>Strikethrough text</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'strikethrough',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text strikethrough>Strikethrough text</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('uppercase', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text uppercase>Uppercase text</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'uppercase',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text uppercase>Uppercase text</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('monospace', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text monospace>const x = 1234567890;</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'monospace',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text monospace>const x = 1234567890;</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('tabular', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text tabular>1234567890</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'tabular',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text tabular>1234567890</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('fraction', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text fraction>1/2 3/4 5/8</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'fraction',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text fraction>1/2 3/4 5/8</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot.each(['left', 'center', 'right', 'justify'] as const)('%s', align => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 200}}>
-          <Text align={align}>
-            Aligned text that may wrap to multiple lines for justify demo
-          </Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot.each(['left', 'center', 'right', 'justify'] as const)(
+      'align-%s',
+      align => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 200}}>
+            <Text align={align}>
+              Aligned text that may wrap to multiple lines for justify demo
+            </Text>
+          </div>
+        </ThemeProvider>
+      ),
+      align => ({theme: themeName, align})
+    );
 
-    it.snapshot.each(['compressed', 'comfortable'] as const)('%s', density => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text as="p" density={density}>
-            Text with {density} density. Lorem ipsum dolor sit amet, consectetur
-            adipiscing elit.
-          </Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot.each(['compressed', 'comfortable'] as const)(
+      'density-%s',
+      density => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text as="p" density={density}>
+              Text with {density} density. Lorem ipsum dolor sit amet, consectetur
+              adipiscing elit.
+            </Text>
+          </div>
+        </ThemeProvider>
+      ),
+      density => ({theme: themeName, density})
+    );
 
-    it.snapshot('ellipsis', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 200}}>
-          <Text ellipsis>
-            This is a very long text that will be truncated with an ellipsis
-          </Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'ellipsis',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 200}}>
+            <Text ellipsis>
+              This is a very long text that will be truncated with an ellipsis
+            </Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('word-break', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 200}}>
-          <Text wordBreak="break-word">
-            https://example.com/path/?param1=value1&param2=some-awkward-long-value
-          </Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'word-break',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 200}}>
+            <Text wordBreak="break-word">
+              https://example.com/path/?param1=value1&param2=some-awkward-long-value
+            </Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
     it.snapshot.each(['balance', 'pretty', 'nowrap', 'stable'] as const)(
-      '%s',
+      'textWrap-%s',
       textWrap => (
         <ThemeProvider theme={themes[themeName]}>
           <div style={{padding: 8, width: 200}}>
@@ -157,67 +217,92 @@ describe('Text', () => {
             </Text>
           </div>
         </ThemeProvider>
-      )
+      ),
+      textWrap => ({theme: themeName, textWrap})
     );
 
-    it.snapshot.each(['nowrap', 'pre', 'pre-line', 'pre-wrap'] as const)('%s', wrap => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8, width: 200}}>
-          <Text wrap={wrap}>{'Text with\n  whitespace  handling'}</Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot.each(['nowrap', 'pre', 'pre-line', 'pre-wrap'] as const)(
+      'wrap-%s',
+      wrap => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8, width: 200}}>
+            <Text wrap={wrap}>{'Text with\n  whitespace  handling'}</Text>
+          </div>
+        </ThemeProvider>
+      ),
+      wrap => ({theme: themeName, wrap})
+    );
 
     // === Combined props ===
-    it.snapshot('bold-italic-underline', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text bold italic underline>
-            Bold italic underlined text
-          </Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'bold-italic-underline',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text bold italic underline>
+              Bold italic underlined text
+            </Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('muted-small-italic', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text variant="muted" size="sm" italic>
-            Muted small italic text
-          </Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'muted-small-italic',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text variant="muted" size="sm" italic>
+              Muted small italic text
+            </Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('danger-bold-uppercase', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text variant="danger" bold uppercase>
-            Danger bold uppercase text
-          </Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'danger-bold-uppercase',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text variant="danger" bold uppercase>
+              Danger bold uppercase text
+            </Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('monospace-tabular-small', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <div style={{padding: 8}}>
-          <Text monospace tabular size="sm">
-            42,195.00
-          </Text>
-        </div>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'monospace-tabular-small',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Text monospace tabular size="sm">
+              42,195.00
+            </Text>
+          </div>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
 
-    it.snapshot('paragraph-in-container', () => (
-      <ThemeProvider theme={themes[themeName]}>
-        <Container padding="md" border="primary" width="300px">
-          <Text as="p" density="comfortable">
-            A paragraph of text inside a bordered container with comfortable line height
-            for readable body copy.
-          </Text>
-        </Container>
-      </ThemeProvider>
-    ));
+    it.snapshot(
+      'paragraph-in-container',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <Container padding="md" border="primary" width="300px">
+            <Text as="p" density="comfortable">
+              A paragraph of text inside a bordered container with comfortable line height
+              for readable body copy.
+            </Text>
+          </Container>
+        </ThemeProvider>
+      ),
+      {theme: themeName}
+    );
   });
 });

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -2,6 +2,40 @@ import type {ReactElement} from 'react';
 
 import {closeBrowser, takeSnapshot} from './snapshot';
 
+interface SnapshotDetails {
+  displayName: string;
+  fileSlug: string;
+  group: string | null;
+}
+
+/**
+ * Parses Jest's `currentTestName` to extract snapshot details.
+ *
+ * Jest joins describe blocks and test name with spaces, e.g.:
+ *   "Button dark snapshot: default"
+ *
+ * We split on the " snapshot: " marker (added by snapshotTest) to separate:
+ *   - group: the describe ancestry ("Button dark" -> "Button/dark")
+ *   - displayName: the test name passed to it.snapshot ("default")
+ *   - fileSlug: a path-safe filename combining both ("button/dark/default")
+ */
+function parseSnapshotDetails(testName: string, fallbackName: string): SnapshotDetails {
+  const parts = testName.split(' snapshot: ');
+  if (parts.length < 2) {
+    return {
+      displayName: fallbackName,
+      fileSlug: fallbackName.toLowerCase(),
+      group: null,
+    };
+  }
+
+  const group = parts[0]!.trim().replace(/\s+/g, '/');
+  const displayName = parts[1]!.trim();
+  const fileSlug = `${group}/${displayName}`.replace(/\s+/g, '').toLowerCase();
+
+  return {displayName, fileSlug, group};
+}
+
 function snapshotTest(
   name: string,
   renderFn: () => ReactElement,
@@ -12,17 +46,15 @@ function snapshotTest(
     if (!testPath) {
       throw new Error('Could not determine test file path');
     }
-    // currentTestName looks like "Button dark snapshot: default".
-    // Everything before " snapshot: " is the describe ancestry → group.
-    const describePrefix = currentTestName?.split(' snapshot: ')[0]?.trim() ?? null;
-    const group = describePrefix ? describePrefix.replace(/\s+/g, '/') : null;
-    const fileSlug = group
-      ? `${group}/${name}`.replace(/\s+/g, '/').toLowerCase()
-      : name.toLowerCase();
+
+    const {displayName, fileSlug, group} = parseSnapshotDetails(
+      currentTestName ?? '',
+      name
+    );
 
     await takeSnapshot({
       fileSlug,
-      displayName: name,
+      displayName,
       renderFn,
       testFilePath: testPath,
       group,

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -2,27 +2,44 @@ import type {ReactElement} from 'react';
 
 import {closeBrowser, takeSnapshot} from './snapshot';
 
-function snapshotTest(name: string, renderFn: () => ReactElement): void {
+function snapshotTest(
+  name: string,
+  renderFn: () => ReactElement,
+  metadata: Record<string, string> = {}
+): void {
   test(`snapshot: ${name}`, async () => {
     const {testPath, currentTestName} = expect.getState();
     if (!testPath) {
       throw new Error('Could not determine test file path');
     }
-    // Use the full test name (including describe ancestors) for unique filenames.
-    // currentTestName looks like "Button theme-light snapshot: priority-default".
-    // Strip the "snapshot: " marker to produce a clean filename.
-    const snapshotName = currentTestName
-      ? currentTestName.replace(/\s*snapshot: /, ' ').trim()
-      : name;
-    await takeSnapshot(snapshotName, renderFn, testPath);
+    // currentTestName looks like "Button dark snapshot: default".
+    // Everything before " snapshot: " is the describe ancestry → group.
+    const describePrefix = currentTestName?.split(' snapshot: ')[0]?.trim() ?? null;
+    const group = describePrefix ? describePrefix.replace(/\s+/g, '/') : null;
+    const fileSlug = group
+      ? `${group}/${name}`.replace(/\s+/g, '/').toLowerCase()
+      : name.toLowerCase();
+
+    await takeSnapshot({
+      fileSlug,
+      displayName: name,
+      renderFn,
+      testFilePath: testPath,
+      group,
+      metadata,
+    });
   });
 }
 
 snapshotTest.each = function snapshotEach<T>(table: T[]) {
-  return (name: string, renderFn: (value: T) => ReactElement) => {
+  return (
+    name: string,
+    renderFn: (value: T) => ReactElement,
+    metadataFn?: (value: T) => Record<string, string>
+  ) => {
     for (const value of table) {
       const testName = name.replace('%s', String(value));
-      snapshotTest(testName, () => renderFn(value));
+      snapshotTest(testName, () => renderFn(value), metadataFn?.(value));
     }
   };
 };
@@ -39,7 +56,11 @@ declare global {
       snapshot: typeof snapshotTest & {
         each: <T>(
           table: T[]
-        ) => (name: string, renderFn: (value: T) => ReactElement) => void;
+        ) => (
+          name: string,
+          renderFn: (value: T) => ReactElement,
+          metadataFn?: (value: T) => Record<string, string>
+        ) => void;
       };
     }
   }

--- a/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
@@ -1,5 +1,6 @@
 // Keep in sync with src/sentry/preprod/snapshots/manifest.py
 export interface SnapshotImageMetadata {
   display_name: string;
+  group?: string | null;
   // Skip height, width and image_file_name as they're handled by the CLI
 }

--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -97,11 +97,23 @@ export async function closeBrowser(): Promise<void> {
   }
 }
 
-export async function takeSnapshot(
-  name: string,
-  renderFn: () => ReactElement,
-  testFilePath: string
-): Promise<void> {
+interface TakeSnapshotOptions {
+  displayName: string;
+  fileSlug: string;
+  group: string | null;
+  metadata: Record<string, string>;
+  renderFn: () => ReactElement;
+  testFilePath: string;
+}
+
+export async function takeSnapshot({
+  fileSlug,
+  displayName,
+  renderFn,
+  testFilePath,
+  group,
+  metadata,
+}: TakeSnapshotOptions): Promise<void> {
   const element = renderFn();
   const fullHTML = renderToHTML(element);
 
@@ -122,8 +134,7 @@ export async function takeSnapshot(
 
     const relativePath = path.relative(PROJECT_ROOT, testFilePath);
     const dirOfTestFile = path.dirname(relativePath);
-    const sanitizedName = name.replace(/[^a-zA-Z0-9_-]/g, '-');
-    const coreFilename = sanitizedName;
+    const coreFilename = fileSlug.replace(/[^a-zA-Z0-9_-]/g, '-');
     const imageFilename = `${coreFilename}.png`;
 
     const outputDir = path.join(getOutputDir(), dirOfTestFile);
@@ -131,15 +142,17 @@ export async function takeSnapshot(
       mkdirSync(outputDir, {recursive: true});
     }
 
-    const metadata: SnapshotImageMetadata = {
-      display_name: name,
+    const meta: SnapshotImageMetadata = {
+      display_name: displayName,
+      group,
+      ...metadata,
     };
 
     await Promise.all([
       fs.writeFile(path.join(outputDir, imageFilename), screenshot),
       fs.writeFile(
         path.join(outputDir, `${coreFilename}.json`),
-        JSON.stringify(metadata, null, 2)
+        JSON.stringify(meta, null, 2)
       ),
     ]);
   } finally {


### PR DESCRIPTION
Updates frontend web snapshots to support grouping snapshots by describe blocks. As an example from our `button.snapshots.tsx`

```
describe("Button", () => {
  describe.each(['light', 'dark'] as const)('%s', themeName => {
    it.snapshot.each<ButtonProps['priority']>([
      'default',
      'primary',
      'danger',
      'warning',
      'link',
      'transparent',
    ])(
      '%s',
      priority => (
        <ThemeProvider theme={themes[themeName]}>
          {/* Buttons need a bit of padding as rootElement.screenshot() clips to the
            element's CSS border-box. For buttons, box-shadows/outlines/focus rings
            extending outside #root get cut off. */}

          <div style={{padding: 8}}>
            <Button priority={priority}>{priority}</Button>
          </div>
        </ThemeProvider>
      ),
      priority => ({theme: themeName, priority: String(priority)})
    );
  });
})
```

Would group each button by “Button/${theme}” (so in practice, two groups, Button/light and Button/dark), each 
containing 6 variants - one for each button priority