### PR TITLE
chore(occ-eap): Bump missing trace id to info

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -245,7 +245,7 @@ class SnubaProtocolEventStream(EventStream):
 
         missing_fields = self._missing_required_item_fields(event_data)
         if missing_fields:
-            logger.debug(
+            logger.info(
                 "Event data is missing required fields to forward to items: %s", missing_fields
             )
             return


### PR DESCRIPTION
Currently at debug level; want to understand how often this is happening in production. Info does what we want there.