### PR TITLE
feat(explore): EAP occurrences: resolve issue in query string via group_id

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -831,6 +831,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
             span=request.GET.getlist("spanQuery"),
             log=request.GET.getlist("logQuery"),
             metric=request.GET.getlist("metricQuery"),
+            occurrences=request.GET.getlist("occurrencesQuery"),
         )
 
 

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -818,7 +818,7 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
 
         values: Sequence[str] = rpc_response.values
         if self.context_definition:
-            context = self.context_definition.constructor(self.snuba_params)
+            context = self.context_definition.constructor(self.snuba_params, self.resolver)
             values = [context.value_map.get(value, value) for value in values]
 
         return [

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -381,7 +381,7 @@ class GroupManager(BaseManager["Group"]):
             ]
         ).filter(project__organization=organization_id)
 
-        groups = list(base_group_queryset.filter(short_id_lookup))
+        groups = list(base_group_queryset.filter(short_id_lookup).select_related("project"))
         group_lookup: set[int] = {group.short_id for group in groups}
 
         # If any requested short_ids are missing after the exact slug match,

--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -156,7 +156,7 @@ class AttributeArgumentDefinition(BaseArgumentDefinition):
 
 @dataclass
 class VirtualColumnDefinition:
-    constructor: Callable[[SnubaParams], VirtualColumnContext]
+    constructor: Callable[[SnubaParams, Any], VirtualColumnContext]
     # Allows additional processing to the term after its been resolved
     term_resolver: (
         Callable[
@@ -595,8 +595,8 @@ def datetime_processor(datetime_value: str | float) -> str:
 
 def project_context_constructor(
     column_name: str,
-) -> Callable[[SnubaParams], VirtualColumnContext]:
-    def context_constructor(params: SnubaParams) -> VirtualColumnContext:
+) -> Callable[[SnubaParams, Any], VirtualColumnContext]:
+    def context_constructor(params: SnubaParams, _resolver: Any) -> VirtualColumnContext:
         return VirtualColumnContext(
             from_column_name="sentry.project_id",
             to_column_name=column_name,
@@ -625,7 +625,7 @@ class ColumnDefinitions:
     columns: dict[str, ResolvedAttribute]
     contexts: dict[str, VirtualColumnDefinition]
     trace_item_type: TraceItemType.ValueType
-    filter_aliases: Mapping[str, Callable[[SnubaParams, SearchFilter], list[SearchFilter]]]
+    filter_aliases: Mapping[str, Callable[[SnubaParams, SearchFilter, Any], list[SearchFilter]]]
     alias_to_column: Callable[[str], str | None] | None
     column_to_alias: Callable[[str], str | None] | None
 

--- a/src/sentry/search/eap/common_columns.py
+++ b/src/sentry/search/eap/common_columns.py
@@ -1,5 +1,26 @@
 from sentry.search.eap import constants
-from sentry.search.eap.columns import ResolvedAttribute, datetime_processor
+from sentry.search.eap.columns import (
+    ResolvedAttribute,
+    VirtualColumnDefinition,
+    datetime_processor,
+    project_context_constructor,
+    project_term_resolver,
+)
+
+_PROJECT_VIRTUAL_CONTEXTS: dict[str, VirtualColumnDefinition] = {
+    key: VirtualColumnDefinition(
+        constructor=project_context_constructor(key),
+        term_resolver=project_term_resolver,
+        filter_column="project.id",
+    )
+    for key in constants.PROJECT_FIELDS
+}
+
+
+def project_virtual_contexts() -> dict[str, VirtualColumnDefinition]:
+    """Return a fresh copy of the shared project-field virtual column definitions."""
+    return _PROJECT_VIRTUAL_CONTEXTS.copy()
+
 
 COMMON_COLUMNS = [
     ResolvedAttribute(

--- a/src/sentry/search/eap/occurrences/aggregates.py
+++ b/src/sentry/search/eap/occurrences/aggregates.py
@@ -1,4 +1,8 @@
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Function
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeKey,
+    ExtrapolationMode,
+    Function,
+)
 
 from sentry.search.eap import constants
 from sentry.search.eap.aggregate_utils import (
@@ -23,21 +27,23 @@ OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES = [
     OCCURRENCE_GROUP_ID_KEY,
 ]
 
+COMMON_COUNTABLE_ATTRIBUTE_TYPES = {
+    "duration",
+    "number",
+    "integer",
+    "percentage",
+    "currency",
+    *constants.SIZE_TYPE,
+    *constants.DURATION_TYPE,
+}
+
 OCCURRENCE_AGGREGATE_DEFINITIONS = {
     "avg": AggregateDefinition(
         internal_function=Function.FUNCTION_AVG,
         default_search_type="duration",
         arguments=[
             AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "percentage",
-                    "integer",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
+                attribute_types=COMMON_COUNTABLE_ATTRIBUTE_TYPES,
             )
         ],
     ),
@@ -48,15 +54,7 @@ OCCURRENCE_AGGREGATE_DEFINITIONS = {
         processor=count_processor,
         arguments=[
             AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "integer",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
+                attribute_types=COMMON_COUNTABLE_ATTRIBUTE_TYPES,
                 default_arg="group_id",
             )
         ],
@@ -69,28 +67,16 @@ OCCURRENCE_AGGREGATE_DEFINITIONS = {
         arguments=[
             AttributeArgumentDefinition(
                 attribute_types={
-                    "duration",
-                    "number",
-                    "integer",
-                    "percentage",
-                    "currency",
+                    *COMMON_COUNTABLE_ATTRIBUTE_TYPES,
                     "boolean",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
                 },
                 default_arg="group_id",
             ),
             AttributeArgumentDefinition(
                 attribute_types={
                     "string",
-                    "duration",
-                    "number",
-                    "integer",
-                    "percentage",
-                    "currency",
                     "boolean",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
+                    *COMMON_COUNTABLE_ATTRIBUTE_TYPES,
                 }
             ),
             ValueArgumentDefinition(
@@ -120,14 +106,8 @@ OCCURRENCE_AGGREGATE_DEFINITIONS = {
         arguments=[
             AttributeArgumentDefinition(
                 attribute_types={
-                    "duration",
-                    "number",
-                    "integer",
-                    "percentage",
-                    "currency",
+                    *COMMON_COUNTABLE_ATTRIBUTE_TYPES,
                     "string",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
                 },
             )
         ],
@@ -150,5 +130,19 @@ OCCURRENCE_AGGREGATE_DEFINITIONS = {
                 default_arg="timestamp",
             )
         ],
+    ),
+    "sample_count": AggregateDefinition(
+        internal_function=Function.FUNCTION_COUNT,
+        infer_search_type_from_arguments=False,
+        default_search_type="integer",
+        processor=count_processor,
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types=COMMON_COUNTABLE_ATTRIBUTE_TYPES,
+                default_arg="group_id",
+            )
+        ],
+        attribute_resolver=count_argument_resolver_optimized(OCCURRENCES_ALWAYS_PRESENT_ATTRIBUTES),
+        extrapolation_mode_override=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     ),
 }

--- a/src/sentry/search/eap/occurrences/attributes.py
+++ b/src/sentry/search/eap/occurrences/attributes.py
@@ -1,12 +1,9 @@
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
     ResolvedAttribute,
-    VirtualColumnDefinition,
     datetime_processor,
-    project_context_constructor,
-    project_term_resolver,
 )
-from sentry.search.eap.common_columns import COMMON_COLUMNS
+from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
 from sentry.utils.validators import is_event_id_or_list
 
 OCCURRENCE_ATTRIBUTE_DEFINITIONS = {
@@ -289,10 +286,5 @@ OCCURRENCE_ATTRIBUTE_DEFINITIONS = {
 
 
 OCCURRENCE_VIRTUAL_CONTEXTS = {
-    key: VirtualColumnDefinition(
-        constructor=project_context_constructor(key),
-        term_resolver=project_term_resolver,
-        filter_column="project.id",
-    )
-    for key in constants.PROJECT_FIELDS
+    **project_virtual_contexts(),
 }

--- a/src/sentry/search/eap/occurrences/definitions.py
+++ b/src/sentry/search/eap/occurrences/definitions.py
@@ -6,6 +6,7 @@ from sentry.search.eap.occurrences.attributes import (
     OCCURRENCE_ATTRIBUTE_DEFINITIONS,
     OCCURRENCE_VIRTUAL_CONTEXTS,
 )
+from sentry.search.eap.occurrences.filter_aliases import OCCURRENCE_FILTER_ALIASES
 from sentry.search.eap.occurrences.formulas import OCCURRENCE_FORMULA_DEFINITIONS
 
 OCCURRENCE_DEFINITIONS = ColumnDefinitions(
@@ -14,7 +15,7 @@ OCCURRENCE_DEFINITIONS = ColumnDefinitions(
     columns=OCCURRENCE_ATTRIBUTE_DEFINITIONS,
     contexts=OCCURRENCE_VIRTUAL_CONTEXTS,
     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE,
-    filter_aliases={},
+    filter_aliases=OCCURRENCE_FILTER_ALIASES,
     alias_to_column=None,
     column_to_alias=None,
 )

--- a/src/sentry/search/eap/occurrences/filter_aliases.py
+++ b/src/sentry/search/eap/occurrences/filter_aliases.py
@@ -1,0 +1,68 @@
+from typing import Any
+
+from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.exceptions import InvalidSearchQuery
+from sentry.search.events.filter import to_list
+from sentry.search.events.types import SnubaParams
+
+
+def issue_filter_converter(
+    params: SnubaParams, search_filter: SearchFilter, resolver: Any
+) -> list[SearchFilter]:
+    """
+    Map ``issue`` search filters onto ``group_id``.
+    """
+    if params.organization_id is None:
+        raise InvalidSearchQuery("filter: issue required organization id")
+
+    group_id_key = SearchKey("group_id")
+    raw_values = to_list(search_filter.value.value)
+    short_ids = [v for v in raw_values if v]
+
+    if not short_ids:
+        return _convert_has_issue_filter(search_filter, group_id_key)
+
+    resolved_ids = _get_group_ids(params, short_ids, resolver)
+    mapped_value: list[int] | int
+    if search_filter.is_in_filter:
+        mapped_value = resolved_ids
+    else:
+        mapped_value = resolved_ids[0]
+
+    return [
+        SearchFilter(
+            key=group_id_key,
+            operator=search_filter.operator,
+            value=SearchValue(mapped_value),
+        )
+    ]
+
+
+def _get_group_ids(params: SnubaParams, issue_identifiers: list[str], resolver: Any) -> list[int]:
+    cache: dict[int, dict[str, int]] = resolver.qualified_short_id_to_group_id_cache
+    group_id_issue_map = {}
+    for project_id in params.project_ids:
+        # All project_ids will exist.
+        group_id_issue_map.update(cache.get(project_id, {}))
+
+    return sorted(group_id_issue_map[issue_id] for issue_id in issue_identifiers)
+
+
+def _convert_has_issue_filter(
+    search_filter: SearchFilter, group_id_key: SearchKey
+) -> list[SearchFilter]:
+    """Empty parsed value: only ``has:issue`` (``!=``) is supported for occurrences."""
+    if search_filter.operator != "!=":
+        raise InvalidSearchQuery("issue filter with no short id only supports operator !=")
+    return [
+        SearchFilter(
+            key=group_id_key,
+            operator=search_filter.operator,
+            value=SearchValue(search_filter.value.value),
+        )
+    ]
+
+
+OCCURRENCE_FILTER_ALIASES = {
+    "issue": issue_filter_converter,
+}

--- a/src/sentry/search/eap/occurrences/formulas.py
+++ b/src/sentry/search/eap/occurrences/formulas.py
@@ -1,3 +1,5 @@
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
+
 from sentry.search.eap.columns import FormulaDefinition
 from sentry.search.eap.common_formulas import make_epm, make_eps
 from sentry.search.eap.occurrences.aggregates import OCCURRENCE_GROUP_ID_KEY
@@ -14,5 +16,19 @@ OCCURRENCE_FORMULA_DEFINITIONS = {
         arguments=[],
         formula_resolver=make_epm(OCCURRENCE_GROUP_ID_KEY),
         is_aggregate=True,
+    ),
+    "sample_eps": FormulaDefinition(
+        default_search_type="rate",
+        arguments=[],
+        formula_resolver=make_eps(OCCURRENCE_GROUP_ID_KEY),
+        is_aggregate=True,
+        extrapolation_mode_override=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+    ),
+    "sample_epm": FormulaDefinition(
+        default_search_type="rate",
+        arguments=[],
+        formula_resolver=make_epm(OCCURRENCE_GROUP_ID_KEY),
+        is_aggregate=True,
+        extrapolation_mode_override=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     ),
 }

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -3,12 +3,9 @@ from typing import Literal
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
     ResolvedAttribute,
-    VirtualColumnDefinition,
-    project_context_constructor,
-    project_term_resolver,
     simple_sentry_field,
 )
-from sentry.search.eap.common_columns import COMMON_COLUMNS
+from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
 from sentry.utils.validators import is_event_id_or_list
 
 OURLOG_ATTRIBUTE_DEFINITIONS = {
@@ -103,14 +100,7 @@ for field in {constants.TIMESTAMP_ALIAS, constants.TIMESTAMP_PRECISE_ALIAS, cons
     assert field in OURLOG_ATTRIBUTE_DEFINITIONS, f"{field} must be defined for ourlogs"
 
 
-OURLOG_VIRTUAL_CONTEXTS = {
-    key: VirtualColumnDefinition(
-        constructor=project_context_constructor(key),
-        term_resolver=project_term_resolver,
-        filter_column="project.id",
-    )
-    for key in constants.PROJECT_FIELDS
-}
+OURLOG_VIRTUAL_CONTEXTS = project_virtual_contexts()
 
 LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
     Literal["string", "number", "boolean"], dict[str, str]

--- a/src/sentry/search/eap/profile_functions/attributes.py
+++ b/src/sentry/search/eap/profile_functions/attributes.py
@@ -1,13 +1,8 @@
 from typing import Literal
 
 from sentry.search.eap import constants
-from sentry.search.eap.columns import (
-    ResolvedAttribute,
-    VirtualColumnDefinition,
-    project_context_constructor,
-    project_term_resolver,
-)
-from sentry.search.eap.common_columns import COMMON_COLUMNS
+from sentry.search.eap.columns import ResolvedAttribute
+from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
 from sentry.utils.validators import is_event_id_or_list
 
 PROFILE_FUNCTIONS_ATTRIBUTE_DEFINITIONS = {
@@ -130,14 +125,7 @@ for field in {constants.TIMESTAMP_ALIAS, constants.TRACE_ALIAS}:
         f"{field} must be defined for profile functions"
     )
 
-PROFILE_FUNCTIONS_VIRTUAL_CONTEXTS = {
-    key: VirtualColumnDefinition(
-        constructor=project_context_constructor(key),
-        term_resolver=project_term_resolver,
-        filter_column="project.id",
-    )
-    for key in constants.PROJECT_FIELDS
-}
+PROFILE_FUNCTIONS_VIRTUAL_CONTEXTS = project_virtual_contexts()
 
 PROFILE_FUNCTIONS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
     Literal["string", "number", "boolean"], dict[str, str]

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -39,6 +39,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 from sentry.api import event_search
 from sentry.discover import arithmetic
 from sentry.exceptions import InvalidSearchQuery
+from sentry.models.group import Group, parse_short_id
 from sentry.models.project import Project
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
@@ -63,7 +64,23 @@ from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.events import constants as qb_constants
 from sentry.search.events import fields
 from sentry.search.events import filter as event_filter
+from sentry.search.events.datasets.discover import InvalidIssueSearchQuery
+from sentry.search.events.filter import to_list
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
+
+
+def collect_issue_short_ids_from_parsed_terms(terms: Sequence[object]) -> set[str]:
+    """Collect non-empty issue filter values from a parsed search tree (including OR/AND)."""
+    out: set[str] = set()
+    for term in terms:
+        if isinstance(term, event_search.SearchFilter):
+            if term.key.name == "issue":
+                for v in to_list(term.value.value):
+                    if v:
+                        out.add(str(v))
+        elif isinstance(term, event_search.ParenExpression):
+            out |= collect_issue_short_ids_from_parsed_terms(term.children)
+    return out
 
 
 @dataclass(frozen=True)
@@ -88,6 +105,7 @@ class SearchResolver:
             VirtualColumnDefinition | None,
         ],
     ] = field(default_factory=dict)
+    qualified_short_id_to_group_id_cache: dict[int, dict[str, int]] = field(default_factory=dict)
 
     def get_function_definition(
         self, function_name: str
@@ -201,6 +219,39 @@ class SearchResolver:
             )
         )
 
+    def _init_issue_short_id_cache(
+        self,
+        parsed_terms: Sequence[object],
+    ) -> None:
+        """One bulk Group lookup for issue short ids in the query; store maps on this resolver."""
+        if "issue" not in self.definitions.filter_aliases or self.params.organization_id is None:
+            return
+
+        collected = collect_issue_short_ids_from_parsed_terms(parsed_terms)
+        if not collected:
+            return
+        try:
+            groups = list(
+                Group.objects.by_qualified_short_id_bulk(
+                    organization_id=self.params.organization_id, short_ids_raw=list(collected)
+                )
+            )
+        except Group.DoesNotExist:
+            raise InvalidIssueSearchQuery(sorted(collected))
+
+        idx = {(g.project.slug.lower(), g.short_id): g for g in groups}
+
+        for raw in collected:
+            parsed = parse_short_id(raw)
+            if parsed is None:
+                raise InvalidIssueSearchQuery(sorted(collected))
+            g = idx.get((parsed.project_slug, parsed.short_id))
+            if g is None:
+                raise InvalidIssueSearchQuery(sorted(collected))
+            if g.project.id not in self.qualified_short_id_to_group_id_cache:
+                self.qualified_short_id_to_group_id_cache[g.project.id] = {}
+            self.qualified_short_id_to_group_id_cache[g.project.id][raw] = g.id
+
     def __resolve_query(
         self, querystring: str | None
     ) -> tuple[
@@ -226,6 +277,9 @@ class SearchResolver:
                 raise InvalidSearchQuery(f"Parse error: {e.expr.name} (column {e.column():d})")
             else:
                 raise InvalidSearchQuery(f"Parse error for: {querystring}")
+
+        # If occurrences dataset, cache group_id to issues mapping.
+        self._init_issue_short_id_cache(parsed_terms)
 
         if any(
             isinstance(term, event_search.ParenExpression)
@@ -392,7 +446,7 @@ class SearchResolver:
     ) -> list[str] | str:
         # Convert the term to the expected values
         final_raw_value: str | list[str] = []
-        resolved_context = context.constructor(self.params)
+        resolved_context = context.constructor(self.params, self)
         reversed_context = {v: k for k, v in resolved_context.value_map.items()}
         if isinstance(raw_value, list):
             new_value = []
@@ -437,7 +491,7 @@ class SearchResolver:
 
         converter = self.definitions.filter_aliases.get(name)
         if converter is not None:
-            return converter(self.params, term)
+            return converter(self.params, term, self)
 
         return [term]
 
@@ -664,7 +718,7 @@ class SearchResolver:
         Time series request do not support virtual column contexts, so we have to remap the value back to the original column.
         (see https://github.com/getsentry/eap-planning/issues/236)
         """
-        context = context_definition.constructor(self.params)
+        context = context_definition.constructor(self.params, self)
 
         is_number_column = (
             context.from_column_name in SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS["number"]
@@ -695,7 +749,7 @@ class SearchResolver:
         Time series request do not support virtual column contexts, so we have to remap the value back to the original column.
         (see https://github.com/getsentry/eap-planning/issues/236)
         """
-        context = context_definition.constructor(self.params)
+        context = context_definition.constructor(self.params, self)
         is_number_column = (
             context.from_column_name in SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS["number"]
         )
@@ -856,7 +910,7 @@ class SearchResolver:
         for context_definition in context_definitions:
             if context_definition is None:
                 continue
-            context = context_definition.constructor(self.params)
+            context = context_definition.constructor(self.params, self)
             if context is None or context.to_column_name in existing_target_columns:
                 continue
             else:
@@ -1288,7 +1342,7 @@ class SearchResolver:
     def remap_value_using_context_definition(
         self, context_definition: VirtualColumnDefinition, value: str | int | list[str] | Any
     ) -> str | int | list[str] | Any:
-        context = context_definition.constructor(self.params)
+        context = context_definition.constructor(self.params, self)
 
         # if the value passed is one of the potential values, then it's expected
         # and we should pass it through as is

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -10,12 +10,10 @@ from sentry.search.eap import constants
 from sentry.search.eap.columns import (
     ResolvedAttribute,
     VirtualColumnDefinition,
-    project_context_constructor,
-    project_term_resolver,
     simple_measurements_field,
     simple_sentry_field,
 )
-from sentry.search.eap.common_columns import COMMON_COLUMNS
+from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
 from sentry.search.eap.spans.sentry_conventions import SENTRY_CONVENTIONS_DIRECTORY
 from sentry.search.events.constants import (
     PRECISE_FINISH_TS,
@@ -553,7 +551,7 @@ except Exception as e:
     logger.exception("Failed to update attribute definitions: %s", e)
 
 
-def device_class_context_constructor(params: SnubaParams) -> VirtualColumnContext:
+def device_class_context_constructor(params: SnubaParams, _resolver: Any) -> VirtualColumnContext:
     # EAP defaults to lower case `unknown`, but in querybuilder we used `Unknown`
     value_map = {"": "Unknown"}
     for device_class, values in DEVICE_CLASS.items():
@@ -567,7 +565,7 @@ def device_class_context_constructor(params: SnubaParams) -> VirtualColumnContex
     )
 
 
-def module_context_constructor(params: SnubaParams) -> VirtualColumnContext:
+def module_context_constructor(params: SnubaParams, _resolver: Any) -> VirtualColumnContext:
     value_map = {key: key for key in SPAN_MODULE_CATEGORY_VALUES}
     return VirtualColumnContext(
         from_column_name="sentry.category",
@@ -576,7 +574,9 @@ def module_context_constructor(params: SnubaParams) -> VirtualColumnContext:
     )
 
 
-def is_starred_segment_context_constructor(params: SnubaParams) -> VirtualColumnContext:
+def is_starred_segment_context_constructor(
+    params: SnubaParams, _resolver: Any
+) -> VirtualColumnContext:
     if params.user is None or params.organization_id is None:
         raise ValueError("User and organization is required for is_starred_transaction")
 
@@ -691,14 +691,8 @@ SPAN_VIRTUAL_CONTEXTS = {
         default_value="false",
         processor=lambda x: True if x == "true" else False,
     ),
+    **project_virtual_contexts(),
 }
-
-for key in constants.PROJECT_FIELDS:
-    SPAN_VIRTUAL_CONTEXTS[key] = VirtualColumnDefinition(
-        constructor=project_context_constructor(key),
-        term_resolver=project_term_resolver,
-        filter_column="project.id",
-    )
 
 SPAN_INTERNAL_TO_SECONDARY_ALIASES_MAPPING: dict[str, set[str]] = {}
 

--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -1,5 +1,5 @@
 import string
-from typing import Literal
+from typing import Any, Literal
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.exceptions import InvalidSearchQuery
@@ -17,7 +17,7 @@ from sentry.search.utils import parse_release, validate_snuba_array_parameter
 
 
 def release_filter_converter(
-    params: SnubaParams, search_filter: SearchFilter
+    params: SnubaParams, search_filter: SearchFilter, _resolver: Any
 ) -> list[SearchFilter]:
     if search_filter.value.is_wildcard():
         operator = search_filter.operator
@@ -47,7 +47,7 @@ def release_filter_converter(
 
 
 def release_stage_filter_converter(
-    params: SnubaParams, search_filter: SearchFilter
+    params: SnubaParams, search_filter: SearchFilter, _resolver: Any
 ) -> list[SearchFilter]:
     organization_id = params.organization_id
     if organization_id is None:
@@ -80,7 +80,9 @@ def release_stage_filter_converter(
     return [SearchFilter(SearchKey(constants.RELEASE_ALIAS), "IN", SearchValue(versions))]
 
 
-def semver_filter_converter(params: SnubaParams, search_filter: SearchFilter) -> list[SearchFilter]:
+def semver_filter_converter(
+    params: SnubaParams, search_filter: SearchFilter, _resolver: Any
+) -> list[SearchFilter]:
     organization_id = params.organization_id
     if organization_id is None:
         raise ValueError("organization is a required param")
@@ -143,7 +145,7 @@ def semver_filter_converter(params: SnubaParams, search_filter: SearchFilter) ->
 
 
 def semver_package_filter_converter(
-    params: SnubaParams, search_filter: SearchFilter
+    params: SnubaParams, search_filter: SearchFilter, _resolver: Any
 ) -> list[SearchFilter]:
     organization_id = params.organization_id
     if organization_id is None:
@@ -176,7 +178,7 @@ def semver_package_filter_converter(
 
 
 def semver_build_filter_converter(
-    params: SnubaParams, search_filter: SearchFilter
+    params: SnubaParams, search_filter: SearchFilter, _resolver: Any
 ) -> list[SearchFilter]:
     organization_id = params.organization_id
     if organization_id is None:
@@ -217,7 +219,9 @@ def semver_build_filter_converter(
     return [SearchFilter(SearchKey(constants.RELEASE_ALIAS), "IN", SearchValue(versions))]
 
 
-def trace_filter_converter(params: SnubaParams, search_filter: SearchFilter) -> list[SearchFilter]:
+def trace_filter_converter(
+    params: SnubaParams, search_filter: SearchFilter, _resolver: Any
+) -> list[SearchFilter]:
     operator = search_filter.operator
     value = search_filter.value.value
 

--- a/src/sentry/search/eap/trace_metrics/attributes.py
+++ b/src/sentry/search/eap/trace_metrics/attributes.py
@@ -3,12 +3,9 @@ from typing import Literal
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
     ResolvedAttribute,
-    VirtualColumnDefinition,
-    project_context_constructor,
-    project_term_resolver,
     simple_sentry_field,
 )
-from sentry.search.eap.common_columns import COMMON_COLUMNS
+from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
 from sentry.utils.validators import is_event_id_or_list
 
 TRACE_METRICS_ATTRIBUTE_DEFINITIONS = {
@@ -73,14 +70,7 @@ for field in {constants.TIMESTAMP_ALIAS, constants.TIMESTAMP_PRECISE_ALIAS, cons
         f"{field} must be defined for trace metrics"
     )
 
-TRACE_METRICS_VIRTUAL_CONTEXTS = {
-    key: VirtualColumnDefinition(
-        constructor=project_context_constructor(key),
-        term_resolver=project_term_resolver,
-        filter_column="project.id",
-    )
-    for key in constants.PROJECT_FIELDS
-}
+TRACE_METRICS_VIRTUAL_CONTEXTS = project_virtual_contexts()
 
 TRACE_METRICS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
     Literal["string", "number", "boolean"], dict[str, str]

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -91,3 +91,4 @@ class AdditionalQueries:
     span: list[str] | None
     log: list[str] | None
     metric: list[str] | None
+    occurrences: list[str] | None

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -180,6 +180,7 @@ class RPCBase:
         config: SearchResolverConfig,
         query_params: SnubaParams,
     ) -> list[TraceItemFilterWithType]:
+        from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
         from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
         from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
         from sentry.search.eap.trace_metrics.definitions import TRACE_METRICS_DEFINITIONS
@@ -203,6 +204,11 @@ class RPCBase:
                 additional_queries.metric,
                 TRACE_METRICS_DEFINITIONS,
                 TraceItemType.TRACE_ITEM_TYPE_METRIC,
+            ),
+            (
+                additional_queries.occurrences,
+                OCCURRENCE_DEFINITIONS,
+                TraceItemType.TRACE_ITEM_TYPE_OCCURRENCE,
             ),
         ]:
             if queries is not None:
@@ -1000,7 +1006,9 @@ class RPCBase:
 
                     groupby_value = groupby_attributes[resolved_groupby.internal_name]
                     if context is not None:
-                        groupby_value = context.constructor(params).value_map[groupby_value]
+                        groupby_value = context.constructor(params, search_resolver).value_map[
+                            groupby_value
+                        ]
                         groupby_attributes[resolved_groupby.internal_name] = groupby_value
 
                     remapped_groupby[col] = groupby_value

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3557,6 +3557,7 @@ class OccurrenceTestCase(BaseTestCase, TraceItemTestCase):
         tags: dict[str, str] | None = None,
         attributes: dict[str, Any] | None = None,
         retention_days: int = 90,
+        client_sample_rate: float = 1.0,
     ) -> TraceItem:
         if organization is None:
             organization = self.organization
@@ -3603,6 +3604,7 @@ class OccurrenceTestCase(BaseTestCase, TraceItemTestCase):
             received=timestamp_proto,
             retention_days=retention_days,
             attributes=attributes_proto,
+            client_sample_rate=client_sample_rate,
         )
 
 

--- a/tests/sentry/search/eap/test_occurrences.py
+++ b/tests/sentry/search/eap/test_occurrences.py
@@ -1,0 +1,32 @@
+"""Test Occurrences related utils in SearchResolver"""
+
+from sentry.api import event_search
+from sentry.api.event_search import QueryToken, SearchFilter, SearchKey, SearchValue
+from sentry.search.eap.resolver import collect_issue_short_ids_from_parsed_terms
+
+
+def test_collect_issue_short_ids_flat_and_parens() -> None:
+    terms = [
+        SearchFilter(SearchKey("issue"), "=", SearchValue("PROJ-1")),
+        event_search.SearchBoolean.BOOLEAN_OR,
+        SearchFilter(SearchKey("issue"), "=", SearchValue("PROJ-2")),
+    ]
+    assert collect_issue_short_ids_from_parsed_terms(terms) == {"PROJ-1", "PROJ-2"}
+
+
+def test_collect_issue_short_ids_nested() -> None:
+    inner: list[QueryToken] = [
+        SearchFilter(SearchKey("issue"), "=", SearchValue("A-1")),
+        event_search.SearchBoolean.BOOLEAN_OR,  # type: ignore[list-item]
+        SearchFilter(SearchKey("issue"), "=", SearchValue("B-2")),
+    ]
+    terms = [event_search.ParenExpression(inner)]
+    assert collect_issue_short_ids_from_parsed_terms(terms) == {"A-1", "B-2"}
+
+
+def test_collect_issue_skips_empty_and_other_keys() -> None:
+    terms = [
+        SearchFilter(SearchKey("environment"), "=", SearchValue("prod")),
+        SearchFilter(SearchKey("issue"), "!=", SearchValue("")),
+    ]
+    assert collect_issue_short_ids_from_parsed_terms(terms) == set()

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -28,6 +28,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 
 from sentry.exceptions import InvalidSearchQuery
+from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.spans.sentry_conventions import SENTRY_CONVENTIONS_DIRECTORY
@@ -647,6 +648,28 @@ class SearchResolverQueryTest(TestCase):
             )
         )
 
