### PR TITLE
chore(otlp): Remove organizations:span-v2-otlp-processing feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -355,8 +355,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable standalone span ingestion
     manager.add("organizations:standalone-span-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Process OTLP spans via the Span V2 pipeline in Relay
-    manager.add("organizations:span-v2-otlp-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable mobile starfish app start module view
     manager.add("organizations:starfish-mobile-appstart", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable mobile starfish ui module view

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -78,7 +78,6 @@ EXPOSABLE_FEATURES = [
     "projects:span-v2-experimental-processing",
     "projects:span-v2-attachment-processing",
     "projects:trace-attachment-processing",
-    "organizations:span-v2-otlp-processing",
     "projects:relay-upload-endpoint",
 ]
 


### PR DESCRIPTION
Relay [no longer uses this flag](https://github.com/getsentry/relay/blob/33db70bc9fba30bf763561a0a8b72b299e356f53/relay-dynamic-config/src/feature.rs#L136-L139) and it has been [removed from flagpole](https://github.com/getsentry/sentry-options-automator/pull/6868), so it is safe to remove.

Fixes OPE-71.