### PR TITLE
perf(dashboards): Track window resize render duration via Sentry metrics

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -6,6 +6,7 @@ import {Responsive, WidthProvider} from 'react-grid-layout';
 import {forceCheck} from 'react-lazyload';
 import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import cloneDeep from 'lodash/cloneDeep';
 import debounce from 'lodash/debounce';
 
@@ -21,6 +22,7 @@ import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {DatasetSource} from 'sentry/utils/discover/types';
+import {scheduleMicroTask} from 'sentry/utils/scheduleMicroTask';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -133,7 +135,18 @@ export function Dashboard({
   const forceCheckTimeout = useRef<number | undefined>(undefined);
 
   const debouncedHandleResize = useMemo(
-    () => debounce(() => setWindowWidth(window.innerWidth), 250),
+    () =>
+      debounce(() => {
+        const start = performance.now();
+        setWindowWidth(window.innerWidth);
+        scheduleMicroTask(() => {
+          const duration = performance.now() - start;
+          Sentry.metrics.distribution('dashboards.widget.onResize', duration, {
+            unit: 'millisecond',
+            attributes: {page: 'dashboard'},
+          });
+        });
+      }, 250),
     []
   );
 

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import type {Query} from 'history';
 import debounce from 'lodash/debounce';
 import pick from 'lodash/pick';
@@ -36,6 +37,7 @@ import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {scheduleMicroTask} from 'sentry/utils/scheduleMicroTask';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
@@ -281,6 +283,7 @@ function ManageDashboards() {
     const dashboardGridObserver = new ResizeObserver(
       debounce(entries => {
         entries.forEach((entry: any) => {
+          const start = performance.now();
           const currentWidth = entry.contentRect.width;
 
           setRowsAndColumns(currentWidth);
@@ -294,6 +297,14 @@ function ManageDashboards() {
           ) {
             refetchDashboards();
           }
+
+          scheduleMicroTask(() => {
+            const duration = performance.now() - start;
+            Sentry.metrics.distribution('dashboards.widget.onResize', duration, {
+              unit: 'millisecond',
+              attributes: {page: 'manage'},
+            });
+          });
         });
       }, 10)
     );


### PR DESCRIPTION
Track how long React re-renders take in response to window resize events on both the individual dashboard view and the manage dashboards page.

The existing `dashboards.widget.onEdit` metric (in `detail.tsx`) uses the same `performance.now()` + `scheduleMicroTask` pattern to approximate JS render cost. This PR applies the same approach to resize events, which can be expensive as they trigger layout recalculations across the widget grid.

Each sample is tagged with `page: 'dashboard'` or `page: 'manage'` so the two pages can be compared independently in Sentry metrics.

Refs LINEAR-DAIN-1369