### PR TITLE
feat(preprod): Add Datadog metrics for snapshot upload and diff lifecycle

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from typing import Any
 
 import jsonschema
@@ -383,6 +384,38 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 "image_count": len(images),
             },
         )
+
+        has_vcs = commit_comparison is not None
+
+        metrics.distribution(
+            "preprod.snapshots.upload.image_count",
+            len(images),
+            sample_rate=1.0,
+            tags={"has_vcs": has_vcs},
+        )
+
+        file_name_counts: Counter[str] = Counter(
+            v["image_file_name"] for v in images.values() if v.get("image_file_name")
+        )
+        duplicate_count = sum(c - 1 for c in file_name_counts.values() if c > 1)
+        metrics.distribution(
+            "preprod.snapshots.upload.duplicate_image_file_names",
+            duplicate_count,
+            sample_rate=1.0,
+        )
+
+        if has_vcs:
+            # No composite index on (commit_comparison, project) — acceptable at current
+            # Snapshots customer volume (rate-limited to 100 req/min/org).
+            bundle_count = PreprodArtifact.objects.filter(
+                commit_comparison=commit_comparison,
+                project=project,
+            ).count()
+            metrics.distribution(
+                "preprod.snapshots.upload.bundles_per_commit",
+                bundle_count,
+                sample_rate=1.0,
+            )
 
         create_preprod_snapshot_status_check_task.apply_async(
             kwargs={

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections import Counter
 from typing import Any
 
 import jsonschema
@@ -387,21 +386,17 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
 
         has_vcs = commit_comparison is not None
 
+        metric_tags = {
+            "org_id": str(project.organization_id),
+            "project_id": str(project.id),
+            "app_id": artifact.app_id or "",
+        }
+
         metrics.distribution(
             "preprod.snapshots.upload.image_count",
             len(images),
             sample_rate=1.0,
-            tags={"has_vcs": has_vcs},
-        )
-
-        file_name_counts: Counter[str] = Counter(
-            v["image_file_name"] for v in images.values() if v.get("image_file_name")
-        )
-        duplicate_count = sum(c - 1 for c in file_name_counts.values() if c > 1)
-        metrics.distribution(
-            "preprod.snapshots.upload.duplicate_image_file_names",
-            duplicate_count,
-            sample_rate=1.0,
+            tags={**metric_tags, "has_vcs": has_vcs},
         )
 
         if has_vcs:
@@ -416,6 +411,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                     "preprod.snapshots.upload.bundles_per_commit",
                     bundle_count,
                     sample_rate=1.0,
+                    tags=metric_tags,
                 )
             except Exception:
                 logger.exception("Failed to record bundles_per_commit metric")

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -405,17 +405,20 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         )
 
         if has_vcs:
