### PR TITLE
feat(objectstore): Add CLI rate limiting to Objectstore endpoint

### DIFF
--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -28,6 +28,7 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationReleasePermission
 from sentry.models.organization import Organization
 from sentry.objectstore import parse_accept_encoding
+from sentry.ratelimits.config import RateLimitConfig
 
 
 @cell_silo_endpoint
@@ -40,6 +41,7 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.FOUNDATIONAL_STORAGE
     permission_classes = (OrganizationReleasePermission,)
+    rate_limits = RateLimitConfig(group="CLI")
     parser_classes = ()  # don't attempt to parse request data, so we can access the raw body in wsgi.input
 
     def _check_flag(self, request: Request, organization: Organization) -> Response | None:


### PR DESCRIPTION
Add the `CLI` rate limit group to the Objectstore endpoint, matching the
configuration used by `ChunkUploadEndpoint` and other CLI-facing upload
endpoints.

The Objectstore endpoint will be primarily used by `sentry-cli` for file
uploads, replacing the existing upload endpoints, so it makes sense for it to
have a matching rate limiting config.