### PR TITLE
Refactor has_release_permission to protect mutations

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -712,20 +712,15 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         Does the given request have permission to access this release, based
         on the projects to which the release is attached?
 
-        By default (require_all_projects=False), access is granted if the user
-        has access to *any* project linked to the release. This is appropriate
-        for read operations.
+        By default, access is granted if the user has access to *any* project
+        on the release (suitable for reads). When require_all_projects=True,
+        the user must have access to *all* projects on the release (use for
+        mutations). Without this, a user with access to one project on a
+        multi-project release could modify or delete it, affecting projects
+        they cannot access. The all-projects check respects Open Membership
+        via has_global_access.
 
-        When require_all_projects=True and a release is provided, access is
-        only granted if the user has access to *all* projects linked to the
-        release. Use this for mutations (PUT, DELETE, POST) that affect the
-        entire release across all its projects. This check respects Open
-        Membership: when allow_joinleave is True, has_project_access grants
-        access to all active org projects via has_global_access.
-
-        If the given request has an actor (user or ApiKey), cache the results
-        for a minute on the unique combination of actor, org, release, project
-        ids, and require_all_projects.
+        Results are cached for 60s per actor/org/release/project-ids/mode.
         """
         actor_id = None
         has_perms = None

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -706,14 +706,26 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         organization: Organization | RpcOrganization,
         release: Release | None = None,
         project_ids: set[int] | None = None,
+        require_all_projects: bool = False,
     ) -> bool:
         """
         Does the given request have permission to access this release, based
         on the projects to which the release is attached?
 
+        By default (require_all_projects=False), access is granted if the user
+        has access to *any* project linked to the release. This is appropriate
+        for read operations.
+
+        When require_all_projects=True and a release is provided, access is
+        only granted if the user has access to *all* projects linked to the
+        release. Use this for mutations (PUT, DELETE, POST) that affect the
+        entire release across all its projects. This check respects Open
+        Membership: when allow_joinleave is True, has_project_access grants
+        access to all active org projects via has_global_access.
+
         If the given request has an actor (user or ApiKey), cache the results
