### PR TITLE
ref(explore): Remove search-query-builder-explicit-boolean-filters flag

### DIFF
--- a/static/app/views/detectors/datasetConfig/components/metricsSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/metricsSearchBar.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   METRIC_DETECTOR_FORM_FIELDS,
   useMetricDetectorFormField,
@@ -33,7 +32,6 @@ export function MetricsDetectorSearchBar({
   projectIds,
   disabled,
 }: DetectorSearchBarProps) {
-  const organization = useOrganization();
   const aggregateFunction = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
   );
@@ -45,10 +43,6 @@ export function MetricsDetectorSearchBar({
     // aggregateFunction may be unset during form init / dataset switching
   }
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
-
-  const hasBooleanFilters = organization.features.includes(
-    'search-query-builder-explicit-boolean-filters'
-  );
 
   const {attributes: numberTags} = useTraceItemAttributeKeys({
     traceItemType: TraceItemDataset.TRACEMETRICS,
@@ -67,7 +61,7 @@ export function MetricsDetectorSearchBar({
   const {attributes: booleanTags} = useTraceItemAttributeKeys({
     traceItemType: TraceItemDataset.TRACEMETRICS,
     type: 'boolean',
-    enabled: Boolean(traceMetricFilter) && hasBooleanFilters,
+    enabled: Boolean(traceMetricFilter),
     query: traceMetricFilter,
     projectIds,
   });

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
@@ -22,7 +22,7 @@ const defaultInitialProps: TraceItemSearchQueryBuilderProps = {
   searchSource: 'test',
 };
 const organization = OrganizationFixture({
-  features: ['search-query-builder-explicit-boolean-filters'],
+  features: [],
 });
 
 describe('useTraceItemSearchQueryBuilderProps', () => {

--- a/static/app/views/explore/contexts/traceItemAttributeContext.spec.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.spec.tsx
@@ -84,36 +84,8 @@ describe('useTraceItemAttributes number filtering', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('does not filter number attributes when flag is off', async () => {
-    const organization = OrganizationFixture({features: []});
-    addAttributeMock('number', [{key: 'is_transaction', name: 'is_transaction'}]);
-    addAttributeMock('string', []);
-    addAttributeMock('boolean', []);
-
-    const {result} = renderHookWithProviders(
-      () =>
-        useTraceItemAttributes(
-          {
-            traceItemType: TraceItemDataset.SPANS,
-            enabled: true,
-          },
-          'number'
-        ),
-      {organization}
-    );
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    // is_transaction should still be present as a number attribute
-    expect('is_transaction' in result.current.attributes).toBe(true);
-  });
-
-  it('filters out number attributes that overlap with boolean attributes when flag is on', async () => {
-    const organization = OrganizationFixture({
-      features: ['search-query-builder-explicit-boolean-filters'],
-    });
+  it('filters out number attributes that overlap with boolean attributes', async () => {
+    const organization = OrganizationFixture();
 
     addAttributeMock('number', [
       {key: 'is_transaction', name: 'is_transaction'},
@@ -143,9 +115,7 @@ describe('useTraceItemAttributes number filtering', () => {
   });
 
   it('filters number attributes that overlap with default boolean attributes', async () => {
-    const organization = OrganizationFixture({
-      features: ['search-query-builder-explicit-boolean-filters'],
-    });
+    const organization = OrganizationFixture();
 
     addAttributeMock('number', [
       {key: 'is_transaction', name: 'is_transaction'},
@@ -175,9 +145,7 @@ describe('useTraceItemAttributes number filtering', () => {
   });
 
   it('filters tags[key,number] format when boolean version exists', async () => {
-    const organization = OrganizationFixture({
-      features: ['search-query-builder-explicit-boolean-filters'],
-    });
+    const organization = OrganizationFixture();
 
     addAttributeMock('number', [
       {key: 'tags[is_transaction,number]', name: 'tags[is_transaction,number]'},
@@ -209,9 +177,7 @@ describe('useTraceItemAttributes number filtering', () => {
   });
 
   it('filters overlapping number secondary aliases when boolean version exists', async () => {
-    const organization = OrganizationFixture({
-      features: ['search-query-builder-explicit-boolean-filters'],
-    });
+    const organization = OrganizationFixture();
 
     addAttributeMock('number', [
       {
@@ -246,9 +212,7 @@ describe('useTraceItemAttributes number filtering', () => {
   });
 
   it('preserves non-overlapping number attributes', async () => {
-    const organization = OrganizationFixture({
-      features: ['search-query-builder-explicit-boolean-filters'],
-    });
+    const organization = OrganizationFixture();
 
     addAttributeMock('number', [
       {key: 'custom_metric', name: 'custom_metric'},

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -3,7 +3,6 @@ import {useMemo} from 'react';
 import type {TagCollection} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {FieldKind} from 'sentry/utils/fields';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   DASHBOARD_ONLY_SPAN_ATTRIBUTES,
   SENTRY_LOG_BOOLEAN_TAGS,
@@ -49,8 +48,6 @@ type TraceItemAttributeResult = {
   secondaryAliases: TagCollection;
 };
 
-const EMPTY_STRING_SET = new Set<string>();
-
 export type TraceItemAttributeConfig = {
   enabled: boolean;
   traceItemType: TraceItemDataset;
@@ -74,11 +71,6 @@ function useTraceItemAttributeConfig({
   search,
   query,
 }: TraceItemAttributeConfig): TypedTraceItemAttributesResult {
-  const organization = useOrganization();
-  const hasBooleanFilters = organization.features.includes(
-    'search-query-builder-explicit-boolean-filters'
-  );
-
   const projects = rawProjects && isProjectArray(rawProjects) ? rawProjects : undefined;
   const projectIds =
     rawProjects && !isProjectArray(rawProjects) ? rawProjects : undefined;
@@ -107,7 +99,7 @@ function useTraceItemAttributeConfig({
 
   const {attributes: booleanAttributes, isLoading: booleanAttributesLoading} =
     useTraceItemAttributeKeys({
-      enabled: enabled && hasBooleanFilters,
+      enabled,
       type: 'boolean',
       traceItemType,
       projectIds,
@@ -117,20 +109,16 @@ function useTraceItemAttributeConfig({
     });
 
   const booleanBaseKeys = useMemo(() => {
-    if (!hasBooleanFilters) {
-      return EMPTY_STRING_SET;
-    }
-
     const keys = new Set(getDefaultBooleanAttributes(traceItemType));
     for (const key of Object.keys(booleanAttributes ?? {})) {
       keys.add(extractBaseKey(key));
     }
 
     return keys;
-  }, [booleanAttributes, hasBooleanFilters, traceItemType]);
+  }, [booleanAttributes, traceItemType]);
 
   const allNumberAttributes = useMemo(() => {
-    const shouldRemove = hasBooleanFilters && booleanBaseKeys.size > 0;
+    const shouldRemove = booleanBaseKeys.size > 0;
     const attributes: TagCollection = {};
     const secondaryAliases: TagCollection = {};
 
@@ -165,7 +153,7 @@ function useTraceItemAttributeConfig({
     }
 
     return {attributes, secondaryAliases};
-  }, [numberAttributes, traceItemType, booleanBaseKeys, hasBooleanFilters]);
+  }, [numberAttributes, traceItemType, booleanBaseKeys]);
 
   const allStringAttributes = useMemo(() => {
     const tags = getDefaultStringAttributes(traceItemType).map(tag => [
@@ -185,10 +173,6 @@ function useTraceItemAttributeConfig({
   }, [stringAttributes, traceItemType]);
 
   const allBooleanAttributes = useMemo(() => {
-    if (!hasBooleanFilters) {
-      return {attributes: {}, secondaryAliases: {}};
-    }
-
     const tags = getDefaultBooleanAttributes(traceItemType).map(tag => [
       tag,
       {key: tag, name: tag, kind: FieldKind.BOOLEAN},
@@ -203,7 +187,7 @@ function useTraceItemAttributeConfig({
       attributes: {...booleanAttributes, ...Object.fromEntries(tags)},
       secondaryAliases,
     };
-  }, [booleanAttributes, hasBooleanFilters, traceItemType]);
+  }, [booleanAttributes, traceItemType]);
 
   return useMemo(
     () => ({

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -57,6 +57,13 @@ describe('LogsToolbar', () => {
       ],
       match: [MockApiClient.matchQuery({attributeType: 'string', itemType: 'logs'})],
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+      match: [MockApiClient.matchQuery({attributeType: 'boolean', itemType: 'logs'})],
+    });
   });
 
   describe('visualize section', () => {
@@ -301,6 +308,19 @@ describe('LogsToolbar', () => {
       match: [
         MockApiClient.matchQuery({
           attributeType: 'number',
+          itemType: 'logs',
+          substringMatch: 'searched',
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({
+          attributeType: 'boolean',
           itemType: 'logs',
           substringMatch: 'searched',
         }),

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -11,7 +11,6 @@ import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {prettifyTagKey} from 'sentry/utils/fields';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
@@ -49,10 +48,6 @@ interface AggregatesTabProps {
 export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTabProps) {
   const topEvents = useTopEvents();
   const tableRef = useRef<HTMLDivElement>(null);
-  const organization = useOrganization();
-  const hasBooleanFilters = organization.features.includes(
-    'search-query-builder-explicit-boolean-filters'
-  );
 
   const {result, eventView, fields} = useMetricAggregatesTable({
     enabled: Boolean(traceMetric.name) && !isMetricOptionsEmpty,
@@ -85,7 +80,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
   const {attributes: booleanTags} = useTraceItemAttributeKeys({
     traceItemType: TraceItemDataset.TRACEMETRICS,
     type: 'boolean',
-    enabled: Boolean(traceMetricFilter) && hasBooleanFilters,
+    enabled: Boolean(traceMetricFilter),
     query: traceMetricFilter,
   });
 

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -3,7 +3,6 @@ import {useMemo} from 'react';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
@@ -32,12 +31,8 @@ interface FilterProps {
 }
 
 export function Filter({traceMetric}: FilterProps) {
-  const organization = useOrganization();
   const query = useQueryParamsQuery();
   const setQuery = useSetQueryParamsQuery();
-  const hasBooleanFilters = organization.features.includes(
-    'search-query-builder-explicit-boolean-filters'
-  );
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
 
@@ -56,7 +51,7 @@ export function Filter({traceMetric}: FilterProps) {
   const {attributes: booleanTags} = useTraceItemAttributeKeys({
     traceItemType: TraceItemDataset.TRACEMETRICS,
     type: 'boolean',
-    enabled: Boolean(traceMetricFilter) && hasBooleanFilters,
+    enabled: Boolean(traceMetricFilter),
     query: traceMetricFilter,
   });
 

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -5,7 +5,6 @@ import type {SelectOption} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {t} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
@@ -33,10 +32,6 @@ interface GroupBySelectorProps {
 export function GroupBySelector({traceMetric}: GroupBySelectorProps) {
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
-  const organization = useOrganization();
-  const hasBooleanFilters = organization.features.includes(
-    'search-query-builder-explicit-boolean-filters'
-  );
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
 
@@ -58,7 +53,7 @@ export function GroupBySelector({traceMetric}: GroupBySelectorProps) {
     useTraceItemAttributeKeys({
       traceItemType: TraceItemDataset.TRACEMETRICS,
       type: 'boolean',
-      enabled: Boolean(traceMetricFilter) && hasBooleanFilters,
+      enabled: Boolean(traceMetricFilter),
       query: traceMetricFilter,
     });
 

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -76,6 +76,12 @@ describe('ExploreToolbar', () => {
       ],
       match: [MockApiClient.matchQuery({attributeType: 'string'})],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+      match: [MockApiClient.matchQuery({attributeType: 'boolean'})],
+    });
   });
 
   it('disables changing visualize fields for count', async () => {


### PR DESCRIPTION
Remove the `search-query-builder-explicit-boolean-filters` feature flag from the explore attribute context and all consuming metric components. Boolean attribute filtering is now always enabled.

The flag was guarding boolean attribute loading and the logic that filters overlapping number attributes when a boolean version exists. This is now the default behavior, so the flag checks, associated `useOrganization` calls, and the `EMPTY_STRING_SET` constant are removed.

Affected areas:
- `traceItemAttributeContext` — core context that manages attribute types
- `metricsSearchBar`, `aggregatesTab`, `filter`, `groupBySelector` — metric components that had redundant flag guards on `useTraceItemAttributeKeys` for boolean types