### PR TITLE
feat(preprod): Reduce snapshots retention to 30 days

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_retention.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_retention.py
@@ -72,6 +72,6 @@ class OrganizationPreprodRetentionEndpoint(OrganizationEndpoint):
             {
                 "size": size_retention,
                 "buildDistribution": build_distribution_retention,
-                "snapshots": 30,  # hardcoded for now
+                "snapshots": 30,  # Hardcoded for now, check with Objectstore before increasing
             }
         )

--- a/src/sentry/preprod/api/endpoints/organization_preprod_retention.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_retention.py
@@ -72,6 +72,6 @@ class OrganizationPreprodRetentionEndpoint(OrganizationEndpoint):
             {
                 "size": size_retention,
                 "buildDistribution": build_distribution_retention,
-                "snapshots": 396,  # hardcoded for now
+                "snapshots": 30,  # hardcoded for now
             }
         )

--- a/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
@@ -53,7 +53,9 @@ class ProjectPreprodUploadOptionsEndpoint(ProjectEndpoint):
                 ("org", str(organization.id)),
                 ("project", str(project.id)),
             ],
-            expirationPolicy=format_expiration(TimeToLive(timedelta(days=30))),  # Hardcoded for now
+            expirationPolicy=format_expiration(
+                TimeToLive(timedelta(days=30))
+            ),  # Hardcoded for now, check with Objectstore before increasing
         )
 
         return Response({"objectstore": options})

--- a/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
@@ -53,9 +53,7 @@ class ProjectPreprodUploadOptionsEndpoint(ProjectEndpoint):
                 ("org", str(organization.id)),
                 ("project", str(project.id)),
             ],
-            expirationPolicy=format_expiration(
-                TimeToLive(timedelta(days=396))
-            ),  # Hardcoded for now
+            expirationPolicy=format_expiration(TimeToLive(timedelta(days=30))),  # Hardcoded for now
         )
 
         return Response({"objectstore": options})

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_retention.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_retention.py
@@ -25,7 +25,7 @@ class OrganizationPreprodRetentionEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["size"] == 90
         assert response.data["buildDistribution"] == 90
-        assert response.data["snapshots"] == 396
+        assert response.data["snapshots"] == 30
 
     @patch("sentry.quotas.backend.get_event_retention")
     def test_get_custom_retention(self, mock_get_retention) -> None:
@@ -39,7 +39,7 @@ class OrganizationPreprodRetentionEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["size"] == 30
         assert response.data["buildDistribution"] == 60
-        assert response.data["snapshots"] == 396
+        assert response.data["snapshots"] == 30
 
     def test_get_requires_authentication(self) -> None:
         client = APIClient()

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
@@ -27,7 +27,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
 
         assert data["scopes"] == [("org", str(self.org.id)), ("project", str(self.project.id))]
 
-        assert data["expirationPolicy"] == "ttl:396 days"
+        assert data["expirationPolicy"] == "ttl:30 days"
 
     def test_objectstore_url_uses_region_endpoint(self):
         with (


### PR DESCRIPTION
As discussed with @rbro112, this reduces the hardcoded snapshots retention period returned to `sentry-cli` for the `snapshots` subcommand (via `ProjectPreprodUploadOptionsEndpoint`) to 30 days instead of 396.
After the necessary changes are made for Objectstore to handle uploads with both retention periods optimally, we can still support 396 days retention for certain customers.

I'm not sure what `OrganizationPreprodRetentionEndpoint` is used for, but this endpoint also hardcoded 396, so I've changed it to reflect the updated value of 30 from `ProjectPreprodUploadOptionsEndpoint`.