### PR TITLE
feat(claude integration): return full text block alongside URL

### DIFF
--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -733,8 +733,13 @@ def get_claude_code_client(clients, agent_id, org_id, integration_id: int | None
     return client
 
 
-def extract_result_url_from_events(events: list[ClaudeSessionEvent]) -> str | None:
-    """Extract a GitHub PR or branch URL from session events."""
+def extract_result_from_events(events: list[ClaudeSessionEvent]) -> tuple[str | None, str | None]:
+    """Extract a GitHub PR or branch URL and its surrounding text block from session events.
+
+    Returns:
+        Tuple of (url, text_block). text_block is the full text content of the agent
+        event block that contained the URL, suitable for display as a result description.
+    """
     pr_pattern = re.compile(r"https://github\.com/[^/]+/[^/]+/pull/\d+")
     branch_pattern = re.compile(r"https://github\.com/[^/]+/[^/]+/tree/[-\w./]*[-\w]")
 
@@ -746,12 +751,12 @@ def extract_result_url_from_events(events: list[ClaudeSessionEvent]) -> str | No
                 text = block.get("text", "")
                 pr_match = pr_pattern.search(text)
                 if pr_match:
-                    return pr_match.group(0)
+                    return pr_match.group(0), text
                 branch_match = branch_pattern.search(text)
                 if branch_match:
-                    return branch_match.group(0)
+                    return branch_match.group(0), text
 
-    return None
+    return None, None
 
 
 def build_result_from_events(
@@ -763,8 +768,9 @@ def build_result_from_events(
 ) -> tuple[Any | None, CodingAgentStatus]:
     result = None
     pr_url = None
+    description = ""
     if new_status == CodingAgentStatus.COMPLETED:
-        pr_url = extract_result_url_from_events(events)
+        pr_url, description = extract_result_from_events(events)
         if not pr_url:
             logger.warning(
                 "coding_agent.claude_code.no_result_url_in_response",
@@ -777,6 +783,8 @@ def build_result_from_events(
             agent_name=agent_name,
             pr_url=pr_url,
         )
+        if result:
+            result.description = description or ""
     except Exception:
         logger.exception(
             "coding_agent.claude_code.build_result_error",

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -768,7 +768,7 @@ def build_result_from_events(
 ) -> tuple[Any | None, CodingAgentStatus]:
     result = None
     pr_url = None
-    description = ""
+    description: str | None = None
     if new_status == CodingAgentStatus.COMPLETED:
         pr_url, description = extract_result_from_events(events)
         if not pr_url:

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -10,7 +10,7 @@ from sentry.integrations.github_copilot.models import (
 )
 from sentry.seer.autofix.coding_agent import (
     _launch_agents_for_repos,
-    extract_result_url_from_events,
+    extract_result_from_events,
     poll_claude_code_agents,
     poll_github_copilot_agents,
 )
@@ -703,41 +703,40 @@ def _make_agent_event(text: str) -> ClaudeSessionEvent:
     return ClaudeSessionEvent(type="agent", content=[{"type": "text", "text": text}])
 
 
-class TestExtractResultUrlFromEvents(TestCase):
+class TestExtractResultFromEvents(TestCase):
     def test_extracts_pr_url(self):
-        events = [_make_agent_event("PR created: https://github.com/org/repo/pull/123")]
-        assert extract_result_url_from_events(events) == "https://github.com/org/repo/pull/123"
+        text = "PR created: https://github.com/org/repo/pull/123"
+        events = [_make_agent_event(text)]
+        url, block = extract_result_from_events(events)
+        assert url == "https://github.com/org/repo/pull/123"
+        assert block == text
 
     def test_extracts_branch_url(self):
-        events = [_make_agent_event("Pushed to https://github.com/org/repo/tree/my-branch")]
-        assert (
-            extract_result_url_from_events(events) == "https://github.com/org/repo/tree/my-branch"
-        )
+        text = "Pushed to https://github.com/org/repo/tree/my-branch"
+        events = [_make_agent_event(text)]
+        url, block = extract_result_from_events(events)
+        assert url == "https://github.com/org/repo/tree/my-branch"
+        assert block == text
 
     def test_strips_trailing_period(self):
         events = [_make_agent_event("See https://github.com/org/repo/tree/my-branch.")]
-        assert (
-            extract_result_url_from_events(events) == "https://github.com/org/repo/tree/my-branch"
-        )
+        url, _ = extract_result_from_events(events)
+        assert url == "https://github.com/org/repo/tree/my-branch"
 
     def test_strips_trailing_comma(self):
         events = [_make_agent_event("https://github.com/org/repo/tree/my-branch, ready")]
-        assert (
-            extract_result_url_from_events(events) == "https://github.com/org/repo/tree/my-branch"
-        )
+        url, _ = extract_result_from_events(events)
+        assert url == "https://github.com/org/repo/tree/my-branch"
 
     def test_branch_with_slashes(self):
         events = [_make_agent_event("https://github.com/org/repo/tree/feat/sub/thing")]
-        assert (
-            extract_result_url_from_events(events)
-            == "https://github.com/org/repo/tree/feat/sub/thing"
-        )
+        url, _ = extract_result_from_events(events)
+        assert url == "https://github.com/org/repo/tree/feat/sub/thing"
 
     def test_branch_with_dots_in_name(self):
         events = [_make_agent_event("https://github.com/org/repo/tree/v1.2.3-fix")]
-        assert (
-            extract_result_url_from_events(events) == "https://github.com/org/repo/tree/v1.2.3-fix"
-        )
+        url, _ = extract_result_from_events(events)
+        assert url == "https://github.com/org/repo/tree/v1.2.3-fix"
 
     def test_pr_preferred_over_branch(self):
         events = [
@@ -746,23 +745,27 @@ class TestExtractResultUrlFromEvents(TestCase):
                 "and PR https://github.com/org/repo/pull/42"
             )
         ]
-        assert extract_result_url_from_events(events) == "https://github.com/org/repo/pull/42"
+        url, _ = extract_result_from_events(events)
+        assert url == "https://github.com/org/repo/pull/42"
 
     def test_returns_none_when_no_url(self):
         events = [_make_agent_event("All done, no link.")]
-        assert extract_result_url_from_events(events) is None
+        url, block = extract_result_from_events(events)
+        assert url is None
+        assert block is None
 
     def test_returns_none_for_empty_events(self):
-        assert extract_result_url_from_events([]) is None
+        url, block = extract_result_from_events([])
+        assert url is None
+        assert block is None
 
     def test_searches_most_recent_event_first(self):
         events = [
             _make_agent_event("https://github.com/org/repo/tree/old-branch"),
             _make_agent_event("https://github.com/org/repo/tree/new-branch"),
         ]
-        assert (
-            extract_result_url_from_events(events) == "https://github.com/org/repo/tree/new-branch"
-        )
+        url, _ = extract_result_from_events(events)
+        assert url == "https://github.com/org/repo/tree/new-branch"
 
     def test_skips_non_agent_events(self):
         events = [
@@ -772,7 +775,9 @@ class TestExtractResultUrlFromEvents(TestCase):
             ),
             _make_agent_event("No URL here"),
         ]
-        assert extract_result_url_from_events(events) is None
+        url, block = extract_result_from_events(events)
+        assert url is None
+        assert block is None
 
 
 class TestPollClaudeCodeAgents(TestCase):


### PR DESCRIPTION
Change claude integration to return full response text as description on coding agent card. This is the backend half which will be followed up with a frontend change.