### PR TITLE
fix(tracemetrics): Open in explore for multi metrics opens each

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
@@ -225,6 +225,46 @@ describe('getWidgetMetricsUrl', () => {
       const metricQuery = JSON.parse(metrics[0]!);
       expect(metricQuery.metric.unit).toBe('second');
     });
+
+    it('reads the tracemetric from each aggregate', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Multi Aggregate',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: [
+              'avg(value,test_metric_a,duration,-)',
+              'p95(value,test_metric_b,gauge,-)',
+              'count(value,test_metric_c,counter,-)',
+            ],
+            columns: [],
+            conditions: 'transaction:"/api/users"',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      // Should have 3 metric query parameters (one for each aggregate)
+      expect(params.metric).toBeDefined();
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+
+      const parsedMetrics = metrics.map(metric => JSON.parse(metric as string));
+      expect(parsedMetrics).toHaveLength(3);
+      expect(parsedMetrics.map(m => m.metric)).toEqual([
+        {name: 'test_metric_a', type: 'duration'},
+        {name: 'test_metric_b', type: 'gauge'},
+        {name: 'test_metric_c', type: 'counter'},
+      ]);
+    });
   });
 
   describe('multiple queries', () => {

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
@@ -1,12 +1,13 @@
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {explodeFieldString} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {applyDashboardFilters} from 'sentry/views/dashboards/utils';
-import {extractTraceMetricFromWidget} from 'sentry/views/dashboards/utils/extractTraceMetricFromWidget';
+import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
 import {getMetricsUrl, makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
@@ -23,17 +24,15 @@ export function getWidgetMetricsUrl(
   selection: PageFilters,
   organization: Organization
 ): string {
-  const traceMetric = extractTraceMetricFromWidget(widget);
-
-  if (!traceMetric?.name || !widget.queries[0]?.aggregates) {
+  if (!widget.queries[0]?.aggregates) {
     // If we can't extract a valid trace metric, return a basic metrics URL
     return makeMetricsPathname({organizationSlug: organization.slug, path: '/'});
   }
 
   const chartType = getChartTypeFromDisplayType(widget.displayType);
 
-  const metricQueries: BaseMetricQuery[] = widget.queries[0].aggregates.flatMap(
-    aggregate => {
+  const metricQueries = widget.queries[0].aggregates
+    .flatMap(aggregate => {
       // For each aggregate, create a metric query for each widget query
       return widget.queries.map(query => {
         const queryString =
@@ -50,6 +49,11 @@ export function getWidgetMetricsUrl(
           new VisualizeFunction(aggregate, {chartType}),
           ...groupByFields,
         ];
+
+        const traceMetric = extractTraceMetricFromColumn(explodeFieldString(aggregate));
+        if (!traceMetric) {
+          return undefined;
+        }
 
         return {
           metric: traceMetric,
@@ -68,8 +72,8 @@ export function getWidgetMetricsUrl(
           }),
         };
       });
-    }
-  );
+    })
+    .filter(defined);
 
   return getMetricsUrl({
     organization,


### PR DESCRIPTION
Each aggregate should be evaluated individually for the `metric` param because we're opening up to multi-metric support in Dashboards. This shouldn't change functionality because we should be actively storing the tracemetric in the aggregates _already_, this just makes it read each one to figure out what tracemetric to set instead of doing that reading upfront and propagating it through to every other aggregate assuming it's the same.