+    def test_cache_update_for_issues(self) -> None:
+        resolver = SearchResolver(
+            params=SnubaParams(organization=self.organization, projects=[self.project]),
+            config=SearchResolverConfig(),
+            definitions=OCCURRENCE_DEFINITIONS,
+        )
+        group1 = self.create_group(project=self.project)
+        group2 = self.create_group(project=self.project)
+        resolver.resolve_query(f"issue:{group1.qualified_short_id}")
+        project_id = group1.project_id
+        assert project_id in resolver.qualified_short_id_to_group_id_cache
+        assert len(resolver.qualified_short_id_to_group_id_cache[project_id]) == 1
+        assert (
+            group1.qualified_short_id in resolver.qualified_short_id_to_group_id_cache[project_id]
+        )
+
+        resolver.resolve_query(f"issue:{group2.qualified_short_id}")
+        assert len(resolver.qualified_short_id_to_group_id_cache[project_id]) == 2
+        assert (
+            group2.qualified_short_id in resolver.qualified_short_id_to_group_id_cache[project_id]
+        )
+
 
 class SearchResolverColumnTest(TestCase):
     def setUp(self) -> None:
@@ -671,7 +694,9 @@ class SearchResolverColumnTest(TestCase):
             name="project", type=AttributeKey.Type.TYPE_STRING
         )
         assert virtual_context is not None
