### PR TITLE
perf(issues): Batch nodestore fetches in SimpleEventSerializer

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -11,6 +11,7 @@ import sqlparse
 from django.contrib.auth.models import AnonymousUser
 from sentry_relay.processing import meta_with_chunks
 
+from sentry import options
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.release import GroupEventReleaseSerializer
 from sentry.api.serializers.models.userreport import UserReportSerializerResponse
@@ -22,6 +23,7 @@ from sentry.models.release import Release
 from sentry.models.userreport import UserReport
 from sentry.sdk_updates import SdkSetupState, get_suggested_updates
 from sentry.search.utils import convert_user_tag_to_query, map_device_class_level
+from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.users.models.user import User
@@ -609,6 +611,19 @@ class SimpleEventSerializer(EventSerializer):
     """
 
     def get_attrs(self, item_list, user, **kwargs):
+        # Batch-fetch event bodies from nodestore in a single multi-get RPC.
+        # serialize() accesses properties (tags, message, title,
+        # get_event_metadata, etc.) that fall through to nodestore when the
+        # corresponding Snuba columns are missing from _snuba_data. Without
+        # this pre-fetch, each event triggers a separate Bigtable get — an
+        # N+1 pattern (~100 sequential RPCs, each ~90ms).
+        # Skip events whose node data is already loaded (e.g. when the caller
+        # used eventstore.get_events which calls bind_nodes internally).
+        if options.get("issues.group_events.batch_nodestore_enabled"):
+            unbound = [e for e in item_list if e.data._node_data is None]
+            if unbound:
+                eventstore.backend.bind_nodes(unbound)
+
         crash_files = get_crash_files(item_list)
         serialized_files = {
             file.event_id: serialized

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1083,6 +1083,15 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Killswitch for batched nodestore fetches in group events endpoint.
+# When disabled, falls back to lazy per-event nodestore fetches.
+register(
+    "issues.group_events.batch_nodestore_enabled",
+    default=True,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Killswitch for all Seer services
 #
 # TODO: So far this is only being checked when calling the Seer similar issues service during


### PR DESCRIPTION
## Problem

All endpoints using `SimpleEventSerializer` suffer from N+1 nodestore/Bigtable lookups: `GroupEventsEndpoint`, `ProjectEventsEndpoint`, and `GroupHashesEndpoint`.

### Evidence from production traces

Searching for `SimpleEventSerializer` spans >2s in the last 7 days shows widespread impact, with the worst at **22 seconds**:

| Trace | Transaction | Duration |
|---|---|---|
| [`4c9c9a51...`](https://sentry.sentry.io/explore/traces/trace/4c9c9a51cf67459b871db190b5325cc1) | `/api/0/issues\|groups/{issue_id}/events/` | 22.2s |
| [`cfda6d45...`](https://sentry.sentry.io/explore/traces/trace/cfda6d453fe7466da7648a625c02847c) | `/api/0/organizations/{org}/issues\|groups/{issue_id}/events/` | 21.8s |
| [`70dba92a...`](https://sentry.sentry.io/explore/traces/trace/70dba92a9165454f83bca9005fa6c14f) | `/api/0/organizations/{org}/issues\|groups/{issue_id}/events/` | 21.7s |

Here is a detailed breakdown of one representative trace ([`34432d12...`](https://sentry.sentry.io/explore/traces/trace/34432d124b9a4aca9fbc5d3dfe7a38c0/), span [`979c831f...`](https://sentry.sentry.io/explore/traces/trace/34432d124b9a4aca9fbc5d3dfe7a38c0/?node=span-979c831fb8154304)):

| Operation | Count | Total Duration | Avg Duration |
|---|---|---|---|
| `bigtable.get` | 97 | 8,701ms | 89.7ms |
| `nodestore.get` | 100 | 9,261ms | 92.6ms |

```
http.server                               9,779ms
└─ ratelimit.__call__                     9,758ms
   └─ http.client (gateway→region)        9,753ms
      └─ http.server                      9,703ms
         └─ ratelimit.__call__            9,684ms
            └─ GroupEventsEndpoint.get    9,591ms
               └─ paginate.on_results     9,466ms  ← HERE
                  └─ SimpleEventSerializer 9,466ms
                     └─ get_attrs          9,423ms
                        └─ 100× nodestore.get → bigtable.get
```

### Root cause

`SimpleEventSerializer.serialize()` accesses properties like `obj.tags`, `obj.message`, `obj.title`, and `obj.get_event_metadata()` that fall through to nodestore when the corresponding Snuba columns are missing from `_snuba_data`. Callers typically only provide a handful of Snuba columns (`id`, `project.id`, `issue.id`, `timestamp`), so every property access on every event triggers a separate lazy Bigtable fetch — an N+1 pattern.

## Fix

Add `eventstore.backend.bind_nodes()` in `SimpleEventSerializer.get_attrs()` to batch-fetch all event bodies in a single `get_multi` → `BigtableKVStorage.read_rows(RowSet)` RPC before serialization begins.

Placing the fix in the **serializer** rather than individual endpoints ensures **all callers benefit** — `GroupEventsEndpoint`, `ProjectEventsEndpoint`, `GroupHashesEndpoint`, and any future users.

### Rollback

The `issues.group_events.batch_nodestore_enabled` option (default: `True`) can be set to `False` via configoptions for instant rollback without a deploy.

### Expected performance impact

- **Before**: ~100 sequential Bigtable RPCs × ~93ms = **~9.3 seconds**
- **After**: 1 batched Bigtable `read_rows` call = **~150–400ms**
- **Improvement**: ~25–60× faster serialization

### Why this is safe

- `bind_nodes()` is **idempotent** and well-exercised — `EventSerializer` (the full serializer) already relies on callers to use it
- `SimpleEventSerializer` already handles nodestore-backed data correctly (it just wasn't pre-loaded)
- **No API response shape changes** — the same data is returned, just fetched more efficiently
- `bind_nodes` accesses `NodeData.id` (not `.data`) to collect node IDs, so it does **not** trigger lazy fetches itself

## Follow-up opportunity

A deeper fix would add the missing columns (`title`, `culprit`, `location`, `platform`, `event.type`, `tags.key`, `tags.value`, `user.*`, `message`) to the Snuba queries and pass them through to `_snuba_data`. This would eliminate the nodestore round-trip entirely for `SimpleEventSerializer`. However, `message` and `get_event_metadata()` have **no Snuba fallback** in the `BaseEvent` model, so they'd need new fallback paths. That's a bigger change — this batching fix gives most of the speedup with minimal blast radius.