### PR TITLE
fix(tasks): Replace org iteration with options allowlist for context engine indexing

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1198,6 +1198,12 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "explorer.context_engine_indexing.allowed_org_ids",
+    default=[1],
+    type=Sequence,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "explorer.service_map.max_edges",
     default=5000,
     type=Int,

--- a/src/sentry/tasks/context_engine_index.py
+++ b/src/sentry/tasks/context_engine_index.py
@@ -34,14 +34,11 @@ from sentry.seer.signed_seer_api import (
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.taskworker.retry import Retry
-from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
 logger = logging.getLogger(__name__)
 INDEXING_DAY = 6  # Sunday
-CONTEXT_ENGINE_ENABLED_ORG_IDS = "context_engine_indexing:enabled_org_ids"
-CONTEXT_ENGINE_CACHE_TTL = 8 * 24 * 60 * 60  # 8 days
 
 
 @instrumented_task(
@@ -213,37 +210,29 @@ def build_service_map(organization_id: int, *args, **kwargs) -> None:
 
 def get_allowed_org_ids_context_engine_indexing() -> tuple[list[int], list[int]]:
     """
-    Get the list of allowed organizations for context engine indexing.
+    Get the list of allowed organizations for context engine indexing
+    from the options-based allowlist.
 
-    Only includes orgs that have the seer-explorer-context-engine feature flag
-    enabled. On the weekly indexing day (Sunday), spreads orgs evenly across
-    24 hourly slots via md5 hash. On other days, only newly-enabled orgs
-    (detected via cache diff) are returned as eligible.
+    On the weekly indexing day (Sunday), spreads orgs evenly across
+    24 hourly slots via md5 hash. On other days, returns all allowed orgs.
+
+    # TODO: This has to be changed so we can iterate over all orgs and check the feature flag.
     """
     now = datetime.now(UTC)
     TOTAL_HOURLY_SLOTS = 24
 
-    eligible_org_ids: list[int] = []
-    # TODO: This has to be changed so we can iterate over all orgs and check the feature flag.
     all_enabled_org_ids: list[int] = list(
         options.get("explorer.context_engine_indexing.allowed_org_ids")
     )
+    eligible_org_ids: list[int] = []
 
     if now.weekday() == INDEXING_DAY:
         slot = now.hour
         for org_id in all_enabled_org_ids:
             if int(md5_text(str(org_id)).hexdigest(), 16) % TOTAL_HOURLY_SLOTS == slot:
                 eligible_org_ids.append(org_id)
-
-    previous_enabled_org_ids = cache.get(CONTEXT_ENGINE_ENABLED_ORG_IDS)
-    if previous_enabled_org_ids is not None:
-        newly_added_org_ids_set = set(all_enabled_org_ids) - set(previous_enabled_org_ids)
-        if newly_added_org_ids_set:
-            logger.info(
-                "Adding context engine index for recently enabled orgs",
-                extra={"org_ids": list(newly_added_org_ids_set)},
-            )
-            eligible_org_ids = list(set(eligible_org_ids).union(newly_added_org_ids_set))
+    else:
+        eligible_org_ids = all_enabled_org_ids
 
     return all_enabled_org_ids, eligible_org_ids
 
@@ -264,7 +253,7 @@ def schedule_context_engine_indexing_tasks() -> None:
         logger.info("explorer.context_engine_indexing.enable flag is disabled")
         return
 
-    feature_enabled_org_ids, allowed_org_ids = get_allowed_org_ids_context_engine_indexing()
+    _all_enabled_org_ids, allowed_org_ids = get_allowed_org_ids_context_engine_indexing()
 
     dispatched = 0
     for org_id in allowed_org_ids:
@@ -277,13 +266,6 @@ def schedule_context_engine_indexing_tasks() -> None:
                 "Failed to dispatch context engine tasks for org",
                 extra={"org_id": org_id},
             )
-
-    # Store full currently-enabled orgs so next run can compute a stable diff.
-    cache.set(CONTEXT_ENGINE_ENABLED_ORG_IDS, feature_enabled_org_ids, CONTEXT_ENGINE_CACHE_TTL)
-    logger.info(
-        "Stored context engine enabled org ids cache size",
-        extra={"size": len(feature_enabled_org_ids)},
-    )
 
     logger.info(
         "Scheduled context engine indexing tasks",

--- a/src/sentry/tasks/context_engine_index.py
+++ b/src/sentry/tasks/context_engine_index.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta, timezone
 
 import sentry_sdk
 
-from sentry import features, options
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -36,7 +36,6 @@ from sentry.taskworker.namespaces import seer_tasks
 from sentry.taskworker.retry import Retry
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
-from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
 logger = logging.getLogger(__name__)
@@ -225,14 +224,10 @@ def get_allowed_org_ids_context_engine_indexing() -> tuple[list[int], list[int]]
     TOTAL_HOURLY_SLOTS = 24
 
     eligible_org_ids: list[int] = []
-    all_enabled_org_ids: list[int] = []
-
-    for org in RangeQuerySetWrapper(
-        Organization.objects.filter(status=ObjectStatus.ACTIVE),
-        result_value_getter=lambda o: o.id,
-    ):
-        if features.has("organizations:seer-explorer-context-engine", org):
-            all_enabled_org_ids.append(org.id)
+    # TODO: This has to be changed so we can iterate over all orgs and check the feature flag.
+    all_enabled_org_ids: list[int] = list(
+        options.get("explorer.context_engine_indexing.allowed_org_ids")
+    )
 
     if now.weekday() == INDEXING_DAY:
         slot = now.hour

--- a/tests/sentry/tasks/test_context_engine_index.py
+++ b/tests/sentry/tasks/test_context_engine_index.py
@@ -120,21 +120,14 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
     def test_returns_only_orgs_assigned_to_current_slot(self):
         from sentry.utils.hashlib import md5_text
 
-        orgs = [self.create_organization() for _ in range(50)]
-        org_ids = [org.id for org in orgs]
+        org_ids = list(range(1, 51))
 
         TOTAL_SLOTS = 24
         target_slot = int(md5_text(str(org_ids[0])).hexdigest(), 16) % TOTAL_SLOTS
         frozen_time = f"2024-01-14 {target_slot:02d}:00:00"
 
-        def feature_enabled_for_test_orgs(_flag_name: str, org, *args, **kwargs) -> bool:
-            return org.id in org_ids
-
         with freeze_time(frozen_time):
-            with mock.patch(
-                "sentry.tasks.context_engine_index.features.has",
-                side_effect=feature_enabled_for_test_orgs,
-            ):
+            with override_options({"explorer.context_engine_indexing.allowed_org_ids": org_ids}):
                 _feature_enabled, eligible = get_allowed_org_ids_context_engine_indexing()
 
         assert len(eligible) > 0
@@ -143,34 +136,26 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
         for org_id in eligible:
             assert int(md5_text(str(org_id)).hexdigest(), 16) % TOTAL_SLOTS == target_slot
 
-    def test_excludes_orgs_without_feature_flag(self):
+    def test_excludes_orgs_not_in_allowlist(self):
         from sentry.utils.hashlib import md5_text
 
-        org_with_flag = self.create_organization()
-        org_without_flag = self.create_organization()
+        allowed_org_id = 100
+        excluded_org_id = 200
 
         TOTAL_SLOTS = 24
-        target_slot = int(md5_text(str(org_without_flag.id)).hexdigest(), 16) % TOTAL_SLOTS
+        target_slot = int(md5_text(str(excluded_org_id)).hexdigest(), 16) % TOTAL_SLOTS
         frozen_time = f"2024-01-14 {target_slot:02d}:00:00"
 
         with freeze_time(frozen_time):
-            with self.feature(
-                {
-                    "organizations:seer-explorer": [org_with_flag.slug],
-                    "organizations:seer-explorer-context-engine": [org_with_flag.slug],
-                }
+            with override_options(
+                {"explorer.context_engine_indexing.allowed_org_ids": [allowed_org_id]}
             ):
                 _feature_enabled, eligible = get_allowed_org_ids_context_engine_indexing()
 
-        assert org_without_flag.id not in eligible
+        assert excluded_org_id not in eligible
 
-    def test_returns_empty_when_no_orgs_have_feature_flag(self):
-        with self.feature(
-            {
-                "organizations:seer-explorer": False,
-                "organizations:seer-explorer-context-engine": False,
-            }
-        ):
+    def test_returns_empty_when_allowlist_is_empty(self):
+        with override_options({"explorer.context_engine_indexing.allowed_org_ids": []}):
             feature_enabled, eligible = get_allowed_org_ids_context_engine_indexing()
 
         assert feature_enabled == []

--- a/tests/sentry/tasks/test_context_engine_index.py
+++ b/tests/sentry/tasks/test_context_engine_index.py
@@ -187,7 +187,12 @@ class TestScheduleContextEngineIndexingTasks(TestCase):
     @mock.patch("sentry.tasks.context_engine_index.build_service_map.apply_async")
     @mock.patch("sentry.tasks.context_engine_index.index_org_project_knowledge.apply_async")
     def test_noop_when_no_allowed_orgs(self, mock_index, mock_build):
-        with override_options({"explorer.context_engine_indexing.enable": True}):
+        with override_options(
+            {
+                "explorer.context_engine_indexing.enable": True,
+                "explorer.context_engine_indexing.allowed_org_ids": [],
+            }
+        ):
             schedule_context_engine_indexing_tasks()
 
         mock_index.assert_not_called()


### PR DESCRIPTION
+ The schedule_context_engine_indexing_tasks task was hitting ProcessingDeadlineExceeded (900s) because get_allowed_org_ids iterates all active organizations and calls features.has() per org, which triggers subscription and plan trial DB lookups for each one.
+ Replace the expensive all-orgs iteration with an options-based allowlist (explorer.context_engine_indexing.allowed_org_ids), defaulting to org ID 1 (Sentry). This eliminates the per-org feature flag overhead entirely. The allowlist can be expanded via sentry-options-automator as the feature rolls out.
+ https://sentry.sentry.io/issues/7345940147/?project=1&query=is%3Aunresolved%20%22schedule_context_engine_indexing_tasks%22&referrer=issue-stream

