### PR TITLE
feat(dashboards): use theme tokens for dashboard widget previews

### DIFF
--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -176,12 +176,12 @@ const Detail = styled('div')`
 `;
 
 const CardBody = styled('div')`
-  background: ${p => p.theme.colors.gray100};
+  background: ${p => p.theme.tokens.background.secondary};
   padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
   max-height: 100px;
   min-height: 100px;
   overflow: hidden;
-  border-bottom: 1px solid ${p => p.theme.colors.gray100};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
 `;
 
 const DateSelected = styled('div')`

--- a/static/app/views/dashboards/manage/gridPreview/chartPreviews/area.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/chartPreviews/area.tsx
@@ -1,10 +1,14 @@
-export function AreaPreview() {
+interface AreaPreviewProps {
+  color: string;
+}
+
+export function AreaPreview({color}: AreaPreviewProps) {
   return (
     <svg
       viewBox="0 0 141 54"
       xmlns="http://www.w3.org/2000/svg"
       preserveAspectRatio="none"
-      fill="#7A5088"
+      fill={color}
       height="100%"
       width="100%"
     >

--- a/static/app/views/dashboards/manage/gridPreview/chartPreviews/bar.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/chartPreviews/bar.tsx
@@ -1,10 +1,14 @@
-export function BarPreview() {
+interface BarPreviewProps {
+  color: string;
+}
+
+export function BarPreview({color}: BarPreviewProps) {
   return (
     <svg
       viewBox="0 0 140 48"
       xmlns="http://www.w3.org/2000/svg"
       preserveAspectRatio="none"
-      fill="#B85586"
+      fill={color}
       height="100%"
       width="100%"
     >

--- a/static/app/views/dashboards/manage/gridPreview/chartPreviews/line.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/chartPreviews/line.tsx
@@ -1,11 +1,15 @@
-export function LinePreview() {
+interface LinePreviewProps {
+  color: string;
+}
+
+export function LinePreview({color}: LinePreviewProps) {
   return (
     <svg
       viewBox="0 0 143 48"
       xmlns="http://www.w3.org/2000/svg"
       preserveAspectRatio="none"
       fill="none"
-      stroke="#E9626E"
+      stroke={color}
       strokeWidth="1"
       height="100%"
       width="100%"

--- a/static/app/views/dashboards/manage/gridPreview/chartPreviews/number.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/chartPreviews/number.tsx
@@ -1,9 +1,13 @@
-export function NumberPreview() {
+interface NumberPreviewProps {
+  color: string;
+}
+
+export function NumberPreview({color}: NumberPreviewProps) {
   return (
     <svg
       viewBox="0 0 70 17"
       xmlns="http://www.w3.org/2000/svg"
-      fill="#444674"
+      fill={color}
       preserveAspectRatio="none"
       height="100%"
       width="100%"

--- a/static/app/views/dashboards/manage/gridPreview/chartPreviews/table.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/chartPreviews/table.tsx
@@ -1,4 +1,11 @@
+import {useTheme} from '@emotion/react';
+
 export function TablePreview() {
+  const theme = useTheme();
+  const headerBg = theme.tokens.background.tertiary;
+  const headerText = theme.tokens.content.secondary;
+  const cellText = theme.tokens.border.secondary;
+
   return (
     <svg
       height="155px"
@@ -8,71 +15,71 @@ export function TablePreview() {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <rect width="157" height="13" fill="#B5AEE2" />
-      <rect x="8" y="6" width="42" height="2" rx="1" fill="#9086D4" />
-      <rect x="8" y="21" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="30" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="39" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="92" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="101" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="110" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="119" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="92" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="101" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="110" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="119" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="128" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="137" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="146" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="128" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="137" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="146" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="92" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="101" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="110" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="119" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="128" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="137" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="146" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="92" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="101" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="110" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="119" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="128" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="137" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="146" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="48" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="6" width="12" height="2" rx="1" fill="#9086D4" />
-      <rect x="137" y="21" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="30" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="39" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="48" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="57" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="66" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="75" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="8" y="84" width="42" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="57" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="66" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="75" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="137" y="84" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="6" width="12" height="2" rx="1" fill="#9086D4" />
-      <rect x="119" y="21" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="30" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="39" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="48" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="57" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="66" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="75" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="119" y="84" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="6" width="12" height="2" rx="1" fill="#9086D4" />
-      <rect x="101" y="21" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="30" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="39" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="48" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="57" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="66" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="75" width="12" height="2" rx="1" fill="#D4D1EC" />
-      <rect x="101" y="84" width="12" height="2" rx="1" fill="#D4D1EC" />
+      <rect width="157" height="13" fill={headerBg} />
+      <rect x="8" y="6" width="42" height="2" rx="1" fill={headerText} />
+      <rect x="8" y="21" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="30" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="39" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="92" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="101" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="110" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="119" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="92" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="101" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="110" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="119" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="128" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="137" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="146" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="128" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="137" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="146" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="92" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="101" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="110" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="119" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="128" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="137" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="146" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="92" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="101" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="110" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="119" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="128" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="137" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="146" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="48" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="6" width="12" height="2" rx="1" fill={headerText} />
+      <rect x="137" y="21" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="30" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="39" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="48" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="57" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="66" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="75" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="8" y="84" width="42" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="57" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="66" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="75" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="137" y="84" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="6" width="12" height="2" rx="1" fill={headerText} />
+      <rect x="119" y="21" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="30" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="39" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="48" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="57" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="66" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="75" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="119" y="84" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="6" width="12" height="2" rx="1" fill={headerText} />
+      <rect x="101" y="21" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="30" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="39" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="48" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="57" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="66" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="75" width="12" height="2" rx="1" fill={cellText} />
+      <rect x="101" y="84" width="12" height="2" rx="1" fill={cellText} />
     </svg>
   );
 }

--- a/static/app/views/dashboards/manage/gridPreview/index.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/index.tsx
@@ -13,37 +13,26 @@ import {
 import type {WidgetLayout, WidgetPreview} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
-import {AreaPreview as WidgetArea} from './chartPreviews/area';
-import {BarPreview as WidgetBar} from './chartPreviews/bar';
-import {LinePreview as WidgetLine} from './chartPreviews/line';
-import {NumberPreview as WidgetBigNumber} from './chartPreviews/number';
-import {TablePreview as WidgetTable} from './chartPreviews/table';
+import {AreaPreview} from './chartPreviews/area';
+import {BarPreview} from './chartPreviews/bar';
+import {LinePreview} from './chartPreviews/line';
+import {NumberPreview} from './chartPreviews/number';
+import {TablePreview} from './chartPreviews/table';
 
-function miniWidget(
-  displayType: DisplayType,
-  chartColor: string
-): () => React.JSX.Element {
+function MiniWidget({displayType, color}: {color: string; displayType: DisplayType}) {
   switch (displayType) {
     case DisplayType.BAR:
-      return function () {
-        return <WidgetBar color={chartColor} />;
-      };
+      return <BarPreview color={color} />;
     case DisplayType.AREA:
     case DisplayType.TOP_N:
-      return function () {
-        return <WidgetArea color={chartColor} />;
-      };
+      return <AreaPreview color={color} />;
     case DisplayType.BIG_NUMBER:
-      return function () {
-        return <WidgetBigNumber color={chartColor} />;
-      };
+      return <NumberPreview color={color} />;
     case DisplayType.TABLE:
-      return WidgetTable;
+      return <TablePreview />;
     case DisplayType.LINE:
     default:
-      return function () {
-        return <WidgetLine color={chartColor} />;
-      };
+      return <LinePreview color={color} />;
   }
 }
 
@@ -73,11 +62,10 @@ export function GridPreview({widgetPreview}: Props) {
     >
       {renderPreview.map(({displayType, layout}, index) => {
         const color = chartPalette[index % chartPalette.length]!;
-        const Preview = miniWidget(displayType, color);
         return (
           <Chart key={uniqueId()} data-grid={{...layout}}>
             <PreviewWrapper>
-              <Preview />
+              <MiniWidget displayType={displayType} color={color} />
             </PreviewWrapper>
           </Chart>
         );
@@ -109,7 +97,7 @@ const Chart = styled('div')`
     width: max(30px, 30%);
     height: 4px;
     background-color: ${p => p.theme.tokens.background.tertiary};
