### PR TITLE
chore: add codeowners-coverage to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ default = true
 
 [dependency-groups]
 dev = [
+    "codeowners-coverage>=0.2.1",
     "covdefaults>=2.3.0",
     "devservices>=1.2.4",
     "docker>=7.1.0",


### PR DESCRIPTION
- Needs to be added to our internal pypi before merging https://github.com/getsentry/pypi/pull/1998