### PR TITLE
feat(gitlab): Add `get_access_token()` to GitLab integration

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -105,6 +105,12 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         prepared_request.headers["Authorization"] = f"Bearer {access_token}"
         return prepared_request
 
+    @control_silo_function
+    def get_access_token(self) -> dict[str, str | None] | None:
+        if self.identity.data["access_token"]:
+            return {"access_token": self.identity.data["access_token"], "permissions": None}
+        return None
+
     def _refresh_auth(self):
         """
         Modeled after Doorkeeper's docs

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -58,6 +58,19 @@ class GitLabClientTest(GitLabTestCase):
 
 
 @control_silo_test
+class GitLabGetAccessTokenTest(GitLabClientTest):
+    def test_returns_token_dict(self) -> None:
+        result = self.gitlab_client.get_access_token()
+        expected_token = self.gitlab_client.identity.data["access_token"]
+        assert result == {"access_token": expected_token, "permissions": None}
+
+    def test_returns_none_when_token_empty(self) -> None:
+        self.gitlab_client.identity.data["access_token"] = ""
+        result = self.gitlab_client.get_access_token()
+        assert result is None
+
+
+@control_silo_test
 class GitlabRefreshAuthTest(GitLabClientTest):
     get_user_should_succeed = True
 


### PR DESCRIPTION
This mirrors [`get_access_token` in the GitHub integration](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/github/client.py#L325-L355). To be used in https://github.com/getsentry/sentry/pull/110987
