### PR TITLE
ref(utils): Add functional updater support to useSessionStorage

### DIFF
--- a/static/app/utils/useSessionStorage.spec.tsx
+++ b/static/app/utils/useSessionStorage.spec.tsx
@@ -57,6 +57,18 @@ describe('useSessionStorage', () => {
     expect(JSON.parse(sessionStorageWrapper.getItem('key')!)).toEqual({a: 1, b: 2});
   });
 
+  it('removeItem wins over a pending write in the same tick', () => {
+    const {result} = renderHook(() => useSessionStorage('key', 'initial'));
+
+    act(() => {
+      result.current[1]('updated');
+      result.current[2]();
+    });
+
+    expect(result.current[0]).toBe('initial');
+    expect(sessionStorageWrapper.getItem('key')).toBeNull();
+  });
+
   it('removes item from storage', () => {
     sessionStorageWrapper.setItem('key', JSON.stringify('stored'));
     const {result} = renderHook(() => useSessionStorage('key', 'initial'));

--- a/static/app/utils/useSessionStorage.spec.tsx
+++ b/static/app/utils/useSessionStorage.spec.tsx
@@ -1,0 +1,71 @@
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
+
+import {useSessionStorage} from './useSessionStorage';
+
+describe('useSessionStorage', () => {
+  beforeEach(() => {
+    sessionStorageWrapper.clear();
+  });
+
+  it('returns initial value when storage is empty', () => {
+    const {result} = renderHook(() => useSessionStorage('key', 'initial'));
+    expect(result.current[0]).toBe('initial');
+  });
+
+  it('reads existing value from session storage', () => {
+    sessionStorageWrapper.setItem('key', JSON.stringify('stored'));
+    const {result} = renderHook(() => useSessionStorage('key', 'initial'));
+    expect(result.current[0]).toBe('stored');
+  });
+
+  it('sets a direct value', () => {
+    const {result} = renderHook(() => useSessionStorage('key', 'initial'));
+
+    act(() => {
+      result.current[1]('updated');
+    });
+
+    expect(result.current[0]).toBe('updated');
+    expect(JSON.parse(sessionStorageWrapper.getItem('key')!)).toBe('updated');
+  });
+
+  it('supports functional updater', () => {
+    const {result} = renderHook(() => useSessionStorage('key', 0));
+
+    act(() => {
+      result.current[1](prev => prev + 1);
+    });
+
+    expect(result.current[0]).toBe(1);
+    expect(JSON.parse(sessionStorageWrapper.getItem('key')!)).toBe(1);
+  });
+
+  it('functional updater reads latest state for sequential calls', () => {
+    const {result} = renderHook(() =>
+      useSessionStorage<{a?: number; b?: number}>('key', {})
+    );
+
+    act(() => {
+      result.current[1](prev => ({...prev, a: 1}));
+      result.current[1](prev => ({...prev, b: 2}));
+    });
+
+    // Both updates should be applied -- b should not clobber a
+    expect(result.current[0]).toEqual({a: 1, b: 2});
+    expect(JSON.parse(sessionStorageWrapper.getItem('key')!)).toEqual({a: 1, b: 2});
+  });
+
+  it('removes item from storage', () => {
+    sessionStorageWrapper.setItem('key', JSON.stringify('stored'));
+    const {result} = renderHook(() => useSessionStorage('key', 'initial'));
+
+    act(() => {
+      result.current[2]();
+    });
+
+    expect(result.current[0]).toBe('initial');
+    expect(sessionStorageWrapper.getItem('key')).toBeNull();
+  });
+});

--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect, useState, type SetStateAction} from 'react';
 
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
@@ -26,7 +26,7 @@ export function readStorageValue<T>(key: string, initialValue: T) {
 export function useSessionStorage<T>(
   key: string,
   initialValue: T
-): [T, (value: T) => void, () => void] {
+): [T, (value: SetStateAction<T>) => void, () => void] {
   const [state, setState] = useState<T>(() => readStorageValue(key, initialValue));
 
   useEffect(() => {
@@ -36,14 +36,21 @@ export function useSessionStorage<T>(
   }, [key]);
 
   const wrappedSetState = useCallback(
-    (value: T) => {
-      setState(value);
+    (valueOrUpdater: SetStateAction<T>) => {
+      setState(prev => {
+        const next =
+          typeof valueOrUpdater === 'function'
+            ? (valueOrUpdater as (prev: T) => T)(prev)
+            : valueOrUpdater;
 
-      try {
-        sessionStorageWrapper.setItem(key, JSON.stringify(value));
-      } catch {
-        // Best effort and just update the in-memory value.
-      }
+        try {
+          sessionStorageWrapper.setItem(key, JSON.stringify(next));
+        } catch {
+          // Best effort and just update the in-memory value.
+        }
+
+        return next;
+      });
     },
     [key]
   );

--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -38,6 +38,8 @@ export function useSessionStorage<T>(
   const wrappedSetState = useCallback(
     (valueOrUpdater: SetStateAction<T>) => {
       setState(prev => {
+        // Cast needed: TS can't narrow SetStateAction<T> via typeof when T
+        // could itself be a function type.
         const next =
           typeof valueOrUpdater === 'function'
             ? (valueOrUpdater as (prev: T) => T)(prev)

--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -58,8 +58,10 @@ export function useSessionStorage<T>(
   );
 
   const removeItem = useCallback(() => {
-    setState(initialValue);
-    sessionStorageWrapper.removeItem(key);
+    setState(() => {
+      sessionStorageWrapper.removeItem(key);
+      return initialValue;
+    });
   }, [key, initialValue]);
 
   if (!isBrowser) {


### PR DESCRIPTION
## Summary

- Support `SetStateAction<T>` (function updater) in `useSessionStorage`'s setter, matching React's `useState` API
- Prevents stale-state bugs when multiple sequential calls spread the same snapshot, since each updater receives the latest `prev` value
- Adds spec file with 6 tests covering direct values, functional updaters, sequential calls, and item removal

Split out from #110883 per review feedback.

## Test plan

- [x] `CI=true pnpm test static/app/utils/useSessionStorage.spec.tsx` -- 6 tests passing
- [x] Key test: sequential functional updaters don't clobber each other (`{a: 1}` then `{b: 2}` results in `{a: 1, b: 2}`)