### PR TITLE
fix(github_copilot): Handle new task API response format

### DIFF
--- a/src/sentry/integrations/github_copilot/client.py
+++ b/src/sentry/integrations/github_copilot/client.py
@@ -98,8 +98,11 @@ class GithubCopilotAgentClient(CodingAgentClient):
             },
         )
 
-        task_response = GithubCopilotTaskResponse.validate(api_response.json)
-        task = task_response.task
+        response_json = api_response.json
+        if isinstance(response_json, dict) and "task" in response_json:
+            task = GithubCopilotTaskResponse.validate(response_json).task
+        else:
+            task = GithubCopilotTask.validate(response_json)
 
         agent_id = self.encode_agent_id(owner, repo, task.id)
 

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -117,14 +117,12 @@ class GithubCopilotAgentClientTest(TestCase):
 
     @patch.object(GithubCopilotAgentClient, "post")
     def test_launch_with_created_at(self, mock_post: Mock) -> None:
-        """Test launch correctly parses created_at from the response"""
+        """Test launch correctly parses created_at from a direct task response"""
         mock_response = Mock()
         mock_response.json = {
-            "task": {
-                "id": "task-123",
-                "status": "in_progress",
-                "created_at": "2024-06-01T12:00:00Z",
-            }
+            "id": "task-123",
+            "status": "in_progress",
+            "created_at": "2024-06-01T12:00:00Z",
         }
         mock_response.status_code = 200
         mock_post.return_value = mock_response
@@ -144,10 +142,8 @@ class GithubCopilotAgentClientTest(TestCase):
         """Test launch falls back to now() when created_at is missing"""
         mock_response = Mock()
         mock_response.json = {
-            "task": {
-                "id": "task-456",
-                "status": "in_progress",
-            }
+            "id": "task-456",
+            "status": "in_progress",
         }
         mock_response.status_code = 200
         mock_post.return_value = mock_response
@@ -162,6 +158,28 @@ class GithubCopilotAgentClientTest(TestCase):
         assert result.id == "getsentry:sentry:task-456"
         assert result.status == CodingAgentStatus.RUNNING
         assert before <= result.started_at <= after
+
+    @patch.object(GithubCopilotAgentClient, "post")
+    def test_launch_with_legacy_task_envelope(self, mock_post: Mock) -> None:
+        """Test launch handles the legacy {"task": {...}} response envelope"""
+        mock_response = Mock()
+        mock_response.json = {
+            "task": {
+                "id": "task-789",
+                "status": "in_progress",
+                "created_at": "2024-06-01T12:00:00Z",
+            }
+        }
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        result = self.copilot_client.launch(
+            webhook_url="https://example.com/webhook",
+            request=self._make_launch_request(),
+        )
+
+        assert result.id == "getsentry:sentry:task-789"
+        assert result.status == CodingAgentStatus.RUNNING
 
     @patch.object(GithubCopilotAgentClient, "post")
     def test_get_pr_from_graphql_success(self, mock_post: Mock) -> None:
@@ -221,7 +239,7 @@ class GithubCopilotAgentClientTest(TestCase):
         request = self._make_launch_request(prompt)
 
         mock_response = Mock()
-        mock_response.json = {"task": {"id": "t-1", "created_at": "2026-01-01T00:00:00Z"}}
+        mock_response.json = {"id": "t-1", "created_at": "2024-01-01T00:00:00Z"}
         mock_response.status_code = 200
         mock_post.return_value = mock_response
 
@@ -238,7 +256,7 @@ class GithubCopilotAgentClientTest(TestCase):
         request = self._make_launch_request(prompt)
 
         mock_response = Mock()
-        mock_response.json = {"task": {"id": "t-1", "created_at": "2026-01-01T00:00:00Z"}}
+        mock_response.json = {"id": "t-1", "created_at": "2024-01-01T00:00:00Z"}
         mock_response.status_code = 200
         mock_post.return_value = mock_response
 


### PR DESCRIPTION
The GitHub Copilot Tasks API changed its response format — it no longer wraps
responses in a `{"task": {...}}` envelope and instead returns the task object
directly at the top level. This caused a pydantic `ValidationError` when
parsing the response (`task` field required but missing).

The `launch` method now checks whether the response contains a `"task"` key
and parses accordingly, supporting both the new direct format and the legacy
envelope for backward compatibility.

Verified the new format by calling the live API.

Fixes SENTRY-5M80


Agent transcript: https://claudescope.sentry.dev/share/nnOwNScC5NRWw6cq33Lzb0wQLp42fKJ3uv1a5Lu2Vc0