-    border-radius: 8px;
+    border-radius: ${p => p.theme.radius.lg};
   }
 `;
 

--- a/static/app/views/dashboards/manage/gridPreview/index.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/index.tsx
@@ -1,6 +1,7 @@
 import 'react-grid-layout/css/styles.css';
 
 import GridLayout, {WidthProvider} from 'react-grid-layout';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {defined} from 'sentry/utils';
@@ -18,20 +19,31 @@ import {LinePreview as WidgetLine} from './chartPreviews/line';
 import {NumberPreview as WidgetBigNumber} from './chartPreviews/number';
 import {TablePreview as WidgetTable} from './chartPreviews/table';
 
-function miniWidget(displayType: DisplayType): () => React.JSX.Element {
+function miniWidget(
+  displayType: DisplayType,
+  chartColor: string
+): () => React.JSX.Element {
   switch (displayType) {
     case DisplayType.BAR:
-      return WidgetBar;
+      return function () {
+        return <WidgetBar color={chartColor} />;
+      };
     case DisplayType.AREA:
     case DisplayType.TOP_N:
-      return WidgetArea;
+      return function () {
+        return <WidgetArea color={chartColor} />;
+      };
     case DisplayType.BIG_NUMBER:
-      return WidgetBigNumber;
+      return function () {
+        return <WidgetBigNumber color={chartColor} />;
+      };
     case DisplayType.TABLE:
       return WidgetTable;
     case DisplayType.LINE:
     default:
-      return WidgetLine;
+      return function () {
+        return <WidgetLine color={chartColor} />;
+      };
   }
 }
 
@@ -40,6 +52,9 @@ type Props = {
 };
 
 export function GridPreview({widgetPreview}: Props) {
+  const theme = useTheme();
+  const chartPalette = theme.chart.getColorPalette(3);
+
   const definedLayouts = widgetPreview
     .map(({layout}) => layout)
     .filter((layout): layout is WidgetLayout => defined(layout));
@@ -56,8 +71,9 @@ export function GridPreview({widgetPreview}: Props) {
       useCSSTransforms={false}
       measureBeforeMount
     >
-      {renderPreview.map(({displayType, layout}) => {
-        const Preview = miniWidget(displayType);
+      {renderPreview.map(({displayType, layout}, index) => {
+        const color = chartPalette[index % chartPalette.length]!;
+        const Preview = miniWidget(displayType, color);
         return (
           <Chart key={uniqueId()} data-grid={{...layout}}>
             <PreviewWrapper>
@@ -77,10 +93,13 @@ const PreviewWrapper = styled('div')`
   overflow: hidden;
 `;
 
-// ::before is the widget title and ::after is the border
+// ::before is the widget title placeholder
 const Chart = styled('div')`
