### PR TITLE
chore(integrations): Mark GroupIntegrationDetailsEndpoint private

### DIFF
--- a/src/sentry/issues/endpoints/group_integration_details.py
+++ b/src/sentry/issues/endpoints/group_integration_details.py
@@ -75,10 +75,10 @@ class IntegrationIssueConfigSerializer(IntegrationSerializer):
 class GroupIntegrationDetailsEndpoint(GroupEndpoint):
     owner = ApiOwner.ECOSYSTEM
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
-        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
+        "DELETE": ApiPublishStatus.PRIVATE,
     }
 
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])


### PR DESCRIPTION
This endpoint can always be marked public in the future if there are requests or use cases but for now this gets it out of the unknown state.

Fixes RTC-1148