### PR TITLE
ref(issues): Remove some usages of useHasStreamlinedUI

### DIFF
--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -68,7 +68,7 @@ type GetArchiveActionsProps = Pick<
   disableArchiveUntilOccurrence?: boolean;
 };
 
-export function getArchiveActions({
+function getArchiveActions({
   shouldConfirm,
   confirmLabel,
   confirmMessage,

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -3,7 +3,7 @@ import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Button, LinkButton} from '@sentry/scraps/button';
+import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
 import {bulkDelete, bulkUpdate} from 'sentry/actionCreators/group';
@@ -16,13 +16,11 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal, openReprocessEventModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
 import {FeatureDisabled} from 'sentry/components/acl/featureDisabled';
-import {ArchiveActions, getArchiveActions} from 'sentry/components/actions/archive';
+import {ArchiveActions} from 'sentry/components/actions/archive';
 import {ResolveActions} from 'sentry/components/actions/resolve';
 import {renderArchiveReason} from 'sentry/components/archivedBox';
-import {GuideAnchor} from 'sentry/components/assistant/guideAnchor';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
 import {renderResolutionReason} from 'sentry/components/resolutionBox';
 import {
   IconCheckmark,
@@ -37,12 +35,9 @@ import {IssueListCacheStore} from 'sentry/stores/IssueListCacheStore';
 import type {Event} from 'sentry/types/event';
 import type {Group, GroupStatusResolution, MarkReviewed} from 'sentry/types/group';
 import {GroupStatus, GroupSubstatus} from 'sentry/types/group';
-import type {SavedQueryVersions} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
-import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets, SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {displayReprocessEventAction} from 'sentry/utils/displayReprocessEventAction';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {uniqueId} from 'sentry/utils/guid';
@@ -53,17 +48,12 @@ import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
-import {NewIssueExperienceButton} from 'sentry/views/issueDetails/actions/newIssueExperienceButton';
 import {ShareIssueModal} from 'sentry/views/issueDetails/actions/shareModal';
 import {SubscribeAction} from 'sentry/views/issueDetails/actions/subscribeAction';
 import {Divider} from 'sentry/views/issueDetails/divider';
 import {makeFetchGroupQueryKey} from 'sentry/views/issueDetails/useGroup';
 import {useProjectReleaseVersionIsSemver} from 'sentry/views/issueDetails/useProjectReleaseVersionIsSemver';
-import {
-  useEnvironmentsFromUrl,
-  useHasStreamlinedUI,
-} from 'sentry/views/issueDetails/utils';
+import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 import {isVersionInfoSemver} from 'sentry/views/releases/utils';
 
 type UpdateData =
@@ -89,7 +79,6 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
   const organization = useOrganization();
   const navigate = useNavigate();
   const location = useLocation();
-  const hasStreamlinedUI = useHasStreamlinedUI();
   const queryClient = useQueryClient();
   const environments = useEnvironmentsFromUrl();
 
@@ -129,31 +118,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
       share: shareCap,
     },
     customCopy: {resolution: resolvedCopyCap},
-    discover: discoverCap,
   } = config;
-
-  const getDiscoverUrl = () => {
-    const {title, type, shortId} = group;
-
-    const discoverQuery = {
-      id: undefined,
-      name: title || type,
-      fields: ['title', 'release', 'environment', 'user.display', 'timestamp'],
-      orderby: '-timestamp',
-      query: `issue:${shortId}`,
-      projects: [Number(project.id)],
-      version: 2 as SavedQueryVersions,
-      range: '90d',
-      dataset: config.usesIssuePlatform ? DiscoverDatasets.ISSUE_PLATFORM : undefined,
-    };
-
-    const discoverView = EventView.fromSavedQuery(discoverQuery);
-    return discoverView.getResultsViewUrlTarget(
-      organization,
-      false,
-      hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
-    );
-  };
 
   const trackIssueAction = (
     action:
@@ -163,7 +128,6 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
       | 'subscribed'
       | 'mark_reviewed'
       | 'discarded'
-      | 'open_in_discover'
       | GroupStatus,
     substatus?: GroupSubstatus | null,
     statusDetailsKey?: string
@@ -393,134 +357,113 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
     };
   };
 
-  const {dropdownItems: archiveDropdownItems} = getArchiveActions({
-    onUpdate,
-  });
   return (
     <Flex align="center" gap="xs">
-      {hasStreamlinedUI &&
-        (isResolved || isIgnored ? (
-          <Flex align="center" gap="md">
-            <ResolvedWrapper>
-              <IconCheckmark size="md" />
-              <Flex direction="column">
-                {isResolved ? resolvedCopyCap || t('Resolved') : t('Archived')}
-                <ReasonBanner>
-                  {group.status === 'resolved'
-                    ? renderResolutionReason({
-                        statusDetails: group.statusDetails,
-                        activities: group.activity,
-                        hasStreamlinedUI,
-                        project,
-                        organization,
-                      })
-                    : null}
-                  {group.status === 'ignored'
-                    ? renderArchiveReason({
-                        substatus: group.substatus,
-                        statusDetails: group.statusDetails,
-                        organization,
-                        hasStreamlinedUI,
-                      })
-                    : null}
-                </ReasonBanner>
-              </Flex>
-            </ResolvedWrapper>
+      {isResolved || isIgnored ? (
+        <Flex align="center" gap="md">
+          <ResolvedWrapper>
+            <IconCheckmark size="md" />
+            <Flex direction="column">
+              {isResolved ? resolvedCopyCap || t('Resolved') : t('Archived')}
+              <ReasonBanner>
+                {group.status === 'resolved'
+                  ? renderResolutionReason({
+                      statusDetails: group.statusDetails,
+                      activities: group.activity,
+                      hasStreamlinedUI: true,
+                      project,
+                      organization,
+                    })
+                  : null}
+                {group.status === 'ignored'
+                  ? renderArchiveReason({
+                      substatus: group.substatus,
+                      statusDetails: group.statusDetails,
+                      organization,
+                      hasStreamlinedUI: true,
+                    })
+                  : null}
+              </ReasonBanner>
+            </Flex>
+          </ResolvedWrapper>
 
-            <Divider />
-            {resolveCap.enabled && isResolved && (
-              <Button
-                size="sm"
-                disabled={disabled || isAutoResolved}
-                onClick={() =>
-                  onUpdate({
-                    status: GroupStatus.UNRESOLVED,
-                    statusDetails: {},
-                    substatus: GroupSubstatus.ONGOING,
-                  })
-                }
-              >
-                {t('Unresolve')}
-              </Button>
-            )}
-            {isIgnored && (
-              <Button
-                size="sm"
-                disabled={disabled || isAutoResolved}
-                onClick={() =>
-                  onUpdate({
-                    status: GroupStatus.UNRESOLVED,
-                    statusDetails: {},
-                    substatus: GroupSubstatus.ONGOING,
-                  })
-                }
-              >
-                {t('Unarchive')}
-              </Button>
-            )}
-          </Flex>
-        ) : (
-          <Fragment>
-            {resolveCap.enabled && (
-              <ResolveActions
-                disableResolveInRelease={!resolveInReleaseCap.enabled}
-                disabled={disabled}
-                disableDropdown={disabled}
-                hasRelease={hasRelease}
-                latestRelease={project.latestRelease}
-                hasSemverReleaseFeature={hasSemverReleaseFeature}
-                onUpdate={onUpdate}
-                projectSlug={project.slug}
-                isResolved={isResolved}
-                isAutoResolved={isAutoResolved}
-                size="sm"
-                priority="primary"
-              />
-            )}
-            <ArchiveActions
-              className={hasStreamlinedUI ? undefined : 'hidden-xs'}
+          <Divider />
+          {resolveCap.enabled && isResolved && (
+            <Button
               size="sm"
-              isArchived={isIgnored}
-              onUpdate={onUpdate}
-              disabled={disabled}
-              disableArchiveUntilOccurrence={!archiveUntilOccurrenceCap.enabled}
-            />
-            {!hasStreamlinedUI && (
-              <SubscribeAction
-                className={hasStreamlinedUI ? undefined : 'hidden-xs'}
-                disabled={disabled}
-                disablePriority
-                group={group}
-                onClick={handleClick(onToggleSubscribe)}
-                icon={group.isSubscribed ? <IconSubscribed /> : <IconUnsubscribed />}
-                size="sm"
-              />
-            )}
-          </Fragment>
-        ))}
-      {hasStreamlinedUI && (
+              disabled={disabled || isAutoResolved}
+              onClick={() =>
+                onUpdate({
+                  status: GroupStatus.UNRESOLVED,
+                  statusDetails: {},
+                  substatus: GroupSubstatus.ONGOING,
+                })
+              }
+            >
+              {t('Unresolve')}
+            </Button>
+          )}
+          {isIgnored && (
+            <Button
+              size="sm"
+              disabled={disabled || isAutoResolved}
+              onClick={() =>
+                onUpdate({
+                  status: GroupStatus.UNRESOLVED,
+                  statusDetails: {},
+                  substatus: GroupSubstatus.ONGOING,
+                })
+              }
+            >
+              {t('Unarchive')}
+            </Button>
+          )}
+        </Flex>
+      ) : (
         <Fragment>
-          <SubscribeAction
-            className={hasStreamlinedUI ? undefined : 'hidden-xs'}
-            disabled={disabled}
-            disablePriority
-            group={group}
-            onClick={handleClick(onToggleSubscribe)}
-            icon={group.isSubscribed ? <IconSubscribed /> : <IconUnsubscribed />}
+          {resolveCap.enabled && (
+            <ResolveActions
+              disableResolveInRelease={!resolveInReleaseCap.enabled}
+              disabled={disabled}
+              disableDropdown={disabled}
+              hasRelease={hasRelease}
+              latestRelease={project.latestRelease}
+              hasSemverReleaseFeature={hasSemverReleaseFeature}
+              onUpdate={onUpdate}
+              projectSlug={project.slug}
+              isResolved={isResolved}
+              isAutoResolved={isAutoResolved}
+              size="sm"
+              priority="primary"
+            />
+          )}
+          <ArchiveActions
             size="sm"
-          />
-          <Button
-            size="sm"
-            onClick={openShareModal}
-            icon={<IconUpload />}
-            aria-label={t('Share')}
-            tooltipProps={{title: t('Share Issue')}}
+            isArchived={isIgnored}
+            onUpdate={onUpdate}
             disabled={disabled}
-            analyticsEventKey="issue_details.share_action_clicked"
-            analyticsEventName="Issue Details: Share Action Clicked"
+            disableArchiveUntilOccurrence={!archiveUntilOccurrenceCap.enabled}
           />
         </Fragment>
       )}
+      <SubscribeAction
+        disabled={disabled}
+        disablePriority
+        group={group}
+        onClick={handleClick(onToggleSubscribe)}
+        icon={group.isSubscribed ? <IconSubscribed /> : <IconUnsubscribed />}
+        size="sm"
+      />
+      <Button
+        size="sm"
+        onClick={openShareModal}
+        icon={<IconUpload />}
+        aria-label={t('Share')}
+        tooltipProps={{title: t('Share Issue')}}
+        disabled={disabled}
+        analyticsEventKey="issue_details.share_action_clicked"
+        analyticsEventName="Issue Details: Share Action Clicked"
+      />
       <DropdownMenu
         triggerProps={{
           'aria-label': t('More Actions'),
@@ -529,46 +472,6 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
           size: 'sm',
         }}
         items={[
-          // XXX: Never show for streamlined UI
-          ...(isIgnored || hasStreamlinedUI
-            ? []
-            : [
-                {
-                  key: 'Archive',
-                  className: hasStreamlinedUI
-                    ? undefined
-                    : 'hidden-sm hidden-md hidden-lg',
-                  label: t('Archive'),
-                  isSubmenu: true,
-                  disabled,
-                  children: archiveDropdownItems,
-                },
-              ]),
-          // We don't hide the subscribe or discover button for streamlined UI
-          ...(hasStreamlinedUI
-            ? []
-            : [
-                {
-                  key: 'share',
-                  label: t('Share'),
-                  onAction: openShareModal,
-                  disabled,
-                },
-                {
-                  key: group.isSubscribed ? 'unsubscribe' : 'subscribe',
-                  className: 'hidden-sm hidden-md hidden-lg',
-                  label: group.isSubscribed ? t('Unsubscribe') : t('Subscribe'),
-                  disabled: disabled || group.subscriptionDetails?.disabled,
-                  onAction: onToggleSubscribe,
-                },
-                {
-                  key: 'open-in-discover',
-                  className: 'hidden-sm hidden-md hidden-lg',
-                  label: t('Open in Discover'),
-                  to: disabled ? '' : getDiscoverUrl(),
-                  onAction: () => trackIssueAction('open_in_discover'),
-                },
-              ]),
           {
             key: 'mark-review',
             label: t('Mark reviewed'),
@@ -608,92 +511,6 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
           },
         ]}
       />
-      {!hasStreamlinedUI && (
-        <Fragment>
-          <NewIssueExperienceButton />
-          <SubscribeAction
-            className="hidden-xs"
-            disabled={disabled}
-            disablePriority
-            group={group}
-            onClick={handleClick(onToggleSubscribe)}
-            icon={group.isSubscribed ? <IconSubscribed /> : <IconUnsubscribed />}
-            size="sm"
-          />
-          <div className="hidden-xs">
-            <EnvironmentPageFilter position="bottom-end" size="sm" />
-          </div>
-          {discoverCap.enabled && (
-            <Feature
-              hookName="feature-disabled:open-in-discover"
-              features="discover-basic"
-              organization={organization}
-            >
-              <LinkButton
-                className="hidden-xs"
-                disabled={disabled}
-                to={disabled ? '' : getDiscoverUrl()}
-                onClick={() => trackIssueAction('open_in_discover')}
-                size="sm"
-              >
-                {t('Open in Discover')}
-              </LinkButton>
-            </Feature>
-          )}
-          {isResolved || isIgnored ? (
-            <Button
-              priority="primary"
-              tooltipProps={{
-                title: isAutoResolved
-                  ? t(
-                      'This event is resolved due to the Auto Resolve configuration for this project'
-                    )
-                  : t('Change status to unresolved'),
-              }}
-              size="sm"
-              disabled={disabled || isAutoResolved || !resolveCap.enabled}
-              onClick={() =>
-                onUpdate({
-                  status: GroupStatus.UNRESOLVED,
-                  statusDetails: {},
-                  substatus: GroupSubstatus.ONGOING,
-                })
-              }
-            >
-              {isIgnored ? t('Archived') : t('Resolved')}
-            </Button>
-          ) : (
-            <Fragment>
-              <ArchiveActions
-                className="hidden-xs"
-                size="sm"
-                isArchived={isIgnored}
-                onUpdate={onUpdate}
-                disabled={disabled}
-                disableArchiveUntilOccurrence={!archiveUntilOccurrenceCap.enabled}
-              />
-              {resolveCap.enabled && (
-                <GuideAnchor target="resolve" position="bottom" offset={20}>
-                  <ResolveActions
-                    disableResolveInRelease={!resolveInReleaseCap.enabled}
-                    hasSemverReleaseFeature={hasSemverReleaseFeature}
-                    disabled={disabled}
-                    disableDropdown={disabled}
-                    hasRelease={hasRelease}
-                    latestRelease={project.latestRelease}
-                    onUpdate={onUpdate}
-                    projectSlug={project.slug}
-                    isResolved={isResolved}
-                    isAutoResolved={isAutoResolved}
-                    size="sm"
-                    priority="primary"
-                  />
-                </GuideAnchor>
-              )}
-            </Fragment>
-          )}
-        </Fragment>
-      )}
     </Flex>
   );
 }

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -3,8 +3,6 @@ import styled from '@emotion/styled';
 
 import issueDetailsPreview from 'sentry-images/issue_details/issue-details-preview.png';
 
-import {Button} from '@sentry/scraps/button';
-
 import {openModal} from 'sentry/actionCreators/modal';
 import {DropdownButton} from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -17,14 +15,11 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
-import {useMutateUserOptions} from 'sentry/utils/useMutateUserOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import {
   ISSUE_DETAILS_TOUR_GUIDE_KEY,
   useIssueDetailsTour,
 } from 'sentry/views/issueDetails/issueDetailsTour';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 /**
  * This hook will cause the promotional modal to appear if:
@@ -38,7 +33,6 @@ import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
  */
 function useIssueDetailsPromoModal() {
   const organization = useOrganization();
-  const hasStreamlinedUI = useHasStreamlinedUI();
   const {mutate: mutateAssistant} = useMutateAssistant();
   const {
     startTour,
@@ -57,7 +51,6 @@ function useIssueDetailsPromoModal() {
     isTourRegistered &&
     !isTourCompleted &&
     currentStepId === null &&
-    hasStreamlinedUI &&
     !localTourState.hasSeen;
 
   const handleEndTour = useCallback(() => {
@@ -124,7 +117,6 @@ function useIssueDetailsPromoModal() {
 
 export function NewIssueExperienceButton() {
   const organization = useOrganization();
-  const user = useUser();
   const isSuperUser = isActiveSuperuser();
   const {
     startTour,
@@ -152,46 +144,13 @@ export function NewIssueExperienceButton() {
     return () => clearTimeout(timeout);
   }, [isTourCompleted, organization]);
 
-  const hasStreamlinedUI = useHasStreamlinedUI();
-
   const openForm = useFeedbackForm();
-  const {mutate: mutateUserOptions} = useMutateUserOptions();
-
-  const handleToggle = useCallback(() => {
-    mutateUserOptions({['prefersIssueDetailsStreamlinedUI']: !hasStreamlinedUI});
-    trackAnalytics('issue_details.streamline_ui_toggle', {
-      isEnabled: !hasStreamlinedUI,
-      organization,
-      enforced_streamline_ui: user?.options?.prefersIssueDetailsStreamlinedUI === null,
-    });
-  }, [
-    mutateUserOptions,
-    organization,
-    hasStreamlinedUI,
-    user?.options?.prefersIssueDetailsStreamlinedUI,
-  ]);
-
-  if (!hasStreamlinedUI) {
-    return (
-      <TryNewButton
-        icon={<IconLab />}
-        size="sm"
-        tooltipProps={{title: t('Switch to the new issue experience')}}
-        aria-label={t('Switch to the new issue experience')}
-        onClick={() => {
-          handleToggle();
-        }}
-      >
-        {t('Try New UI')}
-      </TryNewButton>
-    );
-  }
 
   const items = [
     {
       key: 'take-tour',
       label: t('Take a tour'),
-      hidden: hasStreamlinedUI && !isTourRegistered,
+      hidden: !isTourRegistered,
       onAction: () => {
         trackAnalytics('issue_details.tour.started', {organization, method: 'dropdown'});
         startTour();
@@ -249,11 +208,11 @@ export function NewIssueExperienceButton() {
             trigger={triggerProps => (
               <StyledDropdownButton
                 {...triggerProps}
-                size={hasStreamlinedUI ? 'xs' : 'sm'}
+                size="xs"
                 aria-label={t('Manage issue experience')}
               >
                 {/* Passing icon as child to avoid extra icon margin */}
-                <IconLab isSolid={hasStreamlinedUI} />
+                <IconLab isSolid />
               </StyledDropdownButton>
             )}
             items={items}
@@ -269,18 +228,5 @@ const StyledDropdownButton = styled(DropdownButton)`
   color: ${p => p.theme.colors.blue400};
   :hover {
     color: ${p => p.theme.colors.blue400};
-  }
-`;
-
-const TryNewButton = styled(Button)`
-  background: linear-gradient(90deg, #3468d8, #248574);
-  color: ${p => p.theme.colors.white};
-  &:hover,
-  &:active,
-  &:focus {
-    color: ${p => p.theme.colors.white};
-  }
-  ::after {
-    background: linear-gradient(90deg, #3468d8, #248574);
   }
 `;

--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -24,7 +24,6 @@ import {useApi} from 'sentry/utils/useApi';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {SectionDivider} from 'sentry/views/issueDetails/streamline/foldSection';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 interface ShareIssueModalProps extends ModalRenderProps {
   event: Event | null;
@@ -64,7 +63,6 @@ export function ShareIssueModal({
   const api = useApi({persistInFlight: true});
   const [loading, setLoading] = useState(false);
   const isPublished = group?.isPublic;
-  const hasStreamlinedUI = useHasStreamlinedUI();
 
   const hasPublicShare = organization.features.includes('shared-issues') && hasIssueShare;
 
@@ -236,9 +234,6 @@ export function ShareIssueModal({
                       }
                       analyticsEventKey="issue_details.publish_issue_modal.copy_link"
                       analyticsEventName="Issue Details: Publish Issue Modal Copy Link"
-                      analyticsParams={{
-                        streamline: hasStreamlinedUI,
-                      }}
                     >
                       {t('Copy Public Link')}
                     </Button>


### PR DESCRIPTION
One part of many code deletions now that the old experience is dead.

- `/actions/index.tsx`
- `/actions/shareModal.tsx`
- `newExperienceButton.tsx`