### PR TITLE
fix(dashboards): Show hidden dashboards in linked dashboards list

### DIFF
--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -13,6 +13,7 @@ import {TOP_N} from 'sentry/utils/discover/types';
 import {fetchMutation, type QueryClient} from 'sentry/utils/queryClient';
 import {getQueryKey} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
 import {
+  DashboardFilter,
   DisplayType,
   type DashboardDetails,
   type DashboardListItem,
@@ -21,12 +22,16 @@ import {
 import {flattenErrors} from 'sentry/views/dashboards/utils';
 import {getResultsLimit} from 'sentry/views/dashboards/widgetBuilder/utils';
 
-export function fetchDashboards(api: Client, orgSlug: string) {
+export function fetchDashboards(
+  api: Client,
+  orgSlug: string,
+  query?: {filter?: DashboardFilter; sort?: string}
+) {
   const promise: Promise<DashboardListItem[]> = api.requestPromise(
     `/organizations/${orgSlug}/dashboards/`,
     {
       method: 'GET',
-      query: {sort: 'myDashboardsAndRecentlyViewed'},
+      query: {sort: 'myDashboardsAndRecentlyViewed', ...query},
     }
   );
 

--- a/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
@@ -15,12 +15,13 @@ import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {DashboardCreateLimitWrapper} from 'sentry/views/dashboards/createLimitWrapper';
-import type {
-  DashboardDetails,
-  DashboardListItem,
-  LinkedDashboard,
+import {
+  DashboardFilter,
+  MAX_WIDGETS,
+  type DashboardDetails,
+  type DashboardListItem,
+  type LinkedDashboard,
 } from 'sentry/views/dashboards/types';
-import {MAX_WIDGETS} from 'sentry/views/dashboards/types';
 import {NEW_DASHBOARD_ID} from 'sentry/views/dashboards/widgetBuilder/utils';
 
 export type LinkToDashboardModalProps = {
@@ -57,7 +58,9 @@ export function LinkToDashboardModal({
 
     setIsDashboardListLoading(true);
 
-    const dashboardListPromise = fetchDashboards(api, organization.slug);
+    const dashboardListPromise = fetchDashboards(api, organization.slug, {
+      filter: DashboardFilter.SHOW_HIDDEN,
+    });
     const linkedDashboardPromise = currentLinkedDashboard?.dashboardId
       ? fetchDashboard(api, organization.slug, currentLinkedDashboard.dashboardId).catch(
           () => null

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -17,6 +17,7 @@ export enum DashboardFilter {
   SHARED = 'shared',
   EXCLUDE_PREBUILT = 'excludePrebuilt',
   ONLY_PREBUILT = 'onlyPrebuilt',
+  SHOW_HIDDEN = 'showHidden',
 }
 
 export type LegendType = 'default' | 'breakdown';

--- a/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
+++ b/static/app/views/dashboards/utils/usePopulateLinkedDashboards.tsx
@@ -6,7 +6,11 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {fetchDataQuery, useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
+import {
+  DashboardFilter,
+  type DashboardDetails,
+  type Widget,
+} from 'sentry/views/dashboards/types';
 import {
   PREBUILT_DASHBOARDS,
   PrebuiltDashboardId,
@@ -169,7 +173,7 @@ function makeDashboardsQueryKey(
     {
       query: {
         prebuiltId: prebuiltIds.sort(),
-        filter: 'showHidden',
+        filter: DashboardFilter.SHOW_HIDDEN,
       },
     },
   ];

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -67,8 +67,16 @@ import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
+import {SpanFields} from 'sentry/views/insights/types';
 
 export const NONE = 'none';
+
+/**
+ * Fields that should not show the linked dashboard button.
+ */
+const FIELDS_DISABLED_FOR_LINKING: readonly string[] = [
+  SpanFields.IS_STARRED_TRANSACTION,
+];
 
 const NONE_AGGREGATE = {
   textValue: t('field'),
@@ -962,7 +970,10 @@ export function Visualize({error, setError}: VisualizeProps) {
                           )}
                           {hasDrillDownFlows &&
                             isTableWidget &&
-                            fields[index]?.kind === FieldValueKind.FIELD && (
+                            fields[index]?.kind === FieldValueKind.FIELD &&
+                            !FIELDS_DISABLED_FOR_LINKING.includes(
+                              fields[index]?.field ?? ''
+                            ) && (
                               <Button
                                 priority="transparent"
                                 icon={<IconLink />}


### PR DESCRIPTION
Add `filter=showHidden` query param to the `fetchDashboards` call in the link-to-dashboard modal so that hidden dashboards appear in the selection list.

Also adds `SHOW_HIDDEN` to the `DashboardFilter` enum and updates `usePopulateLinkedDashboards` to use the enum value instead of a string literal.

Disables the linked dashboard button for the `is_starred_transaction` field since it is not suitable for drill-down flows.

Refs LINEAR-BROWSE-452