### PR TITLE
chore: Remove graduated feature flags (performance-spans-new-ui, performance-vitals-standalone-cls-lcp, starfish-mobile-appstart, statistical-detectors-rca-spans-only)

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -220,11 +220,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-transaction-name-only-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the EAP-powered transactions summary view
     manager.add("organizations:performance-transaction-summary-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables the new UI for span summary and the spans tab
-    manager.add("organizations:performance-spans-new-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:performance-use-metrics", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    # Enable standalone cls and lcp in the web vitals module
-    manager.add("organizations:performance-vitals-standalone-cls-lcp", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Suggestions for Web Vitals Module
     manager.add("organizations:performance-web-vitals-seer-suggestions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
@@ -359,14 +355,10 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable standalone span ingestion
     manager.add("organizations:standalone-span-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable mobile starfish app start module view
-    manager.add("organizations:starfish-mobile-appstart", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable mobile starfish ui module view
     manager.add("organizations:starfish-mobile-ui-module", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the new experimental starfish view
     manager.add("organizations:starfish-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable UI for regression issues RCA using spans data
-    manager.add("organizations:statistical-detectors-rca-spans-only", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Allow organizations to configure all symbol sources.
     manager.add("organizations:symbol-sources", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable static ClickHouse sampling for `OrganizationTagsEndpoint`

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.spec.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.spec.tsx
@@ -30,6 +30,54 @@ const defaultProject = ProjectFixture();
 describe('AggregateSpanDiff', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    // Spans endpoint is always queried first (primary data source)
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [
+          {
+            'span.op': 'db',
+            'span.group': 'abc123',
+            'span.description': 'SELECT * FROM users',
+            [`regression_score(span.self_time,${BREAKPOINT_TIMESTAMP})`]: 0.9,
+            [`avg_by_timestamp(span.self_time,less,${BREAKPOINT_TIMESTAMP})`]: 10000,
+            [`avg_by_timestamp(span.self_time,greater,${BREAKPOINT_TIMESTAMP})`]: 20000,
+            [`epm_by_timestamp(less,${BREAKPOINT_TIMESTAMP})`]: 100.0,
+            [`epm_by_timestamp(greater,${BREAKPOINT_TIMESTAMP})`]: 90.0,
+          },
+        ],
+      },
+    });
+  });
+
+  it('renders the Potential Causes section with span data', async () => {
+    render(<AggregateSpanDiff event={defaultEvent} project={defaultProject} />);
+
+    expect(await screen.findByText('SELECT * FROM users')).toBeInTheDocument();
+    expect(screen.getByText('db')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no spans are returned', async () => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: []},
+    });
+
+    render(<AggregateSpanDiff event={defaultEvent} project={defaultProject} />);
+
+    expect(
+      await screen.findByText('No results found for your query')
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to RCA endpoint when spans query fails', async () => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      statusCode: 500,
+      body: {detail: 'Internal Server Error'},
+    });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-root-cause-analysis/',
       body: [
@@ -45,39 +93,10 @@ describe('AggregateSpanDiff', () => {
         },
       ],
     });
-  });
 
-  it('renders the Potential Causes section with span data', async () => {
     render(<AggregateSpanDiff event={defaultEvent} project={defaultProject} />);
 
     expect(await screen.findByText('SELECT * FROM users')).toBeInTheDocument();
     expect(screen.getByText('db')).toBeInTheDocument();
-  });
-
-  it('renders empty state when no spans are returned', async () => {
-    MockApiClient.clearMockResponses();
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events-root-cause-analysis/',
-      body: [],
-    });
-
-    render(<AggregateSpanDiff event={defaultEvent} project={defaultProject} />);
-
-    expect(
-      await screen.findByText('No results found for your query')
-    ).toBeInTheDocument();
-  });
-
-  it('renders error state when request fails', async () => {
-    MockApiClient.clearMockResponses();
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events-root-cause-analysis/',
-      statusCode: 500,
-      body: {detail: 'Internal Server Error'},
-    });
-
-    render(<AggregateSpanDiff event={defaultEvent} project={defaultProject} />);
-
-    expect(await screen.findByText(/events-root-cause-analysis/)).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
@@ -81,9 +81,6 @@ interface AggregateSpanDiffProps {
 export function AggregateSpanDiff({event, project}: AggregateSpanDiffProps) {
   const organization = useOrganization();
   const location = useLocation();
-  const isSpansOnly = organization.features.includes(
-    'statistical-detectors-rca-spans-only'
-  );
 
   const [causeType, setCauseType] = useState<'duration' | 'throughput'>('duration');
 
@@ -126,7 +123,6 @@ export function AggregateSpanDiff({event, project}: AggregateSpanDiffProps) {
       ],
       sorts: [{field: `regression_score(span.self_time,${breakpoint})`, kind: 'desc'}],
       limit: 10,
-      enabled: isSpansOnly,
     },
     'api.insights.transactions.statistical-detector-root-cause-analysis'
   );
@@ -141,12 +137,12 @@ export function AggregateSpanDiff({event, project}: AggregateSpanDiffProps) {
     end: endISO,
     breakpoint: new Date(breakpoint * 1000).toISOString(),
     projectId: project.id,
-    enabled: !isSpansOnly || isSpansDataError,
+    enabled: isSpansDataError,
   });
 
   // The spans dataset may reject some legacy RCA fields/functions for certain orgs.
   // When that happens, fall back to the RCA endpoint so this section still renders.