-        assert virtual_context.constructor(self.resolver.params) == VirtualColumnContext(
+        assert virtual_context.constructor(
+            self.resolver.params, self.resolver
+        ) == VirtualColumnContext(
             from_column_name="sentry.project_id",
             to_column_name="project",
             value_map={str(self.project.id): self.project.slug},
@@ -683,7 +708,9 @@ class SearchResolverColumnTest(TestCase):
             name="project.slug", type=AttributeKey.Type.TYPE_STRING
         )
         assert virtual_context is not None
-        assert virtual_context.constructor(self.resolver.params) == VirtualColumnContext(
+        assert virtual_context.constructor(
+            self.resolver.params, self.resolver
+        ) == VirtualColumnContext(
             from_column_name="sentry.project_id",
             to_column_name="project.slug",
             value_map={str(self.project.id): self.project.slug},

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -2,7 +2,11 @@ import uuid
 from datetime import timedelta
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from rest_framework.response import Response
 
+from sentry.models.group import Group
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.testutils.cases import OccurrenceTestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -19,6 +23,14 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
     def setUp(self) -> None:
         super().setUp()
 
+    def request_with_feature_flag(self, payload: dict) -> Response:
+        with self.options(
+            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+        ):
+            response = self.do_request({**payload, "dataset": "occurrences"})
+        assert response.status_code == 200, response.content
+        return response
+
     def test_simple(self) -> None:
         event_id = uuid.uuid4().hex
         trace_id = uuid.uuid4().hex
@@ -34,17 +46,12 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         )
         self.store_eap_items([occ])
 
-        with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
-        ):
-            response = self.do_request(
-                {
-                    "field": ["id", "group_id", "trace"],
-                    "project": [self.project.id],
-                    "dataset": "occurrences",
-                }
-            )
-        assert response.status_code == 200
+        response = self.request_with_feature_flag(
+            {
+                "field": ["id", "group_id", "trace"],
+                "project": [self.project.id],
+            }
+        )
         assert len(response.data["data"]) == 1
         row = response.data["data"][0]
         assert row["id"] == event_id
@@ -66,18 +73,14 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         )
         self.store_eap_items([occ])
 
