### PR TITLE
ref(preprod): Add commit_comparison_id to status check logging

### DIFF
--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -49,7 +49,7 @@ def compare_preprod_artifact_size_analysis(
 ) -> None:
     logger.info(
         "preprod.size_analysis.compare.start",
-        extra={"artifact_id": artifact_id},
+        extra={"artifact_id": artifact_id, "project_id": project_id, "org_id": org_id},
     )
 
     try:
@@ -229,6 +229,15 @@ def compare_preprod_artifact_size_analysis(
                 },
             )
             _run_size_analysis_comparison(org_id, head_metric, base_metric)
+
+        logger.info(
+            "preprod.size_analysis.compare.dispatching_status_checks",
+            extra={
+                "artifact_id": artifact.id,
+                "commit_comparison_id": artifact.commit_comparison_id,
+                "status_check_artifact_ids": list(preprod_artifact_status_check_updates),
+            },
+        )
 
         for artifact_id in preprod_artifact_status_check_updates:
             # Update all artifact's status check with the new comparison

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -637,6 +637,14 @@ def _assemble_preprod_artifact_size_analysis(
         )
 
         # Always trigger status check update (success or failure)
+        logger.info(
+            "preprod.status_checks.dispatching",
+            extra={
+                "preprod_artifact_id": artifact_id,
+                "commit_comparison_id": preprod_artifact.commit_comparison_id,
+                "caller": "assemble_completion",
+            },
+        )
         create_preprod_status_check_task.apply_async(
             kwargs={
                 "preprod_artifact_id": artifact_id,

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -172,7 +172,11 @@ def create_preprod_status_check_task(
 
     logger.info(
         "preprod.status_checks.create.start",
-        extra={"artifact_id": preprod_artifact.id, "caller": caller},
+        extra={
+            "artifact_id": preprod_artifact.id,
+            "caller": caller,
+            "commit_comparison_id": preprod_artifact.commit_comparison_id,
+        },
     )
 
     if not preprod_artifact.commit_comparison:
@@ -207,6 +211,16 @@ def create_preprod_status_check_task(
 
     # Get all artifacts for this commit across all projects in the organization
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
+
+    logger.info(
+        "preprod.status_checks.create.sibling_artifacts",
+        extra={
+            "artifact_id": preprod_artifact.id,
+            "commit_comparison_id": commit_comparison.id,
+            "sibling_artifact_ids": [a.id for a in all_artifacts],
+            "sibling_count": len(all_artifacts),
+        },
+    )
 
     client, repository = get_status_check_client(preprod_artifact.project, commit_comparison)
     if not client or not repository:
@@ -324,6 +338,7 @@ def create_preprod_status_check_task(
     except Exception as e:
         extra: dict[str, Any] = {
             "artifact_id": preprod_artifact.id,
+            "commit_comparison_id": commit_comparison.id,
             "organization_id": preprod_artifact.project.organization_id,
             "organization_slug": preprod_artifact.project.organization.slug,
             "error_type": type(e).__name__,
@@ -342,6 +357,7 @@ def create_preprod_status_check_task(
             "preprod.status_checks.create.failed",
             extra={
                 "artifact_id": preprod_artifact.id,
+                "commit_comparison_id": commit_comparison.id,
                 "organization_id": preprod_artifact.project.organization_id,
                 "organization_slug": preprod_artifact.project.organization.slug,
                 "error_type": "null_check_id",
@@ -366,6 +382,7 @@ def create_preprod_status_check_task(
         "preprod.status_checks.create.success",
         extra={
             "artifact_id": preprod_artifact.id,
+            "commit_comparison_id": commit_comparison.id,
             "status": status.value,
             "check_id": check_id,
             "organization_id": preprod_artifact.project.organization_id,


### PR DESCRIPTION
Add `commit_comparison_id` to all log lines in the status check creation
task and its dispatch points so that all task invocations for a single
`CommitComparison` can be correlated.

Currently when debugging status check issues, you can only filter by
`artifact_id` — but in monorepo setups multiple artifacts share the same
`CommitComparison`. Without `commit_comparison_id` there's no way to see
all the status check tasks that ran for a single commit/PR.

Changes:
- Add `commit_comparison_id` to `.start`, `.success`, and `.failed` logs
  in `create_preprod_status_check_task`
- Add new `.sibling_artifacts` log showing which artifacts were found for
  the commit comparison
- Add `commit_comparison_id` to the dispatch log in
  `compare_preprod_artifact_size_analysis` when it fans out status check
  tasks
- Add a dispatch log in `_assemble_preprod_artifact_size_analysis` before
  triggering the status check task