### PR TITLE
fix(tracemetrics): Legend labels should be labelled uniquely with different aggs

### DIFF
--- a/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
@@ -268,10 +268,10 @@ describe('TraceMetricsConfig', () => {
       expect(result).toHaveLength(4);
       // With multiple yAxes and groupings, series names should include function name
       // to uniquely identify them
-      expect(result[0]!.seriesName).toBe('frontend : avg(…)');
-      expect(result[1]!.seriesName).toBe('backend : avg(…)');
-      expect(result[2]!.seriesName).toBe('frontend : p50(…)');
-      expect(result[3]!.seriesName).toBe('backend : p50(…)');
+      expect(result[0]!.seriesName).toBe('frontend : avg(test_metric)');
+      expect(result[1]!.seriesName).toBe('backend : avg(test_metric)');
+      expect(result[2]!.seriesName).toBe('frontend : p50(test_metric)');
+      expect(result[3]!.seriesName).toBe('backend : p50(test_metric)');
     });
 
     it('uniquely identifies series with multiple groupings', () => {
@@ -349,10 +349,10 @@ describe('TraceMetricsConfig', () => {
 
       expect(result).toHaveLength(4);
       // Multiple groupings should be comma-separated, with function name appended
-      expect(result[0]!.seriesName).toBe('frontend,production : avg(…)');
-      expect(result[1]!.seriesName).toBe('frontend,staging : avg(…)');
-      expect(result[2]!.seriesName).toBe('frontend,production : p50(…)');
-      expect(result[3]!.seriesName).toBe('frontend,staging : p50(…)');
+      expect(result[0]!.seriesName).toBe('frontend,production : avg(test_metric)');
+      expect(result[1]!.seriesName).toBe('frontend,staging : avg(test_metric)');
+      expect(result[2]!.seriesName).toBe('frontend,production : p50(test_metric)');
+      expect(result[3]!.seriesName).toBe('frontend,staging : p50(test_metric)');
     });
 
     it('handles null groupBy values', () => {
@@ -398,8 +398,8 @@ describe('TraceMetricsConfig', () => {
 
       expect(result).toHaveLength(2);
       // Null values should be labeled "(no value)" and include function name for uniqueness
-      expect(result[0]!.seriesName).toBe('(no value) : avg(…)');
-      expect(result[1]!.seriesName).toBe('(no value) : p50(…)');
+      expect(result[0]!.seriesName).toBe('(no value) : avg(test_metric)');
+      expect(result[1]!.seriesName).toBe('(no value) : p50(test_metric)');
     });
 
     it('prefixes series names with query name using : separator for single aggregate and no groupings', () => {
@@ -586,10 +586,10 @@ describe('TraceMetricsConfig', () => {
 
       expect(result).toHaveLength(4);
       // With query name, multiple aggregates AND groupings, use > separator
-      expect(result[0]!.seriesName).toBe('My Query > frontend : avg(…)');
-      expect(result[1]!.seriesName).toBe('My Query > backend : avg(…)');
-      expect(result[2]!.seriesName).toBe('My Query > frontend : p50(…)');
-      expect(result[3]!.seriesName).toBe('My Query > backend : p50(…)');
+      expect(result[0]!.seriesName).toBe('My Query > frontend : avg(test_metric)');
+      expect(result[1]!.seriesName).toBe('My Query > backend : avg(test_metric)');
+      expect(result[2]!.seriesName).toBe('My Query > frontend : p50(test_metric)');
+      expect(result[3]!.seriesName).toBe('My Query > backend : p50(test_metric)');
     });
 
     it('distinguishes series from different widget queries using their query names', () => {

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -15,6 +15,7 @@ import {
   type DataUnit,
   type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
+import {SERIES_NAME_PART_DELIMITER} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {
   type DatasetConfig,
@@ -339,33 +340,24 @@ export const TraceMetricsConfig: DatasetConfig<
       ) ?? {}
     );
   },
-  getSeriesResultType(data, widgetQuery) {
+  getSeriesResultType(data, _widgetQuery) {
     return data.timeSeries.reduce(
       (acc, timeSeries) => {
-        const label = formatMetricsTimeseriesLabel({
-          widgetQuery,
-          timeSeries,
-        });
-        acc[label] = timeSeries.meta.valueType as AggregationOutputType;
+        acc[timeSeries.yAxis] = timeSeries.meta.valueType as AggregationOutputType;
         return acc;
       },
       {} as Record<string, AggregationOutputType>
     );
   },
-  getSeriesResultUnit: (data, widgetQuery) => {
+  getSeriesResultUnit: (data, _widgetQuery) => {
     return data.timeSeries.reduce(
       (acc, timeSeries) => {
-        const label = formatMetricsTimeseriesLabel({
-          widgetQuery,
-          timeSeries,
-        });
-
-        if (label.includes('per_second(')) {
-          acc[label] = RateUnit.PER_SECOND;
-        } else if (label.includes('per_minute(')) {
-          acc[label] = RateUnit.PER_MINUTE;
+        if (timeSeries.yAxis.includes('per_second(')) {
+          acc[timeSeries.yAxis] = RateUnit.PER_SECOND;
+        } else if (timeSeries.yAxis.includes('per_minute(')) {
+          acc[timeSeries.yAxis] = RateUnit.PER_MINUTE;
         } else {
-          acc[label] = timeSeries.meta.valueUnit as DataUnit;
+          acc[timeSeries.yAxis] = timeSeries.meta.valueUnit as DataUnit;
         }
         return acc;
       },
@@ -433,13 +425,12 @@ function formatMetricsTimeseriesLabel({
 
   // When we have both multiple aggregates and groupings, append function name for uniqueness
   if (multiYAxis && hasGroupings && func) {
-    baseName = `${baseName} : ${func.name}(…)`;
+    baseName = `${baseName} : ${func.name}(${func.arguments[1] ?? '…'})`;
   }
 
   // Add query name prefix with appropriate separator if an alias is present
   if (widgetQuery.name) {
-    const separator = multiYAxis && hasGroupings ? ' > ' : ' : ';
-    return `${widgetQuery.name}${separator}${baseName}`;
+    return `${widgetQuery.name}${SERIES_NAME_PART_DELIMITER}${baseName}`;
   }
 
   return baseName;

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -15,7 +15,6 @@ import {
   type DataUnit,
   type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
-import {SERIES_NAME_PART_DELIMITER} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {
   type DatasetConfig,
@@ -430,7 +429,8 @@ function formatMetricsTimeseriesLabel({
 
   // Add query name prefix with appropriate separator if an alias is present
   if (widgetQuery.name) {
-    return `${widgetQuery.name}${SERIES_NAME_PART_DELIMITER}${baseName}`;
+    const separator = multiYAxis && hasGroupings ? ' > ' : ' : ';
+    return `${widgetQuery.name}${separator}${baseName}`;
   }
 
   return baseName;

--- a/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
+++ b/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
@@ -5,7 +5,8 @@ import {
   SERIES_QUERY_DELIMITER,
   transformLegacySeriesToTimeSeries,
 } from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
-import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
+import {formatTraceMetricsFunction} from 'sentry/views/dashboards/datasetConfig/traceMetrics';
+import {WidgetType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 
@@ -68,7 +69,14 @@ export function transformWidgetSeriesToTimeSeries(
     queryDelimiterIndex >= 0 ? {...series, seriesName: unprefixedName} : series;
 
   const yAxis =
-    aggregates.find(aggregate => splitUnprefixedName.includes(aggregate)) ??
+    aggregates.find(aggregate => {
+      if (widget.widgetType === WidgetType.TRACEMETRICS) {
+        return splitUnprefixedName.includes(
+          formatTraceMetricsFunction(aggregate) as string
+        );
+      }
+      return splitUnprefixedName.includes(aggregate);
+    }) ??
     aggregates[0] ??
     '';
 

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -251,7 +251,11 @@ export function combineConfidenceForSeries(series: TimeSeries[]): Confidence {
   let highs = 0;
   let nulls = 0;
 
-  for (const s of series) {
+  // We filter the series because there are cases where the series is a sparse array,
+  // meaning we have possible undefined values. This typically happens in multi-yaxis
+  // charts when we have a grouping so the data is positioned in such a way to make
+  // series colors consistent when rendering
+  for (const s of series.filter(defined)) {
     const confidence = determineTimeSeriesConfidence(s);
     if (confidence === 'low') {
       lows += 1;


### PR DESCRIPTION
Currently the logic for rendering the legends for tracemetrics is broken because it can't match up the right y-axis to generate the label, so it falls back to always showing the first aggregate (i.e. `aggregates[0]`). So when you select multiple metrics, the legend and tooltips should show the pretty labels and they should be distinct

I couldn't find a way to do this cleanly without special casing tracemetrics since anything else would require generalizing formatters and it's not usually necessary. We can consider it if there's time for cleanup/it makes things easier to reason about.

Essentially, this PR changes the `yAxis` lookup to work with the formatted series name, and formats the series name to push into the label. I also changed the units and types to use `yAxis` because it's a bit clearer with the aggregate lookup