-        with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
-        ):
-            response = self.do_request(
-                {
-                    "field": ["count()"],
-                    "statsPeriod": "1h",
-                    "query": f"project:{group.project.slug} group_id:{group.id}",
-                    "dataset": "occurrences",
-                }
-            )
-        assert response.status_code == 200, response.content
+        response = self.request_with_feature_flag(
+            {
+                "field": ["count()", "group_id"],
+                "statsPeriod": "1h",
+                "query": f"project:{group.project.slug} group_id:{group.id}",
+            }
+        )
+
         assert response.data["data"][0]["count()"] == 1
 
     def _request_table_rate(self, field: str):
@@ -96,22 +99,17 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
             ),
         ]
         self.store_eap_items(occurrences)
-        with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
-        ):
-            return self.do_request(
-                {
-                    "field": [field],
-                    "statsPeriod": "2h",
-                    "project": [self.project.id],
-                    "dataset": "occurrences",
-                }
-            )
+        return self.request_with_feature_flag(
+            {
+                "field": [field],
+                "statsPeriod": "2h",
+                "project": [self.project.id],
+            }
+        )
 
     def test_eps_rate_aggregate(self) -> None:
         # 2 events / 7200 seconds (2h).
         response = self._request_table_rate("eps()")
-        assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
         assert data[0]["eps()"] == pytest.approx(2 / 7200, abs=0.0001)
