### PR TITLE
fix(dashboards): Prevent double HTML-escaping in chart tooltips

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -31,7 +31,7 @@ import type {
   EChartHighlightHandler,
   ReactEchartsRef,
 } from 'sentry/types/echarts';
-import {defined} from 'sentry/utils';
+import {defined, escape} from 'sentry/utils';
 import {uniq} from 'sentry/utils/array/uniq';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {RangeMap, type Range} from 'sentry/utils/number/rangeMap';
@@ -348,8 +348,17 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           return defined(sampleId) ? sampleId.toString() : seriesName;
         }
 
-        const name = aliases[seriesName] ?? seriesName;
-        return truncationFormatter(name, true, false);
+        const alias = aliases[seriesName];
+        if (alias) {
+          // The alias value comes from `plottable.label` and is not
+          // HTML-escaped. Escape it for safe insertion into raw HTML
+          // tooltip strings.
+          return escape(truncationFormatter(alias, true, false));
+        }
+        // `seriesName` is already HTML-escaped by `getFormatter`, so
+        // skip escaping to avoid double-encoding (e.g., `>` → `&gt;`
+        // → `&amp;gt;`).
+        return truncationFormatter(seriesName, true, false);
       },
       valueFormatter: function (value, _field, valueFormatterParams) {
         // Use the series to figure out the corresponding `Plottable`, and get the field type. From that, use whichever unit we chose for that field type.

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -349,7 +349,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         }
 
         const name = aliases[seriesName] ?? seriesName;
-        return truncationFormatter(name, true);
+        return truncationFormatter(name, true, false);
       },
       valueFormatter: function (value, _field, valueFormatterParams) {
         // Use the series to figure out the corresponding `Plottable`, and get the field type. From that, use whichever unit we chose for that field type.


### PR DESCRIPTION
Prevent double HTML-escaping of series names in time series widget chart tooltips.

When a widget has multiple queries with a `groupBy`, series names use ` > ` as a delimiter (e.g., `My Query > prod : count()`). The tooltip `nameFormatter` in `TimeSeriesWidgetVisualization` called `truncationFormatter` with escaping enabled, but the outer `truncationFormatter` in `getFormatter` (tooltip.tsx) already escapes. This caused `>` to be double-escaped to `&amp;gt;`, which rendered as literal `&gt;` in tooltips.

The fix passes `escaped = false` to the inner `truncationFormatter` call, matching the existing pattern in `categoricalSeriesWidgetVisualization` (line 272-276) and the legend formatter (line 707-714, which has a comment explicitly explaining why escaping is disabled).

The ` > ` delimiter has been in series names since Jan 2025 (`transformEventsResponseToSeries`), but the double-escaping was introduced when `TimeSeriesWidgetVisualization` was created with its `nameFormatter` that redundantly escapes.

Fixes DAIN-1223