### PR TITLE
feat(preprod): Support absolute detectors from single-build path

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -66,11 +66,11 @@ class SizeAnalysisMetadata(TypedDict):
 
     platform: str  # "android", "apple", or "unknown"
     head_metric_id: int
-    base_metric_id: int
+    base_metric_id: NotRequired[int]
     head_artifact_id: int
-    base_artifact_id: int
+    base_artifact_id: NotRequired[int]
     head_artifact: PreprodArtifact
-    base_artifact: PreprodArtifact
+    base_artifact: NotRequired[PreprodArtifact]
 
 
 class SizeAnalysisValue(TypedDict):
@@ -222,17 +222,20 @@ class PreprodSizeAnalysisDetectorHandler(
         }
         if metadata:
             evidence_data["head_artifact_id"] = metadata["head_artifact_id"]
-            evidence_data["base_artifact_id"] = metadata["base_artifact_id"]
+            if "base_artifact_id" in metadata:
+                evidence_data["base_artifact_id"] = metadata["base_artifact_id"]
             evidence_data["head_size_metric_id"] = metadata["head_metric_id"]
-            evidence_data["base_size_metric_id"] = metadata["base_metric_id"]
+            if "base_metric_id" in metadata:
+                evidence_data["base_size_metric_id"] = metadata["base_metric_id"]
 
         tags: dict[str, str] = {}
         if metadata:
             tags["regression_kind"] = measurement.replace("_size", "")
             for key, value in _artifact_to_tags(metadata["head_artifact"]).items():
                 tags[f"head.{key}"] = value
-            for key, value in _artifact_to_tags(metadata["base_artifact"]).items():
-                tags[f"base.{key}"] = value
+            if "base_artifact" in metadata:
+                for key, value in _artifact_to_tags(metadata["base_artifact"]).items():
+                    tags[f"base.{key}"] = value
 
             commit_comparison = metadata["head_artifact"].commit_comparison
             if commit_comparison is not None:

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -28,6 +28,11 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
 from sentry.utils import metrics
+
+# Threshold type categories for filtering detectors by path.
+# These must stay in sync with the enum in PreprodSizeAnalysisGroupType.detector_settings.config_schema.
+DIFF_THRESHOLD_TYPES = frozenset({"absolute_diff", "relative_diff"})
+ABSOLUTE_THRESHOLD_TYPES = frozenset({"absolute"})
 from sentry.utils.json import dumps_htmlsafe
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.processors.detector import process_detectors
@@ -583,6 +588,15 @@ def _maybe_emit_issues(
         )
         return
 
+    # Only process diff-based detectors from the comparison path
+    detectors = [d for d in detectors if d.config.get("threshold_type") in DIFF_THRESHOLD_TYPES]
+    if not detectors:
+        logger.info(
+            "preprod.size_analysis.no_diff_detectors",
+            extra={"project_id": project_id},
+        )
+        return
+
     diff = comparison_results.size_metric_diff_item
     head_artifact = head_metric.preprod_artifact
     base_artifact = base_metric.preprod_artifact
