### PR TITLE
ref(dashboards): Replace renderExtraActions function prop with component

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -5,8 +5,10 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 
+import {openLinkToDashboardModal} from 'sentry/actionCreators/modal';
 import {OnDemandWarningIcon} from 'sentry/components/alerts/onDemandMetricAlert';
 import {FieldGroup} from 'sentry/components/forms/fieldGroup';
+import {IconLink} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -21,10 +23,13 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   OnDemandExtractionState,
   WidgetType,
+  type LinkedDashboard,
   type ValidateWidgetResponse,
 } from 'sentry/views/dashboards/types';
+import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {useDashboardWidgetSource} from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
 import type {generateFieldOptions} from 'sentry/views/discover/utils';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
@@ -42,7 +47,7 @@ interface Props {
   validatedWidgetResponse: UseApiQueryResult<ValidateWidgetResponse, RequestError>;
   columns?: QueryFieldValue[];
   disable?: boolean;
-  renderExtraActions?: (column: QueryFieldValue, index: number) => ReactNode;
+  showDashboardLinkButton?: boolean;
   style?: React.CSSProperties;
   widgetType?: WidgetType;
 }
@@ -55,7 +60,7 @@ export function GroupBySelector({
   style,
   widgetType,
   disable,
-  renderExtraActions,
+  showDashboardLinkButton,
 }: Props) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const organization = useOrganization();
@@ -222,7 +227,9 @@ export function GroupBySelector({
                     canDrag={canDrag}
                     canDelete={canDelete}
                     disabled={disable}
-                    renderExtraActions={renderExtraActions?.(column, index)}
+                    renderExtraActions={
+                      showDashboardLinkButton && <LinkToDashboardAction column={column} />
+                    }
                     renderTagOverride={renderTagOverride}
                   />
                 ))}
