### PR TITLE
ref: Use EAP for sessions read query

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -326,6 +326,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable GitLab as a supported SCM provider for Seer
     manager.add("organizations:seer-gitlab-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disable select orgs from ingesting mobile replay events.
+    # Enable double-read from EAP for session health data validation
+    manager.add("organizations:session-health-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:session-replay-video-disabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable data scrubbing of replay recording payloads in Relay.
     manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)

--- a/src/sentry/release_health/eap_sessions_rollout.py
+++ b/src/sentry/release_health/eap_sessions_rollout.py
@@ -1,0 +1,804 @@
+"""Double-read rollout for session health data from EAP.
+
+Queries EAP in parallel with existing metrics and compares results.
+Always returns the control (metrics) data. User-facing behavior never changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING
+
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
+    AttributeConditionalAggregation,
+)
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    Expression,
+    TimeSeriesRequest,
+    TimeSeriesResponse,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    AttributeValue,
+    Function,
+    StrArray,
+)
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    AndFilter,
+    ComparisonFilter,
+    TraceItemFilter,
+)
+
+from sentry.release_health.base import SessionsQueryResult
+from sentry.release_health.metrics_sessions_v2 import SessionStatus
+from sentry.snuba.sessions_v2 import get_timestamps, isoformat_z
+from sentry.utils import metrics
+from sentry.utils.snuba_rpc import timeseries_rpc
+
+if TYPE_CHECKING:
+    from sentry.snuba.metrics.query import DeprecatingMetricsQuery
+    from sentry.snuba.sessions_v2 import QueryDefinition
+
+logger = logging.getLogger(__name__)
+
+# Mapping from session MRI to sessions_v2-style field name.
+# Used to translate metrics/data endpoint queries into the format
+# the existing EAP request builder expects.
+_SESSION_MRI_TO_V2_FIELD: dict[str, str] = {
+    "e:sessions/all@none": "sum(session)",
+    "e:sessions/crash_free_rate@ratio": "crash_free_rate(session)",
+    "e:sessions/crash_rate@ratio": "crash_rate(session)",
+    "e:sessions/abnormal_rate@ratio": "abnormal_rate(session)",
+    "e:sessions/errored_rate@ratio": "errored_rate(session)",
+    "e:sessions/unhealthy_rate@ratio": "unhealthy_rate(session)",
+    "s:sessions/user@none": "count_unique(user)",
+    "e:sessions/user.all@none": "count_unique(user)",
+    "e:sessions/user.crash_free_rate@ratio": "crash_free_rate(user)",
+    "e:sessions/user.crash_rate@ratio": "crash_rate(user)",
+    "e:sessions/user.anr_rate@ratio": "anr_rate()",
+    "e:sessions/user.foreground_anr_rate@ratio": "foreground_anr_rate()",
+}
+
+# Mapping from metrics groupBy field names to sessions_v2 groupBy names
+_GROUPBY_METRICS_TO_V2: dict[str, str] = {
+    "project_id": "project",
+    "project": "project",
+    "release": "release",
+    "environment": "environment",
+    "session.status": "session.status",
+}
+
+# Session-count based rate fields and their (numerator_status, is_inverted) info.
+# is_inverted means the rate is `1 - numerator/denominator`.
+_SESSION_RATE_FIELDS: dict[str, tuple[str, bool]] = {
+    "crash_free_rate(session)": ("crashed", True),
+    "crash_rate(session)": ("crashed", False),
+    "errored_rate(session)": ("errored", False),
+    "abnormal_rate(session)": ("abnormal", False),
+    "unhandled_rate(session)": ("unhandled", False),
+}
+
+# User-count based rate fields
+_USER_RATE_FIELDS: dict[str, tuple[str, bool]] = {
+    "crash_free_rate(user)": ("crashed", True),
+    "crash_rate(user)": ("crashed", False),
+    "errored_rate(user)": ("errored", False),
+    "abnormal_rate(user)": ("abnormal", False),
+    "unhandled_rate(user)": ("unhandled", False),
+}
+
+# All status values used in conditional aggregations
+_SESSION_STATUSES = ("init", "crashed", "errored_preaggr", "abnormal", "unhandled")
+
+
+def _status_filter(status: str) -> TraceItemFilter:
+    """Build a TraceItemFilter matching status=<value>."""
+    return TraceItemFilter(
+        comparison_filter=ComparisonFilter(
+            key=AttributeKey(name="status", type=AttributeKey.Type.TYPE_STRING),
+            op=ComparisonFilter.OP_EQUALS,
+            value=AttributeValue(val_str=status),
+        )
+    )
+
+
+_SESSION_COUNT_FIELDS = {
+    "sum(session)",
+    "unhealthy_rate(session)",
+} | set(_SESSION_RATE_FIELDS)
+
+_ANR_FIELDS = {"anr_rate()", "foreground_anr_rate()"}
+
+_USER_COUNT_FIELDS = {"count_unique(user)"} | set(_USER_RATE_FIELDS) | _ANR_FIELDS
+
+
+def _needs_session_counts(query: QueryDefinition) -> bool:
+    """Whether we need session_count conditional aggregations."""
+    return "session.status" in query.raw_groupby or bool(
+        set(query.raw_fields) & _SESSION_COUNT_FIELDS
+    )
+
+
+def _needs_user_counts(query: QueryDefinition) -> bool:
+    """Whether we need user_id_hash conditional aggregations."""
+    return "session.status" in query.raw_groupby or bool(set(query.raw_fields) & _USER_COUNT_FIELDS)
+
+
+def _needs_anr_counts(query: QueryDefinition) -> bool:
+    """Whether we need abnormal_mechanism-filtered user count aggregations."""
+    return bool(set(query.raw_fields) & _ANR_FIELDS)
+
+
+def _build_eap_timeseries_request(org_id: int, query: QueryDefinition) -> TimeSeriesRequest:
+    """Translate a QueryDefinition into a TimeSeriesRequest protobuf."""
+    start_timestamp = Timestamp()
+    start_timestamp.FromDatetime(query.start)
+    end_timestamp = Timestamp()
+    end_timestamp.FromDatetime(query.end)
+
+    project_ids = query.params["project_id"]
+
+    expressions: list[Expression] = []
+
+    # Build conditional aggregations for session counts per status
+    if _needs_session_counts(query):
+        for status in _SESSION_STATUSES:
+            label = f"sum_session_{status}"
+            expressions.append(
+                Expression(
+                    conditional_aggregation=AttributeConditionalAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(name="session_count", type=AttributeKey.Type.TYPE_INT),
+                        filter=_status_filter(status),
+                        label=label,
+                    ),
+                    label=label,
+                )
+            )
+        # Count of distinct errored sessions from the error set items
+        expressions.append(
+            Expression(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_UNIQ,
+                    key=AttributeKey(
+                        name="errored_session_id_hash", type=AttributeKey.Type.TYPE_ARRAY
+                    ),
+                    label="errored_set_count",
+                ),
+                label="errored_set_count",
+            )
+        )
+
+    # Build aggregations for user counts per status
+    if _needs_user_counts(query):
+        # Total unique users (non-conditional — user set items don't have "init" status)
+        expressions.append(
+            Expression(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_UNIQ,
+                    key=AttributeKey(
+                        name="user_id_hash",
+                        type=AttributeKey.Type.TYPE_ARRAY,
+                    ),
+                    label="uniq_user_all",
+                ),
+                label="uniq_user_all",
+            )
+        )
+        # Status-filtered user counts (errored, crashed, abnormal, unhandled
+        # are valid statuses on user set items)
+        for status in ("errored", "crashed", "abnormal", "unhandled"):
+            label = f"uniq_user_{status}"
+            expressions.append(
+                Expression(
+                    conditional_aggregation=AttributeConditionalAggregation(
+                        aggregate=Function.FUNCTION_UNIQ,
+                        key=AttributeKey(
+                            name="user_id_hash",
+                            type=AttributeKey.Type.TYPE_ARRAY,
+                        ),
+                        filter=_status_filter(status),
+                        label=label,
+                    ),
+                    label=label,
+                )
+            )
+
+    # Build conditional aggregations for ANR user counts
+    if _needs_anr_counts(query):
+        # All ANRs (foreground + background)
+        expressions.append(
+            Expression(
+                conditional_aggregation=AttributeConditionalAggregation(
+                    aggregate=Function.FUNCTION_UNIQ,
+                    key=AttributeKey(name="user_id_hash", type=AttributeKey.Type.TYPE_ARRAY),
+                    filter=TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=AttributeKey(
+                                name="abnormal_mechanism",
+                                type=AttributeKey.Type.TYPE_STRING,
+                            ),
+                            op=ComparisonFilter.OP_IN,
+                            value=AttributeValue(
+                                val_str_array=StrArray(values=["anr_foreground", "anr_background"])
+                            ),
+                        )
+                    ),
+                    label="uniq_user_anr",
+                ),
+                label="uniq_user_anr",
+            )
+        )
+        # Foreground ANRs only
+        expressions.append(
+            Expression(
+                conditional_aggregation=AttributeConditionalAggregation(
+                    aggregate=Function.FUNCTION_UNIQ,
+                    key=AttributeKey(name="user_id_hash", type=AttributeKey.Type.TYPE_ARRAY),
+                    filter=TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=AttributeKey(
+                                name="abnormal_mechanism",
+                                type=AttributeKey.Type.TYPE_STRING,
+                            ),
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str="anr_foreground"),
+                        )
+                    ),
+                    label="uniq_user_foreground_anr",
+                ),
+                label="uniq_user_foreground_anr",
+            )
+        )
+
+    # Group-by translation
+    group_by: list[AttributeKey] = []
+    for gb in query.raw_groupby:
+        if gb == "project":
+            group_by.append(AttributeKey(name="sentry.project_id", type=AttributeKey.Type.TYPE_INT))
+        elif gb == "release":
+            group_by.append(AttributeKey(name="release", type=AttributeKey.Type.TYPE_STRING))
+        elif gb == "environment":
+            group_by.append(AttributeKey(name="environment", type=AttributeKey.Type.TYPE_STRING))
+        # session.status is handled in post-processing, not as a group-by
+
+    # Filter translation
+    filters: list[TraceItemFilter] = []
+    try:
+        conditions = query.get_filter_conditions()
+        for cond in conditions:
+            from snuba_sdk import Column, Condition
+
+            if not isinstance(cond, Condition) or not isinstance(cond.lhs, Column):
+                continue
+            col_name = cond.lhs.name
+            if col_name == "release":
+                eap_key = AttributeKey(name="release", type=AttributeKey.Type.TYPE_STRING)
+            elif col_name == "environment":
+                eap_key = AttributeKey(name="environment", type=AttributeKey.Type.TYPE_STRING)
+            elif col_name == "project_id":
+                # project_id is handled via RequestMeta.project_ids
+                continue
+            else:
+                continue
+
+            from snuba_sdk import Op
+
+            if cond.op == Op.EQ:
+                filters.append(
+                    TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=eap_key,
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str=str(cond.rhs)),
+                        )
+                    )
+                )
+            elif cond.op == Op.IN:
+                filters.append(
+                    TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=eap_key,
+                            op=ComparisonFilter.OP_IN,
+                            value=AttributeValue(
+                                val_str_array=StrArray(values=[str(v) for v in cond.rhs])
+                            ),
+                        )
+                    )
+                )
+    except Exception:
+        logger.exception("eap_sessions.filter_translation_failed")
+
+    query_filter = None
+    if filters:
+        if len(filters) == 1:
+            query_filter = filters[0]
+        else:
+            query_filter = TraceItemFilter(and_filter=AndFilter(filters=filters))
+
+    request = TimeSeriesRequest(
+        meta=RequestMeta(
+            organization_id=org_id,
+            project_ids=project_ids,
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_USER_SESSION,
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
+        ),
+        expressions=expressions,
+        granularity_secs=query.rollup,
+        group_by=group_by,
+    )
+    if query_filter is not None:
+        request.filter.CopyFrom(query_filter)
+
+    return request
+
+
+def _safe_rate(
+    numerator: float | None, denominator: float | None, invert: bool = False
+) -> float | None:
+    """Compute a rate, returning None for division by zero."""
+    if denominator is None or denominator == 0 or numerator is None:
+        return None
+    rate = numerator / denominator
+    if invert:
+        rate = 1.0 - rate
+    if not math.isfinite(rate):
+        return None
+    return rate
+
+
+def _transform_eap_response(
+    response: TimeSeriesResponse, query: QueryDefinition
+) -> SessionsQueryResult:
+    """Convert a TimeSeriesResponse into SessionsQueryResult format."""
+    intervals = get_timestamps(query)
+    num_buckets = len(intervals)
+    has_status_groupby = "session.status" in query.raw_groupby
+
+    # Collect timeseries data by (group_key, label)
+    # group_key is a frozenset of (attr_name, attr_value) pairs
+    grouped: dict[frozenset[tuple[str, str]], dict[str, list[float]]] = {}
+
+    for ts in response.result_timeseries:
+        group_key = frozenset(ts.group_by_attributes.items())
+        label = ts.label
+        if group_key not in grouped:
+            grouped[group_key] = {}
+
+        values: list[float] = []
+        for dp in ts.data_points:
+            values.append(dp.data if dp.data_present else 0.0)
+        # Pad or truncate to match expected buckets
+        while len(values) < num_buckets:
+            values.append(0.0)
+        grouped[group_key][label] = values[:num_buckets]
+
+    # Build groups
+    eap_groupby_to_sessions_key = {
+        "sentry.project_id": "project",
+        "release": "release",
+        "environment": "environment",
+    }
+
+    result_groups: list[dict] = []
+
+    other_groupbys = [gb for gb in query.raw_groupby if gb != "session.status"]
+    if not grouped and has_status_groupby and not other_groupbys:
+        grouped[frozenset()] = {}
+
+    if has_status_groupby:
+        for group_key, label_data in grouped.items():
+            by: dict[str, str | int] = {}
+            for attr_name, attr_value in group_key:
+                sessions_key = eap_groupby_to_sessions_key.get(attr_name)
+                if sessions_key:
+                    by[sessions_key] = int(attr_value) if sessions_key == "project" else attr_value
+
+            for session_status in SessionStatus:
+                status = session_status.value
+                status_by = {**by, "session.status": status}
+                series: dict[str, list[float | None]] = {}
+                totals: dict[str, float | None] = {}
+
+                for field_name in query.raw_fields:
+                    s, t = _extract_status_field(field_name, status, label_data, num_buckets)
+                    series[field_name] = s
+                    totals[field_name] = t
+
+                result_groups.append({"by": status_by, "series": series, "totals": totals})
+    else:
+        for group_key, label_data in grouped.items():
+            by = {}
+            for attr_name, attr_value in group_key:
+                sessions_key = eap_groupby_to_sessions_key.get(attr_name)
+                if sessions_key:
+                    by[sessions_key] = int(attr_value) if sessions_key == "project" else attr_value
+
+            series: dict[str, list[float | None]] = {}
+            totals: dict[str, float | None] = {}
+
+            for field_name in query.raw_fields:
+                s, t = _extract_field(field_name, label_data, num_buckets)
+                series[field_name] = s
+                totals[field_name] = t
+
+            result_groups.append({"by": by, "series": series, "totals": totals})
+
+    return {
+        "start": isoformat_z(query.start),
+        "end": isoformat_z(query.end),
+        "intervals": intervals,
+        "groups": result_groups,
+        "query": query.query,
+    }
+
+
+def _extract_field(
+    field_name: str,
+    label_data: dict[str, list[float]],
+    num_buckets: int,
+) -> tuple[list[float | None], float | None]:
+    """Extract series and total for a non-status-grouped field."""
+    if field_name == "sum(session)":
+        values = label_data.get("sum_session_init", [0.0] * num_buckets)
+        int_values = [int(v) for v in values]
+        return int_values, int(sum(values))
+
+    if field_name == "count_unique(user)":
+        values = label_data.get("uniq_user_all", [0.0] * num_buckets)
+        int_values = [int(v) for v in values]
+        return int_values, int(sum(values))
+
+    if field_name in _SESSION_RATE_FIELDS:
+        status, invert = _SESSION_RATE_FIELDS[field_name]
+        init_values = label_data.get("sum_session_init", [0.0] * num_buckets)
+        if status == "errored":
+            # errored_all = errored_preaggr + errored_set
+            preaggr = label_data.get("sum_session_errored_preaggr", [0.0] * num_buckets)
+            eset = label_data.get("errored_set_count", [0.0] * num_buckets)
+            status_values = [preaggr[i] + eset[i] for i in range(num_buckets)]
+        else:
+            status_values = label_data.get(f"sum_session_{status}", [0.0] * num_buckets)
+        series = [_safe_rate(status_values[i], init_values[i], invert) for i in range(num_buckets)]
+        total = _safe_rate(sum(status_values), sum(init_values), invert)
+        return series, total
+
+    if field_name == "unhealthy_rate(session)":
+        init_values = label_data.get("sum_session_init", [0.0] * num_buckets)
+        errored_preaggr = label_data.get("sum_session_errored_preaggr", [0.0] * num_buckets)
+        errored_set = label_data.get("errored_set_count", [0.0] * num_buckets)
+        series = []
+        total_unhealthy = 0.0
+        total_init = 0.0
+        for i in range(num_buckets):
+            unhealthy = errored_preaggr[i] + errored_set[i]
+            series.append(_safe_rate(unhealthy, init_values[i]))
+            total_unhealthy += unhealthy
+            total_init += init_values[i]
+        total = _safe_rate(total_unhealthy, total_init)
+        return series, total
+
+    if field_name in _USER_RATE_FIELDS:
+        status, invert = _USER_RATE_FIELDS[field_name]
+        all_values = label_data.get("uniq_user_all", [0.0] * num_buckets)
+        status_values = label_data.get(f"uniq_user_{status}", [0.0] * num_buckets)
+        series = [_safe_rate(status_values[i], all_values[i], invert) for i in range(num_buckets)]
+        total = _safe_rate(sum(status_values), sum(all_values), invert)
+        return series, total
+
+    if field_name == "anr_rate()":
+        return _extract_anr_field(label_data, num_buckets, foreground_only=False)
+
+    if field_name == "foreground_anr_rate()":
+        return _extract_anr_field(label_data, num_buckets, foreground_only=True)
+
+    # Unknown field — return zeros
+    return [0.0] * num_buckets, 0.0
+
+
+def _extract_anr_field(
+    label_data: dict[str, list[float]],
+    num_buckets: int,
+    foreground_only: bool,
+) -> tuple[list[float | None], float | None]:
+    """Compute ANR rate from abnormal_mechanism-filtered user counts."""
+    all_values = label_data.get("uniq_user_all", [0.0] * num_buckets)
+    anr_label = "uniq_user_foreground_anr" if foreground_only else "uniq_user_anr"
+    anr_values = label_data.get(anr_label, [0.0] * num_buckets)
+    series = [_safe_rate(anr_values[i], all_values[i]) for i in range(num_buckets)]
+    total = _safe_rate(sum(anr_values), sum(all_values))
+    return series, total
+
+
+def _extract_status_field(
+    field_name: str,
+    status: str,
+    label_data: dict[str, list[float]],
+    num_buckets: int,
+) -> tuple[list[float | None], float | None]:
+    """Extract series/total for a field within a session.status group."""
+    if field_name == "sum(session)":
+        return _session_count_for_status(status, label_data, num_buckets)
+
+    if field_name == "count_unique(user)":
+        return _user_count_for_status(status, label_data, num_buckets)
+
+    # Rate fields in status-grouped context
+    if (
+        field_name in _SESSION_RATE_FIELDS
+        or field_name in _USER_RATE_FIELDS
+        or field_name == "unhealthy_rate(session)"
+    ):
+        return _extract_field(field_name, label_data, num_buckets)
+
+    if field_name in ("anr_rate()", "foreground_anr_rate()"):
+        return _extract_field(field_name, label_data, num_buckets)
+
+    return [0.0] * num_buckets, 0.0
+
+
+def _session_count_for_status(
+    status: str,
+    label_data: dict[str, list[float]],
+    num_buckets: int,
+) -> tuple[list[float | None], float | None]:
+    """Get session count for a specific status."""
+    if status == "healthy":
+        init = label_data.get("sum_session_init", [0.0] * num_buckets)
+        errored_preaggr = label_data.get("sum_session_errored_preaggr", [0.0] * num_buckets)
+        errored_set = label_data.get("errored_set_count", [0.0] * num_buckets)
+        values = [
+            int(max(init[i] - errored_preaggr[i] - errored_set[i], 0)) for i in range(num_buckets)
+        ]
+        return values, sum(values)
+
+    if status == "errored":
+        errored_preaggr = label_data.get("sum_session_errored_preaggr", [0.0] * num_buckets)
+        errored_set = label_data.get("errored_set_count", [0.0] * num_buckets)
+        crashed = label_data.get("sum_session_crashed", [0.0] * num_buckets)
+        abnormal = label_data.get("sum_session_abnormal", [0.0] * num_buckets)
+        values = [
+            int(max(errored_preaggr[i] + errored_set[i] - crashed[i] - abnormal[i], 0))
+            for i in range(num_buckets)
+        ]
+        return values, sum(values)
+
+    key = f"sum_session_{status}"
+    values = label_data.get(key, [0.0] * num_buckets)
+    return [int(v) for v in values], int(sum(values))
+
+
+def _user_count_for_status(
+    status: str,
+    label_data: dict[str, list[float]],
+    num_buckets: int,
+) -> tuple[list[float | None], float | None]:
+    """Get user count for a specific status."""
+    if status == "healthy":
+        all_users = label_data.get("uniq_user_all", [0.0] * num_buckets)
+        errored = label_data.get("uniq_user_errored", [0.0] * num_buckets)
+        values = [int(max(all_users[i] - errored[i], 0)) for i in range(num_buckets)]
+        return values, sum(values)
+
+    if status == "errored":
+        errored = label_data.get("uniq_user_errored", [0.0] * num_buckets)
+        crashed = label_data.get("uniq_user_crashed", [0.0] * num_buckets)
+        abnormal = label_data.get("uniq_user_abnormal", [0.0] * num_buckets)
+        values = [int(max(errored[i] - crashed[i] - abnormal[i], 0)) for i in range(num_buckets)]
+        return values, sum(values)
+
+    key = f"uniq_user_{status}"
+    values = label_data.get(key, [0.0] * num_buckets)
+    return [int(v) for v in values], int(sum(values))
+
+
+def run_sessions_query_eap(org_id: int, query: QueryDefinition) -> SessionsQueryResult:
+    """Query EAP for session health data, translating to SessionsQueryResult format."""
+    request = _build_eap_timeseries_request(org_id, query)
+    responses = timeseries_rpc([request])
+    assert len(responses) == 1
+    return _transform_eap_response(responses[0], query)
+
+
+def compare_results(control: SessionsQueryResult, experimental: SessionsQueryResult) -> None:
+    """Shadow-compare control (legacy metrics) and experimental (EAP) results.
+
+    Emits a metric indicating whether the results match. The control result
+    is always used downstream — this is purely for validation.
+    """
+    exact_match = control == experimental
+    is_null = len(experimental.get("groups", [])) == 0
+    if not exact_match:
+        logger.error(f"Control and eap results do not match: {control} != {experimental}")
+
+    metrics.incr(
+        "eap_sessions.compare",
+        tags={
+            "exact_match": str(exact_match),
+            "is_null_result": str(is_null),
+        },
+    )
+
+
+class _MetricsQueryAdapter:
+    """Adapts a DeprecatingMetricsQuery to the sessions_v2 QueryDefinition
+    interface expected by _build_eap_timeseries_request."""
+
+    def __init__(
+        self,
+        raw_fields: list[str],
+        raw_groupby: list[str],
+        start,
+        end,
+        rollup: int,
+        project_ids: list[int],
+        query: str,
+        where: list,
+    ):
+        self.raw_fields = raw_fields
+        self.raw_groupby = raw_groupby
+        self.start = start
+        self.end = end
+        self.rollup = rollup
+        self.params = {"project_id": project_ids}
+        self.query = query
+        self._where = where
+
+    def get_filter_conditions(self):
+        return self._where
+
+
+def is_session_metrics_query(metrics_query: DeprecatingMetricsQuery) -> bool:
+    """Check if a DeprecatingMetricsQuery targets session metrics."""
+    for field in metrics_query.select:
+        if field.metric_mri in _SESSION_MRI_TO_V2_FIELD:
+            return True
+    return False
+
+
+def _translate_metrics_query(
+    metrics_query: DeprecatingMetricsQuery,
+) -> tuple[_MetricsQueryAdapter, dict[str, str]] | None:
+    """Translate a DeprecatingMetricsQuery to a sessions_v2-compatible adapter.
+
+    Returns (adapter, field_mapping) where field_mapping maps
+    sessions_v2 field names back to the metric field aliases used in
+    get_series results. Returns None if any field cannot be translated.
+    """
+    raw_fields: list[str] = []
+    # Maps sessions_v2 field name -> metric alias (for result remapping)
+    field_mapping: dict[str, str] = {}
+
+    for field in metrics_query.select:
+        v2_name = _SESSION_MRI_TO_V2_FIELD.get(field.metric_mri)
+        if v2_name is None:
+            return None
+        raw_fields.append(v2_name)
+        field_mapping[v2_name] = field.alias
+
+    raw_groupby: list[str] = []
+    if metrics_query.groupby:
+        for gb in metrics_query.groupby:
+            gb_name = gb.name if hasattr(gb, "name") else str(gb.field)
+            v2_gb = _GROUPBY_METRICS_TO_V2.get(gb_name)
+            if v2_gb is None:
+                return None
+            raw_groupby.append(v2_gb)
+
+    adapter = _MetricsQueryAdapter(
+        raw_fields=raw_fields,
+        raw_groupby=raw_groupby,
+        start=metrics_query.start,
+        end=metrics_query.end,
+        rollup=metrics_query.granularity.granularity,
+        project_ids=list(metrics_query.project_ids),
+        query="",
+        where=list(metrics_query.where) if metrics_query.where else [],
+    )
+    return adapter, field_mapping
+
+
+def get_series_eap(
+    metrics_query: DeprecatingMetricsQuery,
+    org_id: int,
+) -> dict | None:
+    """Query EAP for session data matching a metrics/data endpoint query.
+
+    Returns the result in the same format as get_series() with field names
+    matching the metric aliases, or None if the query can't be translated.
+    """
+    translated = _translate_metrics_query(metrics_query)
+    if translated is None:
+        return None
+
+    adapter, field_mapping = translated
+    request = _build_eap_timeseries_request(org_id, adapter)
+    logger.error(
+        "eap_sessions.get_series_eap_request",
+        extra={
+            "org_id": org_id,
+            "project_ids": list(adapter.params["project_id"]),
+            "raw_fields": adapter.raw_fields,
+            "raw_groupby": adapter.raw_groupby,
+            "start": str(adapter.start),
+            "end": str(adapter.end),
+            "rollup": adapter.rollup,
+            "num_expressions": len(request.expressions),
+            "expression_labels": [e.label for e in request.expressions],
+        },
+    )
+    responses = timeseries_rpc([request])
+    assert len(responses) == 1
+    logger.error(
+        "eap_sessions.get_series_eap_response",
+        extra={
+            "num_timeseries": len(responses[0].result_timeseries),
+            "labels": [ts.label for ts in responses[0].result_timeseries],
+        },
+    )
+    eap_result = _transform_eap_response(responses[0], adapter)
+
+    include_totals = metrics_query.include_totals
+    include_series = metrics_query.include_series
+
+    # Remap field names and conform to get_series() output shape
+    for group in eap_result.get("groups", []):
+        for section in ("series", "totals"):
+            old_data = group.get(section, {})
+            new_data = {}
+            for v2_name, value in old_data.items():
+                metric_alias = field_mapping.get(v2_name, v2_name)
+                # get_series returns float values, match that
+                if isinstance(value, list):
+                    new_data[metric_alias] = [float(v) if v is not None else None for v in value]
+                elif value is not None:
+                    new_data[metric_alias] = float(value)
+                else:
+                    new_data[metric_alias] = None
+            group[section] = new_data
+
+        # Strip totals/series to match get_series() behavior
+        if not include_totals:
+            group.pop("totals", None)
+        if not include_series:
+            group.pop("series", None)
+
+        # Remap groupBy keys: "project" -> "project_id"
+        by = group.get("by", {})
+        if "project" in by:
+            by["project_id"] = by.pop("project")
+
+    return eap_result
+
+
+def compare_get_series_results(control: dict, experimental: dict) -> None:
+    """Shadow-compare get_series results from legacy metrics and EAP.
+
+    Similar to compare_results but for the get_series response format
+    where start/end are datetime objects (not ISO strings).
+    """
+    control_groups = control.get("groups", [])
+    exp_groups = experimental.get("groups", [])
+    exact_match = control_groups == exp_groups
+    is_null = len(exp_groups) == 0
+
+    if not exact_match:
+        logger.error(
+            "********************** eap_sessions.get_series_mismatch",
+            extra={"control_groups": control_groups, "eap_groups": exp_groups},
+        )
+    else:
+        logger.error("********************** SUCCESS!")
+
+    metrics.incr(
+        "eap_sessions.get_series_compare",
+        tags={
+            "exact_match": str(exact_match),
+            "is_null_result": str(is_null),
+        },
+    )

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -406,7 +406,25 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         query: QueryDefinition,
         span_op: str,
     ) -> SessionsQueryResult:
-        return run_sessions_query(org_id, query, span_op)
+        control_result = run_sessions_query(org_id, query, span_op)
+        logger.error(f"Control result {query}")
+
+        try:
+            from sentry import features
+            from sentry.models.organization import Organization
+            from sentry.release_health.eap_sessions_rollout import (
+                compare_results,
+                run_sessions_query_eap,
+            )
+
+            org = Organization.objects.get_from_cache(id=org_id)
+            if True or features.has("organizations:session-health-eap", org):
+                eap_result = run_sessions_query_eap(org_id, query)
+                compare_results(control_result, eap_result)
+        except Exception:
+            logger.exception("eap_sessions.double_read_failed")
+
+        return control_result
 
     def get_release_sessions_time_bounds(
         self,

--- a/src/sentry/releases/endpoints/organization_release_health_data.py
+++ b/src/sentry/releases/endpoints/organization_release_health_data.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -17,6 +19,8 @@ from sentry.snuba.metrics.query_builder import parse_field
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
 from sentry.utils.cursors import Cursor, CursorResult
+
+logger = logging.getLogger(__name__)
 
 
 @cell_silo_endpoint
@@ -93,9 +97,10 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
                     allow_mri=True,
                     paginator_kwargs={"limit": limit, "offset": offset},
                 )
+                metrics_query = query.to_metrics_query()
                 data = get_series(
                     projects,
-                    metrics_query=query.to_metrics_query(),
+                    metrics_query=metrics_query,
                     use_case_id=get_use_case_id(request),
                     tenant_ids={"organization_id": organization.id},
                 )
@@ -109,6 +114,26 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
                 )
 
                 data["query"] = query.query
+
+                # EAP shadow read for session metrics
+                try:
+                    from sentry import features
+                    from sentry.release_health.eap_sessions_rollout import (
+                        compare_get_series_results,
+                        get_series_eap,
+                        is_session_metrics_query,
+                    )
+
+                    if features.has(
+                        "organizations:session-health-eap", organization
+                    ) and is_session_metrics_query(metrics_query):
+                        logger.error("EAP query")
+                        eap_result = get_series_eap(metrics_query, organization.id)
+                        if eap_result is not None:
+                            compare_get_series_results(data, eap_result)
+                except Exception:
+                    logger.exception("eap_sessions.get_series_double_read_failed")
+
             except (
                 InvalidParams,
                 DerivedMetricException,

--- a/tests/sentry/release_health/test_eap_sessions_rollout.py
+++ b/tests/sentry/release_health/test_eap_sessions_rollout.py
@@ -1,0 +1,629 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    DataPoint,
+    TimeSeries,
+    TimeSeriesResponse,
+)
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeKey,
+    Function,
+)
+
+from sentry.release_health.eap_sessions_rollout import (
+    _build_eap_timeseries_request,
+    _transform_eap_response,
+    _translate_metrics_query,
+    compare_get_series_results,
+    get_series_eap,
+    is_session_metrics_query,
+)
+from sentry.testutils.cases import TestCase
+
+NOW = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+ONE_HOUR_AGO = NOW - timedelta(hours=1)
+
+
+def _make_query(
+    raw_fields: list[str],
+    raw_groupby: list[str] | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    rollup: int = 3600,
+    project_ids: list[int] | None = None,
+    query: str = "",
+) -> MagicMock:
+    """Create a mock QueryDefinition."""
+    mock = MagicMock()
+    mock.raw_fields = raw_fields
+    mock.raw_groupby = raw_groupby or []
+    mock.start = start or ONE_HOUR_AGO
+    mock.end = end or NOW
+    mock.rollup = rollup
+    mock.params = {"project_id": project_ids or [1]}
+    mock.query = query
+    mock.get_filter_conditions.return_value = []
+    return mock
+
+
+def _make_timestamp(dt: datetime) -> Timestamp:
+    ts = Timestamp()
+    ts.FromDatetime(dt)
+    return ts
+
+
+def _make_timeseries(
+    label: str,
+    values: list[float],
+    group_by: dict[str, str] | None = None,
+    start: datetime | None = None,
+    rollup: int = 3600,
+) -> TimeSeries:
+    base_time = start or ONE_HOUR_AGO
+    buckets = [
+        _make_timestamp(base_time + timedelta(seconds=rollup * i)) for i in range(len(values))
+    ]
+    data_points = [DataPoint(data=v, data_present=True) for v in values]
+    return TimeSeries(
+        label=label,
+        group_by_attributes=group_by or {},
+        buckets=buckets,
+        data_points=data_points,
+    )
+
+
+class TestBuildEapRequest(TestCase):
+    def test_sum_session(self):
+        query = _make_query(["sum(session)"])
+        request = _build_eap_timeseries_request(org_id=1, query=query)
+
+        labels = [expr.label for expr in request.expressions]
+        assert "sum_session_init" in labels
+        assert "sum_session_crashed" in labels
+        assert "errored_set_count" in labels
+
+        for expr in request.expressions:
+            if expr.label == "sum_session_init":
+                agg = expr.conditional_aggregation
+                assert agg.aggregate == Function.FUNCTION_SUM
+                assert agg.key.name == "session_count"
+                assert agg.key.type == AttributeKey.Type.TYPE_INT
+
+    def test_count_unique_user(self):
+        query = _make_query(["count_unique(user)"])
+        request = _build_eap_timeseries_request(org_id=1, query=query)
+
+        labels = [expr.label for expr in request.expressions]
+        assert "uniq_user_all" in labels
+        # init should not be requested — user set items don't have init status
+        assert "uniq_user_init" not in labels
+
+        for expr in request.expressions:
+            if expr.label == "uniq_user_all":
+                agg = expr.aggregation
+                assert agg.aggregate == Function.FUNCTION_UNIQ
+                assert agg.key.name == "user_id_hash"
+                assert agg.key.type == AttributeKey.Type.TYPE_ARRAY
+
+    def test_crash_free_rate(self):
+        query = _make_query(["crash_free_rate(session)"])
+        request = _build_eap_timeseries_request(org_id=1, query=query)
+
+        labels = [expr.label for expr in request.expressions]
+        assert "sum_session_init" in labels
+        assert "sum_session_crashed" in labels
+
+    def test_with_groupby(self):
+        query = _make_query(["sum(session)"], raw_groupby=["project", "release", "environment"])
+        request = _build_eap_timeseries_request(org_id=1, query=query)
+
+        group_by_names = [gb.name for gb in request.group_by]
+        assert "sentry.project_id" in group_by_names
+        assert "release" in group_by_names
+        assert "environment" in group_by_names
+
+    def test_with_status_groupby(self):
+        query = _make_query(["sum(session)"], raw_groupby=["session.status"])
+        request = _build_eap_timeseries_request(org_id=1, query=query)
+
+        labels = [expr.label for expr in request.expressions]
+        for status in ["init", "crashed", "errored_preaggr", "abnormal", "unhandled"]:
+            assert f"sum_session_{status}" in labels
+        assert "errored_set_count" in labels
+
+        # session.status should NOT be in group_by (handled in post-processing)
+        group_by_names = [gb.name for gb in request.group_by]
+        assert "session.status" not in group_by_names
+        assert "status" not in group_by_names
+
+
+class TestTransformResponse(TestCase):
+    def test_basic_sum_session(self):
+        query = _make_query(["sum(session)"])
+        response = TimeSeriesResponse(
+            result_timeseries=[
+                _make_timeseries("sum_session_init", [100.0]),
+            ]
+        )
+
+        result = _transform_eap_response(response, query)
+        assert len(result["groups"]) == 1
+        group = result["groups"][0]
+        assert group["series"]["sum(session)"] == [100.0]
+        assert group["totals"]["sum(session)"] == 100.0
+
+    def test_crash_free_rate(self):
+        query = _make_query(["crash_free_rate(session)"])
+        response = TimeSeriesResponse(
+            result_timeseries=[
+                _make_timeseries("sum_session_init", [100.0]),
+                _make_timeseries("sum_session_crashed", [5.0]),
+                _make_timeseries("sum_session_errored_preaggr", [0.0]),
+                _make_timeseries("errored_set_count", [0.0]),
+                _make_timeseries("sum_session_abnormal", [0.0]),
+                _make_timeseries("sum_session_unhandled", [0.0]),
+            ]
+        )
+
+        result = _transform_eap_response(response, query)
+        group = result["groups"][0]
+        assert group["totals"]["crash_free_rate(session)"] == pytest.approx(0.95)
+        assert group["series"]["crash_free_rate(session)"] == [pytest.approx(0.95)]
+
+    def test_healthy_computation(self):
+        query = _make_query(["sum(session)"], raw_groupby=["session.status"])
+        response = TimeSeriesResponse(
+            result_timeseries=[
+                _make_timeseries("sum_session_init", [100.0]),
+                _make_timeseries("sum_session_crashed", [3.0]),
+                _make_timeseries("sum_session_errored_preaggr", [7.0]),
+                _make_timeseries("errored_set_count", [4.0]),
+                _make_timeseries("sum_session_abnormal", [2.0]),
+                _make_timeseries("sum_session_unhandled", [5.0]),
+            ]
+        )
+
+        result = _transform_eap_response(response, query)
+        groups_by_status = {g["by"]["session.status"]: g for g in result["groups"]}
+
+        # errored_all = errored_preaggr + errored_set = 7 + 4 = 11
+        # healthy = init - errored_all = 100 - 11 = 89
+        assert groups_by_status["healthy"]["totals"]["sum(session)"] == 89.0
+        assert groups_by_status["crashed"]["totals"]["sum(session)"] == 3.0
+        # errored = errored_all - crashed - abnormal = 11 - 3 - 2 = 6
+        assert groups_by_status["errored"]["totals"]["sum(session)"] == 6.0
+        assert groups_by_status["abnormal"]["totals"]["sum(session)"] == 2.0
+        assert groups_by_status["unhandled"]["totals"]["sum(session)"] == 5.0
+
+    def test_empty_response(self):
+        query = _make_query(["sum(session)"])
+        response = TimeSeriesResponse(result_timeseries=[])
+        result = _transform_eap_response(response, query)
+        assert result["groups"] == []
+
+    def test_grouped_response(self):
+        query = _make_query(["sum(session)"], raw_groupby=["release"])
+        response = TimeSeriesResponse(
+            result_timeseries=[
+                _make_timeseries(
+                    "sum_session_init",
+                    [50.0],
+                    group_by={"release": "1.0"},
+                ),
+                _make_timeseries(
+                    "sum_session_init",
+                    [30.0],
+                    group_by={"release": "2.0"},
+                ),
+            ]
+        )
+        for status in ["crashed", "errored_preaggr", "abnormal", "unhandled"]:
+            response.result_timeseries.append(
+                _make_timeseries(
+                    f"sum_session_{status}",
+                    [0.0],
+                    group_by={"release": "1.0"},
+                )
+            )
+            response.result_timeseries.append(
+                _make_timeseries(
+                    f"sum_session_{status}",
+                    [0.0],
+                    group_by={"release": "2.0"},
+                )
+            )
+        for release in ["1.0", "2.0"]:
+            response.result_timeseries.append(
+                _make_timeseries(
+                    "errored_set_count",
+                    [0.0],
+                    group_by={"release": release},
+                )
+            )
+
+        result = _transform_eap_response(response, query)
+        assert len(result["groups"]) == 2
+        groups_by_release = {g["by"]["release"]: g for g in result["groups"]}
+        assert groups_by_release["1.0"]["totals"]["sum(session)"] == 50.0
+        assert groups_by_release["2.0"]["totals"]["sum(session)"] == 30.0
+
+
+class TestDoubleRead(TestCase):
+    @patch("sentry.release_health.eap_sessions_rollout.run_sessions_query_eap")
+    def test_flag_off_no_eap_query(self, mock_eap_query):
+        """When feature flag is off, EAP query is never called."""
+        from sentry.release_health.metrics import MetricsReleaseHealthBackend
+
+        backend = MetricsReleaseHealthBackend()
+        query = _make_query(["sum(session)"])
+
+        control_result = {
+            "start": ONE_HOUR_AGO,
+            "end": NOW,
+            "intervals": [],
+            "groups": [
+                {"by": {}, "series": {"sum(session)": [100.0]}, "totals": {"sum(session)": 100.0}}
+            ],
+            "query": "",
+        }
+
+        with patch("sentry.release_health.metrics.run_sessions_query", return_value=control_result):
+            with self.feature({"organizations:session-health-eap": False}):
+                result = backend.run_sessions_query(self.organization.id, query, "test")
+
+        assert result == control_result
+        mock_eap_query.assert_not_called()
+
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_flag_on_returns_control(self, mock_rpc):
+        """When flag is on, always returns control data."""
+        from sentry.release_health.metrics import MetricsReleaseHealthBackend
+
+        backend = MetricsReleaseHealthBackend()
+        query = _make_query(["sum(session)"])
+
+        control_result = {
+            "start": ONE_HOUR_AGO,
+            "end": NOW,
+            "intervals": [],
+            "groups": [
+                {"by": {}, "series": {"sum(session)": [100.0]}, "totals": {"sum(session)": 100.0}}
+            ],
+            "query": "",
+        }
+
+        mock_rpc.return_value = [TimeSeriesResponse(result_timeseries=[])]
+
+        with patch("sentry.release_health.metrics.run_sessions_query", return_value=control_result):
+            with self.feature({"organizations:session-health-eap": True}):
+                result = backend.run_sessions_query(self.organization.id, query, "test")
+
+        assert result == control_result
+
+    @patch(
+        "sentry.release_health.eap_sessions_rollout.timeseries_rpc",
+        side_effect=Exception("EAP is down"),
+    )
+    def test_eap_failure_returns_control(self, mock_rpc):
+        """EAP failure does not affect response — control data is returned."""
+        from sentry.release_health.metrics import MetricsReleaseHealthBackend
+
+        backend = MetricsReleaseHealthBackend()
+        query = _make_query(["sum(session)"])
+
+        control_result = {
+            "start": ONE_HOUR_AGO,
+            "end": NOW,
+            "intervals": [],
+            "groups": [
+                {"by": {}, "series": {"sum(session)": [100.0]}, "totals": {"sum(session)": 100.0}}
+            ],
+            "query": "",
+        }
+
+        with patch("sentry.release_health.metrics.run_sessions_query", return_value=control_result):
+            with self.feature({"organizations:session-health-eap": True}):
+                result = backend.run_sessions_query(self.organization.id, query, "test")
+
+        assert result == control_result
+
+
+def _make_metrics_query(
+    fields: list[tuple[str | None, str]],
+    groupby: list[str] | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    rollup: int = 3600,
+    project_ids: list[int] | None = None,
+) -> MagicMock:
+    """Create a mock DeprecatingMetricsQuery for testing.
+
+    fields: list of (op, metric_mri) tuples
+    """
+    mock = MagicMock()
+    mock_fields = []
+    for op, mri in fields:
+        field = MagicMock()
+        field.op = op
+        field.metric_mri = mri
+        if op:
+            name_parts = mri.split("/")[-1].split("@")[0]
+            field.alias = f"{op}(session.{name_parts})" if "session" in mri else f"{op}({mri})"
+        else:
+            name_parts = mri.split("/")[-1].split("@")[0]
+            field.alias = f"session.{name_parts}" if "session" in mri else mri
+        mock_fields.append(field)
+    mock.select = mock_fields
+
+    mock_groupby = []
+    for gb_name in groupby or []:
+        gb = MagicMock()
+        gb.name = gb_name
+        gb.field = gb_name
+        mock_groupby.append(gb)
+    mock.groupby = mock_groupby
+
+    mock.start = start or ONE_HOUR_AGO
+    mock.end = end or NOW
+
+    granularity = MagicMock()
+    granularity.granularity = rollup
+    mock.granularity = granularity
+
+    mock.project_ids = project_ids or [1]
+    mock.where = []
+    mock.include_totals = True
+    mock.include_series = True
+
+    return mock
+
+
+class TestIsSessionMetricsQuery(TestCase):
+    def test_session_all_is_session_query(self):
+        query = _make_metrics_query([("sum", "e:sessions/all@none")])
+        assert is_session_metrics_query(query) is True
+
+    def test_crash_free_rate_is_session_query(self):
+        query = _make_metrics_query([(None, "e:sessions/crash_free_rate@ratio")])
+        assert is_session_metrics_query(query) is True
+
+    def test_non_session_metric_is_not_session_query(self):
+        query = _make_metrics_query([("avg", "d:transactions/duration@millisecond")])
+        assert is_session_metrics_query(query) is False
+
+    def test_mixed_fields_with_session(self):
+        query = _make_metrics_query(
+            [
+                ("sum", "e:sessions/all@none"),
+                ("avg", "d:transactions/duration@millisecond"),
+            ]
+        )
+        assert is_session_metrics_query(query) is True
+
+
+class TestTranslateMetricsQuery(TestCase):
+    def test_translates_sum_session_all(self):
+        query = _make_metrics_query([("sum", "e:sessions/all@none")])
+        result = _translate_metrics_query(query)
+        assert result is not None
+        adapter, field_mapping = result
+        assert adapter.raw_fields == ["sum(session)"]
+        assert "sum(session)" in field_mapping
+
+    def test_translates_crash_free_rate(self):
+        query = _make_metrics_query([(None, "e:sessions/crash_free_rate@ratio")])
+        result = _translate_metrics_query(query)
+        assert result is not None
+        adapter, field_mapping = result
+        assert adapter.raw_fields == ["crash_free_rate(session)"]
+
+    def test_translates_groupby(self):
+        query = _make_metrics_query(
+            [("sum", "e:sessions/all@none")],
+            groupby=["project_id", "release"],
+        )
+        result = _translate_metrics_query(query)
+        assert result is not None
+        adapter, _ = result
+        assert adapter.raw_groupby == ["project", "release"]
+
+    def test_returns_none_for_unknown_mri(self):
+        query = _make_metrics_query([("avg", "d:transactions/duration@millisecond")])
+        assert _translate_metrics_query(query) is None
+
+    def test_returns_none_for_unknown_groupby(self):
+        query = _make_metrics_query(
+            [("sum", "e:sessions/all@none")],
+            groupby=["unknown_field"],
+        )
+        assert _translate_metrics_query(query) is None
+
+    def test_adapter_has_correct_time_range(self):
+        query = _make_metrics_query(
+            [("sum", "e:sessions/all@none")],
+            start=ONE_HOUR_AGO,
+            end=NOW,
+            rollup=3600,
+            project_ids=[1, 2],
+        )
+        result = _translate_metrics_query(query)
+        assert result is not None
+        adapter, _ = result
+        assert adapter.start == ONE_HOUR_AGO
+        assert adapter.end == NOW
+        assert adapter.rollup == 3600
+        assert adapter.params["project_id"] == [1, 2]
+
+
+class TestGetSeriesEap(TestCase):
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_returns_result_with_metric_field_names(self, mock_rpc):
+        query = _make_metrics_query([("sum", "e:sessions/all@none")])
+        query.select[0].alias = "sum(session.all)"
+
+        mock_rpc.return_value = [
+            TimeSeriesResponse(
+                result_timeseries=[
+                    _make_timeseries("sum_session_init", [100.0]),
+                ]
+            )
+        ]
+
+        result = get_series_eap(query, org_id=1)
+        assert result is not None
+        assert len(result["groups"]) == 1
+        group = result["groups"][0]
+        assert "sum(session.all)" in group["series"]
+        assert "sum(session.all)" in group["totals"]
+
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_remaps_project_groupby(self, mock_rpc):
+        query = _make_metrics_query(
+            [("sum", "e:sessions/all@none")],
+            groupby=["project_id"],
+        )
+        query.select[0].alias = "sum(session.all)"
+
+        mock_rpc.return_value = [
+            TimeSeriesResponse(
+                result_timeseries=[
+                    _make_timeseries(
+                        "sum_session_init",
+                        [50.0],
+                        group_by={"sentry.project_id": "1"},
+                    ),
+                ]
+            )
+        ]
+
+        result = get_series_eap(query, org_id=1)
+        assert result is not None
+        group = result["groups"][0]
+        assert "project_id" in group["by"]
+        assert "project" not in group["by"]
+
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_strips_totals_when_include_totals_false(self, mock_rpc):
+        query = _make_metrics_query([("sum", "e:sessions/all@none")])
+        query.select[0].alias = "sum(session.all)"
+        query.include_totals = False
+
+        mock_rpc.return_value = [
+            TimeSeriesResponse(result_timeseries=[_make_timeseries("sum_session_init", [100.0])])
+        ]
+
+        result = get_series_eap(query, org_id=1)
+        assert result is not None
+        group = result["groups"][0]
+        assert "totals" not in group
+        assert "series" in group
+
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_returns_float_values(self, mock_rpc):
+        """get_series returns floats, so EAP results should too."""
+        query = _make_metrics_query([("sum", "e:sessions/all@none")])
+        query.select[0].alias = "sum(session.all)"
+
+        mock_rpc.return_value = [
+            TimeSeriesResponse(result_timeseries=[_make_timeseries("sum_session_init", [5.0])])
+        ]
+
+        result = get_series_eap(query, org_id=1)
+        assert result is not None
+        group = result["groups"][0]
+        # Values should be float, not int
+        assert group["series"]["sum(session.all)"] == [5.0]
+        assert isinstance(group["series"]["sum(session.all)"][0], float)
+        assert group["totals"]["sum(session.all)"] == 5.0
+        assert isinstance(group["totals"]["sum(session.all)"], float)
+
+    def test_returns_none_for_non_session_query(self):
+        query = _make_metrics_query([("avg", "d:transactions/duration@millisecond")])
+        result = get_series_eap(query, org_id=1)
+        assert result is None
+
+
+class TestCompareGetSeriesResults(TestCase):
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_matching_results(self, mock_metrics):
+        control = {
+            "groups": [
+                {
+                    "by": {},
+                    "series": {"sum(session.all)": [100]},
+                    "totals": {"sum(session.all)": 100},
+                }
+            ]
+        }
+        experimental = {
+            "groups": [
+                {
+                    "by": {},
+                    "series": {"sum(session.all)": [100]},
+                    "totals": {"sum(session.all)": 100},
+                }
+            ]
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"exact_match": "True", "is_null_result": "False"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_mismatched_results(self, mock_metrics):
+        control = {
+            "groups": [
+                {
+                    "by": {},
+                    "series": {"sum(session.all)": [100]},
+                    "totals": {"sum(session.all)": 100},
+                }
+            ]
+        }
+        experimental = {
+            "groups": [
+                {"by": {}, "series": {"sum(session.all)": [50]}, "totals": {"sum(session.all)": 50}}
+            ]
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"exact_match": "False", "is_null_result": "False"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_null_eap_result(self, mock_metrics):
+        control = {
+            "groups": [
+                {
+                    "by": {},
+                    "series": {"sum(session.all)": [100]},
+                    "totals": {"sum(session.all)": 100},
+                }
+            ]
+        }
+        experimental = {"groups": []}
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"exact_match": "False", "is_null_result": "True"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_structural_mismatch_is_detected(self, mock_metrics):
+        """Extra totals in experimental that control doesn't have should mismatch."""
+        control = {"groups": [{"by": {}, "series": {"session.all": [5.0]}}]}
+        experimental = {
+            "groups": [{"by": {}, "series": {"session.all": [5.0]}, "totals": {"session.all": 5.0}}]
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"exact_match": "False", "is_null_result": "False"},
+        )


### PR DESCRIPTION
Adds a second read from snuba (EAP) when the feature flag is enabled. The result is only used to compare to the legacy result, which is always still returned