### PR TITLE
chore: Remove graduated feature flag performance-new-trends

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -8,7 +8,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from snuba_sdk import Column
 
-from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
@@ -69,15 +68,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsEndpointBase):
         }
     )
 
-    def has_feature(self, organization, request):
-        return features.has(
-            "organizations:performance-new-trends", organization, actor=request.user
-        )
-
     def get(self, request: Request, organization: Organization) -> Response:
-        if not self.has_feature(organization, request):
-            return Response(status=404)
-
         viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
 
         try:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1401,7 +1401,6 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 # Sentry and internal client configuration
 
 SENTRY_EARLY_FEATURES = {
-    "organizations:performance-new-trends": "Enable new trends",
     "organizations:performance-new-widget-designs": "Enable updated landing page widget designs",
     "organizations:profiling-global-suspect-functions": "Enable global suspect functions in profiling",
 }

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -200,8 +200,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Re-enable histograms for Metrics Enhanced Performance Views
     manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable new trends
-    manager.add("organizations:performance-new-trends", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable updated landing page widget designs
     manager.add("organizations:performance-new-widget-designs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable MongoDB support for the Queries module

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1094,7 +1094,7 @@ class DashboardDetail extends Component<Props, State> {
       dashboardState !== DashboardState.CREATE &&
       hasUnsavedFilterChanges(dashboard, location);
 
-    const eventView = generatePerformanceEventView(location, projects, {}, organization);
+    const eventView = generatePerformanceEventView(location, projects, {});
 
     const isDashboardUsingTransaction = dashboard.widgets.some(
       isWidgetUsingTransactionName

--- a/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/am1OverviewPage.tsx
@@ -103,7 +103,7 @@ export function Am1MobileOverviewPage({datePageFilterProps}: Am1MobileOverviewPa
   const eventView = generateMobilePerformanceEventView(
     location,
     projects,
-    generateGenericPerformanceEventView(location, withStaticFilters, organization),
+    generateGenericPerformanceEventView(location, withStaticFilters),
     withStaticFilters
   );
   const searchBarEventView = eventView.clone();

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -125,7 +125,7 @@ function EAPMobileOverviewPage({datePageFilterProps}: EAPMobileOverviewPageProps
   const eventView = generateMobilePerformanceEventView(
     location,
     projects,
-    generateGenericPerformanceEventView(location, withStaticFilters, organization),
+    generateGenericPerformanceEventView(location, withStaticFilters),
     withStaticFilters,
     true
   );

--- a/static/app/views/performance/data.spec.tsx
+++ b/static/app/views/performance/data.spec.tsx
@@ -1,5 +1,4 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
   MEPState,
@@ -11,15 +10,8 @@ import {
 } from 'sentry/views/performance/data';
 
 describe('generatePerformanceEventView()', () => {
-  const organization = OrganizationFixture();
-
   it('generates default values', () => {
-    const result = generatePerformanceEventView(
-      LocationFixture({query: {}}),
-      [],
-      {},
-      organization
-    );
+    const result = generatePerformanceEventView(LocationFixture({query: {}}), [], {});
 
     expect(result.id).toBeUndefined();
     expect(result.name).toBe('Performance');
@@ -34,8 +26,7 @@ describe('generatePerformanceEventView()', () => {
     const result = generatePerformanceEventView(
       LocationFixture({query: {sort: ['-p50', '-count']}}),
       [],
-      {},
-      organization
+      {}
     );
 
     expect(result.sorts).toEqual([{kind: 'desc', field: 'p50'}]);
@@ -46,8 +37,7 @@ describe('generatePerformanceEventView()', () => {
     const result = generatePerformanceEventView(
       LocationFixture({query: {statsPeriod: ['90d', '45d']}}),
       [],
-      {},
-      organization
+      {}
     );
     expect(result.start).toBeUndefined();
     expect(result.end).toBeUndefined();
@@ -60,8 +50,7 @@ describe('generatePerformanceEventView()', () => {
         query: {start: '2020-04-25T12:00:00', end: '2020-05-25T12:00:00'},
       }),
       [],
-      {},
-      organization
+      {}
     );
     expect(result.start).toBe('2020-04-25T12:00:00.000');
     expect(result.end).toBe('2020-05-25T12:00:00.000');
@@ -72,8 +61,7 @@ describe('generatePerformanceEventView()', () => {
     const result = generatePerformanceEventView(
       LocationFixture({query: {query: 'things.update'}}),
       [],
-      {},
-      organization
+      {}
     );
     expect(result.query).toEqual(expect.stringContaining('transaction:*things.update*'));
     expect(result.getQueryWithAdditionalConditions()).toEqual(
@@ -85,8 +73,7 @@ describe('generatePerformanceEventView()', () => {
     const result = generatePerformanceEventView(
       LocationFixture({query: {query: 'things.update transaction:thing.gone'}}),
       [],
-      {},
-      organization
+      {}
     );
     expect(result.query).toEqual(expect.stringContaining('transaction:*things.update*'));
     expect(result.getQueryWithAdditionalConditions()).toEqual(
@@ -99,8 +86,7 @@ describe('generatePerformanceEventView()', () => {
     const result = generatePerformanceEventView(
       LocationFixture({query: {query: 'key:value tag:value'}}),
       [],
-      {},
-      organization
+      {}
     );
     expect(result.query).toEqual(expect.stringContaining('key:value'));
     expect(result.query).toEqual(expect.stringContaining('tag:value'));
@@ -113,8 +99,7 @@ describe('generatePerformanceEventView()', () => {
     const result = generatePerformanceEventView(
       LocationFixture({query: {query: 'key:value tag:value'}}),
       [],
-      {},
-      organization
+      {}
     );
     expect(result.fields).toEqual(
       expect.arrayContaining([expect.objectContaining({field: 'user_misery()'})])
@@ -136,8 +121,7 @@ describe('generatePerformanceEventView()', () => {
         },
       }),
       [],
-      {withStaticFilters: true},
-      organization
+      {withStaticFilters: true}
     );
     expect(result.query).toBe('transaction:*auth*');
   });

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -456,8 +456,7 @@ export function generateFrontendOtherPerformanceEventView(
 export function generatePerformanceEventView(
   location: Location,
   projects: Project[],
-  {isTrends = false, withStaticFilters = false} = {},
-  organization: Organization
+  {isTrends = false, withStaticFilters = false} = {}
 ) {
   const eventView = generateGenericPerformanceEventView(location, withStaticFilters);
   if (isTrends) {

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -9,10 +9,8 @@ import {t, tct} from 'sentry/locale';
 import type {NewQuery, Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import EventView from 'sentry/utils/discover/eventView';
-import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {getCurrentTrendParameter} from 'sentry/views/performance/trends/utils';
 
 import {getCurrentLandingDisplay, LandingDisplayField} from './landing/utils';
 
@@ -224,19 +222,6 @@ export function generateGenericPerformanceEventView(
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
-
-  if (query.trendParameter) {
-    // projects and projectIds are not necessary here since trendParameter will always
-    // be present in location and will not be determined based on the project type
-    const trendParameter = getCurrentTrendParameter(location, [], []);
-    if (
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      WEB_VITAL_DETAILS[trendParameter.column] &&
-      !organization.features.includes('performance-new-trends')
-    ) {
-      eventView.additionalConditions.addFilterValues('has', [trendParameter.column]);
-    }
-  }
 
   return eventView;
 }

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -179,8 +179,7 @@ export function prepareQueryForLandingPage(searchQuery: any, withStaticFilters: 
 
 export function generateGenericPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean,
-  organization: Organization
+  withStaticFilters: boolean
 ): EventView {
   const {query} = location;
 
@@ -460,11 +459,7 @@ export function generatePerformanceEventView(
   {isTrends = false, withStaticFilters = false} = {},
   organization: Organization
 ) {
-  const eventView = generateGenericPerformanceEventView(
-    location,
-    withStaticFilters,
-    organization
-  );
+  const eventView = generateGenericPerformanceEventView(location, withStaticFilters);
   if (isTrends) {
     return eventView;
   }

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -64,10 +64,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
     InteractiveTitle,
   } = props;
 
-  const withBreakpoint =
-    organization.features.includes('performance-new-trends') &&
-    !isCardinalityCheckLoading &&
-    !outcome?.forceTransactionsOnly;
+  const withBreakpoint = !isCardinalityCheckLoading && !outcome?.forceTransactionsOnly;
 
   const trendChangeType =
     props.chartSetting === PerformanceWidgetSetting.MOST_IMPROVED

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -236,7 +236,7 @@ export function TransactionSummaryCharts({
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
             projects={project ? [project] : []}
-            withBreakpoint={organization.features.includes('performance-new-trends')}
+            withBreakpoint
           />
         )}
         {display === DisplayModes.VITALS && (

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -119,9 +119,7 @@ export function Chart({
     navigate(to);
   };
 
-  const derivedTrendChangeType = organization.features.includes('performance-new-trends')
-    ? transaction?.change
-    : trendChangeType;
+  const derivedTrendChangeType = transaction?.change ?? trendChangeType;
 
   const trendToColor = makeTrendToColorMapping(theme);
   const lineColor =

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -7,7 +7,6 @@ import {LineChart} from 'sentry/components/charts/lineChart';
 import TransitionChart from 'sentry/components/charts/transitionChart';
 import {TransparentLoadingMask} from 'sentry/components/charts/transparentLoadingMask';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
-import type {OrganizationSummary} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {
@@ -41,7 +40,6 @@ import {
 
 type Props = ViewProps & {
   isLoading: boolean;
-  organization: OrganizationSummary;
   projects: Project[];
   statsData: TrendsStats;
   trendChangeType: TrendChangeType;
@@ -93,7 +91,6 @@ export function Chart({
   height,
   projects,
   project,
-  organization,
   additionalSeries,
   applyRegressionFormatToInterval = false,
 }: Props) {

--- a/static/app/views/performance/trends/utils/index.tsx
+++ b/static/app/views/performance/trends/utils/index.tsx
@@ -29,8 +29,6 @@ import {
   ProjectPerformanceType,
 } from 'sentry/views/performance/utils';
 
-export const DEFAULT_MAX_DURATION = '15min';
-
 export const TRENDS_FUNCTIONS: TrendFunction[] = [
   {
     label: 'p99',

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -28,7 +28,6 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
-import {DEFAULT_MAX_DURATION} from 'sentry/views/performance/trends/utils';
 
 export const QUERY_KEYS = [
   'environment',
@@ -226,32 +225,7 @@ export function trendsTargetRoute({
     ...additionalQuery,
   };
 
-  const query = decodeScalar(location.query.query, '');
-  const conditions = new MutableSearch(query);
-
   const modifiedConditions = initialConditions ?? new MutableSearch([]);
-
-  // Trends on metrics don't need these conditions
-  if (!organization.features.includes('performance-new-trends')) {
-    // No need to carry over tpm filters to transaction summary
-    if (conditions.hasFilter('tpm()')) {
-      modifiedConditions.setFilterValues('tpm()', conditions.getFilterValues('tpm()'));
-    } else {
-      modifiedConditions.setFilterValues('tpm()', ['>0.01']);
-    }
-
-    if (conditions.hasFilter('transaction.duration')) {
-      modifiedConditions.setFilterValues(
-        'transaction.duration',
-        conditions.getFilterValues('transaction.duration')
-      );
-    } else {
-      modifiedConditions.setFilterValues('transaction.duration', [
-        '>0',
-        `<${DEFAULT_MAX_DURATION}`,
-      ]);
-    }
-  }
   newQuery.query = modifiedConditions.formatString();
 
   return {pathname: getPerformanceTrendsUrl(organization, view), query: {...newQuery}};

--- a/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
@@ -48,26 +48,11 @@ class OrganizationEventsTrendsStatsV2EndpointTest(MetricsAPIBaseTestCase):
 
         self.features = {
             "organizations:performance-view": True,
-            "organizations:performance-new-trends": True,
         }
 
     @property
     def now(self):
         return MetricsAPIBaseTestCase.MOCK_DATETIME
-
-    def test_no_feature_flag(self) -> None:
-        response = self.client.get(
-            self.url,
-            format="json",
-            data={
-                "end": self.now - timedelta(minutes=1),
-                "start": self.now - timedelta(hours=4),
-                "field": ["project", "transaction"],
-                "query": "event.type:transaction",
-            },
-        )
-
-        assert response.status_code == 404, response.content
 
     def test_no_project(self) -> None:
         with self.feature(self.features):


### PR DESCRIPTION
This flag is fully rolled out. Remove the flag registration, endpoint feature gate, and simplify all gated code paths: breakpoint detection in trends widgets and charts is now always enabled, dead filter conditions and unused imports are removed.

<!-- Describe your PR here. -->