### PR TITLE
feat(dashboards): Adds serializer check to dashboards generation on completion hook

### DIFF
--- a/src/sentry/dashboards/on_completion_hook.py
+++ b/src/sentry/dashboards/on_completion_hook.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
+from typing import Any
 
 from pydantic import ValidationError
 
+from sentry.api.serializers.rest_framework import DashboardSerializer
 from sentry.dashboards.models.generate_dashboard_artifact import GeneratedDashboard
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.explorer.client_utils import fetch_run_status
 from sentry.seer.explorer.on_completion_hook import ExplorerOnCompletionHook
@@ -18,13 +22,41 @@ FIX_PROMPT_SECONDARY = "Please fix the following issues and regenerate the dashb
 MAX_VALIDATION_RETRIES = 3
 
 
+def _validate_with_serializer(
+    artifact: GeneratedDashboard, organization: Organization
+) -> dict[str, Any] | None:
+    """
+    Run the generated dashboard through the DRF DashboardSerializer to catch
+    issues the Pydantic model doesn't cover (invalid search syntax, unknown
+    aggregates, dataset compatibility, etc.).
+    """
+
+    projects = list(Project.objects.filter(organization=organization, status=0)[:1])
+
+    serializer = DashboardSerializer(
+        data=artifact.dict(),
+        context={
+            "organization": organization,
+            "request": SimpleNamespace(user=None),  # mock request to satisfy serializer
+            "projects": projects,
+            "environment": [],
+        },
+    )
+    if not serializer.is_valid():
+        return serializer.errors
+    return None
+
+
 class DashboardOnCompletionHook(ExplorerOnCompletionHook):
     """
     Hook called when a dashboard generation Explorer run completes.
 
-    Validates the generated dashboard artifact against the GeneratedDashboard
-    Pydantic model. If validation fails (e.g. blocklisted functions), asks Seer
-    to regenerate with the error details.
+    Validates the generated dashboard artifact first against the
+    GeneratedDashboard Pydantic model (schema-level: blocklisted functions,
+    field types, layout constraints), then against the DRF DashboardSerializer
+    (semantic-level: search syntax, aggregate/column validity, dataset
+    compatibility). If either validation fails, asks Seer to regenerate with
+    the error details.
 
     The hook is limited to MAX_VALIDATION_RETRIES retry attempts to prevent
     infinite loops, since on_completion_hooks persist across continue_run calls.
@@ -48,39 +80,15 @@ class DashboardOnCompletionHook(ExplorerOnCompletionHook):
             artifact = state.get_artifact("dashboard", GeneratedDashboard)
         except ValidationError as validation_error:
             logger.info(
-                "dashboards.on_completion_hook.validation_failed",
+                "dashboards.on_completion_hook.pydantic_validation_failed",
                 extra={
                     "run_id": run_id,
                     "organization_id": organization.id,
                 },
             )
 
-            # Count consecutive fix requests in the current failure chain by
-            # scanning blocks in reverse. A non-fix user message (i.e. the user
-            # explicitly continuing the conversation) breaks the chain so each
-            # new user-driven generation gets its own retry budget.
-            retry_count = 0
-            for block in reversed(state.blocks):
-                if (
-                    block.message.role == "user"
-                    and block.message.content
-                    and block.message.content.startswith(FIX_PROMPT)
-                ):
-                    retry_count += 1
-                elif block.message.role == "user":
-                    break
-            if retry_count >= MAX_VALIDATION_RETRIES:
-                logger.info(
-                    "dashboards.on_completion_hook.max_retries_reached",
-                    extra={
-                        "run_id": run_id,
-                        "organization_id": organization.id,
-                        "retry_count": retry_count,
-                    },
-                )
-                return
-
-            cls._request_fix(organization, run_id, validation_error)
+            if cls._within_retry_budget(state):
+                cls._request_fix(organization, run_id, str(validation_error))
             return
 
         if artifact is None:
@@ -90,16 +98,59 @@ class DashboardOnCompletionHook(ExplorerOnCompletionHook):
             )
             return
 
+        serializer_errors = _validate_with_serializer(artifact, organization)
+        if serializer_errors is not None:
+            logger.info(
+                "dashboards.on_completion_hook.serializer_validation_failed",
+                extra={
+                    "run_id": run_id,
+                    "organization_id": organization.id,
+                    "errors": serializer_errors,
+                },
+            )
+
+            if cls._within_retry_budget(state):
+                cls._request_fix(organization, run_id, str(serializer_errors))
+            return
+
         logger.info(
             "dashboards.on_completion_hook.validation_passed",
             extra={"run_id": run_id, "organization_id": organization.id},
         )
 
     @classmethod
-    def _request_fix(cls, organization: Organization, run_id: int, error: ValidationError) -> None:
+    def _within_retry_budget(cls, state: Any) -> bool:
+        """
+        Count consecutive fix requests in the current failure chain by
+        scanning blocks in reverse. A non-fix user message (i.e. the user
+        explicitly continuing the conversation) breaks the chain so each
+        new user-driven generation gets its own retry budget.
+        """
+        retry_count = 0
+        for block in reversed(state.blocks):
+            if (
+                block.message.role == "user"
+                and block.message.content
+                and block.message.content.startswith(FIX_PROMPT)
+            ):
+                retry_count += 1
+            elif block.message.role == "user":
+                break
+
+        if retry_count >= MAX_VALIDATION_RETRIES:
+            logger.info(
+                "dashboards.on_completion_hook.max_retries_reached",
+                extra={
+                    "retry_count": retry_count,
+                },
+            )
+            return False
+        return True
+
+    @classmethod
+    def _request_fix(cls, organization: Organization, run_id: int, error: str) -> None:
         try:
             client = SeerExplorerClient(organization=organization, user=None)
-            # We only request a single regeneration. No further generation requests are made if this fails.
             client.continue_run(
                 run_id,
                 prompt=(f"{FIX_PROMPT} {FIX_PROMPT_SECONDARY}\n\n{error}"),

--- a/src/sentry/dashboards/on_completion_hook.py
+++ b/src/sentry/dashboards/on_completion_hook.py
@@ -33,14 +33,16 @@ def _validate_with_serializer(
     """
 
     # Projects are unused in this check, but we need at least one project to satisfy the serializer
