### PR TITLE
chore(autofix): Remove GA'd autofix-send-code-mappings feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -300,8 +300,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-context-engine-fe-override-ui-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code editing tools in Seer Explorer chat
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Send code mappings to Seer for autofix to avoid expensive git tree fetches
-    manager.add("organizations:autofix-send-code-mappings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Autofix to use Seer Explorer instead of legacy Celery pipeline
     manager.add("organizations:autofix-on-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Autofix to use Seer Explorer V2 designs

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -739,11 +739,10 @@ def trigger_autofix(
 
     # Pre-resolve stacktrace frame paths using code mappings so Seer can skip
     # expensive git tree fetches for large repos.
-    if features.has("organizations:autofix-send-code-mappings", group.organization):
-        try:
-            _pre_resolve_stacktrace_frames(serialized_event, code_mappings)
-        except Exception:
-            logger.exception("Failed to pre-resolve stacktrace frames")
+    try:
+        _pre_resolve_stacktrace_frames(serialized_event, code_mappings)
+    except Exception:
+        logger.exception("Failed to pre-resolve stacktrace frames")
 
     # get trace tree of transactions and errors for this event
     try:


### PR DESCRIPTION
## Summary
- Remove the `organizations:autofix-send-code-mappings` feature flag which has been GA'd at 100% rollout
- Make code mapping pre-resolution in autofix unconditional
- Companion PR in sentry-options-automator to remove the flagpole config

## Test plan
- [ ] CI passes
- [ ] Autofix continues to pre-resolve stacktrace frames without the flag gate


Agent transcript: https://claudescope.sentry.dev/share/SJ7h6lGgiDOdYm2_Zo758cttXdqQSx615lOoaFhA4aA