### PR TITLE
feat(preprod): Add group support to snapshots frontend

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {InlineCode} from '@sentry/scraps/code';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
@@ -55,7 +56,6 @@ export function SnapshotMainContent({
     if (!currentPair) {
       return null;
     }
-    const displayName = getImageName(currentPair.head_image);
     const totalVariants = selectedItem.pairs.length;
     return (
       <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
@@ -69,9 +69,18 @@ export function SnapshotMainContent({
               />
             )}
             <Stack gap="md">
-              <Text size="lg" bold>
-                {displayName}
-              </Text>
+              <Flex align="center" gap="md">
+                {currentPair.head_image.display_name && (
+                  <Text size="lg" bold>
+                    {currentPair.head_image.display_name}
+                  </Text>
+                )}
+                {currentPair.head_image.image_file_name && (
+                  <InlineCode variant="neutral">
+                    {currentPair.head_image.image_file_name}
+                  </InlineCode>
+                )}
+              </Flex>
               {totalVariants > 1 && (
                 <Text variant="muted" size="sm">
                   {t('Variant %s / %s', variantIndex + 1, totalVariants)}
@@ -164,9 +173,16 @@ export function SnapshotMainContent({
           />
         )}
         <Stack gap="md">
-          <Text size="lg" bold>
-            {displayName}
-          </Text>
+          <Flex align="center" gap="md">
+            {currentImage.display_name && (
+              <Text size="lg" bold>
+                {currentImage.display_name}
+              </Text>
+            )}
+            {currentImage.image_file_name && (
+              <InlineCode variant="neutral">{currentImage.image_file_name}</InlineCode>
+            )}
+          </Flex>
           <Flex align="center" gap="sm">
             <Text variant="muted" size="sm">
               ({statusLabel})

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -51,13 +51,34 @@ export function SnapshotMainContent({
   }
 
   if (selectedItem.type === 'changed') {
-    const displayName = getImageName(selectedItem.pair.head_image);
+    const currentPair = selectedItem.pairs[variantIndex];
+    if (!currentPair) {
+      return null;
+    }
+    const displayName = getImageName(currentPair.head_image);
+    const totalVariants = selectedItem.pairs.length;
     return (
       <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
         <Flex align="center" justify="between" gap="md" padding="xl">
-          <Text size="lg" bold>
-            {displayName}
-          </Text>
+          <Flex align="center" gap="md">
+            {totalVariants > 1 && (
+              <VariantNavigation
+                variantIndex={variantIndex}
+                totalVariants={totalVariants}
+                onVariantChange={onVariantChange}
+              />
+            )}
+            <Stack gap="md">
+              <Text size="lg" bold>
+                {displayName}
+              </Text>
+              {totalVariants > 1 && (
+                <Text variant="muted" size="sm">
+                  {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+                </Text>
+              )}
+            </Stack>
+          </Flex>
           {diffMode === 'split' && (
             <OverlayControls
               showOverlay={showOverlay}
@@ -69,7 +90,7 @@ export function SnapshotMainContent({
         </Flex>
         <Separator orientation="horizontal" />
         <DiffImageDisplay
-          pair={selectedItem.pair}
+          pair={currentPair}
           imageBaseUrl={imageBaseUrl}
           diffImageBaseUrl={diffImageBaseUrl}
           showOverlay={showOverlay}
@@ -94,24 +115,11 @@ export function SnapshotMainContent({
       <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
         <Flex align="center" gap="md" padding="xl">
           {totalVariants > 1 && (
-            <Flex align="center" gap="sm">
-              <Button
-                size="md"
-                priority="transparent"
-                icon={<IconChevron direction="left" />}
-                aria-label={t('Previous variant')}
-                disabled={variantIndex === 0}
-                onClick={() => onVariantChange(variantIndex - 1)}
-              />
-              <Button
-                size="md"
-                priority="transparent"
-                icon={<IconChevron direction="right" />}
-                aria-label={t('Next variant')}
-                disabled={variantIndex === totalVariants - 1}
-                onClick={() => onVariantChange(variantIndex + 1)}
-              />
-            </Flex>
+            <VariantNavigation
+              variantIndex={variantIndex}
+              totalVariants={totalVariants}
+              onVariantChange={onVariantChange}
+            />
           )}
           <Stack gap="md">
             <Text size="lg" bold>
@@ -130,9 +138,14 @@ export function SnapshotMainContent({
     );
   }
 
-  const image = selectedItem.image;
-  const displayName = getImageName(image);
-  const imageUrl = `${imageBaseUrl}${image.key}/`;
+  // added, removed, renamed, unchanged
+  const currentImage = selectedItem.images[variantIndex];
+  if (!currentImage) {
+    return null;
+  }
+  const displayName = getImageName(currentImage);
+  const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
+  const totalVariants = selectedItem.images.length;
   const STATUS_LABELS: Record<string, string> = {
     added: t('Added'),
     removed: t('Removed'),
@@ -143,15 +156,62 @@ export function SnapshotMainContent({
   return (
     <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
       <Flex align="center" gap="md" padding="xl">
-        <Text size="lg" bold>
-          {displayName}
-        </Text>
-        <Text variant="muted" size="sm">
-          ({statusLabel})
-        </Text>
+        {totalVariants > 1 && (
+          <VariantNavigation
+            variantIndex={variantIndex}
+            totalVariants={totalVariants}
+            onVariantChange={onVariantChange}
+          />
+        )}
+        <Stack gap="md">
+          <Text size="lg" bold>
+            {displayName}
+          </Text>
+          <Flex align="center" gap="sm">
+            <Text variant="muted" size="sm">
+              ({statusLabel})
+            </Text>
+            {totalVariants > 1 && (
+              <Text variant="muted" size="sm">
+                {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+              </Text>
+            )}
+          </Flex>
+        </Stack>
       </Flex>
       <Separator orientation="horizontal" />
       <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
+    </Flex>
+  );
+}
+
+function VariantNavigation({
+  variantIndex,
+  totalVariants,
+  onVariantChange,
+}: {
+  onVariantChange: (index: number) => void;
+  totalVariants: number;
+  variantIndex: number;
+}) {
+  return (
+    <Flex align="center" gap="sm">
+      <Button
+        size="md"
+        priority="transparent"
+        icon={<IconChevron direction="left" />}
+        aria-label={t('Previous variant')}
+        disabled={variantIndex === 0}
+        onClick={() => onVariantChange(variantIndex - 1)}
+      />
+      <Button
+        size="md"
+        priority="transparent"
+        icon={<IconChevron direction="right" />}
+        aria-label={t('Next variant')}
+        disabled={variantIndex === totalVariants - 1}
+        onClick={() => onVariantChange(variantIndex + 1)}
+      />
     </Flex>
   );
 }

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -61,10 +61,10 @@ const SECTION_ORDER: SectionConfig[] = [
 ];
 
 interface SnapshotSidebarContentProps {
-  currentItemName: string | null;
+  currentItemKey: string | null;
   items: SidebarItem[];
   onSearchChange: (query: string) => void;
-  onSelectItem: (name: string) => void;
+  onSelectItem: (key: string) => void;
   searchQuery: string;
   totalItemCount: number;
 }
@@ -72,7 +72,7 @@ interface SnapshotSidebarContentProps {
 export function SnapshotSidebarContent({
   items,
   totalItemCount,
-  currentItemName,
+  currentItemKey,
   searchQuery,
   onSearchChange,
   onSelectItem,
@@ -127,14 +127,14 @@ export function SnapshotSidebarContent({
   }, [items, isDiffMode]);
 
   useEffect(() => {
-    if (!listRef.current || !currentItemName) {
+    if (!listRef.current || !currentItemKey) {
       return;
     }
     const el = listRef.current.querySelector(
-      `[data-item-name="${CSS.escape(currentItemName)}"]`
+      `[data-item-name="${CSS.escape(currentItemKey)}"]`
     );
     el?.scrollIntoView({block: 'nearest'});
-  }, [currentItemName]);
+  }, [currentItemKey]);
 
   const isSearching = searchQuery.length > 0;
 
@@ -144,6 +144,34 @@ export function SnapshotSidebarContent({
   };
 
   const isGroupedDiff = isDiffMode && groupedItems !== null;
+
+  const renderItem = (item: SidebarItem) => {
+    const isSelected = item.key === currentItemKey;
+    return (
+      <SidebarItemRow
+        key={item.key}
+        data-item-name={item.key}
+        isSelected={isSelected}
+        onClick={() => onSelectItem(item.key)}
+      >
+        <Flex align="center" gap="sm" flex="1" minWidth="0">
+          <Text
+            size="md"
+            variant={isSelected ? 'accent' : 'muted'}
+            bold={isSelected}
+            ellipsis
+          >
+            {item.name}
+          </Text>
+        </Flex>
+        {item.badge && (
+          <Text variant="muted" size="xs">
+            {item.badge}
+          </Text>
+        )}
+      </SidebarItemRow>
+    );
+  };
 
   return (
     <Stack height="100%" width="100%">
@@ -195,63 +223,13 @@ export function SnapshotSidebarContent({
                 </SidebarSectionTitle>
                 {isExpanded && (
                   <SidebarSectionContent>
-                    {sectionItems.map(item => {
-                      const isSelected = item.name === currentItemName;
-                      return (
-                        <SidebarItemRow
-                          key={item.name}
-                          data-item-name={item.name}
-                          isSelected={isSelected}
-                          onClick={() => onSelectItem(item.name)}
-                        >
-                          <Flex align="center" gap="sm" flex="1" minWidth="0">
-                            <Text
-                              size="md"
-                              variant={isSelected ? 'accent' : 'muted'}
-                              bold={isSelected}
-                              ellipsis
-                            >
-                              {item.name}
-                            </Text>
-                          </Flex>
-                          <DiffItemBadge item={item} />
-                        </SidebarItemRow>
-                      );
-                    })}
+                    {sectionItems.map(renderItem)}
                   </SidebarSectionContent>
                 )}
               </Disclosure>
             );
           })}
-        {!isGroupedDiff &&
-          items.map(item => {
-            const isSelected = item.name === currentItemName;
-
-            return (
-              <SidebarItemRow
-                key={item.name}
-                data-item-name={item.name}
-                isSelected={isSelected}
-                onClick={() => onSelectItem(item.name)}
-              >
-                <Flex align="center" gap="sm" flex="1" minWidth="0">
-                  <Text
-                    size="md"
-                    variant={isSelected ? 'accent' : 'muted'}
-                    bold={isSelected}
-                    ellipsis
-                  >
-                    {item.name}
-                  </Text>
-                </Flex>
-                {item.type === 'solo' && item.images.length > 1 && (
-                  <Text variant="muted" size="xs">
-                    {item.images.length}
-                  </Text>
-                )}
-              </SidebarItemRow>
-            );
-          })}
+        {!isGroupedDiff && items.map(renderItem)}
         {items.length === 0 && (
           <Flex align="center" justify="center" padding="lg">
             <Text variant="muted" size="sm">
@@ -262,28 +240,6 @@ export function SnapshotSidebarContent({
       </Stack>
     </Stack>
   );
-}
-
-function DiffItemBadge({item}: {item: SidebarItem}) {
-  const count = item.type === 'changed' ? item.pairs.length : item.images.length;
-
-  if (count === 1 && item.type === 'changed' && item.pairs[0]!.diff !== null) {
-    return (
-      <Text variant="muted" size="xs">
-        {`${(item.pairs[0]!.diff * 100).toFixed(1)}%`}
-      </Text>
-    );
-  }
-
-  if (count > 1) {
-    return (
-      <Text variant="muted" size="xs">
-        {count}
-      </Text>
-    );
-  }
-
-  return null;
 }
 
 const SidebarSectionTitle = styled(Button)`

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -212,11 +212,7 @@ export function SnapshotSidebarContent({
                             {item.name}
                           </Text>
                         </Flex>
-                        {item.type === 'changed' && item.pair.diff !== null && (
-                          <Text variant="muted" size="xs">
-                            {`${(item.pair.diff * 100).toFixed(1)}%`}
-                          </Text>
-                        )}
+                        <DiffItemBadge item={item} />
                       </SidebarItemRow>
                     ))}
                   </SidebarSectionContent>
@@ -263,6 +259,28 @@ export function SnapshotSidebarContent({
       </Stack>
     </Stack>
   );
+}
+
+function DiffItemBadge({item}: {item: SidebarItem}) {
+  const count = item.type === 'changed' ? item.pairs.length : item.images.length;
+
+  if (count === 1 && item.type === 'changed' && item.pairs[0]!.diff !== null) {
+    return (
+      <Text variant="muted" size="xs">
+        {`${(item.pairs[0]!.diff * 100).toFixed(1)}%`}
+      </Text>
+    );
+  }
+
+  if (count > 1) {
+    return (
+      <Text variant="muted" size="xs">
+        {count}
+      </Text>
+    );
+  }
+
+  return null;
 }
 
 const SidebarSectionTitle = styled(Button)`

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -195,26 +195,29 @@ export function SnapshotSidebarContent({
                 </SidebarSectionTitle>
                 {isExpanded && (
                   <SidebarSectionContent>
-                    {sectionItems.map(item => (
-                      <SidebarItemRow
-                        key={item.name}
-                        data-item-name={item.name}
-                        isSelected={item.name === currentItemName}
-                        onClick={() => onSelectItem(item.name)}
-                      >
-                        <Flex align="center" gap="sm" flex="1" minWidth="0">
-                          <Text
-                            size="md"
-                            variant={item.name === currentItemName ? 'accent' : 'muted'}
-                            bold={item.name === currentItemName}
-                            ellipsis
-                          >
-                            {item.name}
-                          </Text>
-                        </Flex>
-                        <DiffItemBadge item={item} />
-                      </SidebarItemRow>
-                    ))}
+                    {sectionItems.map(item => {
+                      const isSelected = item.name === currentItemName;
+                      return (
+                        <SidebarItemRow
+                          key={item.name}
+                          data-item-name={item.name}
+                          isSelected={isSelected}
+                          onClick={() => onSelectItem(item.name)}
+                        >
+                          <Flex align="center" gap="sm" flex="1" minWidth="0">
+                            <Text
+                              size="md"
+                              variant={isSelected ? 'accent' : 'muted'}
+                              bold={isSelected}
+                              ellipsis
+                            >
+                              {item.name}
+                            </Text>
+                          </Flex>
+                          <DiffItemBadge item={item} />
+                        </SidebarItemRow>
+                      );
+                    })}
                   </SidebarSectionContent>
                 )}
               </Disclosure>

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -22,6 +22,7 @@ import type {
   SnapshotDiffPair,
   SnapshotImage,
 } from 'sentry/views/preprod/types/snapshotTypes';
+import {computeSidebarBadges} from 'sentry/views/preprod/utils/sidebarUtils';
 
 import {SnapshotDevTools} from './header/snapshotDevTools';
 import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
@@ -55,7 +56,7 @@ export default function SnapshotsPage() {
   );
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedItemName, setSelectedItemName] = useState<string | null>(null);
+  const [selectedItemKey, setSelectedItemName] = useState<string | null>(null);
   const [variantIndex, setVariantIndex] = useState(0);
   const [showOverlay, setShowOverlay] = useState(true);
   const [overlayColor, setOverlayColor] = useState<string>(() => {
@@ -99,7 +100,7 @@ export default function SnapshotsPage() {
         }
       }
       for (const [name, pairs] of changedGroups) {
-        items.push({type: 'changed', name, pairs});
+        items.push({type: 'changed', key: `changed:${name}`, name, badge: null, pairs});
       }
 
       const groupImages = (
@@ -117,7 +118,7 @@ export default function SnapshotsPage() {
           }
         }
         for (const [name, images] of groups) {
-          items.push({type, name, images});
+          items.push({type, key: `${type}:${name}`, name, badge: null, images});
         }
       };
 
@@ -126,6 +127,7 @@ export default function SnapshotsPage() {
       groupImages(data.renamed ?? [], 'renamed');
       groupImages(data.unchanged, 'unchanged');
 
+      computeSidebarBadges(items);
       return items;
     }
 
@@ -142,7 +144,13 @@ export default function SnapshotsPage() {
 
     return [...groups.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([name, images]) => ({type: 'solo' as const, name, images}));
+      .map(([name, images]) => ({
+        type: 'solo' as const,
+        key: `solo:${name}`,
+        name,
+        badge: images.length > 1 ? String(images.length) : null,
+        images,
+      }));
   }, [data, comparisonType]);
 
   const filteredItems = useMemo(() => {
@@ -153,11 +161,11 @@ export default function SnapshotsPage() {
     return sidebarItems.filter(item => item.name.toLowerCase().includes(query));
   }, [sidebarItems, searchQuery]);
 
-  const currentItemName =
-    selectedItemName && filteredItems.some(i => i.name === selectedItemName)
-      ? selectedItemName
-      : (filteredItems[0]?.name ?? null);
-  const currentItem = filteredItems.find(i => i.name === currentItemName) ?? null;
+  const currentItem =
+    (selectedItemKey && filteredItems.find(i => i.key === selectedItemKey)) ||
+    filteredItems[0] ||
+    null;
+  const currentItemKey = currentItem?.key ?? null;
 
   // Clamp variantIndex to valid range when the selected item changes implicitly
   // (e.g. search filtering selects a new item with fewer variants)
@@ -175,8 +183,8 @@ export default function SnapshotsPage() {
   };
 
   // Ref so the keydown handler reads current state without re-registering
-  const stateRef = useRef({filteredItems, currentItemName});
-  stateRef.current = {filteredItems, currentItemName};
+  const stateRef = useRef({filteredItems, currentItemKey});
+  stateRef.current = {filteredItems, currentItemKey};
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -189,15 +197,15 @@ export default function SnapshotsPage() {
       }
       e.preventDefault();
 
-      const {filteredItems: items, currentItemName: current} = stateRef.current;
-      const currentIndex = items.findIndex(i => i.name === current);
+      const {filteredItems: items, currentItemKey: current} = stateRef.current;
+      const currentIndex = items.findIndex(i => i.key === current);
       const nextIndex =
         e.key === 'ArrowDown'
           ? Math.min(currentIndex + 1, items.length - 1)
           : Math.max(currentIndex - 1, 0);
 
       if (nextIndex !== currentIndex && items[nextIndex]) {
-        setSelectedItemName(items[nextIndex].name);
+        setSelectedItemName(items[nextIndex].key);
         setVariantIndex(0);
       }
     }
@@ -267,7 +275,7 @@ export default function SnapshotsPage() {
             <SnapshotSidebarContent
               items={filteredItems}
               totalItemCount={sidebarItems.length}
-              currentItemName={currentItemName}
+              currentItemKey={currentItemKey}
               searchQuery={searchQuery}
               onSearchChange={setSearchQuery}
               onSelectItem={handleSelectItem}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -15,10 +15,11 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
-import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
+import {getImageGroup} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDetailsApiResponse,
+  SnapshotDiffPair,
   SnapshotImage,
 } from 'sentry/views/preprod/types/snapshotTypes';
 
@@ -87,33 +88,55 @@ export default function SnapshotsPage() {
     if (comparisonType === 'diff') {
       const items: SidebarItem[] = [];
 
+      const changedGroups = new Map<string, SnapshotDiffPair[]>();
       for (const pair of data.changed) {
-        items.push({type: 'changed', name: getImageName(pair.head_image), pair});
+        const group = getImageGroup(pair.head_image);
+        const existing = changedGroups.get(group);
+        if (existing) {
+          existing.push(pair);
+        } else {
+          changedGroups.set(group, [pair]);
+        }
       }
-      for (const img of data.added) {
-        items.push({type: 'added', name: getImageName(img), image: img});
+      for (const [name, pairs] of changedGroups) {
+        items.push({type: 'changed', name, pairs});
       }
-      for (const img of data.removed) {
-        items.push({type: 'removed', name: getImageName(img), image: img});
-      }
-      for (const img of data.renamed ?? []) {
-        items.push({type: 'renamed', name: getImageName(img), image: img});
-      }
-      for (const img of data.unchanged) {
-        items.push({type: 'unchanged', name: getImageName(img), image: img});
-      }
+
+      const groupImages = (
+        imgs: SnapshotImage[],
+        type: 'added' | 'removed' | 'renamed' | 'unchanged'
+      ) => {
+        const groups = new Map<string, SnapshotImage[]>();
+        for (const img of imgs) {
+          const group = getImageGroup(img);
+          const existing = groups.get(group);
+          if (existing) {
+            existing.push(img);
+          } else {
+            groups.set(group, [img]);
+          }
+        }
+        for (const [name, images] of groups) {
+          items.push({type, name, images});
+        }
+      };
+
+      groupImages(data.added, 'added');
+      groupImages(data.removed, 'removed');
+      groupImages(data.renamed ?? [], 'renamed');
+      groupImages(data.unchanged, 'unchanged');
 
       return items;
     }
 
     const groups = new Map<string, SnapshotImage[]>();
     for (const image of data.images) {
-      const name = getImageName(image);
-      const existing = groups.get(name);
+      const group = getImageGroup(image);
+      const existing = groups.get(group);
       if (existing) {
         existing.push(image);
       } else {
-        groups.set(name, [image]);
+        groups.set(group, [image]);
       }
     }
 
@@ -138,10 +161,13 @@ export default function SnapshotsPage() {
 
   // Clamp variantIndex to valid range when the selected item changes implicitly
   // (e.g. search filtering selects a new item with fewer variants)
+  const variantCount = currentItem
+    ? currentItem.type === 'changed'
+      ? currentItem.pairs.length
+      : currentItem.images.length
+    : 0;
   const safeVariantIndex =
-    currentItem?.type === 'solo'
-      ? Math.min(variantIndex, currentItem.images.length - 1)
-      : variantIndex;
+    variantCount > 0 ? Math.min(variantIndex, variantCount - 1) : 0;
 
   const handleSelectItem = (name: string) => {
     setSelectedItemName(name);

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -99,8 +99,15 @@ export default function SnapshotsPage() {
           changedGroups.set(group, [pair]);
         }
       }
-      for (const [name, pairs] of changedGroups) {
-        items.push({type: 'changed', key: `changed:${name}`, name, badge: null, pairs});
+      for (const [groupKey, pairs] of changedGroups) {
+        const label = pairs[0]!.head_image.group ?? pairs[0]!.head_image.image_file_name;
+        items.push({
+          type: 'changed',
+          key: `changed:${groupKey}`,
+          name: label,
+          badge: null,
+          pairs,
+        });
       }
 
       const groupImages = (
@@ -117,8 +124,15 @@ export default function SnapshotsPage() {
             groups.set(group, [img]);
           }
         }
-        for (const [name, images] of groups) {
-          items.push({type, key: `${type}:${name}`, name, badge: null, images});
+        for (const [groupKey, images] of groups) {
+          const label = images[0]!.group ?? images[0]!.image_file_name;
+          items.push({
+            type,
+            key: `${type}:${groupKey}`,
+            name: label,
+            badge: null,
+            images,
+          });
         }
       };
 
@@ -144,13 +158,16 @@ export default function SnapshotsPage() {
 
     return [...groups.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([name, images]) => ({
-        type: 'solo' as const,
-        key: `solo:${name}`,
-        name,
-        badge: images.length > 1 ? String(images.length) : null,
-        images,
-      }));
+      .map(([groupKey, images]) => {
+        const label = images[0]!.group ?? images[0]!.image_file_name;
+        return {
+          type: 'solo' as const,
+          key: `solo:${groupKey}`,
+          name: label,
+          badge: images.length > 1 ? String(images.length) : null,
+          images,
+        };
+      });
   }, [data, comparisonType]);
 
   const filteredItems = useMemo(() => {

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -4,6 +4,7 @@ import type {BuildDetailsVcsInfo} from './buildDetailsTypes';
 export interface SnapshotImage {
   display_name: string | null;
   image_file_name: string;
+  group?: string | null;
   height: number;
   key: string;
   width: number;
@@ -66,10 +67,14 @@ export function getImageName(image: SnapshotImage): string {
   return image.display_name ?? image.image_file_name;
 }
 
+export function getImageGroup(image: SnapshotImage): string {
+  return image.group ?? getImageName(image);
+}
+
 export type SidebarItem =
   | {type: 'solo'; name: string; images: SnapshotImage[]}
-  | {type: 'changed'; name: string; pair: SnapshotDiffPair}
-  | {type: 'added'; name: string; image: SnapshotImage}
-  | {type: 'removed'; name: string; image: SnapshotImage}
-  | {type: 'renamed'; name: string; image: SnapshotImage}
-  | {type: 'unchanged'; name: string; image: SnapshotImage};
+  | {type: 'changed'; name: string; pairs: SnapshotDiffPair[]}
+  | {type: 'added'; name: string; images: SnapshotImage[]}
+  | {type: 'removed'; name: string; images: SnapshotImage[]}
+  | {type: 'renamed'; name: string; images: SnapshotImage[]}
+  | {type: 'unchanged'; name: string; images: SnapshotImage[]};

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -68,7 +68,7 @@ export function getImageName(image: SnapshotImage): string {
 }
 
 export function getImageGroup(image: SnapshotImage): string {
-  return image.group ?? getImageName(image);
+  return image.group ?? image.image_file_name;
 }
 
 interface SidebarItemBase {

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -71,10 +71,16 @@ export function getImageGroup(image: SnapshotImage): string {
   return image.group ?? getImageName(image);
 }
 
+interface SidebarItemBase {
+  badge: string | null;
+  key: string;
+  name: string;
+}
+
 export type SidebarItem =
-  | {type: 'solo'; name: string; images: SnapshotImage[]}
-  | {type: 'changed'; name: string; pairs: SnapshotDiffPair[]}
-  | {type: 'added'; name: string; images: SnapshotImage[]}
-  | {type: 'removed'; name: string; images: SnapshotImage[]}
-  | {type: 'renamed'; name: string; images: SnapshotImage[]}
-  | {type: 'unchanged'; name: string; images: SnapshotImage[]};
+  | (SidebarItemBase & {type: 'solo'; images: SnapshotImage[]})
+  | (SidebarItemBase & {type: 'changed'; pairs: SnapshotDiffPair[]})
+  | (SidebarItemBase & {
+      type: 'added' | 'removed' | 'renamed' | 'unchanged';
+      images: SnapshotImage[];
+    });

--- a/static/app/views/preprod/utils/sidebarUtils.ts
+++ b/static/app/views/preprod/utils/sidebarUtils.ts
@@ -1,42 +1,28 @@
-import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
 /**
  * Compute badges for sidebar items.
  *
- * - Grouped changed items: "X / Y" (diffed / total in group)
+ * - Grouped changed items: count of variants with diffs
  * - Individual changed items: diff percentage (e.g. "55.4%")
- * - Groups spanning multiple sections: "X / Y" (section count / total in group)
  * - Multi-image items: plain count
  */
 export function computeSidebarBadges(items: SidebarItem[]): void {
-  // Sum image counts per group name across all diff sections
-  const groupTotals = new Map<string, number>();
   for (const item of items) {
-    const count = item.type === 'changed' ? item.pairs.length : item.images.length;
-    groupTotals.set(item.name, (groupTotals.get(item.name) ?? 0) + count);
-  }
-
-  for (const item of items) {
-    const total = groupTotals.get(item.name) ?? 0;
-
     if (item.type === 'changed') {
       const isGroup = defined(item.pairs[0]?.head_image.group);
       if (isGroup) {
         const diffCount = item.pairs.filter(p => p.diff !== null && p.diff > 0).length;
-        item.badge = t('%s / %s', diffCount, total);
+        item.badge = String(diffCount);
       } else if (item.pairs.length === 1 && item.pairs[0]!.diff !== null) {
         item.badge = `${(item.pairs[0]!.diff * 100).toFixed(1)}%`;
       }
       continue;
     }
 
-    const count = item.images.length;
-    if (total > count) {
-      item.badge = t('%s / %s', count, total);
-    } else if (count > 1) {
-      item.badge = String(count);
+    if (item.images.length > 1) {
+      item.badge = String(item.images.length);
     }
   }
 }

--- a/static/app/views/preprod/utils/sidebarUtils.ts
+++ b/static/app/views/preprod/utils/sidebarUtils.ts
@@ -1,0 +1,42 @@
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
+
+/**
+ * Compute badges for sidebar items.
+ *
+ * - Grouped changed items: "X / Y" (diffed / total in group)
+ * - Individual changed items: diff percentage (e.g. "55.4%")
+ * - Groups spanning multiple sections: "X / Y" (section count / total in group)
+ * - Multi-image items: plain count
+ */
+export function computeSidebarBadges(items: SidebarItem[]): void {
+  // Sum image counts per group name across all diff sections
+  const groupTotals = new Map<string, number>();
+  for (const item of items) {
+    const count = item.type === 'changed' ? item.pairs.length : item.images.length;
+    groupTotals.set(item.name, (groupTotals.get(item.name) ?? 0) + count);
+  }
+
+  for (const item of items) {
+    const total = groupTotals.get(item.name) ?? 0;
+
+    if (item.type === 'changed') {
+      const isGroup = defined(item.pairs[0]?.head_image.group);
+      if (isGroup) {
+        const diffCount = item.pairs.filter(p => p.diff !== null && p.diff > 0).length;
+        item.badge = t('%s / %s', diffCount, total);
+      } else if (item.pairs.length === 1 && item.pairs[0]!.diff !== null) {
+        item.badge = `${(item.pairs[0]!.diff * 100).toFixed(1)}%`;
+      }
+      continue;
+    }
+
+    const count = item.images.length;
+    if (total > count) {
+      item.badge = t('%s / %s', count, total);
+    } else if (count > 1) {
+      item.badge = String(count);
+    }
+  }
+}


### PR DESCRIPTION
Adds support to snapshot frontend for handling the "group" field. Will now group snapshots in the sidebar by the respective group they're in.