### PR TITLE
feat(autofix): Better loading and error states for autofix in sidebar

### DIFF
--- a/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
@@ -24,7 +24,7 @@ import {
 function makeSection(
   step: string,
   artifacts: any[] = [],
-  {status}: {status: string} = {status: 'completed'}
+  {status}: {status: 'completed' | 'processing'} = {status: 'completed'}
 ): AutofixSection {
   return {step, artifacts, messages: [], status};
 }

--- a/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
@@ -21,8 +21,12 @@ import {
   SolutionPreview,
 } from './autofixPreviews';
 
-function makeSection(step: string, ...artifacts: any[]): AutofixSection {
-  return {step, artifacts, messages: [], status: 'completed'};
+function makeSection(
+  step: string,
+  artifacts: any[] = [],
+  {status}: {status: string} = {status: 'completed'}
+): AutofixSection {
+  return {step, artifacts, messages: [], status};
 }
 
 describe('RootCausePreview', () => {
@@ -37,10 +41,18 @@ describe('RootCausePreview', () => {
       },
     };
 
-    render(<RootCausePreview section={makeSection('root_cause', artifact)} />);
+    render(<RootCausePreview section={makeSection('root_cause', [artifact])} />);
 
     expect(screen.getByText('Root Cause')).toBeInTheDocument();
     expect(screen.getByText('Null pointer in user handler')).toBeInTheDocument();
+  });
+
+  it('renders placeholder when processing', () => {
+    render(
+      <RootCausePreview section={makeSection('root_cause', [], {status: 'processing'})} />
+    );
+
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
   });
 
   it('handles null data', () => {
@@ -50,9 +62,14 @@ describe('RootCausePreview', () => {
       data: null,
     };
 
-    render(<RootCausePreview section={makeSection('root_cause', artifact)} />);
+    render(<RootCausePreview section={makeSection('root_cause', [artifact])} />);
 
     expect(screen.getByText('Root Cause')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Seer failed to generate a root cause. This one is on us. Try running it again.'
+      )
+    ).toBeInTheDocument();
   });
 });
 
@@ -67,10 +84,18 @@ describe('SolutionPreview', () => {
       },
     };
 
-    render(<SolutionPreview section={makeSection('solution', artifact)} />);
+    render(<SolutionPreview section={makeSection('solution', [artifact])} />);
 
     expect(screen.getByText('Implementation Plan')).toBeInTheDocument();
     expect(screen.getByText('Add null check before accessing user')).toBeInTheDocument();
+  });
+
+  it('renders placeholder when processing', () => {
+    render(
+      <SolutionPreview section={makeSection('solution', [], {status: 'processing'})} />
+    );
+
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
   });
 
   it('handles null data', () => {
@@ -80,9 +105,14 @@ describe('SolutionPreview', () => {
       data: null,
     };
 
-    render(<SolutionPreview section={makeSection('solution', artifact)} />);
+    render(<SolutionPreview section={makeSection('solution', [artifact])} />);
 
     expect(screen.getByText('Implementation Plan')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Seer failed to generate an implementation plan. This one is on us. Try running it again.'
+      )
+    ).toBeInTheDocument();
   });
 });
 
