### PR TITLE
feat(dashboards): Linkify replay.id and profile.id columns in table widgets

### DIFF
--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -532,6 +532,79 @@ describe('getFieldRenderer', () => {
     });
   });
 
+  it('renders replay.id with ViewReplayLink', () => {
+    const renderer = getFieldRenderer('replay.id', {'replay.id': 'string'});
+
+    render(
+      renderer(
+        {...data, 'replay.id': 'abc123def456'},
+        {location, organization, theme}
+      ) as React.ReactElement<any, any>
+    );
+
+    // ViewReplayLink renders "(missing)" when replay existence can't be confirmed,
+    // but this verifies the renderer is wired up through ViewReplayLink
+    expect(screen.getByText('(missing)')).toBeInTheDocument();
+  });
+
+  it('renders replay.id as empty when missing', () => {
+    const renderer = getFieldRenderer('replay.id', {'replay.id': 'string'});
+
+    render(
+      renderer(
+        {...data, 'replay.id': ''},
+        {location, organization, theme}
+      ) as React.ReactElement<any, any>
+    );
+
+    expect(screen.getByText('(no value)')).toBeInTheDocument();
+  });
+
+  it('renders profile.id as a link to the profile flamechart', () => {
+    const renderer = getFieldRenderer('profile.id', {'profile.id': 'string'});
+
+    render(
+      renderer(
+        {...data, 'profile.id': 'abc123def456'},
+        {location, organization, theme, projects: [project]}
+      ) as React.ReactElement<any, any>
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/explore/profiling/profile/${project.slug}/abc123def456/flamegraph/`
+    );
+    expect(screen.getByText('abc123de')).toBeInTheDocument();
+  });
+
+  it('renders profile.id as plain text when project is not available', () => {
+    const renderer = getFieldRenderer('profile.id', {'profile.id': 'string'});
+
+    render(
+      renderer(
+        {...data, project: 'unknown-project', 'profile.id': 'abc123def456'},
+        {location, organization, theme, projects: [project]}
+      ) as React.ReactElement<any, any>
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('abc123de')).toBeInTheDocument();
+  });
+
+  it('renders profile.id as empty when missing', () => {
+    const renderer = getFieldRenderer('profile.id', {'profile.id': 'string'});
+
+    render(
+      renderer(
+        {...data, 'profile.id': ''},
+        {location, organization, theme, projects: [project]}
+      ) as React.ReactElement<any, any>
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('(no value)')).toBeInTheDocument();
+  });
+
   it('renders opportunity score', () => {
     const renderer = getFieldRenderer('opportunity_score(measurements.score.total)', {
       'opportunity_score(measurements.score.total)': 'score',

--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -532,7 +532,12 @@ describe('getFieldRenderer', () => {
     });
   });
 
-  it('renders replay.id with ViewReplayLink', () => {
+  it('renders replay.id as a link when replay exists', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      body: {abc123def456: 1},
+    });
+
     const renderer = getFieldRenderer('replay.id', {'replay.id': 'string'});
 
     render(
@@ -542,8 +547,25 @@ describe('getFieldRenderer', () => {
       ) as React.ReactElement<any, any>
     );
 
-    // ViewReplayLink renders "(missing)" when replay existence can't be confirmed,
-    // but this verifies the renderer is wired up through ViewReplayLink
+    const link = await screen.findByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/explore/replays/abc123def456/`
+    );
+    expect(screen.getByText('abc123de')).toBeInTheDocument();
+  });
+
+  it('renders replay.id as missing when replay does not exist', () => {
+    const renderer = getFieldRenderer('replay.id', {'replay.id': 'string'});
+
+    render(
+      renderer(
+        {...data, 'replay.id': 'abc123def456'},
+        {location, organization, theme}
+      ) as React.ReactElement<any, any>
+    );
+
+    // ViewReplayLink renders "(missing)" when replay existence can't be confirmed
     expect(screen.getByText('(missing)')).toBeInTheDocument();
   });
 

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -55,6 +55,7 @@ import {formatApdex} from 'sentry/utils/number/formatApdex';
 import {formatFloat} from 'sentry/utils/number/formatFloat';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {toPercent} from 'sentry/utils/number/toPercent';
+import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
 import {Projects} from 'sentry/utils/projects';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {isUrl} from 'sentry/utils/string/isUrl';
