### PR TITLE
feat(explorer): Add relevant repos to explorer

### DIFF
--- a/src/sentry/seer/autofix/artifact_schemas.py
+++ b/src/sentry/seer/autofix/artifact_schemas.py
@@ -62,9 +62,9 @@ class RootCauseArtifact(BaseModel):
     reproduction_steps: list[str] = Field(
         default_factory=list, description="Steps to reproduce the issue"
     )
-    relevant_repos: list[str] = Field(
-        default_factory=list,
-        description="Full repository names (e.g. 'owner/repo') that contain the code relevant to this root cause",
+    relevant_repo: str | None = Field(
+        default=None,
+        description="The full repository name (e.g. 'owner/repo') where the fix should be made. Pick the one repo most directly responsible for the root cause.",
     )
 
 

--- a/src/sentry/seer/autofix/artifact_schemas.py
+++ b/src/sentry/seer/autofix/artifact_schemas.py
@@ -62,6 +62,10 @@ class RootCauseArtifact(BaseModel):
     reproduction_steps: list[str] = Field(
         default_factory=list, description="Steps to reproduce the issue"
     )
+    relevant_repos: list[str] = Field(
+        default_factory=list,
+        description="Full repository names (e.g. 'owner/repo') that contain the code relevant to this root cause",
+    )
 
 
 class SolutionArtifact(BaseModel):

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -363,39 +363,35 @@ def generate_autofix_handoff_prompt(
     return "\n\n".join(parts)
 
 
-def _filter_repos_by_run_state(
+def _get_relevant_repo(
     state: SeerRunState,
     repo_definitions: list[SeerRepoDefinition],
     run_id: int,
     group: Group,
-) -> list[SeerRepoDefinition]:
+) -> SeerRepoDefinition:
     root_cause_artifact = state.get_artifacts().get("root_cause")
-    relevant_repos: list[str] = (
-        (root_cause_artifact.data or {}).get("relevant_repos") or [] if root_cause_artifact else []
+    relevant_repo: str | None = (
+        (root_cause_artifact.data or {}).get("relevant_repo") if root_cause_artifact else None
     )
-    if relevant_repos:
-        filtered = [r for r in repo_definitions if f"{r.owner}/{r.name}" in set(relevant_repos)]
-        if filtered:
-            return filtered
+    warning_extras = {
+        "organization_id": group.organization.id,
+        "run_id": run_id,
+        "project_id": group.project_id,
+    }
+    if relevant_repo:
+        match = next((r for r in repo_definitions if f"{r.owner}/{r.name}" == relevant_repo), None)
+        if match:
+            return match
         logger.warning(
-            "autofix.coding_agent_handoff.relevant_repos_not_found",
-            extra={
-                "organization_id": group.organization.id,
-                "run_id": run_id,
-                "project_id": group.project_id,
-                "relevant_repos": relevant_repos,
-            },
+            "autofix.coding_agent_handoff.relevant_repo_not_found",
+            extra={**warning_extras, "relevant_repo": relevant_repo},
         )
     else:
         logger.warning(
-            "autofix.coding_agent_handoff.no_relevant_repos",
-            extra={
-                "organization_id": group.organization.id,
-                "run_id": run_id,
-                "project_id": group.project_id,
-            },
+            "autofix.coding_agent_handoff.no_relevant_repo",
+            extra=warning_extras,
         )
-    return repo_definitions[:1]
+    return repo_definitions[0]
 
 
 def trigger_coding_agent_handoff(
@@ -454,7 +450,7 @@ def trigger_coding_agent_handoff(
     )
     state = client.get_run(run_id)
 
-    repo_definitions = _filter_repos_by_run_state(state, repo_definitions, run_id, group)
+    repo = _get_relevant_repo(state, repo_definitions, run_id, group)
 
     short_id = group.qualified_short_id
 
@@ -466,7 +462,7 @@ def trigger_coding_agent_handoff(
         provider=provider,
         user_id=user_id,
         prompt=prompt,
-        repos=repo_definitions,
+        repos=[repo],
         branch_name_base=group.title or "seer",
         auto_create_pr=auto_create_pr,
     )

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -374,15 +374,27 @@ def _filter_repos_by_run_state(
         (root_cause_artifact.data or {}).get("relevant_repos") or [] if root_cause_artifact else []
     )
     if relevant_repos:
-        return [r for r in repo_definitions if f"{r.owner}/{r.name}" in set(relevant_repos)]
-    logger.warning(
-        "autofix.coding_agent_handoff.no_relevant_repos",
-        extra={
-            "organization_id": group.organization.id,
-            "run_id": run_id,
-            "project_id": group.project_id,
-        },
-    )
+        filtered = [r for r in repo_definitions if f"{r.owner}/{r.name}" in set(relevant_repos)]
+        if filtered:
+            return filtered
+        logger.warning(
+            "autofix.coding_agent_handoff.relevant_repos_not_found",
+            extra={
+                "organization_id": group.organization.id,
+                "run_id": run_id,
+                "project_id": group.project_id,
+                "relevant_repos": relevant_repos,
+            },
+        )
+    else:
+        logger.warning(
+            "autofix.coding_agent_handoff.no_relevant_repos",
+            extra={
+                "organization_id": group.organization.id,
+                "run_id": run_id,
+                "project_id": group.project_id,
+            },
+        )
     return repo_definitions[:1]
 
 

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -363,6 +363,29 @@ def generate_autofix_handoff_prompt(
     return "\n\n".join(parts)
 
 
+def _filter_repos_by_run_state(
+    state: SeerRunState,
+    repo_definitions: list[SeerRepoDefinition],
+    run_id: int,
+    group: Group,
+) -> list[SeerRepoDefinition]:
+    root_cause_artifact = state.get_artifacts().get("root_cause")
+    relevant_repos: list[str] = (
+        (root_cause_artifact.data or {}).get("relevant_repos") or [] if root_cause_artifact else []
+    )
+    if relevant_repos:
+        return [r for r in repo_definitions if f"{r.owner}/{r.name}" in set(relevant_repos)]
+    logger.warning(
+        "autofix.coding_agent_handoff.no_relevant_repos",
+        extra={
+            "organization_id": group.organization.id,
+            "run_id": run_id,
+            "project_id": group.project_id,
+        },
+    )
+    return repo_definitions[:1]
+
+
 def trigger_coding_agent_handoff(
     group: Group,
     run_id: int,
@@ -418,6 +441,8 @@ def trigger_coding_agent_handoff(
         category_value=str(group.id),
     )
     state = client.get_run(run_id)
+
+    repo_definitions = _filter_repos_by_run_state(state, repo_definitions, run_id, group)
 
     short_id = group.qualified_short_id
 

--- a/src/sentry/seer/autofix/prompts.py
+++ b/src/sentry/seer/autofix/prompts.py
@@ -25,6 +25,7 @@ def root_cause_prompt(*, short_id: str, title: str, culprit: str, artifact_key: 
         - one_line_description: A concise summary under 30 words
         - five_whys: Chain of brief "why" statements leading to the root cause. (do not write the questions, only the answers; e.g. prefer "x -> y -> z", NOT "x -> why x? y -> why y? z")
         - reproduction_steps: Steps that would reproduce this issue, each under 15 words.
+        - relevant_repos: List of full repository names (e.g. "owner/repo") that contain the code relevant to this root cause. Include every repo you searched or found relevant code in.
         """
     )
 

--- a/src/sentry/seer/autofix/prompts.py
+++ b/src/sentry/seer/autofix/prompts.py
@@ -25,7 +25,7 @@ def root_cause_prompt(*, short_id: str, title: str, culprit: str, artifact_key: 
         - one_line_description: A concise summary under 30 words
         - five_whys: Chain of brief "why" statements leading to the root cause. (do not write the questions, only the answers; e.g. prefer "x -> y -> z", NOT "x -> why x? y -> why y? z")
         - reproduction_steps: Steps that would reproduce this issue, each under 15 words.
-        - relevant_repos: List of full repository names (e.g. "owner/repo") that contain the code relevant to this root cause. Include every repo you searched or found relevant code in.
+        - relevant_repo: The full repository name (e.g. "owner/repo") where the fix should be made. Pick the one repo most directly responsible for the root cause.
         """
     )
 

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -595,3 +595,80 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert len(result["failures"]) == 1
         assert "No repositories configured" in result["failures"][0]["error_message"]
         mock_client.launch_coding_agents.assert_not_called()
+
+    @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_coding_agent_handoff_filters_repos_by_relevant_repos(
+        self, mock_client_class, mock_get_prefs
+    ):
+        """Test that repos are filtered to those listed in the root_cause artifact's relevant_repos."""
+        from sentry.seer.models import SeerRepoDefinition
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state(
+            [
+                Artifact(
+                    key="root_cause",
+                    data={"one_line_description": "Bug", "relevant_repos": ["owner/relevant-repo"]},
+                    reason="test",
+                )
+            ]
+        )
+        mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
+        mock_get_prefs.return_value = self._make_preference_response(
+            repos=[
+                SeerRepoDefinition(
+                    provider="github", owner="owner", name="relevant-repo", external_id="1"
+                ),
+                SeerRepoDefinition(
+                    provider="github", owner="owner", name="other-repo", external_id="2"
+                ),
+            ]
+        )
+
+        trigger_coding_agent_handoff(group=self.group, run_id=123, integration_id=456)
+
+        repos = mock_client.launch_coding_agents.call_args.kwargs["repos"]
+        assert len(repos) == 1
+        assert repos[0].name == "relevant-repo"
+
+    @patch("sentry.seer.autofix.autofix_agent.logger")
+    @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_coding_agent_handoff_falls_back_to_first_repo_when_no_relevant_repos(
+        self, mock_client_class, mock_get_prefs, mock_logger
+    ):
+        """Test that when relevant_repos is absent, first configured repo is used and a warning is logged."""
+        from sentry.seer.models import SeerRepoDefinition
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state(
+            [Artifact(key="root_cause", data={"one_line_description": "Bug"}, reason="test")]
+        )
+        mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
+        mock_get_prefs.return_value = self._make_preference_response(
+            repos=[
+                SeerRepoDefinition(
+                    provider="github", owner="owner", name="first-repo", external_id="1"
+                ),
+                SeerRepoDefinition(
+                    provider="github", owner="owner", name="second-repo", external_id="2"
+                ),
+            ]
+        )
+
+        trigger_coding_agent_handoff(group=self.group, run_id=123, integration_id=456)
+
+        repos = mock_client.launch_coding_agents.call_args.kwargs["repos"]
+        assert len(repos) == 1
+        assert repos[0].name == "first-repo"
+        mock_logger.warning.assert_called_once_with(
+            "autofix.coding_agent_handoff.no_relevant_repos",
+            extra={
+                "organization_id": self.group.organization.id,
+                "run_id": 123,
+                "project_id": self.group.project_id,
+            },
+        )

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -672,3 +672,53 @@ class TestTriggerCodingAgentHandoff(TestCase):
                 "project_id": self.group.project_id,
             },
         )
+
+    @patch("sentry.seer.autofix.autofix_agent.logger")
+    @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_coding_agent_handoff_falls_back_when_relevant_repos_dont_match(
+        self, mock_client_class, mock_get_prefs, mock_logger
+    ):
+        """Test that when relevant_repos is non-empty but none match configured repos, first repo is used."""
+        from sentry.seer.models import SeerRepoDefinition
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state(
+            [
+                Artifact(
+                    key="root_cause",
+                    data={
+                        "one_line_description": "Bug",
+                        "relevant_repos": ["owner/nonexistent-repo"],
+                    },
+                    reason="test",
+                )
+            ]
+        )
+        mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
+        mock_get_prefs.return_value = self._make_preference_response(
+            repos=[
+                SeerRepoDefinition(
+                    provider="github", owner="owner", name="first-repo", external_id="1"
+                ),
+                SeerRepoDefinition(
+                    provider="github", owner="owner", name="second-repo", external_id="2"
+                ),
+            ]
+        )
+
+        trigger_coding_agent_handoff(group=self.group, run_id=123, integration_id=456)
+
+        repos = mock_client.launch_coding_agents.call_args.kwargs["repos"]
+        assert len(repos) == 1
+        assert repos[0].name == "first-repo"
+        mock_logger.warning.assert_called_once_with(
+            "autofix.coding_agent_handoff.relevant_repos_not_found",
+            extra={
+                "organization_id": self.group.organization.id,
+                "run_id": 123,
+                "project_id": self.group.project_id,
+                "relevant_repos": ["owner/nonexistent-repo"],
+            },
+        )

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -598,10 +598,10 @@ class TestTriggerCodingAgentHandoff(TestCase):
 
     @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
-    def test_trigger_coding_agent_handoff_filters_repos_by_relevant_repos(
+    def test_trigger_coding_agent_handoff_filters_to_relevant_repo(
         self, mock_client_class, mock_get_prefs
     ):
-        """Test that repos are filtered to those listed in the root_cause artifact's relevant_repos."""
+        """Test that only the repo named in relevant_repo is passed to launch_coding_agents."""
         from sentry.seer.models import SeerRepoDefinition
 
         mock_client = MagicMock()
@@ -610,7 +610,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
             [
                 Artifact(
                     key="root_cause",
-                    data={"one_line_description": "Bug", "relevant_repos": ["owner/relevant-repo"]},
+                    data={"one_line_description": "Bug", "relevant_repo": "owner/relevant-repo"},
                     reason="test",
                 )
             ]
@@ -636,10 +636,10 @@ class TestTriggerCodingAgentHandoff(TestCase):
     @patch("sentry.seer.autofix.autofix_agent.logger")
     @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
-    def test_trigger_coding_agent_handoff_falls_back_to_first_repo_when_no_relevant_repos(
+    def test_trigger_coding_agent_handoff_falls_back_to_first_repo_when_no_relevant_repo(
         self, mock_client_class, mock_get_prefs, mock_logger
     ):
-        """Test that when relevant_repos is absent, first configured repo is used and a warning is logged."""
+        """Test that when relevant_repo is absent, first configured repo is used and a warning is logged."""
         from sentry.seer.models import SeerRepoDefinition
 
         mock_client = MagicMock()
@@ -665,7 +665,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert len(repos) == 1
         assert repos[0].name == "first-repo"
         mock_logger.warning.assert_called_once_with(
-            "autofix.coding_agent_handoff.no_relevant_repos",
+            "autofix.coding_agent_handoff.no_relevant_repo",
             extra={
                 "organization_id": self.group.organization.id,
                 "run_id": 123,
@@ -676,10 +676,10 @@ class TestTriggerCodingAgentHandoff(TestCase):
     @patch("sentry.seer.autofix.autofix_agent.logger")
     @patch("sentry.seer.autofix.autofix_agent.get_project_seer_preferences")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
-    def test_trigger_coding_agent_handoff_falls_back_when_relevant_repos_dont_match(
+    def test_trigger_coding_agent_handoff_falls_back_when_relevant_repo_doesnt_match(
         self, mock_client_class, mock_get_prefs, mock_logger
     ):
-        """Test that when relevant_repos is non-empty but none match configured repos, first repo is used."""
+        """Test that when relevant_repo doesn't match any configured repo, first repo is used."""
         from sentry.seer.models import SeerRepoDefinition
 
         mock_client = MagicMock()
@@ -688,10 +688,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
             [
                 Artifact(
                     key="root_cause",
-                    data={
-                        "one_line_description": "Bug",
-                        "relevant_repos": ["owner/nonexistent-repo"],
-                    },
+                    data={"one_line_description": "Bug", "relevant_repo": "owner/nonexistent-repo"},
                     reason="test",
                 )
             ]
@@ -714,11 +711,11 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert len(repos) == 1
         assert repos[0].name == "first-repo"
         mock_logger.warning.assert_called_once_with(
-            "autofix.coding_agent_handoff.relevant_repos_not_found",
+            "autofix.coding_agent_handoff.relevant_repo_not_found",
             extra={
                 "organization_id": self.group.organization.id,
                 "run_id": 123,
                 "project_id": self.group.project_id,
-                "relevant_repos": ["owner/nonexistent-repo"],
+                "relevant_repo": "owner/nonexistent-repo",
             },
         )


### PR DESCRIPTION
Autofix has a relevant_repos field which allows coding agent integrations to run agents only in the required repositories instead of all of the ones attached to the project. Explorer did not have that set up.

Now the RootCauseArtifact returned by explorer has the field and it is included in the prompt as a return. The repos provided to a coding agent are now filtered by this return value. Tests have been added for this filtering functionality.

I ran this locally and seemed to work with not all repos being returned, but real test will be on prod with complex repos that have issues across them etc.

**Would also be open to thoughts about whether we even want more than one agent spawned at all... there is theoretically a use case, but is it common enough to support?**

Also, claude currently has the ability to attach multiple repos through mcp to one agent so we could pivot to do that, but neither of the other integrations do at the moment so it would be a larger refactor.