### PR TITLE
feat(text): Add variant="inherit" to Text primitive

### DIFF
--- a/static/app/components/core/text/heading.tsx
+++ b/static/app/components/core/text/heading.tsx
@@ -57,9 +57,11 @@ export const Heading = styled(
   text-decoration: ${p => getTextDecoration(p)};
 
   color: ${p =>
-    p.theme.tokens.content[
-      p.variant === 'muted' ? 'secondary' : (p.variant ?? 'primary')
-    ]};
+    p.variant === 'inherit'
+      ? undefined
+      : p.theme.tokens.content[
+          p.variant === 'muted' ? 'secondary' : (p.variant ?? 'primary')
+        ]};
 
   overflow: ${p => (p.ellipsis ? 'hidden' : undefined)};
   text-overflow: ${p => (p.ellipsis ? 'ellipsis' : undefined)};

--- a/static/app/components/core/text/text.mdx
+++ b/static/app/components/core/text/text.mdx
@@ -53,7 +53,7 @@ Text components support different sizes: `xs`, `sm`, `md` (default), `lg`, `xl`,
 
 ## Variants
 
-Text components support various color variants: `primary` (default), `muted`, `accent`, `success`, `warning`, `danger`, and `promotion`.
+Text components support various color variants: `primary` (default), `muted`, `accent`, `success`, `warning`, `danger`, `promotion`, and `inherit`.
 
 <Storybook.Demo>
   <Storybook.SideBySide vertical>
@@ -64,6 +64,7 @@ Text components support various color variants: `primary` (default), `muted`, `a
     <Text variant="warning">Warning text</Text>
     <Text variant="danger">Danger text</Text>
     <Text variant="promotion">Promotion text</Text>
+    <Text variant="inherit">Inherit text (inherits color from parent)</Text>
   </Storybook.SideBySide>
 </Storybook.Demo>
 ```jsx
@@ -74,6 +75,7 @@ Text components support various color variants: `primary` (default), `muted`, `a
 <Text variant="warning">Warning text</Text>
 <Text variant="danger">Danger text</Text>
 <Text variant="promotion">Promotion text</Text>
+<Text variant="inherit">Inherit text (inherits color from parent)</Text>
 ```
 
 ## Custom Elements with `as` Prop

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -177,11 +177,10 @@ export const Text = styled(
 
   color: ${p =>
     p.variant === 'inherit'
-      ? 'inherit'
-      : p.variant
-        ? (p.theme.tokens.content[p.variant === 'muted' ? 'secondary' : p.variant] ??
-          p.theme.tokens.content.primary)
-        : p.theme.tokens.content.primary};
+      ? undefined
+      : p.theme.tokens.content[
+          p.variant === 'muted' ? 'secondary' : (p.variant ?? 'primary')
+        ]};
 
   overflow: ${p => (p.ellipsis ? 'hidden' : undefined)};
   text-overflow: ${p => (p.ellipsis ? 'ellipsis' : undefined)};

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -81,9 +81,11 @@ export interface BaseTextProps {
 
   /**
    * Variant determines the style of the text.
+   * - Use a semantic variant (e.g. `primary`, `muted`) to apply a token-based color.
+   * - Use `inherit` to explicitly inherit the color from the parent element.
    * @default primary
    */
-  variant?: ContentVariant | 'muted';
+  variant?: ContentVariant | 'muted' | 'inherit';
 
   /**
    * Determines where line breaks appear when wrapping the text.
@@ -174,10 +176,12 @@ export const Text = styled(
   cursor: ${p => p.cursor ?? undefined};
 
   color: ${p =>
-    p.variant
-      ? (p.theme.tokens.content[p.variant === 'muted' ? 'secondary' : p.variant] ??
-        p.theme.tokens.content.primary)
-      : p.theme.tokens.content.primary};
+    p.variant === 'inherit'
+      ? 'inherit'
+      : p.variant
+        ? (p.theme.tokens.content[p.variant === 'muted' ? 'secondary' : p.variant] ??
+          p.theme.tokens.content.primary)
+        : p.theme.tokens.content.primary};
 
   overflow: ${p => (p.ellipsis ? 'hidden' : undefined)};
   text-overflow: ${p => (p.ellipsis ? 'ellipsis' : undefined)};


### PR DESCRIPTION
Add an inherit variant to Text. The default to Text color is a rough case here that we probably want to migrate away from, as it opts out of the CSS cascade and forces us to provide an override. 

I'm adding this as a temporary backwards compat so we can cleanly opt-out of that mechanism without having it be the default behavior.