-  background: white;
+  background: ${p => p.theme.tokens.background.primary};
   position: relative;
+  border: 1px solid ${p => p.theme.tokens.border.secondary};
+  border-radius: ${p => p.theme.radius.sm};
+  overflow: hidden;
 
   &::before {
     content: '';
@@ -89,18 +108,8 @@ const Chart = styled('div')`
     top: 10px;
     width: max(30px, 30%);
     height: 4px;
-    background-color: #d4d1ec;
+    background-color: ${p => p.theme.tokens.background.tertiary};
     border-radius: 8px;
-  }
-
-  &::after {
-    content: '';
-    position: absolute;
-    left: 2px;
-    top: 2px;
-    width: 100%;
-    height: 100%;
-    border: 2px solid #444674;
   }
 `;
 


### PR DESCRIPTION
### Before 
<img width="2930" height="1876" alt="CleanShot 2026-03-18 at 09 02 31@2x" src="https://github.com/user-attachments/assets/30ced379-11a9-4c70-a294-59a28ce5e83b" />

<img width="2930" height="1874" alt="CleanShot 2026-03-18 at 09 02 03@2x" src="https://github.com/user-attachments/assets/712b260b-a3c2-415a-b356-496524e074f3" />

### After
<img width="2930" height="1876" alt="CleanShot 2026-03-18 at 09 03 10@2x" src="https://github.com/user-attachments/assets/02f3059d-0207-47ce-b60c-feddd9f3e194" />

<img width="2930" height="1876" alt="CleanShot 2026-03-18 at 09 02 44@2x" src="https://github.com/user-attachments/assets/8ce3efec-379c-4982-901d-ee8376f9985b" />

