### PR TITLE
feat(alerts): Report in Sentry and headers whether legacy models were used

### DIFF
--- a/src/sentry/workflow_engine/utils/legacy_metric_tracking.py
+++ b/src/sentry/workflow_engine/utils/legacy_metric_tracking.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, Literal, TypeVar
 
+import sentry_sdk
 from django.http import HttpResponseBase
 
 from sentry.utils import metrics
@@ -36,6 +37,12 @@ def report_used_legacy_models() -> None:
     track_alert_endpoint_execution decorator exits.
     """
     _legacy_models_used.set(True)
+
+
+# Since backported API implementations should be functionally equivalent to the
+# legacy implementations, it's helpful to include this header to make it explicit
+# which was used so that testers and bug reporters can confirm the source of their data.
+_LEGACY_MODELS_HEADER = "X-Legacy-Models"
 
 
 def track_alert_endpoint_execution(
@@ -67,13 +74,18 @@ def track_alert_endpoint_execution(
             # Reset the context var for this request
             token = _legacy_models_used.set(False)
 
+            legacy_models: bool | None = None
             try:
                 # Execute the endpoint
                 response = func(*args, **kwargs)
+                if isinstance(response, HttpResponseBase):
+                    legacy_models = _legacy_models_used.get()
+                    if not response.has_header(_LEGACY_MODELS_HEADER):
+                        response.headers[_LEGACY_MODELS_HEADER] = str(legacy_models).lower()
                 return response
             finally:
-                # Report the metric after execution
-                legacy_models = _legacy_models_used.get()
+                if legacy_models is None:
+                    legacy_models = _legacy_models_used.get()
 
                 metrics.incr(
                     "alert_endpoint.executed",
@@ -82,6 +94,10 @@ def track_alert_endpoint_execution(
                         "method": method,
                         "legacy_models": str(legacy_models).lower(),
                     },
+                )
+                # Tag our spans so we can more easily do bulk analysis on them in Sentry.
+                sentry_sdk.get_isolation_scope().set_tag(
+                    "legacy_models", str(legacy_models).lower()
                 )
                 # Reset the context var
                 _legacy_models_used.reset(token)

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -85,6 +85,26 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             owner=Actor.from_id(user_id=None, team_id=self.team2.id),
         )
 
+    @with_feature("organizations:incidents")
+    def test_legacy_models_header(self) -> None:
+        """
+        Test that X-Legacy-Models header reflects whether legacy models were used.
+        - Legacy path (without workflow-engine feature): header should be "true"
+        - Workflow engine path (with feature): header should be "false"
+        """
+        self.create_alert_rule()
+
+        # Test legacy path - uses AlertRule/Rule models
+        resp = self.get_success_response(self.organization.slug)
+        assert "X-Legacy-Models" in resp
+        assert resp["X-Legacy-Models"] == "true"
+
+        # Test workflow engine path - uses Detector/Workflow models
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            resp = self.get_success_response(self.organization.slug)
+            assert "X-Legacy-Models" in resp
+            assert resp["X-Legacy-Models"] == "false"
+
     def test_no_cron_monitor_rules(self) -> None:
         """
         Tests that the shadow cron monitor rules are NOT returned as part of


### PR DESCRIPTION
When testing, debugging, and analyzing perf impact, it's useful for us to be able to tell which requests used legacy models both as a client and via spans.