### PR TITLE
fix(tracemetrics): Check type and unit objects for yAxis

### DIFF
--- a/static/app/utils/timeSeries/transformLegacySeriesToTimeSeries.tsx
+++ b/static/app/utils/timeSeries/transformLegacySeriesToTimeSeries.tsx
@@ -43,8 +43,13 @@ export function transformLegacySeriesToTimeSeries(
   const mapped = mapAggregationTypeToValueTypeAndUnit(fieldType, yAxis);
   const seriesName = timeseriesResult.seriesName ?? yAxis;
   const valueType =
-    timeseriesResultsTypes?.[seriesName] ?? (mapped.valueType as AggregationOutputType);
-  const valueUnit = timeseriesResultsUnits?.[seriesName] ?? mapped.valueUnit;
+    timeseriesResultsTypes?.[seriesName] ??
+    timeseriesResultsTypes?.[yAxis] ??
+    (mapped.valueType as AggregationOutputType);
+  const valueUnit =
+    timeseriesResultsUnits?.[seriesName] ??
+    timeseriesResultsUnits?.[yAxis] ??
+    mapped.valueUnit;
 
   const splitSeriesName = seriesName.split(SERIES_NAME_PART_DELIMITER);
 


### PR DESCRIPTION
The yAxis and the series name might differ, so just check the y-axis again to be safe for metrics.

This regression was introduced when making the labels unique by changing it to rely on the y-axis