### PR TITLE
fix(skills): Replace invalid `${CLAUDE_SKILL_ROOT}` with bare relative paths

### DIFF
--- a/.agents/skills/sentry-backend-bugs/SKILL.md
+++ b/.agents/skills/sentry-backend-bugs/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: sentry-backend-bugs
-description: 'Sentry backend bug pattern review based on real production errors. Use when reviewing Python/Django backend code for common bug patterns. Trigger keywords: "backend bug review", "common errors", "error patterns", "sentry bugs".'
-allowed-tools: Read, Grep, Glob, Bash
+description: 'Review Sentry Python and Django changes for bug patterns drawn from real production issues. Use when reviewing a backend diff or PR, checking Warden findings, auditing the current branch, reviewing production-error patterns, or looking for common regressions in `src/` and `tests/`.'
+allowed-tools: Read Grep Glob Bash
 ---
 
 # Sentry Backend Bug Pattern Review
 
-Find bugs in Sentry backend code by checking for the patterns that cause the most production errors.
+Find bugs in Sentry backend code by checking for the patterns that cause the most real production errors.
 
 This skill encodes patterns from 638 real production issues (393 resolved, 220 unresolved, 25 ignored) generating over 27 million error events across 65,000+ affected users. These are not theoretical risks -- they are the actual bugs that ship most often, with known fixes from resolved issues.
 
 ## Scope
 
-You receive scoped code chunks from Warden's diff pipeline. Each chunk is a changed hunk (or coalesced group of nearby hunks) with surrounding context.
+Review the code provided by the user, Warden, or the current branch diff. If the user does not provide a target, review the current branch diff. Start from the changed hunk or file, then read outward only as needed to confirm the behavior.
 
-1. Analyze the chunk against the pattern checks below.
-2. Use `Read` and `Grep` to trace data flow beyond the chunk when needed — follow function calls, check callers, verify types at boundaries.
+1. Analyze the changed code against the pattern checks below.
+2. Use `Read` and `Grep` to trace data flow beyond the initial diff when needed. Follow function calls, callers, serializers, tasks, and ORM boundaries until the behavior is confirmed.
 3. Report only **HIGH** and **MEDIUM** confidence findings.
 
 | Confidence | Criteria                                                              | Action                       |
@@ -251,14 +251,14 @@ Each code location should be reported once under the most specific matching patt
 
 ## Step 3: Report Findings
 
-For each finding, include:
+For each finding, provide the evidence the review harness needs:
 
-- **Title**: Short description of the bug
-- **Severity**: high, medium, or low
-- **Location**: File path and line number
-- **Description**: Root cause → consequences (2-4 sentences)
-- **Precedent**: A real production issue ID (e.g., "Similar to SENTRY-5D9J: Detector.DoesNotExist, 610K events")
-- **Fix**: A unified diff showing the code fix
+- precise location
+- severity and confidence
+- concrete triggering input or state
+- root cause and consequence
+- a matching production precedent when available
+- a concrete code fix, preferably as a unified diff when the harness supports it
 
 Fix suggestions must include actual code. Never suggest a comment or docstring as a fix.
 

--- a/.agents/skills/sentry-backend-bugs/SKILL.md
+++ b/.agents/skills/sentry-backend-bugs/SKILL.md
@@ -28,16 +28,16 @@ You receive scoped code chunks from Warden's diff pipeline. Each chunk is a chan
 
 Determine what you are reviewing and load the relevant reference.
 
-| Code Type                                                         | Load Reference                                            |
-| ----------------------------------------------------------------- | --------------------------------------------------------- |
-| ORM queries, model lookups, `.objects.get()`, FK access           | `${CLAUDE_SKILL_ROOT}/references/missing-records.md`      |
-| Type conversions, None handling, option reads, serializer returns | `${CLAUDE_SKILL_ROOT}/references/null-and-type-errors.md` |
-| Data input parsing, field lengths, request bodies, decompression  | `${CLAUDE_SKILL_ROOT}/references/data-validation.md`      |
-| `get_or_create`, `save()`, unique constraints, integer overflow   | `${CLAUDE_SKILL_ROOT}/references/database-integrity.md`   |
-| Integration webhooks, external API calls, SentryApp hooks         | `${CLAUDE_SKILL_ROOT}/references/integration-errors.md`   |
-| Dict iteration, shared state, concurrent access                   | `${CLAUDE_SKILL_ROOT}/references/concurrency-bugs.md`     |
-| Snuba queries, metric subscriptions, search filters               | `${CLAUDE_SKILL_ROOT}/references/query-validation.md`     |
-| Redirect URLs, URL construction, routing                          | `${CLAUDE_SKILL_ROOT}/references/url-safety.md`           |
+| Code Type                                                         | Load Reference                       |
+| ----------------------------------------------------------------- | ------------------------------------ |
+| ORM queries, model lookups, `.objects.get()`, FK access           | `references/missing-records.md`      |
+| Type conversions, None handling, option reads, serializer returns | `references/null-and-type-errors.md` |
+| Data input parsing, field lengths, request bodies, decompression  | `references/data-validation.md`      |
+| `get_or_create`, `save()`, unique constraints, integer overflow   | `references/database-integrity.md`   |
+| Integration webhooks, external API calls, SentryApp hooks         | `references/integration-errors.md`   |
+| Dict iteration, shared state, concurrent access                   | `references/concurrency-bugs.md`     |
+| Snuba queries, metric subscriptions, search filters               | `references/query-validation.md`     |
+| Redirect URLs, URL construction, routing                          | `references/url-safety.md`           |
 
 If the code spans multiple categories, load all relevant references.
 