@@ -106,7 +136,7 @@ describe('CodeChangesPreview', () => {
   it('renders single file in single repo', () => {
     render(
       <CodeChangesPreview
-        section={makeSection('code_changes', [makePatch('org/repo', 'src/app.py')])}
+        section={makeSection('code_changes', [[makePatch('org/repo', 'src/app.py')]])}
       />
     );
 
@@ -118,9 +148,11 @@ describe('CodeChangesPreview', () => {
     render(
       <CodeChangesPreview
         section={makeSection('code_changes', [
-          makePatch('org/repo', 'src/app.py'),
-          makePatch('org/repo', 'src/utils.py'),
-          makePatch('org/repo', 'src/models.py'),
+          [
+            makePatch('org/repo', 'src/app.py'),
+            makePatch('org/repo', 'src/utils.py'),
+            makePatch('org/repo', 'src/models.py'),
+          ],
         ])}
       />
     );
@@ -132,9 +164,11 @@ describe('CodeChangesPreview', () => {
     render(
       <CodeChangesPreview
         section={makeSection('code_changes', [
-          makePatch('org/repo-a', 'src/app.py'),
-          makePatch('org/repo-a', 'src/utils.py'),
-          makePatch('org/repo-b', 'src/index.ts'),
+          [
+            makePatch('org/repo-a', 'src/app.py'),
+            makePatch('org/repo-a', 'src/utils.py'),
+            makePatch('org/repo-b', 'src/index.ts'),
+          ],
         ])}
       />
     );
@@ -142,11 +176,25 @@ describe('CodeChangesPreview', () => {
     expect(screen.getByText('3 files changed in 2 repos')).toBeInTheDocument();
   });
 
-  it('renders empty array without file counts', () => {
-    render(<CodeChangesPreview section={makeSection('code_changes')} />);
+  it('renders placeholder when processing', () => {
+    render(
+      <CodeChangesPreview
+        section={makeSection('code_changes', [], {status: 'processing'})}
+      />
+    );
+
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+  });
+
+  it('renders empty array with error message', () => {
+    render(<CodeChangesPreview section={makeSection('code_changes', [])} />);
 
     expect(screen.getByText('Code Changes')).toBeInTheDocument();
-    expect(screen.getByText('No files changed')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Seer failed to generate a code change. This one is on us. Try running it again.'
+      )
+    ).toBeInTheDocument();
   });
 });
 
@@ -167,7 +215,7 @@ describe('PullRequestsPreview', () => {
   }
 
   it('renders PR links', () => {
-    render(<PullRequestsPreview section={makeSection('pull_request', [makePR()])} />);
+    render(<PullRequestsPreview section={makeSection('pull_request', [[makePR()]])} />);
 
     expect(screen.getByText('Pull Requests')).toBeInTheDocument();
     const link = screen.getByRole('link', {name: 'org/repo#42'});
@@ -178,8 +226,10 @@ describe('PullRequestsPreview', () => {
     render(
       <PullRequestsPreview
         section={makeSection('pull_request', [
-          makePR({repo_name: 'org/repo-a', pr_number: 10, pr_url: 'https://pr/10'}),
-          makePR({repo_name: 'org/repo-b', pr_number: 20, pr_url: 'https://pr/20'}),
+          [
+            makePR({repo_name: 'org/repo-a', pr_number: 10, pr_url: 'https://pr/10'}),
+            makePR({repo_name: 'org/repo-b', pr_number: 20, pr_url: 'https://pr/20'}),
+          ],
         ])}
       />
     );
@@ -188,24 +238,66 @@ describe('PullRequestsPreview', () => {
     expect(screen.getByRole('link', {name: 'org/repo-b#20'})).toBeInTheDocument();
   });
 
-  it('skips PRs with missing fields', () => {
+  it('renders creating status with placeholder', () => {
     render(
       <PullRequestsPreview
         section={makeSection('pull_request', [
-          makePR({pr_url: null}),
-          makePR({pr_number: null}),
-          makePR({repo_name: '', pr_number: 99, pr_url: 'https://pr/99'}),
-          makePR({
-            repo_name: 'org/valid',
-            pr_number: 55,
-            pr_url: 'https://pr/55',
-          }),
+          [makePR({pr_creation_status: 'creating', pr_url: null, pr_number: null})],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Pull Requests')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+  });
+
+  it('renders error status as failed', () => {
+    render(
+      <PullRequestsPreview
+        section={makeSection('pull_request', [
+          [
+            makePR({
+              pr_creation_status: 'error',
+              pr_url: null,
+              pr_number: null,
+              repo_name: 'org/my-repo',
+            }),
+          ],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Failed to create PR in org/my-repo')).toBeInTheDocument();
+  });
+
+  it('renders failed message for completed PRs with missing fields', () => {
+    render(
+      <PullRequestsPreview
+        section={makeSection('pull_request', [
+          [
+            makePR({
+              repo_name: 'org/repo-a',
+              pr_url: null,
+              pr_creation_status: 'completed',
+            }),
+            makePR({
+              repo_name: 'org/repo-b',
+              pr_number: null,
+              pr_creation_status: 'completed',
+            }),
+            makePR({
+              repo_name: 'org/valid',
+              pr_number: 55,
+              pr_url: 'https://pr/55',
+            }),
+          ],
         ])}
       />
     );
 
     expect(screen.getByRole('link', {name: 'org/valid#55'})).toBeInTheDocument();
-    expect(screen.queryByRole('link', {name: /repo#42/})).not.toBeInTheDocument();
+    // PRs with completed status but missing url/number now show failed message
+    expect(screen.getAllByText(/Failed to create PR/)).toHaveLength(2);
   });
 });
 
@@ -227,7 +319,7 @@ describe('CodingAgentPreview', () => {
     render(
       <CodingAgentPreview
         section={makeSection('coding_agents', [
-          makeCodingAgent({provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT}),
+          [makeCodingAgent({provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT})],
         ])}
       />
     );
@@ -239,7 +331,7 @@ describe('CodingAgentPreview', () => {
     render(
       <CodingAgentPreview
         section={makeSection('coding_agents', [
-          makeCodingAgent({provider: CodingAgentProvider.CLAUDE_CODE_AGENT}),
+          [makeCodingAgent({provider: CodingAgentProvider.CLAUDE_CODE_AGENT})],
         ])}
       />
     );
@@ -251,7 +343,7 @@ describe('CodingAgentPreview', () => {
     render(
       <CodingAgentPreview
         section={makeSection('coding_agents', [
-          makeCodingAgent({provider: CodingAgentProvider.GITHUB_COPILOT_AGENT}),
+          [makeCodingAgent({provider: CodingAgentProvider.GITHUB_COPILOT_AGENT})],
         ])}
       />
     );
@@ -263,7 +355,7 @@ describe('CodingAgentPreview', () => {
     render(
       <CodingAgentPreview
         section={makeSection('coding_agents', [
-          makeCodingAgent({provider: 'unknown' as any}),
+          [makeCodingAgent({provider: 'unknown' as any})],
         ])}
       />
     );
@@ -275,7 +367,7 @@ describe('CodingAgentPreview', () => {
     render(
       <CodingAgentPreview
         section={makeSection('coding_agents', [
-          makeCodingAgent({name: 'Fix auth bug', status: 'completed'}),
+          [makeCodingAgent({name: 'Fix auth bug', status: 'completed'})],
         ])}
       />
     );
@@ -288,7 +380,7 @@ describe('CodingAgentPreview', () => {
     render(
       <CodingAgentPreview
         section={makeSection('coding_agents', [
-          makeCodingAgent({agent_url: 'https://cursor.com/agent/1'}),
+          [makeCodingAgent({agent_url: 'https://cursor.com/agent/1'})],
         ])}
       />
     );
@@ -299,18 +391,46 @@ describe('CodingAgentPreview', () => {
 
   it('does not render "Open in Agent" link when agent_url is absent', () => {
     render(
-      <CodingAgentPreview section={makeSection('coding_agents', [makeCodingAgent()])} />
+      <CodingAgentPreview section={makeSection('coding_agents', [[makeCodingAgent()]])} />
     );
 
     expect(screen.queryByRole('button', {name: 'Open in Agent'})).not.toBeInTheDocument();
+  });
+
+  it('renders pending status tag', () => {
+    render(
+      <CodingAgentPreview
+        section={makeSection('coding_agents', [
+          [makeCodingAgent({name: 'Pending Task', status: 'pending'})],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Pending Task')).toBeInTheDocument();
+    expect(screen.getByText('pending')).toBeInTheDocument();
+  });
+
+  it('renders failed status tag', () => {
+    render(
+      <CodingAgentPreview
+        section={makeSection('coding_agents', [
+          [makeCodingAgent({name: 'Failed Task', status: 'failed'})],
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Failed Task')).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
   });
 
   it('handles multiple agents', () => {
     render(
       <CodingAgentPreview
         section={makeSection('coding_agents', [
-          makeCodingAgent({id: 'a1', name: 'Agent One', status: 'running'}),
-          makeCodingAgent({id: 'a2', name: 'Agent Two', status: 'completed'}),
+          [
+            makeCodingAgent({id: 'a1', name: 'Agent One', status: 'running'}),
+            makeCodingAgent({id: 'a2', name: 'Agent Two', status: 'completed'}),
+          ],
         ])}
       />
     );

--- a/static/app/components/events/autofix/v3/autofixPreviews.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.tsx
@@ -135,11 +135,7 @@ export function CodeChangesPreview({section}: ArtifactPreviewProps) {
 
   return (
     <ArtifactCard icon={<IconCode />} title={t('Code Changes')}>
-      {section.status === 'processing' ? (
-        <Placeholder height="1.5rem" />
-      ) : (
-        <Text>{summary}</Text>
-      )}
+      {section.status === 'processing' ? <Placeholder height="1.5rem" /> : summary}
     </ArtifactCard>
   );
 }

--- a/static/app/components/events/autofix/v3/autofixPreviews.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.tsx
@@ -19,6 +19,7 @@ import {
   isSolutionArtifact,
   type AutofixSection,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {Placeholder} from 'sentry/components/placeholder';
 import {IconOpen} from 'sentry/icons';
 import {IconBot} from 'sentry/icons/iconBot';
 import {IconBug} from 'sentry/icons/iconBug';
@@ -40,7 +41,17 @@ export function RootCausePreview({section}: ArtifactPreviewProps) {
 
   return (
     <ArtifactCard icon={<IconBug />} title={t('Root Cause')}>
-      {artifact?.data?.one_line_description}
+      {section.status === 'processing' ? (
+        <Placeholder height="3rem" />
+      ) : artifact?.data ? (
+        <Text>{artifact.data.one_line_description}</Text>
+      ) : (
+        <Text variant="muted">
+          {t(
+            'Seer failed to generate a root cause. This one is on us. Try running it again.'
+          )}
+        </Text>
+      )}
     </ArtifactCard>
   );
 }
@@ -53,7 +64,17 @@ export function SolutionPreview({section}: ArtifactPreviewProps) {
 
   return (
     <ArtifactCard icon={<IconList />} title={t('Implementation Plan')}>
-      {artifact?.data?.one_line_summary}
+      {section.status === 'processing' ? (
+        <Placeholder height="3rem" />
+      ) : artifact?.data ? (
+        <Text>{artifact.data.one_line_summary}</Text>
+      ) : (
+        <Text variant="muted">
+          {t(
+            'Seer failed to generate an implementation plan. This one is on us. Try running it again.'
+          )}
+        </Text>
+      )}
     </ArtifactCard>
   );
 }
@@ -86,23 +107,39 @@ export function CodeChangesPreview({section}: ArtifactPreviewProps) {
     }
 
     if (reposChanged === 0) {
-      return t('No files changed');
-    }
-
-    if (reposChanged === 1) {
-      return tn(
-        '%s file changed in 1 repo',
-        '%s files changed in 1 repo',
-        filesChanged.size
+      return (
+        <Text variant="muted">
+          {t(
+            'Seer failed to generate a code change. This one is on us. Try running it again.'
+          )}
+        </Text>
       );
     }
 
-    return t('%s files changed in %s repos', filesChanged.size, reposChanged);
+    if (reposChanged === 1) {
+      return (
+        <Text>
+          {tn(
+            '%s file changed in 1 repo',
+            '%s files changed in 1 repo',
+            filesChanged.size
+          )}
+        </Text>
+      );
+    }
+
+    return (
+      <Text>{t('%s files changed in %s repos', filesChanged.size, reposChanged)}</Text>
+    );
   }, [patchesForRepos]);
 
   return (
     <ArtifactCard icon={<IconCode />} title={t('Code Changes')}>
-      {summary}
+      {section.status === 'processing' ? (
+        <Placeholder height="1.5rem" />
+      ) : (
+        <Text>{summary}</Text>
+      )}
     </ArtifactCard>
   );
 }
@@ -116,13 +153,25 @@ export function PullRequestsPreview({section}: ArtifactPreviewProps) {
   return (
     <ArtifactCard icon={<IconPullRequest />} title={t('Pull Requests')}>
       {artifact.map(pullRequest => {
-        if (!pullRequest.repo_name || !pullRequest.pr_number || !pullRequest.pr_url) {
-          return null;
+        if (pullRequest.pr_creation_status === 'creating') {
+          return <Placeholder key={pullRequest.repo_name} height="1.5rem" />;
         }
-        const label = `${pullRequest.repo_name}#${pullRequest.pr_number}`;
+
+        if (
+          pullRequest.pr_creation_status === 'completed' &&
+          pullRequest.pr_url &&
+          pullRequest.pr_number
+        ) {
+          return (
+            <ExternalLink key={pullRequest.repo_name} href={pullRequest.pr_url}>
+              {pullRequest.repo_name}#{pullRequest.pr_number}
+            </ExternalLink>
+          );
+        }
+
         return (
-          <ExternalLink key={label} href={pullRequest.pr_url}>
-            {label}
+          <ExternalLink key={pullRequest.repo_name} disabled>
+            {t('Failed to create PR in %s', pullRequest.repo_name)}
           </ExternalLink>
         );
       })}

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -34,10 +34,10 @@ export function SeerDrawerContent({aiConfig, autofix}: SeerDrawerContentProps) {
     [autofix.runState]
   );
 
-  if (autofix.isLoading) {
+  // we're polling and no blocks have been added yet
+  if (autofix.isPolling && !autofix.runState?.blocks?.length) {
     return (
       <Flex direction="column" gap="xl">
-        <Placeholder height="10rem" />
         <Placeholder height="15rem" />
       </Flex>
     );

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -34,8 +34,12 @@ export function SeerDrawerContent({aiConfig, autofix}: SeerDrawerContentProps) {
     [autofix.runState]
   );
 
-  // we're polling and no blocks have been added yet
-  if (autofix.isPolling && !autofix.runState?.blocks?.length) {
+  if (
+    // autofix results are loading
+    autofix.isLoading ||
+    // we're polling and no blocks have been added yet
+    (autofix.isPolling && !autofix.runState?.blocks?.length)
+  ) {
     return (
       <Flex direction="column" gap="xl">
         <Placeholder height="15rem" />

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -119,7 +119,18 @@ export function AutofixContent({aiConfig, group, project, event}: AutofixContent
   const autofix = useExplorerAutofix(group.id);
   const {data: setupCheck, isPending} = useSeerOnboardingCheck();
 
-  if (isPending || autofix.isLoading || !event || aiConfig.isAutofixSetupLoading) {
+  if (
+    // waiting on the onboarding checks to load
+    isPending ||
+    // autofix results are loading
+    autofix.isLoading ||
+    // waiting for the event to load
+    !event ||
+    // waiting for the ai configs to load
+    aiConfig.isAutofixSetupLoading ||
+    // we're polling and no blocks have been added yet
+    (autofix.isPolling && !autofix.runState?.blocks?.length)
+  ) {
     return <Placeholder height="160px" />;
   }
 


### PR DESCRIPTION
This adds loading and error states so it doesn't just render nothing when the artifact isn't ready yet.

|       | Root Cause | Implementation Plan | Coding Changes | Pull Requests |
| --- | ------------ | -------------------- | ---------------- | -------------- |
| loading | <img width="608" height="390" alt="image" src="https://github.com/user-attachments/assets/7b50c9a7-8f8f-4f2b-8124-e2fa1af3c366" /> | <img width="632" height="652" alt="image" src="https://github.com/user-attachments/assets/1b2c457f-b91e-4dcf-a629-70d9966a56e5" /> | <img width="630" height="820" alt="image" src="https://github.com/user-attachments/assets/c6329cbd-eccd-428d-a198-7164baf57b4e" /> | <img width="626" height="976" alt="image" src="https://github.com/user-attachments/assets/4a938a4c-1dda-416e-89b1-39642b306989" /> |
| no artifact | <img width="614" height="398" alt="image" src="https://github.com/user-attachments/assets/b3d052b6-584d-4e45-8f48-92116614f607" />  | <img width="624" height="678" alt="image" src="https://github.com/user-attachments/assets/80cf0105-a8ad-4d1c-92c6-e417ee22a50d" /> | <img width="624" height="838" alt="image" src="https://github.com/user-attachments/assets/75335df2-02f0-4a36-ba9f-aa8646a14366" /> | <img width="614" height="1010" alt="image" src="https://github.com/user-attachments/assets/f00de129-62e7-4fd7-9268-0a4973ba4963" /> |