-        for a minute on the unique combination of actor,org,release, and project
-        ids.
+        for a minute on the unique combination of actor, org, release, project
+        ids, and require_all_projects.
         """
         actor_id = None
         has_perms = None
@@ -727,20 +739,23 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
             if requested_project_ids is None:
                 requested_project_ids = self.get_requested_project_ids_unchecked(request)
             key = "release_perms:1:%s" % hash_values(
-                [actor_id, organization.id, release.id if release is not None else 0]
+                [
+                    actor_id,
+                    organization.id,
+                    release.id if release is not None else 0,
+                    int(require_all_projects),
+                ]
                 + sorted(requested_project_ids)
             )
             has_perms = cache.get(key)
         if has_perms is None:
             projects = self.get_projects(request, organization, project_ids=project_ids)
-            # XXX(iambriccardo): The logic here is that you have access to this release if any of your projects
-            # associated with this release you have release permissions to.  This is a bit of
-            # a problem because anyone can add projects to a release, so this check is easy
-            # to defeat.
             if release is not None:
                 has_perms = ReleaseProject.objects.filter(
                     release=release, project__in=projects
                 ).exists()
+                if has_perms and require_all_projects:
+                    has_perms = request.access.has_projects_access(list(release.projects.all()))
             else:
                 has_perms = len(projects) > 0
 

--- a/src/sentry/releases/endpoints/organization_release_assemble.py
+++ b/src/sentry/releases/endpoints/organization_release_assemble.py
@@ -36,7 +36,9 @@ class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
-        if not self.has_release_permission(request, organization, release):
+        if not self.has_release_permission(
+            request, organization, release, require_all_projects=True
+        ):
             raise ResourceDoesNotExist
 
         schema = {

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -446,12 +446,10 @@ class OrganizationReleaseDetailsEndpoint(
             scope.set_tag("failure_reason", "Release.DoesNotExist")
             raise ResourceDoesNotExist
 
-        if not self.has_release_permission(request, organization, release):
+        if not self.has_release_permission(
+            request, organization, release, require_all_projects=True
+        ):
             scope.set_tag("failure_reason", "no_release_permission")
-            raise ResourceDoesNotExist
-
-        if not request.access.has_projects_access(list(projects)):
-            scope.set_tag("failure_reason", "no_access_to_all_projects")
             raise ResourceDoesNotExist
 
         serializer = OrganizationReleaseSerializer(data=request.data)
@@ -562,10 +560,9 @@ class OrganizationReleaseDetailsEndpoint(
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
-        if not self.has_release_permission(request, organization, release):
-            raise ResourceDoesNotExist
-
-        if not request.access.has_projects_access(list(release.projects.all())):
+        if not self.has_release_permission(
+            request, organization, release, require_all_projects=True
+        ):
             raise ResourceDoesNotExist
 
         try:

--- a/src/sentry/releases/endpoints/organization_release_file_details.py
+++ b/src/sentry/releases/endpoints/organization_release_file_details.py
@@ -76,7 +76,9 @@ class OrganizationReleaseFileDetailsEndpoint(
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
-        if not self.has_release_permission(request, organization, release):
+        if not self.has_release_permission(
+            request, organization, release, require_all_projects=True
+        ):
             raise ResourceDoesNotExist
 
         return self.update_releasefile(request, release, file_id)
@@ -101,7 +103,9 @@ class OrganizationReleaseFileDetailsEndpoint(
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
-        if not self.has_release_permission(request, organization, release):
+        if not self.has_release_permission(
+            request, organization, release, require_all_projects=True
+        ):
             raise ResourceDoesNotExist
 
         return self.delete_releasefile(release, file_id)

--- a/src/sentry/releases/endpoints/organization_release_files.py
+++ b/src/sentry/releases/endpoints/organization_release_files.py
@@ -103,7 +103,9 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
         logger = logging.getLogger("sentry.files")
         logger.info("organizationreleasefile.start")
 
-        if not self.has_release_permission(request, organization, release):
+        if not self.has_release_permission(
+            request, organization, release, require_all_projects=True
+        ):
             raise ResourceDoesNotExist
 
         return self.post_releasefile(request, release, logger)

--- a/src/sentry/releases/endpoints/release_deploys.py
+++ b/src/sentry/releases/endpoints/release_deploys.py
@@ -207,9 +207,9 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
             )
             raise ResourceDoesNotExist
 
-        if not self.has_release_permission(request, organization, release):
-            # Logic here copied from `has_release_permission` (lightly edited for results to be more
-            # human-readable)
+        if not self.has_release_permission(
+            request, organization, release, require_all_projects=True
+        ):
             if request.user.is_authenticated:
                 auth = f"user.id: {request.user.id}"
             elif request.auth is not None:

--- a/tests/sentry/releases/endpoints/test_organization_release_assemble.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_assemble.py
@@ -26,6 +26,39 @@ class OrganizationReleaseAssembleTest(APITestCase):
             args=[self.organization.slug, self.release.version],
         )
 
+    def test_no_access_to_all_projects(self) -> None:
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+        project1 = self.create_project(teams=[team1], organization=org)
+        project2 = self.create_project(teams=[team2], organization=org)
+
+        release = self.create_release(
+            version="restricted-release.1",
+            project=project1,
+            additional_projects=[project2],
+        )
+
+        self.create_member(teams=[team1], user=user, organization=org)
+        self.login_as(user=user)
+
+        url = reverse(
+            "sentry-api-0-organization-release-assemble",
+            args=[org.slug, release.version],
+        )
+
+        checksum = sha1(b"1").hexdigest()
+        response = self.client.post(
+            url,
+            data={"checksum": checksum, "chunks": [checksum]},
+        )
+
+        assert response.status_code == 404
+
     def test_assemble_json_schema(self) -> None:
         response = self.client.post(
             self.url, data={"lol": "test"}, HTTP_AUTHORIZATION=f"Bearer {self.token.token}"

--- a/tests/sentry/releases/endpoints/test_organization_release_file_details.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_file_details.py
@@ -120,6 +120,80 @@ class ReleaseFileDetailsTest(APITestCase):
 
 
 class ReleaseFileUpdateTest(APITestCase):
+    def test_no_access_to_all_projects(self) -> None:
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+        project1 = self.create_project(teams=[team1], organization=org)
+        project2 = self.create_project(teams=[team2], organization=org)
+
+        release = Release.objects.create(organization_id=org.id, version="1")
+        release.add_project(project1)
+        release.add_project(project2)
+
+        releasefile = ReleaseFile.objects.create(
+            organization_id=org.id,
+            release_id=release.id,
+            file=File.objects.create(name="application.js", type="release.file"),
+            name="http://example.com/application.js",
+        )
+
+        self.create_member(teams=[team1], user=user, organization=org)
+        self.login_as(user=user)
+
+        url = reverse(
+            "sentry-api-0-organization-release-file-details",
+            kwargs={
+                "organization_id_or_slug": org.slug,
+                "version": release.version,
+                "file_id": releasefile.id,
+            },
+        )
+        response = self.client.put(url, {"name": "foobar"})
+
+        assert response.status_code == 404
+
+    def test_no_access_to_all_projects_open_membership(self) -> None:
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = True
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+        project1 = self.create_project(teams=[team1], organization=org)
+        project2 = self.create_project(teams=[team2], organization=org)
+
+        release = Release.objects.create(organization_id=org.id, version="1")
+        release.add_project(project1)
+        release.add_project(project2)
+
+        releasefile = ReleaseFile.objects.create(
+            organization_id=org.id,
+            release_id=release.id,
+            file=File.objects.create(name="application.js", type="release.file"),
+            name="http://example.com/application.js",
+        )
+
+        self.create_member(teams=[team1], user=user, organization=org)
+        self.login_as(user=user)
+
+        url = reverse(
+            "sentry-api-0-organization-release-file-details",
+            kwargs={
+                "organization_id_or_slug": org.slug,
+                "version": release.version,
+                "file_id": releasefile.id,
+            },
+        )
+        response = self.client.put(url, {"name": "foobar"})
+
+        assert response.status_code == 200
+
     def test_simple(self) -> None:
         self.login_as(user=self.user)
 
@@ -155,6 +229,44 @@ class ReleaseFileUpdateTest(APITestCase):
 
 
 class ReleaseFileDeleteTest(APITestCase):
+    def test_no_access_to_all_projects(self) -> None:
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+        project1 = self.create_project(teams=[team1], organization=org)
+        project2 = self.create_project(teams=[team2], organization=org)
+
+        release = Release.objects.create(organization_id=org.id, version="1")
+        release.add_project(project1)
+        release.add_project(project2)
+
+        releasefile = ReleaseFile.objects.create(
+            organization_id=org.id,
+            release_id=release.id,
+            file=File.objects.create(name="application.js", type="release.file"),
+            name="http://example.com/application.js",
+        )
+
+        self.create_member(teams=[team1], user=user, organization=org)
+        self.login_as(user=user)
+
+        url = reverse(
+            "sentry-api-0-organization-release-file-details",
+            kwargs={
+                "organization_id_or_slug": org.slug,
+                "version": release.version,
+                "file_id": releasefile.id,
+            },
+        )
+        response = self.client.delete(url)
+
+        assert response.status_code == 404
+        assert ReleaseFile.objects.filter(id=releasefile.id).exists()
+
     def test_simple(self) -> None:
         self.login_as(user=self.user)
 

--- a/tests/sentry/releases/endpoints/test_organization_release_files.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_files.py
@@ -206,6 +206,44 @@ class ReleaseFilesListTest(APITestCase):
 
 
 class ReleaseFileCreateTest(APITestCase):
+    def test_no_access_to_all_projects(self) -> None:
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+        project1 = self.create_project(teams=[team1], organization=org)
+        project2 = self.create_project(teams=[team2], organization=org)
+
+        release = Release.objects.create(organization_id=org.id, version="1")
+        release.add_project(project1)
+        release.add_project(project2)
+
+        self.create_member(teams=[team1], user=user, organization=org)
+        self.login_as(user=user)
+
+        url = reverse(
+            "sentry-api-0-organization-release-files",
+            kwargs={
+                "organization_id_or_slug": org.slug,
+                "version": release.version,
+            },
+        )
+        response = self.client.post(
+            url,
+            {
+                "name": "http://example.com/application.js",
+                "file": SimpleUploadedFile(
+                    "application.js", b"function() { }", content_type="application/javascript"
+                ),
+            },
+            format="multipart",
+        )
+
+        assert response.status_code == 404
+
     def test_simple(self) -> None:
         project = self.create_project(name="foo")
 

--- a/tests/sentry/releases/endpoints/test_release_deploys.py
+++ b/tests/sentry/releases/endpoints/test_release_deploys.py
@@ -152,6 +152,57 @@ class ReleaseDeploysCreateTest(APITestCase):
         self.create_member(teams=[team], user=user, organization=self.org)
         self.login_as(user=user)
 
+    def test_no_access_to_all_projects(self) -> None:
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        team2 = self.create_team(organization=self.org)
+        project2 = self.create_project(teams=[team2], organization=self.org)
+
+        release = Release.objects.create(organization_id=self.org.id, version="1", total_deploys=0)
+        release.add_project(self.project)
+        release.add_project(project2)
+
+        url = reverse(
+            "sentry-api-0-organization-release-deploys",
+            kwargs={
+                "organization_id_or_slug": self.org.slug,
+                "version": release.version,
+            },
+        )
+        response = self.client.post(
+            url,
+            data={"name": "foo", "environment": "production", "url": "https://www.example.com"},
+        )
+
+        assert response.status_code == 404
+        assert not Deploy.objects.filter(release=release).exists()
+
+    def test_no_access_to_all_projects_open_membership(self) -> None:
+        self.org.flags.allow_joinleave = True
+        self.org.save()
+
+        team2 = self.create_team(organization=self.org)
+        project2 = self.create_project(teams=[team2], organization=self.org)
+
+        release = Release.objects.create(organization_id=self.org.id, version="1", total_deploys=0)
+        release.add_project(self.project)
+        release.add_project(project2)
+
+        url = reverse(
+            "sentry-api-0-organization-release-deploys",
+            kwargs={
+                "organization_id_or_slug": self.org.slug,
+                "version": release.version,
+            },
+        )
+        response = self.client.post(
+            url,
+            data={"name": "foo", "environment": "production", "url": "https://www.example.com"},
+        )
+
+        assert response.status_code == 201
+
     def test_simple(self) -> None:
         release = Release.objects.create(organization_id=self.org.id, version="1", total_deploys=0)
         release.add_project(self.project)


### PR DESCRIPTION
Fixing this three year old weakness https://github.com/getsentry/sentry/commit/14a6b2c8a27e64b613c81e81b12b1ffa6bd0fbce. `had_release permission` was granting access if a user had any project on a release, which was nasty for mutations where a member shouldn't be able modify a release they don't have access to. We had a number of downstream code vulnerability fixes that stemmed from this, but I'm solving it upstream now. 

Changes:
- `has_release_permission` Added `require_all_projects_param` with a false default so it's backward compatible with the previous fixes
-- when true, checks against `request.access.has_projects_access()` 
- Org release details PUT/DELETE, release file details PT/DELETE, release files POST, release assembly POST, and release deploys POST are all happy
- bunch of regression tests

No changes to the read-only endpoints here nor artifactbundle assembly which we recently added explicit project scoping to. 


