### PR TITLE
fix(integrations): Handle forbidden errors in integration proxy

### DIFF
--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -24,6 +24,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.utils.metrics import IntegrationProxyEvent, IntegrationProxyEventType
 from sentry.metrics.base import Tags
 from sentry.shared_integrations.exceptions import (
+    ApiForbiddenError,
     ApiHostError,
     ApiRateLimitedError,
     ApiTimeoutError,
@@ -66,6 +67,7 @@ class IntegrationProxyFailureMetricType(StrEnum):
     HOST_TIMEOUT_ERROR = "host_timeout_error"
     UNAUTHORIZED_ERROR = "unauthorized_error"
     RATE_LIMITED_ERROR = "rate_limited_error"
+    FORBIDDEN_ERROR = "forbidden_error"
     UNKNOWN_ERROR = "unknown_error"
     FAILED_VALIDATION = "failed_validation"
 
@@ -341,6 +343,10 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         elif isinstance(exc, ApiRateLimitedError):
             logger.info("hybrid_cloud.integration_proxy.rate_limited_error", extra=self.log_extra)
             self._add_failure_metric(IntegrationProxyFailureMetricType.RATE_LIMITED_ERROR)
+            return self.respond(status=exc.code)
+        elif isinstance(exc, ApiForbiddenError):
+            logger.info("hybrid_cloud.integration_proxy.forbidden_error", extra=self.log_extra)
+            self._add_failure_metric(IntegrationProxyFailureMetricType.FORBIDDEN_ERROR)
             return self.respond(status=exc.code)
 
         logger.warning(

--- a/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
+++ b/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
@@ -22,6 +22,7 @@ from sentry.integrations.types import EventLifecycleOutcome
 from sentry.metrics.base import Tags
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import (
+    ApiForbiddenError,
     ApiHostError,
     ApiRateLimitedError,
     ApiTimeoutError,
@@ -616,6 +617,46 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         )
         self.assert_failure_metric_count(
             failure_type=IntegrationProxyFailureMetricType.RATE_LIMITED_ERROR,
+            count=1,
+            mock_metrics=mock_metrics,
+        )
+        self.assert_metric_count(
+            metric_name=IntegrationProxySuccessMetricType.COMPLETE_RESPONSE_CODE,
+            count=0,
+            mock_metrics=mock_metrics,
+        )
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
+    @patch.object(metrics, "incr")
+    def test_handles_api_forbidden_error(
+        self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        signature_path = f"/{self.proxy_path}"
+        headers = self.create_request_headers(
+            signature_path=signature_path, integration_id=self.org_integration.id
+        )
+        mock_client.base_url = "https://example.com/api"
+        mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
+        mock_client.request = MagicMock(
+            side_effect=lambda *args, **kwargs: self.raise_exception(ApiForbiddenError, "Forbidden")
+        )
+        mock_get_client.return_value = mock_client
+
+        proxy_response = self.client.get(self.path, **headers)
+
+        assert proxy_response.status_code == 403
+        assert proxy_response.data is None
+
+        self.assert_metric_count(
+            metric_name=IntegrationProxySuccessMetricType.INITIALIZE,
+            count=1,
+            mock_metrics=mock_metrics,
+            kwargs_to_match={"sample_rate": 1.0, "tags": None},
+        )
+        self.assert_failure_metric_count(
+            failure_type=IntegrationProxyFailureMetricType.FORBIDDEN_ERROR,
             count=1,
             mock_metrics=mock_metrics,
         )


### PR DESCRIPTION
Add explicit handling for `ApiForbiddenError` in the integration proxy endpoint's
`handle_exception_with_details` method, following the same pattern established in
#111030 for `ApiUnauthorized` and `ApiRateLimitedError`.

Previously, `ApiForbiddenError` exceptions fell through to the unknown error handler,
which logs at warning level and delegates to the base class (returning 500). Now it
returns the correct 403 status with a dedicated `forbidden_error` failure metric type
and info-level logging.


Agent transcript: https://claudescope.sentry.dev/share/IV3nYCdnIAW35SRn4N0wnSGyQrw4sP8303Ea3PzRkjE