### PR TITLE
perf(issues): Collapse stats on group details request

### DIFF
--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -296,7 +296,7 @@ describe('groupDetails', () => {
         expect.anything(),
         expect.objectContaining({
           query: {
-            collapse: ['release', 'tags'],
+            collapse: ['release', 'tags', 'stats'],
             environment: ['staging'],
             expand: ['inbox', 'owners'],
           },

--- a/static/app/views/issueDetails/useGroup.tsx
+++ b/static/app/views/issueDetails/useGroup.tsx
@@ -22,7 +22,7 @@ export function makeFetchGroupQueryKey({
   const query: Record<string, string | string[]> = {
     ...(environments.length > 0 ? {environment: environments} : {}),
     expand: ['inbox', 'owners'],
-    collapse: ['release', 'tags'],
+    collapse: ['release', 'tags', 'stats'],
   };
 
   return [


### PR DESCRIPTION
Adds `collapse=stats` to the `useGroup` query key so the group details endpoint skips computing 24h/30d time-series stats. The issue details page uses Discover queries for its event graph, not the `stats` field from the group response.

This also benefits the stacktrace preview tooltip, which prefetches group data via `useGroup` on hover.

- Depends on #111155