### PR TITLE
feat(metrics): Add refreshed trace metrics toolbar

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -290,7 +290,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
   setSelectedSection,
   overlayProps,
 }: FilterKeyListBoxProps<T>) {
-  const {filterKeyMenuWidth, wrapperRef, query, portalTarget, enableAISearch} =
+  const {filterKeyMenuWidth, wrapperRef, query, portalTarget, enableAISearch, size} =
     useSearchQueryBuilder();
 
   const hiddenOptionsWithRecentsAndAskSeerAdded = useMemo<Set<SelectKey>>(() => {
@@ -317,7 +317,9 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
 
   useSwitchToValidSection({sections, selectedSection, setSelectedSection});
 
-  const fullWidth = !query;
+  // Full-width mode works well for wide search bars, but for narrow bars it over-constrains
+  // the filter menu and makes the details pane unreadable.
+  const fullWidth = !query && size === 'normal';
   const showDetailsPane = fullWidth && selectedSection !== RECENT_SEARCH_CATEGORY_VALUE;
 
   // Remove bottom border radius of top-level component while the full-width menu is open

--- a/static/app/views/explore/components/toolbar/styles.tsx
+++ b/static/app/views/explore/components/toolbar/styles.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, type ButtonProps} from '@sentry/scraps/button';
 import {Flex, type FlexProps} from '@sentry/scraps/layout';
 
 export const ToolbarSection = styled('div')`
@@ -19,11 +19,18 @@ export const ToolbarLabel = styled('h6')<{disabled?: boolean}>`
   text-decoration-style: dotted;
 `;
 
-export const ToolbarFooterButton = styled(Button)<{disabled?: boolean}>`
-  color: ${p =>
-    p.disabled
-      ? p.theme.tokens.content.disabled
-      : p.theme.tokens.interactive.link.accent.rest};
+export const ToolbarFooterButton = styled(Button)<{
+  disabled?: boolean;
+  priority?: ButtonProps['priority'];
+}>`
+  color: ${p => {
+    if (p.priority === 'link') {
+      return p.disabled
+        ? p.theme.tokens.content.disabled
+        : p.theme.tokens.interactive.link.accent.rest;
+    }
+    return p.theme.tokens.content.primary;
+  }};
 `;
 
 export const ToolbarFooter = styled('div')`

--- a/static/app/views/explore/components/toolbar/styles.tsx
+++ b/static/app/views/explore/components/toolbar/styles.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button, type ButtonProps} from '@sentry/scraps/button';
@@ -23,14 +24,14 @@ export const ToolbarFooterButton = styled(Button)<{
   disabled?: boolean;
   priority?: ButtonProps['priority'];
 }>`
-  color: ${p => {
-    if (p.priority === 'link') {
-      return p.disabled
-        ? p.theme.tokens.content.disabled
-        : p.theme.tokens.interactive.link.accent.rest;
-    }
-    return p.theme.tokens.content.primary;
-  }};
+  ${p =>
+    p.priority === 'link'
+      ? css`
+          color: ${p.disabled
+            ? p.theme.tokens.content.disabled
+            : p.theme.tokens.interactive.link.accent.rest};
+        `
+      : ''}
 `;
 
 export const ToolbarFooter = styled('div')`

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -14,14 +14,12 @@ import {IconGrabbable} from 'sentry/icons/iconGrabbable';
 import {t} from 'sentry/locale';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {getFieldDefinition} from 'sentry/utils/fields';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   ToolbarFooterButton,
   ToolbarHeader,
   ToolbarLabel,
   ToolbarRow,
 } from 'sentry/views/explore/components/toolbar/styles';
-import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 
 export function ToolbarVisualizeHeader() {
   return (
@@ -146,19 +144,14 @@ export function ToolbarVisualizeAddChart({
   add,
   disabled,
   label,
-  display,
+  display = 'link',
 }: ToolbarVisualizeAddProps) {
-  const organization = useOrganization();
-
-  const resolvedDisplay =
-    display ?? (canUseMetricsUIRefresh(organization) ? 'button' : 'link');
-
   return (
     <ToolbarFooterButton
-      size={resolvedDisplay === 'link' ? 'zero' : 'md'}
+      size={display === 'link' ? 'zero' : 'md'}
       icon={<IconAdd />}
       onClick={add}
-      priority={resolvedDisplay === 'link' ? 'link' : undefined}
+      priority={display === 'link' ? 'link' : undefined}
       aria-label={label ?? t('Add Chart')}
       disabled={disabled}
     >

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -138,6 +138,7 @@ export function ToolbarVisualizeDropdown({
 interface ToolbarVisualizeAddProps {
   add: () => void;
   disabled: boolean;
+  display?: 'button' | 'link';
   label?: string;
 }
 
@@ -145,28 +146,19 @@ export function ToolbarVisualizeAddChart({
   add,
   disabled,
   label,
+  display,
 }: ToolbarVisualizeAddProps) {
   const organization = useOrganization();
 
-  if (canUseMetricsUIRefresh(organization)) {
-    return (
-      <Button
-        icon={<IconAdd />}
-        onClick={add}
-        aria-label={label ?? t('Add Metric')}
-        disabled={disabled}
-      >
-        {label ?? t('Add metric')}
-      </Button>
-    );
-  }
+  const resolvedDisplay =
+    display ?? (canUseMetricsUIRefresh(organization) ? 'button' : 'link');
 
   return (
     <ToolbarFooterButton
-      size="zero"
+      size={resolvedDisplay === 'link' ? 'zero' : 'md'}
       icon={<IconAdd />}
       onClick={add}
-      priority="link"
+      priority={resolvedDisplay === 'link' ? 'link' : undefined}
       aria-label={label ?? t('Add Chart')}
       disabled={disabled}
     >

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -14,12 +14,14 @@ import {IconGrabbable} from 'sentry/icons/iconGrabbable';
 import {t} from 'sentry/locale';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {getFieldDefinition} from 'sentry/utils/fields';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   ToolbarFooterButton,
   ToolbarHeader,
   ToolbarLabel,
   ToolbarRow,
 } from 'sentry/views/explore/components/toolbar/styles';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 
 export function ToolbarVisualizeHeader() {
   return (
@@ -144,6 +146,21 @@ export function ToolbarVisualizeAddChart({
   disabled,
   label,
 }: ToolbarVisualizeAddProps) {
+  const organization = useOrganization();
+
+  if (canUseMetricsUIRefresh(organization)) {
+    return (
+      <Button
+        icon={<IconAdd />}
+        onClick={add}
+        aria-label={label ?? t('Add Metric')}
+        disabled={disabled}
+      >
+        {label ?? t('Add metric')}
+      </Button>
+    );
+  }
+
   return (
     <ToolbarFooterButton
       size="zero"

--- a/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
@@ -2,10 +2,25 @@ import {Button} from '@sentry/scraps/button';
 
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 import {useRemoveMetric} from 'sentry/views/explore/metrics/metricsQueryParams';
 
 export function DeleteMetricButton() {
+  const organization = useOrganization();
   const removeMetric = useRemoveMetric();
+
+  if (canUseMetricsUIRefresh(organization)) {
+    return (
+      <Button
+        priority="transparent"
+        icon={<IconDelete />}
+        size="zero"
+        onClick={removeMetric}
+        aria-label={t('Remove Overlay')}
+      />
+    );
+  }
 
   return (
     <Button

--- a/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
@@ -17,7 +17,7 @@ export function DeleteMetricButton() {
         icon={<IconDelete />}
         size="zero"
         onClick={removeMetric}
-        aria-label={t('Remove Overlay')}
+        aria-label={t('Delete Metric')}
       />
     );
   }

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -1,8 +1,10 @@
 import {useCallback} from 'react';
 
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   useMetricVisualize,
   useSetMetricVisualize,
@@ -22,6 +24,7 @@ interface MetricToolbarProps {
 }
 
 export function MetricToolbar({traceMetric, queryIndex}: MetricToolbarProps) {
+  const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const visualize = useMetricVisualize();
   const setVisualize = useSetMetricVisualize();
@@ -29,13 +32,43 @@ export function MetricToolbar({traceMetric, queryIndex}: MetricToolbarProps) {
     setVisualize(visualize.replace({visible: !visualize.visible}));
   }, [setVisualize, visualize]);
   const setTraceMetric = useSetTraceMetric();
+  const canRemoveMetric = metricQueries.length > 1;
+
+  if (canUseMetricsUIRefresh(organization)) {
+    return (
+      <Flex width="100%" align="start" gap="md" data-test-id="metric-toolbar">
+        <VisualizeLabel
+          index={queryIndex}
+          visualize={visualize}
+          onClick={toggleVisibility}
+        />
+        <Stack flex="1" minWidth={0} gap="sm" width="100%">
+          <Flex minWidth={0} gap="xs" align="center">
+            <Container width="100%" maxWidth={canRemoveMetric ? '225px' : undefined}>
+              <MetricSelector traceMetric={traceMetric} onChange={setTraceMetric} />
+            </Container>
+            {canRemoveMetric && <DeleteMetricButton />}
+          </Flex>
+          <Flex flex="2 1 0" minWidth={0}>
+            <AggregateDropdown traceMetric={traceMetric} />
+          </Flex>
+          <Flex flex="3 1 0" minWidth={0}>
+            <GroupBySelector traceMetric={traceMetric} />
+          </Flex>
+          <Flex minWidth={0} width="100%">
+            <Filter traceMetric={traceMetric} />
+          </Flex>
+        </Stack>
+      </Flex>
+    );
+  }
 
   return (
     <Grid
       width="100%"
       align="center"
       gap="md"
-      columns={`34px 2fr 3fr 6fr ${metricQueries.length > 1 ? '40px' : '0'}`}
+      columns={`34px 2fr 3fr 6fr ${canRemoveMetric ? '40px' : '0'}`}
       data-test-id="metric-toolbar"
     >
       <VisualizeLabel
@@ -57,7 +90,7 @@ export function MetricToolbar({traceMetric, queryIndex}: MetricToolbarProps) {
       <Flex minWidth={0}>
         <Filter traceMetric={traceMetric} />
       </Flex>
-      {metricQueries.length > 1 && <DeleteMetricButton />}
+      {canRemoveMetric && <DeleteMetricButton />}
     </Grid>
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -32,7 +32,10 @@ import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {canUseMetricsSidePanelUI} from 'sentry/views/explore/metrics/metricsFlags';
+import {
+  canUseMetricsSidePanelUI,
+  canUseMetricsUIRefresh,
+} from 'sentry/views/explore/metrics/metricsFlags';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
 import {
   TraceMetricKnownFieldKey,
@@ -113,6 +116,7 @@ export function MetricSelector({
   const {data: metricOptionsData, isFetching} = useMetricOptions({
     search: debouncedSearch,
   });
+  const hasMetricsUIRefresh = canUseMetricsUIRefresh(organization);
 
   const {
     isOpen,
@@ -425,6 +429,9 @@ export function MetricSelector({
         {...mergedTriggerProps}
         style={{width: '100%', fontWeight: 'bold', textAlign: 'left'}}
         disabled={isFetching && !traceMetric.name}
+        tooltipProps={
+          hasMetricsUIRefresh ? {title: traceMetric.name || t('None')} : undefined
+        }
       >
         <Text ellipsis>{traceMetric.name || t('None')}</Text>
       </OverlayTrigger.Button>

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -27,3 +27,10 @@ export const canUseMetricsSidePanelUI = (organization: Organization) => {
     organization.features.includes('tracemetrics-attributes-dropdown-side-panel')
   );
 };
+
+export const canUseMetricsUIRefresh = (organization: Organization) => {
+  return (
+    canUseMetricsUI(organization) &&
+    organization.features.includes('tracemetrics-ui-refresh')
+  );
+};

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -578,3 +578,145 @@ describe('MetricsTabContent', () => {
     expect(parsedQuery.aggregateFields).toContainEqual({groupBy: 'test.region'});
   });
 });
+
+describe('MetricsTabContent (tracemetrics-ui-refresh)', () => {
+  const {
+    organization,
+    project,
+    initialLocation,
+    setupPageFilters,
+    setupTraceItemsMock,
+    setupEventsMock,
+  } = initializeTraceMetricsTest({
+    orgFeatures: ['tracemetrics-ui-refresh'],
+    routerQuery: {
+      start: '2025-04-10T14%3A37%3A55',
+      end: '2025-04-10T20%3A04%3A51',
+      metric: ['bar||distribution'],
+      title: 'Test Title',
+    },
+  });
+
+  function ProviderWrapper({children}: {children: React.ReactNode}) {
+    return <MultiMetricsQueryParamsProvider>{children}</MultiMetricsQueryParamsProvider>;
+  }
+
+  const initialRouterConfig = {
+    location: initialLocation,
+    route: '/organizations/:orgId/explore/metrics/',
+  };
+
+  beforeEach(() => {
+    window.localStorage.removeItem('explore-metrics-toolbar');
+    MockApiClient.clearMockResponses();
+    trackAnalyticsMock.mockClear();
+    setupPageFilters();
+
+    const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
+    setupTraceItemsMock(metricFixtures.detailedFixtures);
+    setupEventsMock(metricFixtures.detailedFixtures, [
+      MockApiClient.matchQuery({
+        dataset: 'tracemetrics',
+        referrer: 'api.explore.metric-options',
+      }),
+    ]);
+
+    setupEventsMock(metricFixtures.detailedFixtures, [
+      MockApiClient.matchQuery({
+        dataset: 'tracemetrics',
+        referrer: 'api.explore.metric-aggregates-table',
+      }),
+    ]);
+
+    setupEventsMock(metricFixtures.detailedFixtures, [
+      MockApiClient.matchQuery({
+        dataset: 'tracemetrics',
+        referrer: 'api.explore.metric-samples-table',
+      }),
+    ]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {
+        timeSeries: [TimeSeriesFixture()],
+      },
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.explore.metric-timeseries',
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {
+        timeSeries: [TimeSeriesFixture()],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      method: 'GET',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      method: 'POST',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/`,
+      method: 'GET',
+      body: {},
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/stats_v2/`,
+      method: 'GET',
+      body: {},
+    });
+  });
+
+  it('toggles the query builder sidebar with the expand control', async () => {
+    render(
+      <ProviderWrapper>
+        <MetricsTabContent datePageFilterProps={datePageFilterProps} />
+      </ProviderWrapper>,
+      {
+        initialRouterConfig,
+        organization,
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        within(screen.getAllByTestId('metric-toolbar')[0]!).getByRole('button', {
+          name: 'bar',
+        })
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', {name: 'Collapse sidebar'})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Collapse sidebar'}));
+
+    expect(screen.queryByTestId('metric-toolbar')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Expand sidebar'})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Expand sidebar'}));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('metric-toolbar')).toHaveLength(1);
+    });
+  });
+});

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -9,16 +9,19 @@ import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/e
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {t} from 'sentry/locale';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
 import {
   ExploreBodyContent,
   ExploreBodySearch,
   ExploreContentSection,
+  ExploreControlSection,
 } from 'sentry/views/explore/components/styles';
 import {ToolbarVisualizeAddChart} from 'sentry/views/explore/components/toolbar/toolbarVisualize';
 import {useMetricsAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {MetricPanel} from 'sentry/views/explore/metrics/metricPanel';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MetricToolbar} from 'sentry/views/explore/metrics/metricToolbar';
 import {MetricSaveAs} from 'sentry/views/explore/metrics/metricToolbar/metricSaveAs';
@@ -40,6 +43,20 @@ type MetricsTabProps = {
 };
 
 export function MetricsTabContent({datePageFilterProps}: MetricsTabProps) {
+  const organization = useOrganization();
+
+  if (canUseMetricsUIRefresh(organization)) {
+    return (
+      <MultiMetricsQueryParamsProvider>
+        <MetricsTabFilterSection datePageFilterProps={datePageFilterProps} />
+        <ExploreBodyContent>
+          <MetricsQueryBuilderSection />
+          <MetricsTabBodySection />
+        </ExploreBodyContent>
+      </MultiMetricsQueryParamsProvider>
+    );
+  }
+
   return (
     <MultiMetricsQueryParamsProvider>
       <MetricsTabFilterSection datePageFilterProps={datePageFilterProps} />
@@ -50,6 +67,8 @@ export function MetricsTabContent({datePageFilterProps}: MetricsTabProps) {
 }
 
 function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
+  const organization = useOrganization();
+
   return (
     <ExploreBodySearch>
       <Layout.Main width="full">
@@ -62,7 +81,7 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
               searchPlaceholder={t('Custom range: 2h, 4d, 3w')}
             />
           </StyledPageFilterBar>
-          <MetricSaveAs />
+          {canUseMetricsUIRefresh(organization) ? null : <MetricSaveAs />}
         </FilterBarWithSaveAsContainer>
       </Layout.Main>
     </ExploreBodySearch>
@@ -70,8 +89,41 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
 }
 
 function MetricsQueryBuilderSection() {
+  const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const addMetricQuery = useAddMetricQuery();
+
+  if (canUseMetricsUIRefresh(organization)) {
+    return (
+      <ExploreControlSection expanded>
+        <Flex direction="column" gap="lg" align="start" width="100%">
+          {metricQueries.map((metricQuery, index) => {
+            return (
+              <MetricsQueryParamsProvider
+                key={`queryBuilder-${index}`}
+                queryParams={metricQuery.queryParams}
+                setQueryParams={metricQuery.setQueryParams}
+                traceMetric={metricQuery.metric}
+                setTraceMetric={metricQuery.setTraceMetric}
+                removeMetric={metricQuery.removeMetric}
+              >
+                <Container width="100%">
+                  <MetricToolbar traceMetric={metricQuery.metric} queryIndex={index} />
+                </Container>
+              </MetricsQueryParamsProvider>
+            );
+          })}
+          <ToolbarVisualizeAddChart
+            add={addMetricQuery}
+            disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+            label={t('Add Metric')}
+          />
+          <MetricSaveAs />
+        </Flex>
+      </ExploreControlSection>
+    );
+  }
+
   return (
     <MetricsQueryBuilderContainer borderTop="primary" padding="md" style={{flexGrow: 0}}>
       <Flex direction="column" gap="lg" align="start">
@@ -100,6 +152,7 @@ function MetricsQueryBuilderSection() {
 }
 
 function MetricsTabBodySection() {
+  const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const [interval] = useChartInterval();
   const {isFetching: areToolbarsLoading, isMetricOptionsEmpty} = useMetricOptions({
@@ -111,6 +164,31 @@ function MetricsTabBodySection() {
     areToolbarsLoading,
     isMetricOptionsEmpty,
   });
+
+  if (canUseMetricsUIRefresh(organization)) {
+    return (
+      <ExploreContentSection>
+        <Stack>
+          <WidgetSyncContextProvider groupName={METRICS_CHART_GROUP}>
+            {metricQueries.map((metricQuery, index) => {
+              return (
+                <MetricsQueryParamsProvider
+                  key={`queryPanel-${index}`}
+                  queryParams={metricQuery.queryParams}
+                  setQueryParams={metricQuery.setQueryParams}
+                  traceMetric={metricQuery.metric}
+                  setTraceMetric={metricQuery.setTraceMetric}
+                  removeMetric={metricQuery.removeMetric}
+                >
+                  <MetricPanel traceMetric={metricQuery.metric} queryIndex={index} />
+                </MetricsQueryParamsProvider>
+              );
+            })}
+          </WidgetSyncContextProvider>
+        </Stack>
+      </ExploreContentSection>
+    );
+  }
 
   return (
     <ExploreBodyContent>

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -114,6 +114,7 @@ function MetricsQueryBuilderSection() {
             );
           })}
           <ToolbarVisualizeAddChart
+            display="button"
             add={addMetricQuery}
             disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
             label={t('Add Metric')}

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -1,5 +1,8 @@
+import {useCallback} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -7,10 +10,13 @@ import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/dateP
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
+import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
+import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
 import {
   ExploreBodyContent,
   ExploreBodySearch,
@@ -42,19 +48,47 @@ type MetricsTabProps = {
   datePageFilterProps: DatePageFilterProps;
 };
 
+const METRICS_TOOLBAR_STORAGE_KEY = 'explore-metrics-toolbar';
+
+function useMetricsControlSectionExpanded() {
+  const [controlSectionExpanded, _setControlSectionExpanded] = useLocalStorageState(
+    METRICS_TOOLBAR_STORAGE_KEY,
+    'expanded'
+  );
+
+  const setControlSectionExpanded = useCallback(
+    (expanded: boolean) => {
+      _setControlSectionExpanded(expanded ? 'expanded' : '');
+    },
+    [_setControlSectionExpanded]
+  );
+
+  return [controlSectionExpanded === 'expanded', setControlSectionExpanded] as const;
+}
+
+function MetricsTabContentRefreshLayout({datePageFilterProps}: MetricsTabProps) {
+  const [controlSectionExpanded, setControlSectionExpanded] =
+    useMetricsControlSectionExpanded();
+
+  return (
+    <MultiMetricsQueryParamsProvider>
+      <MetricsTabFilterSection datePageFilterProps={datePageFilterProps} />
+      <ExploreBodyContent>
+        <MetricsQueryBuilderSection controlSectionExpanded={controlSectionExpanded} />
+        <MetricsTabBodySection
+          controlSectionExpanded={controlSectionExpanded}
+          setControlSectionExpanded={setControlSectionExpanded}
+        />
+      </ExploreBodyContent>
+    </MultiMetricsQueryParamsProvider>
+  );
+}
+
 export function MetricsTabContent({datePageFilterProps}: MetricsTabProps) {
   const organization = useOrganization();
 
   if (canUseMetricsUIRefresh(organization)) {
-    return (
-      <MultiMetricsQueryParamsProvider>
-        <MetricsTabFilterSection datePageFilterProps={datePageFilterProps} />
-        <ExploreBodyContent>
-          <MetricsQueryBuilderSection />
-          <MetricsTabBodySection />
-        </ExploreBodyContent>
-      </MultiMetricsQueryParamsProvider>
-    );
+    return <MetricsTabContentRefreshLayout datePageFilterProps={datePageFilterProps} />;
   }
 
   return (
@@ -88,39 +122,47 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
   );
 }
 
-function MetricsQueryBuilderSection() {
+type MetricsQueryBuilderSectionProps = {
+  controlSectionExpanded?: boolean;
+};
+
+function MetricsQueryBuilderSection({
+  controlSectionExpanded,
+}: MetricsQueryBuilderSectionProps = {}) {
   const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const addMetricQuery = useAddMetricQuery();
 
   if (canUseMetricsUIRefresh(organization)) {
     return (
-      <ExploreControlSection expanded>
-        <Flex direction="column" gap="lg" align="start" width="100%">
-          {metricQueries.map((metricQuery, index) => {
-            return (
-              <MetricsQueryParamsProvider
-                key={`queryBuilder-${index}`}
-                queryParams={metricQuery.queryParams}
-                setQueryParams={metricQuery.setQueryParams}
-                traceMetric={metricQuery.metric}
-                setTraceMetric={metricQuery.setTraceMetric}
-                removeMetric={metricQuery.removeMetric}
-              >
-                <Container width="100%">
-                  <MetricToolbar traceMetric={metricQuery.metric} queryIndex={index} />
-                </Container>
-              </MetricsQueryParamsProvider>
-            );
-          })}
-          <ToolbarVisualizeAddChart
-            display="button"
-            add={addMetricQuery}
-            disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
-            label={t('Add Metric')}
-          />
-          <MetricSaveAs />
-        </Flex>
+      <ExploreControlSection expanded={controlSectionExpanded ?? true}>
+        {controlSectionExpanded ? (
+          <Flex direction="column" gap="lg" align="start" width="100%">
+            {metricQueries.map((metricQuery, index) => {
+              return (
+                <MetricsQueryParamsProvider
+                  key={`queryBuilder-${index}`}
+                  queryParams={metricQuery.queryParams}
+                  setQueryParams={metricQuery.setQueryParams}
+                  traceMetric={metricQuery.metric}
+                  setTraceMetric={metricQuery.setTraceMetric}
+                  removeMetric={metricQuery.removeMetric}
+                >
+                  <Container width="100%">
+                    <MetricToolbar traceMetric={metricQuery.metric} queryIndex={index} />
+                  </Container>
+                </MetricsQueryParamsProvider>
+              );
+            })}
+            <ToolbarVisualizeAddChart
+              display="button"
+              add={addMetricQuery}
+              disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+              label={t('Add Metric')}
+            />
+            <MetricSaveAs />
+          </Flex>
+        ) : null}
       </ExploreControlSection>
     );
   }
@@ -152,7 +194,15 @@ function MetricsQueryBuilderSection() {
   );
 }
 
-function MetricsTabBodySection() {
+type MetricsTabBodySectionProps = {
+  controlSectionExpanded?: boolean;
+  setControlSectionExpanded?: (expanded: boolean) => void;
+};
+
+function MetricsTabBodySection({
+  controlSectionExpanded,
+  setControlSectionExpanded,
+}: MetricsTabBodySectionProps = {}) {
   const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const [interval] = useChartInterval();
@@ -169,6 +219,25 @@ function MetricsTabBodySection() {
   if (canUseMetricsUIRefresh(organization)) {
     return (
       <ExploreContentSection>
+        <OverChartButtonGroup>
+          <MetricsToolbarChevronButton
+            aria-label={
+              controlSectionExpanded ? t('Collapse sidebar') : t('Expand sidebar')
+            }
+            expanded={controlSectionExpanded ?? true}
+            size="xs"
+            icon={
+              <IconChevron
+                isDouble
+                direction={controlSectionExpanded ? 'left' : 'right'}
+                size="xs"
+              />
+            }
+            onClick={() => setControlSectionExpanded?.(!(controlSectionExpanded ?? true))}
+          >
+            {controlSectionExpanded ? null : t('Advanced')}
+          </MetricsToolbarChevronButton>
+        </OverChartButtonGroup>
         <Stack>
           <WidgetSyncContextProvider groupName={METRICS_CHART_GROUP}>
             {metricQueries.map((metricQuery, index) => {
@@ -222,4 +291,26 @@ const MetricsQueryBuilderContainer = styled(Container)`
   background-color: ${p => p.theme.tokens.background.primary};
   border-top: none;
   border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
+const MetricsToolbarChevronButton = styled(Button)<{expanded: boolean}>`
+  display: none;
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    display: inline-flex;
+  }
+
+  ${p =>
+    p.expanded &&
+    css`
+      margin-left: -17px;
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+
+      &::after {
+        border-left-color: ${p.theme.tokens.border.primary};
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
+    `}
 `;


### PR DESCRIPTION
This reorganizes the metrics tab so each metric query renders as a stacked toolbar with updated add and remove controls, while the chart panels remain grouped below. The refreshed layout needs more horizontal room than the compact search query builder previously allowed, so this also disables the filter key list box's full-width details mode for compact builders to keep the filter details pane readable.

I considered keeping the existing grid layout and only swapping button styles, but the stacked structure gives each metric control enough space without degrading truncation behavior or making the filter interaction harder to use.

Refs LOGS-621

Example:

<img width="345" height="627" alt="Screenshot 2026-03-19 at 09 30 15" src="https://github.com/user-attachments/assets/b4ff584f-83b3-491d-93a3-35122fe45e7c" />

Made with [Cursor](https://cursor.com)