### PR TITLE
fix(dashboards): Populate linked dashboard in widget builder edit modal

### DIFF
--- a/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
@@ -56,20 +56,41 @@ export function LinkToDashboardModal({
     let unmounted = false;
 
     setIsDashboardListLoading(true);
-    fetchDashboards(api, organization.slug)
-      .then(response => {
-        // If component has unmounted, dont set state
+
+    const dashboardListPromise = fetchDashboards(api, organization.slug);
+    const linkedDashboardPromise = currentLinkedDashboard?.dashboardId
+      ? fetchDashboard(api, organization.slug, currentLinkedDashboard.dashboardId)
+      : Promise.resolve(null);
+
+    Promise.all([dashboardListPromise, linkedDashboardPromise])
+      .then(([dashboardList, linkedDashboard]) => {
         if (unmounted) {
           return;
         }
 
-        setDashboards(response);
-        const currentDashboard = response.find(
-          dashboard => dashboard.id === currentLinkedDashboard?.dashboardId
-        );
-        if (currentDashboard) {
-          setSelectedDashboardId(currentDashboard.id);
+        if (linkedDashboard) {
+          const alreadyIncluded = dashboardList.some(d => d.id === linkedDashboard.id);
+          if (!alreadyIncluded) {
+            // Converts dashboard details to dashboard list item
+            dashboardList.push({
+              id: linkedDashboard.id,
+              title: linkedDashboard.title,
+              filters: linkedDashboard.filters,
+              projects: linkedDashboard.projects ?? [],
+              environment: linkedDashboard.environment ?? [],
+              widgetDisplay: linkedDashboard.widgets.map(w => w.displayType),
+              widgetPreview: linkedDashboard.widgets.map(w => ({
+                displayType: w.displayType,
+                layout: w.layout ?? null,
+              })),
+              dateCreated: linkedDashboard.dateCreated,
+              createdBy: linkedDashboard.createdBy,
+            });
+          }
+          setSelectedDashboardId(linkedDashboard.id);
         }
+
+        setDashboards(dashboardList);
       })
       .finally(() => {
         setIsDashboardListLoading(false);

--- a/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
@@ -59,7 +59,9 @@ export function LinkToDashboardModal({
 
     const dashboardListPromise = fetchDashboards(api, organization.slug);
     const linkedDashboardPromise = currentLinkedDashboard?.dashboardId
-      ? fetchDashboard(api, organization.slug, currentLinkedDashboard.dashboardId)
+      ? fetchDashboard(api, organization.slug, currentLinkedDashboard.dashboardId).catch(
+          () => null
+        )
       : Promise.resolve(null);
 
     Promise.all([dashboardListPromise, linkedDashboardPromise])

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -975,9 +975,12 @@ export function Visualize({error, setError}: VisualizeProps) {
                                         fields[index]?.kind === FieldValueKind.FIELD &&
                                         fields[index]?.field
                                       ) {
+                                        const fieldName = fields[index].field;
                                         const newLinkedDashboards: LinkedDashboard[] = [
-                                          ...linkedDashboards,
-                                          {dashboardId, field: fields[index].field},
+                                          ...linkedDashboards.filter(
+                                            ld => ld.field !== fieldName
+                                          ),
+                                          {dashboardId, field: fieldName},
                                         ];
                                         dispatch({
                                           type: BuilderStateAction.SET_LINKED_DASHBOARDS,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -81,6 +81,7 @@ export type WidgetBuilderStateQueryParams = {
   legendAlias?: string[];
   legendType?: LegendType;
   limit?: number;
+  linkedDashboards?: string[];
   query?: string[];
   selectedAggregate?: number;
   sort?: string[];
@@ -981,6 +982,12 @@ export function useWidgetBuilderState(): {
             setYAxis(deserializeFields(action.payload.yAxis), options);
           }
           setAxisRange(getAxisRange(action.payload.axisRange), options);
+          if (action.payload.linkedDashboards) {
+            setLinkedDashboards(
+              deserializeLinkedDashboards(action.payload.linkedDashboards),
+              options
+            );
+          }
           break;
         case BuilderStateAction.SET_THRESHOLDS:
           setThresholds(action.payload, options);
@@ -1263,7 +1270,9 @@ export function serializeFields(fields: Column[]): string[] {
   });
 }
 
-function serializeLinkedDashboards(linkedDashboards: LinkedDashboard[] = []): string[] {
+export function serializeLinkedDashboards(
+  linkedDashboards: LinkedDashboard[] = []
+): string[] {
   return linkedDashboards.map(linkedDashboard => {
     return JSON.stringify({
       dashboardId: linkedDashboard.dashboardId,

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToStateQueryParams.ts
@@ -3,6 +3,7 @@ import omit from 'lodash/omit';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {
   serializeFields,
+  serializeLinkedDashboards,
   serializeSorts,
   serializeThresholds,
   WIDGET_BUILDER_SESSION_STORAGE_KEY_MAP,
@@ -13,7 +14,7 @@ import {
 export function convertBuilderStateToStateQueryParams(
   state: WidgetBuilderState
 ): WidgetBuilderStateQueryParams {
-  const {fields, yAxis, sort, thresholds, ...rest} = state;
+  const {fields, yAxis, sort, thresholds, linkedDashboards, ...rest} = state;
   const allowedRemainingParams = omit(
     rest,
     // all state params that use session storage instead of url query params
@@ -25,5 +26,8 @@ export function convertBuilderStateToStateQueryParams(
     yAxis: serializeFields(yAxis ?? []),
     sort: serializeSorts(WidgetType.SPANS)(sort ?? []),
     thresholds: thresholds ? serializeThresholds(thresholds) : undefined,
+    linkedDashboards: linkedDashboards
+      ? serializeLinkedDashboards(linkedDashboards)
+      : undefined,
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -9,6 +9,7 @@ import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {getAxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import {
   serializeFields,
+  serializeLinkedDashboards,
   serializeThresholds,
   type WidgetBuilderStateParams,
   type WidgetBuilderStateQueryParams,
@@ -71,6 +72,9 @@ export function convertWidgetToQueryParams(
     legendType: widget.legendType,
     thresholds: widget.thresholds ? serializeThresholds(widget.thresholds) : undefined,
     axisRange: getAxisRange(widget.axisRange) ?? 'auto',
+    linkedDashboards: firstWidgetQuery?.linkedDashboards
+      ? serializeLinkedDashboards(firstWidgetQuery.linkedDashboards)
+      : undefined,
   };
 }
 


### PR DESCRIPTION
Fix the "Link to Dashboard" modal not populating with the pre-existing linked dashboard when editing a widget.

Three issues were addressed:

1. **Linked dashboard not found in list**: The `fetchDashboards` endpoint returns a paginated/sorted list that may not include the currently linked dashboard. Now fetches the linked dashboard separately (in parallel) and merges it into the list if missing.

2. **Linked dashboards lost on edit**: `convertWidgetToQueryParams` didn't carry `linkedDashboards` from the widget query to the builder state, so opening the widget builder for editing always started with empty links. Added serialization of `linkedDashboards` in the conversion and handling in the `SET_STATE` action.

3. **Duplicate linked dashboard entries**: Re-saving an unchanged link appended a duplicate entry because `onLink` always spread the existing array and added a new item. Now filters out the existing entry for the same field before adding.

Fixes BROWSE-450