### PR TITLE
feat(ai-insights): update dashboard widgets

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -93,6 +93,8 @@ const CHART_MAP = {
     import('sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget'),
   overviewAgentsDurationChartWidget: () =>
     import('sentry/views/insights/common/components/widgets/overviewAgentsDurationChartWidget'),
+  overviewLLMCallsChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/overviewLLMCallsChartWidget'),
   overviewApiLatencyChartWidget: () =>
     import('sentry/views/insights/common/components/widgets/overviewApiLatencyChartWidget'),
   overviewCacheMissChartWidget: () =>

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -5,10 +5,11 @@ import {DisplayType, MAX_TABLE_LIMIT, WidgetType} from 'sentry/views/dashboards/
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
-import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 const AGENT_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:agent`;
 const AI_CLIENT_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:ai_client`;
+const AGENT_AND_AI_CLIENT_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:[agent, ai_client]`;
 const TOOL_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:tool`;
 
 const DEFAULT_GLOBAL_FILTERS = [
@@ -38,8 +39,8 @@ export const DEFAULT_TRACES_TABLE_WIDTHS = [
 const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [
     {
-      id: 'ai-agents-overview-runs',
-      title: t('Runs'),
+      id: 'ai-agents-overview-agent-runs',
+      title: t('Agent Runs'),
       displayType: DisplayType.BAR,
       widgetType: WidgetType.SPANS,
       interval: '1h',
@@ -56,20 +57,20 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       ],
     },
     {
-      id: 'ai-agents-overview-error-rate',
-      title: t('Error Rate'),
-      displayType: DisplayType.LINE,
+      id: 'ai-agents-overview-llm-calls-traffic',
+      title: t('LLM Calls'),
+      displayType: DisplayType.BAR,
       widgetType: WidgetType.SPANS,
       interval: '1h',
       queries: [
         {
-          name: t('Error Rate'),
-          conditions: AGENT_FILTER,
-          fields: [`equation|${SpanFunction.TRACE_STATUS_RATE}(internal_error)`],
-          aggregates: [`equation|${SpanFunction.TRACE_STATUS_RATE}(internal_error)`],
+          name: t('Count'),
+          conditions: AI_CLIENT_FILTER,
+          fields: [`count(${SpanFields.SPAN_DURATION})`],
+          aggregates: [`count(${SpanFields.SPAN_DURATION})`],
           columns: [],
-          fieldAliases: [t('Error Rate')],
-          orderby: `-equation|${SpanFunction.TRACE_STATUS_RATE}(internal_error)`,
+          fieldAliases: [t('Count')],
+          orderby: `-count(${SpanFields.SPAN_DURATION})`,
         },
       ],
     },
@@ -82,7 +83,7 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
-          conditions: AGENT_FILTER,
+          conditions: AGENT_AND_AI_CLIENT_FILTER,
           fields: [
             `avg(${SpanFields.SPAN_DURATION})`,
             `p95(${SpanFields.SPAN_DURATION})`,
@@ -104,8 +105,8 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
 const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [
     {
-      id: 'ai-agents-overview-llm-calls',
-      title: t('LLM Calls'),
+      id: 'ai-agents-overview-llm-calls-by-model',
+      title: t('LLM Calls by Model'),
       displayType: DisplayType.BAR,
       widgetType: WidgetType.SPANS,
       interval: '1h',

--- a/static/app/views/insights/common/components/widgets/overviewAgentsDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewAgentsDurationChartWidget.tsx
@@ -12,10 +12,7 @@ import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {ModalChartContainer} from 'sentry/views/insights/common/components/insightsChartContainer';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
-import {
-  getAgentRunsFilter,
-  getHasAiSpansFilter,
-} from 'sentry/views/insights/pages/agents/utils/query';
+import {getAgentAndAIClientFilter} from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -23,7 +20,7 @@ import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 
 export default function OverviewAgentsDurationChartWidget(
-  props: LoadableChartWidgetProps & {hasAgentRuns?: boolean}
+  props: LoadableChartWidgetProps
 ) {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams({
@@ -31,9 +28,7 @@ export default function OverviewAgentsDurationChartWidget(
   });
   const releaseBubbleProps = useReleaseBubbleProps(props);
 
-  const fullQuery = useCombinedQuery(
-    props.hasAgentRuns ? getAgentRunsFilter() : getHasAiSpansFilter()
-  );
+  const fullQuery = useCombinedQuery(getAgentAndAIClientFilter());
 
   const {data, isLoading, error} = useFetchSpanTimeSeries(
     {

--- a/static/app/views/insights/common/components/widgets/overviewLLMCallsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewLLMCallsChartWidget.tsx
@@ -5,7 +5,7 @@ import {getAIGenerationsFilter} from 'sentry/views/insights/pages/agents/utils/q
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {BaseTrafficWidget} from 'sentry/views/insights/pages/platform/shared/baseTrafficWidget';
 
-export function OverviewLLMCallsChartWidget(props: LoadableChartWidgetProps) {
+export default function OverviewLLMCallsChartWidget(props: LoadableChartWidgetProps) {
   const query = useCombinedQuery(getAIGenerationsFilter());
 
   return (

--- a/static/app/views/insights/common/components/widgets/overviewLLMCallsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewLLMCallsChartWidget.tsx
@@ -1,20 +1,20 @@
 import {t} from 'sentry/locale';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
-import {getAgentRunsFilter} from 'sentry/views/insights/pages/agents/utils/query';
+import {getAIGenerationsFilter} from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {BaseTrafficWidget} from 'sentry/views/insights/pages/platform/shared/baseTrafficWidget';
 
-export default function OverviewAgentsRunsChartWidget(props: LoadableChartWidgetProps) {
-  const query = useCombinedQuery(getAgentRunsFilter());
+export default function OverviewLLMCallsChartWidget(props: LoadableChartWidgetProps) {
+  const query = useCombinedQuery(getAIGenerationsFilter());
 
   return (
     <BaseTrafficWidget
-      id="overviewAgentsRunsChartWidget"
-      title={t('Agent Runs')}
-      trafficSeriesName={t('Runs')}
+      id="overviewLLMCallsChartWidget"
+      title={t('LLM Calls')}
+      trafficSeriesName={t('Calls')}
       query={query}
-      referrer={Referrer.AGENT_RUNS_WIDGET}
+      referrer={Referrer.LLM_CALLS_TRAFFIC_WIDGET}
       {...props}
     />
   );

--- a/static/app/views/insights/common/components/widgets/overviewLLMCallsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewLLMCallsChartWidget.tsx
@@ -5,7 +5,7 @@ import {getAIGenerationsFilter} from 'sentry/views/insights/pages/agents/utils/q
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {BaseTrafficWidget} from 'sentry/views/insights/pages/platform/shared/baseTrafficWidget';
 
-export default function OverviewLLMCallsChartWidget(props: LoadableChartWidgetProps) {
+export function OverviewLLMCallsChartWidget(props: LoadableChartWidgetProps) {
   const query = useCombinedQuery(getAIGenerationsFilter());
 
   return (

--- a/static/app/views/insights/pages/agents/components/llmCallsWidget.tsx
+++ b/static/app/views/insights/pages/agents/components/llmCallsWidget.tsx
@@ -133,7 +133,7 @@ export function LLMCallsWidget() {
 
   return (
     <Widget
-      Title={<Widget.WidgetTitle title={t('LLM Calls')} />}
+      Title={<Widget.WidgetTitle title={t('LLM Calls by Model')} />}
       Visualization={visualization}
       Actions={
         organization.features.includes('visibility-explore-view') &&

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -1,14 +1,10 @@
-import styled from '@emotion/styled';
-
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 
 import Feature from 'sentry/components/acl/feature';
 import {useDismissable} from 'sentry/components/banner';
-import {TransparentLoadingMask} from 'sentry/components/charts/transparentLoadingMask';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NoAccess} from 'sentry/components/noAccess';
 import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
@@ -31,12 +27,12 @@ import {InsightsProjectSelector} from 'sentry/views/insights/common/components/p
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsDurationChartWidget';
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
-import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import OverviewLLMCallsChartWidget from 'sentry/views/insights/common/components/widgets/overviewLLMCallsChartWidget';
 import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
 import {useHasPlatformizedInsights} from 'sentry/views/insights/common/utils/useHasPlatformizedInsights';
 import {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
 import {IssuesWidget} from 'sentry/views/insights/pages/agents/components/issuesWidget';
-import {LLMCallsWidget as LLMGenerationsWidget} from 'sentry/views/insights/pages/agents/components/llmCallsWidget';
+import {LLMCallsWidget as LLMCallsByModelWidget} from 'sentry/views/insights/pages/agents/components/llmCallsWidget';
 import {WidgetGrid} from 'sentry/views/insights/pages/agents/components/styles';
 import {TokenUsageWidget} from 'sentry/views/insights/pages/agents/components/tokenUsageWidget';
 import {ToolCallsWidget as ToolUsageWidget} from 'sentry/views/insights/pages/agents/components/toolCallsWidget';
@@ -46,7 +42,6 @@ import {useAgentSpanSearchProps} from 'sentry/views/insights/pages/agents/hooks/
 import {useAITrace} from 'sentry/views/insights/pages/agents/hooks/useAITrace';
 import {useShowAgentOnboarding} from 'sentry/views/insights/pages/agents/hooks/useShowAgentOnboarding';
 import {Onboarding} from 'sentry/views/insights/pages/agents/onboarding';
-import {getAgentRunsFilter} from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {
   TableUrlParams,
@@ -106,22 +101,6 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
   useOverviewPageTrackPageload();
   useAgentMonitoringTrackPageView();
 
-  // Fire a request to check if there are any agent runs
-  // If there are, we show the count/duration of agent runs
-  // If there are not, we show the count/duration of all AI spans
-  const agentRunsRequest = useSpans(
-    {
-      search: getAgentRunsFilter(),
-      fields: ['id'],
-      limit: 1,
-    },
-    Referrer.AGENT_RUNS_WIDGET
-  );
-
-  const hasAgentRuns = agentRunsRequest.isLoading
-    ? undefined
-    : agentRunsRequest.data?.length > 0;
-
   return (
     <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>
       <Layout.Body>
@@ -179,26 +158,18 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
                 <Stack gap="xl">
                   <WidgetGrid rowHeight={210} paddingBottom={0}>
                     <WidgetGrid.Position1>
-                      {hasAgentRuns === undefined ? (
-                        <LoadingPanel />
-                      ) : (
-                        <OverviewAgentsRunsChartWidget hasAgentRuns={hasAgentRuns} />
-                      )}
+                      <OverviewAgentsRunsChartWidget />
                     </WidgetGrid.Position1>
                     <WidgetGrid.Position2>
-                      {hasAgentRuns === undefined ? (
-                        <LoadingPanel />
-                      ) : (
-                        <OverviewAgentsDurationChartWidget hasAgentRuns={hasAgentRuns} />
-                      )}
+                      <OverviewLLMCallsChartWidget />
                     </WidgetGrid.Position2>
                     <WidgetGrid.Position3>
-                      <IssuesWidget />
+                      <OverviewAgentsDurationChartWidget />
                     </WidgetGrid.Position3>
                   </WidgetGrid>
                   <WidgetGrid rowHeight={260} paddingBottom={0}>
                     <WidgetGrid.Position1>
-                      <LLMGenerationsWidget />
+                      <LLMCallsByModelWidget />
                     </WidgetGrid.Position1>
                     <WidgetGrid.Position2>
                       <TokenUsageWidget />
@@ -207,6 +178,7 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
                       <ToolUsageWidget />
                     </WidgetGrid.Position3>
                   </WidgetGrid>
+                  <IssuesWidget />
                   <TracesTable openTraceViewDrawer={openTraceViewDrawer} />
                 </Stack>
               )}
@@ -230,25 +202,5 @@ function PageWithProviders() {
     </DomainOverviewPageProviders>
   );
 }
-
-function LoadingPanel() {
-  return (
-    <Stack
-      position="relative"
-      justify="center"
-      gap="md"
-      height="100%"
-      border="primary"
-      radius="md"
-    >
-      <LoadingMask visible />
-      <LoadingIndicator size={24} />
-    </Stack>
-  );
-}
-
-const LoadingMask = styled(TransparentLoadingMask)`
-  background: ${p => p.theme.tokens.background.primary};
-`;
 
 export default PageWithProviders;

--- a/static/app/views/insights/pages/agents/utils/query.tsx
+++ b/static/app/views/insights/pages/agents/utils/query.tsx
@@ -22,6 +22,10 @@ export const getToolSpansFilter = () => {
   return `gen_ai.operation.type:tool`;
 };
 
+export const getAgentAndAIClientFilter = () => {
+  return `gen_ai.operation.type:[agent, ai_client]`;
+};
+
 export const getAIGenerationsFilter = () => {
   return `gen_ai.operation.type:ai_client`;
 };

--- a/static/app/views/insights/pages/agents/utils/referrers.tsx
+++ b/static/app/views/insights/pages/agents/utils/referrers.tsx
@@ -10,6 +10,7 @@ export enum Referrer {
   TOOL_CALLS_WIDGET = 'api.insights.agent-monitoring.tool-calls-widget',
   TOOL_ERRORS_WIDGET = 'api.insights.agent-monitoring.tool-errors-widget',
   LLM_CALLS_WIDGET = 'api.insights.agent-monitoring.llm-calls-widget',
+  LLM_CALLS_TRAFFIC_WIDGET = 'api.insights.agent-monitoring.llm-calls-traffic-widget',
   AGENT_RUNS_WIDGET = 'api.insights.agent-monitoring.agent-runs-widget',
   AGENT_DURATION_WIDGET = 'api.insights.agent-monitoring.agent-duration-widget',
   AGENT_SELECTOR = 'api.insights.agent-monitoring.agent-selector',


### PR DESCRIPTION
Closes [TET-2104: Update agent monitoring widgets](https://linear.app/getsentry/issue/TET-2104/update-agent-monitoring-widgets)

Before:
<img width="2848" height="1830" alt="CleanShot 2026-03-19 at 14 51 06@2x" src="https://github.com/user-attachments/assets/ea38c8bd-f86c-44dc-9ae8-1a26aaa88ee1" />

After:
<img width="2928" height="1832" alt="CleanShot 2026-03-19 at 14 50 28@2x" src="https://github.com/user-attachments/assets/8eff99bf-1615-4850-8ef7-5ca2ac68b490" />