-    projects = [Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)[0]]
+    project = Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE).first()
 
+    if project is None:
+        return None
     serializer = DashboardSerializer(
         data=artifact.dict(),
         context={
             "organization": organization,
             "request": SimpleNamespace(user=None),  # mock request to satisfy serializer
-            "projects": projects,
+            "projects": [project],
             "environment": [],
         },
     )
@@ -89,7 +91,7 @@ class DashboardOnCompletionHook(ExplorerOnCompletionHook):
                 },
             )
 
-            if cls._within_retry_budget(state):
+            if cls._within_retry_budget(state, organization, run_id):
                 cls._request_fix(organization, run_id, str(validation_error))
             return
 
@@ -111,7 +113,7 @@ class DashboardOnCompletionHook(ExplorerOnCompletionHook):
                 },
             )
 
-            if cls._within_retry_budget(state):
+            if cls._within_retry_budget(state, organization, run_id):
                 cls._request_fix(organization, run_id, str(serializer_errors))
             return
 
@@ -121,7 +123,7 @@ class DashboardOnCompletionHook(ExplorerOnCompletionHook):
         )
 
     @classmethod
-    def _within_retry_budget(cls, state: Any) -> bool:
+    def _within_retry_budget(cls, state: Any, organization: Organization, run_id: int) -> bool:
         """
         Count consecutive fix requests in the current failure chain by
         scanning blocks in reverse. A non-fix user message (i.e. the user
@@ -143,6 +145,8 @@ class DashboardOnCompletionHook(ExplorerOnCompletionHook):
             logger.info(
                 "dashboards.on_completion_hook.max_retries_reached",
                 extra={
+                    "organization_id": organization.id,
+                    "run_id": run_id,
                     "retry_count": retry_count,
                 },
             )

--- a/src/sentry/dashboards/on_completion_hook.py
+++ b/src/sentry/dashboards/on_completion_hook.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from sentry.api.serializers.rest_framework import DashboardSerializer
+from sentry.constants import ObjectStatus
 from sentry.dashboards.models.generate_dashboard_artifact import GeneratedDashboard
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -31,7 +32,8 @@ def _validate_with_serializer(
     aggregates, dataset compatibility, etc.).
     """
 