--- a/.agents/skills/sentry-javascript-bugs/SKILL.md
+++ b/.agents/skills/sentry-javascript-bugs/SKILL.md
@@ -28,15 +28,15 @@ You receive scoped code chunks from Warden's diff pipeline. Each chunk is a chan
 
 Determine what you are reviewing and load the relevant reference.
 
-| Code Type                                                               | Load Reference                                               |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Null/undefined property access, optional chaining, object destructuring | `${CLAUDE_SKILL_ROOT}/references/null-reference-errors.md`   |
-| Dashboard widgets, chart visualization, widget URL generation           | `${CLAUDE_SKILL_ROOT}/references/dashboard-widget-errors.md` |
-| Trace views, span details, trace tree rendering                         | `${CLAUDE_SKILL_ROOT}/references/trace-view-errors.md`       |
-| API calls, response handling, error states, fetch wrappers              | `${CLAUDE_SKILL_ROOT}/references/api-response-handling.md`   |
-| React hooks, context providers, render loops, component lifecycle       | `${CLAUDE_SKILL_ROOT}/references/react-lifecycle-errors.md`  |
-| AI Insights, LLM prompt parsing, gen_ai span data                       | `${CLAUDE_SKILL_ROOT}/references/ai-insights-parsing.md`     |
-| Array operations, date/time values, numeric formatting                  | `${CLAUDE_SKILL_ROOT}/references/range-and-bounds-errors.md` |
+| Code Type                                                               | Load Reference                          |
+| ----------------------------------------------------------------------- | --------------------------------------- |
+| Null/undefined property access, optional chaining, object destructuring | `references/null-reference-errors.md`   |
+| Dashboard widgets, chart visualization, widget URL generation           | `references/dashboard-widget-errors.md` |
+| Trace views, span details, trace tree rendering                         | `references/trace-view-errors.md`       |
+| API calls, response handling, error states, fetch wrappers              | `references/api-response-handling.md`   |
+| React hooks, context providers, render loops, component lifecycle       | `references/react-lifecycle-errors.md`  |
+| AI Insights, LLM prompt parsing, gen_ai span data                       | `references/ai-insights-parsing.md`     |
+| Array operations, date/time values, numeric formatting                  | `references/range-and-bounds-errors.md` |
 
 If the code spans multiple categories, load all relevant references.
 

--- a/.agents/skills/sentry-javascript-bugs/SKILL.md
+++ b/.agents/skills/sentry-javascript-bugs/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: sentry-javascript-bugs
-description: 'Sentry JavaScript frontend bug pattern review based on real production errors. Use when reviewing React/TypeScript frontend code for common bug patterns. Trigger keywords: "javascript bug review", "frontend errors", "react error patterns", "sentry frontend bugs".'
-allowed-tools: Read, Grep, Glob, Bash
+description: 'Review Sentry React and TypeScript changes for bug patterns drawn from real production issues. Use when reviewing a frontend diff or PR, checking Warden findings, auditing the current branch, reviewing production-error patterns, or looking for common regressions in `static/`.'
+allowed-tools: Read Grep Glob Bash
 ---
 
 # Sentry JavaScript Frontend Bug Pattern Review
 
-Find bugs in Sentry frontend code by checking for the patterns that cause real production errors.
+Find bugs in Sentry frontend code by checking for the patterns that cause the most real production errors.
 
 This skill encodes patterns from 428 real production issues (201 resolved, 130 ignored, 97 unresolved) generating over 524,000 error events across 93,000+ affected users. These are not theoretical risks -- they are the actual bugs that ship most often, with known fixes from resolved issues.
 
 ## Scope
 
-You receive scoped code chunks from Warden's diff pipeline. Each chunk is a changed hunk (or coalesced group of nearby hunks) with surrounding context.
+Review the code provided by the user, Warden, or the current branch diff. If the user does not provide a target, review the current branch diff. Start from the changed hunk or file, then read outward only as needed to confirm the behavior.
 
-1. Analyze the chunk against the pattern checks below.
-2. Use `Read` and `Grep` to trace data flow beyond the chunk when needed — follow component props, hook return values, API response shapes.
+1. Analyze the changed code against the pattern checks below.
+2. Use `Read` and `Grep` to trace data flow beyond the initial diff when needed. Follow component props, hook return values, API response shapes, and state transitions until the behavior is confirmed.
 3. Report only **HIGH** and **MEDIUM** confidence findings.
 
 | Confidence | Criteria                                                              | Action                       |
