### PR TITLE
chore(occ-eap): Drop missing trace id log to debug

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -245,7 +245,7 @@ class SnubaProtocolEventStream(EventStream):
 
         missing_fields = self._missing_required_item_fields(event_data)
         if missing_fields:
-            logger.info(
+            logger.debug(
                 "Event data is missing required fields to forward to items: %s", missing_fields
             )
             return


### PR DESCRIPTION
We've gotten the signal we need — 800k events every 5 minutes are missing their trace_id.