-    projects = list(Project.objects.filter(organization=organization, status=0)[:1])
+    # Projects are unused in this check, but we need at least one project to satisfy the serializer
+    projects = [Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)[0]]
 
     serializer = DashboardSerializer(
         data=artifact.dict(),

--- a/tests/sentry/dashboards/test_on_completion_hook.py
+++ b/tests/sentry/dashboards/test_on_completion_hook.py
@@ -94,6 +94,10 @@ INVALID_SERIALIZER_ARTIFACT = {
 
 
 class DashboardOnCompletionHookTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.project
+
     @patch("sentry.dashboards.on_completion_hook.fetch_run_status")
     def test_valid_artifact_passes(self, mock_fetch: MagicMock) -> None:
         mock_fetch.return_value = _make_state(artifact_data=VALID_ARTIFACT)

--- a/tests/sentry/dashboards/test_on_completion_hook.py
+++ b/tests/sentry/dashboards/test_on_completion_hook.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from pydantic import ValidationError
-
 from sentry.dashboards.on_completion_hook import (
     FIX_PROMPT,
     FIX_PROMPT_SECONDARY,
@@ -56,7 +54,7 @@ VALID_ARTIFACT = {
     ],
 }
 
-INVALID_ARTIFACT = {
+INVALID_PYDANTIC_ARTIFACT = {
     "title": "Test Dashboard",
     "widgets": [
         {
@@ -67,6 +65,25 @@ INVALID_ARTIFACT = {
             "queries": [
                 {
                     "aggregates": ["spm()"],
+                    "columns": [],
+                }
+            ],
+            "layout": {"x": 0, "y": 0, "w": 3, "h": 2, "min_h": 2},
+        }
+    ],
+}
+
+INVALID_SERIALIZER_ARTIFACT = {
+    "title": "Test Dashboard",
+    "widgets": [
+        {
+            "title": "Bad Widget",
+            "description": "Uses nonexistent aggregate",
+            "display_type": "line",
+            "widget_type": "error-events",
+            "queries": [
+                {
+                    "aggregates": ["nonexistent_function()"],
                     "columns": [],
                 }
             ],
@@ -86,8 +103,8 @@ class DashboardOnCompletionHookTest(TestCase):
             mock_fix.assert_not_called()
 
     @patch("sentry.dashboards.on_completion_hook.fetch_run_status")
-    def test_invalid_artifact_triggers_fix(self, mock_fetch: MagicMock) -> None:
-        mock_fetch.return_value = _make_state(artifact_data=INVALID_ARTIFACT)
+    def test_invalid_pydantic_artifact_triggers_fix(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.return_value = _make_state(artifact_data=INVALID_PYDANTIC_ARTIFACT)
 
         with patch.object(DashboardOnCompletionHook, "_request_fix") as mock_fix:
             DashboardOnCompletionHook.execute(self.organization, run_id=1)
@@ -95,7 +112,21 @@ class DashboardOnCompletionHookTest(TestCase):
             args = mock_fix.call_args
             assert args[0][0] == self.organization
             assert args[0][1] == 1
-            assert isinstance(args[0][2], ValidationError)
+            assert isinstance(args[0][2], str)
+            assert "spm" in args[0][2]
+
+    @patch("sentry.dashboards.on_completion_hook.fetch_run_status")
+    def test_invalid_serializer_artifact_triggers_fix(self, mock_fetch: MagicMock) -> None:
+        """An artifact that passes Pydantic but fails the DRF serializer should trigger a fix."""
+        mock_fetch.return_value = _make_state(artifact_data=INVALID_SERIALIZER_ARTIFACT)
+
+        with patch.object(DashboardOnCompletionHook, "_request_fix") as mock_fix:
+            DashboardOnCompletionHook.execute(self.organization, run_id=1)
+            mock_fix.assert_called_once()
+            args = mock_fix.call_args
+            assert args[0][0] == self.organization
+            assert args[0][1] == 1
+            assert isinstance(args[0][2], str)
 
     @patch("sentry.dashboards.on_completion_hook.fetch_run_status")
     def test_valid_artifact_after_prior_fix_still_passes(self, mock_fetch: MagicMock) -> None:
@@ -136,7 +167,7 @@ class DashboardOnCompletionHookTest(TestCase):
                 )
             )
         mock_fetch.return_value = _make_state(
-            artifact_data=INVALID_ARTIFACT,
+            artifact_data=INVALID_PYDANTIC_ARTIFACT,
             previous_blocks=blocks,
         )
 
@@ -167,7 +198,7 @@ class DashboardOnCompletionHookTest(TestCase):
             )
         )
         mock_fetch.return_value = _make_state(
-            artifact_data=INVALID_ARTIFACT,
+            artifact_data=INVALID_PYDANTIC_ARTIFACT,
             previous_blocks=blocks,
         )
 


### PR DESCRIPTION
Updates dashboard generation on completion hook to also check artifact result against dashboard serializer. If result fails validation, resumes seer run with error information to regenerate dashboard. 