### PR TITLE
feat(eslint): expand no-default-exports rule to all static default exports

### DIFF
--- a/static/eslint/eslintPluginSentry/no-default-exports.spec.ts
+++ b/static/eslint/eslintPluginSentry/no-default-exports.spec.ts
@@ -34,37 +34,248 @@ export default wrap(MyComponentInner);
       code: `export const util = () => null;`,
       filename: 'valid.tsx',
     },
+    {
+      code: `
+        export const a = 1;
+        export const b = 2;
+      `,
+      filename: 'valid.tsx',
+    },
+    {
+      code: `export class MyClass {}`,
+      filename: 'valid.tsx',
+    },
+    {
+      code: `const x = 1;`,
+      filename: 'valid.tsx',
+    },
+    {
+      code: `export default withConfig(MyComponent);`,
+      filename: 'valid.tsx',
+    },
+    {
+      code: `export default styled(MyComponent)\`color: red;\`;`,
+      filename: 'valid.tsx',
+    },
+    {
+      code: `export default withConfig(MyComponent) as React.FC;`,
+      filename: 'valid.tsx',
+    },
   ],
   invalid: [
     {
-      code: 'function example() {}\nexport default example;',
-      output: 'export function example() {}\n',
+      code: `
+        function example() {}
+        export default example;
+      `,
+      output: `
+        export function example() {}
+      `,
       errors: [{messageId: 'forbidden'}],
       filename: 'invalid.tsx',
     },
     {
       code: `
-export function alsoExported() {}
-export default function defaultExported() {}
-`,
+        export function alsoExported() {}
+        export default function defaultExported() {}
+      `,
       output: `
-export function alsoExported() {}
-export function defaultExported() {}
-`,
+        export function alsoExported() {}
+        export function defaultExported() {}
+      `,
       errors: [{messageId: 'forbidden'}],
       filename: 'invalid.tsx',
     },
     {
-      code: 'function MyComponent() { return <div />; }\nexport default MyComponent;',
-      output: 'export function MyComponent() { return <div />; }\n',
+      code: `
+        function MyComponent() { return <div />; }
+        export default MyComponent;
+      `,
+      output: `
+        export function MyComponent() { return <div />; }
+      `,
       errors: [{messageId: 'forbidden'}],
       filename: 'invalid.tsx',
     },
     {
-      code: `const Panel = styled('div')\`padding: 0;\`;
-export default Panel;`,
-      output: `export const Panel = styled('div')\`padding: 0;\`;
-`,
+      code: `
+        const Panel = styled('div')\`padding: 0;\`;
+        export default Panel;
+      `,
+      output: `
+        export const Panel = styled('div')\`padding: 0;\`;
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        const MyComponent = () => <div />;
+        export default MyComponent;
+      `,
+      output: `
+        export const MyComponent = () => <div />;
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        class MyComponent extends React.Component {};
+        export default MyComponent;
+      `,
+      output: `
+        export class MyComponent extends React.Component {};
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        enum MyShape {};
+        export default MyShape;
+      `,
+      output: `
+        export enum MyShape {};
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        interface MyShape {};
+        export default MyShape;
+      `,
+      output: `
+        export interface MyShape {};
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        type MyShape = {};
+        export default MyShape;
+      `,
+      output: `
+        export type MyShape = {};
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        let count = 0;
+        export default count;
+      `,
+      output: `
+        export let count = 0;
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `export default function myFunction() { return 1; }`,
+      output: `export function myFunction() { return 1; }`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `export default class MyClass {}`,
+      output: `export class MyClass {}`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `export default function() { return 1; }`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `export default class {}`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        const x = 1;
+        export default x as number;
+      `,
+      output: `
+        export const x = 1;
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        function myFn() {}
+        export default myFn as unknown as () => void;
+      `,
+      output: `
+        export function myFn() {}
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `export default { key: "value" };`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `export default [1, 2, 3];`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `export default "hello";`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `export default 42;`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `export default () => null;`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        const a = 1, b = 2;
+        export default b;
+      `,
+      output: `
+        export const a = 1, b = 2;
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        export const a = 1;
+        export default function foo() {}
+      `,
+      output: `
+        export const a = 1;
+        export function foo() {}
+      `,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `
+        export const a = 1;
+        function bar() {}
+        export default bar;
+      `,
+      output: `
+        export const a = 1;
+        export function bar() {}
+      `,
       errors: [{messageId: 'forbidden'}],
       filename: 'invalid.tsx',
     },

--- a/static/eslint/eslintPluginSentry/no-default-exports.ts
+++ b/static/eslint/eslintPluginSentry/no-default-exports.ts
@@ -63,27 +63,24 @@ function collectResolvedImportFiles(program: ts.Program) {
   return allowedFiles;
 }
 
-function findTopLevelFunctionDeclaration(
-  body: TSESTree.ProgramStatement[],
-  name: string
-) {
-  return body.find(
-    statement =>
-      statement.type === AST_NODE_TYPES.FunctionDeclaration && statement.id?.name === name
-  );
-}
-
-function findTopLevelVariableDeclaration(
-  body: TSESTree.ProgramStatement[],
-  name: string
-): TSESTree.VariableDeclaration | undefined {
-  return body.find((statement): statement is TSESTree.VariableDeclaration => {
-    if (statement.type !== AST_NODE_TYPES.VariableDeclaration) {
-      return false;
+function findTopLevelDeclaration(body: TSESTree.ProgramStatement[], name: string) {
+  return body.find(statement => {
+    switch (statement.type) {
+      case AST_NODE_TYPES.FunctionDeclaration:
+      case AST_NODE_TYPES.ClassDeclaration:
+      case AST_NODE_TYPES.TSEnumDeclaration:
+      case AST_NODE_TYPES.TSInterfaceDeclaration:
+      case AST_NODE_TYPES.TSTypeAliasDeclaration:
+        return statement.id?.name === name;
+      case AST_NODE_TYPES.VariableDeclaration:
+        return statement.declarations.some(
+          declaration =>
+            declaration.id.type === AST_NODE_TYPES.Identifier &&
+            declaration.id.name === name
+        );
+      default:
+        return false;
     }
-    return statement.declarations.some(
-      decl => decl.id.type === AST_NODE_TYPES.Identifier && decl.id.name === name
-    );
   });
 }
 
@@ -112,55 +109,80 @@ export const noDefaultExports = ESLintUtils.RuleCreator.withoutDocs({
       return {};
     }
 
+    function visitDeclaration(
+      exported: TSESTree.Node,
+      declaration: TSESTree.ExportDefaultDeclaration
+    ) {
+      switch (exported.type) {
+        case AST_NODE_TYPES.ClassDeclaration:
+        case AST_NODE_TYPES.FunctionDeclaration: {
+          context.report({
+            node: declaration,
+            messageId: 'forbidden',
+            fix: exported.id
+              ? fixer => [
+                  fixer.replaceTextRange(
+                    [declaration.range[0], exported.range[0]],
+                    'export '
+                  ),
+                ]
+              : undefined,
+          });
+          return;
+        }
+
+        case AST_NODE_TYPES.Identifier: {
+          const declarationToExport = findTopLevelDeclaration(
+            declaration.parent.body,
+            exported.name
+          );
+
+          context.report({
+            node: declaration,
+            messageId: 'forbidden',
+            fix: declarationToExport
+              ? fixer => {
+                  const text = context.sourceCode.getText();
+                  let removeStart = declaration.range[0];
+                  while (removeStart > 0 && ' \t'.includes(text[removeStart - 1]!)) {
+                    removeStart--;
+                  }
+                  if (removeStart > 0 && text[removeStart - 1] === '\n') {
+                    removeStart--;
+                  }
+                  return [
+                    fixer.insertTextBefore(declarationToExport, 'export '),
+                    fixer.removeRange([removeStart, declaration.range[1]]),
+                  ];
+                }
+              : undefined,
+          });
+          return;
+        }
+
+        case AST_NODE_TYPES.TSAsExpression:
+          visitDeclaration(exported.expression, declaration);
+          return;
+
+        // Calls like HoCs often result in differences between internal and exported names:
+        //   export default withConfig(MyComponent);
+        //   export default styled(MyComponent)``;
+        case AST_NODE_TYPES.CallExpression:
+        case AST_NODE_TYPES.TaggedTemplateExpression: {
+          return;
+        }
+
+        default:
+          context.report({
+            node: declaration,
+            messageId: 'forbidden',
+          });
+      }
+    }
+
     return {
       ExportDefaultDeclaration(node) {
-        if (
-          node.declaration.type === AST_NODE_TYPES.ClassDeclaration ||
-          node.declaration.type === AST_NODE_TYPES.FunctionDeclaration
-        ) {
-          if (!node.declaration.id) {
-            return;
-          }
-
-          context.report({
-            node,
-            messageId: 'forbidden',
-            fix: fixer => [
-              fixer.replaceTextRange(
-                [node.range[0], node.declaration.range[0]],
-                'export '
-              ),
-            ],
-          });
-          return;
-        }
-
-        if (node.declaration.type === AST_NODE_TYPES.Identifier) {
-          const exportedName = node.declaration.name;
-          const functionDeclaration = findTopLevelFunctionDeclaration(
-            node.parent.body,
-            exportedName
-          );
-          const variableDeclaration = findTopLevelVariableDeclaration(
-            node.parent.body,
-            exportedName
-          );
-
-          const declarationToExport = functionDeclaration ?? variableDeclaration;
-          if (!declarationToExport) {
-            return;
-          }
-
-          context.report({
-            node,
-            messageId: 'forbidden',
-            fix: fixer => [
-              fixer.insertTextBefore(declarationToExport, 'export '),
-              fixer.remove(node),
-            ],
-          });
-          return;
-        }
+        visitDeclaration(node.declaration, node);
       },
     };
   },


### PR DESCRIPTION
Backing lint rule change for #111065. It covers all remaining `export default`s of static constructs: i.e. classes, enums, functions, identifiers, interfaces, type aliases, and variables. Dynamic ones such as call expressions (`export default withApi(MyComponent)`) are not covered as they would take much more work to automate with renames.

Fixes ENG-7107.