### PR TITLE
fix(insights): Filter SDK update alert by package name

### DIFF
--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -381,7 +381,11 @@ export function agentMonitoring({
 } = {}): OnboardingConfig {
   return {
     introduction: params => (
-      <SdkUpdateAlert projectId={params.project.id} minVersion={minVersion} />
+      <SdkUpdateAlert
+        projectId={params.project.id}
+        minVersion={minVersion}
+        packageName={packageName}
+      />
     ),
     install: params =>
       getInstallStep(params, {

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -471,7 +471,11 @@ export const agentMonitoring = ({
   packageName?: `@sentry/${string}`;
 } = {}): OnboardingConfig => ({
   introduction: params => (
-    <SdkUpdateAlert projectId={params.project.id} minVersion={minVersion} />
+    <SdkUpdateAlert
+      projectId={params.project.id}
+      minVersion={minVersion}
+      packageName={packageName}
+    />
   ),
   install: params =>
     getInstallStep(params, {

--- a/static/app/gettingStartedDocs/python/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/python/agentMonitoring.tsx
@@ -15,7 +15,11 @@ const MIN_REQUIRED_VERSION = '2.43.0';
 
 export const agentMonitoring: OnboardingConfig = {
   introduction: params => (
-    <SdkUpdateAlert projectId={params.project.id} minVersion={MIN_REQUIRED_VERSION} />
+    <SdkUpdateAlert
+      projectId={params.project.id}
+      minVersion={MIN_REQUIRED_VERSION}
+      packageName="sentry-sdk"
+    />
   ),
   install: () => {
     return [

--- a/static/app/views/insights/pages/agents/components/sdkUpdateAlert.spec.tsx
+++ b/static/app/views/insights/pages/agents/components/sdkUpdateAlert.spec.tsx
@@ -224,6 +224,49 @@ describe('SdkUpdateAlert', () => {
     });
   });
 
+  it('renders alert when one SDK is outdated and another is up-to-date', async () => {
+    // A project can receive events from multiple SDKs (e.g. Python + Node).
+    // If the Python SDK is outdated but the Node SDK is up-to-date, the alert
+    // should still display for the outdated Python SDK.
+    renderMockSdkUpdateRequest({
+      organization,
+      body: [
+        {
+          projectId: project.id,
+          sdkName: 'sentry.python',
+          sdkVersion: '1.0.0',
+          suggestions: [{type: 'updateSdk', newSdkVersion: '2.5.0'}],
+        },
+        {
+          projectId: project.id,
+          sdkName: 'sentry.javascript.node',
+          sdkVersion: '10.0.0',
+        },
+      ],
+    });
+
+    render(
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="2.0.0"
+        packageName="sentry-sdk"
+      />,
+      {organization}
+    );
+
+    expect(
+      await screen.findByText(
+        textWithMarkupMatcher(
+          'Your sentry-sdk version is below the minimum required for agent monitoring.'
+        )
+      )
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(textWithMarkupMatcher('Update to 2.5.0 or later.'))
+    ).toBeInTheDocument();
+  });
+
   it('renders alert without suggested version when suggestions are not available', async () => {
     renderMockSdkUpdateRequest({
       organization,

--- a/static/app/views/insights/pages/agents/components/sdkUpdateAlert.spec.tsx
+++ b/static/app/views/insights/pages/agents/components/sdkUpdateAlert.spec.tsx
@@ -159,37 +159,6 @@ describe('SdkUpdateAlert', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders alert when Python Flask SDK version is below minimum', async () => {
-    renderMockSdkUpdateRequest({
-      organization,
-      body: [
-        {
-          projectId: project.id,
-          sdkName: 'sentry.python.flask',
-          sdkVersion: '1.0.0',
-          suggestions: [{type: 'updateSdk', newSdkVersion: '2.5.0'}],
-        },
-      ],
-    });
-
-    render(
-      <SdkUpdateAlert
-        projectId={project.id}
-        minVersion="2.0.0"
-        packageName="sentry-sdk"
-      />,
-      {organization}
-    );
-
-    expect(
-      await screen.findByText(
-        textWithMarkupMatcher(
-          'Your sentry-sdk version is below the minimum required for agent monitoring.'
-        )
-      )
-    ).toBeInTheDocument();
-  });
-
   it('renders alert when Node SDK version is below minimum', async () => {
     renderMockSdkUpdateRequest({
       organization,
@@ -222,41 +191,6 @@ describe('SdkUpdateAlert', () => {
 
     expect(
       screen.getByText(textWithMarkupMatcher('Update to 10.5.0 or later.'))
-    ).toBeInTheDocument();
-  });
-
-  it('renders alert when React SDK version is below minimum', async () => {
-    renderMockSdkUpdateRequest({
-      organization,
-      body: [
-        {
-          projectId: project.id,
-          sdkName: 'sentry.javascript.react',
-          sdkVersion: '7.0.0',
-          suggestions: [{type: 'updateSdk', newSdkVersion: '8.5.0'}],
-        },
-      ],
-    });
-
-    render(
-      <SdkUpdateAlert
-        projectId={project.id}
-        minVersion="8.0.0"
-        packageName="@sentry/react"
-      />,
-      {organization}
-    );
-
-    expect(
-      await screen.findByText(
-        textWithMarkupMatcher(
-          'Your @sentry/react version is below the minimum required for agent monitoring.'
-        )
-      )
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByText(textWithMarkupMatcher('Update to 8.5.0 or later.'))
     ).toBeInTheDocument();
   });
 

--- a/static/app/views/insights/pages/agents/components/sdkUpdateAlert.spec.tsx
+++ b/static/app/views/insights/pages/agents/components/sdkUpdateAlert.spec.tsx
@@ -55,7 +55,11 @@ describe('SdkUpdateAlert', () => {
     });
 
     const {container} = render(
-      <SdkUpdateAlert projectId={project.id} minVersion="1.0.0" />,
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="1.0.0"
+        packageName="sentry-sdk"
+      />,
       {organization}
     );
 
@@ -72,7 +76,11 @@ describe('SdkUpdateAlert', () => {
     });
 
     const {container} = render(
-      <SdkUpdateAlert projectId={project.id} minVersion="1.0.0" />,
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="1.0.0"
+        packageName="sentry-sdk"
+      />,
       {organization}
     );
 
@@ -81,7 +89,7 @@ describe('SdkUpdateAlert', () => {
     });
   });
 
-  it('renders alert when SDK version is below minimum with suggested version', async () => {
+  it('renders alert when Python SDK version is below minimum', async () => {
     renderMockSdkUpdateRequest({
       organization,
       body: [
@@ -94,9 +102,14 @@ describe('SdkUpdateAlert', () => {
       ],
     });
 
-    render(<SdkUpdateAlert projectId={project.id} minVersion="2.0.0" />, {
-      organization,
-    });
+    render(
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="2.0.0"
+        packageName="sentry-sdk"
+      />,
+      {organization}
+    );
 
     expect(
       await screen.findByText(
@@ -111,7 +124,7 @@ describe('SdkUpdateAlert', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders alert with JavaScript SDK package name', async () => {
+  it('renders alert when JavaScript SDK version is below minimum', async () => {
     renderMockSdkUpdateRequest({
       organization,
       body: [
@@ -124,9 +137,14 @@ describe('SdkUpdateAlert', () => {
       ],
     });
 
-    render(<SdkUpdateAlert projectId={project.id} minVersion="8.0.0" />, {
-      organization,
-    });
+    render(
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="8.0.0"
+        packageName="@sentry/nextjs"
+      />,
+      {organization}
+    );
 
     expect(
       await screen.findByText(
@@ -141,31 +159,135 @@ describe('SdkUpdateAlert', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders alert with fallback message when package name cannot be determined', async () => {
+  it('renders alert when Python Flask SDK version is below minimum', async () => {
     renderMockSdkUpdateRequest({
       organization,
       body: [
         {
           projectId: project.id,
-          sdkName: 'sentry.unknown',
+          sdkName: 'sentry.python.flask',
           sdkVersion: '1.0.0',
+          suggestions: [{type: 'updateSdk', newSdkVersion: '2.5.0'}],
         },
       ],
     });
 
-    render(<SdkUpdateAlert projectId={project.id} minVersion="2.0.0" />, {
-      organization,
-    });
+    render(
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="2.0.0"
+        packageName="sentry-sdk"
+      />,
+      {organization}
+    );
 
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          'Your SDK version is below the minimum required for agent monitoring.'
+          'Your sentry-sdk version is below the minimum required for agent monitoring.'
+        )
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders alert when Node SDK version is below minimum', async () => {
+    renderMockSdkUpdateRequest({
+      organization,
+      body: [
+        {
+          projectId: project.id,
+          sdkName: 'sentry.javascript.node',
+          sdkVersion: '9.0.0',
+          suggestions: [{type: 'updateSdk', newSdkVersion: '10.5.0'}],
+        },
+      ],
+    });
+
+    render(
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="10.0.0"
+        packageName="@sentry/node"
+      />,
+      {organization}
+    );
+
+    expect(
+      await screen.findByText(
+        textWithMarkupMatcher(
+          'Your @sentry/node version is below the minimum required for agent monitoring.'
         )
       )
     ).toBeInTheDocument();
 
-    expect(screen.getByText(/Update to the latest version\./)).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher('Update to 10.5.0 or later.'))
+    ).toBeInTheDocument();
+  });
+
+  it('renders alert when React SDK version is below minimum', async () => {
+    renderMockSdkUpdateRequest({
+      organization,
+      body: [
+        {
+          projectId: project.id,
+          sdkName: 'sentry.javascript.react',
+          sdkVersion: '7.0.0',
+          suggestions: [{type: 'updateSdk', newSdkVersion: '8.5.0'}],
+        },
+      ],
+    });
+
+    render(
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="8.0.0"
+        packageName="@sentry/react"
+      />,
+      {organization}
+    );
+
+    expect(
+      await screen.findByText(
+        textWithMarkupMatcher(
+          'Your @sentry/react version is below the minimum required for agent monitoring.'
+        )
+      )
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(textWithMarkupMatcher('Update to 8.5.0 or later.'))
+    ).toBeInTheDocument();
+  });
+
+  it('does not render when only a non-matching SDK has updates', async () => {
+    // Reproduces a real scenario: a Flask project also receives Rust events.
+    // The Rust SDK has an update suggestion but the Flask SDK is up-to-date.
+    // The alert should not display the Rust update for a Flask project.
+    renderMockSdkUpdateRequest({
+      organization,
+      body: [
+        {
+          projectId: project.id,
+          sdkName: 'sentry.rust',
+          sdkVersion: '0.41.0',
+          suggestions: [{type: 'updateSdk', newSdkVersion: '0.47.0'}],
+        },
+      ],
+    });
+
+    const {container} = render(
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="2.0.0"
+        packageName="sentry-sdk"
+      />,
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
   });
 
   it('renders alert without suggested version when suggestions are not available', async () => {
@@ -180,9 +302,14 @@ describe('SdkUpdateAlert', () => {
       ],
     });
 
-    render(<SdkUpdateAlert projectId={project.id} minVersion="2.0.0" />, {
-      organization,
-    });
+    render(
+      <SdkUpdateAlert
+        projectId={project.id}
+        minVersion="2.0.0"
+        packageName="sentry-sdk"
+      />,
+      {organization}
+    );
 
     expect(
       await screen.findByText(

--- a/static/app/views/insights/pages/agents/components/sdkUpdateAlert.tsx
+++ b/static/app/views/insights/pages/agents/components/sdkUpdateAlert.tsx
@@ -60,21 +60,19 @@ export function SdkUpdateAlert({
     suggestion => suggestion.type === 'updateSdk'
   )?.newSdkVersion;
 
-  const firstSentence = packageName
-    ? tct('Your [sdkName] version is below the minimum required for agent monitoring.', {
-        sdkName: <code>{packageName}</code>,
-      })
-    : t('Your SDK version is below the minimum required for agent monitoring.');
-
-  const secondSentence = suggestedVersion
-    ? tct('Update to [latestVersion] or later.', {
-        latestVersion: <code>{suggestedVersion}</code>,
-      })
-    : t('Update to the latest version.');
-
   return (
     <Alert variant="warning">
-      {firstSentence} {secondSentence}
+      {tct(
+        'Your [packageName] version is below the minimum required for agent monitoring.',
+        {
+          packageName: <code>{packageName}</code>,
+        }
+      )}{' '}
+      {suggestedVersion
+        ? tct('Update to [latestVersion] or later.', {
+            latestVersion: <code>{suggestedVersion}</code>,
+          })
+        : t('Update to the latest version.')}
     </Alert>
   );
 }

--- a/static/app/views/insights/pages/agents/components/sdkUpdateAlert.tsx
+++ b/static/app/views/insights/pages/agents/components/sdkUpdateAlert.tsx
@@ -3,6 +3,10 @@ import {Alert} from '@sentry/scraps/alert';
 import {t, tct} from 'sentry/locale';
 import {useProjectSdkNeedsUpdate} from 'sentry/utils/useProjectSdkNeedsUpdate';
 
+/**
+ * Maps an SDK name to its installable package name.
+ * Returns null for SDKs not supported by agent monitoring.
+ */
 function getPackageNameFromSdkName(sdkName?: string): string | null {
   if (!sdkName) {
     return null;
@@ -29,8 +33,10 @@ function getPackageNameFromSdkName(sdkName?: string): string | null {
 export function SdkUpdateAlert({
   projectId,
   minVersion,
+  packageName,
 }: {
   minVersion: string;
+  packageName: string;
   projectId: string;
 }) {
   const {needsUpdate, isFetching, isError, data} = useProjectSdkNeedsUpdate({
@@ -42,10 +48,15 @@ export function SdkUpdateAlert({
     return null;
   }
 
-  const sdkUpdate = data?.[0];
-  const packageName = getPackageNameFromSdkName(sdkUpdate?.sdkName);
+  const sdkUpdate = data?.find(
+    update => getPackageNameFromSdkName(update.sdkName) === packageName
+  );
 
-  const suggestedVersion = sdkUpdate?.suggestions?.find(
+  if (!sdkUpdate) {
+    return null;
+  }
+
+  const suggestedVersion = sdkUpdate.suggestions?.find(
     suggestion => suggestion.type === 'updateSdk'
   )?.newSdkVersion;
 

--- a/static/app/views/insights/pages/agents/components/sdkUpdateAlert.tsx
+++ b/static/app/views/insights/pages/agents/components/sdkUpdateAlert.tsx
@@ -2,6 +2,7 @@ import {Alert} from '@sentry/scraps/alert';
 
 import {t, tct} from 'sentry/locale';
 import {useProjectSdkNeedsUpdate} from 'sentry/utils/useProjectSdkNeedsUpdate';
+import {semverCompare} from 'sentry/utils/versions/semverCompare';
 
 /**
  * Maps an SDK name to its installable package name.
@@ -39,24 +40,26 @@ export function SdkUpdateAlert({
   packageName: string;
   projectId: string;
 }) {
-  const {needsUpdate, isFetching, isError, data} = useProjectSdkNeedsUpdate({
+  const {isFetching, isError, data} = useProjectSdkNeedsUpdate({
     minVersion,
     projectId: [projectId],
   });
 
-  if (!needsUpdate || isFetching || isError) {
+  if (isFetching || isError) {
     return null;
   }
 
-  const sdkUpdate = data?.find(
-    update => getPackageNameFromSdkName(update.sdkName) === packageName
+  const validSdkUpdate = data?.find(
+    update =>
+      getPackageNameFromSdkName(update.sdkName) === packageName &&
+      semverCompare(update.sdkVersion || '', minVersion) === -1
   );
 
-  if (!sdkUpdate) {
+  if (!validSdkUpdate) {
     return null;
   }
 
-  const suggestedVersion = sdkUpdate.suggestions?.find(
+  const suggestedVersion = validSdkUpdate.suggestions?.find(
     suggestion => suggestion.type === 'updateSdk'
   )?.newSdkVersion;
 


### PR DESCRIPTION
Filter `SdkUpdateAlert` to only match SDK updates relevant to the current onboarding context.

The `/sdk-updates/` endpoint returns all SDKs with available updates for a project. A project can receive events from multiple SDKs (e.g. a Flask project that also receives Rust events). Previously, the component picked the first entry regardless of relevance, which could show a misleading update alert (e.g. suggesting a Rust SDK update on a Python onboarding page).

Now the component accepts a `packageName` prop and uses `getPackageNameFromSdkName` to match the response entry whose package matches the onboarding context. If no matching SDK is found, no alert is shown.

The callers (Python, Node, JavaScript agent monitoring onboarding) already have `packageName` available and now pass it through.


closes https://linear.app/getsentry/issue/TET-2095/update-sdk-instructions-wrong