### PR TITLE
ref(api): mark previous enterprise endpoints as unowned

### DIFF
--- a/src/sentry/api/endpoints/api_application_rotate_secret.py
+++ b/src/sentry/api/endpoints/api_application_rotate_secret.py
@@ -16,7 +16,7 @@ class ApiApplicationRotateSecretEndpoint(ApiApplicationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     authentication_classes = (SessionAuthentication,)
     permission_classes = (SentryIsAuthenticated,)
 

--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -22,7 +22,7 @@ class ApiAuthorizationsEndpoint(Endpoint):
         "DELETE": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     authentication_classes = (SessionAuthentication,)
     permission_classes = (SentryIsAuthenticated,)
 

--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -28,7 +28,7 @@ class AuthConfigEndpoint(Endpoint, OrganizationMixin):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     # Disable authentication and permission requirements.
     permission_classes = ()
 

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -46,7 +46,7 @@ class BaseAuthIndexEndpoint(Endpoint):
     AuthIndexEndpoint and StaffAuthIndexEndpoint (in getsentry)
     """
 
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     authentication_classes = (QuietBasicAuthentication, SessionAuthentication)
 
     permission_classes = ()

--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -20,7 +20,7 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     # Disable authentication and permission requirements.
     permission_classes = ()
 

--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -65,7 +65,7 @@ class OAuthUserInfoEndpoint(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     authentication_classes = ()
     permission_classes = ()
 

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -56,7 +56,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (AccessRequestPermission,)
 
     # TODO(dcramer): this should go onto AccessRequestPermission

--- a/src/sentry/api/endpoints/organization_auth_provider_details.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_details.py
@@ -17,7 +17,7 @@ class OrganizationAuthProviderDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (OrganizationAuthProviderPermission,)
 
     def get(self, request: Request, organization: Organization) -> Response:

--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -16,7 +16,7 @@ class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (OrganizationAuthProviderPermission,)
 
     def get(self, request: Request, organization: Organization) -> Response:

--- a/src/sentry/api/endpoints/organization_auth_token_details.py
+++ b/src/sentry/api/endpoints/organization_auth_token_details.py
@@ -22,7 +22,7 @@ class OrganizationAuthTokenDetailsEndpoint(ControlSiloOrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     authentication_classes = (SessionNoAuthTokenAuthentication,)
     permission_classes = (OrgAuthTokenPermission,)
 

--- a/src/sentry/api/endpoints/organization_auth_tokens.py
+++ b/src/sentry/api/endpoints/organization_auth_tokens.py
@@ -41,7 +41,7 @@ class OrganizationAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     authentication_classes = (SessionNoAuthTokenAuthentication,)
     permission_classes = (OrgAuthTokenPermission,)
 

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -20,7 +20,7 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, StatsMixin):
         # Deprecated APIs remain private until removed
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     def get(self, request: Request, organization) -> Response:
         """

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -127,7 +127,7 @@ class StatsSummaryApiResponse(TypedDict):
 @cell_silo_endpoint
 class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
     publish_status = {"GET": ApiPublishStatus.PUBLIC}
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     @extend_schema(
         operation_id="Retrieve an Organization's Events Count by Project",

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -158,7 +158,7 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
         limit_overrides={

--- a/src/sentry/api/endpoints/project_member_index.py
+++ b/src/sentry/api/endpoints/project_member_index.py
@@ -22,7 +22,7 @@ class ProjectMemberIndexEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     @extend_schema(
         operation_id="List a Project's Organization Members",

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold.py
@@ -50,7 +50,7 @@ class ReleaseThresholdPOSTSerializer(serializers.Serializer[ReleaseThresholdPOST
 @cell_silo_endpoint
 class ReleaseThresholdEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
-    owner: ApiOwner = ApiOwner.ENTERPRISE
+    owner: ApiOwner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "POST": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_details.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_details.py
@@ -52,7 +52,7 @@ class ReleaseThresholdPUTSerializer(serializers.Serializer[ReleaseThresholdPUTDa
 @cell_silo_endpoint
 class ReleaseThresholdDetailsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
-    owner: ApiOwner = ApiOwner.ENTERPRISE
+    owner: ApiOwner = ApiOwner.UNOWNED
     publish_status = {
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
         "GET": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
@@ -32,7 +32,7 @@ class ReleaseThresholdIndexGETValidator(serializers.Serializer[ReleaseThresholdI
 
 @cell_silo_endpoint
 class ReleaseThresholdIndexEndpoint(OrganizationEndpoint):
-    owner: ApiOwner = ApiOwner.ENTERPRISE
+    owner: ApiOwner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -101,7 +101,7 @@ class ReleaseThresholdStatusIndexSerializer(
 @cell_silo_endpoint
 @extend_schema(tags=["Releases"])
 class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
-    owner: ApiOwner = ApiOwner.ENTERPRISE
+    owner: ApiOwner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }

--- a/src/sentry/auth_v2/endpoints/auth_merge_user_accounts.py
+++ b/src/sentry/auth_v2/endpoints/auth_merge_user_accounts.py
@@ -28,7 +28,7 @@ class AuthMergeUserAccountsEndpoint(AuthV2Endpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     """
     List and merge user accounts with the same primary email address.
     """

--- a/src/sentry/auth_v2/endpoints/auth_user_merge_verification_code.py
+++ b/src/sentry/auth_v2/endpoints/auth_user_merge_verification_code.py
@@ -14,7 +14,7 @@ class AuthUserMergeVerificationCodeEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (SentryIsAuthenticated,)
     """
     Generate and update verification codes for the user account merge flow.

--- a/src/sentry/auth_v2/endpoints/csrf.py
+++ b/src/sentry/auth_v2/endpoints/csrf.py
@@ -24,7 +24,7 @@ class CsrfTokenEndpoint(Endpoint):
     NOTE: This endpoint is not protected by the feature flag in AuthV2Endpoint!
     """
 
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "PUT": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/auth_v2/endpoints/feature_flag_view.py
+++ b/src/sentry/auth_v2/endpoints/feature_flag_view.py
@@ -12,7 +12,7 @@ from .base import AuthV2Endpoint
 
 @control_silo_endpoint
 class FeatureFlagView(AuthV2Endpoint):
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     publish_status = {"GET": ApiPublishStatus.EXPERIMENTAL}
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(

--- a/src/sentry/auth_v2/endpoints/user_login_view.py
+++ b/src/sentry/auth_v2/endpoints/user_login_view.py
@@ -10,7 +10,7 @@ from .base import AuthV2Endpoint
 
 @control_silo_endpoint
 class UserLoginView(AuthV2Endpoint):
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/core/endpoints/organization_auditlogs.py
+++ b/src/sentry/core/endpoints/organization_auditlogs.py
@@ -39,7 +39,7 @@ class OrganizationAuditLogsEndpoint(ControlSiloOrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (OrganizationAuditPermission,)
 
     def get(

--- a/src/sentry/core/endpoints/organization_member_details.py
+++ b/src/sentry/core/endpoints/organization_member_details.py
@@ -88,7 +88,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (RelaxedMemberPermission,)
 
     def _get_member(

--- a/src/sentry/core/endpoints/organization_member_index.py
+++ b/src/sentry/core/endpoints/organization_member_index.py
@@ -185,7 +185,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
     )
 
     permission_classes = (MemberAndStaffPermission,)
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     @extend_schema(
         operation_id="List an Organization's Members",

--- a/src/sentry/core/endpoints/organization_member_invite/details.py
+++ b/src/sentry/core/endpoints/organization_member_invite/details.py
@@ -43,7 +43,7 @@ class OrganizationMemberInviteDetailsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (MemberInviteDetailsPermission,)
 
     def convert_args(

--- a/src/sentry/core/endpoints/organization_member_invite/index.py
+++ b/src/sentry/core/endpoints/organization_member_invite/index.py
@@ -114,7 +114,7 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     permission_classes = (MemberInviteAndStaffPermission,)
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     def _invite_member(self, request, organization) -> Response:
         allowed_roles = get_allowed_org_roles(request, organization, creating_org_invite=True)

--- a/src/sentry/core/endpoints/organization_member_invite/reinvite.py
+++ b/src/sentry/core/endpoints/organization_member_invite/reinvite.py
@@ -37,7 +37,7 @@ class OrganizationMemberReinviteEndpoint(OrganizationEndpoint):
     publish_status = {
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (MemberReinvitePermission,)
 
     def convert_args(

--- a/src/sentry/core/endpoints/organization_member_team_details.py
+++ b/src/sentry/core/endpoints/organization_member_team_details.py
@@ -153,7 +153,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         "PUT": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (OrganizationTeamMemberPermission,)
 
     def _can_create_team_member(self, request: Request, team: Team) -> bool:

--- a/src/sentry/core/endpoints/organization_projects_experiment.py
+++ b/src/sentry/core/endpoints/organization_projects_experiment.py
@@ -70,7 +70,7 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrgProjectPermission,)
     logger = logging.getLogger("team-project.create")
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     def should_add_creator_to_team(self, user: User | AnonymousUser) -> TypeIs[User]:
         return user.is_authenticated

--- a/src/sentry/core/endpoints/organization_user_teams.py
+++ b/src/sentry/core/endpoints/organization_user_teams.py
@@ -23,7 +23,7 @@ class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     @extend_schema(
         operation_id="List a User's Teams for an Organization",

--- a/src/sentry/core/endpoints/project_team_details.py
+++ b/src/sentry/core/endpoints/project_team_details.py
@@ -32,7 +32,7 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
         "DELETE": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (ProjectTeamsPermission,)
 
     def convert_args(

--- a/src/sentry/core/endpoints/project_teams.py
+++ b/src/sentry/core/endpoints/project_teams.py
@@ -22,7 +22,7 @@ class ProjectTeamsEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     @extend_schema(
         operation_id="List a Project's Teams",

--- a/src/sentry/core/endpoints/scim/utils.py
+++ b/src/sentry/core/endpoints/scim/utils.py
@@ -142,7 +142,7 @@ class SCIMListBaseResponse(TypedDict):
 
 @extend_schema(tags=["SCIM"])
 class SCIMEndpoint(OrganizationEndpoint):
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     content_negotiation_class = SCIMClientNegotiation
     cursor_name = "startIndex"
 

--- a/src/sentry/core/endpoints/team_members.py
+++ b/src/sentry/core/endpoints/team_members.py
@@ -65,7 +65,7 @@ class TeamMembersEndpoint(TeamEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     @extend_schema(
         operation_id="List a Team's Members",

--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -138,7 +138,7 @@ class TeamProjectsEndpoint(TeamEndpoint):
         "POST": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (TeamProjectPermission,)
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     @extend_schema(
         operation_id="List a Team's Projects",

--- a/src/sentry/core/endpoints/team_stats.py
+++ b/src/sentry/core/endpoints/team_stats.py
@@ -18,7 +18,7 @@ class TeamStatsEndpoint(TeamEndpoint, StatsMixin):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     def get(self, request: Request, team) -> Response:
         """

--- a/src/sentry/data_secrecy/api/waive_data_secrecy.py
+++ b/src/sentry/data_secrecy/api/waive_data_secrecy.py
@@ -53,7 +53,7 @@ class WaiveDataSecrecyEndpoint(ControlSiloOrganizationEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
         "DELETE": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     def get(
         self,

--- a/src/sentry/integrations/api/endpoints/external_team_details.py
+++ b/src/sentry/integrations/api/endpoints/external_team_details.py
@@ -32,7 +32,7 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         "DELETE": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     def convert_args(
         self,

--- a/src/sentry/integrations/api/endpoints/external_team_index.py
+++ b/src/sentry/integrations/api/endpoints/external_team_index.py
@@ -29,7 +29,7 @@ class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     @extend_schema(
         operation_id="Create an External Team",

--- a/src/sentry/integrations/api/endpoints/organization_integration_migrate_opsgenie.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_migrate_opsgenie.py
@@ -19,7 +19,7 @@ class OrganizationIntegrationMigrateOpsgenieEndpoint(RegionOrganizationIntegrati
     publish_status = {
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     def put(
         self,

--- a/src/sentry/integrations/api/endpoints/organization_integrations_index.py
+++ b/src/sentry/integrations/api/endpoints/organization_integrations_index.py
@@ -58,7 +58,7 @@ def filter_by_features(
 @control_silo_endpoint
 @extend_schema(tags=["Integrations"])
 class OrganizationIntegrationsEndpoint(OrganizationIntegrationBaseEndpoint):
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }

--- a/src/sentry/integrations/github/installation.py
+++ b/src/sentry/integrations/github/installation.py
@@ -25,7 +25,7 @@ class GitHubIntegrationsInstallationEndpoint(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     permission_classes = (SentryIsAuthenticated,)
 

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_rotate_secret.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_rotate_secret.py
@@ -77,7 +77,7 @@ class SentryAppRotateSecretEndpoint(SentryAppBaseEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (SentryAppRotateSecretPermission,)
 
     def post(self, request: Request, sentry_app: SentryApp) -> Response:

--- a/src/sentry/users/api/endpoints/authenticator_index.py
+++ b/src/sentry/users/api/endpoints/authenticator_index.py
@@ -16,7 +16,7 @@ class AuthenticatorIndexEndpoint(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (IsAuthenticated,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/users/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_details.py
@@ -30,7 +30,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (OrganizationUserPermission,)
 
     def _get_device_for_rename(

--- a/src/sentry/users/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_enroll.py
@@ -119,7 +119,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     @sudo_required
     def get(self, request: Request, user: User, interface_id: str) -> HttpResponse:

--- a/src/sentry/users/api/endpoints/user_authenticator_index.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_index.py
@@ -16,7 +16,7 @@ class UserAuthenticatorIndexEndpoint(UserEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
 
     def get(self, request: Request, user: User) -> Response:
         """Returns all interface for a user (un-enrolled ones), otherwise an empty array"""

--- a/src/sentry/users/api/endpoints/user_permission_details.py
+++ b/src/sentry/users/api/endpoints/user_permission_details.py
@@ -25,7 +25,7 @@ class UserPermissionDetailsEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     authentication_classes = (SessionAuthentication,)
     permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 

--- a/src/sentry/users/api/endpoints/user_permissions.py
+++ b/src/sentry/users/api/endpoints/user_permissions.py
@@ -15,7 +15,7 @@ class UserPermissionsEndpoint(UserEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def get(self, request: Request, user: User) -> Response:

--- a/src/sentry/users/api/endpoints/user_permissions_config.py
+++ b/src/sentry/users/api/endpoints/user_permissions_config.py
@@ -15,7 +15,7 @@ class UserPermissionsConfigEndpoint(UserEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.UNOWNED
     permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def get(self, request: Request, user: User) -> Response:


### PR DESCRIPTION
Since the enterprise team doesn't exist right now, these endpoints are all technically unowned.