@@ -188,14 +188,14 @@ Each code location should be reported once under the most specific matching patt
 
 ## Step 3: Report Findings
 
-For each finding, include:
+For each finding, provide the evidence the review harness needs:
 
-- **Title**: Short description of the bug
-- **Severity**: high, medium, or low
-- **Location**: File path and line number
-- **Description**: Root cause → consequences (2-4 sentences)
-- **Precedent**: A real production issue ID (e.g., "Similar to JAVASCRIPT-2NQW: null charCodeAt in SQL parser, 39K events")
-- **Fix**: A unified diff showing the code fix
+- precise location
+- severity and confidence
+- concrete triggering input or state
+- root cause and consequence
+- a matching production precedent when available
+- a concrete code fix, preferably as a unified diff when the harness supports it
 
 Fix suggestions must include actual code. Never suggest a comment or docstring as a fix.
 

--- a/.agents/skills/sentry-security/SKILL.md
+++ b/.agents/skills/sentry-security/SKILL.md
@@ -26,17 +26,17 @@ Report only **HIGH** and **MEDIUM** confidence findings. Do not report theoretic
 
 Determine what you're reviewing and load the relevant reference.
 
-| Code Type                                | Load Reference                                            |
-| ---------------------------------------- | --------------------------------------------------------- |
-| API endpoint (inherits from `*Endpoint`) | `${CLAUDE_SKILL_ROOT}/references/endpoint-patterns.md`    |
-| Serializer or form field                 | `${CLAUDE_SKILL_ROOT}/references/serializer-patterns.md`  |
-| Email template or HTML rendering         | `${CLAUDE_SKILL_ROOT}/references/output-sanitization.md`  |
-| Token, OAuth, or session handling        | `${CLAUDE_SKILL_ROOT}/references/token-lifecycle.md`      |
-| Role or permission logic                 | `${CLAUDE_SKILL_ROOT}/references/privilege-escalation.md` |
+| Code Type                                | Load Reference                       |
+| ---------------------------------------- | ------------------------------------ |
+| API endpoint (inherits from `*Endpoint`) | `references/endpoint-patterns.md`    |
+| Serializer or form field                 | `references/serializer-patterns.md`  |
+| Email template or HTML rendering         | `references/output-sanitization.md`  |
+| Token, OAuth, or session handling        | `references/token-lifecycle.md`      |
+| Role or permission logic                 | `references/privilege-escalation.md` |
 
 If the code spans multiple categories, load all relevant references.
 
-**Always load** `${CLAUDE_SKILL_ROOT}/references/enforcement-layers.md` — it documents where security checks can legitimately live in Sentry's request lifecycle. A check in any layer counts as enforcement.
+**Always load** `references/enforcement-layers.md` — it documents where security checks can legitimately live in Sentry's request lifecycle. A check in any layer counts as enforcement.
 
 ## Step 2: Check for the Top 6 Vulnerability Classes
 

--- a/.agents/skills/setup-dev/SKILL.md
+++ b/.agents/skills/setup-dev/SKILL.md
@@ -228,7 +228,7 @@ The `_find_docker_socket()` function needs to check multiple socket paths. On ma
 2. `~/.orbstack/run/docker.sock` (OrbStack)
 3. `/var/run/docker.sock` (Docker Desktop / default)
 
-If only Colima is checked, patch it to support all runtimes. Read `${CLAUDE_SKILL_ROOT}/references/orbstack-fix.md` for the exact pattern.
+If only Colima is checked, patch it to support all runtimes. Read `references/orbstack-fix.md` for the exact pattern.
 
 ### Then: Seed the Database
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,14 @@ Cursor is configured to automatically load relevant AGENTS.md files based on the
 
 **Note**: These `.mdc` files only _reference_ AGENTS.md files—they don't duplicate content. All actual guidance should be added to the appropriate AGENTS.md file, not to Cursor rules.
 
+## Agent Skills
+
+Skills under `.agents/skills/` should follow the same current-practice conventions as the rest of the repo:
+
+- Prefer diff-first review workflows. When no explicit file or patch is provided, default to the current branch diff.
+- Keep skill descriptions aligned with natural user requests like PR review, branch audit, and Warden follow-up.
+- If a downstream review harness controls the final response shape, do not hardcode a competing output format in the skill. Specify required evidence instead.
+
 ## Backend
 
 For backend development patterns, security guidelines, and architecture, see `src/AGENTS.md`.


### PR DESCRIPTION
`${CLAUDE_SKILL_ROOT}` is not a recognized Claude Code variable, so all 22 file references using it were passed through as literal strings and never resolved. While `${CLAUDE_SKILL_DIR}` does work, it is scoped to bash injection commands (backtick-bang syntax) where the working directory may differ from the skill directory. For plain markdown file references like these, bare relative paths (e.g. `references/endpoint-patterns.md`) are the standard approach per the Agent Skills spec.
