### PR TITLE
ref(debug_files): Use keys instead of set(keys)

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -529,7 +529,7 @@ def batch_assemble(project, files):
     checksums_to_check -= checksums_without_chunks
 
     # 4. Find missing chunks and group them per checksum.
-    all_missing_chunks = find_missing_chunks(project.organization.id, set(chunks_to_check.keys()))
+    all_missing_chunks = find_missing_chunks(project.organization.id, chunks_to_check.keys())
 
     missing_chunks_per_checksum: dict[str, set[str]] = {}
     for chunk in all_missing_chunks:

--- a/src/sentry/debug_files/upload.py
+++ b/src/sentry/debug_files/upload.py
@@ -1,3 +1,4 @@
+from collections.abc import Set
 from datetime import timedelta
 
 import sentry_sdk
@@ -6,7 +7,7 @@ from django.utils import timezone
 from sentry.models.files import FileBlob
 
 
-def find_missing_chunks(organization_id: int, chunks: set[str]) -> list[str]:
+def find_missing_chunks(organization_id: int, chunks: Set[str]) -> list[str]:
     """Returns a list of chunks which are missing for an org."""
     with sentry_sdk.start_span(op="find_missing_chunks") as span:
         span.set_tag("organization_id", organization_id)


### PR DESCRIPTION
Initially, I included this change in #110856, but realized it's technically an independent change, so I split it off.
