### PR TITLE
feat(workflow_engine): Action Filter cache invalidation

### DIFF
--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -73,7 +73,6 @@ def _populate_cache(action_filters_by_workflow: ActionFiltersByWorkflow) -> None
         for workflow_id, action_filters in action_filters_by_workflow.items()
     }
 
-    # TODO -- Add cache invalidation
     _action_filters_cache.set_many(cache_items, CACHE_TTL)
 
 
@@ -94,7 +93,7 @@ def get_action_filters_by_workflows(
         dict[WorkflowId, list[DataConditionGroup]] mapping workflow IDs to their action filters.
             Each list contains the DataConditionGroups with prefetched conditions.
     """
-    # TODO - use this hook in `processors/workflow.py`'s evaluate_workflows_action_filters
+    # TODO - use this hook in `processors/workflow.py`'s evaluate_workflows_action_filters <- last item.
     if not workflows:
         return {}
 

--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -109,3 +109,14 @@ def get_action_filters_by_workflows(
             action_filters_by_workflow[workflow_id] = action_filters
 
     return action_filters_by_workflow
+
+
+@scopedstats.timer()
+def invalidate_action_filter_cache_by_workflow_ids(workflow_ids: list[int]) -> None:
+    """
+    Takes a list of workflow ids and clears the cached values for the stored information
+    """
+    metrics_incr(f"{METRIC_PREFIX}.invalidated", value=len(workflow_ids))
+    cache_keys = [_ActionFilterCacheKey(wid) for wid in workflow_ids]
+
+    return _action_filters_cache.delete_many(cache_keys)

--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -111,7 +111,7 @@ def get_action_filters_by_workflows(
 
 
 @scopedstats.timer()
-def invalidate_action_filter_cache_by_workflow_ids(workflow_ids: list[int]) -> None:
+def invalidate_action_filter_cache_by_workflow_ids(workflow_ids: list[WorkflowId]) -> None:
     """
     Takes a list of workflow ids and clears the cached values for the stored information
 
@@ -125,4 +125,4 @@ def invalidate_action_filter_cache_by_workflow_ids(workflow_ids: list[int]) -> N
     metrics_incr(f"{METRIC_PREFIX}.invalidated", value=len(workflow_ids))
     cache_keys = [_ActionFilterCacheKey(wid) for wid in workflow_ids]
 
-    return _action_filters_cache.delete_many(cache_keys)
+    _action_filters_cache.delete_many(cache_keys)

--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -114,6 +114,13 @@ def get_action_filters_by_workflows(
 def invalidate_action_filter_cache_by_workflow_ids(workflow_ids: list[int]) -> None:
     """
     Takes a list of workflow ids and clears the cached values for the stored information
+
+    Models that have receivers to invalidate the cache:
+    - ✅ WorkflowDataConditionGroup post_save - When an action filter is created on a workflow
+    - WorkflowDataConditionGroup pre_delete - When an action filter is removed from the workflow
+    - ✅ DataCondition post_save - When a condition on a filter is changed
+    - ✅ DataCondition pre_delete - When a condition on the filter being removed
+    - DataConditionGroup post_save - When an update to the logic type in the condition group
     """
     metrics_incr(f"{METRIC_PREFIX}.invalidated", value=len(workflow_ids))
     cache_keys = [_ActionFilterCacheKey(wid) for wid in workflow_ids]

--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -116,10 +116,10 @@ def invalidate_action_filter_cache_by_workflow_ids(workflow_ids: list[int]) -> N
     Takes a list of workflow ids and clears the cached values for the stored information
 
     Models that have receivers to invalidate the cache:
-    - ✅ WorkflowDataConditionGroup post_save - When an action filter is created on a workflow
+    - WorkflowDataConditionGroup post_save - When an action filter is created on a workflow
     - WorkflowDataConditionGroup pre_delete - When an action filter is removed from the workflow
-    - ✅ DataCondition post_save - When a condition on a filter is changed
-    - ✅ DataCondition pre_delete - When a condition on the filter being removed
+    - DataCondition post_save - When a condition on a filter is changed
+    - DataCondition pre_delete - When a condition on the filter being removed
     - DataConditionGroup post_save - When an update to the logic type in the condition group
     """
     metrics_incr(f"{METRIC_PREFIX}.invalidated", value=len(workflow_ids))

--- a/src/sentry/workflow_engine/receivers/__init__.py
+++ b/src/sentry/workflow_engine/receivers/__init__.py
@@ -5,3 +5,4 @@ from .data_source_detector import *  # NOQA
 from .detector import *  # NOQA
 from .detector_workflow import *  # NOQA
 from .workflow import *  # NOQA
+from .workflow_data_condition_group import *  # NOQA

--- a/src/sentry/workflow_engine/receivers/__init__.py
+++ b/src/sentry/workflow_engine/receivers/__init__.py
@@ -1,5 +1,6 @@
 from .action import *  # NOQA
 from .data_condition import *  # NOQA
+from .data_condition_group import *  # NOQA
 from .data_source import *  # NOQA
 from .data_source_detector import *  # NOQA
 from .detector import *  # NOQA

--- a/src/sentry/workflow_engine/receivers/data_condition.py
+++ b/src/sentry/workflow_engine/receivers/data_condition.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from django.db import router, transaction
-from django.db.models.signals import post_save, pre_save
+from django.db.models.signals import post_save, pre_delete, pre_save
 from django.dispatch import receiver
 
 from sentry.workflow_engine.caches.action_filters import (
@@ -17,14 +17,19 @@ from sentry.workflow_engine.types import WorkflowId
 
 @receiver(pre_save, sender=DataCondition)
 def enforce_comparison_schema(
-    sender: type[DataCondition], instance: DataCondition, **kwargs: Any
+    sender: type[DataCondition],
+    instance: DataCondition,
+    **kwargs: Any,
 ) -> None:
     enforce_data_condition_json_schema(instance)
 
 
+@receiver(pre_delete, sender=DataCondition)
 @receiver(post_save, sender=DataCondition)
 def invlidate_action_filter_cache_by_data_condition(
-    sender: type[DataCondition], instance: DataCondition, **kwargs: Any
+    sender: type[DataCondition],
+    instance: DataCondition,
+    **kwargs: Any,
 ) -> None:
     workflow_ids: list[WorkflowId] | None = None
 
@@ -37,7 +42,7 @@ def invlidate_action_filter_cache_by_data_condition(
     except WorkflowDataConditionGroup.DoesNotExist:
         pass
 
-    if workflow_ids is not None:
+    if workflow_ids:
         # ensure the execution is after the transaction is committed
         def execute_invalidation() -> None:
             invalidate_action_filter_cache_by_workflow_ids(workflow_ids)

--- a/src/sentry/workflow_engine/receivers/data_condition.py
+++ b/src/sentry/workflow_engine/receivers/data_condition.py
@@ -26,23 +26,18 @@ def enforce_comparison_schema(
 
 @receiver(pre_delete, sender=DataCondition)
 @receiver(post_save, sender=DataCondition)
-def invlidate_action_filter_cache_by_data_condition(
+def invalidate_action_filter_cache_by_data_condition(
     sender: type[DataCondition],
     instance: DataCondition,
     **kwargs: Any,
 ) -> None:
-    workflow_ids: list[WorkflowId] | None = None
-
-    try:
-        # TODO -- see if we can determine if the DataCondition is
-        # an ActionFilter, to skip querying for the workflow.
-        workflow_ids = list(
-            WorkflowDataConditionGroup.objects.filter(
-                condition_group__conditions__id=instance.id
-            ).values_list("workflow_id", flat=True)
-        )
-    except WorkflowDataConditionGroup.DoesNotExist:
-        pass
+    # TODO -- see if we can determine if the DataCondition is
+    # an ActionFilter, to skip querying for the workflow.
+    workflow_ids: list[WorkflowId] = list(
+        WorkflowDataConditionGroup.objects.filter(
+            condition_group__conditions__id=instance.id
+        ).values_list("workflow_id", flat=True)
+    )
 
     if workflow_ids:
         # ensure the execution is after the transaction is committed

--- a/src/sentry/workflow_engine/receivers/data_condition.py
+++ b/src/sentry/workflow_engine/receivers/data_condition.py
@@ -47,4 +47,7 @@ def invlidate_action_filter_cache_by_data_condition(
         def execute_invalidation() -> None:
             invalidate_action_filter_cache_by_workflow_ids(workflow_ids)
 
-        transaction.on_commit(execute_invalidation, router.db_for_write(DataCondition))
+        transaction.on_commit(
+            execute_invalidation,
+            router.db_for_write(DataCondition),
+        )

--- a/src/sentry/workflow_engine/receivers/data_condition.py
+++ b/src/sentry/workflow_engine/receivers/data_condition.py
@@ -1,12 +1,18 @@
 from typing import Any
 
+from django.db import router, transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
+from sentry.workflow_engine.caches.action_filters import (
+    invalidate_action_filter_cache_by_workflow_ids,
+)
+from sentry.workflow_engine.models import WorkflowDataConditionGroup
 from sentry.workflow_engine.models.data_condition import (
     DataCondition,
     enforce_data_condition_json_schema,
 )
+from sentry.workflow_engine.types import WorkflowId
 
 
 @receiver(pre_save, sender=DataCondition)
@@ -17,10 +23,23 @@ def enforce_comparison_schema(
 
 
 @receiver(post_save, sender=DataCondition)
-def invlidate_action_filter_cache(
+def invlidate_action_filter_cache_by_data_condition(
     sender: type[DataCondition], instance: DataCondition, **kwargs: Any
 ) -> None:
-    # TODO - when an action filter is updated, we need to invalidate
-    # the related workflows cache. Can this simply check the instance
-    # and see if the type of condition is an action filter?
-    pass
+    workflow_ids: list[WorkflowId] | None = None
+
+    try:
+        # TODO -- see if we can determine if the DataCondition is
+        # an ActionFilter, to skip querying for the workflow.
+        workflow_ids = WorkflowDataConditionGroup.objects.filter(
+            condition_group__conditions__id=instance.id
+        ).values_list("workflow_id", flat=True)
+    except WorkflowDataConditionGroup.DoesNotExist:
+        pass
+
+    if workflow_ids is not None:
+        # ensure the execution is after the transaction is committed
+        def execute_invalidation() -> None:
+            invalidate_action_filter_cache_by_workflow_ids(workflow_ids)
+
+        transaction.on_commit(execute_invalidation, router.db_for_write(DataCondition))

--- a/src/sentry/workflow_engine/receivers/data_condition.py
+++ b/src/sentry/workflow_engine/receivers/data_condition.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.db.models.signals import pre_save
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
 from sentry.workflow_engine.models.data_condition import (
@@ -14,3 +14,13 @@ def enforce_comparison_schema(
     sender: type[DataCondition], instance: DataCondition, **kwargs: Any
 ) -> None:
     enforce_data_condition_json_schema(instance)
+
+
+@receiver(post_save, sender=DataCondition)
+def invlidate_action_filter_cache(
+    sender: type[DataCondition], instance: DataCondition, **kwargs: Any
+) -> None:
+    # TODO - when an action filter is updated, we need to invalidate
+    # the related workflows cache. Can this simply check the instance
+    # and see if the type of condition is an action filter?
+    pass

--- a/src/sentry/workflow_engine/receivers/data_condition.py
+++ b/src/sentry/workflow_engine/receivers/data_condition.py
@@ -36,9 +36,11 @@ def invlidate_action_filter_cache_by_data_condition(
     try:
         # TODO -- see if we can determine if the DataCondition is
         # an ActionFilter, to skip querying for the workflow.
-        workflow_ids = WorkflowDataConditionGroup.objects.filter(
-            condition_group__conditions__id=instance.id
-        ).values_list("workflow_id", flat=True)
+        workflow_ids = list(
+            WorkflowDataConditionGroup.objects.filter(
+                condition_group__conditions__id=instance.id
+            ).values_list("workflow_id", flat=True)
+        )
     except WorkflowDataConditionGroup.DoesNotExist:
         pass
 

--- a/src/sentry/workflow_engine/receivers/data_condition_group.py
+++ b/src/sentry/workflow_engine/receivers/data_condition_group.py
@@ -28,21 +28,16 @@ def invalidate_action_filters_cache_by_condition_group(
     if kwargs.get("created"):
         return
 
-    workflow_ids: list[WorkflowId] | None = None
-
-    try:
-        # TODO -- see if we can determine if the DataConditionGroup is
-        # an ActionFilter, to skip querying for the workflow.
-        workflow_ids = list(
-            WorkflowDataConditionGroup.objects.filter(
-                condition_group_id=instance.id,
-            ).values_list(
-                "workflow_id",
-                flat=True,
-            )
+    # TODO -- see if we can determine if the DataConditionGroup is
+    # an ActionFilter, to skip querying for the workflow.
+    workflow_ids: list[WorkflowId] = list(
+        WorkflowDataConditionGroup.objects.filter(
+            condition_group_id=instance.id,
+        ).values_list(
+            "workflow_id",
+            flat=True,
         )
-    except WorkflowDataConditionGroup.DoesNotExist:
-        pass
+    )
 
     if workflow_ids:
         # ensure the execution is after the transaction is committed

--- a/src/sentry/workflow_engine/receivers/data_condition_group.py
+++ b/src/sentry/workflow_engine/receivers/data_condition_group.py
@@ -34,8 +34,11 @@ def invalidate_action_filters_cache_by_condition_group(
         # TODO -- see if we can determine if the DataConditionGroup is
         # an ActionFilter, to skip querying for the workflow.
         workflow_ids = list(
-            WorkflowDataConditionGroup.objects.filter(condition_group_id=instance.id).values_list(
-                "workflow_id", flat=True
+            WorkflowDataConditionGroup.objects.filter(
+                condition_group_id=instance.id,
+            ).values_list(
+                "workflow_id",
+                flat=True,
             )
         )
     except WorkflowDataConditionGroup.DoesNotExist:

--- a/src/sentry/workflow_engine/receivers/data_condition_group.py
+++ b/src/sentry/workflow_engine/receivers/data_condition_group.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+from django.db import router, transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from sentry.workflow_engine.caches.action_filters import (
+    invalidate_action_filter_cache_by_workflow_ids,
+)
+from sentry.workflow_engine.models import DataConditionGroup
+from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
+from sentry.workflow_engine.types import WorkflowId
+
+
+@receiver(post_save, sender=DataConditionGroup)
+def invalidate_action_filters_cache_by_condition_group(
+    sender: type[DataConditionGroup],
+    instance: DataConditionGroup,
+    **kwargs: Any,
+) -> None:
+    """
+    This handler only needs to invalidate the cache if the
+    DataConditionGroup is updating. If there is a new condition group
+    added, there will also be WorkflowDataConditionGroup's added / created.
+    Relying on those receivers will reduce the querying required to maintain
+    the cache.
+    """
+    if kwargs.get("created"):
+        return
+
+    workflow_ids: list[WorkflowId] | None = None
+
+    try:
+        # TODO -- see if we can determine if the DataConditionGroup is
+        # an ActionFilter, to skip querying for the workflow.
+        workflow_ids = WorkflowDataConditionGroup.objects.filter(
+            condition_group_id=instance.id
+        ).values_list("workflow_id", flat=True)
+    except WorkflowDataConditionGroup.DoesNotExist:
+        pass
+
+    if workflow_ids:
+        # ensure the execution is after the transaction is committed
+        def execute_invalidation() -> None:
+            invalidate_action_filter_cache_by_workflow_ids(workflow_ids)
+
+        transaction.on_commit(
+            execute_invalidation,
+            router.db_for_write(
+                DataConditionGroup,
+            ),
+        )

--- a/src/sentry/workflow_engine/receivers/data_condition_group.py
+++ b/src/sentry/workflow_engine/receivers/data_condition_group.py
@@ -33,9 +33,11 @@ def invalidate_action_filters_cache_by_condition_group(
     try:
         # TODO -- see if we can determine if the DataConditionGroup is
         # an ActionFilter, to skip querying for the workflow.
-        workflow_ids = WorkflowDataConditionGroup.objects.filter(
-            condition_group_id=instance.id
-        ).values_list("workflow_id", flat=True)
+        workflow_ids = list(
+            WorkflowDataConditionGroup.objects.filter(condition_group_id=instance.id).values_list(
+                "workflow_id", flat=True
+            )
+        )
     except WorkflowDataConditionGroup.DoesNotExist:
         pass
 

--- a/src/sentry/workflow_engine/receivers/workflow_data_condition_group.py
+++ b/src/sentry/workflow_engine/receivers/workflow_data_condition_group.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from django.db import router, transaction
+from django.db.models.signals import post_save, pre_delete
+from django.dispatch import receiver
+
+from sentry.workflow_engine.caches.action_filters import (
+    invalidate_action_filter_cache_by_workflow_ids,
+)
+from sentry.workflow_engine.models import WorkflowDataConditionGroup
+
+
+@receiver(pre_delete, sender=WorkflowDataConditionGroup)
+@receiver(post_save, sender=WorkflowDataConditionGroup)
+def invalidate_action_filters(
+    sender: type[WorkflowDataConditionGroup],
+    instance: WorkflowDataConditionGroup,
+    **kwargs: Any,
+) -> None:
+    """
+    When we delete or update a WorkflowDataConditionGroup,
+    the workflow needs to be cleared from the cache.
+
+    If the relationship to the workflow changes, then we need to invalidate the cache.
+    """
+    if kwargs.get("created") is not None:
+        # no need to invalidate the cache if we just created the relationship
+        return
+
+    def execute_invalidation() -> None:
+        invalidate_action_filter_cache_by_workflow_ids([instance.workflow_id])
+
+    transaction.on_commit(execute_invalidation, router.db_for_write(WorkflowDataConditionGroup))

--- a/src/sentry/workflow_engine/receivers/workflow_data_condition_group.py
+++ b/src/sentry/workflow_engine/receivers/workflow_data_condition_group.py
@@ -23,9 +23,6 @@ def invalidate_action_filters(
 
     If the relationship to the workflow changes, then we need to invalidate the cache.
     """
-    if kwargs.get("created") is not None:
-        # no need to invalidate the cache if we just created the relationship
-        return
 
     def execute_invalidation() -> None:
         invalidate_action_filter_cache_by_workflow_ids([instance.workflow_id])

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.caches.action_filters import (
     ActionFiltersByWorkflow,
+    _action_filters_cache,
+    _ActionFilterCacheKey,
     _CacheResults,
     _populate_cache,
     get_action_filters_by_workflows,
@@ -37,14 +39,13 @@ def mock_check_action_filters_cache(
         yield mock_cache
 
 
-class TestActionFilterCache(TestCase):
-    def create_workflow_with_filters(
-        self, num_filters: int = 1, num_conditions: int = 1
-    ) -> tuple[
-        Workflow,
-        list[DataConditionGroup],
-    ]:
-        workflow = self.create_workflow()
+class ActionFilterTestCase(TestCase):
+    def create_action_filters_for_workflow(
+        self,
+        workflow: Workflow,
+        num_filters: int = 1,
+        num_conditions: int = 0,
+    ) -> list[DataConditionGroup]:
         action_filters: list[DataConditionGroup] = [
             self.create_data_condition_group() for _ in range(num_filters)
         ]
@@ -61,7 +62,21 @@ class TestActionFilterCache(TestCase):
                 ]
             )
 
-        return workflow, action_filters
+        return action_filters
+
+    def populate_action_filter_cache(
+        cache_data: ActionFiltersByWorkflow,
+    ) -> list[_ActionFilterCacheKey]:
+        _populate_cache(cache_data)
+        cache_keys = [_ActionFilterCacheKey(wid) for wid in cache_data.keys()]
+
+        for cache_key in cache_keys:
+            assert _action_filters_cache.get(cache_key) == cache_data[cache_key.workflow_id]
+
+        return cache_keys
+
+    def get_data_from_cache(cache_keys: list[_ActionFilterCacheKey]) -> ActionFiltersByWorkflow:
+        return _action_filters_cache.get_many(cache_keys)
 
     def assert_cache_result(
         self,
@@ -85,13 +100,18 @@ class TestActionFilterCache(TestCase):
             ):
                 assert result_cond.id == expected_cond.id
 
+
+class TestActionFilterCache(ActionFilterTestCase):
     def test_no_workflows_passed(self) -> None:
         result = get_action_filters_by_workflows([])
         assert result == {}
 
     def test_all_cache_miss__one_workflow(self) -> None:
-        num_conditions = 2
-        workflow, action_filters = self.create_workflow_with_filters(num_conditions=num_conditions)
+        workflow = self.create_workflow()
+        action_filters = self.create_action_filters_for_workflow(
+            workflow=workflow,
+            num_conditions=2,
+        )
 
         with mock_check_action_filters_cache(_CacheResults(cached={}, missed_ids=[workflow.id])):
             results = get_action_filters_by_workflows([workflow])
@@ -99,8 +119,11 @@ class TestActionFilterCache(TestCase):
         self.assert_cache_result(results, workflow, action_filters)
 
     def test_all_cache_hits__one_workflow(self) -> None:
-        num_conditions = 2
-        workflow, action_filters = self.create_workflow_with_filters(num_conditions=num_conditions)
+        workflow = self.create_workflow()
+        action_filters = self.create_action_filters_for_workflow(
+            workflow=workflow,
+            num_conditions=2,
+        )
 
         _populate_cache({workflow.id: action_filters})
 
@@ -111,8 +134,17 @@ class TestActionFilterCache(TestCase):
         self.assert_cache_result(results, workflow, action_filters)
 
     def test_all_cache_miss__many_workflows(self) -> None:
-        workflow, action_filters = self.create_workflow_with_filters()
-        workflow_two, action_filters_two = self.create_workflow_with_filters(num_filters=2)
+        workflow = self.create_workflow()
+        action_filters = self.create_action_filters_for_workflow(
+            workflow=workflow,
+            num_conditions=1,
+        )
+
+        workflow_two = self.create_workflow()
+        action_filters_two = self.create_action_filters_for_workflow(
+            workflow=workflow_two,
+            num_filters=2,
+        )
 
         with mock_check_action_filters_cache(
             _CacheResults(cached={}, missed_ids=[workflow.id, workflow_two.id])
@@ -123,8 +155,18 @@ class TestActionFilterCache(TestCase):
         self.assert_cache_result(results, workflow_two, action_filters_two)
 
     def test_all_cache_hits__many_workflows(self) -> None:
-        workflow, action_filters = self.create_workflow_with_filters()
-        workflow_two, action_filters_two = self.create_workflow_with_filters(num_filters=2)
+        workflow = self.create_workflow()
+        action_filters = self.create_action_filters_for_workflow(
+            workflow=workflow,
+            num_conditions=1,
+        )
+
+        workflow_two = self.create_workflow()
+        action_filters_two = self.create_action_filters_for_workflow(
+            workflow=workflow_two,
+            num_filters=2,
+            num_conditions=1,
+        )
 
         _populate_cache(
             {
@@ -141,8 +183,18 @@ class TestActionFilterCache(TestCase):
         self.assert_cache_result(results, workflow_two, action_filters_two)
 
     def test_mixed_cache_hits(self) -> None:
-        workflow, action_filters = self.create_workflow_with_filters()
-        workflow_two, action_filters_two = self.create_workflow_with_filters(num_filters=2)
+        workflow = self.create_workflow()
+        action_filters = self.create_action_filters_for_workflow(
+            workflow=workflow,
+            num_conditions=1,
+        )
+
+        workflow_two = self.create_workflow()
+        action_filters_two = self.create_action_filters_for_workflow(
+            workflow=workflow_two,
+            num_filters=2,
+            num_conditions=1,
+        )
 
         _populate_cache(
             {
@@ -156,8 +208,17 @@ class TestActionFilterCache(TestCase):
         self.assert_cache_result(results, workflow_two, action_filters_two)
 
     def test_mixed_cache_hits__filters_query(self) -> None:
-        workflow, action_filters = self.create_workflow_with_filters()
-        workflow_two, action_filters_two = self.create_workflow_with_filters(num_filters=2)
+        workflow = self.create_workflow()
+        action_filters = self.create_action_filters_for_workflow(
+            workflow=workflow,
+            num_conditions=1,
+        )
+        workflow_two = self.create_workflow()
+        action_filters_two = self.create_action_filters_for_workflow(
+            workflow=workflow_two,
+            num_filters=2,
+            num_conditions=1,
+        )
 
         _populate_cache(
             {
@@ -187,7 +248,11 @@ class TestActionFilterCache(TestCase):
         assert result[workflow.id] == []
 
     def test_prefetched_conditions_survive_cache(self) -> None:
-        workflow, _ = self.create_workflow_with_filters(num_conditions=2)
+        workflow = self.create_workflow()
+        self.create_action_filters_for_workflow(
+            workflow=workflow,
+            num_conditions=2,
+        )
 
         # First call populates cache
         get_action_filters_by_workflows([workflow])

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -15,6 +15,7 @@ from sentry.workflow_engine.models import (
     DataConditionGroup,
     Workflow,
 )
+from sentry.workflow_engine.types import WorkflowId
 
 
 @contextmanager
@@ -79,7 +80,7 @@ class ActionFilterTestCase(TestCase):
     def get_data_from_cache(
         self,
         cache_keys: list[_ActionFilterCacheKey],
-    ) -> ActionFiltersByWorkflow:
+    ) -> dict[WorkflowId, list[DataConditionGroup] | None]:
         cache_results = _action_filters_cache.get_many(cache_keys)
         return {key.workflow_id: values for key, values in cache_results.items()}
 

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -65,6 +65,7 @@ class ActionFilterTestCase(TestCase):
         return action_filters
 
     def populate_action_filter_cache(
+        self,
         cache_data: ActionFiltersByWorkflow,
     ) -> list[_ActionFilterCacheKey]:
         _populate_cache(cache_data)
@@ -75,8 +76,12 @@ class ActionFilterTestCase(TestCase):
 
         return cache_keys
 
-    def get_data_from_cache(cache_keys: list[_ActionFilterCacheKey]) -> ActionFiltersByWorkflow:
-        return _action_filters_cache.get_many(cache_keys)
+    def get_data_from_cache(
+        self,
+        cache_keys: list[_ActionFilterCacheKey],
+    ) -> ActionFiltersByWorkflow:
+        cache_results = _action_filters_cache.get_many(cache_keys)
+        return {key.workflow_id: values for key, values in cache_results.items()}
 
     def assert_cache_result(
         self,

--- a/tests/sentry/workflow_engine/receivers/test_data_condition.py
+++ b/tests/sentry/workflow_engine/receivers/test_data_condition.py
@@ -3,6 +3,27 @@ from sentry.workflow_engine.models import DataCondition
 from tests.sentry.workflow_engine.caches.test_action_filters import ActionFilterTestCase
 
 
+class TestPreDeleteActionFilterCacheInvalidation(ActionFilterTestCase):
+    def test_delete_data_condition(self) -> None:
+        workflow = self.create_workflow()
+        condition_groups = self.create_action_filters_for_workflow(
+            workflow,
+            num_filters=1,
+            num_conditions=1,
+        )
+
+        # Warm the cache
+        cache_data: ActionFiltersByWorkflow = {workflow.id: condition_groups}
+        cache_keys = self.populate_action_filter_cache(cache_data)
+        assert self.get_data_from_cache(cache_keys) == cache_data
+
+        first_condition = condition_groups[0].conditions.all().first()
+        assert isinstance(first_condition, DataCondition)
+
+        first_condition.delete()
+        assert self.get_data_from_cache(cache_keys) == {workflow.id: None}
+
+
 class TestPostSaveActionFilterCacheInvalidation(ActionFilterTestCase):
     def test_new_condition_added_to_filters(self) -> None:
         workflow = self.create_workflow()
@@ -12,7 +33,7 @@ class TestPostSaveActionFilterCacheInvalidation(ActionFilterTestCase):
         cache_data: ActionFiltersByWorkflow = {workflow.id: condition_groups}
         cache_keys = self.populate_action_filter_cache(cache_data)
 
-        # Make a change that invalidates the cache
+        # Make a change that invalidates the cache.
         new_condition = self.create_data_condition(condition_group=condition_groups[0])
 
         assert new_condition is not None

--- a/tests/sentry/workflow_engine/receivers/test_data_condition.py
+++ b/tests/sentry/workflow_engine/receivers/test_data_condition.py
@@ -1,0 +1,51 @@
+from sentry.workflow_engine.caches.action_filters import ActionFiltersByWorkflow
+from sentry.workflow_engine.models import DataCondition
+from tests.sentry.workflow_engine.caches.test_action_filters import ActionFilterTestCase
+
+
+class TestPostSaveActionFilterCacheInvalidation(ActionFilterTestCase):
+    def test_new_condition_added_to_filters(self) -> None:
+        workflow = self.create_workflow()
+        condition_groups = self.create_action_filters_for_workflow(workflow)
+
+        # Warm the cache
+        cache_data: ActionFiltersByWorkflow = {workflow.id: condition_groups}
+        cache_keys = self.populate_action_filter_cache(cache_data)
+
+        # Make a change that invalidates the cache
+        new_condition = self.create_data_condition(condition_group=condition_groups[0])
+
+        assert new_condition is not None
+
+        cached_value = self.get_data_from_cache(cache_keys)[workflow.id]
+        assert cached_value is None
+
+    def test_new_condition_without_associations_keeps_cache_intact(self) -> None:
+        workflow = self.create_workflow()
+        condition_groups = self.create_action_filters_for_workflow(workflow)
+
+        # Warm the cache
+        cache_data: ActionFiltersByWorkflow = {workflow.id: condition_groups}
+        cache_keys = self.populate_action_filter_cache(cache_data)
+
+        # ensure a new condition is created correctly
+        new_condition = self.create_data_condition()
+        assert isinstance(new_condition, DataCondition)
+
+        # validate the previously cached data is intact
+        cached_value = self.get_data_from_cache(cache_keys)[workflow.id]
+        assert cached_value == cache_data[workflow.id]
+
+    def test_multiple_groups__update_one_condition(self) -> None:
+        workflow = self.create_workflow()
+        condition_groups = self.create_action_filters_for_workflow(workflow=workflow, num_filters=2)
+        new_condition = self.create_data_condition(condition_group=condition_groups[0])
+
+        # Warm the cache
+        cache_keys = self.populate_action_filter_cache({workflow.id: condition_groups})
+
+        # create a second set of filters and trigger the receiver
+        new_condition.name = "Test Model Change"
+        new_condition.save()
+
+        assert self.get_data_from_cache(cache_keys)[workflow.id] is None

--- a/tests/sentry/workflow_engine/receivers/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/receivers/test_data_condition_group.py
@@ -1,0 +1,23 @@
+from sentry.workflow_engine.caches.action_filters import ActionFiltersByWorkflow
+from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+from tests.sentry.workflow_engine.caches.test_action_filters import ActionFilterTestCase
+
+
+class TestPostSaveActionFilterCacheDCG(ActionFilterTestCase):
+    def test_modify_action_filter_condition_logic(self) -> None:
+        workflow = self.create_workflow()
+        condition_groups = self.create_action_filters_for_workflow(
+            workflow=workflow,
+            num_filters=1,
+        )
+
+        # Warm the cache
+        cache_data: ActionFiltersByWorkflow = {workflow.id: condition_groups}
+        cache_keys = self.populate_action_filter_cache(cache_data)
+        assert self.get_data_from_cache(cache_keys) == cache_data
+
+        condition_group = condition_groups[0]
+        condition_group.logic_type = DataConditionGroup.Type.ALL.value
+        condition_group.save()
+
+        assert self.get_data_from_cache(cache_keys) == {workflow.id: None}

--- a/tests/sentry/workflow_engine/receivers/test_workflow_data_condition_group.py
+++ b/tests/sentry/workflow_engine/receivers/test_workflow_data_condition_group.py
@@ -1,71 +1,35 @@
-from sentry.testutils.cases import TestCase
-from sentry.workflow_engine.caches.action_filters import (
-    _action_filters_cache,
-    _ActionFilterCacheKey,
-    _populate_cache,
-)
-from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
-from sentry.workflow_engine.models.workflow import Workflow
+from sentry.workflow_engine.caches.action_filters import ActionFiltersByWorkflow
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
+from tests.sentry.workflow_engine.caches.test_action_filters import ActionFilterTestCase
 
 
-class TestWorkflowDataConditionGroupReceivers(TestCase):
-    def create_workflow_with_filters(
-        self, num_filters: int = 1, num_conditions: int = 1
-    ) -> tuple[
-        Workflow,
-        list[DataConditionGroup],
-        list[WorkflowDataConditionGroup],
-    ]:
-        workflow = self.create_workflow()
-        action_filters: list[DataConditionGroup] = [
-            self.create_data_condition_group() for _ in range(num_filters)
-        ]
+class TestWorkflowDataConditionGroupReceivers(ActionFilterTestCase):
+    def setUp(self) -> None:
+        self.workflow = self.create_workflow()
+        self.action_filters = self.create_action_filters_for_workflow(
+            workflow=self.workflow,
+        )
 
-        workflow_condition_groups: list[WorkflowDataConditionGroup] = []
-        for action_filter in action_filters:
-            wcg = self.create_workflow_data_condition_group(
-                workflow=workflow, condition_group=action_filter
-            )
-
-            workflow_condition_groups.append(wcg)
-
-            action_filter.conditions.set(
-                [
-                    self.create_data_condition(condition_group=action_filter)
-                    for _ in range(num_conditions)
-                ]
-            )
-
-        return workflow, action_filters, workflow_condition_groups
+        action_filter_ids = [action_filter.id for action_filter in self.action_filters]
+        self.workflow_data_condition_groups = WorkflowDataConditionGroup.objects.filter(
+            condition_group_id__in=action_filter_ids,
+        )
 
     def test_cache_invalidation_on_delete(self) -> None:
-        workflow, action_filters, workflow_data_condition_groups = (
-            self.create_workflow_with_filters()
-        )
-
-        _populate_cache({workflow.id: action_filters})
-        cache_key = _ActionFilterCacheKey(workflow.id)
+        cache_data: ActionFiltersByWorkflow = {self.workflow.id: self.action_filters}
+        cache_keys = self.populate_action_filter_cache(cache_data)
 
         # ensure the cache is populated
-        assert len(_action_filters_cache.get(cache_key)) == 1
+        assert self.get_data_from_cache(cache_keys) == cache_data
 
-        workflow_data_condition_groups[0].delete()
-        assert _action_filters_cache.get(cache_key) is None
+        self.workflow_data_condition_groups[0].delete()
+        assert self.get_data_from_cache(cache_keys) == {self.workflow.id: None}
 
     def test_cache_invalidation_on_save(self) -> None:
-        workflow, action_filters, _ = self.create_workflow_with_filters()
-
-        # ensure the cache is populated
-        _populate_cache({workflow.id: action_filters})
-        cache_key = _ActionFilterCacheKey(workflow.id)
-        assert len(_action_filters_cache.get(cache_key)) == 1
+        cache_data: ActionFiltersByWorkflow = {self.workflow.id: self.action_filters}
+        cache_keys = self.populate_action_filter_cache(cache_data)
 
         # add another data condition group to the workflow
-        new_action_filter = self.create_data_condition_group()
-        self.create_workflow_data_condition_group(
-            workflow=workflow,
-            condition_group=new_action_filter,
-        )
+        self.create_action_filters_for_workflow(workflow=self.workflow, num_filters=1)
 
-        assert _action_filters_cache.get(cache_key) is None
+        assert self.get_data_from_cache(cache_keys) == {self.workflow.id: None}

--- a/tests/sentry/workflow_engine/receivers/test_workflow_data_condition_group.py
+++ b/tests/sentry/workflow_engine/receivers/test_workflow_data_condition_group.py
@@ -62,10 +62,10 @@ class TestWorkflowDataConditionGroupReceivers(TestCase):
         assert len(_action_filters_cache.get(cache_key)) == 1
 
         # add another data condition group to the workflow
-        action_filter = self.create_data_condition_group()
+        new_action_filter = self.create_data_condition_group()
         self.create_workflow_data_condition_group(
             workflow=workflow,
-            condition_group=action_filter,
+            condition_group=new_action_filter,
         )
 
-        assert len(_action_filters_cache.get(cache_key)) == 0
+        assert _action_filters_cache.get(cache_key) is None

--- a/tests/sentry/workflow_engine/receivers/test_workflow_data_condition_group.py
+++ b/tests/sentry/workflow_engine/receivers/test_workflow_data_condition_group.py
@@ -1,0 +1,71 @@
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.caches.action_filters import (
+    _action_filters_cache,
+    _ActionFilterCacheKey,
+    _populate_cache,
+)
+from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+from sentry.workflow_engine.models.workflow import Workflow
+from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
+
+
+class TestWorkflowDataConditionGroupReceivers(TestCase):
+    def create_workflow_with_filters(
+        self, num_filters: int = 1, num_conditions: int = 1
+    ) -> tuple[
+        Workflow,
+        list[DataConditionGroup],
+        list[WorkflowDataConditionGroup],
+    ]:
+        workflow = self.create_workflow()
+        action_filters: list[DataConditionGroup] = [
+            self.create_data_condition_group() for _ in range(num_filters)
+        ]
+
+        workflow_condition_groups: list[WorkflowDataConditionGroup] = []
+        for action_filter in action_filters:
+            wcg = self.create_workflow_data_condition_group(
+                workflow=workflow, condition_group=action_filter
+            )
+
+            workflow_condition_groups.append(wcg)
+
+            action_filter.conditions.set(
+                [
+                    self.create_data_condition(condition_group=action_filter)
+                    for _ in range(num_conditions)
+                ]
+            )
+
+        return workflow, action_filters, workflow_condition_groups
+
+    def test_cache_invalidation_on_delete(self) -> None:
+        workflow, action_filters, workflow_data_condition_groups = (
+            self.create_workflow_with_filters()
+        )
+
+        _populate_cache({workflow.id: action_filters})
+        cache_key = _ActionFilterCacheKey(workflow.id)
+
+        # ensure the cache is populated
+        assert len(_action_filters_cache.get(cache_key)) == 1
+
+        workflow_data_condition_groups[0].delete()
+        assert _action_filters_cache.get(cache_key) is None
+
+    def test_cache_invalidation_on_save(self) -> None:
+        workflow, action_filters, _ = self.create_workflow_with_filters()
+
+        # ensure the cache is populated
+        _populate_cache({workflow.id: action_filters})
+        cache_key = _ActionFilterCacheKey(workflow.id)
+        assert len(_action_filters_cache.get(cache_key)) == 1
+
+        # add another data condition group to the workflow
+        action_filter = self.create_data_condition_group()
+        self.create_workflow_data_condition_group(
+            workflow=workflow,
+            condition_group=action_filter,
+        )
+
+        assert len(_action_filters_cache.get(cache_key)) == 0

--- a/tests/sentry/workflow_engine/receivers/test_workflow_data_condition_group.py
+++ b/tests/sentry/workflow_engine/receivers/test_workflow_data_condition_group.py
@@ -33,3 +33,13 @@ class TestWorkflowDataConditionGroupReceivers(ActionFilterTestCase):
         self.create_action_filters_for_workflow(workflow=self.workflow, num_filters=1)
 
         assert self.get_data_from_cache(cache_keys) == {self.workflow.id: None}
+
+    def test_cascade_delete_for_groups(self) -> None:
+        # The data_condition_groups relying on the cascade delete to invalidate
+        cache_data: ActionFiltersByWorkflow = {self.workflow.id: self.action_filters}
+        cache_keys = self.populate_action_filter_cache(cache_data)
+
+        action_filter = self.action_filters[0]
+        action_filter.delete()
+
+        assert self.get_data_from_cache(cache_keys) == {self.workflow.id: None}


### PR DESCRIPTION
# Description
Signal handlers for cache invalidation. There's not a rollout flag included here yet, because any exceptions or failures are limited to the scope of these invalidation methods and it keeps that a little simpler.

When we invalidate the Action Filters / Data conditions:
| Model | Signal | Reason |
|--------|--------|--------|
| WorkflowDataConditionGroup | post_save | When an action filter is created on a workflow |
| WorkflowDataConditionGroup | pre_delete | When an action filter is removed from the workflow |
| DataConditionGroup | post_save | When an update to the logic type in the condition |
| DataCondition | post_save | When a condition on a filter is created or changed |
| DataCondition | pre_delete | When a condition on the filter being removed | 

## Remaining Work
- [ ] Update the `evaluate_workflows_action_filters` method to read from the cache with a rollout flag.