@@ -599,35 +600,52 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
   },
   replayId: {
     sortField: 'replayId',
-    renderFunc: (data, {organization}) => {
+    renderFunc: (data, baggage) => {
       const replayId = data?.replayId;
       if (typeof replayId !== 'string' || !replayId) {
         return emptyValue;
       }
-
-      const target = makeReplaysPathname({
-        path: `/${replayId}/`,
-        organization,
-      });
-
-      return (
-        <Container>
-          <ViewReplayLink replayId={replayId} to={target}>
-            {getShortEventId(replayId)}
-          </ViewReplayLink>
-        </Container>
-      );
+      return renderReplayIdAsLink(replayId, baggage);
+    },
+  },
+  'replay.id': {
+    sortField: 'replay.id',
+    renderFunc: (data, baggage) => {
+      const replayId = data?.['replay.id'];
+      if (typeof replayId !== 'string' || !replayId) {
+        return emptyValue;
+      }
+      return renderReplayIdAsLink(replayId, baggage);
     },
   },
   'profile.id': {
     sortField: 'profile.id',
-    renderFunc: data => {
-      const id: string | unknown = data?.['profile.id'];
-      if (typeof id !== 'string' || id === '') {
+    renderFunc: (data, {organization, projects}) => {
+      const profileId: string | unknown = data?.['profile.id'];
+      if (typeof profileId !== 'string' || profileId === '') {
         return emptyValue;
       }
 
-      return <Container>{getShortEventId(id)}</Container>;
+      const projectSlug = data.project ?? data['project.name'];
+      const projectMatch = projects?.find(p => p.slug === projectSlug);
+
+      if (!projectMatch) {
+        return <Container>{getShortEventId(profileId)}</Container>;
+      }
+
+      const target = generateProfileFlamechartRouteWithQuery({
+        organization,
+        projectSlug: projectMatch.slug,
+        profileId,
+      });
+
+      return (
+        <Link to={target}>
+          <StyledTooltip title={t('View Profile')}>
+            <Container>{getShortEventId(profileId)}</Container>
+          </StyledTooltip>
+        </Link>
+      );
     },
   },
   issue: {
@@ -1353,6 +1371,21 @@ const StyledTooltip = styled(Tooltip)`
   overflow: hidden;
   text-overflow: ellipsis;
 `;
+
+function renderReplayIdAsLink(replayId: string, {organization}: RenderFunctionBaggage) {
+  const target = makeReplaysPathname({
+    path: `/${replayId}/`,
+    organization,
+  });
+
+  return (
+    <Container>
+      <ViewReplayLink replayId={replayId} to={target}>
+        {getShortEventId(replayId)}
+      </ViewReplayLink>
+    </Container>
+  );
+}
 
 export function getFieldRenderer(
   field: string,

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1379,11 +1379,9 @@ function renderReplayIdAsLink(replayId: string, {organization}: RenderFunctionBa
   });
 
   return (
-    <Container>
-      <ViewReplayLink replayId={replayId} to={target}>
-        {getShortEventId(replayId)}
-      </ViewReplayLink>
-    </Container>
+    <ViewReplayLink replayId={replayId} to={target}>
+      {getShortEventId(replayId)}
+    </ViewReplayLink>
   );
 }
 

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1379,9 +1379,11 @@ function renderReplayIdAsLink(replayId: string, {organization}: RenderFunctionBa
   });
 
   return (
-    <ViewReplayLink replayId={replayId} to={target}>
-      {getShortEventId(replayId)}
-    </ViewReplayLink>
+    <Container>
+      <ViewReplayLink replayId={replayId} to={target}>
+        {getShortEventId(replayId)}
+      </ViewReplayLink>
+    </Container>
   );
 }
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/pageSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/pageSummary.ts
@@ -274,12 +274,13 @@ export const WEB_VITALS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
       displayType: DisplayType.TABLE,
       widgetType: WidgetType.SPANS,
       interval: '5m',
-      tableWidths: [-1, 200, -1, -1, -1, -1, -1],
+      tableWidths: [-1, -1, 200, -1, -1, -1, -1, -1],
       queries: [
         {
           name: '',
           conditions: `has:measurements.lcp`,
           fields: [
+            'project',
             'trace',
             'lcp.element',
             'measurements.lcp',
@@ -290,6 +291,7 @@ export const WEB_VITALS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           ],
           aggregates: [],
           columns: [
+            'project',
             'trace',
             'lcp.element',
             'measurements.lcp',
@@ -320,6 +322,7 @@ export const WEB_VITALS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           name: '',
           conditions: `has:measurements.inp`,
           fields: [
+            'project',
             'trace',
             'measurements.inp',
             'profile.id',
@@ -329,6 +332,7 @@ export const WEB_VITALS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           ],
           aggregates: [],
           columns: [
+            'project',
             'trace',
             'measurements.inp',
             'profile.id',
@@ -358,6 +362,7 @@ export const WEB_VITALS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           name: '',
           conditions: `has:measurements.cls`,
           fields: [
+            'project',
             'trace',
             'measurements.cls',
             'profile.id',
@@ -367,6 +372,7 @@ export const WEB_VITALS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
           ],
           aggregates: [],
           columns: [
+            'project',
             'trace',
             'measurements.cls',
             'profile.id',

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -20,7 +20,6 @@ import {getFieldRenderer, nullableValue} from 'sentry/utils/discover/fieldRender
 import {Container} from 'sentry/utils/discover/styles';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {getShortEventId} from 'sentry/utils/events';
-import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
 import {isValidUrl} from 'sentry/utils/string/isValidUrl';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -150,6 +149,7 @@ function BaseExploreFieldRenderer({
     organization,
     theme,
     unit,
+    projects,
   });
 
   if (field === 'timestamp') {
@@ -282,15 +282,6 @@ function BaseExploreFieldRenderer({
     if (field === 'id') {
       return rendered;
     }
-  }
-
-  if (field === 'profile.id') {
-    const target = generateProfileFlamechartRouteWithQuery({
-      organization,
-      projectSlug: data.project,
-      profileId: data['profile.id'],
-    });
-    rendered = <Link to={target}>{rendered}</Link>;
   }
 
   return (


### PR DESCRIPTION
`replay.id` and `profile.id` columns in dashboard table widgets rendered as plain text instead of clickable links. This was because `SPECIAL_FIELDS` in `fieldRenderers.tsx` only had a `replayId` (camelCase) entry but no `replay.id` (dot notation), and the `profile.id` entry rendered a shortened ID without a link.

Since `getFieldRenderer` checks `SPECIAL_FIELDS` first, fixing the renderers there makes them work everywhere (dashboards, discover, etc.) without needing to touch individual dataset configs.

- Added `replay.id` entry to `SPECIAL_FIELDS` that shares a `renderReplayIdAsLink` helper with the existing `replayId` entry
- Updated `profile.id` entry to link to the profile flamechart page, with a plaintext fallback when the project slug can't be resolved
- Added `project` column to prebuilt Web Vitals sample tables (LCP, INP, CLS) so the profile renderer can resolve the project slug needed for the link

Refs DAIN-1292