### PR TITLE
feat(seer): Use Seer model_used response field for seer_model on GroupHashMetadata

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -332,10 +332,11 @@ def get_seer_similar_issues(
     event: Event,
     event_grouphash: GroupHash,
     variants: dict[str, BaseVariant],
-) -> tuple[float | None, GroupHash | None]:
+) -> tuple[float | None, GroupHash | None, str | None]:
     """
-    Ask Seer for the given event's nearest neighbor(s) and return the stacktrace distance and
-    matching GroupHash of the closest match (if any), or `(None, None)` if no match found.
+    Ask Seer for the given event's nearest neighbor(s) and return the stacktrace distance,
+    matching GroupHash of the closest match (if any), and the model Seer actually used,
+    or `(None, None, None)` if no match found.
 
     Args:
         event: The event being grouped
@@ -349,7 +350,7 @@ def get_seer_similar_issues(
     request_data, seer_request_metric_tags = _build_seer_request(event, variants)
 
     viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
-    seer_results = get_similarity_data_from_seer(
+    seer_results, model_used = get_similarity_data_from_seer(
         request_data,
         {**seer_request_metric_tags, "hybrid_fingerprint": event_has_hybrid_fingerprint},
         viewer_context=viewer_context,
@@ -476,7 +477,7 @@ def get_seer_similar_issues(
         },
     )
 
-    return (stacktrace_distance, winning_parent_grouphash)
+    return (stacktrace_distance, winning_parent_grouphash, model_used)
 
 
 def _should_use_seer_match_for_grouping(
@@ -554,8 +555,8 @@ def maybe_check_seer_for_matching_grouphash(
         record_did_call_seer_metric(event, call_made=True, blocker="none")
 
         try:
-            # If no matching group is found in Seer, these will both be None
-            seer_match_distance, seer_matched_grouphash = get_seer_similar_issues(
+            # If no matching group is found in Seer, these will all be None
+            seer_match_distance, seer_matched_grouphash, seer_model_used = get_seer_similar_issues(
                 event, event_grouphash, variants
             )
         except Exception as e:  # Insurance - in theory we shouldn't ever land here
@@ -605,7 +606,7 @@ def maybe_check_seer_for_matching_grouphash(
                 date_added=gh_metadata.date_added or timestamp,
                 seer_date_sent=gh_metadata.date_added or timestamp,
                 seer_event_sent=event.event_id,
-                seer_model=model_version.value,
+                seer_model=seer_model_used or model_version.value,
                 seer_matched_grouphash=seer_matched_grouphash,
                 seer_match_distance=seer_match_distance,
                 seer_latest_training_model=model_version.value,

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -142,7 +142,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         viewer_context = SeerViewerContext(
             organization_id=group.project.organization.id, user_id=request.user.id
         )
-        results = get_similarity_data_from_seer(
+        results, _model_used = get_similarity_data_from_seer(
             similar_issues_params, viewer_context=viewer_context
         )
 

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -185,7 +185,7 @@ def get_similarity_data_from_seer(
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={**metric_tags, "outcome": "no_similar_groups"},
         )
-        return ([], None)
+        return ([], model_used)
 
     # This may get overwritten as we process the results, but by this point we know that Seer at
     # least found *something*

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -62,10 +62,10 @@ def get_similarity_data_from_seer(
     metric_tags: Mapping[str, str | int | bool] | None = None,
     raise_on_error: bool = False,
     viewer_context: SeerViewerContext | None = None,
-) -> list[SeerSimilarIssueData]:
+) -> tuple[list[SeerSimilarIssueData], str | None]:
     """
