### PR TITLE
fix(tracemetrics): Update filter bar to handle multiple metrics

### DIFF
--- a/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
@@ -1,17 +1,50 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import type {Organization} from 'sentry/types/organization';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {
   formatTraceMetricsFunction,
   TraceMetricsConfig,
 } from 'sentry/views/dashboards/datasetConfig/traceMetrics';
-import type {WidgetQuery} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType, type WidgetQuery} from 'sentry/views/dashboards/types';
+import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+
+jest.mock('sentry/views/explore/components/traceItemSearchQueryBuilder', () => {
+  return {
+    ...jest.requireActual('sentry/views/explore/components/traceItemSearchQueryBuilder'),
+    TraceItemSearchQueryBuilder: jest.fn(props => (
+      <div
+        data-test-id="trace-item-search-query-builder"
+        data-namespace={props.namespace ?? ''}
+        data-disable-recent-searches={String(props.disableRecentSearches ?? false)}
+      />
+    )),
+  };
+});
+
+const DASHBOARD_WIDGET_BUILDER_PATHNAME =
+  '/organizations/org-slug/dashboards/new/widget/new/';
 
 describe('TraceMetricsConfig', () => {
   let organization: Organization;
   beforeEach(() => {
     organization = OrganizationFixture();
+
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}));
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [],
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
   });
 
   describe('formatTraceMetricsFunction', () => {
@@ -652,6 +685,113 @@ describe('TraceMetricsConfig', () => {
       expect(result2).toHaveLength(2);
       expect(result2[0]!.seriesName).toBe('Cache Metrics : prod');
       expect(result2[1]!.seriesName).toBe('Cache Metrics : dev');
+    });
+  });
+
+  describe('TraceMetricsSearchBar', () => {
+    const SearchBar = TraceMetricsConfig.SearchBar;
+
+    const defaultWidgetQuery: WidgetQuery = {
+      name: '',
+      fields: [],
+      columns: [],
+      fieldAliases: [],
+      aggregates: [],
+      conditions: '',
+      orderby: '',
+    };
+
+    const defaultSearchBarProps = {
+      widgetQuery: defaultWidgetQuery,
+      onSearch: jest.fn(),
+      portalTarget: null,
+      onClose: jest.fn(),
+      getFilterWarning: undefined,
+      pageFilters: PageFiltersFixture(),
+    };
+
+    it('disables recent searches and clears namespace when multiple metrics are selected', async () => {
+      render(
+        <WidgetBuilderProvider>
+          <SearchBar {...defaultSearchBarProps} />
+        </WidgetBuilderProvider>,
+        {
+          organization: OrganizationFixture({
+            features: ['tracemetrics-multi-metric-selection-in-dashboards'],
+          }),
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+              query: {
+                yAxis: ['avg(value,metric_a,counter,-)', 'avg(value,metric_b,gauge,-)'],
+                dataset: WidgetType.TRACEMETRICS,
+                displayType: DisplayType.LINE,
+              },
+            },
+          },
+        }
+      );
+
+      const searchBar = await screen.findByTestId('trace-item-search-query-builder');
+      expect(searchBar).toHaveAttribute('data-disable-recent-searches', 'true');
+      expect(searchBar).toHaveAttribute('data-namespace', '');
+    });
+
+    it('sets namespace to metric name and enables recent searches for single metric', async () => {
+      render(
+        <WidgetBuilderProvider>
+          <SearchBar {...defaultSearchBarProps} />
+        </WidgetBuilderProvider>,
+        {
+          organization: OrganizationFixture({
+            features: ['tracemetrics-multi-metric-selection-in-dashboards'],
+          }),
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+              query: {
+                yAxis: ['avg(value,my_metric,counter,-)'],
+                dataset: WidgetType.TRACEMETRICS,
+                displayType: DisplayType.LINE,
+              },
+            },
+          },
+        }
+      );
+
+      const searchBar = await screen.findByTestId('trace-item-search-query-builder');
+      expect(searchBar).toHaveAttribute('data-disable-recent-searches', 'false');
+      expect(searchBar).toHaveAttribute('data-namespace', 'my_metric');
+    });
+
+    it('does not treat duplicate metrics as multiple metrics', async () => {
+      render(
+        <WidgetBuilderProvider>
+          <SearchBar {...defaultSearchBarProps} />
+        </WidgetBuilderProvider>,
+        {
+          organization: OrganizationFixture({
+            features: ['tracemetrics-multi-metric-selection-in-dashboards'],
+          }),
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+              query: {
+                yAxis: [
+                  'avg(value,same_metric,counter,-)',
+                  'p50(value,same_metric,counter,-)',
+                ],
+                dataset: WidgetType.TRACEMETRICS,
+                displayType: DisplayType.LINE,
+              },
+            },
+          },
+        }
+      );
+
+      const searchBar = await screen.findByTestId('trace-item-search-query-builder');
+      expect(searchBar).toHaveAttribute('data-disable-recent-searches', 'false');
+      expect(searchBar).toHaveAttribute('data-namespace', 'same_metric');
     });
   });
 });

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -4,6 +4,7 @@ import pickBy from 'lodash/pickBy';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData} from 'sentry/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -29,8 +30,10 @@ import {
 import {combineBaseFieldsWithTags} from 'sentry/views/dashboards/datasetConfig/utils/combineBaseFieldsWithEapTags';
 import {DisplayType, type WidgetQuery} from 'sentry/views/dashboards/types';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {useTraceMetricMultiMetricSelection} from 'sentry/views/dashboards/widgetBuilder/hooks/useTraceMetricMultiMetricSelection';
 import {
   extractTraceMetricFromAggregates,
+  extractTraceMetricFromColumn,
   getTraceMetricAggregateSource,
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {
@@ -82,32 +85,57 @@ function TraceMetricsSearchBar({
     selection: {projects},
   } = usePageFilters();
   const {state: widgetBuilderState} = useWidgetBuilderContext();
+  const hasMultiMetricSelection = useTraceMetricMultiMetricSelection();
 
   const aggregateSource = getTraceMetricAggregateSource(
     widgetBuilderState.displayType,
     widgetBuilderState.yAxis,
     widgetBuilderState.fields
   );
-  const traceMetric = extractTraceMetricFromAggregates(aggregateSource) ?? {
-    name: '',
-    type: '',
-  };
+  const traceMetrics =
+    aggregateSource?.map(extractTraceMetricFromColumn).filter(defined) ?? [];
 
+  // Create a set of the trace metrics in a consistent string format to
+  // check if there are multiple metrics
+  const countUniqueMetrics = new Set(
+    traceMetrics.map(({name, type, unit}) => `${name},${type},${unit}`)
+  ).size;
+  const hasMultipleMetrics = hasMultiMetricSelection && countUniqueMetrics > 1;
+
+  // In the case of multiple metrics, wipe the query so it fetches all attributes
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
     useTraceMetricItemAttributes(
-      {query: createTraceMetricFilter(traceMetric)},
+      {
+        query:
+          !hasMultipleMetrics && traceMetrics[0]
+            ? createTraceMetricFilter(traceMetrics[0])
+            : undefined,
+        enabled: defined(traceMetrics[0]), // Only enable if there is at least one metric
+      },
       'string',
       HiddenTraceMetricSearchFields
     );
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
     useTraceMetricItemAttributes(
-      {query: createTraceMetricFilter(traceMetric)},
+      {
+        query:
+          !hasMultipleMetrics && traceMetrics[0]
+            ? createTraceMetricFilter(traceMetrics[0])
+            : undefined,
+        enabled: defined(traceMetrics[0]),
+      },
       'number',
       HiddenTraceMetricSearchFields
     );
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useTraceMetricItemAttributes(
-      {query: createTraceMetricFilter(traceMetric)},
+      {
+        query:
+          !hasMultipleMetrics && traceMetrics[0]
+            ? createTraceMetricFilter(traceMetrics[0])
+            : undefined,
+        enabled: defined(traceMetrics[0]),
+      },
       'boolean',
       HiddenTraceMetricSearchFields
     );
@@ -129,7 +157,8 @@ function TraceMetricsSearchBar({
       onChange={(query, state) => {
         onClose?.(query, {validSearch: state.queryIsValid});
       }}
-      namespace={traceMetric?.name}
+      namespace={hasMultipleMetrics ? undefined : traceMetrics?.[0]?.name}
+      disableRecentSearches={hasMultipleMetrics}
     />
   );
 }

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
@@ -168,6 +168,35 @@ describe('useTraceItemSearchQueryBuilderProps', () => {
     expect(result.current.disallowUnsupportedFilters).toBe(false);
   });
 
+  it('disables recent searches regardless of item type when disableRecentSearches is true', () => {
+    for (const itemType of [
+      TraceItemDataset.SPANS,
+      TraceItemDataset.LOGS,
+      TraceItemDataset.TRACEMETRICS,
+    ]) {
+      const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+        initialProps: {
+          ...defaultInitialProps,
+          itemType,
+          disableRecentSearches: true,
+        },
+        organization,
+      });
+
+      expect(result.current.recentSearches).toBeUndefined();
+      expect(result.current.namespace).toBeUndefined();
+    }
+  });
+
+  it('enables recent searches by default', () => {
+    const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+      initialProps: defaultInitialProps,
+      organization,
+    });
+
+    expect(result.current.recentSearches).toBeDefined();
+  });
+
   it('getTagKeys fetches keys across string, number, and boolean attributes', async () => {
     const stringMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-items/attributes/',

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
@@ -168,12 +168,9 @@ describe('useTraceItemSearchQueryBuilderProps', () => {
     expect(result.current.disallowUnsupportedFilters).toBe(false);
   });
 
-  it('disables recent searches regardless of item type when disableRecentSearches is true', () => {
-    for (const itemType of [
-      TraceItemDataset.SPANS,
-      TraceItemDataset.LOGS,
-      TraceItemDataset.TRACEMETRICS,
-    ]) {
+  it.each([TraceItemDataset.SPANS, TraceItemDataset.LOGS, TraceItemDataset.TRACEMETRICS])(
+    'disables recent searches when disableRecentSearches is true for item type %s',
+    itemType => {
       const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
         initialProps: {
           ...defaultInitialProps,
@@ -186,7 +183,7 @@ describe('useTraceItemSearchQueryBuilderProps', () => {
       expect(result.current.recentSearches).toBeUndefined();
       expect(result.current.namespace).toBeUndefined();
     }
-  });
+  );
 
   it('enables recent searches by default', () => {
     const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -28,6 +28,7 @@ export type TraceItemSearchQueryBuilderProps = {
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
   caseInsensitive?: CaseInsensitive;
+  disableRecentSearches?: boolean;
   disabled?: boolean;
   disallowFreeText?: boolean;
   disallowHas?: boolean;
@@ -101,6 +102,7 @@ export function useTraceItemSearchQueryBuilderProps({
   disallowHas,
   disallowFreeText,
   disallowLogicalOperators,
+  disableRecentSearches,
 }: TraceItemSearchQueryBuilderProps) {
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
   const functionTags = useFunctionTags(itemType, supportedAggregates);
@@ -149,7 +151,9 @@ export function useTraceItemSearchQueryBuilderProps({
       disallowUnsupportedFilters: !getTagKeys,
       disallowFreeText,
       disallowLogicalOperators,
-      recentSearches: itemTypeToRecentSearches(itemType),
+      recentSearches: disableRecentSearches
+        ? undefined
+        : itemTypeToRecentSearches(itemType),
       namespace,
       showUnsubmittedIndicator: true,
       portalTarget,
@@ -168,6 +172,7 @@ export function useTraceItemSearchQueryBuilderProps({
       caseInsensitive,
       disallowFreeText,
       disallowLogicalOperators,
+      disableRecentSearches,
       filterKeySections,
       filterTags,
       getFilterTokenWarning,
@@ -220,6 +225,7 @@ export function TraceItemSearchQueryBuilder({
   disallowHas,
   disallowFreeText,
   disallowLogicalOperators,
+  disableRecentSearches,
 }: TraceItemSearchQueryBuilderProps) {
   const searchQueryBuilderProps = useTraceItemSearchQueryBuilderProps({
     itemType,
@@ -246,6 +252,7 @@ export function TraceItemSearchQueryBuilder({
     disallowHas,
     disallowFreeText,
     disallowLogicalOperators,
+    disableRecentSearches,
   });
 
   return (


### PR DESCRIPTION
This PR handles the options provided when multiple metrics are selected. We've chosen to go the easier route at first because it's the baseline functionality across different datasets, e.g. spans.

e.g. if we select multiple metrics we:
- fetch all attributes instead of scoping them down
- disable recent searches
  - we have to do this because we added a small hack to recent searches where we share the tracemetrics enum in the backend, but we have a hidden filter that prefixes the metric name. This doesn't work well with multiple metrics.