### PR TITLE
fix(dashboards): Replace ugly red dashboard widget error states

### DIFF
--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
 import {LazyRender} from 'sentry/components/lazyRender';
-import {PanelAlert} from 'sentry/components/panels/panelAlert';
 import {t} from 'sentry/locale';
 import type {User} from 'sentry/types/user';
 import type {Sort} from 'sentry/utils/discover/fields';
@@ -15,7 +14,6 @@ import {useWidgetSlideout} from 'sentry/views/dashboards/utils/useWidgetSlideout
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
 
-import {useWidgetErrorCallback} from './contexts/widgetErrorContext';
 import {checkUserHasEditAccess} from './utils/checkUserHasEditAccess';
 import {DashboardsMEPProvider} from './widgetCard/dashboardsMEPContext';
 import {Toolbar} from './widgetCard/toolbar';
@@ -85,7 +83,6 @@ export function SortableWidget(props: Props) {
   const organization = useOrganization();
   const currentUser = useUser();
   const {teams: userTeams} = useUserTeams();
-  const onWidgetError = useWidgetErrorCallback();
   const hasEditAccess =
     checkUserHasEditAccess(
       currentUser,
@@ -140,20 +137,6 @@ export function SortableWidget(props: Props) {
     index,
     dashboardFilters,
     widgetLegendState,
-    renderErrorMessage: errorMessage => {
-      if (
-        typeof errorMessage === 'string' &&
-        errorMessage !== t('No data found') &&
-        onWidgetError
-      ) {
-        onWidgetError(widget, errorMessage);
-      }
-      return (
-        typeof errorMessage === 'string' && (
-          <PanelAlert variant="danger">{errorMessage}</PanelAlert>
-        )
-      );
-    },
     isMobile,
     windowWidth,
     tableItemLimit:

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -1,7 +1,6 @@
 import {useState} from 'react';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {PanelAlert} from 'sentry/components/panels/panelAlert';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
@@ -113,11 +112,6 @@ export function WidgetPreview({
       isEditingDashboard={false}
       widgetLimitReached={false}
       showContextMenu={false}
-      renderErrorMessage={errorMessage =>
-        typeof errorMessage === 'string' && (
-          <PanelAlert variant="danger">{errorMessage}</PanelAlert>
-        )
-      }
       widgetInterval={
         organization.features.includes('dashboards-interval-selection')
           ? chartInterval

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -167,7 +167,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -193,7 +192,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -217,7 +215,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -252,7 +249,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -287,7 +283,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -324,7 +319,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -353,7 +347,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={mock}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -380,7 +373,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={mock}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLegendState={widgetLegendState}
         widgetLimitReached
@@ -407,7 +399,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={mock}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -434,7 +425,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={mock}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -468,7 +458,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={mock}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         tableItemLimit={20}
@@ -503,7 +492,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={mock}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -549,7 +537,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         tableItemLimit={20}
@@ -593,7 +580,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         tableItemLimit={20}
@@ -631,7 +617,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         index="10"
@@ -701,7 +686,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -801,7 +785,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -837,7 +820,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         isPreview
@@ -862,7 +844,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         widgetLegendState={widgetLegendState}
@@ -891,7 +872,6 @@ describe('Dashboards > WidgetCard', () => {
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
-        renderErrorMessage={() => undefined}
         showContextMenu
         widgetLimitReached={false}
         isPreview

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -116,7 +116,6 @@ type Props = WithRouterProps & {
   onWidgetSplitDecision?: (splitDecision: WidgetType) => void;
   onWidgetTableResizeColumn?: (columns: TabularColumn[]) => void;
   onWidgetTableSort?: (sort: Sort) => void;
-  renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   shouldResize?: boolean;
   showConfidenceWarning?: boolean;
   showContextMenu?: boolean;
@@ -171,7 +170,6 @@ function WidgetCard(props: Props) {
     selection,
     widget,
     isMobile,
-    renderErrorMessage,
     tableItemLimit,
     windowWidth,
     dashboardFilters,
@@ -398,7 +396,6 @@ function WidgetCard(props: Props) {
             selection={selection}
             widget={widget}
             isMobile={isMobile}
-            renderErrorMessage={renderErrorMessage}
             tableItemLimit={tableItemLimit}
             windowWidth={windowWidth}
             onDataFetched={onDataFetched}

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -355,7 +355,6 @@ function WidgetCard(props: Props) {
               onDataFetched={onDataFetched}
               onWidgetTableSort={onWidgetTableSort}
               onWidgetTableResizeColumn={onWidgetTableResizeColumn}
-              renderErrorMessage={renderErrorMessage}
               onDataFetchStart={onDataFetchStart}
               tableItemLimit={tableItemLimit}
               widgetInterval={widgetInterval}

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -14,7 +14,6 @@ import {
 } from 'sentry/components/modals/widgetViewerModal/utils';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {PanelAlert} from 'sentry/components/panels/panelAlert';
-import {Placeholder} from 'sentry/components/placeholder';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {Token} from 'sentry/components/searchSyntax/parser';
 import {t, tct} from 'sentry/locale';
@@ -40,7 +39,7 @@ import {withPageFilters} from 'sentry/utils/withPageFilters';
 // eslint-disable-next-line no-restricted-imports
 import {withSentryRouter} from 'sentry/utils/withSentryRouter';
 import {DASHBOARD_CHART_GROUP} from 'sentry/views/dashboards/dashboard';
-import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import type {DashboardFilters, Widget as TWidget} from 'sentry/views/dashboards/types';
 import {
   DashboardFilterKeys,
   DisplayType,
@@ -51,6 +50,7 @@ import {widgetCanUseTimeSeriesVisualization} from 'sentry/views/dashboards/utils
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
 import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 
 import {useDashboardsMEPContext} from './dashboardsMEPContext';
 import {VisualizationWidget} from './visualizationWidget';
@@ -89,7 +89,7 @@ type Props = WithRouterProps & {
   location: Location;
   organization: Organization;
   selection: PageFilters;
-  widget: Widget;
+  widget: TWidget;
   widgetLegendState: WidgetLegendSelectionState;
   widgetLimitReached: boolean;
   borderless?: boolean;
@@ -112,7 +112,7 @@ type Props = WithRouterProps & {
   onEdit?: () => void;
   onLegendSelectChanged?: () => void;
   onSetTransactionsDataset?: () => void;
-  onUpdate?: (widget: Widget | null) => void;
+  onUpdate?: (widget: TWidget | null) => void;
   onWidgetSplitDecision?: (splitDecision: WidgetType) => void;
   onWidgetTableResizeColumn?: (columns: TabularColumn[]) => void;
   onWidgetTableSort?: (sort: Sort) => void;
@@ -319,12 +319,24 @@ function WidgetCard(props: Props) {
     ? t('Widget query condition is invalid.')
     : undefined;
 
+  const errorBoundaryHandler = () => {
+    return (
+      <Widget
+        Title={<Widget.WidgetTitle title={widget.title} />}
+        Visualization={
+          <Widget.WidgetError
+            error={t("Something went wrong with this widget, we're looking into it!")}
+          />
+        }
+        noVisualizationPadding
+      />
+    );
+  };
+
   const canUseTimeseriesVisualization = widgetCanUseTimeSeriesVisualization(widget);
   if (canUseTimeseriesVisualization) {
     return (
-      <ErrorBoundary
-        customComponent={() => <ErrorCard>{t('Error loading widget data')}</ErrorCard>}
-      >
+      <ErrorBoundary customComponent={errorBoundaryHandler}>
         <VisuallyCompleteWithData
           id="DashboardList-FirstWidgetCard"
           hasData={
@@ -365,9 +377,7 @@ function WidgetCard(props: Props) {
   }
 
   return (
-    <ErrorBoundary
-      customComponent={() => <ErrorCard>{t('Error loading widget data')}</ErrorCard>}
-    >
+    <ErrorBoundary customComponent={errorBoundaryHandler}>
       <VisuallyCompleteWithData
         id="DashboardList-FirstWidgetCard"
         hasData={
@@ -423,7 +433,7 @@ function WidgetCard(props: Props) {
 
 export default withApi(withOrganization(withPageFilters(withSentryRouter(WidgetCard))));
 
-function useOnDemandWarning(props: {widget: Widget}): string | null {
+function useOnDemandWarning(props: {widget: TWidget}): string | null {
   const organization = useOrganization();
 
   if (!hasOnDemandMetricWidgetFeature(organization)) {
@@ -459,7 +469,7 @@ function useOnDemandWarning(props: {widget: Widget}): string | null {
   return null;
 }
 
-function useTimeRangeWarning({widget}: {widget: Widget}) {
+function useTimeRangeWarning({widget}: {widget: TWidget}) {
   const {
     selection: {datetime},
   } = usePageFilters();
@@ -505,7 +515,7 @@ function useConflictingFilterWarning({
   dashboardFilters,
 }: {
   dashboardFilters: DashboardFilters | undefined;
-  widget: Widget;
+  widget: TWidget;
 }) {
   const conflictingFilterKeys = useMemo(() => {
     if (!dashboardFilters) return [];
@@ -537,17 +547,6 @@ function useConflictingFilterWarning({
 
   return null;
 }
-
-const ErrorCard = styled(Placeholder)`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: ${p => p.theme.colors.red100};
-  border: 1px solid ${p => p.theme.colors.red200};
-  color: ${p => p.theme.colors.red200};
-  border-radius: ${p => p.theme.radius.md};
-  margin-bottom: ${p => p.theme.space.xl};
-`;
 
 export const WidgetDescription = styled('small')`
   display: block;

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -7,7 +7,6 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {IconWarning} from 'sentry/icons';
 import type {PageFilters} from 'sentry/types/core';
 import type {EChartDataZoomHandler, Series} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
@@ -42,6 +41,7 @@ import {createPlottableFromTimeSeries} from 'sentry/views/dashboards/widgets/tim
 import type {Plottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/plottable';
 import {Thresholds} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
@@ -73,7 +73,6 @@ interface VisualizationWidgetProps {
   onWidgetTableResizeColumn?: (columns: TabularColumn[]) => void;
   onWidgetTableSort?: (sort: Sort) => void;
   onZoom?: EChartDataZoomHandler;
-  renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   showConfidenceWarning?: boolean;
   showReleaseAs?: LoadableChartWidgetProps['showReleaseAs'];
   tableItemLimit?: number;
@@ -88,7 +87,6 @@ export function VisualizationWidget({
   onDataFetchStart,
   tableItemLimit,
   widgetInterval,
-  renderErrorMessage,
   showReleaseAs = 'bubble',
   showConfidenceWarning,
   onZoom,
@@ -138,7 +136,6 @@ export function VisualizationWidget({
             loading={loading}
             releases={releases}
             showReleaseAs={showReleaseAs}
-            renderErrorMessage={renderErrorMessage}
             dashboardFilters={dashboardFilters}
             showConfidenceWarning={showConfidenceWarning}
             confidence={confidence}
@@ -169,7 +166,6 @@ interface VisualizationWidgetContentProps {
   legendSelection?: LegendSelection;
   onLegendSelectionChange?: (selection: LegendSelection) => void;
   onZoom?: EChartDataZoomHandler;
-  renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   sampleCount?: number;
   showConfidenceWarning?: boolean;
   tableResults?: TableDataWithTitle[];
@@ -187,7 +183,6 @@ function VisualizationWidgetContent({
   loading,
   releases,
   showReleaseAs,
-  renderErrorMessage,
   dashboardFilters,
   showConfidenceWarning,
   confidence,
@@ -243,9 +238,6 @@ function VisualizationWidgetContent({
       ];
     })
     .filter(defined);
-
-  const errorDisplay =
-    renderErrorMessage && errorMessage ? renderErrorMessage(errorMessage) : null;
 
   const plottableWithNeedsColor = timeSeriesWithPlottable.filter(
     ([_, plottable]) => plottable.needsColor
@@ -381,8 +373,9 @@ function VisualizationWidgetContent({
   if (loading) {
     return <TimeSeriesWidgetVisualization.LoadingPlaceholder />;
   }
-  if (errorDisplay) {
-    return errorDisplay;
+
+  if (errorMessage) {
+    return <Widget.WidgetError error={errorMessage} />;
   }
 
   const timeseriesContainerPadding: ContainerProps = {
@@ -411,13 +404,9 @@ function VisualizationWidgetContent({
   // This prevents TimeSeriesWidgetVisualization from throwing an error
   // that would get caught by ErrorBoundary and persist across filter changes
   const hasNoPlottableData = plottables.every(plottable => plottable.isEmpty);
+
   if (hasNoPlottableData) {
-    return (
-      <Flex align="center" justify="center" height="100%" gap="xs">
-        <IconWarning size="sm" variant="muted" />
-        <Text variant="muted">{MISSING_DATA_MESSAGE}</Text>
-      </Flex>
-    );
+    return <Widget.WidgetError error={MISSING_DATA_MESSAGE} />;
   }
 
   const confidenceFooter = showConfidenceWarning ? (

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -21,7 +21,7 @@ import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {
   WidgetType,
   type DashboardFilters,
-  type Widget,
+  type Widget as TWidget,
 } from 'sentry/views/dashboards/types';
 import {applyDashboardFilters, usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {
@@ -57,7 +57,7 @@ import {WidgetCardDataLoader} from './widgetCardDataLoader';
 
 interface VisualizationWidgetProps {
   selection: PageFilters;
-  widget: Widget;
+  widget: TWidget;
   dashboardFilters?: DashboardFilters;
   legendSelection?: LegendSelection;
   onDataFetchStart?: () => void;
@@ -160,7 +160,7 @@ interface VisualizationWidgetContentProps {
   releases: Array<{timestamp: string; version: string}>;
   showReleaseAs: LoadableChartWidgetProps['showReleaseAs'];
   timeseriesResults: Series[];
-  widget: Widget;
+  widget: TWidget;
   confidence?: Confidence;
   dashboardFilters?: DashboardFilters;
   dataScanned?: 'full' | 'partial';

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -17,6 +17,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
+import {useWidgetErrorCallback} from 'sentry/views/dashboards/contexts/widgetErrorContext';
 import {
   WidgetType,
   type DashboardFilters,
@@ -93,6 +94,8 @@ export function VisualizationWidget({
   legendSelection,
   onLegendSelectionChange,
 }: VisualizationWidgetProps) {
+  const onWidgetError = useWidgetErrorCallback();
+
   const {releases: releasesWithDate} = useReleaseStats(selection, {
     enabled: showReleaseAs !== 'none',
   });
@@ -125,6 +128,10 @@ export function VisualizationWidget({
         isSampled,
         sampleCount,
       }) => {
+        if (errorMessage && onWidgetError) {
+          onWidgetError(widget, errorMessage);
+        }
+
         return (
           <VisualizationWidgetContent
             widget={widget}

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -19,6 +19,7 @@ import {usesTimeSeriesData, widgetFetchesOwnData} from 'sentry/views/dashboards/
 import {WidgetLegendNameEncoderDecoder} from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
 import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 
 import WidgetCardChart from './chart';
 import {WidgetCardDataLoader} from './widgetCardDataLoader';
@@ -57,7 +58,6 @@ type Props = {
   onWidgetTableResizeColumn?: (columns: TabularColumn[]) => void;
   onWidgetTableSort?: (sort: Sort) => void;
   onZoom?: EChartDataZoomHandler;
-  renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   shouldResize?: boolean;
   showConfidenceWarning?: boolean;
   showLoadingText?: boolean;
@@ -71,7 +71,6 @@ export function WidgetCardChartContainer({
   widget,
   dashboardFilters,
   isMobile,
-  renderErrorMessage,
   tableItemLimit,
   windowWidth,
   onZoom,
@@ -152,11 +151,12 @@ export function WidgetCardChartContainer({
               widget.displayType
             );
 
+        if (errorOrEmptyMessage) {
+          return <Widget.WidgetError error={errorOrEmptyMessage} />;
+        }
+
         return (
           <Fragment>
-            {typeof renderErrorMessage === 'function'
-              ? renderErrorMessage(errorOrEmptyMessage)
-              : null}
             <WidgetCardChart
               disableZoom={disableZoom}
               timeseriesResults={modifiedTimeseriesResults}

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -13,7 +13,7 @@ import type {
 import type {Confidence} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, Sort} from 'sentry/utils/discover/fields';
-import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import type {DashboardFilters, Widget as TWidget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData, widgetFetchesOwnData} from 'sentry/views/dashboards/utils';
 import {WidgetLegendNameEncoderDecoder} from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
@@ -25,7 +25,7 @@ import {WidgetCardDataLoader} from './widgetCardDataLoader';
 
 type Props = {
   selection: PageFilters;
-  widget: Widget;
+  widget: TWidget;
   widgetLegendState: WidgetLegendSelectionState;
   api?: Client;
   chartGroup?: string;

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -157,7 +157,7 @@ export function WidgetCardChartContainer({
         if (errorOrEmptyMessage) {
           if (
             typeof errorOrEmptyMessage === 'string' &&
-            errorMessage !== t('No data found') &&
+            errorOrEmptyMessage !== t('No data found') &&
             onWidgetError
           ) {
             onWidgetError(widget, errorOrEmptyMessage);

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -13,6 +13,7 @@ import type {
 import type {Confidence} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, Sort} from 'sentry/utils/discover/fields';
+import {useWidgetErrorCallback} from 'sentry/views/dashboards/contexts/widgetErrorContext';
 import type {DashboardFilters, Widget as TWidget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData, widgetFetchesOwnData} from 'sentry/views/dashboards/utils';
@@ -92,6 +93,8 @@ export function WidgetCardChartContainer({
   disableTableActions,
   widgetInterval,
 }: Props) {
+  const onWidgetError = useWidgetErrorCallback();
+
   const keepLegendState: EChartLegendSelectChangeHandler = ({selected}) => {
     widgetLegendState.setWidgetSelectionState(selected, widget);
   };
@@ -152,6 +155,14 @@ export function WidgetCardChartContainer({
             );
 
         if (errorOrEmptyMessage) {
+          if (
+            typeof errorOrEmptyMessage === 'string' &&
+            errorMessage !== t('No data found') &&
+            onWidgetError
+          ) {
+            onWidgetError(widget, errorOrEmptyMessage);
+          }
+
           return <Widget.WidgetError error={errorOrEmptyMessage} />;
         }
 


### PR DESCRIPTION
Closes DAIN-1375. Current dashboard widgets have a very horrible red banner for error states, and an even more horrible error boundary:

**e.g.,**
<img width="840" height="103" alt="Screenshot 2026-03-19 at 3 34 43 PM" src="https://github.com/user-attachments/assets/869642cf-fe6f-42fe-b6e2-de46edd57ed0" />
<img width="836" height="273" alt="Screenshot 2026-03-19 at 3 04 55 PM" src="https://github.com/user-attachments/assets/919ea3ca-2fb9-40d9-9ddd-c2514e72186d" />

This PR replaces both of them with `Widget.WidgetError` which is the standard way to handle this.

**e.g.,**
<img width="836" height="279" alt="Screenshot 2026-03-19 at 3 40 22 PM" src="https://github.com/user-attachments/assets/916b211a-532a-4f74-9186-029ed32ef2bd" />

I had to alias `Widget` to `TWidget` to allow importing the `Widget` component in a few places, but overall, this PR just replaces a bunch of custom error handling done through render props with a simple conditional that uses `WidgetError` to render errors.