### PR TITLE
feat(api): Track camelCase vs snake_case parameter key usage in CamelSnakeSerializer

### DIFF
--- a/src/sentry/api/serializers/rest_framework/base.py
+++ b/src/sentry/api/serializers/rest_framework/base.py
@@ -8,7 +8,44 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import empty
 from rest_framework.serializers import ModelSerializer, Serializer
 
+from sentry.utils import metrics
+
 T = TypeVar("T")
+
+
+def _classify_key_case(data: dict) -> str:
+    """Classify the top-level keys of a dict as camel, snake, mixed, or none."""
+    has_camel = False
+    has_snake = False
+    for key in data:
+        converted = camel_to_snake_case(key)
+        if converted != key:
+            has_camel = True
+        elif "_" in key:
+            has_snake = True
+    if has_camel and has_snake:
+        return "mixed"
+    if has_camel:
+        return "camel"
+    if has_snake:
+        return "snake"
+
+    # Uncertain data could be because the data doesn't have enough information to classify.
+    # For example, if the parameters are all single word keys, then they would show up the same
+    # whether they are camel or snake case.
+    return "uncertain"
+
+
+def _record_key_case_metric(serializer_name: str, data: dict) -> None:
+    """Emit a metric classifying the parameter key case of incoming data."""
+    key_case = _classify_key_case(data)
+    metrics.incr(
+        "api.serializer.parameter_key_case",
+        tags={
+            "key_case": key_case,
+            "serializer": serializer_name,
+        },
+    )
 
 
 def camel_to_snake_case(value):
@@ -58,6 +95,8 @@ class CamelSnakeSerializer(Serializer[T]):
 
     def __init__(self, instance=None, data=empty, **kwargs):
         if data is not empty:
+            if isinstance(data, dict):
+                _record_key_case_metric(type(self).__name__, data)
             data = convert_dict_key_case(data, camel_to_snake_case)
         super().__init__(instance=instance, data=data, **kwargs)
 
@@ -79,6 +118,8 @@ class CamelSnakeModelSerializer(ModelSerializer[M]):
 
     def __init__(self, instance=None, data=empty, **kwargs):
         if data is not empty:
+            if isinstance(data, dict):
+                _record_key_case_metric(type(self).__name__, data)
             data = convert_dict_key_case(data, camel_to_snake_case)
         super().__init__(instance=instance, data=data, **kwargs)
 

--- a/tests/sentry/api/serializers/rest_framework/test_base.py
+++ b/tests/sentry/api/serializers/rest_framework/test_base.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
@@ -5,6 +7,7 @@ from rest_framework import serializers
 from sentry.api.serializers.rest_framework.base import (
     CamelSnakeModelSerializer,
     CamelSnakeSerializer,
+    _classify_key_case,
     camel_to_snake_case,
     convert_dict_key_case,
     snake_to_camel_case,
@@ -78,3 +81,74 @@ def test_convert_dict_key_case() -> None:
     }
 
     assert camelData == convert_dict_key_case(snake_data, snake_to_camel_case)
+
+
+class ClassifyKeyCaseTest(TestCase):
+    def test_camel_keys(self) -> None:
+        assert _classify_key_case({"firstName": "a", "lastName": "b"}) == "camel"
+
+    def test_snake_keys(self) -> None:
+        assert _classify_key_case({"first_name": "a", "last_name": "b"}) == "snake"
+
+    def test_mixed_keys(self) -> None:
+        assert _classify_key_case({"firstName": "a", "last_name": "b"}) == "mixed"
+
+    def test_single_word_keys_only(self) -> None:
+        assert _classify_key_case({"name": "a", "id": "b"}) == "uncertain"
+
+    def test_empty_dict(self) -> None:
+        assert _classify_key_case({}) == "uncertain"
+
+    def test_camel_with_single_word(self) -> None:
+        assert _classify_key_case({"firstName": "a", "name": "b"}) == "camel"
+
+    def test_snake_with_single_word(self) -> None:
+        assert _classify_key_case({"first_name": "a", "name": "b"}) == "snake"
+
+
+class RecordKeyCaseMetricTest(TestCase):
+    @patch("sentry.api.serializers.rest_framework.base.metrics")
+    def test_camel_case_emits_metric(self, mock_metrics: MagicMock) -> None:
+        PersonSerializer(data={"worksAt": "Sentry", "name": "Rick"})
+        mock_metrics.incr.assert_called_once_with(
+            "api.serializer.parameter_key_case",
+            tags={
+                "key_case": "camel",
+                "serializer": "PersonSerializer",
+            },
+        )
+
+    @patch("sentry.api.serializers.rest_framework.base.metrics")
+    def test_snake_case_emits_metric(self, mock_metrics: MagicMock) -> None:
+        PersonSerializer(data={"works_at": "Sentry", "name": "Rick"})
+        mock_metrics.incr.assert_called_once_with(
+            "api.serializer.parameter_key_case",
+            tags={
+                "key_case": "snake",
+                "serializer": "PersonSerializer",
+            },
+        )
+
+    @patch("sentry.api.serializers.rest_framework.base.metrics")
+    def test_uncertain_data_emits_metric(self, mock_metrics: MagicMock) -> None:
+        PersonSerializer(data={"name": "Rick"})
+        mock_metrics.incr.assert_called_once_with(
+            "api.serializer.parameter_key_case",
+            tags={
+                "key_case": "uncertain",
+                "serializer": "PersonSerializer",
+            },
+        )
+
+    @patch("sentry.api.serializers.rest_framework.base.metrics")
+    def test_list_data_skips_metric(self, mock_metrics: MagicMock) -> None:
+        PersonSerializer(data=[{"worksAt": "Sentry"}])
+        mock_metrics.incr.assert_not_called()
+
+    @patch("sentry.api.serializers.rest_framework.base.metrics")
+    def test_model_serializer_emits_metric(self, mock_metrics: MagicMock) -> None:
+        ContentTypeSerializer(data={"appLabel": "hello", "model": "Something"})
+        mock_metrics.incr.assert_called_once()
+        tags = mock_metrics.incr.call_args[1]["tags"]
+        assert tags["key_case"] == "camel"
+        assert tags["serializer"] == "ContentTypeSerializer"


### PR DESCRIPTION
Add temporary metrics to understand whether API callers send camelCase or snake_case parameter keys. This emits an `api.serializer.parameter_key_case` metric with key_case and serializer tags from both CamelSnakeSerializer and CamelSnakeModelSerializer __init__ methods.

The point of this is to investigate how customers actually use our APIs. We want to see whether it is feasible to choose _one and only one_ way of accepting API inputs.

The cardinality for this metric should be bounded because we have only finite number of serializers.