-  const shouldUseSpansData = isSpansOnly && !isSpansDataError;
+  const shouldUseSpansData = !isSpansDataError;
 
   const tableData = useMemo(() => {
     if (shouldUseSpansData) {

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.spec.tsx
@@ -72,17 +72,17 @@ describe('PageOverviewWebVitalsDetailPanel', () => {
   });
 
   it('renders correctly with web vital', async () => {
-    render(<PageOverviewWebVitalsDetailPanel webVital="lcp" />, {
+    render(<PageOverviewWebVitalsDetailPanel webVital="fcp" />, {
       organization,
     });
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
-    expect(screen.getAllByText('Largest Contentful Paint (P75)')).toHaveLength(2);
+    expect(screen.getAllByText('First Contentful Paint (P75)')).toHaveLength(2);
     expect(screen.getByText('Transaction')).toBeInTheDocument();
     expect(screen.getByText('Profile')).toBeInTheDocument();
     expect(screen.getByText('Replay')).toBeInTheDocument();
-    expect(screen.getByText('lcp')).toBeInTheDocument();
-    expect(screen.getByText('lcp Score')).toBeInTheDocument();
+    expect(screen.getByText('fcp')).toBeInTheDocument();
+    expect(screen.getByText('fcp Score')).toBeInTheDocument();
   });
 });

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
@@ -92,7 +92,6 @@ export function PageOverviewWebVitalsDetailPanel({
   const browserTypes = decodeBrowserTypes(location.query[SpanFields.BROWSER_NAME]);
   const subregions = location.query[SpanFields.USER_GEO_SUBREGION] as SubregionCode[];
   const isSpansWebVital = defined(webVital) && ['inp', 'cls', 'lcp'].includes(webVital);
-  const isInp = webVital === 'inp';
 
   const replayLinkGenerator = generateReplayLink(routes);
 
@@ -343,31 +342,18 @@ export function PageOverviewWebVitalsDetailPanel({
           )}
         </ChartContainer>
         <TableContainer>
-          {isInp ? (
-            <GridEditable
-              data={spansTableData}
-              isLoading={isSpansLoading}
-              columnOrder={SPANS_SAMPLES_COLUMN_ORDER}
-              columnSortBy={[sort]}
-              grid={{
-                renderHeadCell,
-                renderBodyCell: renderSpansBodyCell,
-              }}
-            />
-          ) : (
-            <GridEditable
-              data={spansTableData}
-              isLoading={isSpansLoading}
-              columnOrder={
-                isSpansWebVital ? SPANS_SAMPLES_COLUMN_ORDER : PAGELOADS_COLUMN_ORDER
-              }
-              columnSortBy={[sort]}
-              grid={{
-                renderHeadCell,
-                renderBodyCell: renderSpansBodyCell,
-              }}
-            />
-          )}
+          <GridEditable
+            data={spansTableData}
+            isLoading={isSpansLoading}
+            columnOrder={
+              isSpansWebVital ? SPANS_SAMPLES_COLUMN_ORDER : PAGELOADS_COLUMN_ORDER
+            }
+            columnSortBy={[sort]}
+            grid={{
+              renderHeadCell,
+              renderBodyCell: renderSpansBodyCell,
+            }}
+          />
         </TableContainer>
         <PageAlert />
       </SampleDrawerBody>

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
@@ -93,9 +93,6 @@ export function PageOverviewWebVitalsDetailPanel({
   const subregions = location.query[SpanFields.USER_GEO_SUBREGION] as SubregionCode[];
   const isSpansWebVital = defined(webVital) && ['inp', 'cls', 'lcp'].includes(webVital);
   const isInp = webVital === 'inp';
-  const useSpansWebVitals = organization.features.includes(
-    'performance-vitals-standalone-cls-lcp'
-  );
 
   const replayLinkGenerator = generateReplayLink(routes);
 
@@ -362,9 +359,7 @@ export function PageOverviewWebVitalsDetailPanel({
               data={spansTableData}
               isLoading={isSpansLoading}
               columnOrder={
-                isSpansWebVital && useSpansWebVitals
-                  ? SPANS_SAMPLES_COLUMN_ORDER
-                  : PAGELOADS_COLUMN_ORDER
+                isSpansWebVital ? SPANS_SAMPLES_COLUMN_ORDER : PAGELOADS_COLUMN_ORDER
               }
               columnSortBy={[sort]}
               grid={{

--- a/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
@@ -156,12 +156,10 @@ export function Am1MobileOverviewPage({datePageFilterProps}: Am1MobileOverviewPa
   if (organization.features.includes('insight-modules')) {
     doubleChartRowCharts[0] = PerformanceWidgetSetting.SLOW_SCREENS_BY_TTID;
   }
-  if (organization.features.includes('starfish-mobile-appstart')) {
-    doubleChartRowCharts.push(
-      PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START,
-      PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START
-    );
-  }
+  doubleChartRowCharts.push(
+    PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START,
+    PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START
+  );
 
   if (organization.features.includes('insight-modules')) {
     doubleChartRowCharts.push(PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS);

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -172,12 +172,10 @@ function EAPMobileOverviewPage({datePageFilterProps}: EAPMobileOverviewPageProps
   if (organization.features.includes('insight-modules')) {
     doubleChartRowCharts[0] = PerformanceWidgetSetting.SLOW_SCREENS_BY_TTID;
   }
-  if (organization.features.includes('starfish-mobile-appstart')) {
-    doubleChartRowCharts.push(
-      PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START,
-      PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START
-    );
-  }
+  doubleChartRowCharts.push(
+    PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START,
+    PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START
+  );
 
   if (organization.features.includes('insight-modules')) {
     doubleChartRowCharts.push(PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS);

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -89,9 +89,7 @@ export function SpanDescription({
     return formatter.toString(span.description ?? '');
   }, [span.description, resolvedModule, span.sentry_tags?.description, system]);
 
-  const hasNewSpansUIFlag =
-    organization.features.includes('performance-spans-new-ui') &&
-    organization.features.includes('insight-modules');
+  const hasNewSpansUIFlag = organization.features.includes('insight-modules');
 
   // The new spans UI relies on the group hash assigned by Relay, which is different from the hash available on the span itself
   const groupHash = hasNewSpansUIFlag

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -89,10 +89,10 @@ export function SpanDescription({
     return formatter.toString(span.description ?? '');
   }, [span.description, resolvedModule, span.sentry_tags?.description, system]);
 
-  const hasNewSpansUIFlag = organization.features.includes('insight-modules');
+  const hasInsightModules = organization.features.includes('insight-modules');
 
   // The new spans UI relies on the group hash assigned by Relay, which is different from the hash available on the span itself
-  const groupHash = hasNewSpansUIFlag
+  const groupHash = hasInsightModules
     ? (span.sentry_tags?.group ?? '')
     : (span.hash ?? '');
   const showAction = hasExploreEnabled ? !!span.description : !!span.op && !!span.hash;
@@ -157,7 +157,7 @@ export function SpanDescription({
           <MissingFrame />
         )}
       </Stack>
-    ) : hasNewSpansUIFlag &&
+    ) : hasInsightModules &&
       resolvedModule === ModuleName.RESOURCE &&
       span.op === 'resource.img' ? (
       <ResourceImageDescription formattedDescription={formattedDescription} node={node} />


### PR DESCRIPTION
These flags are fully rolled out. Remove the flag registrations and simplify all gated code paths to use the graduated behavior directly rather than leaving behind trivially-true variables.
