### PR TITLE
feat(metrics): Refresh metrics panels behind tracemetrics-ui-refresh flag

### DIFF
--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -194,7 +194,6 @@ function Graph({
       <VisualizeLabel
         justify="center"
         align="center"
-        background="tertiary"
         radius="md"
         paddingLeft="sm"
         paddingRight="sm"

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -1,8 +1,11 @@
 import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Text} from '@sentry/scraps/text';
 
 import {IconClock, IconGraph} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -16,6 +19,10 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
 import {ConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
 import type {TableOrientation} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
+import {
+  canUseMetricsMultiAggregateUI,
+  canUseMetricsUIRefresh,
+} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   useMetricLabel,
   useMetricName,
@@ -31,6 +38,7 @@ import {
   useQueryParamsTopEventsLimit,
 } from 'sentry/views/explore/queryParams/context';
 import {EXPLORE_CHART_TYPE_OPTIONS} from 'sentry/views/explore/spans/charts';
+import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 import {useRawCounts} from 'sentry/views/explore/useRawCounts';
 import {
   combineConfidenceForSeries,
@@ -54,11 +62,13 @@ interface MetricsGraphProps {
   additionalActions?: React.ReactNode;
   infoContentHidden?: boolean;
   isMetricOptionsEmpty?: boolean;
+  queryIndex?: number;
 }
 
 export function MetricsGraph({
   timeseriesResult,
   orientation,
+  queryIndex = 0,
   additionalActions,
   infoContentHidden,
   isMetricOptionsEmpty,
@@ -88,6 +98,7 @@ export function MetricsGraph({
       additionalActions={additionalActions}
       infoContentHidden={infoContentHidden}
       isMetricOptionsEmpty={isMetricOptionsEmpty}
+      queryIndex={queryIndex}
     />
   );
 }
@@ -107,7 +118,9 @@ function Graph({
   infoContentHidden,
   additionalActions,
   isMetricOptionsEmpty,
+  queryIndex = 0,
 }: GraphProps) {
+  const organization = useOrganization();
   const aggregate = visualize.yAxis;
   const topEventsLimit = useQueryParamsTopEventsLimit();
   const metricLabel = useMetricLabel();
@@ -176,7 +189,27 @@ function Graph({
     return metricLabel ?? prettifyAggregation(aggregate) ?? aggregate;
   }, [aggregate, metricLabel, metricName, visualizes.length]);
 
-  const Title = <Widget.WidgetTitle title={chartTitle} />;
+  const Title = canUseMetricsUIRefresh(organization) ? (
+    <Flex align="center" gap="xs">
+      <VisualizeLabel
+        justify="center"
+        align="center"
+        background="tertiary"
+        radius="md"
+        paddingLeft="sm"
+        paddingRight="sm"
+        paddingTop="xs"
+        paddingBottom="xs"
+      >
+        <Text bold variant="accent">
+          {getVisualizeLabel(queryIndex)}
+        </Text>
+      </VisualizeLabel>
+      <Widget.WidgetTitle title={chartTitle} />
+    </Flex>
+  ) : (
+    <Widget.WidgetTitle title={chartTitle} />
+  );
 
   const chartIcon =
     visualize.chartType === ChartType.LINE
@@ -230,8 +263,21 @@ function Graph({
   const showEmptyState = isMetricOptionsEmpty && visualize.visible;
   const showChart = visualize.visible && !isMetricOptionsEmpty;
 
+  let height: number | undefined = MINIMIZED_GRAPH_HEIGHT;
+  if (visualize.visible) {
+    if (orientation === 'bottom' || infoContentHidden) {
+      height = STACKED_GRAPH_HEIGHT;
+    } else if (canUseMetricsUIRefresh(organization)) {
+      height = STACKED_GRAPH_HEIGHT;
+    } else {
+      height = undefined;
+    }
+  }
+
   return (
-    <WidgetWrapper hideFooterBorder={orientation === 'bottom'}>
+    <WidgetWrapper
+      hideFooterBorder={orientation === 'bottom' || canUseMetricsUIRefresh(organization)}
+    >
       <Widget
         Title={Title}
         Actions={Actions}
@@ -263,16 +309,14 @@ function Graph({
             />
           )
         }
-        height={
-          visualize.visible
-            ? orientation === 'bottom' || infoContentHidden
-              ? STACKED_GRAPH_HEIGHT
-              : undefined
-            : MINIMIZED_GRAPH_HEIGHT
-        }
+        height={height}
         revealActions="always"
         borderless
       />
     </WidgetWrapper>
   );
 }
+
+const VisualizeLabel = styled(Flex)`
+  background-color: ${p => p.theme.tokens.background.transparent.accent.muted};
+`;

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -13,16 +13,14 @@ import {defined} from 'sentry/utils';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
 import {ConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
 import type {TableOrientation} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
-import {
-  canUseMetricsMultiAggregateUI,
-  canUseMetricsUIRefresh,
-} from 'sentry/views/explore/metrics/metricsFlags';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   useMetricLabel,
   useMetricName,

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -2,6 +2,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {TabList, TabPanels, TabStateProvider} from '@sentry/scraps/tabs';
 
 import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import type {TableOrientation} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
 import {AggregatesTab} from 'sentry/views/explore/metrics/metricInfoTabs/aggregatesTab';
 import {
@@ -11,6 +12,7 @@ import {
 } from 'sentry/views/explore/metrics/metricInfoTabs/metricInfoTabStyles';
 import {SamplesTab} from 'sentry/views/explore/metrics/metricInfoTabs/samplesTab';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {
   useQueryParamsMode,
@@ -33,16 +35,22 @@ export function MetricInfoTabs({
   orientation,
   isMetricOptionsEmpty,
 }: MetricInfoTabsProps) {
+  const organization = useOrganization();
   const visualize = useMetricVisualize();
   const queryParamsMode = useQueryParamsMode();
   const setAggregatesMode = useSetQueryParamsMode();
+
+  const hasMetricsUIRefresh = canUseMetricsUIRefresh(organization);
+
+  const size = hasMetricsUIRefresh ? 'md' : 'xs';
+
   return (
     <TabStateProvider<Mode>
       value={queryParamsMode}
       onChange={mode => {
         setAggregatesMode(mode);
       }}
-      size="xs"
+      size={size}
     >
       {(orientation === 'right' || visualize.visible) && (
         <Flex direction="row" justify="between" align="center" paddingRight="xl">

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -1,0 +1,248 @@
+import type {ReactNode} from 'react';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
+import {
+  createTraceMetricFixtures,
+  initializeTraceMetricsTest,
+} from 'sentry-fixture/tracemetrics';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {MetricPanel} from 'sentry/views/explore/metrics/metricPanel';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+
+function createWrapper({
+  queryParams,
+  traceMetric,
+}: {
+  queryParams: ReadableQueryParams;
+  traceMetric: TraceMetric;
+}) {
+  return function Wrapper({children}: {children: ReactNode}) {
+    return (
+      <MultiMetricsQueryParamsProvider>
+        <MetricsQueryParamsProvider
+          traceMetric={traceMetric}
+          queryParams={queryParams}
+          setQueryParams={() => {}}
+          setTraceMetric={() => {}}
+          removeMetric={() => {}}
+        >
+          {children}
+        </MetricsQueryParamsProvider>
+      </MultiMetricsQueryParamsProvider>
+    );
+  };
+}
+
+function setupMocks(orgSlug: string) {
+  MockApiClient.addMockResponse({
+    url: `/organizations/${orgSlug}/events-timeseries/`,
+    method: 'GET',
+    body: {
+      timeSeries: [TimeSeriesFixture()],
+    },
+  });
+
+  // Catch-all for /events/ requests not matched by specific referrer mocks
+  // (e.g. useRawCounts referrers: api.explore.metrics.raw-count.normal/high-accuracy)
+  MockApiClient.addMockResponse({
+    url: `/organizations/${orgSlug}/events/`,
+    method: 'GET',
+    body: {data: [], meta: {fields: {}, units: {}, dataScanned: 'full'}},
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${orgSlug}/recent-searches/`,
+    method: 'GET',
+    body: [],
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${orgSlug}/recent-searches/`,
+    method: 'POST',
+    body: [],
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/customers/${orgSlug}/`,
+    method: 'GET',
+    body: {},
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${orgSlug}/trace-items/attributes/`,
+    method: 'GET',
+    body: [],
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${orgSlug}/stats_v2/`,
+    method: 'GET',
+    body: {},
+  });
+}
+
+describe('MetricPanel', () => {
+  const traceMetric: TraceMetric = {name: 'bar', type: 'distribution'};
+  const queryParams = new ReadableQueryParams({
+    extrapolate: true,
+    mode: Mode.SAMPLES,
+    query: '',
+    cursor: '',
+    fields: ['id', 'timestamp'],
+    sortBys: [{field: 'timestamp', kind: 'desc'}],
+    aggregateCursor: '',
+    aggregateFields: [new VisualizeFunction('per_second(value)')],
+    aggregateSortBys: [{field: 'per_second(value)', kind: 'desc'}],
+  });
+
+  describe('flag OFF (tracemetrics-enabled only)', () => {
+    const {
+      organization,
+      project,
+      setupPageFilters,
+      setupEventsMock,
+      setupTraceItemsMock,
+    } = initializeTraceMetricsTest({
+      orgFeatures: ['tracemetrics-enabled'],
+    });
+
+    beforeEach(() => {
+      MockApiClient.clearMockResponses();
+      setupPageFilters();
+
+      const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
+      setupTraceItemsMock(metricFixtures.detailedFixtures);
+
+      setupEventsMock(metricFixtures.detailedFixtures, [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-options',
+        }),
+      ]);
+
+      setupEventsMock(metricFixtures.detailedFixtures, [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-aggregates-table',
+        }),
+      ]);
+
+      setupEventsMock(metricFixtures.detailedFixtures, [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-samples-table',
+        }),
+      ]);
+
+      setupMocks(organization.slug);
+    });
+
+    it('renders the metric panel', async () => {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+        organization,
+        additionalWrapper: createWrapper({queryParams, traceMetric}),
+      });
+
+      expect(await screen.findByTestId('metric-panel')).toBeInTheDocument();
+    });
+
+    it('does not render the visualize label badge', async () => {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+        organization,
+        additionalWrapper: createWrapper({queryParams, traceMetric}),
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('metric-panel')).toBeInTheDocument();
+      });
+
+      // The visualize label badge ("A") should NOT be present
+      expect(screen.queryByText('A')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('flag ON (tracemetrics-enabled + tracemetrics-ui-refresh)', () => {
+    const {
+      organization,
+      project,
+      setupPageFilters,
+      setupEventsMock,
+      setupTraceItemsMock,
+    } = initializeTraceMetricsTest({
+      orgFeatures: ['tracemetrics-enabled', 'tracemetrics-ui-refresh'],
+    });
+
+    beforeEach(() => {
+      MockApiClient.clearMockResponses();
+      setupPageFilters();
+
+      const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
+      setupTraceItemsMock(metricFixtures.detailedFixtures);
+
+      setupEventsMock(metricFixtures.detailedFixtures, [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-options',
+        }),
+      ]);
+
+      setupEventsMock(metricFixtures.detailedFixtures, [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-aggregates-table',
+        }),
+      ]);
+
+      setupEventsMock(metricFixtures.detailedFixtures, [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-samples-table',
+        }),
+      ]);
+
+      setupMocks(organization.slug);
+    });
+
+    it('renders the metric panel', async () => {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+        organization,
+        additionalWrapper: createWrapper({queryParams, traceMetric}),
+      });
+
+      expect(await screen.findByTestId('metric-panel')).toBeInTheDocument();
+    });
+
+    it('renders the visualize label badge', async () => {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+        organization,
+        additionalWrapper: createWrapper({queryParams, traceMetric}),
+      });
+
+      // The visualize label badge "A" (from getVisualizeLabel(0)) should be present
+      expect(await screen.findByText('A')).toBeInTheDocument();
+    });
+
+    it('does not render orientation controls', async () => {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+        organization,
+        additionalWrapper: createWrapper({queryParams, traceMetric}),
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('metric-panel')).toBeInTheDocument();
+      });
+
+      // Orientation controls should NOT be present in the refreshed UI
+      expect(
+        screen.queryByRole('button', {name: 'Table bottom'})
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Table right'})).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -1,8 +1,11 @@
 import {useState} from 'react';
 
+import {Stack} from '@sentry/scraps/layout';
+
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useMetricsPanelAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
@@ -11,9 +14,12 @@ import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMe
 import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
 import {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
 import {useTableOrientationControl} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
+import {MetricsGraph} from 'sentry/views/explore/metrics/metricGraph';
+import {MetricInfoTabs} from 'sentry/views/explore/metrics/metricInfoTabs';
 import {SideBySideOrientation} from 'sentry/views/explore/metrics/metricPanel/sideBySideOrientation';
 import {StackedOrientation} from 'sentry/views/explore/metrics/metricPanel/stackedOrientation';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 import {getMetricTableColumnType} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsAggregateSortBys,
@@ -30,6 +36,7 @@ interface MetricPanelProps {
 }
 
 export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
+  const organization = useOrganization();
   const {
     orientation,
     setOrientation: setUserPreferenceOrientation,
@@ -44,6 +51,8 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
 
   const columns = TraceSamplesTableColumns;
   const fields = columns.filter(c => getMetricTableColumnType(c) !== 'stat');
+
+  const hasMetricsUIRefresh = canUseMetricsUIRefresh(organization);
 
   const metricSamplesTableResult = useMetricSamplesTable({
     disabled: !traceMetric?.name || isMetricOptionsEmpty,
@@ -77,6 +86,30 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
     aggregateSortBys,
     panelIndex: queryIndex,
   });
+
+  if (hasMetricsUIRefresh) {
+    return (
+      <Panel data-test-id="metric-panel">
+        <PanelBody>
+          <Stack gap="sm">
+            <MetricsGraph
+              timeseriesResult={timeseriesResult}
+              orientation={orientation}
+              isMetricOptionsEmpty={isMetricOptionsEmpty}
+              queryIndex={queryIndex}
+            />
+            <MetricInfoTabs
+              traceMetric={traceMetric}
+              additionalActions={undefined}
+              contentsHidden={infoContentHidden}
+              orientation={orientation}
+              isMetricOptionsEmpty={isMetricOptionsEmpty}
+            />
+          </Stack>
+        </PanelBody>
+      </Panel>
+    );
+  }
 
   return (
     <Panel data-test-id="metric-panel">

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -27,3 +27,10 @@ export const canUseMetricsSidePanelUI = (organization: Organization) => {
     organization.features.includes('tracemetrics-attributes-dropdown-side-panel')
   );
 };
+
+export const canUseMetricsUIRefresh = (organization: Organization) => {
+  return (
+    canUseMetricsUI(organization) &&
+    organization.features.includes('tracemetrics-ui-refresh')
+  );
+};


### PR DESCRIPTION
Add a refreshed UI for trace metrics panels, gated behind the `tracemetrics-ui-refresh` feature flag.

The refreshed layout simplifies the metric panel by rendering MetricsGraph and MetricInfoTabs in a vertical stack without orientation controls. The graph gets a visualize label badge (A, B, C…) in its title, uses full height in the refreshed layout, and hides the footer border. Info tabs increase from `xs` to `md` size.

When the flag is off, the existing side-by-side / stacked orientation UI is unchanged.

Refs LOGS-620
|||
|-|-|
|Before (Right Oriented)|<img width="1260" height="333" alt="Screenshot 2026-03-18 at 11 59 52" src="https://github.com/user-attachments/assets/2bf43178-37c8-450d-9339-6056b2ac3f6b" />|
|Before (Vertical Oriented)|<img width="1244" height="649" alt="Screenshot 2026-03-18 at 11 58 23" src="https://github.com/user-attachments/assets/0e2486ba-1bee-47c7-b960-719b8c3e5854" />|
|After|<img width="1621" height="753" alt="Screenshot 2026-03-18 at 11 08 59" src="https://github.com/user-attachments/assets/554b3181-302b-4354-aa63-aef359236ec6" />|