@@ -281,6 +288,43 @@ function FieldValidationErrors(props: {
       msg={t('This group has too many unique values to collect metrics for it.')}
     />
   ) : null;
+}
+
+function LinkToDashboardAction({column}: {column: QueryFieldValue}) {
+  const {state, dispatch} = useWidgetBuilderContext();
+  const source = useDashboardWidgetSource();
+
+  if (column.kind !== FieldValueKind.FIELD || !column.field) {
+    return null;
+  }
+
+  const field = column.field;
+  const currentLinkedDashboards = state.linkedDashboards ?? [];
+
+  return (
+    <Button
+      priority="transparent"
+      icon={<IconLink />}
+      aria-label={t('Link field')}
+      size="zero"
+      onClick={() => {
+        openLinkToDashboardModal({
+          onLink: dashboardId => {
+            const newLinkedDashboards: LinkedDashboard[] = [
+              ...currentLinkedDashboards.filter(ld => ld.field !== field),
+              {dashboardId, field},
+            ];
+            dispatch({
+              type: BuilderStateAction.SET_LINKED_DASHBOARDS,
+              payload: newLinkedDashboards,
+            });
+          },
+          currentLinkedDashboard: currentLinkedDashboards.find(ld => ld.field === field),
+          source,
+        });
+      }}
+    />
+  );
 }
 
 const StyledField = styled(FieldGroup)`

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -227,7 +227,7 @@ export function GroupBySelector({
                     canDrag={canDrag}
                     canDelete={canDelete}
                     disabled={disable}
-                    renderExtraActions={
+                    extraActions={
                       showDashboardLinkButton && <LinkToDashboardAction column={column} />
                     }
                     renderTagOverride={renderTagOverride}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/queryField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/queryField.tsx
@@ -18,12 +18,12 @@ export interface QueryFieldProps {
   canDelete?: boolean;
   canDrag?: boolean;
   disabled?: boolean;
+  extraActions?: ReactNode;
   fieldValidationError?: ReactNode;
   isDragging?: boolean;
   listeners?: DraggableSyntheticListeners;
   onDelete?: () => void;
   ref?: React.Ref<HTMLDivElement>;
-  renderExtraActions?: ReactNode;
   renderTagOverride?: (
     kind: FieldValueKind,
     label: ReactNode,
@@ -46,7 +46,7 @@ export function QueryField({
   fieldValidationError,
   isDragging,
   disabled,
-  renderExtraActions,
+  extraActions,
   renderTagOverride,
 }: QueryFieldProps) {
   return (
@@ -73,7 +73,7 @@ export function QueryField({
             renderTagOverride={renderTagOverride}
           />
           {fieldValidationError ? fieldValidationError : null}
-          {renderExtraActions}
+          {extraActions}
           {canDelete && (
             <Button
               size="zero"

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
@@ -1,9 +1,5 @@
-import {Fragment, useCallback, useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 
-import {Button} from '@sentry/scraps/button';
-
-import {openLinkToDashboardModal} from 'sentry/actionCreators/modal';
-import {IconLink} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {type QueryFieldValue} from 'sentry/utils/discover/fields';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
@@ -12,19 +8,13 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTags} from 'sentry/utils/useTags';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {useHasDrillDownFlows} from 'sentry/views/dashboards/hooks/useHasDrillDownFlows';
-import {
-  WidgetType,
-  type LinkedDashboard,
-  type ValidateWidgetResponse,
-} from 'sentry/views/dashboards/types';
+import {WidgetType, type ValidateWidgetResponse} from 'sentry/views/dashboards/types';
 import {GroupBySelector} from 'sentry/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import {useDashboardWidgetSource} from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import {useDisableTransactionWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useDisableTransactionWidget';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {useWidgetBuilderTraceItemConfig} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig';
-import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
@@ -39,7 +29,6 @@ export function WidgetBuilderGroupBySelector({
   const {state, dispatch} = useWidgetBuilderContext();
   const disableTransactionWidget = useDisableTransactionWidget();
   const hasDrillDownFlows = useHasDrillDownFlows();
-  const source = useDashboardWidgetSource();
 
   const organization = useOrganization();
 
@@ -104,45 +93,7 @@ export function WidgetBuilderGroupBySelector({
     dispatch({type: BuilderStateAction.SET_FIELDS, payload: newValue});
   };
 
-  const renderExtraActions = useCallback(
-    (column: QueryFieldValue, _index: number) => {
-      if (!hasDrillDownFlows || state.legendType !== 'breakdown') {
-        return null;
-      }
-      if (column.kind !== FieldValueKind.FIELD || !column.field) {
-        return null;
-      }
-      const field = column.field;
-      const currentLinkedDashboards = state.linkedDashboards ?? [];
-      return (
-        <Button
-          priority="transparent"
-          icon={<IconLink />}
-          aria-label={t('Link field')}
-          size="zero"
-          onClick={() => {
-            openLinkToDashboardModal({
-              onLink: dashboardId => {
-                const newLinkedDashboards: LinkedDashboard[] = [
-                  ...currentLinkedDashboards.filter(ld => ld.field !== field),
-                  {dashboardId, field},
-                ];
-                dispatch({
-                  type: BuilderStateAction.SET_LINKED_DASHBOARDS,
-                  payload: newLinkedDashboards,
-                });
-              },
-              currentLinkedDashboard: currentLinkedDashboards.find(
-                ld => ld.field === field
-              ),
-              source,
-            });
-          }}
-        />
-      );
-    },
-    [hasDrillDownFlows, state.legendType, state.linkedDashboards, dispatch, source]
-  );
+  const showExtraActions = hasDrillDownFlows && state.legendType === 'breakdown';
 
   return (
     <Fragment>
@@ -162,7 +113,7 @@ export function WidgetBuilderGroupBySelector({
         style={{paddingRight: 0}}
         widgetType={state.dataset}
         disable={disableTransactionWidget}
-        renderExtraActions={renderExtraActions}
+        showDashboardLinkButton={showExtraActions}
       />
     </Fragment>
   );

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
@@ -93,8 +93,6 @@ export function WidgetBuilderGroupBySelector({
     dispatch({type: BuilderStateAction.SET_FIELDS, payload: newValue});
   };
 
-  const showExtraActions = hasDrillDownFlows && state.legendType === 'breakdown';
-
   return (
     <Fragment>
       <SectionHeader
@@ -113,7 +111,7 @@ export function WidgetBuilderGroupBySelector({
         style={{paddingRight: 0}}
         widgetType={state.dataset}
         disable={disableTransactionWidget}
-        showDashboardLinkButton={showExtraActions}
+        showDashboardLinkButton={hasDrillDownFlows && state.legendType === 'breakdown'}
       />
     </Fragment>
   );


### PR DESCRIPTION
Replace the `renderExtraActions` render function prop on `GroupBySelector` with a
`showDashboardLinkButton` boolean and a colocated `LinkToDashboardAction` component.

Passing render functions as props causes unnecessary re-renders of children because
a new function reference is created on every parent render. Using a boolean prop with
a colocated component avoids this and simplifies the API — the caller no longer needs
to know about the rendering details of the link button.

The `LinkToDashboardAction` component now lives in `groupBySelector.tsx` alongside
`GroupBySelector` and accesses widget builder context via its own hooks.