-            # No composite index on (commit_comparison, project) — acceptable at current
-            # Snapshots customer volume (rate-limited to 100 req/min/org).
-            bundle_count = PreprodArtifact.objects.filter(
-                commit_comparison=commit_comparison,
-                project=project,
-            ).count()
-            metrics.distribution(
-                "preprod.snapshots.upload.bundles_per_commit",
-                bundle_count,
-                sample_rate=1.0,
-            )
+            try:
+                # No composite index on (commit_comparison, project) — acceptable at current
+                # Snapshots customer volume (rate-limited to 100 req/min/org).
+                bundle_count = PreprodArtifact.objects.filter(
+                    commit_comparison=commit_comparison,
+                    project=project,
+                ).count()
+                metrics.distribution(
+                    "preprod.snapshots.upload.bundles_per_commit",
+                    bundle_count,
+                    sample_rate=1.0,
+                )
+            except Exception:
+                logger.exception("Failed to record bundles_per_commit metric")
 
         create_preprod_snapshot_status_check_task.apply_async(
             kwargs={

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -123,6 +123,7 @@ def compare_snapshots(
     head_artifact_id: int,
     base_artifact_id: int,
 ) -> None:
+    task_start_time = timezone.now()
     logger.info(
         "Snapshot comparison kicked off for artifacts",
         extra={
@@ -516,7 +517,7 @@ def compare_snapshots(
 
         time_now = timezone.now()
 
-        diff_duration_s = (time_now - comparison.date_added).total_seconds()
+        diff_duration_s = (time_now - task_start_time).total_seconds()
         metrics.distribution(
             "preprod.snapshots.diff.duration_s",
             diff_duration_s,
@@ -537,7 +538,7 @@ def compare_snapshots(
                 sample_rate=1.0,
             )
 
-        if changed_count == 0 and not added and not removed:
+        if changed_count == 0 and not added and not removed and not renamed_pairs:
             metrics.incr("preprod.snapshots.diff.zero_changes", sample_rate=1.0)
 
         create_preprod_snapshot_status_check_task.apply_async(

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -517,11 +517,18 @@ def compare_snapshots(
 
         time_now = timezone.now()
 
+        metric_tags = {
+            "org_id": str(org_id),
+            "project_id": str(project_id),
+            "app_id": head_artifact.app_id or "",
+        }
+
         diff_duration_s = (time_now - task_start_time).total_seconds()
         metrics.distribution(
             "preprod.snapshots.diff.duration_s",
             diff_duration_s,
             sample_rate=1.0,
+            tags=metric_tags,
         )
 
         e2e_duration_s = (time_now - head_artifact.date_added).total_seconds()
@@ -529,6 +536,7 @@ def compare_snapshots(
             "preprod.snapshots.e2e_duration_s",
             e2e_duration_s,
             sample_rate=1.0,
+            tags=metric_tags,
         )
 
         if total_fetched_count > 0:
@@ -536,6 +544,7 @@ def compare_snapshots(
                 "preprod.snapshots.image.avg_size_bytes",
                 total_fetched_bytes / total_fetched_count,
                 sample_rate=1.0,
+                tags=metric_tags,
             )
 
         if (
@@ -545,7 +554,7 @@ def compare_snapshots(
             and not renamed_pairs
             and not error_count
         ):
-            metrics.incr("preprod.snapshots.diff.zero_changes", sample_rate=1.0)
+            metrics.incr("preprod.snapshots.diff.zero_changes", sample_rate=1.0, tags=metric_tags)
 
         create_preprod_snapshot_status_check_task.apply_async(
             kwargs={

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -538,7 +538,13 @@ def compare_snapshots(
                 sample_rate=1.0,
             )
 
-        if changed_count == 0 and not added and not removed and not renamed_pairs:
+        if (
+            changed_count == 0
+            and not added
+            and not removed
+            and not renamed_pairs
+            and not error_count
+        ):
             metrics.incr("preprod.snapshots.diff.zero_changes", sample_rate=1.0)
 
         create_preprod_snapshot_status_check_task.apply_async(

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -5,6 +5,7 @@ from typing import NamedTuple
 
 import orjson
 from django.db import IntegrityError
+from django.utils import timezone
 from objectstore_client.client import RequestError
 from pydantic import ValidationError
 
@@ -25,6 +26,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
 from sentry.taskworker.retry import Retry
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -325,6 +327,9 @@ def compare_snapshots(
             },
         )
 
+        total_fetched_bytes = 0
+        total_fetched_count = 0
+
         batches = _create_pixel_batches(eligible, MAX_PIXELS_PER_BATCH)
 
         logger.info(
@@ -368,6 +373,8 @@ def compare_snapshots(
                             "reason": "image_fetch_failed",
                         }
                         continue
+                    total_fetched_bytes += len(head_data) + len(base_data)
+                    total_fetched_count += 2
                     diff_pairs.append((base_data, head_data))
                     batch_names.append(candidate.name)
                     batch_hashes.append((candidate.head_hash, candidate.base_hash))
@@ -506,6 +513,32 @@ def compare_snapshots(
                 "date_updated",
             ]
         )
+
+        time_now = timezone.now()
+
+        diff_duration_s = (time_now - comparison.date_added).total_seconds()
+        metrics.distribution(
+            "preprod.snapshots.diff.duration_s",
+            diff_duration_s,
+            sample_rate=1.0,
+        )
+
+        e2e_duration_s = (time_now - head_artifact.date_added).total_seconds()
+        metrics.distribution(
+            "preprod.snapshots.e2e_duration_s",
+            e2e_duration_s,
+            sample_rate=1.0,
+        )
+
+        if total_fetched_count > 0:
+            metrics.distribution(
+                "preprod.snapshots.image.avg_size_bytes",
+                total_fetched_bytes / total_fetched_count,
+                sample_rate=1.0,
+            )
+
+        if changed_count == 0 and not added and not removed:
+            metrics.incr("preprod.snapshots.diff.zero_changes", sample_rate=1.0)
 
         create_preprod_snapshot_status_check_task.apply_async(
             kwargs={


### PR DESCRIPTION
Adds `metrics.distribution` and `metrics.incr` instrumentation to the snapshot upload endpoint and `compare_snapshots` task so the Preprod Health dashboard can track snapshot usage and build quality signals.

## Metrics added

**On upload** (`ProjectPreprodSnapshotEndpoint.post`):

- `preprod.snapshots.upload.image_count` — number of images per upload, tagged `has_vcs` to distinguish CI builds from standalone uploads
- `preprod.snapshots.upload.duplicate_image_file_names` — count of `image_file_name` collisions within a single manifest (proxy for same screen uploaded under multiple hashes)
- `preprod.snapshots.upload.bundles_per_commit` — how many snapshot bundles have been uploaded for the same commit (only emitted when `has_vcs=True`)

**On diff completion** (`compare_snapshots` task):

- `preprod.snapshots.diff.duration_s` — time from comparison record creation to diff task completion
- `preprod.snapshots.e2e_duration_s` — time from artifact upload to diff completion, mirrors the existing `preprod.size_analysis.results_e2e` pattern
- `preprod.snapshots.image.avg_size_bytes` — average byte size of images actually fetched for pixel diff (excludes added/removed)
- `preprod.snapshots.diff.zero_changes` — incremented when a diff completes with no changed, added, or removed images

All metrics use `sample_rate=1.0`. No Amplitude analytics events are included — this is Datadog/tracemetrics only, targeting the existing Preprod Health dashboard.