### PR TITLE
feat(dashboards): Add tooltips explaining dashboard linking

### DIFF
--- a/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
@@ -3,12 +3,14 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Grid, type GridProps} from '@sentry/scraps/layout';
+import {Flex, Grid, type GridProps} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {fetchDashboard, fetchDashboards} from 'sentry/actionCreators/dashboards';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Spinner} from 'sentry/components/forms/spinner';
+import {IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import {useApi} from 'sentry/utils/useApi';
@@ -180,7 +182,18 @@ export function LinkToDashboardModal({
 
   return (
     <Fragment>
-      <Header closeButton>{t('Link to Dashboard')}</Header>
+      <Header closeButton>
+        <Flex align="center" gap="sm">
+          {t('Link to Dashboard')}
+          <Tooltip
+            title={t(
+              'Dashboard linking allows you to create a connection between a field in this widget and another dashboard. When users click on a value in the linked field, they will be taken to the linked dashboard with relevant filters applied.'
+            )}
+          >
+            <IconInfo size="sm" />
+          </Tooltip>
+        </Flex>
+      </Header>
       <Body>
         <Wrapper>
           <DashboardCreateLimitWrapper>

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -4,6 +4,7 @@ import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {openLinkToDashboardModal} from 'sentry/actionCreators/modal';
 import {OnDemandWarningIcon} from 'sentry/components/alerts/onDemandMetricAlert';
@@ -30,6 +31,7 @@ import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/con
 import {useDashboardWidgetSource} from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {LINK_FIELD_TOOLTIP} from 'sentry/views/dashboards/widgetBuilder/settings';
 import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
 import type {generateFieldOptions} from 'sentry/views/discover/utils';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
@@ -302,28 +304,32 @@ function LinkToDashboardAction({column}: {column: QueryFieldValue}) {
   const currentLinkedDashboards = state.linkedDashboards ?? [];
 
   return (
-    <Button
-      priority="transparent"
-      icon={<IconLink />}
-      aria-label={t('Link field')}
-      size="zero"
-      onClick={() => {
-        openLinkToDashboardModal({
-          onLink: dashboardId => {
-            const newLinkedDashboards: LinkedDashboard[] = [
-              ...currentLinkedDashboards.filter(ld => ld.field !== field),
-              {dashboardId, field},
-            ];
-            dispatch({
-              type: BuilderStateAction.SET_LINKED_DASHBOARDS,
-              payload: newLinkedDashboards,
-            });
-          },
-          currentLinkedDashboard: currentLinkedDashboards.find(ld => ld.field === field),
-          source,
-        });
-      }}
-    />
+    <Tooltip title={LINK_FIELD_TOOLTIP}>
+      <Button
+        priority="transparent"
+        icon={<IconLink />}
+        aria-label={t('Link field')}
+        size="zero"
+        onClick={() => {
+          openLinkToDashboardModal({
+            onLink: dashboardId => {
+              const newLinkedDashboards: LinkedDashboard[] = [
+                ...currentLinkedDashboards.filter(ld => ld.field !== field),
+                {dashboardId, field},
+              ];
+              dispatch({
+                type: BuilderStateAction.SET_LINKED_DASHBOARDS,
+                payload: newLinkedDashboards,
+              });
+            },
+            currentLinkedDashboard: currentLinkedDashboards.find(
+              ld => ld.field === field
+            ),
+            source,
+          });
+        }}
+      />
+    </Tooltip>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -10,6 +10,7 @@ import {CompactSelect, TriggerLabel} from '@sentry/scraps/compactSelect';
 import {Input} from '@sentry/scraps/input';
 import {Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {openLinkToDashboardModal} from 'sentry/actionCreators/modal';
 import {RadioLineItem} from 'sentry/components/forms/controls/radioGroup';
@@ -61,6 +62,7 @@ import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/us
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {useWidgetBuilderTraceItemConfig} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig';
 import {SESSIONS_TAGS} from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
+import {LINK_FIELD_TOOLTIP} from 'sentry/views/dashboards/widgetBuilder/settings';
 import {ArithmeticInput} from 'sentry/views/discover/table/arithmeticInput';
 import {validateColumnTypes} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
@@ -974,48 +976,52 @@ export function Visualize({error, setError}: VisualizeProps) {
                             !FIELDS_DISABLED_FOR_LINKING.includes(
                               fields[index]?.field ?? ''
                             ) && (
-                              <Button
-                                priority="transparent"
-                                icon={<IconLink />}
-                                aria-label={t('Link field')}
-                                size="zero"
-                                onClick={() => {
-                                  openLinkToDashboardModal({
-                                    onLink: dashboardId => {
-                                      if (
-                                        fields[index]?.kind === FieldValueKind.FIELD &&
-                                        fields[index]?.field
-                                      ) {
-                                        const fieldName = fields[index].field;
-                                        const newLinkedDashboards: LinkedDashboard[] = [
-                                          ...linkedDashboards.filter(
-                                            ld => ld.field !== fieldName
-                                          ),
-                                          {dashboardId, field: fieldName},
-                                        ];
-                                        dispatch({
-                                          type: BuilderStateAction.SET_LINKED_DASHBOARDS,
-                                          payload: newLinkedDashboards,
-                                        });
-                                      }
-                                    },
-                                    currentLinkedDashboard: linkedDashboards.find(
-                                      linkedDashboard => {
+                              <Tooltip title={LINK_FIELD_TOOLTIP}>
+                                <Button
+                                  priority="transparent"
+                                  icon={<IconLink />}
+                                  aria-label={t('Link field')}
+                                  size="zero"
+                                  onClick={() => {
+                                    openLinkToDashboardModal({
+                                      onLink: dashboardId => {
                                         if (
                                           fields[index]?.kind === FieldValueKind.FIELD &&
                                           fields[index]?.field
                                         ) {
-                                          return (
-                                            linkedDashboard.field === fields[index].field
-                                          );
+                                          const fieldName = fields[index].field;
+                                          const newLinkedDashboards: LinkedDashboard[] = [
+                                            ...linkedDashboards.filter(
+                                              ld => ld.field !== fieldName
+                                            ),
+                                            {dashboardId, field: fieldName},
+                                          ];
+                                          dispatch({
+                                            type: BuilderStateAction.SET_LINKED_DASHBOARDS,
+                                            payload: newLinkedDashboards,
+                                          });
                                         }
-                                        return false;
-                                      }
-                                    ),
-                                    source,
-                                  });
-                                }}
-                              />
+                                      },
+                                      currentLinkedDashboard: linkedDashboards.find(
+                                        linkedDashboard => {
+                                          if (
+                                            fields[index]?.kind ===
+                                              FieldValueKind.FIELD &&
+                                            fields[index]?.field
+                                          ) {
+                                            return (
+                                              linkedDashboard.field ===
+                                              fields[index].field
+                                            );
+                                          }
+                                          return false;
+                                        }
+                                      ),
+                                      source,
+                                    });
+                                  }}
+                                />
+                              </Tooltip>
                             )}
                           {(!isBigNumberWidget || datasetConfig.enableEquations) && (
                             <Button

--- a/static/app/views/dashboards/widgetBuilder/settings.ts
+++ b/static/app/views/dashboards/widgetBuilder/settings.ts
@@ -1,0 +1,3 @@
+import {t} from 'sentry/locale';
+
+export const LINK_FIELD_TOOLTIP = t('Link this field to another dashboard');


### PR DESCRIPTION
## Summary
- Most of the file changes is just spacing/reformatting from wrapping in `<Tooltip>`
- Adds a tooltip on the dashboard link button in the widget builder saying "Link this field to another dashboard" (both in the Visualize and Group By sections)
- Adds an `(i)` info icon with a tooltip next to the "Link to Dashboard" modal header explaining what dashboard linking does
- Extracts the shared tooltip text into a `LINK_FIELD_TOOLTIP` constant in a new `widgetBuilder/settings.ts` file