### PR TITLE
feat(tracemetrics): Show all attributes in group by for multi metrics

### DIFF
--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -36,6 +36,7 @@ import {
   extractTraceMetricFromColumn,
   getTraceMetricAggregateSource,
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+import {hasMultipleMetricsSelected} from 'sentry/views/dashboards/widgetBuilder/utils/hasMultipleMetricsSelected';
 import {
   useTraceMetricsSeriesQuery,
   useTraceMetricsTableQuery,
@@ -95,12 +96,10 @@ function TraceMetricsSearchBar({
   const traceMetrics =
     aggregateSource?.map(extractTraceMetricFromColumn).filter(defined) ?? [];
 
-  // Create a set of the trace metrics in a consistent string format to
-  // check if there are multiple metrics
-  const countUniqueMetrics = new Set(
-    traceMetrics.map(({name, type, unit}) => `${name},${type},${unit}`)
-  ).size;
-  const hasMultipleMetrics = hasMultiMetricSelection && countUniqueMetrics > 1;
+  const hasMultipleMetrics = hasMultipleMetricsSelected(
+    traceMetrics,
+    hasMultiMetricSelection
+  );
 
   // In the case of multiple metrics, wipe the query so it fetches all attributes
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.spec.tsx
@@ -1,0 +1,84 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {WidgetType} from 'sentry/views/dashboards/types';
+import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {useWidgetBuilderTraceItemConfig} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/useNavigate');
+
+const mockedUseLocation = jest.mocked(useLocation);
+const mockedUseNavigate = jest.mocked(useNavigate);
+
+describe('useWidgetBuilderTraceItemConfig', () => {
+  beforeEach(() => {
+    mockedUseNavigate.mockReturnValue(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined query when multiple metrics are selected', () => {
+    mockedUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {
+          dataset: WidgetType.TRACEMETRICS,
+          displayType: 'line',
+          yAxis: ['avg(value,metric_one,gauge,-)', 'sum(value,metric_two,counter,-)'],
+        },
+      })
+    );
+
+    const organization = OrganizationFixture({
+      features: [
+        'visibility-explore-view',
+        'tracemetrics-multi-metric-selection-in-dashboards',
+      ],
+    });
+
+    const {result} = renderHookWithProviders(() => useWidgetBuilderTraceItemConfig(), {
+      organization,
+      additionalWrapper: WidgetBuilderProvider,
+    });
+
+    expect(result.current.traceItemType).toBe(TraceItemDataset.TRACEMETRICS);
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.query).toBeUndefined();
+  });
+
+  it('returns a query when a single metric is selected', () => {
+    mockedUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {
+          dataset: WidgetType.TRACEMETRICS,
+          displayType: 'line',
+          yAxis: ['avg(value,metric_one,gauge,-)', 'max(value,metric_one,gauge,-)'],
+        },
+      })
+    );
+
+    const organization = OrganizationFixture({
+      features: [
+        'visibility-explore-view',
+        'tracemetrics-multi-metric-selection-in-dashboards',
+      ],
+    });
+
+    const {result} = renderHookWithProviders(() => useWidgetBuilderTraceItemConfig(), {
+      organization,
+      additionalWrapper: WidgetBuilderProvider,
+    });
+
+    expect(result.current.traceItemType).toBe(TraceItemDataset.TRACEMETRICS);
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.query).toBeDefined();
+    expect(result.current.query).toContain('metric_one');
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.ts
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.ts
@@ -47,7 +47,7 @@ export function useWidgetBuilderTraceItemConfig(): TraceItemAttributeConfig {
 
     return {
       traceItemType: TraceItemDataset.TRACEMETRICS,
-      enabled: true,
+      enabled: traceMetrics.length > 0 && defined(traceMetrics?.[0]?.name),
       query:
         !hasMultipleMetrics && traceMetrics[0]
           ? createTraceMetricFilter(traceMetrics[0])

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.ts
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.ts
@@ -1,10 +1,13 @@
+import {defined} from 'sentry/utils';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {useTraceMetricMultiMetricSelection} from 'sentry/views/dashboards/widgetBuilder/hooks/useTraceMetricMultiMetricSelection';
 import {
-  extractTraceMetricFromAggregates,
+  extractTraceMetricFromColumn,
   getTraceMetricAggregateSource,
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+import {hasMultipleMetricsSelected} from 'sentry/views/dashboards/widgetBuilder/utils/hasMultipleMetricsSelected';
 import type {TraceItemAttributeConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
@@ -13,6 +16,7 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 export function useWidgetBuilderTraceItemConfig(): TraceItemAttributeConfig {
   const {state} = useWidgetBuilderContext();
   const organization = useOrganization();
+  const hasMultiMetricSelection = useTraceMetricMultiMetricSelection();
 
   if (state.dataset === WidgetType.SPANS) {
     return {
@@ -34,15 +38,21 @@ export function useWidgetBuilderTraceItemConfig(): TraceItemAttributeConfig {
       state.yAxis,
       state.fields
     );
-    const traceMetric = extractTraceMetricFromAggregates(aggregateSource);
+    const traceMetrics =
+      aggregateSource?.map(extractTraceMetricFromColumn).filter(defined) ?? [];
+    const hasMultipleMetrics = hasMultipleMetricsSelected(
+      traceMetrics,
+      hasMultiMetricSelection
+    );
 
-    if (traceMetric) {
-      return {
-        traceItemType: TraceItemDataset.TRACEMETRICS,
-        enabled: true,
-        query: createTraceMetricFilter(traceMetric),
-      };
-    }
+    return {
+      traceItemType: TraceItemDataset.TRACEMETRICS,
+      enabled: true,
+      query:
+        !hasMultipleMetrics && traceMetrics[0]
+          ? createTraceMetricFilter(traceMetrics[0])
+          : undefined,
+    };
   }
 
   if (state.dataset === WidgetType.PREPROD_APP_SIZE) {

--- a/static/app/views/dashboards/widgetBuilder/utils/hasMultipleMetricsSelected.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/hasMultipleMetricsSelected.tsx
@@ -1,0 +1,13 @@
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+
+export function hasMultipleMetricsSelected(
+  traceMetrics: TraceMetric[],
+  hasMultiMetricSelection: boolean
+) {
+  // Create a set of the trace metrics in a consistent string format to
+  // check if there are multiple metrics
+  const countUniqueMetrics = new Set(
+    traceMetrics.map(({name, type, unit}) => `${name},${type},${unit}`)
+  ).size;
+  return hasMultiMetricSelection && countUniqueMetrics > 1;
+}


### PR DESCRIPTION
When there are multiple metrics selected, remove the attribute filter from the config where we define properties to use for the trace item attributes request.

Ideally we only fetch the ones that are relevant but I'm not entirely sure the backend supports OR requests properly yet, so we're going to go easy and just fetch everything.