### PR TITLE
fix(insights): Use span.duration in Queries dashboards

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -148,15 +148,12 @@ export const BACKEND_OVERVIEW_SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
-          fields: [
-            SpanFields.NORMALIZED_DESCRIPTION,
-            `p75(${SpanFields.SPAN_SELF_TIME})`,
-          ],
-          aggregates: [`p75(${SpanFields.SPAN_SELF_TIME})`],
+          fields: [SpanFields.NORMALIZED_DESCRIPTION, `p75(${SpanFields.SPAN_DURATION})`],
+          aggregates: [`p75(${SpanFields.SPAN_DURATION})`],
           columns: [SpanFields.NORMALIZED_DESCRIPTION],
           fieldAliases: [''],
           conditions: `${SpanFields.DB_SYSTEM}:[${Object.values(SupportedDatabaseSystem).join(',')}]`,
-          orderby: `-sum(${SpanFields.SPAN_SELF_TIME})`,
+          orderby: `-sum(${SpanFields.SPAN_DURATION})`,
           linkedDashboards: [
             {
               dashboardId: '-1',

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
@@ -88,10 +88,10 @@ export const QUERIES_PREBUILT_CONFIG: PrebuiltDashboard = {
         {
           name: AVERAGE_DURATION_TEXT,
           conditions: FILTER_STRING,
-          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
-          aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          fields: [`avg(${SpanFields.SPAN_DURATION})`],
+          aggregates: [`avg(${SpanFields.SPAN_DURATION})`],
           columns: [],
-          orderby: `avg(${SpanFields.SPAN_SELF_TIME})`,
+          orderby: `avg(${SpanFields.SPAN_DURATION})`,
         },
       ],
       layout: {
@@ -116,16 +116,16 @@ export const QUERIES_PREBUILT_CONFIG: PrebuiltDashboard = {
           fields: [
             SpanFields.NORMALIZED_DESCRIPTION,
             'epm()',
-            `avg(${SpanFields.SPAN_SELF_TIME})`,
-            `sum(${SpanFields.SPAN_SELF_TIME})`,
+            `avg(${SpanFields.SPAN_DURATION})`,
+            `sum(${SpanFields.SPAN_DURATION})`,
           ],
           aggregates: [
             'epm()',
-            `avg(${SpanFields.SPAN_SELF_TIME})`,
-            `sum(${SpanFields.SPAN_SELF_TIME})`,
+            `avg(${SpanFields.SPAN_DURATION})`,
+            `sum(${SpanFields.SPAN_DURATION})`,
           ],
           columns: [SpanFields.NORMALIZED_DESCRIPTION],
-          orderby: `-sum(${SpanFields.SPAN_SELF_TIME})`,
+          orderby: `-sum(${SpanFields.SPAN_DURATION})`,
           fieldAliases: [
             t('Query Description'),
             `${t('Queries')} ${RATE_UNIT_TITLE[RateUnit.PER_MINUTE]}`,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
@@ -61,8 +61,8 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
       queries: [
         {
           name: AVERAGE_DURATION_TEXT,
-          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
-          aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          fields: [`avg(${SpanFields.SPAN_DURATION})`],
+          aggregates: [`avg(${SpanFields.SPAN_DURATION})`],
           columns: [],
           conditions: FILTER_STRING,
           orderby: '',
@@ -82,8 +82,8 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
       queries: [
         {
           name: '',
-          fields: [`sum(${SpanFields.SPAN_SELF_TIME})`],
-          aggregates: [`sum(${SpanFields.SPAN_SELF_TIME})`],
+          fields: [`sum(${SpanFields.SPAN_DURATION})`],
+          aggregates: [`sum(${SpanFields.SPAN_DURATION})`],
           columns: [],
           conditions: FILTER_STRING,
           orderby: '',
@@ -127,12 +127,12 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
       queries: [
         {
           name: '',
-          fields: ['transaction', 'epm()', `sum(${SpanFields.SPAN_SELF_TIME})`],
-          aggregates: ['epm()', `sum(${SpanFields.SPAN_SELF_TIME})`],
+          fields: ['transaction', 'epm()', `sum(${SpanFields.SPAN_DURATION})`],
+          aggregates: ['epm()', `sum(${SpanFields.SPAN_DURATION})`],
           columns: [SpanFields.TRANSACTION],
           fieldAliases: [t('Found In'), t('Queries Per Minute'), t('Time Spent')],
           conditions: FILTER_STRING,
-          orderby: `-sum(${SpanFields.SPAN_SELF_TIME})`,
+          orderby: `-sum(${SpanFields.SPAN_DURATION})`,
           onDemand: [],
           isHidden: false,
           linkedDashboards: [],
@@ -176,12 +176,12 @@ export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
       queries: [
         {
           name: AVERAGE_DURATION_TEXT,
-          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
-          aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
+          fields: [`avg(${SpanFields.SPAN_DURATION})`],
+          aggregates: [`avg(${SpanFields.SPAN_DURATION})`],
           columns: [],
           fieldAliases: [],
           conditions: FILTER_STRING,
-          orderby: `avg(${SpanFields.SPAN_SELF_TIME})`,
+          orderby: `avg(${SpanFields.SPAN_DURATION})`,
           onDemand: [],
           isHidden: false,
         },


### PR DESCRIPTION
I think using `span.duration` instead of `span.self_time` for DB queries is better for two reasons:

1. It's more semantically correct: since a DB query span represents a DB query, the span's length represents the query's runtime, regardless of any child spans.
2. `span.duration` is available on all spans, whereas `span.self_time` is only available for spans that have gone through the span buffer/segment enrichment during ingestion.

Changes all uses in the Queries and Query Summary dashboards, and the Backend landing page's Queries widget.

See BROWSE-454.