### PR TITLE
ref(api): move relevant endpoint ownership from enterprise -> integrations 

### DIFF
--- a/src/sentry/integrations/api/endpoints/external_team_details.py
+++ b/src/sentry/integrations/api/endpoints/external_team_details.py
@@ -32,7 +32,7 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         "DELETE": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.INTEGRATIONS
 
     def convert_args(
         self,

--- a/src/sentry/integrations/api/endpoints/external_team_index.py
+++ b/src/sentry/integrations/api/endpoints/external_team_index.py
@@ -29,7 +29,7 @@ class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.INTEGRATIONS
 
     @extend_schema(
         operation_id="Create an External Team",

--- a/src/sentry/integrations/api/endpoints/organization_integration_migrate_opsgenie.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_migrate_opsgenie.py
@@ -19,7 +19,7 @@ class OrganizationIntegrationMigrateOpsgenieEndpoint(CellOrganizationIntegration
     publish_status = {
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.INTEGRATIONS
 
     def put(
         self,

--- a/src/sentry/integrations/api/endpoints/organization_integrations_index.py
+++ b/src/sentry/integrations/api/endpoints/organization_integrations_index.py
@@ -58,7 +58,7 @@ def filter_by_features(
 @control_silo_endpoint
 @extend_schema(tags=["Integrations"])
 class OrganizationIntegrationsEndpoint(OrganizationIntegrationBaseEndpoint):
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.INTEGRATIONS
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }

--- a/src/sentry/integrations/github/installation.py
+++ b/src/sentry/integrations/github/installation.py
@@ -25,7 +25,7 @@ class GitHubIntegrationsInstallationEndpoint(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.INTEGRATIONS
 
     permission_classes = (SentryIsAuthenticated,)
 


### PR DESCRIPTION
Breaking up https://github.com/getsentry/sentry/pull/111002. Move ownership for integrations-related endpoints from enterprise, which doesn't exist anymore, to integrations.