### PR TITLE
feat(seer): Add a message to seer settings when Gen AI Features are disabled

### DIFF
--- a/static/gsApp/views/seerAutomation/components/aiFeaturesAreDisabledBanner.tsx
+++ b/static/gsApp/views/seerAutomation/components/aiFeaturesAreDisabledBanner.tsx
@@ -32,7 +32,7 @@ export function AiFeaturesAreDisabledBanner() {
       });
     },
     onSuccess: updated => {
-      addSuccessMessage(t('Generative AI Features enabled'));
+      addSuccessMessage(t('Generative AI features enabled'));
       updateOrganization(updated);
     },
     onError: () => addErrorMessage(t('Unable to save change')),
@@ -42,14 +42,14 @@ export function AiFeaturesAreDisabledBanner() {
     <Container border="warning" radius="md" overflow="hidden">
       <Stack>
         <Alert system showIcon={false} variant="warning">
-          {t('Generative AI Features are disabled for your organization.')}
+          {t('Generative AI features are disabled for your organization.')}
         </Alert>
         <Flex align="center" gap="xl" padding="2xl">
           {hasWriteAccess ? (
             <Fragment>
               <Text>
                 {tct(
-                  'Seer is part of your plan, but you need to enable Generative AI Features in your organization in order to use it. Seer includes Autofix and Code Review. Read more about [seer:Seer] and other [ai:generative AI features] in the docs.',
+                  'Seer is part of your plan, but you need to enable generative AI features in your organization in order to use it. Seer includes Autofix and Code Review. Read more about [seer:Seer] and other [ai:generative AI features] in the docs.',
                   {
                     seer: (
                       <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/" />
@@ -67,7 +67,7 @@ export function AiFeaturesAreDisabledBanner() {
           ) : (
             <Text>
               {tct(
-                'Seer is part of your plan, but you need an admin to enable Generative AI Features in your organization in order to use it. Seer includes Autofix and Code Review. Read more about [seer:Seer] and other [ai:generative AI features] in the docs.',
+                'Seer is part of your plan, but you need an admin to enable generative AI features in your organization in order to use it. Seer includes Autofix and Code Review. Read more about [seer:Seer] and other [ai:generative AI features] in the docs.',
                 {
                   seer: (
                     <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/" />

--- a/static/gsApp/views/seerAutomation/components/aiFeaturesAreDisabledBanner.tsx
+++ b/static/gsApp/views/seerAutomation/components/aiFeaturesAreDisabledBanner.tsx
@@ -1,0 +1,86 @@
+import {Fragment} from 'react';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {updateOrganization} from 'sentry/actionCreators/organizations';
+import {t, tct} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export function AiFeaturesAreDisabledBanner() {
+  const organization = useOrganization();
+
+  const hasWriteAccess = organization.access.includes('org:write');
+
+  const {mutate} = useMutation({
+    mutationFn: () => {
+      addLoadingMessage(t('Saving changes...'));
+      return fetchMutation<Organization>({
+        method: 'PUT',
+        url: `/organizations/${organization.slug}/`,
+        data: {hideAiFeatures: false}, // Hard-coded so we only go in the 'enable AI' direction
+      });
+    },
+    onSuccess: updated => {
+      addSuccessMessage(t('Generative AI Features enabled'));
+      updateOrganization(updated);
+    },
+    onError: () => addErrorMessage(t('Unable to save change')),
+  });
+
+  return (
+    <Container border="warning" radius="md" overflow="hidden">
+      <Stack>
+        <Alert system showIcon={false} variant="warning">
+          {t('Generative AI Features are disabled for your organization.')}
+        </Alert>
+        <Flex align="center" gap="xl" padding="2xl">
+          {hasWriteAccess ? (
+            <Fragment>
+              <Text>
+                {tct(
+                  'Seer is part of your plan, but you need to enable Generative AI Features in your organization in order to use it. Seer includes Autofix and Code Review. Read more about [seer:Seer] and other [ai:generative AI features] in the docs.',
+                  {
+                    seer: (
+                      <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/" />
+                    ),
+                    ai: (
+                      <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/#ai-powered-features" />
+                    ),
+                  }
+                )}
+              </Text>
+              <Button size="sm" priority="default" onClick={() => mutate()}>
+                {t('Enable Generative AI Features')}
+              </Button>
+            </Fragment>
+          ) : (
+            <Text>
+              {tct(
+                'Seer is part of your plan, but you need an admin to enable Generative AI Features in your organization in order to use it. Seer includes Autofix and Code Review. Read more about [seer:Seer] and other [ai:generative AI features] in the docs.',
+                {
+                  seer: (
+                    <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/" />
+                  ),
+                  ai: (
+                    <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/#ai-powered-features" />
+                  ),
+                }
+              )}
+            </Text>
+          )}
+        </Flex>
+      </Stack>
+    </Container>
+  );
+}

--- a/static/gsApp/views/seerAutomation/index.tsx
+++ b/static/gsApp/views/seerAutomation/index.tsx
@@ -12,6 +12,7 @@ import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {AiSetupDataConsent} from 'getsentry/components/ai/AiSetupDataConsent';
+import {AiFeaturesAreDisabledBanner} from 'getsentry/views/seerAutomation/components/aiFeaturesAreDisabledBanner';
 
 export default function SeerAutomationRoot() {
   const organization = useOrganization();
@@ -20,7 +21,13 @@ export default function SeerAutomationRoot() {
   if (organization.hideAiFeatures) {
     return (
       <AnalyticsArea name="seer">
-        <NoAccess />
+        <Stack gap="lg">
+          {organization.features.includes('seat-based-seer-enabled') ? (
+            <AiFeaturesAreDisabledBanner />
+          ) : (
+            <NoAccess />
+          )}
+        </Stack>
       </AnalyticsArea>
     );
   }

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -40,7 +40,6 @@ export function SeerAutomationSettings() {
           }
         )}
       />
-
       <SeerSettingsPageContent>
         <Form
           saveOnBlur

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -40,6 +40,7 @@ export function SeerAutomationSettings() {
           }
         )}
       />
+
       <SeerSettingsPageContent>
         <Form
           saveOnBlur


### PR DESCRIPTION
Before we didn't do a great job explaining why Seer is disabled. This is one condition that we can explain better, and give people the button to recover from.

**Before**
<img width="1081" height="235" alt="SCR-20260317-omwu" src="https://github.com/user-attachments/assets/da7074f9-21dc-4a8b-8666-838a0acbccf0" />


**After - as an admin**
<img width="1083" height="250" alt="SCR-20260317-osha" src="https://github.com/user-attachments/assets/86e7054d-690a-401b-a6d5-ea1e84390275" />

**After - without write permissions**
<img width="1079" height="247" alt="SCR-20260317-osnx" src="https://github.com/user-attachments/assets/e7cd06b3-2eca-46cb-b429-6cd5591ea2e9" />