@@ -122,7 +120,6 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
     def test_epm_rate_aggregate(self) -> None:
         # 2 events / (7200/60) = 2/120 per minute.
         response = self._request_table_rate("epm()")
-        assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
         assert data[0]["epm()"] == pytest.approx(2 / (7200 / 60), abs=0.001)
@@ -148,19 +145,13 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
                 ),
             ]
         )
-        with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
-        ):
-            response = self.do_request(
-                {
-                    "field": ["count()", "count_unique(level)"],
-                    "statsPeriod": "1h",
-                    "project": [self.project.id],
-                    "dataset": "occurrences",
-                }
-            )
-
-        assert response.status_code == 200, response.content
+        response = self.request_with_feature_flag(
+            {
+                "field": ["count()", "count_unique(level)"],
+                "statsPeriod": "1h",
+                "project": [self.project.id],
+            }
+        )
         data = response.data["data"]
         assert len(data) == 1
         assert data[0]["count()"] == 2
@@ -192,22 +183,18 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
                     )
                 ]
             )
-        with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
-        ):
-            response = self.do_request(
-                {
-                    "field": [
-                        "count()",
-                        "count_if(level,equals,error)",
-                        "count_if(level,notEquals,error)",
-                    ],
-                    "statsPeriod": "1h",
-                    "project": [self.project.id],
-                    "dataset": "occurrences",
-                }
-            )
-        assert response.status_code == 200, response.content
+
+        response = self.request_with_feature_flag(
+            {
+                "field": [
+                    "count()",
+                    "count_if(level,equals,error)",
+                    "count_if(level,notEquals,error)",
+                ],
+                "statsPeriod": "1h",
+                "project": [self.project.id],
+            }
+        )
         data = response.data["data"]
         assert len(data) == 1
         assert data[0]["count()"] == 5
