### PR TITLE
fix(insights): Respect usePlatformizedView=0 query param

### DIFF
--- a/static/app/views/insights/common/utils/useHasPlatformizedInsights.tsx
+++ b/static/app/views/insights/common/utils/useHasPlatformizedInsights.tsx
@@ -6,8 +6,8 @@ export function useHasPlatformizedInsights() {
   const organization = useOrganization();
   const location = useLocation();
 
-  if (location.query.usePlatformizedView === '1') {
-    return true;
+  if (location.query.usePlatformizedView) {
+    return location.query.usePlatformizedView === '1';
   }
 
   return hasPlatformizedInsights(organization);


### PR DESCRIPTION
Fix the `usePlatformizedView` query parameter to correctly return `false` when set to `0`.

Previously, `?usePlatformizedView=0` would skip the early return and fall through to the organization-level `hasPlatformizedInsights` check, effectively ignoring the explicit opt-out. Now the hook checks for the presence of the query param first, then evaluates its value.

This makes it easier to disable platformized insights to test