### PR TITLE
feat(scm): Add `get_archive_link` to SCM API

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -511,6 +511,8 @@ class GitHubBaseClient(
             allow_redirects=False,
             raw_response=True,
         )
+        if resp.status_code != 302 or "Location" not in resp.headers:
+            raise ApiError.from_response(resp)
         return resp.headers["Location"]
 
     def get_repo(self, repo: str) -> Any:

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -498,6 +498,21 @@ class GitHubBaseClient(
         """
         return self.get(f"/repos/{repo}/pulls/{pull_number}")
 
+    def get_archive_link(self, repo: str, archive_format: str, ref: str) -> str:
+        """
+        https://docs.github.com/en/rest/repos/contents#download-a-repository-archive-tar-ball-or-zip-ball
+
+        Returns the redirect URL for downloading a repository archive.
+        The API returns a 302; we capture the Location header instead of following it.
+        """
+        resp = self._request(
+            "GET",
+            f"/repos/{repo}/{archive_format}/{ref}",
+            allow_redirects=False,
+            raw_response=True,
+        )
+        return resp.headers["Location"]
+
     def get_repo(self, repo: str) -> Any:
         """
         https://docs.github.com/en/rest/repos/repos#get-a-repository

--- a/src/sentry/integrations/gitlab/utils.py
+++ b/src/sentry/integrations/gitlab/utils.py
@@ -73,6 +73,7 @@ class GitLabApiClientPath:
     projects = "/projects"
     statuses = "/projects/{project}/statuses/{sha}"
     commit_statuses = "/projects/{project}/repository/commits/{sha}/statuses"
+    archive = "/projects/{project}/repository/archive{format}"
     branches = "/projects/{project_id}/repository/branches"
     branch = "/projects/{project_id}/repository/branches/{branch}"
     user = "/user"

--- a/src/sentry/scm/actions.py
+++ b/src/sentry/scm/actions.py
@@ -19,6 +19,7 @@ from sentry.scm.types import (
     SHA,
     ActionResult,
     ArchiveFormat,
+    ArchiveLink,
     BranchName,
     BuildConclusion,
     BuildStatus,
@@ -382,7 +383,7 @@ class SourceCodeManager:
         self,
         ref: str,
         archive_format: ArchiveFormat = "tar.gz",
-    ) -> ActionResult[str]:
+    ) -> ActionResult[ArchiveLink]:
         """Get a URL to download a repository archive."""
         return self._exec(
             ActionMap.get_archive_link,  # type: ignore[type-abstract]

--- a/src/sentry/scm/actions.py
+++ b/src/sentry/scm/actions.py
@@ -18,6 +18,7 @@ from sentry.scm.private.provider import ActionMap, Provider
 from sentry.scm.types import (
     SHA,
     ActionResult,
+    ArchiveFormat,
     BranchName,
     BuildConclusion,
     BuildStatus,
@@ -375,6 +376,17 @@ class SourceCodeManager:
         return self._exec(
             ActionMap.get_file_content,  # type: ignore[type-abstract]
             lambda p: p.get_file_content(path, ref, request_options),
+        )
+
+    def get_archive_link(
+        self,
+        ref: str,
+        archive_format: ArchiveFormat = "tar.gz",
+    ) -> ActionResult[str]:
+        """Get a URL to download a repository archive."""
+        return self._exec(
+            ActionMap.get_archive_link,  # type: ignore[type-abstract]
+            lambda p: p.get_archive_link(ref, archive_format),
         )
 
     def get_commit(

--- a/src/sentry/scm/actions.py
+++ b/src/sentry/scm/actions.py
@@ -382,7 +382,7 @@ class SourceCodeManager:
     def get_archive_link(
         self,
         ref: str,
-        archive_format: ArchiveFormat = "tar.gz",
+        archive_format: ArchiveFormat = "tarball",
     ) -> ActionResult[ArchiveLink]:
         """Get a URL to download a repository archive."""
         return self._exec(

--- a/src/sentry/scm/private/provider.py
+++ b/src/sentry/scm/private/provider.py
@@ -3,6 +3,7 @@ from typing import Protocol, runtime_checkable
 from sentry.scm.types import (
     SHA,
     ActionResult,
+    ArchiveFormat,
     BranchName,
     BuildConclusion,
     BuildStatus,
@@ -401,6 +402,18 @@ class GetFileContentProtocol(Protocol):
     ) -> ActionResult[FileContent]: ...
 
 
+# Archive Protocols
+
+
+@runtime_checkable
+class GetArchiveLinkProtocol(Protocol):
+    def get_archive_link(
+        self,
+        ref: str,
+        archive_format: ArchiveFormat = "tar.gz",
+    ) -> ActionResult[str]: ...
+
+
 # Check Run Protocols
 
 
@@ -558,6 +571,7 @@ class ActionMap:
     create_git_tree = CreateGitTreeProtocol
     create_git_commit = CreateGitCommitProtocol
     get_file_content = GetFileContentProtocol
+    get_archive_link = GetArchiveLinkProtocol
     get_check_run = GetCheckRunProtocol
     create_check_run = CreateCheckRunProtocol
     update_check_run = UpdateCheckRunProtocol

--- a/src/sentry/scm/private/provider.py
+++ b/src/sentry/scm/private/provider.py
@@ -411,7 +411,7 @@ class GetArchiveLinkProtocol(Protocol):
     def get_archive_link(
         self,
         ref: str,
-        archive_format: ArchiveFormat = "tar.gz",
+        archive_format: ArchiveFormat = "tarball",
     ) -> ActionResult[ArchiveLink]: ...
 
 

--- a/src/sentry/scm/private/provider.py
+++ b/src/sentry/scm/private/provider.py
@@ -4,6 +4,7 @@ from sentry.scm.types import (
     SHA,
     ActionResult,
     ArchiveFormat,
+    ArchiveLink,
     BranchName,
     BuildConclusion,
     BuildStatus,
@@ -411,7 +412,7 @@ class GetArchiveLinkProtocol(Protocol):
         self,
         ref: str,
         archive_format: ArchiveFormat = "tar.gz",
-    ) -> ActionResult[str]: ...
+    ) -> ActionResult[ArchiveLink]: ...
 
 
 # Check Run Protocols

--- a/src/sentry/scm/private/providers/github.py
+++ b/src/sentry/scm/private/providers/github.py
@@ -718,9 +718,9 @@ class GitHubProvider:
         github_format = GITHUB_ARCHIVE_FORMAT_MAP[archive_format]
         url = self.client.get_archive_link(self.repository["name"], github_format, ref)
         token_data = self.client.get_access_token()
-        token = token_data["access_token"] if token_data else ""
+        token = token_data["access_token"] if token_data else None
         return ActionResult(
-            data=ArchiveLink(url=url, headers={"Authorization": f"token {token}"}),
+            data=ArchiveLink(url=url, headers={"Authorization": f"token {token}"} if token else {}),
             type="github",
             raw=url,
             meta={},

--- a/src/sentry/scm/private/providers/github.py
+++ b/src/sentry/scm/private/providers/github.py
@@ -9,6 +9,7 @@ from sentry.scm.types import (
     SHA,
     ActionResult,
     ArchiveFormat,
+    ArchiveLink,
     Author,
     BranchName,
     BuildConclusion,
@@ -713,11 +714,13 @@ class GitHubProvider:
         self,
         ref: str,
         archive_format: ArchiveFormat = "tar.gz",
-    ) -> ActionResult[str]:
+    ) -> ActionResult[ArchiveLink]:
         github_format = GITHUB_ARCHIVE_FORMAT_MAP[archive_format]
         url = self.client.get_archive_link(self.repository["name"], github_format, ref)
+        token_data = self.client.get_access_token()
+        token = token_data["access_token"] if token_data else ""
         return ActionResult(
-            data=url,
+            data=ArchiveLink(url=url, headers={"Authorization": f"token {token}"}),
             type="github",
             raw=url,
             meta={},

--- a/src/sentry/scm/private/providers/github.py
+++ b/src/sentry/scm/private/providers/github.py
@@ -108,7 +108,7 @@ REACTION_MAP = {
 }
 
 GITHUB_ARCHIVE_FORMAT_MAP: dict[ArchiveFormat, str] = {
-    "tar.gz": "tarball",
+    "tarball": "tarball",
     "zip": "zipball",
 }
 

--- a/src/sentry/scm/private/providers/github.py
+++ b/src/sentry/scm/private/providers/github.py
@@ -713,7 +713,7 @@ class GitHubProvider:
     def get_archive_link(
         self,
         ref: str,
-        archive_format: ArchiveFormat = "tar.gz",
+        archive_format: ArchiveFormat = "tarball",
     ) -> ActionResult[ArchiveLink]:
         github_format = GITHUB_ARCHIVE_FORMAT_MAP[archive_format]
         url = self.client.get_archive_link(self.repository["name"], github_format, ref)

--- a/src/sentry/scm/private/providers/github.py
+++ b/src/sentry/scm/private/providers/github.py
@@ -8,6 +8,7 @@ from sentry.scm.errors import SCMProviderException
 from sentry.scm.types import (
     SHA,
     ActionResult,
+    ArchiveFormat,
     Author,
     BranchName,
     BuildConclusion,
@@ -103,6 +104,11 @@ REACTION_MAP = {
     "hooray": GitHubReaction.HOORAY,
     "rocket": GitHubReaction.ROCKET,
     "eyes": GitHubReaction.EYES,
+}
+
+GITHUB_ARCHIVE_FORMAT_MAP: dict[ArchiveFormat, str] = {
+    "tar.gz": "tarball",
+    "zip": "zipball",
 }
 
 GITHUB_REVIEW_EVENT_MAP: dict[ReviewEvent, str] = {
@@ -701,6 +707,21 @@ class GitHubProvider:
             data["output"] = output
         raw = self.client.update_check_run(self.repository["name"], check_run_id, data)
         return map_action(raw, map_check_run)
+
+    @catch_provider_exception
+    def get_archive_link(
+        self,
+        ref: str,
+        archive_format: ArchiveFormat = "tar.gz",
+    ) -> ActionResult[str]:
+        github_format = GITHUB_ARCHIVE_FORMAT_MAP[archive_format]
+        url = self.client.get_archive_link(self.repository["name"], github_format, ref)
+        return ActionResult(
+            data=url,
+            type="github",
+            raw=url,
+            meta={},
+        )
 
     @catch_provider_exception
     def minimize_comment(self, comment_node_id: str, reason: str) -> None:

--- a/src/sentry/scm/private/providers/gitlab.py
+++ b/src/sentry/scm/private/providers/gitlab.py
@@ -32,6 +32,7 @@ from sentry.scm.types import (
     SHA,
     ActionResult,
     ArchiveFormat,
+    ArchiveLink,
     Author,
     BranchName,
     Comment,
@@ -333,14 +334,16 @@ class GitLabProvider:
         self,
         ref: str,
         archive_format: ArchiveFormat = "tar.gz",
-    ) -> ActionResult[str]:
+    ) -> ActionResult[ArchiveLink]:
         fmt = GITLAB_ARCHIVE_FORMAT_MAP[archive_format]
         path = GitLabApiClientPath.archive.format(project=self._repo_id, format=fmt)
         url = GitLabApiClientPath.build_api_url(self.client.base_url, path)
         if ref:
             url = f"{url}?sha={ref}"
+        token_data = self.client.get_access_token()
+        token = token_data["access_token"] if token_data else ""
         return ActionResult(
-            data=url,
+            data=ArchiveLink(url=url, headers={"Authorization": f"Bearer {token}"}),
             type="gitlab",
             raw=url,
             meta={},

--- a/src/sentry/scm/private/providers/gitlab.py
+++ b/src/sentry/scm/private/providers/gitlab.py
@@ -74,7 +74,7 @@ REACTION_BY_AWARD_NAME: dict[str, Reaction] = {
 }
 
 GITLAB_ARCHIVE_FORMAT_MAP: dict[ArchiveFormat, str] = {
-    "tar.gz": ".tar.gz",
+    "tarball": ".tar.gz",
     "zip": ".zip",
 }
 
@@ -333,7 +333,7 @@ class GitLabProvider:
     def get_archive_link(
         self,
         ref: str,
-        archive_format: ArchiveFormat = "tar.gz",
+        archive_format: ArchiveFormat = "tarball",
     ) -> ActionResult[ArchiveLink]:
         fmt = GITLAB_ARCHIVE_FORMAT_MAP[archive_format]
         path = GitLabApiClientPath.archive.format(project=self._repo_id, format=fmt)
@@ -341,9 +341,10 @@ class GitLabProvider:
         if ref:
             url = f"{url}?sha={ref}"
         token_data = self.client.get_access_token()
-        token = token_data["access_token"] if token_data else ""
+        token = token_data["access_token"] if token_data else None
+        data = ArchiveLink(url=url, headers={"Authorization": f"Bearer {token}"} if token else {})
         return ActionResult(
-            data=ArchiveLink(url=url, headers={"Authorization": f"Bearer {token}"}),
+            data=data,
             type="gitlab",
             raw=url,
             meta={},

--- a/src/sentry/scm/private/providers/gitlab.py
+++ b/src/sentry/scm/private/providers/gitlab.py
@@ -26,10 +26,12 @@ from collections.abc import Callable
 from typing import Any, Iterable
 
 from sentry.integrations.gitlab.client import GitLabApiClient
+from sentry.integrations.gitlab.utils import GitLabApiClientPath
 from sentry.scm.errors import SCMProviderException
 from sentry.scm.types import (
     SHA,
     ActionResult,
+    ArchiveFormat,
     Author,
     BranchName,
     Comment,
@@ -68,6 +70,11 @@ AWARD_NAME_BY_REACTION: dict[Reaction, str] = {
 
 REACTION_BY_AWARD_NAME: dict[str, Reaction] = {
     award: reaction for reaction, award in AWARD_NAME_BY_REACTION.items()
+}
+
+GITLAB_ARCHIVE_FORMAT_MAP: dict[ArchiveFormat, str] = {
+    "tar.gz": ".tar.gz",
+    "zip": ".zip",
 }
 
 PULL_REQUEST_STATE_RETRIEVE_MAP: dict[PullRequestState, list[str]] = {
@@ -320,6 +327,24 @@ class GitLabProvider:
     def create_branch(self, branch: BranchName, sha: SHA) -> ActionResult[GitRef]:
         raw = self.client.create_branch(self._repo_id, branch, sha)
         return make_result(map_git_ref, raw)
+
+    @catch_provider_exception
+    def get_archive_link(
+        self,
+        ref: str,
+        archive_format: ArchiveFormat = "tar.gz",
+    ) -> ActionResult[str]:
+        fmt = GITLAB_ARCHIVE_FORMAT_MAP[archive_format]
+        path = GitLabApiClientPath.archive.format(project=self._repo_id, format=fmt)
+        url = GitLabApiClientPath.build_api_url(self.client.base_url, path)
+        if ref:
+            url = f"{url}?sha={ref}"
+        return ActionResult(
+            data=url,
+            type="gitlab",
+            raw=url,
+            meta={},
+        )
 
     @catch_provider_exception
     def get_file_content(

--- a/src/sentry/scm/private/providers/gitlab.py
+++ b/src/sentry/scm/private/providers/gitlab.py
@@ -24,6 +24,7 @@ import datetime
 import functools
 from collections.abc import Callable
 from typing import Any, Iterable
+from urllib.parse import urlencode
 
 from sentry.integrations.gitlab.client import GitLabApiClient
 from sentry.integrations.gitlab.utils import GitLabApiClientPath
@@ -339,7 +340,7 @@ class GitLabProvider:
         path = GitLabApiClientPath.archive.format(project=self._repo_id, format=fmt)
         url = GitLabApiClientPath.build_api_url(self.client.base_url, path)
         if ref:
-            url = f"{url}?sha={ref}"
+            url = f"{url}?{urlencode({'sha': ref})}"
         token_data = self.client.get_access_token()
         token = token_data["access_token"] if token_data else None
         data = ArchiveLink(url=url, headers={"Authorization": f"Bearer {token}"} if token else {})

--- a/src/sentry/scm/private/rpc.py
+++ b/src/sentry/scm/private/rpc.py
@@ -127,4 +127,5 @@ scm_action_registry: dict[str, Callable] = {
     "get_check_run_v1": SourceCodeManager.get_check_run,
     "update_check_run_v1": SourceCodeManager.update_check_run,
     "minimize_comment_v1": SourceCodeManager.minimize_comment,
+    "get_archive_link_v1": SourceCodeManager.get_archive_link,
 }

--- a/src/sentry/scm/types.py
+++ b/src/sentry/scm/types.py
@@ -54,6 +54,9 @@ type FileStatus = Literal[
 - unknown: file status could not be positively identified
 """
 
+type ArchiveFormat = Literal["tar.gz", "zip"]
+"""Normalized archive format identifiers shared across all SCM providers."""
+
 type BuildStatus = Literal["pending", "running", "completed"]
 """The lifecycle stage of a CI build.
 

--- a/src/sentry/scm/types.py
+++ b/src/sentry/scm/types.py
@@ -57,6 +57,14 @@ type FileStatus = Literal[
 type ArchiveFormat = Literal["tar.gz", "zip"]
 """Normalized archive format identifiers shared across all SCM providers."""
 
+
+class ArchiveLink(TypedDict):
+    """A download URL bundled with the authentication headers required to fetch it."""
+
+    url: str
+    headers: dict[str, str]
+
+
 type BuildStatus = Literal["pending", "running", "completed"]
 """The lifecycle stage of a CI build.
 

--- a/src/sentry/scm/types.py
+++ b/src/sentry/scm/types.py
@@ -54,7 +54,7 @@ type FileStatus = Literal[
 - unknown: file status could not be positively identified
 """
 
-type ArchiveFormat = Literal["tar.gz", "zip"]
+type ArchiveFormat = Literal["tarball", "zip"]
 """Normalized archive format identifiers shared across all SCM providers."""
 
 

--- a/tests/sentry/scm/test_fixtures.py
+++ b/tests/sentry/scm/test_fixtures.py
@@ -1559,6 +1559,10 @@ class FakeGitHubApiClient(GitHubApiClient):
             conclusion=data.get("conclusion"),
         )
 
+    def get_access_token(self, token_minimum_validity_time=None):
+        self._record_call("get_access_token")
+        return {"access_token": "fake-github-token", "permissions": None}
+
     def get_archive_link(self, repo: str, archive_format: str, ref: str) -> str:
         self._record_call("get_archive_link", repo, archive_format, ref)
         self._maybe_raise()

--- a/tests/sentry/scm/test_fixtures.py
+++ b/tests/sentry/scm/test_fixtures.py
@@ -1247,6 +1247,7 @@ class FakeGitHubApiClient(GitHubApiClient):
         self.review_data: dict[str, Any] | None = None
         self.check_run_data: dict[str, Any] | None = None
         self.updated_check_run_data: dict[str, Any] | None = None
+        self.archive_link_data: str = "https://codeload.github.com/test-org/test-repo/legacy.tar.gz/refs/heads/main?token=fake"
 
         self.raise_api_error: bool = False
         self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
@@ -1557,3 +1558,8 @@ class FakeGitHubApiClient(GitHubApiClient):
             status=data.get("status", "completed"),
             conclusion=data.get("conclusion"),
         )
+
+    def get_archive_link(self, repo: str, archive_format: str, ref: str) -> str:
+        self._record_call("get_archive_link", repo, archive_format, ref)
+        self._maybe_raise()
+        return self.archive_link_data

--- a/tests/sentry/scm/unit/test_github_provider.py
+++ b/tests/sentry/scm/unit/test_github_provider.py
@@ -1354,7 +1354,8 @@ class TestGetArchiveLink:
 
         result = provider.get_archive_link("main")
 
-        assert result["data"] == client.archive_link_data
+        assert result["data"]["url"] == client.archive_link_data
+        assert result["data"]["headers"] == {"Authorization": "token fake-github-token"}
         assert result["type"] == "github"
         assert ("get_archive_link", ("test-org/test-repo", "tarball", "main"), {}) in client.calls
 

--- a/tests/sentry/scm/unit/test_github_provider.py
+++ b/tests/sentry/scm/unit/test_github_provider.py
@@ -126,6 +126,7 @@ ALL_PROVIDER_METHODS: list[tuple[str, dict[str, Any]]] = [
     ("create_check_run", {"name": "check", "head_sha": "abc"}),
     ("get_check_run", {"check_run_id": "300"}),
     ("update_check_run", {"check_run_id": "300"}),
+    ("get_archive_link", {"ref": "main"}),
 ]
 
 
@@ -1343,3 +1344,25 @@ class TestGetPullRequestCommentsEdgeCases:
             ("test-org/test-repo", "42"),
             {},
         ) in client.calls
+
+
+class TestGetArchiveLink:
+    def test_returns_archive_url(self):
+        repository = make_repository()
+        client = _make_client()
+        provider = GitHubProvider(client, repository["organization_id"], repository)
+
+        result = provider.get_archive_link("main")
+
+        assert result["data"] == client.archive_link_data
+        assert result["type"] == "github"
+        assert ("get_archive_link", ("test-org/test-repo", "tarball", "main"), {}) in client.calls
+
+    def test_zip_format_uses_zipball(self):
+        repository = make_repository()
+        client = _make_client()
+        provider = GitHubProvider(client, repository["organization_id"], repository)
+
+        provider.get_archive_link("main", "zip")
+
+        assert ("get_archive_link", ("test-org/test-repo", "zipball", "main"), {}) in client.calls

--- a/tests/sentry/scm/unit/test_gitlab_provider.py
+++ b/tests/sentry/scm/unit/test_gitlab_provider.py
@@ -13071,27 +13071,41 @@ def test_forward_to_client(client, provider: GitLabProvider, param: ForwardToCli
 class TestGetArchiveLink:
     def test_returns_tar_gz_url(self, provider: GitLabProvider, client: GitLabApiClient):
         client.base_url = "https://gitlab.example.com"
+        client.get_access_token.return_value = {
+            "access_token": "fake-gitlab-token",
+            "permissions": None,
+        }
 
         result = provider.get_archive_link("main")
 
         assert result["type"] == "gitlab"
-        assert result["data"] == (
+        assert result["data"]["url"] == (
             "https://gitlab.example.com/api/v4/projects/79787061/repository/archive.tar.gz?sha=main"
         )
+        assert result["data"]["headers"] == {"Authorization": "Bearer fake-gitlab-token"}
 
     def test_returns_zip_url(self, provider: GitLabProvider, client: GitLabApiClient):
         client.base_url = "https://gitlab.example.com"
+        client.get_access_token.return_value = {
+            "access_token": "fake-gitlab-token",
+            "permissions": None,
+        }
 
         result = provider.get_archive_link("main", "zip")
 
         assert result["type"] == "gitlab"
-        assert result["data"] == (
+        assert result["data"]["url"] == (
             "https://gitlab.example.com/api/v4/projects/79787061/repository/archive.zip?sha=main"
         )
+        assert result["data"]["headers"] == {"Authorization": "Bearer fake-gitlab-token"}
 
     def test_empty_ref_omits_sha_param(self, provider: GitLabProvider, client: GitLabApiClient):
         client.base_url = "https://gitlab.example.com"
+        client.get_access_token.return_value = {
+            "access_token": "fake-gitlab-token",
+            "permissions": None,
+        }
 
         result = provider.get_archive_link("")
 
-        assert "?sha=" not in result["data"]
+        assert "?sha=" not in result["data"]["url"]

--- a/tests/sentry/scm/unit/test_gitlab_provider.py
+++ b/tests/sentry/scm/unit/test_gitlab_provider.py
@@ -13069,7 +13069,7 @@ def test_forward_to_client(client, provider: GitLabProvider, param: ForwardToCli
 
 
 class TestGetArchiveLink:
-    def test_returns_tar_gz_url(self, provider: GitLabProvider, client: GitLabApiClient):
+    def test_returns_tar_gz_url(self, provider: GitLabProvider, client: unittest.mock.MagicMock):
         client.base_url = "https://gitlab.example.com"
         client.get_access_token.return_value = {
             "access_token": "fake-gitlab-token",
@@ -13084,7 +13084,7 @@ class TestGetArchiveLink:
         )
         assert result["data"]["headers"] == {"Authorization": "Bearer fake-gitlab-token"}
 
-    def test_returns_zip_url(self, provider: GitLabProvider, client: GitLabApiClient):
+    def test_returns_zip_url(self, provider: GitLabProvider, client: unittest.mock.MagicMock):
         client.base_url = "https://gitlab.example.com"
         client.get_access_token.return_value = {
             "access_token": "fake-gitlab-token",
@@ -13099,7 +13099,9 @@ class TestGetArchiveLink:
         )
         assert result["data"]["headers"] == {"Authorization": "Bearer fake-gitlab-token"}
 
-    def test_empty_ref_omits_sha_param(self, provider: GitLabProvider, client: GitLabApiClient):
+    def test_empty_ref_omits_sha_param(
+        self, provider: GitLabProvider, client: unittest.mock.MagicMock
+    ):
         client.base_url = "https://gitlab.example.com"
         client.get_access_token.return_value = {
             "access_token": "fake-gitlab-token",

--- a/tests/sentry/scm/unit/test_gitlab_provider.py
+++ b/tests/sentry/scm/unit/test_gitlab_provider.py
@@ -13066,3 +13066,32 @@ def test_forward_to_client(client, provider: GitLabProvider, param: ForwardToCli
         assert mock_call[0] == client_call.client_method
         assert mock_call[1] == client_call.client_args
         assert mock_call[2] == client_call.client_kwds
+
+
+class TestGetArchiveLink:
+    def test_returns_tar_gz_url(self, provider: GitLabProvider, client: GitLabApiClient):
+        client.base_url = "https://gitlab.example.com"
+
+        result = provider.get_archive_link("main")
+
+        assert result["type"] == "gitlab"
+        assert result["data"] == (
+            "https://gitlab.example.com/api/v4/projects/79787061/repository/archive.tar.gz?sha=main"
+        )
+
+    def test_returns_zip_url(self, provider: GitLabProvider, client: GitLabApiClient):
+        client.base_url = "https://gitlab.example.com"
+
+        result = provider.get_archive_link("main", "zip")
+
+        assert result["type"] == "gitlab"
+        assert result["data"] == (
+            "https://gitlab.example.com/api/v4/projects/79787061/repository/archive.zip?sha=main"
+        )
+
+    def test_empty_ref_omits_sha_param(self, provider: GitLabProvider, client: GitLabApiClient):
+        client.base_url = "https://gitlab.example.com"
+
+        result = provider.get_archive_link("")
+
+        assert "?sha=" not in result["data"]


### PR DESCRIPTION
This adds a new API to get a download repository URL. Note that GitHub returns 302 with a presigned URL in the Location header whereas GitLab streams the content directly. I believe we also need to supply an auth header for GitLab as well (but havent confirmed yet).

This is needed to replicate behavior for [downloading a repo](https://github.com/getsentry/seer/blob/main/src/seer/automation/codebase/repo_manager.py#L151-L162) in Seer
