### PR TITLE
ref(preprod): Pass through extra fields from image manifests

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -199,7 +199,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         first_class = SnapshotImageResponse.__fields__
         image_list = [
             SnapshotImageResponse(
-                **{k: v for k, v in metadata.extras().items() if k not in first_class},
+                **{k: v for k, v in metadata.dict().items() if k not in first_class},
                 key=key,
                 display_name=metadata.display_name,
                 image_file_name=metadata.image_file_name,

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -196,13 +196,10 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             )
         )
 
+        first_class = SnapshotImageResponse.__fields__
         image_list = [
             SnapshotImageResponse(
-                **{
-                    k: v
-                    for k, v in metadata.extras().items()
-                    if k not in SnapshotImageResponse.__fields__
-                },
+                **{k: v for k, v in metadata.extras().items() if k not in first_class},
                 key=key,
                 display_name=metadata.display_name,
                 image_file_name=metadata.image_file_name,

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -198,6 +198,11 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         image_list = [
             SnapshotImageResponse(
+                **{
+                    k: v
+                    for k, v in metadata.extras().items()
+                    if k not in SnapshotImageResponse.__fields__
+                },
                 key=key,
                 display_name=metadata.display_name,
                 image_file_name=metadata.image_file_name,

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -28,6 +28,9 @@ class SnapshotImageResponse(BaseModel):
     height: int
     previous_image_file_name: str | None = None
 
+    class Config:
+        extra = "allow"
+
 
 class SnapshotDiffPair(BaseModel):
     base_image: SnapshotImageResponse

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -40,7 +40,7 @@ def _build_base_images(
     result: dict[str, SnapshotImageResponse] = {}
     for key, meta in base_images.items():
         result[meta.image_file_name] = SnapshotImageResponse(
-            **{k: v for k, v in meta.extras().items() if k not in first_class},
+            **{k: v for k, v in meta.dict().items() if k not in first_class},
             key=key,
             display_name=meta.display_name,
             image_file_name=meta.image_file_name,

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -36,10 +36,11 @@ def _base_image_from_comparison(name: str, img: ComparisonImageResult) -> Snapsh
 def _build_base_images(
     base_images: dict[str, ImageMetadata],
 ) -> dict[str, SnapshotImageResponse]:
+    first_class = SnapshotImageResponse.__fields__
     result: dict[str, SnapshotImageResponse] = {}
     for key, meta in base_images.items():
         result[meta.image_file_name] = SnapshotImageResponse(
-            **{k: v for k, v in meta.extras().items() if k not in SnapshotImageResponse.__fields__},
+            **{k: v for k, v in meta.extras().items() if k not in first_class},
             key=key,
             display_name=meta.display_name,
             image_file_name=meta.image_file_name,

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -39,6 +39,7 @@ def _build_base_images(
     result: dict[str, SnapshotImageResponse] = {}
     for key, meta in base_images.items():
         result[meta.image_file_name] = SnapshotImageResponse(
+            **{k: v for k, v in meta.extras().items() if k not in SnapshotImageResponse.__fields__},
             key=key,
             display_name=meta.display_name,
             image_file_name=meta.image_file_name,

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -14,10 +14,6 @@ class ImageMetadata(BaseModel):
     class Config:
         extra = "allow"
 
-    def extras(self) -> dict[str, object]:
-        """Return extra fields that are not first-class model fields."""
-        return {k: v for k, v in self.dict().items() if k not in self.__fields__}
-
 
 class SnapshotManifest(BaseModel):
     images: dict[str, ImageMetadata]

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -14,6 +14,10 @@ class ImageMetadata(BaseModel):
     class Config:
         extra = "allow"
 
+    def extras(self) -> dict[str, object]:
+        """Return extra fields that are not first-class model fields."""
+        return {k: v for k, v in self.dict().items() if k not in self.__fields__}
+
 
 class SnapshotManifest(BaseModel):
     images: dict[str, ImageMetadata]


### PR DESCRIPTION
We allow setting arbitrary extra props in image manifest data. But we inadvertently strip those values when passing the manifest data to the frontend. This ensures we pass the extra props to the frontend and also preserve our first-class params. 