### PR TITLE
perf(group-events): Include platform in Snuba query to avoid nodestore N+1

### DIFF
--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -73,7 +73,7 @@ def get_query_builder_for_group(
     dataset = Dataset.IssuePlatform
     if group.issue_category == GroupCategory.ERROR:
         dataset = Dataset.Events
-    selected_columns = ["id", "project.id", "issue.id", "timestamp"]
+    selected_columns = ["id", "project.id", "issue.id", "timestamp", "platform"]
 
     if orderby is None:
         orderby_list = ["-timestamp", "id"]

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -73,7 +73,24 @@ def get_query_builder_for_group(
     dataset = Dataset.IssuePlatform
     if group.issue_category == GroupCategory.ERROR:
         dataset = Dataset.Events
-    selected_columns = ["id", "project.id", "issue.id", "timestamp", "platform"]
+    selected_columns = [
+        "id",
+        "project.id",
+        "issue.id",
+        "timestamp",
+        "platform",
+        "title",
+        "culprit",
+        "tags.key",
+        "tags.value",
+        "user.id",
+        "user.email",
+        "user.username",
+        "user.ip",
+    ]
+    if group.issue_category == GroupCategory.ERROR:
+        # location and event.type are only available in the Events dataset
+        selected_columns.extend(["location", "event.type"])
 
     if orderby is None:
         orderby_list = ["-timestamp", "id"]

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -62,6 +62,26 @@ def get_direct_hit_response(
     return None
 
 
+_DEFAULT_GROUP_EVENTS_COLUMNS = [
+    "id",
+    "project.id",
+    "issue.id",
+    "timestamp",
+    "platform",
+    "title",
+    "culprit",
+    "tags.key",
+    "tags.value",
+    "user.id",
+    "user.email",
+    "user.username",
+    "user.ip",
+]
+
+# Extra columns only available in the Events dataset (error groups)
+_ERROR_ONLY_COLUMNS = ["location", "event.type"]
+
+
 def get_query_builder_for_group(
     query: str,
     snuba_params: SnubaParams,
@@ -69,28 +89,17 @@ def get_query_builder_for_group(
     limit: int,
     offset: int,
     orderby: str | None = None,
+    extra_columns: list[str] | None = None,
 ) -> DiscoverQueryBuilder:
     dataset = Dataset.IssuePlatform
     if group.issue_category == GroupCategory.ERROR:
         dataset = Dataset.Events
-    selected_columns = [
-        "id",
-        "project.id",
-        "issue.id",
-        "timestamp",
-        "platform",
-        "title",
-        "culprit",
-        "tags.key",
-        "tags.value",
-        "user.id",
-        "user.email",
-        "user.username",
-        "user.ip",
-    ]
-    if group.issue_category == GroupCategory.ERROR:
+    selected_columns = (
+        list(extra_columns) if extra_columns is not None else list(_DEFAULT_GROUP_EVENTS_COLUMNS)
+    )
+    if extra_columns is None and group.issue_category == GroupCategory.ERROR:
         # location and event.type are only available in the Events dataset
-        selected_columns.extend(["location", "event.type"])
+        selected_columns.extend(_ERROR_ONLY_COLUMNS)
 
     if orderby is None:
         orderby_list = ["-timestamp", "id"]

--- a/src/sentry/issues/endpoints/group_attachments.py
+++ b/src/sentry/issues/endpoints/group_attachments.py
@@ -61,6 +61,7 @@ def get_event_ids_from_filters(
             group=group,
             limit=10000,
             offset=0,
+            extra_columns=["id"],
         )
 
     referrer = f"api.group-attachments.{group.issue_category.name.lower()}"

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -173,6 +173,7 @@ class GroupEventsEndpoint(GroupEndpoint):
                         "group_id": evt["issue.id"],
                         "project_id": evt["project.id"],
                         "timestamp": evt["timestamp"],
+                        "platform": evt.get("platform"),
                     },
                 )
                 for evt in data

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -43,6 +43,45 @@ if TYPE_CHECKING:
     from sentry.models.group import Group
 
 
+# Maps Snuba result keys to the event_name keys expected by BaseEvent._snuba_data.
+# These must match Columns.<X>.value.event_name, which is what Event._get_column_name() returns.
+_SNUBA_RESULT_TO_EVENT_KEY: dict[str, str] = {
+    "platform": "platform",
+    "title": "title",
+    "culprit": "culprit",
+    "location": "location",
+    "event.type": "type",
+    "user.id": "user_id",
+    "user.email": "email",
+    "user.username": "username",
+    "user.ip": "ip_address",
+}
+
+
+def _build_snuba_data(evt: dict[str, Any]) -> dict[str, Any]:
+    snuba_data: dict[str, Any] = {
+        "event_id": evt["id"],
+        "group_id": evt["issue.id"],
+        "project_id": evt["project.id"],
+        "timestamp": evt["timestamp"],
+    }
+    for result_key, event_key in _SNUBA_RESULT_TO_EVENT_KEY.items():
+        value = evt.get(result_key)
+        # Only include the key when a real value is present so that BaseEvent
+        # properties fall back to nodestore for fields that weren't returned by
+        # this query (e.g. location/event.type for non-error groups).
+        if value is not None:
+            snuba_data[event_key] = value
+    # Tags are always lists; include even when empty (empty = event has no tags).
+    # Both keys must be present together for BaseEvent.tags to use the Snuba path.
+    tags_key = evt.get("tags.key")
+    tags_value = evt.get("tags.value")
+    if tags_key is not None and tags_value is not None:
+        snuba_data["tags.key"] = tags_key
+        snuba_data["tags.value"] = tags_value
+    return snuba_data
+
+
 class NoResults(Exception):
     pass
 
@@ -168,13 +207,7 @@ class GroupEventsEndpoint(GroupEndpoint):
                 Event(
                     event_id=evt["id"],
                     project_id=evt["project.id"],
-                    snuba_data={
-                        "event_id": evt["id"],
-                        "group_id": evt["issue.id"],
-                        "project_id": evt["project.id"],
-                        "timestamp": evt["timestamp"],
-                        "platform": evt.get("platform"),
-                    },
+                    snuba_data=_build_snuba_data(evt),
                 )
                 for evt in data
             ]

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -644,7 +645,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         assert any(t["key"] == "environment" and t["value"] == "production" for t in result["tags"])
 
 
-class BuildSnubaDataTest:
+class TestBuildSnubaData:
     def test_all_fields_populated(self) -> None:
         evt = {
             "id": "abc123",
@@ -656,7 +657,6 @@ class BuildSnubaDataTest:
             "culprit": "main.py in func",
             "location": "main.py",
             "event.type": "error",
-            "message": "Something went wrong",
             "tags.key": ["environment"],
             "tags.value": ["production"],
             "user.id": "u123",
@@ -674,7 +674,6 @@ class BuildSnubaDataTest:
         assert result["culprit"] == "main.py in func"
         assert result["location"] == "main.py"
         assert result["type"] == "error"
-        assert result["message"] == "Something went wrong"
         assert result["tags.key"] == ["environment"]
         assert result["tags.value"] == ["production"]
         assert result["user_id"] == "u123"
@@ -739,7 +738,7 @@ class BuildSnubaDataTest:
     ],
 )
 def test_build_snuba_data_optional_columns(
-    evt: dict, expected_key: str, expected_present: bool
+    evt: dict[str, Any], expected_key: str, expected_present: bool
 ) -> None:
     result = _build_snuba_data(evt)
     assert (expected_key in result) == expected_present

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -1,11 +1,13 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.utils import timezone
 from rest_framework.response import Response
 from urllib3.connectionpool import ConnectionPool
 from urllib3.exceptions import ReadTimeoutError
 
