### PR TITLE
fix(claude integration): use installation path for Claude Code in explorer handoff

### DIFF
--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -14,7 +14,6 @@ from requests import HTTPError
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from sentry import features
-from sentry.integrations.claude_code.integration import PROVIDER_KEY as CLAUDE_CODE_PROVIDER_KEY
 from sentry.integrations.coding_agent.client import CodingAgentClient
 from sentry.integrations.coding_agent.integration import CodingAgentIntegration
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
@@ -44,8 +43,8 @@ def _resolve_client(
     """
     Resolve the coding agent client and/or installation for the given parameters.
 
-    For API-driven agents (GitHub Copilot, Claude Code), returns a client directly.
-    For UI-handoff agents (Cursor), returns an installation.
+    For per-user token agents (GitHub Copilot), returns a client directly.
+    For org-installed integrations (Claude Code, Cursor), returns an installation.
 
     Returns:
         Tuple of (client, installation). Exactly one will be non-None.
@@ -65,13 +64,7 @@ def _resolve_client(
         return GithubCopilotAgentClient(user_access_token), None
 
     if integration_id is not None:
-        integration, installation = _validate_and_get_integration(organization, integration_id)
-
-        # API-driven agents (e.g., Claude Code) get a direct client
-        if integration.provider == CLAUDE_CODE_PROVIDER_KEY:
-            return installation.get_client(), None
-
-        # UI-handoff agents (e.g., Cursor) use installation.launch()
+        _integration, installation = _validate_and_get_integration(organization, integration_id)
         return None, installation
 
     raise ValidationError("Either integration_id or provider must be provided")
@@ -129,11 +122,7 @@ def launch_coding_agents(
 
         try:
             if client is not None:
-                # User-authenticated client (e.g., GitHub Copilot)
                 coding_agent_state = client.launch(webhook_url="", request=launch_request)
-                # Set integration_id here for org-installed integrations like Claude Code.
-                if integration_id is not None:
-                    coding_agent_state.integration_id = integration_id
             elif installation is not None:
                 # Org-installed integration (e.g., Cursor)
                 coding_agent_state = installation.launch(launch_request)

--- a/tests/sentry/seer/explorer/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/explorer/test_coding_agent_handoff.py
@@ -229,21 +229,18 @@ class TestResolveClient(TestCase):
         mock_validate.assert_called_once_with(self.organization, 1)
 
     @patch(f"{MOCK_HANDOFF_PATH}._validate_and_get_integration")
-    def test_returns_client_for_claude_code(self, mock_validate):
+    def test_returns_installation_for_claude_code(self, mock_validate):
         mock_integration = MagicMock()
         mock_integration.provider = "claude_code"
         mock_installation = MagicMock()
-        mock_client = MagicMock()
-        mock_installation.get_client.return_value = mock_client
         mock_validate.return_value = (mock_integration, mock_installation)
 
         client, installation = _resolve_client(
             self.organization, integration_id=1, provider=None, user_id=None
         )
 
-        assert client is mock_client
-        assert installation is None
-        mock_installation.get_client.assert_called_once()
+        assert client is None
+        assert installation is mock_installation
 
     @patch(f"{MOCK_HANDOFF_PATH}.features.has", return_value=True)
     @patch(f"{MOCK_HANDOFF_PATH}.github_copilot_identity_service")


### PR DESCRIPTION
Had decided to skip installation path and use client directly because claude didn't have a webhook url, but then agents weren't persisting between runs. Now, we use the path and the url is unused safely. 

Updated tests to match