### PR TITLE
fix(sandbox): don't show warning about account not belonging to org on sandbox

### DIFF
--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -10,6 +10,7 @@ from django.views.decorators.cache import never_cache
 from sentry.auth.helper import AuthHelper
 from sentry.auth.store import FLOW_LOGIN
 from sentry.constants import WARN_SESSION_EXPIRED
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org
 from sentry.models.authprovider import AuthProvider
 from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.utils.auth import initiate_login
@@ -82,17 +83,20 @@ class AuthOrganizationLoginView(AuthLoginView):
             auth_provider = None
 
         if request.method == "GET" and request.user.is_authenticated:
-            membership = organization_service.check_membership_by_id(
-                organization_id=organization.id, user_id=request.user.id
-            )
-            if membership is None:
-                messages.add_message(
-                    request,
-                    messages.WARNING,
-                    f"Your account ({request.user.email}) is not a member of the "
-                    f"{organization.name} organization. Ask an organization admin to "
-                    f"invite you, or sign in with a different account.",
+            # Don't show the "not a member" warning for the demo org, since
+            # users visiting the sandbox are expected to not be members.
+            if not (is_demo_mode_enabled() and is_demo_org(organization)):
+                membership = organization_service.check_membership_by_id(
+                    organization_id=organization.id, user_id=request.user.id
                 )
+                if membership is None:
+                    messages.add_message(
+                        request,
+                        messages.WARNING,
+                        f"Your account ({request.user.email}) is not a member of the "
+                        f"{organization.name} organization. Ask an organization admin to "
+                        f"invite you, or sign in with a different account.",
+                    )
 
         session_expired = "session_expired" in request.COOKIES
         if session_expired:

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -4,6 +4,7 @@ from urllib.parse import quote as urlquote
 from urllib.parse import urlencode
 
 from django.contrib.auth import get_user
+from django.contrib.messages import get_messages
 from django.test import override_settings
 from django.urls import reverse
 
@@ -1301,7 +1302,7 @@ class OrganizationAuthLoginDemoModeTest(AuthProviderTestCase):
 
             # Demo mode auto-logs in and redirects, but no warning should be
             # added to the messages framework for the demo org.
-            stored_messages = list(resp.wsgi_request._messages)
+            stored_messages = list(get_messages(resp.wsgi_request))
             assert not any("is not a member of the" in str(m) for m in stored_messages)
 
     def test_non_member_warning_still_shown_for_non_demo_org(self) -> None:

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -1281,6 +1281,52 @@ class OrganizationAuthLoginDemoModeTest(AuthProviderTestCase):
             resp = self.fetch_org_login_page(self.normal_org)
             assert not self.is_logged_in_to_org(resp, self.normal_org)
 
+    def test_no_non_member_warning_for_demo_org(self) -> None:
+        """
+        When demo mode is enabled and a Google OAuth user navigates to the demo org,
+        the "not a member" warning should not be shown.
+        """
+        external_user = self.create_user("external@example.com")
+        self.login_as(external_user)
+
+        with override_options(
+            {
+                "demo-mode.enabled": True,
+                "demo-mode.users": [self.demo_user.id],
+                "demo-mode.orgs": [self.demo_org.id],
+            }
+        ):
+            path = reverse("sentry-auth-organization", args=[self.demo_org.slug])
+            resp = self.client.get(path, follow=True)
+
+            # Demo mode auto-logs in and redirects, but no warning should be
+            # added to the messages framework for the demo org.
+            stored_messages = list(resp.wsgi_request._messages)
+            assert not any("is not a member of the" in str(m) for m in stored_messages)
+
+    def test_non_member_warning_still_shown_for_non_demo_org(self) -> None:
+        """
+        The "not a member" warning should still appear for non-demo orgs
+        even when demo mode is enabled.
+        """
+        external_user = self.create_user("external@example.com")
+        self.login_as(external_user)
+
+        with override_options(
+            {
+                "demo-mode.enabled": True,
+                "demo-mode.users": [self.demo_user.id],
+                "demo-mode.orgs": [self.demo_org.id],
+            }
+        ):
+            path = reverse("sentry-auth-organization", args=[self.normal_org.slug])
+            resp = self.client.get(path)
+
+            assert resp.status_code == 200
+            messages_list = list(resp.context["messages"])
+            assert len(messages_list) == 1
+            assert "is not a member of the" in str(messages_list[0])
+
     def test_demo_user_joins_existing_sso_organization(self) -> None:
         """
         Test that when a demo user is logged in and tries to join an existing SSO organization,


### PR DESCRIPTION
- Don't show the message that the user is not an org on sandbox / demo users. This can happen as a kind of race condition which we should fix separately, but this fixes that sometimes users will see this when visiting sandbox after visiting their org. 

Closes TET-2057