### PR TITLE
ref(layout) convert to react query and move higher in the tree

### DIFF
--- a/static/app/views/organizationLayout/body.tsx
+++ b/static/app/views/organizationLayout/body.tsx
@@ -1,25 +1,18 @@
-import {useState} from 'react';
-
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 
-import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t, tct} from 'sentry/locale';
 import {AlertStore} from 'sentry/stores/alertStore';
 import type {Organization} from 'sentry/types/organization';
+import {useMutation} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
-type OrganizationProps = {
+interface OrganizationDeletionInProgressProps {
   organization: Organization;
-};
+}
 
-type BodyProps = {
-  children: React.ReactNode;
-};
-
-function DeletionInProgress({organization}: OrganizationProps) {
+function OrganizationDeletionInProgress(props: OrganizationDeletionInProgressProps) {
   return (
     <Layout.Body>
       <Layout.Main>
@@ -28,7 +21,7 @@ function DeletionInProgress({organization}: OrganizationProps) {
             {tct(
               'The [organization] organization is currently in the process of being deleted from Sentry.',
               {
-                organization: <strong>{organization.slug}</strong>,
+                organization: <strong>{props.organization.slug}</strong>,
               }
             )}
           </Alert>
@@ -38,28 +31,28 @@ function DeletionInProgress({organization}: OrganizationProps) {
   );
 }
 
-function DeletionPending({organization}: OrganizationProps) {
+interface OrganizatonDeletionPendingProps {
+  organization: Organization;
+}
+
+function OrganizationDeletionPending(props: OrganizatonDeletionPendingProps) {
   const api = useApi();
-  const [isRestoring, setIsRestoring] = useState(false);
 
-  const onRestore = async () => {
-    setIsRestoring(true);
-
-    try {
-      await api.requestPromise(`/organizations/${organization.slug}/`, {
+  const {mutate: onRestore, isPending: isRestoring} = useMutation({
+    mutationFn: () =>
+      api.requestPromise(`/organizations/${props.organization?.slug}/`, {
         method: 'PUT',
         data: {cancelDeletion: true},
-      });
-      window.location.reload();
-    } catch {
-      setIsRestoring(false);
+      }),
+    onSuccess: () => window.location.reload(),
+    onError: () => {
       AlertStore.addAlert({
         message:
           'We were unable to restore this organization. Please try again or contact support.',
         variant: 'danger',
       });
-    }
-  };
+    },
+  });
 
   return (
     <Layout.Body>
@@ -67,11 +60,11 @@ function DeletionPending({organization}: OrganizationProps) {
         <h3>{t('Deletion Scheduled')}</h3>
         <p>
           {tct('The [organization] organization is currently scheduled for deletion.', {
-            organization: <strong>{organization.slug}</strong>,
+            organization: <strong>{props.organization.slug}</strong>,
           })}
         </p>
 
-        {organization.access.includes('org:admin') ? (
+        {props.organization.access.includes('org:admin') ? (
           <div>
             <p>
               {t(
@@ -79,7 +72,11 @@ function DeletionPending({organization}: OrganizationProps) {
               )}
             </p>
             <p>
-              <Button priority="primary" onClick={onRestore} disabled={isRestoring}>
+              <Button
+                priority="primary"
+                onClick={() => onRestore()}
+                disabled={isRestoring}
+              >
                 {t('Restore Organization')}
               </Button>
             </p>
@@ -101,21 +98,4 @@ function DeletionPending({organization}: OrganizationProps) {
       </Layout.Main>
     </Layout.Body>
   );
-}
-
-export function OrganizationDetailsBody({children}: BodyProps) {
-  // Organization may be null in account settings
-  const organization = useOrganization({allowNull: true});
-
-  const status = organization?.status?.id;
-
-  if (organization && status === 'pending_deletion') {
-    return <DeletionPending organization={organization} />;
-  }
-
-  if (organization && status === 'deletion_in_progress') {
-    return <DeletionInProgress organization={organization} />;
-  }
-
-  return <ErrorBoundary>{children}</ErrorBoundary>;
 }

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -1,6 +1,9 @@
 import {Outlet, ScrollRestoration} from 'react-router-dom';
 
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
 
 import {DemoHeader} from 'sentry/components/demo/demoHeader';
 import {useFeatureFlagOnboardingDrawer} from 'sentry/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar';
@@ -8,12 +11,17 @@ import {useFeedbackOnboardingDrawer} from 'sentry/components/feedback/feedbackOn
 import {Footer} from 'sentry/components/footer';
 import {GlobalDrawer} from 'sentry/components/globalDrawer';
 import {HookOrDefault} from 'sentry/components/hookOrDefault';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {usePerformanceOnboardingDrawer} from 'sentry/components/performanceOnboarding/sidebar';
 import {useProfilingOnboardingDrawer} from 'sentry/components/profiling/profilingOnboardingSidebar';
 import {useReplaysOnboardingDrawer} from 'sentry/components/replaysOnboarding/sidebar';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {t, tct} from 'sentry/locale';
+import {AlertStore} from 'sentry/stores/alertStore';
 import type {Organization} from 'sentry/types/organization';
+import {useMutation} from 'sentry/utils/queryClient';
 import {useRouteAnalyticsHookSetup} from 'sentry/utils/routeAnalytics/useRouteAnalyticsHookSetup';
+import {useApi} from 'sentry/utils/useApi';
 import {useInitSentryToolbar} from 'sentry/utils/useInitSentryToolbar';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AppBodyContent} from 'sentry/views/app/appBodyContent';
@@ -23,8 +31,17 @@ import {PrimaryNavigationContextProvider} from 'sentry/views/navigation/primaryN
 import {OrganizationContainer} from 'sentry/views/organizationContainer';
 import {useReleasesDrawer} from 'sentry/views/releases/drawer/useReleasesDrawer';
 
-import {OrganizationDetailsBody} from './body';
+/**
+ * Pulled into its own component to avoid re-rendering the OrganizationLayout
+ * TODO: figure out why these analytics hooks trigger rerenders
+ */
+function GlobalAnalytics() {
+  useRouteAnalyticsHookSetup();
+  useRegisterDomainViewUsage();
+  return null;
+}
 
+// Org header is for rendering the getsentry banners at the top of the page
 const OrganizationHeader = HookOrDefault({
   hookName: 'component:organization-header',
 });
@@ -80,9 +97,14 @@ function AppLayout({organization}: LayoutProps) {
           <DemoHeader />
           <AppBodyContent>
             {organization && <OrganizationHeader organization={organization} />}
-            <OrganizationDetailsBody>
+            {/* Check if organization is in a deleted or pending deletion state and block the route from rendering */}
+            {organization?.status?.id === 'pending_deletion' ? (
+              <OrganizationDeletionPending organization={organization} />
+            ) : organization?.status?.id === 'deletion_in_progress' ? (
+              <OrganizationDeletionInProgress organization={organization} />
+            ) : (
               <Outlet />
-            </OrganizationDetailsBody>
+            )}
           </AppBodyContent>
           <Footer />
         </Stack>
@@ -92,13 +114,95 @@ function AppLayout({organization}: LayoutProps) {
   );
 }
 
-/**
- * Pulled into its own component to avoid re-rendering the OrganizationLayout
- * TODO: figure out why these analytics hooks trigger rerenders
- */
-function GlobalAnalytics() {
-  useRouteAnalyticsHookSetup();
-  useRegisterDomainViewUsage();
+// @TODO(Jonas): Give these pages some creative love, they look very poor and could use a good illustration
+interface OrganizationDeletionInProgressProps {
+  organization: Organization;
+}
 
-  return null;
+function OrganizationDeletionInProgress(props: OrganizationDeletionInProgressProps) {
+  return (
+    <Layout.Body>
+      <Layout.Main>
+        <Alert.Container>
+          <Alert variant="warning">
+            {tct(
+              'The [organization] organization is currently in the process of being deleted from Sentry.',
+              {
+                organization: <strong>{props.organization.slug}</strong>,
+              }
+            )}
+          </Alert>
+        </Alert.Container>
+      </Layout.Main>
+    </Layout.Body>
+  );
+}
+
+interface OrganizatonDeletionPendingProps {
+  organization: Organization;
+}
+
+function OrganizationDeletionPending(props: OrganizatonDeletionPendingProps) {
+  const api = useApi();
+
+  const {mutate: onRestore, isPending: isRestoring} = useMutation({
+    mutationFn: () =>
+      api.requestPromise(`/organizations/${props.organization?.slug}/`, {
+        method: 'PUT',
+        data: {cancelDeletion: true},
+      }),
+    onSuccess: () => window.location.reload(),
+    onError: () => {
+      AlertStore.addAlert({
+        message:
+          'We were unable to restore this organization. Please try again or contact support.',
+        variant: 'danger',
+      });
+    },
+  });
+
+  return (
+    <Layout.Body>
+      <Layout.Main>
+        <Heading as="h3">{t('Deletion Scheduled')}</Heading>
+        <p>
+          {tct('The [organization] organization is currently scheduled for deletion.', {
+            organization: <strong>{props.organization.slug}</strong>,
+          })}
+        </p>
+
+        {props.organization.access.includes('org:admin') ? (
+          <div>
+            <p>
+              {t(
+                'Would you like to cancel this process and restore the organization back to the original state?'
+              )}
+            </p>
+            <p>
+              <Button
+                priority="primary"
+                onClick={() => onRestore()}
+                disabled={isRestoring}
+              >
+                {t('Restore Organization')}
+              </Button>
+            </p>
+          </div>
+        ) : (
+          <p>
+            {t(
+              'If this is a mistake, contact an organization owner and ask them to restore this organization.'
+            )}
+          </p>
+        )}
+        <p>
+          <small>
+            {t(
+              "Note: Restoration is available until the process begins. Once it does, there's no recovering the data that has been removed."
+            )}
+          </small>
+        </p>
+      </Layout.Main>
+    </Layout.Body>
+  );
 }


### PR DESCRIPTION
Move the pending deletion components to the layout itself and swap the state management for react query