@@ -235,20 +222,256 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
                 ),
             ]
         )
-        with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
-        ):
-            response = self.do_request(
-                {
-                    "field": ["last_seen()"],
-                    "statsPeriod": "2h",
-                    "project": [self.project.id],
-                    "dataset": "occurrences",
-                }
-            )
-        assert response.status_code == 200, response.content
+
+        response = self.request_with_feature_flag(
+            {
+                "field": ["last_seen()"],
+                "statsPeriod": "2h",
+                "project": [self.project.id],
+            }
+        )
+
         data = response.data["data"]
         assert len(data) == 1
         # EAP returns last_seen as Unix timestamp in seconds (float).
         expected_seconds = (base + timedelta(minutes=10)).timestamp()
         assert data[0]["last_seen()"] == pytest.approx(expected_seconds, abs=1)
+
+    def test_issue_filter(self):
+        group1 = self.create_group(project=self.project)
+        group2 = self.create_group(project=self.project)
+        occurrences = [
+            self.create_eap_occurrence(
+                group_id=group1.id,
+                project=self.project,
+                attributes={"fingerprint": ["g1"]},
+            ),
+            self.create_eap_occurrence(
+                group_id=group2.id,
+                project=self.project,
+                attributes={"fingerprint": ["g2"]},
+            ),
+        ]
+        self.store_eap_items(occurrences)
+        response = self.request_with_feature_flag(
+            {
+                "query": f"issue:{group1.qualified_short_id}",
+                "field": ["group_id", "project", "project.name"],
+                "statsPeriod": "2h",
+                "project": [self.project.id],
+            }
+        )
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["group_id"] == group1.id
+
+    def test_issue_filter_or_two_short_ids(self) -> None:
+        """Several issue: terms should resolve via one primed bulk lookup (not one DB round-trip per OR branch)."""
+        group1 = self.create_group(project=self.project)
+        group2 = self.create_group(project=self.project)
+        occurrences = [
+            self.create_eap_occurrence(
+                group_id=group1.id,
+                project=self.project,
+                attributes={"fingerprint": ["g1"]},
+            ),
+            self.create_eap_occurrence(
+                group_id=group2.id,
+                project=self.project,
+                attributes={"fingerprint": ["g2"]},
+            ),
+        ]
+        self.store_eap_items(occurrences)
+        response = self.request_with_feature_flag(
+            {
+                "query": (
+                    f"issue:{group1.qualified_short_id} OR issue:{group2.qualified_short_id}"
+                ),
+                "field": ["group_id", "project", "project.name"],
+                "statsPeriod": "2h",
+                "project": [self.project.id],
+            }
+        )
+        data = response.data["data"]
+        assert len(data) == 2
+        assert {row["group_id"] for row in data} == {group1.id, group2.id}
+
+    def test_has_filter_on_project(self) -> None:
+        group1 = self.create_group(project=self.project)
+        occurrences = [
+            self.create_eap_occurrence(
+                group_id=group1.id,
+                project=self.project,
+                attributes={"fingerprint": ["g1"]},
+            ),
+            self.create_eap_occurrence(
+                project=self.project,
+                attributes={"fingerprint": ["g2"]},
+            ),
+        ]
+        self.store_eap_items(occurrences)
+        response = self.request_with_feature_flag(
+            {
+                "query": "has:issue",
+                "field": ["group_id", "project", "project.name"],
+                "statsPeriod": "2h",
+                "project": [self.project.id],
+            }
+        )
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["group_id"] == group1.id
+
+    def test_additional_query_with_logs(self) -> None:
+        grp_a = self.create_group(project=self.project)
+        grp_b = self.create_group(project=self.project)
+        trace_id = uuid.uuid4().hex
+        excluded_trace_id = uuid.uuid4().hex
+        occurrences = [
+            self.create_eap_occurrence(
+                group_id=grp_a.id,
+                project=self.project,
+                tags={"foo": "five"},
+                title="baz",
+                trace_id=trace_id,
+            ),
+            self.create_eap_occurrence(
+                group_id=grp_b.id,
+                project=self.project,
+                tags={"foo": "eight"},
+                title="baz",
+                trace_id=excluded_trace_id,
+            ),
+        ]
+        logs = [
+            self.create_ourlog(
+                extra_data={"trace_id": trace_id, "body": "foo"},
+            ),
+            self.create_ourlog(
+                extra_data={"trace_id": excluded_trace_id, "body": "bar"},
+            ),
+        ]
+        self.store_eap_items(logs + occurrences)
+
+        response = self.request_with_feature_flag(
+            {
+                "query": "title:baz",
+                "field": ["title", "trace"],
+                "project": [self.project.id],
+                "logQuery": ["message:foo"],
+            }
+        )
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["trace"] == trace_id
+
+    def test_sampled_vs_upsampled_eps(self):
+        group1 = self.create_group(project=self.project)
+        group2 = self.create_group(project=self.project)
+        occurrences = [
+            self.create_eap_occurrence(
+                group_id=group1.id,
+                project=self.project,
+                attributes={"fingerprint": ["g1"]},
+                client_sample_rate=0.1,
+            ),
+            self.create_eap_occurrence(
+                group_id=group2.id,
+                project=self.project,
+                attributes={"fingerprint": ["g2"]},
+            ),
+            self.create_eap_occurrence(
+                group_id=group2.id,
+                project=self.project,
+                attributes={"fingerprint": ["g2"]},
+            ),
+        ]
+
+        self.store_eap_items(occurrences)
+        response = self.request_with_feature_flag(
+            {
+                "field": ["eps()", "sample_eps()", "group_id"],
+                "statsPeriod": "2h",
+                "project": [self.project.id],
+            }
+        )
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        data = sorted(data, key=lambda x: x["group_id"])
+        group1_data = data[0]
+        group2_data = data[1]
+        # Group1, sample rate => 0.1 => 10,
+        # Group2 no sample rate.
+        assert group1_data["sample_eps()"] == pytest.approx(1 / 7200, abs=0.001)
+        assert group1_data["eps()"] == pytest.approx(10 / 7200, abs=0.001)
+
+        assert group2_data["sample_eps()"] == pytest.approx(2 / 7200, abs=0.001)
+        assert group2_data["eps()"] == pytest.approx(2 / 7200, abs=0.001)
+
+        assert meta["fields"]["eps()"] == "rate"
+        assert meta["units"]["eps()"] == "1/second"
+        assert meta["fields"]["sample_eps()"] == "rate"
+        assert meta["units"]["sample_eps()"] == "1/second"
+
+    def test_sample_vs_upsampled_count(self):
+        group1 = self.create_group(project=self.project)
+        occurrences = [
+            self.create_eap_occurrence(
+                group_id=group1.id,
+                project=self.project,
+                attributes={"fingerprint": ["g1"]},
+                client_sample_rate=0.1,
+            )
+        ]
+
+        self.store_eap_items(occurrences)
+        response = self.request_with_feature_flag(
+            {
+                "field": ["count()", "sample_count()", "group_id"],
+                "statsPeriod": "2h",
+                "project": [self.project.id],
+            }
+        )
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["count()"] == 10
+        assert data[0]["sample_count()"] == 1
+        assert data[0]["group_id"] == group1.id
+
+    def test_three_issue_uses_single_group_table_query(self) -> None:
+        """
+        Prime + cached map: resolving issue:A OR issue:B OR issue:C must not call
+        by_qualified_short_id_bulk once per OR branch (each converter run).
+        """
+        g1 = self.create_group(project=self.project)
+        g2 = self.create_group(project=self.project)
+        g3 = self.create_group(project=self.project)
+        occurrences = [
+            self.create_eap_occurrence(
+                group_id=g1.id,
+                project=self.project,
+                attributes={"fingerprint": ["g1"]},
+                client_sample_rate=0.1,
+            )
+        ]
+        self.store_eap_items(occurrences)
+
+        query_string = (
+            f"issue:{g1.qualified_short_id} OR issue:{g2.qualified_short_id} OR "
+            f"issue:{g3.qualified_short_id}"
+        )
+        group_table = Group._meta.db_table
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.request_with_feature_flag(
+                {
+                    "field": ["count()", "sample_count()", "group_id"],
+                    "query": query_string,
+                    "statsPeriod": "2h",
+                    "project": [self.project.id],
+                }
+            )
+        group_sql_hits = sum(1 for q in ctx.captured_queries if group_table in q["sql"])
+        assert group_sql_hits == 1, [
+            q["sql"] for q in ctx.captured_queries if group_table in q["sql"]
+        ]
+        assert len(response.data["data"]) == 1


### PR DESCRIPTION
Occurrences errors dataset should support queries like "issue:<ISSUE_TAG>",  "has:issue" and show fields like "issue".
This involves mapping group_id to Issue (group's short qualified id). 
Add caching mechanism to avoid hammering Group's Table. 