### PR TITLE
Codeowners configuration update

### DIFF
--- a/.codeowners-config.yml
+++ b/.codeowners-config.yml
@@ -9,10 +9,13 @@ baseline_path: '.github/codeowners-coverage-baseline.txt'
 team_allowlist:
   - getsentry/alerts-create-issues
   - getsentry/alerts-notifications
+  - getsentry/app-backend
   - getsentry/app-frontend
   - getsentry/codecov
   - getsentry/codecov-merge
   - getsentry/coding-workflows
+  - getsentry/coding-workflows-sentry-backend
+  - getsentry/coding-workflows-sentry-frontend
   - getsentry/crons
   - getsentry/dashboards
   - getsentry/data
@@ -58,6 +61,7 @@ team_allowlist:
   - getsentry/team-javascript-sdks
   - getsentry/team-web-sdk-backend
   - getsentry/telemetry-experience
+  - getsentry/value-discovery
 
 # File patterns to exclude from coverage checking
 exclusions:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,6 @@
 /src/sentry/testutils/                                  @getsentry/app-backend
 /src/sentry/users/                                      @getsentry/app-backend
 /tests/sentry/api/                                      @getsentry/app-backend
-/tests/sentry/api/                                      @getsentry/app-backend
 /src/sentry/templates/                                  @getsentry/app-backend
 /src/sentry/tasks/                                      @getsentry/app-backend
 /.agents/skills/sentry-backend-bugs/                    @getsentry/app-backend


### PR DESCRIPTION
### Fixes

-   Removed duplicate `/tests/sentry/api/` entry from `.github/CODEOWNERS`.
-   Added missing teams (`getsentry/app-backend`, `getsentry/value-discovery`, `getsentry/coding-workflows-sentry-frontend`, `getsentry/coding-workflows-sentry-backend`) to the `team_allowlist` in `.codeowners-config.yml` to ensure accurate CODEOWNERS coverage checks.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.