### PR TITLE
fix(autofix): Better loading states for agent handoffs

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -550,6 +550,12 @@ export function useExplorerAutofix(
   const orgSlug = organization.slug;
 
   const [waitingForResponse, setWaitingForResponse] = useState(false);
+
+  /**
+   * Triggering coding agents take a while and explorer state doesn't update until the end.
+   * This means while the request on ongoing, we need to disable the UI to prevent users
+   * from clicking other steps.
+   */
   const [waitingForCodingAgent, setWaitingForCodingAgent] = useState(false);
 
   const {data: apiData, isPending} = useApiQuery<ExplorerAutofixResponse>(

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -550,6 +550,7 @@ export function useExplorerAutofix(
   const orgSlug = organization.slug;
 
   const [waitingForResponse, setWaitingForResponse] = useState(false);
+  const [waitingForCodingAgent, setWaitingForCodingAgent] = useState(false);
 
   const {data: apiData, isPending} = useApiQuery<ExplorerAutofixResponse>(
     makeExplorerAutofixQueryKey(orgSlug, groupId),
@@ -675,7 +676,7 @@ export function useExplorerAutofix(
    */
   const triggerCodingAgentHandoff = useCallback(
     async (runId: number, integration: CodingAgentIntegration) => {
-      setWaitingForResponse(true);
+      setWaitingForCodingAgent(true);
 
       trackAnalytics('coding_integration.send_to_agent_clicked', {
         organization,
@@ -775,7 +776,7 @@ export function useExplorerAutofix(
         addErrorMessage(e?.responseJSON?.detail ?? 'Failed to launch coding agent');
         throw e;
       } finally {
-        setWaitingForResponse(false);
+        setWaitingForCodingAgent(false);
       }
     },
     [api, orgSlug, groupId, queryClient, organization, user.id]
@@ -801,7 +802,8 @@ export function useExplorerAutofix(
     /**
      * Whether we're actively processing (used for UI indicators).
      */
-    isPolling: isActivelyProcessing(runState, waitingForResponse),
+    isPolling:
+      isActivelyProcessing(runState, waitingForResponse) || waitingForCodingAgent,
     /**
      * Start or continue an autofix step.
      */

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -670,6 +670,7 @@ export function useExplorerAutofix(
    */
   const reset = useCallback(() => {
     setWaitingForResponse(false);
+    setWaitingForCodingAgent(false);
     setApiQueryData<ExplorerAutofixResponse>(
       queryClient,
       makeExplorerAutofixQueryKey(orgSlug, groupId),

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -62,7 +62,7 @@ interface NextStepProps {
 }
 
 function RootCauseNextStep({autofix, runId, section}: NextStepProps) {
-  const {startStep} = autofix;
+  const {isPolling, startStep} = autofix;
 
   const handleYesClick = useCallback(() => {
     startStep('solution', runId);
@@ -86,6 +86,7 @@ function RootCauseNextStep({autofix, runId, section}: NextStepProps) {
 
   return (
     <NextStepTemplate
+      isProcessing={isPolling}
       prompt={t('Are you happy with this root cause?')}
       labelYes={t('Yes, make an implementation plan')}
       onClickYes={handleYesClick}
@@ -101,7 +102,7 @@ function RootCauseNextStep({autofix, runId, section}: NextStepProps) {
 
 function SolutionNextStep({autofix, runId, section}: NextStepProps) {
   const organization = useOrganization();
-  const {startStep, triggerCodingAgentHandoff} = autofix;
+  const {isPolling, startStep, triggerCodingAgentHandoff} = autofix;
 
   const {data: codingAgentResponse} = useQuery(
     organizationIntegrationsCodingAgents(organization)
@@ -146,6 +147,7 @@ function SolutionNextStep({autofix, runId, section}: NextStepProps) {
 
   return (
     <NextStepTemplate
+      isProcessing={isPolling}
       prompt={t('Are you happy with this implementation plan?')}
       labelYes={t('Yes, write a code fix')}
       onClickYes={handleYesClick}
@@ -164,7 +166,7 @@ function SolutionNextStep({autofix, runId, section}: NextStepProps) {
 }
 
 function CodeChangesNextStep({autofix, runId, section}: NextStepProps) {
-  const {createPR, startStep} = autofix;
+  const {isPolling, createPR, startStep} = autofix;
 
   const handleYesClick = useCallback(() => {
     createPR(runId);
@@ -188,6 +190,7 @@ function CodeChangesNextStep({autofix, runId, section}: NextStepProps) {
 
   return (
     <NextStepTemplate
+      isProcessing={isPolling}
       prompt={t('Are you happy with these code changes?')}
       labelYes={t('Yes, draft a PR')}
       onClickYes={handleYesClick}
@@ -202,6 +205,7 @@ function CodeChangesNextStep({autofix, runId, section}: NextStepProps) {
 }
 
 interface NextStepTemplateProps {
+  isProcessing: boolean;
   labelNevermind: ReactNode;
   labelNo: ReactNode;
   labelRethink: ReactNode;
@@ -216,6 +220,7 @@ interface NextStepTemplateProps {
 }
 
 function NextStepTemplate({
+  isProcessing,
   prompt,
   labelYes,
   onClickYes,
@@ -263,8 +268,14 @@ function NextStepTemplate({
           onChange={event => setUserContext(event.target.value)}
         />
         <Flex gap="md">
-          <Button onClick={onClickYes}>{labelNevermind}</Button>
-          <Button priority="primary" onClick={() => onClickNo(userContext)}>
+          <Button disabled={isProcessing} onClick={onClickYes}>
+            {labelNevermind}
+          </Button>
+          <Button
+            priority="primary"
+            disabled={isProcessing}
+            onClick={() => onClickNo(userContext)}
+          >
             {labelRethink}
           </Button>
         </Flex>
@@ -276,9 +287,11 @@ function NextStepTemplate({
     <Flex direction="column" gap="lg">
       <Text>{prompt}</Text>
       <Flex gap="md">
-        <Button onClick={() => handleClickedNo(true)}>{labelNo}</Button>
+        <Button disabled={isProcessing} onClick={() => handleClickedNo(true)}>
+          {labelNo}
+        </Button>
         <ButtonBar>
-          <Button priority="primary" onClick={onClickYes}>
+          <Button priority="primary" disabled={isProcessing} onClick={onClickYes}>
             {labelYes}
           </Button>
           {codingAgentOptions?.length ? (
@@ -287,7 +300,7 @@ function NextStepTemplate({
               trigger={(triggerProps, isOpen) => (
                 <Button
                   {...triggerProps}
-                  disabled={codingAgentOptions.length <= 0}
+                  disabled={isProcessing}
                   priority="primary"
                   icon={<IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />}
                   aria-label={t('More code fix options')}


### PR DESCRIPTION
When launching coding agents, sometimes it takes a while for the api to respond. During this time, we should disable the buttons in the ui to prevent users from starting a different step in the meantime.