### PR TITLE
feat(autofix): Support autofix configurations in redesigns

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -16,6 +16,7 @@ import type {
   useMaxPickableDays,
 } from 'sentry/utils/useMaxPickableDays';
 import type {WidgetType} from 'sentry/views/dashboards/types';
+import type {AutofixContentProps} from 'sentry/views/issueDetails/streamline/sidebar/autofixSection';
 import type {OrganizationStatsProps} from 'sentry/views/organizationStats';
 import type {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 import type {NavigationSection} from 'sentry/views/settings/types';
@@ -189,6 +190,7 @@ type DashboardLimitProviderProps = {
  * Component wrapping hooks
  */
 type ComponentHooks = {
+  'component:ai-configure-seer-quota-sidebar': () => React.ComponentType<AutofixContentProps>;
   'component:ai-setup-configuration': () => React.ComponentType<AiSetupConfigrationProps>;
   'component:ai-setup-data-consent': () => React.ComponentType<AiSetupDataConsentProps> | null;
   'component:codecov-integration-settings-link': () => React.ComponentType<CodecovLinkProps>;

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
@@ -42,7 +42,20 @@ describe('AutofixSection', () => {
       body: AutofixSetupFixture({
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
+        seerReposLinked: true,
+        autofixEnabled: true,
       }),
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/onboarding-check/`,
+      body: {
+        hasSupportedScmIntegration: true,
+        isAutofixEnabled: true,
+        isCodeReviewEnabled: true,
+        isSeerConfigured: true,
+        needsConfigReminder: false,
+      },
     });
   });
 
@@ -310,7 +323,7 @@ describe('AutofixSection', () => {
     expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
   });
 
-  it('shows loading place holder while event is pending', () => {
+  it('shows loading placeholder while event is pending', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {
@@ -366,11 +379,10 @@ describe('AutofixSection', () => {
 
     // The Seer title should still render
     expect(screen.getByText('Seer')).toBeInTheDocument();
-    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+    expect(await screen.findByTestId('loading-placeholder')).toBeInTheDocument();
   });
 
-  it('shows loading placeholder while autofix data is pending', () => {
-    // Don't add autofix mock response so the query stays pending
+  it('shows empty state when autofix returns null', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
       body: {autofix: null},
@@ -383,7 +395,7 @@ describe('AutofixSection', () => {
 
     // The Seer title should still render
     expect(screen.getByText('Seer')).toBeInTheDocument();
-    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+    expect(await screen.findByText('Have Seer...')).toBeInTheDocument();
   });
 
   it('renders multiple artifact types in order', async () => {
@@ -471,6 +483,91 @@ describe('AutofixSection', () => {
     expect(screen.getByText('Implementation Plan')).toBeInTheDocument();
     expect(screen.getByText('Code Changes')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
+  });
+
+  it('shows org setup UI when SCM integration is missing', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/onboarding-check/`,
+      body: {
+        hasSupportedScmIntegration: false,
+        isAutofixEnabled: false,
+        isCodeReviewEnabled: false,
+        isSeerConfigured: false,
+        needsConfigReminder: false,
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+
+    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+      organization,
+    });
+
+    expect(await screen.findByText('Finish Configuring Seer')).toBeInTheDocument();
+    const link = screen.getByRole('button', {name: 'Set Up Seer'});
+    expect(link).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/seer/onboarding/`
+    );
+  });
+
+  it('shows project setup UI when repos are not linked', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
+      body: AutofixSetupFixture({
+        integration: {ok: true, reason: null},
+        githubWriteIntegration: {ok: true, repos: []},
+        seerReposLinked: false,
+        autofixEnabled: true,
+      }),
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+
+    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+      organization,
+    });
+
+    expect(await screen.findByText('Finish Configuring Seer')).toBeInTheDocument();
+    const link = screen.getByRole('button', {name: 'Set Up Seer for This Project'});
+    expect(link).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/projects/${mockProject.slug}/seer/`
+    );
+  });
+
+  it('shows project setup UI when autofix is not enabled', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
+      body: AutofixSetupFixture({
+        integration: {ok: true, reason: null},
+        githubWriteIntegration: {ok: true, repos: []},
+        seerReposLinked: true,
+        autofixEnabled: false,
+      }),
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+
+    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+      organization,
+    });
+
+    expect(await screen.findByText('Finish Configuring Seer')).toBeInTheDocument();
+    const link = screen.getByRole('button', {name: 'Set Up Seer for This Project'});
+    expect(link).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/projects/${mockProject.slug}/seer/`
+    );
   });
 
   it('shows empty state when there are no artifacts', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import seerConfigConnectImg from 'sentry-images/spot/seer-config-connect-2.svg';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Image} from '@sentry/scraps/image';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -25,6 +25,7 @@ import {
   RootCausePreview,
   SolutionPreview,
 } from 'sentry/components/events/autofix/v3/autofixPreviews';
+import {HookOrDefault} from 'sentry/components/hookOrDefault';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconBug} from 'sentry/icons';
 import {IconSeer} from 'sentry/icons/iconSeer';
@@ -33,6 +34,8 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useSeerOnboardingCheck} from 'sentry/utils/useSeerOnboardingCheck';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {SidebarFoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
@@ -89,18 +92,85 @@ export function AutofixSection({group, project, event}: AutofixSectionProps) {
       sectionKey={SectionKey.SEER}
       preventCollapse={false}
     >
-      <AutofixContent group={group} project={project} event={event} />
+      <AutofixContentHook
+        aiConfig={aiConfig}
+        group={group}
+        project={project}
+        event={event}
+      />
     </SidebarFoldSection>
   );
 }
 
-interface AutofixContentProps {
+const AutofixContentHook = HookOrDefault({
+  hookName: 'component:ai-configure-seer-quota-sidebar',
+  defaultComponent: AutofixContent,
+});
+
+export interface AutofixContentProps extends AutofixArtifactsProps {
+  aiConfig: ReturnType<typeof useAiConfig>;
+}
+
+export function AutofixContent({aiConfig, group, project, event}: AutofixContentProps) {
+  const organization = useOrganization();
+  const {data: setupCheck} = useSeerOnboardingCheck();
+
+  const needOrgSetup =
+    // scm integration doesn't exist
+    !setupCheck?.hasSupportedScmIntegration;
+
+  const needProjSetup =
+    // scm integration not linked to project
+    !aiConfig.seerReposLinked ||
+    // autofix setting not enabled
+    !aiConfig.autofixEnabled;
+
+  if (needOrgSetup || needProjSetup) {
+    return (
+      <Flex direction="column" border="muted" radius="md" padding="lg" gap="lg">
+        <Text bold>{t('Finish Configuring Seer')}</Text>
+        <Text>
+          {t(
+            'Your organization has access to Seer, which will allow you to run Autofix on your issues, but you aren’t getting the most out of it.'
+          )}
+        </Text>
+        <Text>{t('Autofix can:')}</Text>
+        <Container as="ol" margin="0">
+          <li>{t('Determine the root cause of your issue and how to reproduce it')}</li>
+          <li>{t('Propose a solution')}</li>
+          <li>{t('Create a code fix')}</li>
+        </Container>
+        <Flex>
+          {needOrgSetup ? (
+            <LinkButton
+              to={`/settings/${organization.slug}/seer/onboarding/`}
+              icon={<IconSeer />}
+            >
+              {t('Set Up Seer')}
+            </LinkButton>
+          ) : needProjSetup ? (
+            <LinkButton
+              to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
+              icon={<IconSeer />}
+            >
+              {t('Set Up Seer for This Project')}
+            </LinkButton>
+          ) : null}
+        </Flex>
+      </Flex>
+    );
+  }
+
+  return <AutofixArtifacts group={group} project={project} event={event} />;
+}
+
+interface AutofixArtifactsProps {
   group: Group;
   project: Project;
   event?: Event;
 }
 
-function AutofixContent({group, project, event}: AutofixContentProps) {
+function AutofixArtifacts({group, project, event}: AutofixArtifactsProps) {
   const autofix = useExplorerAutofix(group.id);
   const artifacts = useMemo(
     () => getOrderedAutofixArtifacts(autofix.runState),

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -113,7 +113,11 @@ export interface AutofixContentProps extends AutofixArtifactsProps {
 
 export function AutofixContent({aiConfig, group, project, event}: AutofixContentProps) {
   const organization = useOrganization();
-  const {data: setupCheck} = useSeerOnboardingCheck();
+  const {data: setupCheck, isPending} = useSeerOnboardingCheck();
+
+  if (isPending) {
+    return <Placeholder height="160px" />;
+  }
 
   const needOrgSetup =
     // scm integration doesn't exist

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -119,7 +119,7 @@ export function AutofixContent({aiConfig, group, project, event}: AutofixContent
   const autofix = useExplorerAutofix(group.id);
   const {data: setupCheck, isPending} = useSeerOnboardingCheck();
 
-  if (isPending || autofix.isLoading || !event) {
+  if (isPending || autofix.isLoading || !event || aiConfig.isAutofixSetupLoading) {
     return <Placeholder height="160px" />;
   }
 

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -107,15 +107,19 @@ const AutofixContentHook = HookOrDefault({
   defaultComponent: AutofixContent,
 });
 
-export interface AutofixContentProps extends AutofixArtifactsProps {
+export interface AutofixContentProps {
   aiConfig: ReturnType<typeof useAiConfig>;
+  group: Group;
+  project: Project;
+  event?: Event;
 }
 
 export function AutofixContent({aiConfig, group, project, event}: AutofixContentProps) {
   const organization = useOrganization();
+  const autofix = useExplorerAutofix(group.id);
   const {data: setupCheck, isPending} = useSeerOnboardingCheck();
 
-  if (isPending) {
+  if (isPending || autofix.isLoading || !event) {
     return <Placeholder height="160px" />;
   }
 
@@ -165,25 +169,23 @@ export function AutofixContent({aiConfig, group, project, event}: AutofixContent
     );
   }
 
-  return <AutofixArtifacts group={group} project={project} event={event} />;
+  return (
+    <AutofixArtifacts autofix={autofix} group={group} project={project} event={event} />
+  );
 }
 
 interface AutofixArtifactsProps {
+  autofix: ReturnType<typeof useExplorerAutofix>;
   group: Group;
   project: Project;
   event?: Event;
 }
 
-function AutofixArtifacts({group, project, event}: AutofixArtifactsProps) {
-  const autofix = useExplorerAutofix(group.id);
+function AutofixArtifacts({autofix, group, project, event}: AutofixArtifactsProps) {
   const artifacts = useMemo(
     () => getOrderedAutofixArtifacts(autofix.runState),
     [autofix.runState]
   );
-
-  if (autofix.isLoading || !event) {
-    return <Placeholder height="160px" />;
-  }
 
   if (!artifacts.length) {
     return (

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -176,9 +176,9 @@ export function AutofixContent({aiConfig, group, project, event}: AutofixContent
 
 interface AutofixArtifactsProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
+  event: Event;
   group: Group;
   project: Project;
-  event?: Event;
 }
 
 function AutofixArtifacts({autofix, group, project, event}: AutofixArtifactsProps) {

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
@@ -59,7 +59,7 @@ describe('AiConfigureSeerQuotaSidebar', () => {
     expect(screen.queryByText('Meet Seer, your AI assistant')).not.toBeInTheDocument();
   });
 
-  it('renders AutofixContent when user has autofix quota', async () => {
+  it('renders AutofixContent when user has autofix quota', () => {
     const organization = OrganizationFixture({features: ['seer-billing']});
     const subscription = SubscriptionFixture({organization});
     act(() => SubscriptionStore.set(organization.slug, subscription));
@@ -88,7 +88,7 @@ describe('AiConfigureSeerQuotaSidebar', () => {
     expect(screen.queryByText('Meet Seer, your AI assistant')).not.toBeInTheDocument();
   });
 
-  it('renders AutofixContent when seer-billing feature is not present', async () => {
+  it('renders AutofixContent when seer-billing feature is not present', () => {
     const organization = OrganizationFixture({features: []});
     const subscription = SubscriptionFixture({organization});
     act(() => SubscriptionStore.set(organization.slug, subscription));

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
@@ -75,6 +75,11 @@ describe('AiConfigureSeerQuotaSidebar', () => {
       },
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/autofix/`,
+      body: {autofix: null},
+    });
+
     render(
       <AiConfigureSeerQuotaSidebar
         aiConfig={makeAiConfig({hasAutofixQuota: true})}
@@ -102,6 +107,11 @@ describe('AiConfigureSeerQuotaSidebar', () => {
         isSeerConfigured: true,
         needsConfigReminder: false,
       },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/autofix/`,
+      body: {autofix: null},
     });
 
     render(

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
@@ -41,7 +41,7 @@ describe('AiConfigureSeerQuotaSidebar', () => {
   });
 
   it('renders loading placeholder when autofix setup is loading', () => {
-    const organization = OrganizationFixture({features: ['seer-billing']});
+    const organization = OrganizationFixture();
     const subscription = SubscriptionFixture({organization});
     act(() => SubscriptionStore.set(organization.slug, subscription));
 
@@ -60,7 +60,7 @@ describe('AiConfigureSeerQuotaSidebar', () => {
   });
 
   it('renders AutofixContent when user has autofix quota', () => {
-    const organization = OrganizationFixture({features: ['seer-billing']});
+    const organization = OrganizationFixture();
     const subscription = SubscriptionFixture({organization});
     act(() => SubscriptionStore.set(organization.slug, subscription));
 
@@ -93,43 +93,8 @@ describe('AiConfigureSeerQuotaSidebar', () => {
     expect(screen.queryByText('Meet Seer, your AI assistant')).not.toBeInTheDocument();
   });
 
-  it('renders AutofixContent when seer-billing feature is not present', () => {
-    const organization = OrganizationFixture({features: []});
-    const subscription = SubscriptionFixture({organization});
-    act(() => SubscriptionStore.set(organization.slug, subscription));
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/seer/onboarding-check/`,
-      body: {
-        hasSupportedScmIntegration: true,
-        isAutofixEnabled: true,
-        isCodeReviewEnabled: true,
-        isSeerConfigured: true,
-        needsConfigReminder: false,
-      },
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/autofix/`,
-      body: {autofix: null},
-    });
-
-    render(
-      <AiConfigureSeerQuotaSidebar
-        aiConfig={makeAiConfig({hasAutofixQuota: false})}
-        group={group}
-        project={project}
-        event={event}
-      />,
-      {organization}
-    );
-
-    expect(screen.queryByText('Meet Seer, your AI assistant')).not.toBeInTheDocument();
-  });
-
   it('renders upsell card with enabled button when user has billing permissions', () => {
     const organization = OrganizationFixture({
-      features: ['seer-billing'],
       access: ['org:billing'] as any,
     });
     const subscription = SubscriptionFixture({organization, canSelfServe: true});
@@ -157,7 +122,6 @@ describe('AiConfigureSeerQuotaSidebar', () => {
 
   it('renders upsell card with disabled button when user lacks billing permissions', () => {
     const organization = OrganizationFixture({
-      features: ['seer-billing'],
       access: [] as any,
     });
     const subscription = SubscriptionFixture({organization, canSelfServe: false});

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
@@ -1,0 +1,170 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
+
+import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
+
+import {AiConfigureSeerQuotaSidebar} from './aiConfigureSeerQuotaSidebar';
+
+function makeAiConfig(
+  overrides: Partial<ReturnType<typeof useAiConfig>> = {}
+): ReturnType<typeof useAiConfig> {
+  return {
+    areAiFeaturesAllowed: true,
+    autofixEnabled: true,
+    hasAutofix: true,
+    hasAutofixQuota: true,
+    hasGithubIntegration: true,
+    hasResources: true,
+    hasSummary: true,
+    isAutofixSetupLoading: false,
+    orgNeedsGenAiAcknowledgement: false,
+    refetchAutofixSetup: jest.fn(),
+    seerReposLinked: true,
+    ...overrides,
+  };
+}
+
+describe('AiConfigureSeerQuotaSidebar', () => {
+  const group = GroupFixture();
+  const project = ProjectFixture();
+  const event = EventFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders loading placeholder when autofix setup is loading', () => {
+    const organization = OrganizationFixture({features: ['seer-billing']});
+    const subscription = SubscriptionFixture({organization});
+    act(() => SubscriptionStore.set(organization.slug, subscription));
+
+    render(
+      <AiConfigureSeerQuotaSidebar
+        aiConfig={makeAiConfig({isAutofixSetupLoading: true})}
+        group={group}
+        project={project}
+        event={event}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+    expect(screen.queryByText('Meet Seer, your AI assistant')).not.toBeInTheDocument();
+  });
+
+  it('renders AutofixContent when user has autofix quota', async () => {
+    const organization = OrganizationFixture({features: ['seer-billing']});
+    const subscription = SubscriptionFixture({organization});
+    act(() => SubscriptionStore.set(organization.slug, subscription));
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/onboarding-check/`,
+      body: {
+        hasSupportedScmIntegration: true,
+        isAutofixEnabled: true,
+        isCodeReviewEnabled: true,
+        isSeerConfigured: true,
+        needsConfigReminder: false,
+      },
+    });
+
+    render(
+      <AiConfigureSeerQuotaSidebar
+        aiConfig={makeAiConfig({hasAutofixQuota: true})}
+        group={group}
+        project={project}
+        event={event}
+      />,
+      {organization}
+    );
+
+    expect(screen.queryByText('Meet Seer, your AI assistant')).not.toBeInTheDocument();
+  });
+
+  it('renders AutofixContent when seer-billing feature is not present', async () => {
+    const organization = OrganizationFixture({features: []});
+    const subscription = SubscriptionFixture({organization});
+    act(() => SubscriptionStore.set(organization.slug, subscription));
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/onboarding-check/`,
+      body: {
+        hasSupportedScmIntegration: true,
+        isAutofixEnabled: true,
+        isCodeReviewEnabled: true,
+        isSeerConfigured: true,
+        needsConfigReminder: false,
+      },
+    });
+
+    render(
+      <AiConfigureSeerQuotaSidebar
+        aiConfig={makeAiConfig({hasAutofixQuota: false})}
+        group={group}
+        project={project}
+        event={event}
+      />,
+      {organization}
+    );
+
+    expect(screen.queryByText('Meet Seer, your AI assistant')).not.toBeInTheDocument();
+  });
+
+  it('renders upsell card with enabled button when user has billing permissions', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-billing'],
+      access: ['org:billing'] as any,
+    });
+    const subscription = SubscriptionFixture({organization, canSelfServe: true});
+    act(() => SubscriptionStore.set(organization.slug, subscription));
+
+    render(
+      <AiConfigureSeerQuotaSidebar
+        aiConfig={makeAiConfig({hasAutofixQuota: false})}
+        group={group}
+        project={project}
+        event={event}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('Meet Seer, your AI assistant')).toBeInTheDocument();
+    const button = screen.getByRole('button', {name: 'Try out Seer now'});
+    expect(button).toBeInTheDocument();
+    expect(button).not.toHaveAttribute('aria-disabled', 'true');
+    expect(button).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/billing/overview/?product=seer`
+    );
+  });
+
+  it('renders upsell card with disabled button when user lacks billing permissions', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-billing'],
+      access: [] as any,
+    });
+    const subscription = SubscriptionFixture({organization, canSelfServe: false});
+    act(() => SubscriptionStore.set(organization.slug, subscription));
+
+    render(
+      <AiConfigureSeerQuotaSidebar
+        aiConfig={makeAiConfig({hasAutofixQuota: false})}
+        group={group}
+        project={project}
+        event={event}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('Meet Seer, your AI assistant')).toBeInTheDocument();
+    const button = screen.getByRole('button', {name: 'Try out Seer now'});
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
@@ -1,0 +1,68 @@
+import {LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {Placeholder} from 'sentry/components/placeholder';
+import {IconOpen} from 'sentry/icons/iconOpen';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  AutofixContent,
+  type AutofixContentProps,
+} from 'sentry/views/issueDetails/streamline/sidebar/autofixSection';
+
+import {useSubscription} from 'getsentry/hooks/useSubscription';
+import {hasAccessToSubscriptionOverview} from 'getsentry/utils/billing';
+
+export function AiConfigureSeerQuotaSidebar({
+  aiConfig,
+  group,
+  project,
+  event,
+}: AutofixContentProps) {
+  const organization = useOrganization();
+  const subscription = useSubscription();
+
+  if (aiConfig.isAutofixSetupLoading) {
+    return <Placeholder height="160px" />;
+  }
+
+  const hasAutofixQuota =
+    aiConfig.hasAutofixQuota || !organization.features.includes('seer-billing');
+
+  if (hasAutofixQuota) {
+    return (
+      <AutofixContent aiConfig={aiConfig} group={group} project={project} event={event} />
+    );
+  }
+
+  const hasBillingPerms = hasAccessToSubscriptionOverview(subscription, organization);
+
+  return (
+    <Flex direction="column" border="muted" radius="md" padding="lg" gap="lg">
+      <Text bold>{t('Meet Seer, your AI assistant')}</Text>
+      <Text>
+        {t(
+          'Debug faster with Sentry’s agent, Seer. Seer connects to your repos, scans your issues, highlights quick fixes, and proposes solutions. You can even integrate with your favorite agent to implement changes in code.'
+        )}
+      </Text>
+      <Flex>
+        <Tooltip
+          title={t(
+            'You need to be a billing member to try out Seer. Please contact your organization owner to upgrade your plan.'
+          )}
+          disabled={hasBillingPerms}
+        >
+          <LinkButton
+            to={`/settings/${organization.slug}/billing/overview/?product=seer`}
+            icon={<IconOpen />}
+            disabled={!hasBillingPerms}
+          >
+            {t('Try out Seer now')}
+          </LinkButton>
+        </Tooltip>
+      </Flex>
+    </Flex>
+  );
+}

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
@@ -28,10 +28,7 @@ export function AiConfigureSeerQuotaSidebar({
     return <Placeholder height="160px" />;
   }
 
-  const hasAutofixQuota =
-    aiConfig.hasAutofixQuota || !organization.features.includes('seer-billing');
-
-  if (hasAutofixQuota) {
+  if (aiConfig.hasAutofixQuota) {
     return (
       <AutofixContent aiConfig={aiConfig} group={group} project={project} event={event} />
     );

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -5,6 +5,7 @@ import {IconBusiness} from 'sentry/icons';
 import {HookStore} from 'sentry/stores/hookStore';
 import type {Hooks} from 'sentry/types/hooks';
 
+import {AiConfigureSeerQuotaSidebar} from 'getsentry/components/ai/aiConfigureSeerQuotaSidebar';
 import {AiSetupConfiguration} from 'getsentry/components/ai/aiSetupConfiguration';
 import {AiSetupDataConsent} from 'getsentry/components/ai/AiSetupDataConsent';
 import CronsBillingBanner from 'getsentry/components/crons/cronsBillingBanner';
@@ -207,6 +208,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
    */
   'component:insights-date-range-query-limit-footer': () =>
     InsightsDateRangeQueryLimitFooter,
+  'component:ai-configure-seer-quota-sidebar': () => AiConfigureSeerQuotaSidebar,
   'component:ai-setup-configuration': () => AiSetupConfiguration,
   'component:ai-setup-data-consent': () => AiSetupDataConsent,
   'component:codecov-integration-settings-link': () => CodecovSettingsLink,


### PR DESCRIPTION
This adds in the steps to
1. ensure the org has configured billing for seer
2. ensure the org has configured a scm
3. ensure the project has linked a scm

| Seer Not Available Admin | Seer Not Available Member |
| ------------------------- | --------------------------- |
| <img width="640" height="604" alt="image" src="https://github.com/user-attachments/assets/b2d05bde-c076-4d5e-88d2-a5fd4938642c" /> | <img width="316" height="298" alt="Screenshot 2026-03-19 at 10 43 30 AM" src="https://github.com/user-attachments/assets/a68d9927-801f-4948-81e9-109a6e7e5c5a" /> |


| SCM Not Available for Organization | SCM Not Available for Project |
| ----------------------------------- | ----------------------------- |
| <img width="620" height="740" alt="image" src="https://github.com/user-attachments/assets/41fca2f4-a4d2-48ea-b65b-3ab57c00e9ba" /> | <img width="618" height="744" alt="image" src="https://github.com/user-attachments/assets/49c2fb4d-85d8-47f3-877b-78178f26e267" /> |