### PR TITLE
fix(trace): Remove trace spans format

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -4,7 +4,6 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
@@ -66,11 +65,6 @@ class OrganizationTraceEndpoint(OrganizationEventsEndpointBase):
             additional_attributes,
             include_uptime,
             organization=organization,
-        )
-
-    def has_feature(self, organization: Organization, request: Request) -> bool:
-        return bool(
-            features.has("organizations:trace-spans-format", organization, actor=request.user)
         )
 
     def get(self, request: Request, organization: Organization, trace_id: str) -> HttpResponse:

--- a/src/sentry/seer/endpoints/organization_trace_summary.py
+++ b/src/sentry/seer/endpoints/organization_trace_summary.py
@@ -47,11 +47,7 @@ class OrganizationTraceSummaryEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationTraceSummaryPermission,)
 
     def post(self, request: Request, organization: Organization) -> Response:
-        if not features.has(
-            "organizations:single-trace-summary", organization, actor=request.user
-        ) and not features.has(
-            "organizations:trace-spans-format", organization, actor=request.user
-        ):
+        if not features.has("organizations:single-trace-summary", organization, actor=request.user):
             return Response({"detail": "Feature flag not enabled"}, status=400)
 
         data: dict = orjson.loads(request.body) if request.body else {}

--- a/tests/acceptance/test_trace_view_from_explore.py
+++ b/tests/acceptance/test_trace_view_from_explore.py
@@ -17,7 +17,6 @@ class TraceViewFromExploreTest(AcceptanceTestCase, TraceTestCase, SnubaTestCase)
     FEATURES = [
         "organizations:visibility-explore-view",
         "organizations:performance-view",
-        "organizations:trace-spans-format",
     ]
 
     def setUp(self) -> None:

--- a/tests/acceptance/test_trace_view_waterfall.py
+++ b/tests/acceptance/test_trace_view_waterfall.py
@@ -14,7 +14,6 @@ class TraceViewWaterfallTest(AcceptanceTestCase, TraceTestCase, SnubaTestCase):
     FEATURES = [
         "organizations:visibility-explore-view",
         "organizations:performance-view",
-        "organizations:trace-spans-format",
     ]
 
     def setUp(self) -> None:

--- a/tests/sentry/api/endpoints/test_organization_insights_tree.py
+++ b/tests/sentry/api/endpoints/test_organization_insights_tree.py
@@ -13,7 +13,6 @@ class OrganizationInsightsTreeEndpointTest(
     OrganizationEventsEndpointTestBase, SnubaTestCase, SpanTestCase
 ):
     url_name = "sentry-api-0-organization-insights-tree"
-    FEATURES = ["organizations:trace-spans-format"]
 
     def setUp(self) -> None:
         super().setUp()
@@ -86,19 +85,18 @@ class OrganizationInsightsTreeEndpointTest(
 
     def test_get_nextjs_function_data(self) -> None:
         self.login_as(user=self.user)
-        with self.feature(self.FEATURES):
-            response = self.client.get(
-                self.url,
-                data={
-                    "statsPeriod": "14d",
-                    "noPagination": True,
-                    "query": "span.op:function.nextjs",
-                    "mode": "aggregate",
-                    "field": ["span.description", "avg(span.duration)", "count(span.duration)"],
-                    "project": self.project.id,
-                    "dataset": "spans",
-                },
-            )
+        response = self.client.get(
+            self.url,
+            data={
+                "statsPeriod": "14d",
+                "noPagination": True,
+                "query": "span.op:function.nextjs",
+                "mode": "aggregate",
+                "field": ["span.description", "avg(span.duration)", "count(span.duration)"],
+                "project": self.project.id,
+                "dataset": "spans",
+            },
+        )
         assert response.status_code == 200
         span_descriptions = [row["span.description"] for row in response.data["data"]]
         assert "Page Server Component (/app/[category]/[product]/)" in span_descriptions

--- a/tests/sentry/seer/endpoints/test_organization_trace_summary.py
+++ b/tests/sentry/seer/endpoints/test_organization_trace_summary.py
@@ -10,7 +10,6 @@ pytestmark = [requires_snuba]
 
 
 @with_feature("organizations:single-trace-summary")
-@with_feature("organizations:trace-spans-format")
 class OrganizationTraceSummaryEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -191,7 +191,6 @@ class OrganizationEventsTraceEndpointTest(
     OrganizationEventsTraceEndpointBase, UptimeResultEAPTestCase
 ):
     url_name = "sentry-api-0-organization-trace"
-    FEATURES = ["organizations:trace-spans-format"]
 
     def assert_event(self, result, event_data, message):
         assert result["transaction"] == event_data.transaction, message
@@ -274,11 +273,10 @@ class OrganizationEventsTraceEndpointTest(
             kwargs={"organization_id_or_slug": org.slug, "trace_id": uuid4().hex},
         )
 
-        with self.feature(self.FEATURES):
-            response = self.client.get(
-                url,
-                format="json",
-            )
+        response = self.client.get(
+            url,
+            format="json",
+        )
 
         assert response.status_code == 404, response.content
 

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -262,7 +262,6 @@ class OrganizationEventsTraceMetaEndpointTest(
 
 class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, UptimeResultEAPTestCase):
     url_name = "sentry-api-0-organization-trace-meta"
-    FEATURES = ["organizations:trace-spans-format"]
 
     def create_uptime_check(self, trace_id=None, **kwargs):
         defaults = {


### PR DESCRIPTION
- We want to enable the new trace views for am1 customers so we shouldn't restrict our endpoints behind a separate flag anymore
