### PR TITLE
fix(integrations): Handle unauthorized and rate-limited errors in integration proxy

### DIFF
--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -23,7 +23,12 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.utils.metrics import IntegrationProxyEvent, IntegrationProxyEventType
 from sentry.metrics.base import Tags
-from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError
+from sentry.shared_integrations.exceptions import (
+    ApiHostError,
+    ApiRateLimitedError,
+    ApiTimeoutError,
+    ApiUnauthorized,
+)
 from sentry.silo.base import SiloMode
 from sentry.silo.util import (
     PROXY_BASE_URL_HEADER,
@@ -59,6 +64,8 @@ class IntegrationProxyFailureMetricType(StrEnum):
     INVALID_IDENTITY = "invalid_identity"
     HOST_UNREACHABLE_ERROR = "host_unreachable_error"
     HOST_TIMEOUT_ERROR = "host_timeout_error"
+    UNAUTHORIZED_ERROR = "unauthorized_error"
+    RATE_LIMITED_ERROR = "rate_limited_error"
     UNKNOWN_ERROR = "unknown_error"
     FAILED_VALIDATION = "failed_validation"
 
@@ -327,6 +334,18 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             logger.info("hybrid_cloud.integration_proxy.host_timeout_error", extra=self.log_extra)
             self._add_failure_metric(IntegrationProxyFailureMetricType.HOST_TIMEOUT_ERROR)
             return self.respond(status=exc.code)
+        elif isinstance(exc, ApiUnauthorized):
+            logger.info("hybrid_cloud.integration_proxy.unauthorized_error", extra=self.log_extra)
+            self._add_failure_metric(IntegrationProxyFailureMetricType.UNAUTHORIZED_ERROR)
+            return self.respond(status=exc.code)
+        elif isinstance(exc, ApiRateLimitedError):
+            logger.info("hybrid_cloud.integration_proxy.rate_limited_error", extra=self.log_extra)
+            self._add_failure_metric(IntegrationProxyFailureMetricType.RATE_LIMITED_ERROR)
+            return self.respond(status=exc.code)
 
+        logger.warning(
+            "hybrid_cloud.integration_proxy.unknown_error",
+            extra={**self.log_extra, "exception_class": type(exc).__name__},
+        )
         self._add_failure_metric(IntegrationProxyFailureMetricType.UNKNOWN_ERROR)
         return super().handle_exception_with_details(request, exc, handler_context, scope)

--- a/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
+++ b/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
@@ -21,7 +21,12 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.metrics.base import Tags
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
-from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError
+from sentry.shared_integrations.exceptions import (
+    ApiHostError,
+    ApiRateLimitedError,
+    ApiTimeoutError,
+    ApiUnauthorized,
+)
 from sentry.silo.base import SiloMode
 from sentry.silo.util import (
     PROXY_BASE_PATH,
@@ -527,6 +532,90 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         )
         self.assert_failure_metric_count(
             failure_type=IntegrationProxyFailureMetricType.HOST_TIMEOUT_ERROR,
+            count=1,
+            mock_metrics=mock_metrics,
+        )
+        self.assert_metric_count(
+            metric_name=IntegrationProxySuccessMetricType.COMPLETE_RESPONSE_CODE,
+            count=0,
+            mock_metrics=mock_metrics,
+        )
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
+    @patch.object(metrics, "incr")
+    def test_handles_api_unauthorized_error(
+        self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        signature_path = f"/{self.proxy_path}"
+        headers = self.create_request_headers(
+            signature_path=signature_path, integration_id=self.org_integration.id
+        )
+        mock_client.base_url = "https://example.com/api"
+        mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
+        mock_client.request = MagicMock(
+            side_effect=lambda *args, **kwargs: self.raise_exception(
+                ApiUnauthorized, "Unauthorized"
+            )
+        )
+        mock_get_client.return_value = mock_client
+
+        proxy_response = self.client.get(self.path, **headers)
+
+        assert proxy_response.status_code == 401
+        assert proxy_response.data is None
+
+        self.assert_metric_count(
+            metric_name=IntegrationProxySuccessMetricType.INITIALIZE,
+            count=1,
+            mock_metrics=mock_metrics,
+            kwargs_to_match={"sample_rate": 1.0, "tags": None},
+        )
+        self.assert_failure_metric_count(
+            failure_type=IntegrationProxyFailureMetricType.UNAUTHORIZED_ERROR,
+            count=1,
+            mock_metrics=mock_metrics,
+        )
+        self.assert_metric_count(
+            metric_name=IntegrationProxySuccessMetricType.COMPLETE_RESPONSE_CODE,
+            count=0,
+            mock_metrics=mock_metrics,
+        )
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
+    @patch.object(metrics, "incr")
+    def test_handles_api_rate_limited_error(
+        self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        signature_path = f"/{self.proxy_path}"
+        headers = self.create_request_headers(
+            signature_path=signature_path, integration_id=self.org_integration.id
+        )
+        mock_client.base_url = "https://example.com/api"
+        mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
+        mock_client.request = MagicMock(
+            side_effect=lambda *args, **kwargs: self.raise_exception(
+                ApiRateLimitedError, "Rate limited"
+            )
+        )
+        mock_get_client.return_value = mock_client
+
+        proxy_response = self.client.get(self.path, **headers)
+
+        assert proxy_response.status_code == 429
+        assert proxy_response.data is None
+
+        self.assert_metric_count(
+            metric_name=IntegrationProxySuccessMetricType.INITIALIZE,
+            count=1,
+            mock_metrics=mock_metrics,
+            kwargs_to_match={"sample_rate": 1.0, "tags": None},
+        )
+        self.assert_failure_metric_count(
+            failure_type=IntegrationProxyFailureMetricType.RATE_LIMITED_ERROR,
             count=1,
             mock_metrics=mock_metrics,
         )


### PR DESCRIPTION
## Summary
- Add explicit handling for `ApiUnauthorized` and `ApiRateLimitedError` exceptions in the integration proxy endpoint, with dedicated failure metric types and logging
- Add a warning-level log with `exception_class` for unknown errors to improve debugging visibility

Agent transcript: https://claudescope.sentry.dev/share/t1d06MXJhqJXHLiOQoJ3l_tYycfgtt9wBO3ypV3W-9w