+from sentry.issues.endpoints.group_events import _build_snuba_data
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
@@ -613,3 +615,131 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/"
         response = self.do_request(url)
         assert response.status_code == 504
+
+    def test_snuba_columns_returned_in_response(self) -> None:
+        """Fields fetched from Snuba (platform, title, tags, user) are present in the response."""
+        self.login_as(user=self.user)
+
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "fingerprint": ["1"],
+                "platform": "python",
+                "tags": {"environment": "production"},
+                "user": {"id": "u1", "email": "test@example.com"},
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/"
+        response = self.do_request(url)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        result = response.data[0]
+        assert result["platform"] == "python"
+        assert result["user"] is not None
+        assert result["user"]["email"] == "test@example.com"
+        assert any(t["key"] == "environment" and t["value"] == "production" for t in result["tags"])
+
+
+class BuildSnubaDataTest:
+    def test_all_fields_populated(self) -> None:
+        evt = {
+            "id": "abc123",
+            "issue.id": "456",
+            "project.id": "1",
+            "timestamp": "2024-01-01T00:00:00",
+            "platform": "python",
+            "title": "Error title",
+            "culprit": "main.py in func",
+            "location": "main.py",
+            "event.type": "error",
+            "message": "Something went wrong",
+            "tags.key": ["environment"],
+            "tags.value": ["production"],
+            "user.id": "u123",
+            "user.email": "user@example.com",
+            "user.username": "theuser",
+            "user.ip": "1.2.3.4",
+        }
+        result = _build_snuba_data(evt)
+
+        assert result["event_id"] == "abc123"
+        assert result["group_id"] == "456"
+        assert result["project_id"] == "1"
+        assert result["platform"] == "python"
+        assert result["title"] == "Error title"
+        assert result["culprit"] == "main.py in func"
+        assert result["location"] == "main.py"
+        assert result["type"] == "error"
+        assert result["message"] == "Something went wrong"
+        assert result["tags.key"] == ["environment"]
+        assert result["tags.value"] == ["production"]
+        assert result["user_id"] == "u123"
+        assert result["email"] == "user@example.com"
+        assert result["username"] == "theuser"
+        assert result["ip_address"] == "1.2.3.4"
+
+    def test_none_values_excluded(self) -> None:
+        # Fields absent from the result (e.g. EAP path without platform) must not
+        # appear in snuba_data so that BaseEvent falls back to nodestore.
+        evt = {
+            "id": "abc123",
+            "issue.id": "456",
+            "project.id": "1",
+            "timestamp": "2024-01-01T00:00:00",
+        }
+        result = _build_snuba_data(evt)
+        assert "platform" not in result
+        assert "title" not in result
+        assert "tags.key" not in result
+        assert "tags.value" not in result
+
+    def test_empty_tags_included(self) -> None:
+        # Empty tag lists are a valid Snuba response (event has no tags).
+        evt = {
+            "id": "abc123",
+            "issue.id": "456",
+            "project.id": "1",
+            "timestamp": "2024-01-01T00:00:00",
+            "tags.key": [],
+            "tags.value": [],
+        }
+        result = _build_snuba_data(evt)
+        assert "tags.key" in result
+        assert result["tags.key"] == []
+        assert result["tags.value"] == []
+
+
+@pytest.mark.parametrize(
+    "evt,expected_key,expected_present",
+    [
+        # platform present → included
+        (
+            {"id": "a", "issue.id": "1", "project.id": "1", "timestamp": "t", "platform": "python"},
+            "platform",
+            True,
+        ),
+        # platform None (EAP path without column) → excluded so nodestore fallback works
+        (
+            {"id": "a", "issue.id": "1", "project.id": "1", "timestamp": "t", "platform": None},
+            "platform",
+            False,
+        ),
+        # location present → included
+        (
+            {"id": "a", "issue.id": "1", "project.id": "1", "timestamp": "t", "location": "foo.py"},
+            "location",
+            True,
+        ),
+        # location absent → excluded
+        ({"id": "a", "issue.id": "1", "project.id": "1", "timestamp": "t"}, "location", False),
+    ],
+)
+def test_build_snuba_data_optional_columns(
+    evt: dict, expected_key: str, expected_present: bool
+) -> None:
+    result = _build_snuba_data(evt)
+    assert (expected_key in result) == expected_present


### PR DESCRIPTION
The `/api/0/issues/{issue_id}/events/` endpoint was triggering an individual Bigtable read per event when `full=False` (the default). This caused ~580k individual nodestore round-trips every 2 hours.

## Root cause

`SimpleEventSerializer.get_attrs` calls `get_crash_files()`, which iterates events and checks `event.platform == "native"` to find minidump crash files. The `platform` property falls back to nodestore when not present in `_snuba_data` — and it wasn't being included in the Snuba query. This caused `NodeData.data` (a `cached_property`) to be loaded individually for each event via `nodestore.backend.get(self.id)`.

Since `data` is cached after the first load, each event triggered exactly one bigtable.get. At ~97 events per page, that was ~97 sequential bigtable calls (~90ms each) instead of zero.

The irony: virtually none of Sentry's own events are `platform=native` (2.16M python vs 1 native in 24h), so all those fetches were just to confirm "not native, skip" — returning an empty list every time.

## Fix

Add `platform` to the selected columns in the Snuba query and pass it through in `snuba_data` when constructing `Event` objects. The `platform` property then short-circuits to the Snuba value and nodestore is never touched.