@@ -620,6 +634,92 @@ def _maybe_emit_issues(
     results = process_detectors(data_packet, detectors)
     logger.info(
         "preprod.size_analysis.process_detectors.completed",
+        extra={
+            "project_id": project_id,
+            "detector_count": len(results),
+        },
+    )
+
+
+def maybe_emit_issues_from_absolute_size_results(
+    head_metric: PreprodArtifactSizeMetrics,
+) -> None:
+    try:
+        _maybe_emit_issues_from_absolute_size_results(head_metric=head_metric)
+    except Exception:
+        logger.exception("Error emitting issues from absolute size results")
+
+
+def _maybe_emit_issues_from_absolute_size_results(
+    head_metric: PreprodArtifactSizeMetrics,
+) -> None:
+    project = head_metric.preprod_artifact.project
+    project_id = project.id
+    organization_id = project.organization.id
+
+    if not features.has("organizations:preprod-issues", project.organization):
+        logger.info(
+            "preprod.size_analysis.size_results.issues.disabled",
+            extra={
+                "project_id": project_id,
+                "organization_id": organization_id,
+            },
+        )
+        return
+
+    detectors = list(
+        Detector.objects.filter(
+            project_id=project_id,
+            type=PreprodSizeAnalysisGroupType.slug,
+            enabled=True,
+        )
+    )
+    if not detectors:
+        logger.info(
+            "preprod.size_analysis.size_results.no_detectors",
+            extra={"project_id": project_id},
+        )
+        return
+
+    # Only process absolute detectors from the single-build path
+    detectors = [d for d in detectors if d.config.get("threshold_type") in ABSOLUTE_THRESHOLD_TYPES]
+    if not detectors:
+        logger.info(
+            "preprod.size_analysis.size_results.no_absolute_detectors",
+            extra={"project_id": project_id},
+        )
+        return
+
+    head_artifact = head_metric.preprod_artifact
+
+    metadata: SizeAnalysisMetadata = {
+        "platform": _get_platform(head_artifact),
+        "head_metric_id": head_metric.id,
+        "head_artifact_id": head_artifact.id,
+        "head_artifact": head_artifact,
+    }
+
+    size_data: SizeAnalysisValue = {
+        "head_install_size_bytes": head_metric.max_install_size or 0,
+        "head_download_size_bytes": head_metric.max_download_size or 0,
+        "metadata": metadata,
+    }
+
+    data_packet: SizeAnalysisDataPacket = DataPacket(
+        source_id=f"preprod-size-analysis:{project_id}",
+        packet=size_data,
+    )
+
+    logger.info(
+        "preprod.size_analysis.size_results.process_detectors.starting",
+        extra={
+            "project_id": project_id,
+            "detector_count": len(detectors),
+        },
+    )
+    results = process_detectors(data_packet, detectors)
+    logger.info(
+        "preprod.size_analysis.size_results.process_detectors.completed",
         extra={
             "project_id": project_id,
             "detector_count": len(results),

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -29,7 +29,10 @@ from sentry.preprod.models import (
 from sentry.preprod.producer import PreprodFeature, produce_preprod_artifact_to_kafka
 from sentry.preprod.quotas import has_installable_quota, has_size_quota
 from sentry.preprod.size_analysis.models import SizeAnalysisResults
-from sentry.preprod.size_analysis.tasks import compare_preprod_artifact_size_analysis
+from sentry.preprod.size_analysis.tasks import (
+    compare_preprod_artifact_size_analysis,
+    maybe_emit_issues_from_absolute_size_results,
+)
 from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
@@ -540,6 +543,9 @@ def _assemble_preprod_artifact_size_analysis(
                     "error": str(eap_error),
                 },
             )
+
+        for size_metric in size_metrics_updated:
+            maybe_emit_issues_from_absolute_size_results(head_metric=size_metric)
 
         if size_analysis_results.analysis_duration is not None:
             with transaction.atomic(router.db_for_write(PreprodArtifact)):

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -9,6 +9,7 @@ from sentry.preprod.size_analysis.models import ComparisonResults, SizeMetricDif
 from sentry.preprod.size_analysis.tasks import (
     _get_platform,
     maybe_emit_issues,
+    maybe_emit_issues_from_absolute_size_results,
 )
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models.data_condition import Condition
@@ -67,14 +68,14 @@ class MaybeEmitIssuesTest(TestCase):
         self.create_data_condition(
             condition_group=condition_group,
             type=Condition.GREATER,
-            comparison=1000000,
+            comparison=500000,
             condition_result=DetectorPriorityLevel.HIGH,
         )
         self.create_detector(
             name="test-detector",
             project=self.project,
             type=PreprodSizeAnalysisGroupType.slug,
-            config={"threshold_type": "absolute", "measurement": "install_size"},
+            config={"threshold_type": "absolute_diff", "measurement": "install_size"},
             workflow_condition_group=condition_group,
         )
 
@@ -187,14 +188,14 @@ class MaybeEmitIssuesTest(TestCase):
         self.create_data_condition(
             condition_group=condition_group,
             type=Condition.GREATER,
-            comparison=1000000,
+            comparison=500000,
             condition_result=DetectorPriorityLevel.HIGH,
         )
         self.create_detector(
             name="test-detector",
             project=self.project,
             type=PreprodSizeAnalysisGroupType.slug,
-            config={"threshold_type": "absolute", "measurement": "install_size"},
+            config={"threshold_type": "absolute_diff", "measurement": "install_size"},
             workflow_condition_group=condition_group,
         )
 
@@ -216,6 +217,236 @@ class MaybeEmitIssuesTest(TestCase):
             assert metadata["base_artifact_id"] == base_artifact.id
             assert metadata["head_artifact"].id == head_artifact.id
             assert metadata["base_artifact"].id == base_artifact.id
+
+    def test_maybe_emit_issues_skips_absolute_detectors(self):
+        """Absolute detectors should not fire from the comparison path."""
+        head_artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
+        base_artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
+
+        head_metric = self.create_preprod_artifact_size_metrics(
+            head_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier=None,
+            max_install_size=5000000,
+            max_download_size=2000000,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        base_metric = self.create_preprod_artifact_size_metrics(
+            base_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier=None,
+            max_install_size=4000000,
+            max_download_size=1500000,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=1000000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        self.create_detector(
+            name="absolute-detector",
+            project=self.project,
+            type=PreprodSizeAnalysisGroupType.slug,
+            config={"threshold_type": "absolute", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        comparison_results = self._create_comparison_results()
+
+        with self.feature("organizations:preprod-issues"):
+            with patch(
+                "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
+            ) as mock_produce:
+                maybe_emit_issues(comparison_results, head_metric, base_metric)
+
+            assert mock_produce.call_count == 0
+
+
+class MaybeEmitIssuesFromSizeResultsTest(TestCase):
+    """Tests for the maybe_emit_issues_from_absolute_size_results function."""
+
+    def test_triggers_absolute_detector(self):
+        artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
+        metric = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier=None,
+            max_install_size=5000000,
+            max_download_size=2000000,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=1000000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        self.create_detector(
+            name="absolute-detector",
+            project=self.project,
+            type=PreprodSizeAnalysisGroupType.slug,
+            config={"threshold_type": "absolute", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        with self.feature("organizations:preprod-issues"):
+            with patch(
+                "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
+            ) as mock_produce:
+                maybe_emit_issues_from_absolute_size_results(head_metric=metric)
+
+            assert mock_produce.call_count == 1
+
+    def test_skips_diff_detectors(self):
+        """Diff-based detectors should not fire from the single-build path."""
+        artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
+        metric = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier=None,
+            max_install_size=5000000,
+            max_download_size=2000000,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=500000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        self.create_detector(
+            name="diff-detector",
+            project=self.project,
+            type=PreprodSizeAnalysisGroupType.slug,
+            config={"threshold_type": "absolute_diff", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        with self.feature("organizations:preprod-issues"):
+            with patch(
+                "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
+            ) as mock_produce:
+                maybe_emit_issues_from_absolute_size_results(head_metric=metric)
+
+            assert mock_produce.call_count == 0
+
+    def test_feature_flag_disabled(self):
+        artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
+        metric = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier=None,
+            max_install_size=5000000,
+            max_download_size=2000000,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=1000000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        self.create_detector(
+            name="absolute-detector",
+            project=self.project,
+            type=PreprodSizeAnalysisGroupType.slug,
+            config={"threshold_type": "absolute", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        with patch(
+            "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
+        ) as mock_produce:
+            maybe_emit_issues_from_absolute_size_results(head_metric=metric)
+
+        assert mock_produce.call_count == 0
+
+    def test_populates_metadata_without_base(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            app_id="com.example.app",
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+        )
+        metric = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier=None,
+            max_install_size=5000000,
+            max_download_size=2000000,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=1000000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        self.create_detector(
+            name="absolute-detector",
+            project=self.project,
+            type=PreprodSizeAnalysisGroupType.slug,
+            config={"threshold_type": "absolute", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        with self.feature("organizations:preprod-issues"):
+            with patch("sentry.preprod.size_analysis.tasks.process_detectors") as mock_process:
+                mock_process.return_value = {}
+                maybe_emit_issues_from_absolute_size_results(head_metric=metric)
+
+            assert mock_process.call_count == 1
+            data_packet = mock_process.call_args[0][0]
+            metadata = data_packet.packet["metadata"]
+
+            assert metadata["platform"] == "android"
+            assert metadata["head_metric_id"] == metric.id
+            assert metadata["head_artifact_id"] == artifact.id
+            assert metadata["head_artifact"].id == artifact.id
+            assert "base_metric_id" not in metadata
+            assert "base_artifact_id" not in metadata
+            assert "base_artifact" not in metadata
+
+    def test_no_detectors(self):
+        artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
+        metric = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier=None,
+            max_install_size=5000000,
+            max_download_size=2000000,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        with self.feature("organizations:preprod-issues"):
+            with patch(
+                "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
+            ) as mock_produce:
+                maybe_emit_issues_from_absolute_size_results(head_metric=metric)
+
+            assert mock_produce.call_count == 0
 
 
 class GetPlatformTest(TestCase):


### PR DESCRIPTION
Add `maybe_emit_issues_from_size_results` so that "absolute" threshold detectors fire as soon as a single build's size metrics are committed, without waiting for a comparison against a base artifact.

Previously, all issue emission went through the comparison path (`maybe_emit_issues`), which requires both head and base artifacts. This meant absolute detectors — which only need one build's size — couldn't fire until a comparison happened. Now:

- The **single-build path** (called after metrics commit in `_assemble_preprod_artifact_size_analysis`) processes only `threshold_type == "absolute"` detectors
- The **comparison path** (`_maybe_emit_issues`) processes only `threshold_type in ("absolute_diff", "relative_diff")` detectors
- `SizeAnalysisMetadata` base fields (`base_metric_id`, `base_artifact_id`, `base_artifact`) are now `NotRequired`, and `create_occurrence` conditionally populates base-related evidence and tags


Agent transcript: https://claudescope.sentry.dev/share/UgFhB6vtmF1RiOVM-Ble2aoN68w7YgfkO_BzAXfdxnE