### PR TITLE
fix(tagstore): Pass requested sort order to Snuba in tag value paginator

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1757,7 +1757,7 @@ class SnubaTagStorage(TagStorage):
             group,
             environment_ids,
             key,
-            orderby="-last_seen",
+            orderby=order_by,
             tenant_ids=tenant_ids,
         )
 

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -1105,11 +1105,86 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
             self.proj1group1,
             [],
             "foo",
+            order_by="-last_seen",
             tenant_ids={"referrer": "r", "organization_id": 1234},
         ).get_result(1)[0]
 
         # top key should be "quux" as it's the most recent than "bar"
         assert top_key.value == "quux"
+
+    @mock.patch.object(
+        SnubaTagStorage.get_group_tag_value_iter,
+        "__defaults__",
+        (
+            "-first_seen",  # orderby default (unchanged)
+            1,  # limit default (set to 1 for test)
+            0,  # offset default (unchanged)
+            None,  # tenant_ids default (unchanged)
+        ),
+    )
+    def test_get_group_tag_value_paginator_sort_by_count_with_limit(self) -> None:
+        """When sorting by count with a limited fetch, the most frequent value should be returned."""
+        # Use a unique fingerprint so we get a fresh group with no setUp noise
+        # "frequent" has 2 events but older last_seen
+        event1 = self.store_event(
+            data={
+                "event_id": "a1" * 16,
+                "message": "count sort test",
+                "platform": "python",
+                "environment": "test",
+                "fingerprint": ["count-sort-test"],
+                "timestamp": (self.now - timedelta(seconds=5)).isoformat(),
+                "tags": {"foo": "frequent"},
+                "user": {"id": "user1"},
+                "exception": exception,
+            },
+            project_id=self.proj1.id,
+        )
+        test_group = event1.group
+
+        self.store_event(
+            data={
+                "event_id": "a2" * 16,
+                "message": "count sort test",
+                "platform": "python",
+                "environment": "test",
+                "fingerprint": ["count-sort-test"],
+                "timestamp": (self.now - timedelta(seconds=4)).isoformat(),
+                "tags": {"foo": "frequent"},
+                "user": {"id": "user1"},
+                "exception": exception,
+            },
+            project_id=self.proj1.id,
+        )
+
+        # "recent" has 1 event but more recent last_seen
+        self.store_event(
+            data={
+                "event_id": "a3" * 16,
+                "message": "count sort test",
+                "platform": "python",
+                "environment": "test",
+                "fingerprint": ["count-sort-test"],
+                "timestamp": self.now.isoformat(),
+                "tags": {"foo": "recent"},
+                "user": {"id": "user2"},
+                "exception": exception,
+            },
+            project_id=self.proj1.id,
+        )
+
+        top_key = self.ts.get_group_tag_value_paginator(
+            test_group,
+            [],
+            "foo",
+            order_by="-times_seen",
+            tenant_ids={"referrer": "r", "organization_id": 1234},
+        ).get_result(1)[0]
+
+        # With limit=1, only 1 value is fetched from Snuba.
+        # Before the fix, it always fetched by -last_seen, so "recent"
+        # would be returned instead of "frequent" (most seen).
+        assert top_key.value == "frequent"
 
     def test_error_upsampling_tag_value_counts(self) -> None:
         """Test that tag value counts are properly weighted when projects use error upsampling."""


### PR DESCRIPTION
Fixes #94727

## Problem

When viewing Tag Details for high-cardinality tags (10k+ distinct values), the top value by count can be missing from the results.

The `get_group_tag_value_paginator` method always fetched the top 1000 values from Snuba ordered by `-last_seen`, regardless of the user's requested sort. It then re-sorted those 1000 values in memory using a `SequencePaginator`.

For tags with more than 1000 distinct values, if the most frequent value wasn't among the 1000 most recently seen, it was silently excluded — causing the Tag Details pane to show incomplete data that doesn't match the tag summary.

## Fix

Pass the actual requested `order_by` to `get_group_tag_value_iter` instead of hardcoding `-last_seen`. This ensures Snuba returns the correct top 1000 values for the requested sort order.

For the vast majority of tags (<1000 distinct values), behavior is unchanged since all values are fetched regardless of sort order.

## Test

- Added `test_get_group_tag_value_paginator_sort_by_count_with_limit` which mocks the fetch limit to 1 and verifies that sorting by count returns the most frequent value, not the most recently seen.
- Fixed `test_get_group_tag_value_paginator_sort_by_last_seen` to explicitly pass `order_by="-last_seen"` instead of relying on the (incorrect) hardcoded default.

### Legal Boilerplate
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.