-    Request similar issues data from seer and normalize the results. Returns similar groups
-    sorted in order of descending similarity.
+    Request similar issues data from seer and normalize the results. Returns a tuple of
+    (similar groups sorted in order of descending similarity, model_used from Seer response).
     """
     event_id = similar_issues_request["event_id"]
     project_id = similar_issues_request["project_id"]
@@ -107,7 +107,7 @@ def get_similarity_data_from_seer(
         circuit_breaker.record_error()
         if raise_on_error:
             raise
-        return []
+        return ([], None)
 
     metric_tags["response_status"] = response.status
 
@@ -140,10 +140,12 @@ def get_similarity_data_from_seer(
             raise Exception(
                 f"Received {response.status} from Seer endpoint {SEER_SIMILAR_ISSUES_URL}"
             )
-        return []
+        return ([], None)
 
     try:
-        response_data = json.loads(response.data.decode("utf-8")).get("responses")
+        response_json = json.loads(response.data.decode("utf-8"))
+        response_data = response_json.get("responses")
+        model_used = response_json.get("model_used")
     except (
         AttributeError,  # caused by a response with no data and therefore no `.decode` method
         UnicodeError,
@@ -164,7 +166,7 @@ def get_similarity_data_from_seer(
         )
         if raise_on_error:
             raise
-        return []
+        return ([], None)
 
     # TODO: Temporary log to prove things are working as they should. This should come in a pair
     # with the `get_seer_similar_issues.follow_up_seer_request` log in `seer.py`.
@@ -183,7 +185,7 @@ def get_similarity_data_from_seer(
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={**metric_tags, "outcome": "no_similar_groups"},
         )
-        return []
+        return ([], None)
 
     # This may get overwritten as we process the results, but by this point we know that Seer at
     # least found *something*
@@ -339,7 +341,10 @@ def get_similarity_data_from_seer(
         sample_rate=options.get("seer.similarity.metrics_sample_rate"),
         tags=metric_tags,
     )
-    return sorted(
-        normalized_results,
-        key=lambda issue_data: issue_data.stacktrace_distance,
+    return (
+        sorted(
+            normalized_results,
+            key=lambda issue_data: issue_data.stacktrace_distance,
+        ),
+        model_used,
     )

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -51,6 +51,7 @@ class RawSeerSimilarIssueData(TypedDict):
 
 class SimilarIssuesEmbeddingsResponse(TypedDict):
     responses: list[RawSeerSimilarIssueData]
+    model_used: NotRequired[str]
 
 
 # Like the data that comes back from seer, but guaranteed to have an existing parent hash

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -304,7 +304,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
             "sentry.grouping.ingest.seer.get_seer_similar_issues"
         ) as mock_get_seer_similar_issues:
             # This will allow grouphash_b to be matched to grouphash_a by Seer
-            mock_get_seer_similar_issues.return_value = (0.01, grouphash_a)
+            mock_get_seer_similar_issues.return_value = (0.01, grouphash_a, "v1")
 
             # Event B will be kept - different exception to ensure different group hash to grouphash_a
             event_b = self.store_event(

--- a/tests/sentry/deletions/test_grouphash.py
+++ b/tests/sentry/deletions/test_grouphash.py
@@ -47,7 +47,7 @@ class DeleteGroupHashTest(TestCase):
             patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
             patch(
                 "sentry.grouping.ingest.seer.get_seer_similar_issues",
-                return_value=(0.01, existing_grouphash),
+                return_value=(0.01, existing_grouphash, "v1"),
             ),
         ):
             new_event = self.store_event(
@@ -91,7 +91,7 @@ class DeleteGroupHashTest(TestCase):
             patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
             patch(
                 "sentry.grouping.ingest.seer.get_seer_similar_issues",
-                return_value=(0.01, existing_grouphash),
+                return_value=(0.01, existing_grouphash, "v1"),
             ),
         ):
             new_event = self.store_event(

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -11,7 +11,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.mocking import capture_results
 
-EMPTY_SEER_RESULTS = (None, None)
+EMPTY_SEER_RESULTS = (None, None, None)
 
 
 def get_event_data(dog: str = "Charlie") -> dict[str, Any]:
@@ -66,7 +66,7 @@ class SeerEventManagerGroupingTest(TestCase):
             ) as get_seer_similar_issues_spy,
             patch(
                 "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-                return_value=[seer_result_data],
+                return_value=([seer_result_data], "v1"),
             ),
             patch(
                 "sentry.grouping.ingest.seer._event_content_is_seer_eligible",
@@ -143,7 +143,7 @@ class SeerEventManagerGroupingTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=[seer_result_data],
+            return_value=([seer_result_data], None),
         ) as mock_get_similarity_data:
             new_event = save_new_event(get_event_data(), self.project)
 
@@ -155,7 +155,7 @@ class SeerEventManagerGroupingTest(TestCase):
         existing_event = save_new_event({"message": "Dogs are great!"}, self.project)
 
         with patch(
-            "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[]
+            "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v1")
         ) as mock_get_similarity_data:
             new_event = save_new_event(get_event_data(), self.project)
 
@@ -172,6 +172,7 @@ class StoredSeerMetadataTest(TestCase):
         expected_seer_model: str | None,
         expected_seer_matched_grouphash: GroupHash | None,
         expected_seer_match_distance: float | None,
+        expected_seer_latest_training_model: str | None = None,
     ) -> None:
         metadata = grouphash.metadata
 
@@ -181,13 +182,19 @@ class StoredSeerMetadataTest(TestCase):
         assert metadata.seer_model == expected_seer_model
         assert metadata.seer_matched_grouphash == expected_seer_matched_grouphash
         assert metadata.seer_match_distance == expected_seer_match_distance
-        assert metadata.seer_latest_training_model == expected_seer_model
+        # If not explicitly provided, seer_latest_training_model defaults to expected_seer_model
+        expected_training = (
+            expected_seer_latest_training_model
+            if expected_seer_latest_training_model is not None
+            else expected_seer_model
+        )
+        assert metadata.seer_latest_training_model == expected_training
 
     @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
     def test_group_with_no_seer_match(self, _: MagicMock) -> None:
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=[],
+            return_value=([], "v1"),
         ) as mock_get_similarity_data_from_seer:
             event = save_new_event(get_event_data(), self.project)
 
@@ -226,7 +233,7 @@ class StoredSeerMetadataTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=[seer_result_data],
+            return_value=([seer_result_data], None),
         ) as mock_get_similarity_data_from_seer:
             new_event = save_new_event(get_event_data(dog="Maisey"), self.project)
 
@@ -250,6 +257,54 @@ class StoredSeerMetadataTest(TestCase):
                 GroupingVersion.V1.value,
                 existing_event_grouphash,
                 seer_result_data.stacktrace_distance,
+            )
+
+    @patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True)
+    def test_seer_model_fallback_recorded_separately(self, _: MagicMock) -> None:
+        """When Seer falls back to a different model, seer_model reflects what Seer actually
+        used while seer_latest_training_model reflects what we requested."""
+        existing_event = save_new_event(get_event_data(), self.project)
+        existing_event_grouphash = GroupHash.objects.filter(
+            hash=existing_event.get_primary_hash(), project_id=self.project.id
+        ).first()
+        assert existing_event.group_id is not None
+
+        seer_result_data = SeerSimilarIssueData(
+            parent_hash=existing_event.get_primary_hash(),
+            parent_group_id=existing_event.group_id,
+            stacktrace_distance=0.01,
+            should_group=True,
+        )
+
+        # Mock Seer responding with v1 even though we'd request v2
+        with (
+            patch(
+                "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
+                return_value=([seer_result_data], "v1"),
+            ),
+            patch(
+                "sentry.grouping.ingest.seer.get_grouping_model_version",
+                return_value=GroupingVersion.V2,
+            ),
+        ):
+            new_event = save_new_event(get_event_data(dog="Maisey"), self.project)
+
+            new_event_grouphash = GroupHash.objects.filter(
+                hash=new_event.get_primary_hash(), project_id=self.project.id
+            ).first()
+
+            assert new_event_grouphash and new_event_grouphash.metadata
+
+            # seer_model should be what Seer actually used (v1)
+            # seer_latest_training_model should be what we requested (v2)
+            self.assert_correct_seer_metadata(
+                new_event_grouphash,
+                new_event_grouphash.metadata.date_added,
+                new_event.event_id,
+                GroupingVersion.V1.value,
+                existing_event_grouphash,
+                seer_result_data.stacktrace_distance,
+                expected_seer_latest_training_model=GroupingVersion.V2.value,
             )
 
     def test_event_not_sent_to_seer(self) -> None:
@@ -280,7 +335,7 @@ class StoredSeerMetadataTest(TestCase):
         with (
             patch(
                 "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-                return_value=[],
+                return_value=([], "v1"),
             ),
             patch(
                 "sentry.grouping.ingest.hashing.create_or_update_grouphash_metadata_if_needed",

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -90,7 +90,7 @@ def assert_metrics_call(
 
 
 class GetSeerSimilarIssuesTest(TestCase):
-    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])
+    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v1"))
     def test_sends_expected_data_to_seer(self, mock_get_similarity_data: MagicMock) -> None:
         new_event, new_variants, new_grouphash, new_stacktrace_string = create_new_event(
             self.project
@@ -145,7 +145,7 @@ class GetSeerSimilarIssuesTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ) as mock_get_similarity_data:
             get_seer_similar_issues(new_event, new_grouphash, new_variants)
 
@@ -204,7 +204,7 @@ class GetSeerSimilarIssuesTest(TestCase):
             ]
 
     @patch("sentry.grouping.ingest.seer.metrics.incr")
-    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])
+    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v1"))
     def test_non_training_mode_metrics(
         self,
         mock_get_similarity_data: MagicMock,
@@ -249,11 +249,12 @@ class ParentGroupFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 0.01,
                 existing_grouphash,
+                "v1",
             )
 
             assert_metrics_call(
@@ -311,11 +312,12 @@ class ParentGroupFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 0.01,
                 existing_grouphash,
+                "v1",
             )
 
             # Metric from `_should_use_seer_match_for_grouping`
@@ -366,9 +368,13 @@ class ParentGroupFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                None,
+                None,
+                "v1",
+            )
 
             # Metric from `_should_use_seer_match_for_grouping`
             assert_metrics_call(mock_incr, "hybrid_fingerprint_match_check", "no_fingerprint_match")
@@ -421,9 +427,13 @@ class ParentGroupFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                None,
+                None,
+                "v1",
+            )
 
             # Metric from `_should_use_seer_match_for_grouping`
             assert_metrics_call(mock_incr, "hybrid_fingerprint_match_check", "only_event_hybrid")
@@ -473,9 +483,13 @@ class ParentGroupFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                None,
+                None,
+                "v1",
+            )
 
             # Metric from `_should_use_seer_match_for_grouping`
             assert_metrics_call(mock_incr, "hybrid_fingerprint_match_check", "only_parent_hybrid")
@@ -541,9 +555,13 @@ class ParentGroupFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                None,
+                None,
+                "v1",
+            )
 
             # Metric from `_should_use_seer_match_for_grouping`
             assert_metrics_call(mock_incr, "hybrid_fingerprint_match_check", "no_parent_metadata")
@@ -604,12 +622,13 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
             # It picks the first, more similar match
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 0.01,
                 existing_grouphash,
+                "v1",
             )
 
             assert_metrics_call(
@@ -680,12 +699,13 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
             # It picks the first result because the fingerprint matches the new event
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 0.01,
                 existing_grouphash,
+                "v1",
             )
 
             # Metric from `_should_use_seer_match_for_grouping`
@@ -756,13 +776,14 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
             # It picks the second result even though it's less similar because the fingerprint
             # matches the new event
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 0.02,
                 existing_grouphash2,
+                "v1",
             )
 
             # Metrics from `_should_use_seer_match_for_grouping`
@@ -829,9 +850,13 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                None,
+                None,
+                "v1",
+            )
 
             # Metric from `_should_use_seer_match_for_grouping`
             assert_metrics_call(mock_incr, "hybrid_fingerprint_match_check", "no_fingerprint_match")
@@ -896,9 +921,13 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                None,
+                None,
+                "v1",
+            )
 
             # Metric from `_should_use_seer_match_for_grouping`
             assert_metrics_call(mock_incr, "hybrid_fingerprint_match_check", "only_event_hybrid")
@@ -960,9 +989,13 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                None,
+                None,
+                "v1",
+            )
 
             # Metric from `_should_use_seer_match_for_grouping`
             assert_metrics_call(mock_incr, "hybrid_fingerprint_match_check", "only_parent_hybrid")
@@ -1025,13 +1058,14 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
             # It picks the second result even though it's less similar because it has to find a
             # match which isn't hybrid, since the new event isn't hybrid
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 0.02,
                 existing_grouphash2,
+                "v1",
             )
 
             # Metrics from `_should_use_seer_match_for_grouping`
@@ -1109,7 +1143,7 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
             # It picks the second result even though it's less similar, and even though the first
             # result has a matching fingerprint, because it has to find a match whose fingerprint it
@@ -1117,6 +1151,7 @@ class MultipleParentGroupsFoundTest(TestCase):
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 0.02,
                 existing_grouphash2,
+                "v1",
             )
 
             # Metrics from `_should_use_seer_match_for_grouping`
@@ -1201,13 +1236,14 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
             # It picks the second result even though it's less similar because the fingerprint
             # matches the new event
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 0.02,
                 existing_grouphash2,
+                "v1",
             )
 
             # Metrics from `_should_use_seer_match_for_grouping`
@@ -1270,11 +1306,12 @@ class MultipleParentGroupsFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=seer_result_data,
+            return_value=(seer_result_data, "v1"),
         ):
             assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
                 0.01,
                 existing_grouphash,
+                "v1",
             )
 
             # It doesn't consider this a hybrid fingerprint case because neither the incoming event
@@ -1312,9 +1349,13 @@ class NoParentGroupFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=[],
+            return_value=([], "v1"),
         ):
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                None,
+                None,
+                "v1",
+            )
 
             assert_metrics_call(
                 mock_incr,
@@ -1350,9 +1391,13 @@ class NoParentGroupFoundTest(TestCase):
 
         with patch(
             "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-            return_value=[],
+            return_value=([], "v1"),
         ):
-            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (None, None)
+            assert get_seer_similar_issues(new_event, new_grouphash, new_variants) == (
+                None,
+                None,
+                "v1",
+            )
 
             assert_metrics_call(
                 mock_incr,

--- a/tests/sentry/grouping/seer_similarity/test_seer.py
+++ b/tests/sentry/grouping/seer_similarity/test_seer.py
@@ -10,7 +10,7 @@ from sentry.testutils.cases import TestCase
 
 
 class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
-    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])
+    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v1"))
     def test_simple(self, mock_get_similarity_data: MagicMock) -> None:
         self.project.update_option("sentry:similarity_backfill_completed", int(time()))
 
@@ -141,7 +141,7 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
 
             mock_get_similar_issues.assert_not_called()
 
-    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])
+    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v1"))
     def test_bypassed_platform_calls_seer_regardless_of_length(
         self, mock_get_similarity_data: MagicMock
     ) -> None:

--- a/tests/sentry/grouping/seer_similarity/test_seer_eligibility.py
+++ b/tests/sentry/grouping/seer_similarity/test_seer_eligibility.py
@@ -274,7 +274,7 @@ class ShouldCallSeerTest(TestCase):
             self.event, call_made=False, blocker="race_condition", training_mode=False
         )
 
-    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[])
+    @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v1"))
     def test_stacktrace_string_not_saved_in_event(
         self, mock_get_similarity_data: MagicMock
     ) -> None:

--- a/tests/sentry/grouping/seer_similarity/test_training_mode.py
+++ b/tests/sentry/grouping/seer_similarity/test_training_mode.py
@@ -58,7 +58,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
         with (
             patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
             patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[]
+                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v2")
             ) as mock_get_similarity_data,
             self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
         ):
@@ -83,7 +83,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
         with (
             patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
             patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[]
+                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v2")
             ) as mock_get_similarity_data,
             self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
         ):
@@ -102,7 +102,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
         with (
             patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
             patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[]
+                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v2")
             ) as mock_get_similarity_data,
             self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
         ):
@@ -128,7 +128,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
         with (
             patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
             patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=[]
+                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v2")
             ) as mock_get_similarity_data,
             self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
         ):

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -92,9 +92,9 @@ class GetSimilarityDataFromSeerTest(TestCase):
     def test_no_groups_found(
         self, mock_seer_request: MagicMock, mock_metrics_incr: MagicMock
     ) -> None:
-        mock_seer_request.return_value = self._make_response({"responses": []})
+        mock_seer_request.return_value = self._make_response({"responses": [], "model_used": "v1"})
 
-        assert get_similarity_data_from_seer(self.request_params) == ([], None)
+        assert get_similarity_data_from_seer(self.request_params) == ([], "v1")
         mock_metrics_incr.assert_any_call(
             "seer.similar_issues_request",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -63,16 +63,19 @@ class GetSimilarityDataFromSeerTest(TestCase):
         ]
 
         for raw_data, expected_outcome in cases:
-            mock_seer_request.return_value = self._make_response({"responses": [raw_data]})
+            mock_seer_request.return_value = self._make_response(
+                {"responses": [raw_data], "model_used": "v1"}
+            )
 
             similar_issue_data: Any = {
                 **raw_data,
                 "parent_group_id": self.similar_event.group_id,
             }
 
-            assert get_similarity_data_from_seer(self.request_params) == [
-                SeerSimilarIssueData(**similar_issue_data)
-            ]
+            assert get_similarity_data_from_seer(self.request_params) == (
+                [SeerSimilarIssueData(**similar_issue_data)],
+                "v1",
+            )
             mock_metrics_incr.assert_any_call(
                 "seer.similar_issues_request",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
@@ -91,7 +94,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
     ) -> None:
         mock_seer_request.return_value = self._make_response({"responses": []})
 
-        assert get_similarity_data_from_seer(self.request_params) == []
+        assert get_similarity_data_from_seer(self.request_params) == ([], None)
         mock_metrics_incr.assert_any_call(
             "seer.similar_issues_request",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
@@ -157,7 +160,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         for response_data, expected_error in cases:
             mock_seer_request.return_value = self._make_response(response_data)
 
-            assert get_similarity_data_from_seer(self.request_params) == []
+            assert get_similarity_data_from_seer(self.request_params) == ([], None)
             mock_metrics_incr.assert_any_call(
                 "seer.similar_issues_request",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
@@ -182,7 +185,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             status=308, headers={"location": "/new/and/improved/endpoint/"}
         )
 
-        assert get_similarity_data_from_seer(self.request_params) == []
+        assert get_similarity_data_from_seer(self.request_params) == ([], None)
         mock_logger.error.assert_called_with(
             f"Encountered redirect when calling Seer endpoint {SEER_SIMILAR_ISSUES_URL}. Please update `SEER_SIMILAR_ISSUES_URL` in `sentry.conf.server` to be '/new/and/improved/endpoint/'."
         )
@@ -213,7 +216,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         ]:
             mock_seer_request.side_effect = request_error
 
-            assert get_similarity_data_from_seer(self.request_params) == []
+            assert get_similarity_data_from_seer(self.request_params) == ([], None)
             mock_logger.warning.assert_called_with(
                 "get_seer_similar_issues.request_error",
                 extra={
@@ -250,7 +253,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         ]:
             mock_seer_request.return_value = HTTPResponse(response, status=status)
 
-            assert get_similarity_data_from_seer(self.request_params) == []
+            assert get_similarity_data_from_seer(self.request_params) == ([], None)
             mock_logger.error.assert_called_with(
                 f"Received {status} when calling Seer endpoint {SEER_SIMILAR_ISSUES_URL}.",
                 extra={"response_data": response},
@@ -281,7 +284,10 @@ class GetSimilarityDataFromSeerTest(TestCase):
 
         # Note that the less similar issue is first in the list as it comes back from Seer
         mock_seer_request.return_value = self._make_response(
-            {"responses": [raw_less_similar_issue_data, raw_similar_issue_data]}
+            {
+                "responses": [raw_less_similar_issue_data, raw_similar_issue_data],
+                "model_used": "v1",
+            }
         )
 
         similar_issue_data: Any = {
@@ -294,10 +300,13 @@ class GetSimilarityDataFromSeerTest(TestCase):
         }
 
         # The results have been reordered so that the more similar issue comes first
-        assert get_similarity_data_from_seer(self.request_params) == [
-            SeerSimilarIssueData(**similar_issue_data),
-            SeerSimilarIssueData(**less_similar_issue_data),
-        ]
+        assert get_similarity_data_from_seer(self.request_params) == (
+            [
+                SeerSimilarIssueData(**similar_issue_data),
+                SeerSimilarIssueData(**less_similar_issue_data),
+            ],
+            "v1",
+        )
 
     @mock.patch("sentry.seer.similarity.similar_issues.delete_seer_grouping_records_by_hash")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
@@ -434,7 +443,8 @@ class GetSimilarityDataFromSeerTest(TestCase):
                         "should_group": True,
                         "stacktrace_distance": 0.01,
                     }
-                ]
+                ],
+                "model_used": "v1",
             }
         )
 
@@ -456,14 +466,17 @@ class GetSimilarityDataFromSeerTest(TestCase):
         mock_logger.info.assert_any_call(
             "get_similarity_data_from_seer.parent_hash_missing_group.retry_success", extra=ANY
         )
-        assert results == [
-            SeerSimilarIssueData(
-                parent_group_id=self.group.id,
-                parent_hash="dogs_are_great",
-                should_group=True,
-                stacktrace_distance=0.01,
-            )
-        ]
+        assert results == (
+            [
+                SeerSimilarIssueData(
+                    parent_group_id=self.group.id,
+                    parent_hash="dogs_are_great",
+                    should_group=True,
+                    stacktrace_distance=0.01,
+                )
+            ],
+            "v1",
+        )
 
     @mock.patch("sentry.seer.similarity.similar_issues.logger")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
@@ -496,4 +509,37 @@ class GetSimilarityDataFromSeerTest(TestCase):
         mock_logger.info.assert_any_call(
             "get_similarity_data_from_seer.parent_hash_missing_group.retry_failure", extra=ANY
         )
-        assert results == []
+        assert results == ([], None)
+
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
+    def test_model_used_returned_from_response(self, mock_seer_request: MagicMock) -> None:
+        raw_data: RawSeerSimilarIssueData = {
+            "parent_hash": self.similar_event_hash,
+            "should_group": True,
+            "stacktrace_distance": 0.01,
+        }
+        mock_seer_request.return_value = self._make_response(
+            {"responses": [raw_data], "model_used": "v2"}
+        )
+
+        results, model_used = get_similarity_data_from_seer(self.request_params)
+
+        assert model_used == "v2"
+        assert len(results) == 1
+
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
+    def test_model_used_missing_from_response_returns_none(
+        self, mock_seer_request: MagicMock
+    ) -> None:
+        """Backward compat: if Seer somehow doesn't return model_used, we get None."""
+        raw_data: RawSeerSimilarIssueData = {
+            "parent_hash": self.similar_event_hash,
+            "should_group": True,
+            "stacktrace_distance": 0.01,
+        }
+        mock_seer_request.return_value = self._make_response({"responses": [raw_data]})
+
+        results, model_used = get_similarity_data_from_seer(self.request_params)
+
+        assert model_used is None
+        assert len(results) == 1


### PR DESCRIPTION
Use Seer's `model_used` response field to record what model Seer actually used, separately from what we requested.

When Sentry calls Seer for similarity grouping, `GroupHashMetadata.seer_model` was previously set from what Sentry *requested*. If Seer internally falls back from v2 to v1, we had no visibility into that. Seer now returns a `model_used` field in the response — this PR consumes it.

- `seer_model` ← what Seer actually used (`model_used` from response, falling back to the requested version)
- `seer_latest_training_model` ← what we sent (always the requested version)

**Changes:**

- Add `model_used: NotRequired[str]` to `SimilarIssuesEmbeddingsResponse`
- `get_similarity_data_from_seer` now returns `tuple[list[SeerSimilarIssueData], str | None]`
- `get_seer_similar_issues` now returns a 3-tuple threading `model_used` through
- `maybe_check_seer_for_matching_grouphash` sets `seer_model` from the response value

Backward compatible: `model_used` is parsed with `.get()` defaulting to `None`, and `seer_model_used or model_version.value` means behavior is identical to today if the field is absent. No migration needed.