### PR TITLE
perf(issues): Support collapse=stats on group details endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -199,8 +199,6 @@ class GroupDetailsEndpoint(GroupEndpoint):
                 )
             )
 
-            hourly_stats, daily_stats = self.__group_hourly_daily_stats(group, environment_ids)
-
             if "inbox" in expand:
                 inbox_map = get_inbox_details([group])
                 inbox_reason = inbox_map.get(group.id)
@@ -277,10 +275,13 @@ class GroupDetailsEndpoint(GroupEndpoint):
                     "pluginIssues": get_available_issue_plugins(group),
                     "pluginContexts": self._get_context_plugins(request, group),
                     "userReportCount": user_reports.count(),
-                    "stats": {"24h": hourly_stats, "30d": daily_stats},
                     "count": get_group_global_count(group),
                 }
             )
+
+            if "stats" not in collapse:
+                hourly_stats, daily_stats = self.__group_hourly_daily_stats(group, environment_ids)
+                data["stats"] = {"24h": hourly_stats, "30d": daily_stats}
 
             participants = user_service.serialize_many(
                 filter={"user_ids": GroupSubscriptionManager.get_participating_user_ids(group)},

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -262,6 +262,21 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, {"collapse": ["tags"]})
         assert "tags" not in response.data
 
+    def test_collapse_stats(self) -> None:
+        self.login_as(user=self.user)
+        group = self.create_group()
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
+
+        # Without collapse param, stats should be present
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert "stats" in response.data
+
+        # With collapse param, stats should not be present
+        response = self.client.get(url, {"collapse": ["stats"]})
+        assert response.status_code == 200
+        assert "stats" not in response.data
+
     def test_count_with_buffer(self) -> None:
         """Test that group count includes the count from the buffer."""
         self.login_as(user=self.user)

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -262,21 +262,6 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, {"collapse": ["tags"]})
         assert "tags" not in response.data
 
-    def test_collapse_stats(self) -> None:
-        self.login_as(user=self.user)
-        group = self.create_group()
-        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
-
-        # Without collapse param, stats should be present
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert "stats" in response.data
-
-        # With collapse param, stats should not be present
-        response = self.client.get(url, {"collapse": ["stats"]})
-        assert response.status_code == 200
-        assert "stats" not in response.data
-
     def test_count_with_buffer(self) -> None:
         """Test that group count includes the count from the buffer."""
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -276,31 +276,20 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             ]
         }
 
-    def test_collapse_stats_does_not_work(self) -> None:
-        """
-        'collapse' param should hide the stats data and not return anything in the response, but the impl
-        doesn't seem to respect this param.
-
-        include this test here in-case the endpoint behavior changes in the future.
-        """
+    def test_collapse_stats(self) -> None:
         self.login_as(user=self.user)
-
         event = self.store_event(
             data={"timestamp": before_now(minutes=3).isoformat()},
             project_id=self.project.id,
         )
-        group = event.group
-
-        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
+        url = f"/api/0/organizations/{event.group.organization.slug}/issues/{event.group.id}/"
 
         response = self.client.get(url, {"collapse": ["stats"]}, format="json")
         assert response.status_code == 200
-        assert int(response.data["id"]) == event.group.id
-        assert response.data["stats"]  # key shouldn't be present
-        assert response.data["count"] is not None  # key shouldn't be present
-        assert response.data["userCount"] is not None  # key shouldn't be present
-        assert response.data["firstSeen"] is not None  # key shouldn't be present
-        assert response.data["lastSeen"] is not None  # key shouldn't be present
+        assert "stats" not in response.data
+        # Seen stats from the serializer should still be present
+        assert response.data["firstSeen"] is not None
+        assert response.data["lastSeen"] is not None
 
     def test_issue_type_category(self) -> None:
         """Test that the issue's type and category is returned in the results"""


### PR DESCRIPTION
The group details endpoint (`/organizations/{org}/issues/{id}/`) computes 24h hourly and 30d daily time-series stats via two TSDB queries on every request. These populate the `stats` response field, but the issue details frontend doesn't use this data — it fetches its event graph via Discover queries instead.

This adds `collapse=stats` support to the endpoint, matching the existing pattern for `release` and `tags`. When collapsed, the two TSDB queries are skipped entirely.

Saves ~350ms on ~1sec trace [link](https://sentry.sentry.io/explore/traces/trace/a23978175568482b821b9fbfa23bd1d9/?fov=5481.543579310185%2C1376.42240858078&node=span-9508e545dba9bfa6&project=1&query=is_transaction%3Atrue%20span.description%3A%EF%80%8DContains%EF%80%8D%22%2Fapi%2F0%2Fissues%7Cgroups%2F%7Bissue_id%7D%2F%22%20organization.slug%3Asentry&source=traces&statsPeriod=24h&targetId=a56ba9d41cb02644&timestamp=1773876894)

<img width="1243" height="552" alt="Screenshot 2026-03-19 at 2 25 10 PM" src="https://github.com/user-attachments/assets/1800cad5-bb21-4d6e-a7b0-49b15f2eab8d" />
