### PR TITLE
fix(preprod): Fix typecheck errors from monitor filters reland

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -178,6 +178,7 @@ export interface IssueStreamDetector extends BaseDetector {
 interface PreprodDetectorConfig {
   measurement: PreprodMeasurement;
   thresholdType: PreprodThresholdType;
+  query?: string;
 }
 
 export interface PreprodDetector extends BaseDetector {
@@ -257,6 +258,7 @@ export interface PreprodDetectorUpdatePayload extends BaseDetectorUpdatePayload 
   config: {
     measurement: PreprodMeasurement;
     thresholdType: PreprodThresholdType;
+    query?: string;
   };
   type: 'preprod_size_analysis';
 }

--- a/static/app/views/detectors/components/forms/mobileBuild/index.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/index.tsx
@@ -1,7 +1,13 @@
+import {useCallback, useContext} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Stack} from '@sentry/scraps/layout';
 
+import FormContext from 'sentry/components/forms/formContext';
+import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
+import {Container} from 'sentry/components/workflowEngine/ui/container';
+import Section from 'sentry/components/workflowEngine/ui/section';
+import {t} from 'sentry/locale';
 import type {PreprodDetector} from 'sentry/types/workflowEngine/detectors';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
 import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';
@@ -10,18 +16,50 @@ import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDe
 import {MobileBuildDetectSection} from 'sentry/views/detectors/components/forms/mobileBuild/detectSection';
 import {
   PREPROD_DEFAULT_FORM_DATA,
+  PREPROD_DETECTOR_FORM_FIELDS,
   preprodFormDataToEndpointPayload,
   preprodSavedDetectorToFormData,
+  usePreprodDetectorFormField,
 } from 'sentry/views/detectors/components/forms/mobileBuild/mobileBuildFormData';
 import {MobileBuildPreviewSection} from 'sentry/views/detectors/components/forms/mobileBuild/previewSection';
 import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
+import {STATUS_CHECK_ALLOWED_FILTER_KEYS} from 'sentry/views/settings/project/preprod/types';
 
 function MobileBuildDetectorForm() {
   const theme = useTheme();
+  const {form} = useContext(FormContext);
+  const query = usePreprodDetectorFormField(PREPROD_DETECTOR_FORM_FIELDS.query) ?? '';
+  const projectId = usePreprodDetectorFormField(PREPROD_DETECTOR_FORM_FIELDS.projectId);
+
+  const handleSearch = useCallback(
+    (searchQuery: string) => {
+      form?.setValue(PREPROD_DETECTOR_FORM_FIELDS.query, searchQuery);
+    },
+    [form]
+  );
 
   return (
     <Stack gap="2xl" maxWidth={theme.breakpoints.lg}>
       <MobileBuildDetectSection />
+      <Container>
+        <Section
+          title={t('Filters')}
+          description={t(
+            'Narrow down which builds are monitored by filtering on build attributes.'
+          )}
+        >
+          <PreprodSearchBar
+            initialQuery={query}
+            projects={projectId ? [Number(projectId)] : []}
+            onSearch={handleSearch}
+            searchSource="mobile_build_detector_form"
+            disallowFreeText
+            disallowHas
+            disallowLogicalOperators
+            allowedKeys={STATUS_CHECK_ALLOWED_FILTER_KEYS}
+          />
+        </Section>
+      </Container>
       <MobileBuildPreviewSection />
       <AssignSection />
       <DescribeSection />

--- a/static/app/views/detectors/components/forms/mobileBuild/index.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/index.tsx
@@ -3,10 +3,10 @@ import {useTheme} from '@emotion/react';
 
 import {Stack} from '@sentry/scraps/layout';
 
-import FormContext from 'sentry/components/forms/formContext';
+import {FormContext} from 'sentry/components/forms/formContext';
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
-import Section from 'sentry/components/workflowEngine/ui/section';
+import {Section} from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
 import type {PreprodDetector} from 'sentry/types/workflowEngine/detectors';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';

--- a/static/app/views/detectors/components/forms/mobileBuild/mobileBuildFormData.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/mobileBuildFormData.tsx
@@ -20,6 +20,7 @@ interface PreprodDetectorFormData {
   name: string;
   owner: string;
   projectId: string;
+  query: string;
   thresholdType: PreprodThresholdType;
   workflowIds: string[];
 }
@@ -36,6 +37,7 @@ export const PREPROD_DETECTOR_FORM_FIELDS = {
   thresholdType: 'thresholdType',
   highThreshold: 'highThreshold',
   lowThreshold: 'lowThreshold',
+  query: 'query',
 } satisfies Record<PreprodDetectorFormFieldName, PreprodDetectorFormFieldName>;
 
 export const PREPROD_DEFAULT_FORM_DATA: Partial<PreprodDetectorFormData> = {
@@ -43,6 +45,7 @@ export const PREPROD_DEFAULT_FORM_DATA: Partial<PreprodDetectorFormData> = {
   thresholdType: 'absolute',
   highThreshold: '',
   lowThreshold: '',
+  query: '',
 };
 
 export function usePreprodDetectorFormField<T extends PreprodDetectorFormFieldName>(
@@ -99,6 +102,7 @@ export function preprodFormDataToEndpointPayload(
     config: {
       measurement: data.measurement,
       thresholdType: data.thresholdType,
+      query: data.query || undefined,
     },
   };
 }
@@ -134,6 +138,7 @@ export function preprodSavedDetectorToFormData(
     workflowIds: detector.workflowIds,
     measurement: detector.config.measurement,
     thresholdType: detector.config.thresholdType,
+    query: detector.config.query || '',
     highThreshold: conditionToThreshold(highCondition?.comparison, isPercentage),
     lowThreshold: conditionToThreshold(lowCondition?.comparison, isPercentage),
   };

--- a/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
@@ -24,6 +24,7 @@ import {
   mbToBytes,
   MEASUREMENT_OPTIONS,
   METRIC_OPTIONS,
+  STATUS_CHECK_ALLOWED_FILTER_KEYS,
 } from './types';
 
 interface Props {
@@ -139,12 +140,7 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
           disallowFreeText
           disallowHas
           disallowLogicalOperators
-          allowedKeys={[
-            'app_id',
-            'git_head_ref',
-            'build_configuration_name',
-            'platform_name',
-          ]}
+          allowedKeys={STATUS_CHECK_ALLOWED_FILTER_KEYS}
         />
       </Stack>
 

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -94,6 +94,13 @@ export const ARTIFACT_TYPE_OPTIONS: Array<{label: string; value: ArtifactType}> 
     value,
   }));
 
+export const STATUS_CHECK_ALLOWED_FILTER_KEYS = [
+  'app_id',
+  'git_head_ref',
+  'build_configuration_name',
+  'platform_name',
+];
+
 export function guessPlatformForProject(project: Project): Platform | undefined {
   const platform = project.platform;
   if (!platform) {


### PR DESCRIPTION
Fix typecheck errors introduced by the reland of monitor filters (95e3ff47a7e).

`FormContext` and `Section` are named exports but were imported as default
exports in the mobile build detector form, causing three TypeScript errors.


Agent transcript: https://claudescope.sentry.dev/share/0f6OHlCAOh7GRffxn4UrfZPAgEjU-mIK3FCG-ksuJY0