### PR TITLE
feat(ACI): Make rule stats and group history endpoints backwards compatible

### DIFF
--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -192,7 +192,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         workflow_id, rule_id = get_rule_workflow_ids(target)
 
         if not workflow_id and isinstance(target, Rule):
-            logger.exception("No workflow associated with rule", extra={"rule_id": rule_id})
+            logger.warning("No workflow associated with rule", extra={"rule_id": rule_id})
             return self._fetch_rule_fire_history(target, start, end, per_page, cursor)
 
         return self._fetch_combined_rule_workflow_fire_history(
@@ -263,7 +263,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
         workflow_id, rule_id = get_rule_workflow_ids(target)
         if not workflow_id and isinstance(target, Rule):
-            logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
+            logger.warning("No workflow associated with rule", extra={"rule_id": target.id})
             existing_data = self._fetch_rule_fire_history_hourly_stats(target, start, end)
             return convert_hourly_stats(existing_data, start, end)
 

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -200,7 +200,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         end: datetime,
         cursor: Cursor | None = None,
         per_page: int = 25,
-    ) -> CursorResult[RuleGroupHistory[RuleGroupHistory]]:
+    ) -> CursorResult[RuleGroupHistory]:
         if isinstance(target, Workflow):
             try:
                 alert_rule_workflow = AlertRuleWorkflow.objects.get(workflow=target)
@@ -224,7 +224,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
     def fetch_combined_rule_workflow_hourly_stats(
         self, rule_id: int, workflow_id: int, start: datetime, end: datetime
-    ) -> Sequence[TimeSeriesValue]:
+    ) -> dict[datetime, TimeSeriesValue]:
         existing_data: dict[datetime, TimeSeriesValue] = {}
         # Use raw SQL to combine data from both tables
         with connection.cursor() as db_cursor:
@@ -262,7 +262,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
     def fetch_rule_fire_history_hourly_stats(
         self, rule: Rule, start: datetime, end: datetime
-    ) -> Sequence[TimeSeriesValue]:
+    ) -> dict[datetime, TimeSeriesValue]:
         qs = (
             RuleFireHistory.objects.filter(
                 rule=rule,
@@ -317,8 +317,8 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
             try:
                 alert_rule_workflow = AlertRuleWorkflow.objects.get(workflow=target)
                 rule_id = alert_rule_workflow.rule_id
-                existing_data: dict[datetime, TimeSeriesValue] = (
-                    self.fetch_combined_rule_workflow_hourly_stats(rule_id, target.id, start, end)
+                existing_data = self.fetch_combined_rule_workflow_hourly_stats(
+                    rule_id, target.id, start, end
                 )
             except AlertRuleWorkflow.DoesNotExist:
                 existing_data = self.fetch_workflow_hourly_stats(target.id, start, end)
@@ -326,10 +326,8 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
             try:
                 alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
                 workflow = alert_rule_workflow.workflow
-                existing_data: dict[datetime, TimeSeriesValue] = (
-                    self.fetch_combined_rule_workflow_hourly_stats(
-                        target.id, workflow.id, start, end
-                    )
+                existing_data = self.fetch_combined_rule_workflow_hourly_stats(
+                    target.id, workflow.id, start, end
                 )
             except AlertRuleWorkflow.DoesNotExist:
                 # If no workflow is associated with this rule, just use the original behavior

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, NamedTuple, TypedDict
 
 from django.db import connection
 from django.db.models import Count, Max, OuterRef, Subquery
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class IdPair(NamedTuple):
+    # One must be set.
+    workflow_id: int | None
+    rule_id: int | None
+
+
 class _Result(TypedDict):
     group: int
     count: int
@@ -36,6 +42,35 @@ def convert_results(results: Sequence[_Result]) -> Sequence[RuleGroupHistory]:
         RuleGroupHistory(group_lookup[r["group"]], r["count"], r["last_triggered"], r["event_id"])
         for r in results
     ]
+
+
+def convert_hourly_stats(
+    existing_data: dict[datetime, TimeSeriesValue], start: datetime, end: datetime
+) -> dict[datetime, TimeSeriesValue]:
+    results = []
+    current = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    while current <= end.replace(minute=0, second=0, microsecond=0):
+        results.append(existing_data.get(current, TimeSeriesValue(current, 0)))
+        current += timedelta(hours=1)
+    return results
+
+
+def get_rule_workflow_ids(target: Workflow | Rule) -> IdPair:
+    if isinstance(target, Workflow):
+        workflow_id = target.id
+        try:
+            alert_rule_workflow = AlertRuleWorkflow.objects.get(workflow=target)
+            rule_id = alert_rule_workflow.rule_id
+        except AlertRuleWorkflow.DoesNotExist:
+            rule_id = None
+    else:
+        rule_id = target.id
+        try:
+            alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
+            workflow_id = alert_rule_workflow.workflow.id
+        except AlertRuleWorkflow.DoesNotExist:
+            workflow_id = None
+    return IdPair(workflow_id=workflow_id, rule_id=rule_id)
 
 
 # temporary hack for removing unnecessary subqueries from group by list
@@ -61,54 +96,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
             notification_uuid=notification_uuid,
         )
 
-    def fetch_workflow_fire_history(
-        self,
-        workflow_id: int,
-        start: datetime,
-        end: datetime,
-        per_page: int,
-        cursor: Cursor | None = None,
-    ) -> CursorResult[RuleGroupHistory]:
-        """
-        Look up WorkflowFireHistory for a single written Workflow
-        """
-
-        def data_fn(offset: int, limit: int) -> list[_Result]:
-            query = """
-                WITH workflow_data AS (
-                    SELECT group_id, date_added, event_id
-                    FROM workflow_engine_workflowfirehistory
-                    WHERE workflow_id = %s
-                    AND date_added >= %s AND date_added < %s
-                )
-                SELECT
-                    group_id as group,
-                    COUNT(*) as count,
-                    MAX(date_added) as last_triggered,
-                    (ARRAY_AGG(event_id ORDER BY date_added DESC))[1] as event_id
-                FROM workflow_data
-                GROUP BY group_id
-                ORDER BY count DESC, last_triggered DESC
-                LIMIT %s OFFSET %s
-            """
-
-            with connection.cursor() as cursor:
-                cursor.execute(query, [workflow_id, start, end, limit, offset])
-                return [
-                    _Result(
-                        group=row[0],
-                        count=row[1],
-                        last_triggered=row[2],
-                        event_id=row[3],
-                    )
-                    for row in cursor.fetchall()
-                ]
-
-        result = GenericOffsetPaginator(data_fn=data_fn).get_result(per_page, cursor)
-        result.results = convert_results(result.results)
-        return result
-
-    def fetch_rule_fire_history(
+    def _fetch_rule_fire_history(
         self,
         rule: Rule,
         start: datetime,
@@ -141,10 +129,10 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
             qs, order_by=("-count", "-last_triggered"), on_results=convert_results
         ).get_result(per_page, cursor)
 
-    def fetch_combined_rule_workflow_fire_history(
+    def _fetch_combined_rule_workflow_fire_history(
         self,
-        rule_id: int,
-        workflow_id: int,
+        rule_id: int | None,
+        workflow_id: int | None,
         start: datetime,
         end: datetime,
         per_page: int,
@@ -201,29 +189,18 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         cursor: Cursor | None = None,
         per_page: int = 25,
     ) -> CursorResult[RuleGroupHistory]:
-        if isinstance(target, Workflow):
-            try:
-                alert_rule_workflow = AlertRuleWorkflow.objects.get(workflow=target)
-                rule_id = alert_rule_workflow.rule_id
-                return self.fetch_combined_rule_workflow_fire_history(
-                    rule_id, target.id, start, end, per_page, cursor
-                )
-            except AlertRuleWorkflow.DoesNotExist:
-                return self.fetch_workflow_fire_history(target.id, start, end, per_page, cursor)
-        else:
-            try:
-                alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
-                workflow_id = alert_rule_workflow.workflow.id
-                return self.fetch_combined_rule_workflow_fire_history(
-                    target.id, workflow_id, start, end, per_page, cursor
-                )
-            except AlertRuleWorkflow.DoesNotExist:
-                # If no workflow is associated with this rule, lookup RuleFireHistory only
-                logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
-                return self.fetch_rule_fire_history(target, start, end, per_page, cursor)
+        workflow_id, rule_id = get_rule_workflow_ids(target)
 
-    def fetch_combined_rule_workflow_hourly_stats(
-        self, rule_id: int, workflow_id: int, start: datetime, end: datetime
+        if not workflow_id and rule_id:
+            logger.exception("No workflow associated with rule", extra={"rule_id": rule_id})
+            return self._fetch_rule_fire_history(rule_id, start, end, per_page, cursor)
+
+        return self._fetch_combined_rule_workflow_fire_history(
+            rule_id, workflow_id, start, end, per_page, cursor
+        )
+
+    def _fetch_combined_rule_workflow_hourly_stats(
+        self, rule_id: int | None, workflow_id: int | None, start: datetime, end: datetime
     ) -> dict[datetime, TimeSeriesValue]:
         existing_data: dict[datetime, TimeSeriesValue] = {}
         # Use raw SQL to combine data from both tables
@@ -260,7 +237,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         existing_data = {row[0]: TimeSeriesValue(row[0], row[1]) for row in results}
         return existing_data
 
-    def fetch_rule_fire_history_hourly_stats(
+    def _fetch_rule_fire_history_hourly_stats(
         self, rule: Rule, start: datetime, end: datetime
     ) -> dict[datetime, TimeSeriesValue]:
         qs = (
@@ -277,35 +254,6 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         existing_data = {row["bucket"]: TimeSeriesValue(row["bucket"], row["count"]) for row in qs}
         return existing_data
 
-    def fetch_workflow_hourly_stats(
-        self, workflow_id: int, start: datetime, end: datetime
-    ) -> dict[datetime, TimeSeriesValue]:
-        # Use raw SQL to combine data from both tables
-        with connection.cursor() as db_cursor:
-            db_cursor.execute(
-                """
-                SELECT
-                    DATE_TRUNC('hour', date_added) as bucket,
-                    COUNT(*) as count
-                FROM (
-                    SELECT date_added
-                    FROM workflow_engine_workflowfirehistory
-                    WHERE workflow_id = %s
-                        AND date_added >= %s
-                        AND date_added < %s
-                ) combined_data
-                GROUP BY DATE_TRUNC('hour', date_added)
-                ORDER BY bucket
-                """,
-                [workflow_id, start, end],
-            )
-
-            results = db_cursor.fetchall()
-
-        # Convert raw SQL results to the expected format
-        existing_data = {row[0]: TimeSeriesValue(row[0], row[1]) for row in results}
-        return existing_data
-
     def fetch_rule_hourly_stats(
         self, target: Rule | Workflow, start: datetime, end: datetime
     ) -> Sequence[TimeSeriesValue]:
@@ -313,33 +261,13 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         end = end.replace(tzinfo=timezone.utc)
         existing_data: dict[datetime, TimeSeriesValue] = {}
 
-        if isinstance(target, Workflow):
-            try:
-                alert_rule_workflow = AlertRuleWorkflow.objects.get(workflow=target)
-                rule_id = alert_rule_workflow.rule_id
-                existing_data = self.fetch_combined_rule_workflow_hourly_stats(
-                    rule_id, target.id, start, end
-                )
-            except AlertRuleWorkflow.DoesNotExist:
-                existing_data = self.fetch_workflow_hourly_stats(target.id, start, end)
-            except Workflow.DoesNotExist:
-                existing_data = {}
-        else:
-            try:
-                alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
-                workflow = alert_rule_workflow.workflow
-                existing_data = self.fetch_combined_rule_workflow_hourly_stats(
-                    target.id, workflow.id, start, end
-                )
-            except AlertRuleWorkflow.DoesNotExist:
-                # If no workflow is associated with this rule, just use the original behavior
-                logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
-                existing_data = self.fetch_rule_fire_history_hourly_stats(target, start, end)
+        workflow_id, rule_id = get_rule_workflow_ids(target)
+        if not workflow_id and rule_id:
+            logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
+            existing_data = self._fetch_rule_fire_history_hourly_stats(target, start, end)
+            return convert_hourly_stats(existing_data, start, end)
 
-        # Fill in gaps with zero values for missing hours
-        results = []
-        current = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
-        while current <= end.replace(minute=0, second=0, microsecond=0):
-            results.append(existing_data.get(current, TimeSeriesValue(current, 0)))
-            current += timedelta(hours=1)
-        return results
+        existing_data = self._fetch_combined_rule_workflow_hourly_stats(
+            rule_id, workflow_id, start, end
+        )
+        return convert_hourly_stats(existing_data, start, end)

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -61,62 +61,66 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
             notification_uuid=notification_uuid,
         )
 
-    def fetch_rule_groups_paginated(
+    def fetch_workflow_fire_history(
         self,
-        target: Rule | Workflow,
+        workflow_id: int,
         start: datetime,
         end: datetime,
+        per_page: int,
         cursor: Cursor | None = None,
-        per_page: int = 25,
     ) -> CursorResult[RuleGroupHistory]:
-        try:
-            if not isinstance(target, Workflow):
-                alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
-                target = alert_rule_workflow.workflow
+        """
+        Look up WorkflowFireHistory for a single written Workflow
+        """
 
-            # Performs the raw SQL query with pagination
-            def data_fn(offset: int, limit: int) -> list[_Result]:
-                query = """
-                    WITH workflow_data AS (
-                        SELECT group_id, date_added, event_id
-                        FROM workflow_engine_workflowfirehistory
-                        WHERE workflow_id = %s
-                        AND date_added >= %s AND date_added < %s
+        def data_fn(offset: int, limit: int) -> list[_Result]:
+            query = """
+                WITH workflow_data AS (
+                    SELECT group_id, date_added, event_id
+                    FROM workflow_engine_workflowfirehistory
+                    WHERE workflow_id = %s
+                    AND date_added >= %s AND date_added < %s
+                )
+                SELECT
+                    group_id as group,
+                    COUNT(*) as count,
+                    MAX(date_added) as last_triggered,
+                    (ARRAY_AGG(event_id ORDER BY date_added DESC))[1] as event_id
+                FROM workflow_data
+                GROUP BY group_id
+                ORDER BY count DESC, last_triggered DESC
+                LIMIT %s OFFSET %s
+            """
+
+            with connection.cursor() as cursor:
+                cursor.execute(query, [workflow_id, start, end, limit, offset])
+                return [
+                    _Result(
+                        group=row[0],
+                        count=row[1],
+                        last_triggered=row[2],
+                        event_id=row[3],
                     )
-                    SELECT
-                        group_id as group,
-                        COUNT(*) as count,
-                        MAX(date_added) as last_triggered,
-                        (ARRAY_AGG(event_id ORDER BY date_added DESC))[1] as event_id
-                    FROM workflow_data
-                    GROUP BY group_id
-                    ORDER BY count DESC, last_triggered DESC
-                    LIMIT %s OFFSET %s
-                """
+                    for row in cursor.fetchall()
+                ]
 
-                with connection.cursor() as cursor:
-                    cursor.execute(query, [target.id, start, end, limit, offset])
-                    return [
-                        _Result(
-                            group=row[0],
-                            count=row[1],
-                            last_triggered=row[2],
-                            event_id=row[3],
-                        )
-                        for row in cursor.fetchall()
-                    ]
+        result = GenericOffsetPaginator(data_fn=data_fn).get_result(per_page, cursor)
+        result.results = convert_results(result.results)
+        return result
 
-            result = GenericOffsetPaginator(data_fn=data_fn).get_result(per_page, cursor)
-            result.results = convert_results(result.results)
-            return result
-
-        except AlertRuleWorkflow.DoesNotExist:
-            # If no workflow is associated with this rule, just use the original behavior
-            logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
-            pass
-
+    def fetch_rule_fire_history(
+        self,
+        rule: Rule,
+        start: datetime,
+        end: datetime,
+        per_page: int,
+        cursor: Cursor | None = None,
+    ) -> CursorResult[RuleGroupHistory]:
+        """
+        Look up RuleFireHistory for a given Rule
+        """
         rule_filtered_history = RuleFireHistory.objects.filter(
-            rule=target,
+            rule=rule,
             date_added__gte=start,
             date_added__lt=end,
         )
@@ -137,64 +141,200 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
             qs, order_by=("-count", "-last_triggered"), on_results=convert_results
         ).get_result(per_page, cursor)
 
+    def fetch_combined_rule_workflow_fire_history(
+        self,
+        rule_id: int,
+        workflow_id: int,
+        start: datetime,
+        end: datetime,
+        per_page: int,
+        cursor: Cursor | None = None,
+    ) -> CursorResult[RuleGroupHistory]:
+        """
+        Look up both WorkflowFireHistory and RuleFireHistory. Performs the raw SQL query with pagination.
+        """
+
+        def data_fn(offset: int, limit: int) -> list[_Result]:
+            query = """
+                WITH combined_data AS (
+                    SELECT group_id, date_added, event_id
+                    FROM sentry_rulefirehistory
+                    WHERE rule_id = %s AND date_added >= %s AND date_added < %s
+                    UNION ALL
+                    SELECT group_id, date_added, event_id
+                    FROM workflow_engine_workflowfirehistory
+                    WHERE workflow_id = %s
+                    AND date_added >= %s AND date_added < %s
+                )
+                SELECT
+                    group_id as group,
+                    COUNT(*) as count,
+                    MAX(date_added) as last_triggered,
+                    (ARRAY_AGG(event_id ORDER BY date_added DESC))[1] as event_id
+                FROM combined_data
+                GROUP BY group_id
+                ORDER BY count DESC, last_triggered DESC
+                LIMIT %s OFFSET %s
+            """
+
+            with connection.cursor() as cursor:
+                cursor.execute(query, [rule_id, start, end, workflow_id, start, end, limit, offset])
+                return [
+                    _Result(
+                        group=row[0],
+                        count=row[1],
+                        last_triggered=row[2],
+                        event_id=row[3],
+                    )
+                    for row in cursor.fetchall()
+                ]
+
+        result = GenericOffsetPaginator(data_fn=data_fn).get_result(per_page, cursor)
+        result.results = convert_results(result.results)
+        return result
+
+    def fetch_rule_groups_paginated(
+        self,
+        target: Rule | Workflow,
+        start: datetime,
+        end: datetime,
+        cursor: Cursor | None = None,
+        per_page: int = 25,
+    ) -> CursorResult[RuleGroupHistory[RuleGroupHistory]]:
+        if isinstance(target, Workflow):
+            try:
+                alert_rule_workflow = AlertRuleWorkflow.objects.get(workflow=target)
+                rule_id = alert_rule_workflow.rule_id
+                return self.fetch_combined_rule_workflow_fire_history(
+                    rule_id, target.id, start, end, per_page, cursor
+                )
+            except AlertRuleWorkflow.DoesNotExist:
+                return self.fetch_workflow_fire_history(target.id, start, end, per_page, cursor)
+        else:
+            try:
+                alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
+                workflow_id = alert_rule_workflow.workflow.id
+                return self.fetch_combined_rule_workflow_fire_history(
+                    target.id, workflow_id, start, end, per_page, cursor
+                )
+            except AlertRuleWorkflow.DoesNotExist:
+                # If no workflow is associated with this rule, lookup RuleFireHistory only
+                logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
+                return self.fetch_rule_fire_history(target, start, end, per_page, cursor)
+
+    def fetch_combined_rule_workflow_hourly_stats(
+        self, rule_id: int, workflow_id: int, start: datetime, end: datetime
+    ) -> Sequence[TimeSeriesValue]:
+        existing_data: dict[datetime, TimeSeriesValue] = {}
+        # Use raw SQL to combine data from both tables
+        with connection.cursor() as db_cursor:
+            db_cursor.execute(
+                """
+                SELECT
+                    DATE_TRUNC('hour', date_added) as bucket,
+                    COUNT(*) as count
+                FROM (
+                    SELECT date_added
+                    FROM sentry_rulefirehistory
+                    WHERE rule_id = %s
+                        AND date_added >= %s
+                        AND date_added < %s
+
+                    UNION ALL
+
+                    SELECT date_added
+                    FROM workflow_engine_workflowfirehistory
+                    WHERE workflow_id = %s
+                        AND date_added >= %s
+                        AND date_added < %s
+                ) combined_data
+                GROUP BY DATE_TRUNC('hour', date_added)
+                ORDER BY bucket
+                """,
+                [rule_id, start, end, workflow_id, start, end],
+            )
+
+            results = db_cursor.fetchall()
+
+        # Convert raw SQL results to the expected format
+        existing_data = {row[0]: TimeSeriesValue(row[0], row[1]) for row in results}
+        return existing_data
+
+    def fetch_rule_fire_history_hourly_stats(
+        self, rule: Rule, start: datetime, end: datetime
+    ) -> Sequence[TimeSeriesValue]:
+        qs = (
+            RuleFireHistory.objects.filter(
+                rule=rule,
+                date_added__gte=start,
+                date_added__lt=end,
+            )
+            .annotate(bucket=TruncHour("date_added"))
+            .order_by("bucket")
+            .values("bucket")
+            .annotate(count=Count("id"))
+        )
+        existing_data = {row["bucket"]: TimeSeriesValue(row["bucket"], row["count"]) for row in qs}
+        return existing_data
+
+    def fetch_workflow_hourly_stats(
+        self, workflow_id: int, start: datetime, end: datetime
+    ) -> dict[datetime, TimeSeriesValue]:
+        # Use raw SQL to combine data from both tables
+        with connection.cursor() as db_cursor:
+            db_cursor.execute(
+                """
+                SELECT
+                    DATE_TRUNC('hour', date_added) as bucket,
+                    COUNT(*) as count
+                FROM (
+                    SELECT date_added
+                    FROM workflow_engine_workflowfirehistory
+                    WHERE workflow_id = %s
+                        AND date_added >= %s
+                        AND date_added < %s
+                ) combined_data
+                GROUP BY DATE_TRUNC('hour', date_added)
+                ORDER BY bucket
+                """,
+                [workflow_id, start, end],
+            )
+
+            results = db_cursor.fetchall()
+
+        # Convert raw SQL results to the expected format
+        existing_data = {row[0]: TimeSeriesValue(row[0], row[1]) for row in results}
+        return existing_data
+
     def fetch_rule_hourly_stats(
         self, target: Rule | Workflow, start: datetime, end: datetime
     ) -> Sequence[TimeSeriesValue]:
         start = start.replace(tzinfo=timezone.utc)
         end = end.replace(tzinfo=timezone.utc)
-
         existing_data: dict[datetime, TimeSeriesValue] = {}
 
-        try:
-            if not isinstance(target, Workflow):
+        if isinstance(target, Workflow):
+            try:
+                alert_rule_workflow = AlertRuleWorkflow.objects.get(workflow=target)
+                rule_id = alert_rule_workflow.rule_id
+                existing_data: dict[datetime, TimeSeriesValue] = (
+                    self.fetch_combined_rule_workflow_hourly_stats(rule_id, target.id, start, end)
+                )
+            except AlertRuleWorkflow.DoesNotExist:
+                existing_data = self.fetch_workflow_hourly_stats(target.id, start, end)
+        else:
+            try:
                 alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
-                target = alert_rule_workflow.workflow
-
-            # Use raw SQL to combine data from both tables
-            with connection.cursor() as db_cursor:
-                db_cursor.execute(
-                    """
-                    SELECT
-                        DATE_TRUNC('hour', date_added) as bucket,
-                        COUNT(*) as count
-                    FROM (
-                        SELECT date_added
-                        FROM workflow_engine_workflowfirehistory
-                        WHERE workflow_id = %s
-                            AND date_added >= %s
-                            AND date_added < %s
-                    ) combined_data
-                    GROUP BY DATE_TRUNC('hour', date_added)
-                    ORDER BY bucket
-                    """,
-                    [target.id, start, end],
+                workflow = alert_rule_workflow.workflow
+                existing_data: dict[datetime, TimeSeriesValue] = (
+                    self.fetch_combined_rule_workflow_hourly_stats(
+                        target.id, workflow.id, start, end
+                    )
                 )
-
-                results = db_cursor.fetchall()
-
-            # Convert raw SQL results to the expected format
-            existing_data = {row[0]: TimeSeriesValue(row[0], row[1]) for row in results}
-
-        except AlertRuleWorkflow.DoesNotExist:
-            # If no workflow is associated with this rule, just use the original behavior
-            logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
-            pass
-
-        if not existing_data:
-            qs = (
-                RuleFireHistory.objects.filter(
-                    rule=target,
-                    date_added__gte=start,
-                    date_added__lt=end,
-                )
-                .annotate(bucket=TruncHour("date_added"))
-                .order_by("bucket")
-                .values("bucket")
-                .annotate(count=Count("id"))
-            )
-            existing_data = {
-                row["bucket"]: TimeSeriesValue(row["bucket"], row["count"]) for row in qs
-            }
+            except AlertRuleWorkflow.DoesNotExist:
+                # If no workflow is associated with this rule, just use the original behavior
+                logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
+                existing_data = self.fetch_rule_fire_history_hourly_stats(target, start, end)
 
         # Fill in gaps with zero values for missing hours
         results = []

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -46,7 +46,7 @@ def convert_results(results: Sequence[_Result]) -> Sequence[RuleGroupHistory]:
 
 def convert_hourly_stats(
     existing_data: dict[datetime, TimeSeriesValue], start: datetime, end: datetime
-) -> dict[datetime, TimeSeriesValue]:
+) -> list[TimeSeriesValue]:
     results = []
     current = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
     while current <= end.replace(minute=0, second=0, microsecond=0):
@@ -191,9 +191,9 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
     ) -> CursorResult[RuleGroupHistory]:
         workflow_id, rule_id = get_rule_workflow_ids(target)
 
-        if not workflow_id and rule_id:
+        if not workflow_id and isinstance(target, Rule):
             logger.exception("No workflow associated with rule", extra={"rule_id": rule_id})
-            return self._fetch_rule_fire_history(rule_id, start, end, per_page, cursor)
+            return self._fetch_rule_fire_history(target, start, end, per_page, cursor)
 
         return self._fetch_combined_rule_workflow_fire_history(
             rule_id, workflow_id, start, end, per_page, cursor
@@ -262,7 +262,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         existing_data: dict[datetime, TimeSeriesValue] = {}
 
         workflow_id, rule_id = get_rule_workflow_ids(target)
-        if not workflow_id and rule_id:
+        if not workflow_id and isinstance(target, Rule):
             logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
             existing_data = self._fetch_rule_fire_history_hourly_stats(target, start, end)
             return convert_hourly_stats(existing_data, start, end)

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -15,6 +15,7 @@ from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.history.base import RuleGroupHistory, RuleHistoryBackend, TimeSeriesValue
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.workflow_engine.models import AlertRuleWorkflow
+from sentry.workflow_engine.models.workflow import Workflow
 
 if TYPE_CHECKING:
     from sentry.models.rule import Rule
@@ -62,24 +63,21 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
     def fetch_rule_groups_paginated(
         self,
-        rule: Rule,
+        target: Rule | Workflow,
         start: datetime,
         end: datetime,
         cursor: Cursor | None = None,
         per_page: int = 25,
     ) -> CursorResult[RuleGroupHistory]:
         try:
-            alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id)
-            workflow = alert_rule_workflow.workflow
+            if not isinstance(target, Workflow):
+                alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
+                target = alert_rule_workflow.workflow
 
             # Performs the raw SQL query with pagination
             def data_fn(offset: int, limit: int) -> list[_Result]:
                 query = """
-                    WITH combined_data AS (
-                        SELECT group_id, date_added, event_id
-                        FROM sentry_rulefirehistory
-                        WHERE rule_id = %s AND date_added >= %s AND date_added < %s
-                        UNION ALL
+                    WITH workflow_data AS (
                         SELECT group_id, date_added, event_id
                         FROM workflow_engine_workflowfirehistory
                         WHERE workflow_id = %s
@@ -90,16 +88,14 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                         COUNT(*) as count,
                         MAX(date_added) as last_triggered,
                         (ARRAY_AGG(event_id ORDER BY date_added DESC))[1] as event_id
-                    FROM combined_data
+                    FROM workflow_data
                     GROUP BY group_id
                     ORDER BY count DESC, last_triggered DESC
                     LIMIT %s OFFSET %s
                 """
 
                 with connection.cursor() as cursor:
-                    cursor.execute(
-                        query, [rule.id, start, end, workflow.id, start, end, limit, offset]
-                    )
+                    cursor.execute(query, [target.id, start, end, limit, offset])
                     return [
                         _Result(
                             group=row[0],
@@ -112,16 +108,15 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
             result = GenericOffsetPaginator(data_fn=data_fn).get_result(per_page, cursor)
             result.results = convert_results(result.results)
-
             return result
 
         except AlertRuleWorkflow.DoesNotExist:
             # If no workflow is associated with this rule, just use the original behavior
-            logger.exception("No workflow associated with rule", extra={"rule_id": rule.id})
+            logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
             pass
 
         rule_filtered_history = RuleFireHistory.objects.filter(
-            rule=rule,
+            rule=target,
             date_added__gte=start,
             date_added__lt=end,
         )
@@ -143,7 +138,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         ).get_result(per_page, cursor)
 
     def fetch_rule_hourly_stats(
-        self, rule: Rule, start: datetime, end: datetime
+        self, target: Rule | Workflow, start: datetime, end: datetime
     ) -> Sequence[TimeSeriesValue]:
         start = start.replace(tzinfo=timezone.utc)
         end = end.replace(tzinfo=timezone.utc)
@@ -151,8 +146,9 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         existing_data: dict[datetime, TimeSeriesValue] = {}
 
         try:
-            alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id)
-            workflow = alert_rule_workflow.workflow
+            if not isinstance(target, Workflow):
+                alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
+                target = alert_rule_workflow.workflow
 
             # Use raw SQL to combine data from both tables
             with connection.cursor() as db_cursor:
@@ -163,14 +159,6 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                         COUNT(*) as count
                     FROM (
                         SELECT date_added
-                        FROM sentry_rulefirehistory
-                        WHERE rule_id = %s
-                            AND date_added >= %s
-                            AND date_added < %s
-
-                        UNION ALL
-
-                        SELECT date_added
                         FROM workflow_engine_workflowfirehistory
                         WHERE workflow_id = %s
                             AND date_added >= %s
@@ -179,7 +167,7 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                     GROUP BY DATE_TRUNC('hour', date_added)
                     ORDER BY bucket
                     """,
-                    [rule.id, start, end, workflow.id, start, end],
+                    [target.id, start, end],
                 )
 
                 results = db_cursor.fetchall()
@@ -189,13 +177,13 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
 
         except AlertRuleWorkflow.DoesNotExist:
             # If no workflow is associated with this rule, just use the original behavior
-            logger.exception("No workflow associated with rule", extra={"rule_id": rule.id})
+            logger.exception("No workflow associated with rule", extra={"rule_id": target.id})
             pass
 
         if not existing_data:
             qs = (
                 RuleFireHistory.objects.filter(
-                    rule=rule,
+                    rule=target,
                     date_added__gte=start,
                     date_added__lt=end,
                 )

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -67,7 +67,7 @@ def get_rule_workflow_ids(target: Workflow | Rule) -> IdPair:
         rule_id = target.id
         try:
             alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
-            workflow_id = alert_rule_workflow.workflow.id
+            workflow_id = alert_rule_workflow.workflow_id
         except AlertRuleWorkflow.DoesNotExist:
             workflow_id = None
     return IdPair(workflow_id=workflow_id, rule_id=rule_id)

--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -322,6 +322,8 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
                 )
             except AlertRuleWorkflow.DoesNotExist:
                 existing_data = self.fetch_workflow_hourly_stats(target.id, start, end)
+            except Workflow.DoesNotExist:
+                existing_data = {}
         else:
             try:
                 alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)

--- a/src/sentry/rules/history/base.py
+++ b/src/sentry/rules/history/base.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sentry.utils.services import Service
+from sentry.workflow_engine.models.workflow import Workflow
 
 if TYPE_CHECKING:
     from typing import Any
@@ -49,16 +50,16 @@ class RuleHistoryBackend(Service):
         raise NotImplementedError
 
     def fetch_rule_groups_paginated(
-        self, rule: Rule, start: datetime, end: datetime, cursor: Cursor, per_page: int
+        self, target: Rule | Workflow, start: datetime, end: datetime, cursor: Cursor, per_page: int
     ) -> CursorResult[RuleGroupHistory]:
         """
-        Fetches groups that triggered a rule within a given timeframe, ordered by number of
+        Fetches groups that triggered a rule or workflow within a given timeframe, ordered by number of
         times each group fired.
         """
         raise NotImplementedError
 
     def fetch_rule_hourly_stats(
-        self, rule: Rule, start: datetime, end: datetime
+        self, rule: Rule | Workflow, start: datetime, end: datetime
     ) -> Sequence[TimeSeriesValue]:
         """
         Fetches counts of how often a rule has fired withing a given datetime range, bucketed by

--- a/src/sentry/rules/history/base.py
+++ b/src/sentry/rules/history/base.py
@@ -59,7 +59,7 @@ class RuleHistoryBackend(Service):
         raise NotImplementedError
 
     def fetch_rule_hourly_stats(
-        self, rule: Rule | Workflow, start: datetime, end: datetime
+        self, target: Rule | Workflow, start: datetime, end: datetime
     ) -> Sequence[TimeSeriesValue]:
         """
         Fetches counts of how often a rule has fired withing a given datetime range, bucketed by

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.rule import RuleEndpoint
+from sentry.api.bases.rule import WorkflowEngineRuleEndpoint
 from sentry.api.serializers import Serializer, serialize
 from sentry.api.serializers.models.group import BaseGroupSerializerResponse
 from sentry.api.utils import get_date_range_from_params
@@ -22,6 +22,7 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.rules.history import fetch_rule_groups_paginated
 from sentry.rules.history.base import RuleGroupHistory
+from sentry.workflow_engine.models.workflow import Workflow
 
 
 class RuleGroupHistoryResponse(TypedDict):
@@ -55,7 +56,7 @@ class RuleGroupHistorySerializer(Serializer):
 
 @extend_schema(tags=["issue_alerts"])
 @cell_silo_endpoint
-class ProjectRuleGroupHistoryIndexEndpoint(RuleEndpoint):
+class ProjectRuleGroupHistoryIndexEndpoint(WorkflowEngineRuleEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
@@ -74,7 +75,7 @@ class ProjectRuleGroupHistoryIndexEndpoint(RuleEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project: Project, rule: Rule) -> Response:
+    def get(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         per_page = self.get_per_page(request)
         cursor = self.get_cursor_from_request(request)
         try:

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.rule import RuleEndpoint
+from sentry.api.bases.rule import WorkflowEngineRuleEndpoint
 from sentry.api.serializers import Serializer, serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
@@ -19,6 +19,7 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.rules.history import fetch_rule_hourly_stats
 from sentry.rules.history.base import TimeSeriesValue
+from sentry.workflow_engine.models.workflow import Workflow
 
 
 class TimeSeriesValueResponse(TypedDict):
@@ -38,7 +39,7 @@ class TimeSeriesValueSerializer(Serializer):
 
 @extend_schema(tags=["issue_alerts"])
 @cell_silo_endpoint
-class ProjectRuleStatsIndexEndpoint(RuleEndpoint):
+class ProjectRuleStatsIndexEndpoint(WorkflowEngineRuleEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
@@ -57,7 +58,7 @@ class ProjectRuleStatsIndexEndpoint(RuleEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project: Project, rule: Rule) -> Response:
+    def get(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """
         Note that results are returned in hourly buckets.
         """

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -44,7 +44,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest, BaseWorkf
         assert result.results == expected, (result.results, expected)
         return result
 
-    def test_me(self) -> None:
+    def test(self) -> None:
         history = []
         rule = self.create_project_rule(project=self.event.project)
         for i in range(3):

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -7,7 +7,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.models import WorkflowFireHistory
+from sentry.workflow_engine.models import AlertRuleWorkflow, WorkflowFireHistory
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 pytestmark = [requires_snuba]
@@ -268,6 +268,107 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest, BaseWorkf
                     group=group_2,
                     count=1,
                     last_triggered=before_now(days=2),
+                    event_id="workflow_event_group2",
+                ),
+            ],
+            per_page=1,
+            cursor=result.next,
+        )
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_combined_rule_and_workflow_history(self) -> None:
+        """Test combining RuleFireHistory and WorkflowFireHistory when both exist"""
+        rule = self.create_project_rule(project=self.event.project)
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
+        )
+        AlertRuleWorkflow.objects.create(rule_id=rule.id, workflow=workflow)
+
+        # RuleFireHistory: self.group fired 2 days ago, group_2 fired 4 days ago
+        rfh1 = RuleFireHistory.objects.create(
+            project=rule.project,
+            rule=rule,
+            group=self.group,
+            date_added=before_now(days=2),
+            event_id="rule_event_group1",
+        )
+        rfh1.update(date_added=before_now(days=2))
+
+        group_2 = self.create_group()
+        rfh2 = RuleFireHistory.objects.create(
+            project=rule.project,
+            rule=rule,
+            group=group_2,
+            date_added=before_now(days=4),
+            event_id="rule_event_group2",
+        )
+        rfh2.update(date_added=before_now(days=4))
+
+        # WorkflowFireHistory: self.group fired 1 day ago (more recent), group_2 fired 3 days ago
+        wfh1 = WorkflowFireHistory.objects.create(
+            workflow=workflow,
+            group=self.group,
+            date_added=before_now(days=1),
+            event_id="workflow_event_group1",
+        )
+        wfh1.update(date_added=before_now(days=1))
+
+        wfh2 = WorkflowFireHistory.objects.create(
+            workflow=workflow,
+            group=group_2,
+            date_added=before_now(days=3),
+            event_id="workflow_event_group2",
+        )
+        wfh2.update(date_added=before_now(days=3))
+
+        # self.group: 2 total (1 rule + 1 workflow), last_triggered=1 day ago
+        # group_2: 2 total (1 rule + 1 workflow), last_triggered=3 days ago
+        self.run_test(
+            workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                RuleGroupHistory(
+                    group=self.group,
+                    count=2,
+                    last_triggered=before_now(days=1),
+                    event_id="workflow_event_group1",
+                ),
+                RuleGroupHistory(
+                    group=group_2,
+                    count=2,
+                    last_triggered=before_now(days=3),
+                    event_id="workflow_event_group2",
+                ),
+            ],
+        )
+
+        # Test pagination
+        result = self.run_test(
+            workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                RuleGroupHistory(
+                    group=self.group,
+                    count=2,
+                    last_triggered=before_now(days=1),
+                    event_id="workflow_event_group1",
+                ),
+            ],
+            per_page=1,
+        )
+        self.run_test(
+            workflow,
+            before_now(days=6),
+            before_now(days=0),
+            [
+                RuleGroupHistory(
+                    group=group_2,
+                    count=2,
+                    last_triggered=before_now(days=3),
                     event_id="workflow_event_group2",
                 ),
             ],

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -450,3 +450,59 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         # Hour 3: 2 (workflow)
         # Hour 4: 0 total
         assert [r.count for r in results[-5:]] == [0, 2, 0, 1, 0]
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_combined_rule_and_workflow_history(self) -> None:
+        """Test combining RuleFireHistory and WorkflowFireHistory when both exist"""
+        rule = self.create_project_rule(project=self.event.project)
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
+        )
+        AlertRuleWorkflow.objects.create(rule_id=rule.id, workflow=workflow)
+
+        # RuleFireHistory: hour 2 has 1 entry, hour 4 has 2 entries
+        rfh1 = RuleFireHistory.objects.create(
+            project=rule.project,
+            rule=rule,
+            group=self.group,
+            date_added=before_now(hours=2),
+        )
+        rfh1.update(date_added=before_now(hours=2))
+
+        for _ in range(2):
+            rfh = RuleFireHistory.objects.create(
+                project=rule.project,
+                rule=rule,
+                group=self.group,
+                date_added=before_now(hours=4),
+            )
+            rfh.update(date_added=before_now(hours=4))
+
+        # WorkflowFireHistory: hour 1 has 1 entry, hour 3 has 2 entries
+        wfh1 = WorkflowFireHistory.objects.create(
+            workflow=workflow,
+            group=self.group,
+            date_added=before_now(hours=1),
+        )
+        wfh1.update(date_added=before_now(hours=1))
+
+        for _ in range(2):
+            wfh = WorkflowFireHistory.objects.create(
+                workflow=workflow,
+                group=self.group,
+                date_added=before_now(hours=3),
+            )
+            wfh.update(date_added=before_now(hours=3))
+
+        results = self.backend.fetch_rule_hourly_stats(workflow, before_now(hours=24), before_now())
+        assert len(results) == 24
+
+        # Check the last 5 hours (from oldest to most recent):
+        # Hour 4: 2 (rule)
+        # Hour 3: 2 (workflow)
+        # Hour 2: 1 (rule)
+        # Hour 1: 1 (workflow)
+        # Hour 0: 0
+        assert [r.count for r in results[-5:]] == [2, 2, 1, 1, 0]

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -4,9 +4,11 @@ from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.history.backends.postgres import PostgresRuleHistoryBackend
 from sentry.rules.history.base import RuleGroupHistory
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.models import AlertRuleWorkflow, Workflow, WorkflowFireHistory
+from sentry.workflow_engine.models import WorkflowFireHistory
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 pytestmark = [requires_snuba]
 
@@ -36,13 +38,13 @@ class RecordTest(BasePostgresRuleHistoryBackendTest):
 
 
 @freeze_time()
-class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
+class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest, BaseWorkflowTest):
     def run_test(self, rule, start, end, expected, cursor=None, per_page=25):
         result = self.backend.fetch_rule_groups_paginated(rule, start, end, cursor, per_page)
         assert result.results == expected, (result.results, expected)
         return result
 
-    def test(self) -> None:
+    def test_me(self) -> None:
         history = []
         rule = self.create_project_rule(project=self.event.project)
         for i in range(3):
@@ -194,25 +196,14 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             ],
         )
 
-    def test_combined_rule_and_workflow_history(self) -> None:
-        """Test combining RuleFireHistory and WorkflowFireHistory when feature flag is enabled"""
-        rule = self.create_project_rule(project=self.event.project)
-        workflow = Workflow.objects.get(
-            id=AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow_id
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_single_written_workflow_history(self) -> None:
+        """Test using WorkflowFireHistory when feature flag is enabled"""
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
         )
-
-        # Create some RuleFireHistory entries
-        rule_history = []
-        for i in range(2):
-            rule_history.append(
-                RuleFireHistory(
-                    project=rule.project,
-                    rule=rule,
-                    group=self.group,
-                    date_added=before_now(days=i + 1),
-                    event_id=f"rule_event_{i}",
-                )
-            )
 
         # Create some WorkflowFireHistory entries
         for i in range(2):
@@ -224,16 +215,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             )
             wfh.update(date_added=before_now(days=i + 3))
 
-        RuleFireHistory.objects.bulk_create(rule_history)
-
         group_2 = self.create_group()
-        RuleFireHistory.objects.create(
-            project=rule.project,
-            rule=rule,
-            group=group_2,
-            date_added=before_now(days=3),
-            event_id="rule_event_group2",
-        )
         new_workflow_history = WorkflowFireHistory.objects.create(
             workflow=workflow,
             group=group_2,
@@ -243,19 +225,19 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         new_workflow_history.update(date_added=before_now(days=2))
 
         self.run_test(
-            rule,
+            workflow,
             before_now(days=6),
             before_now(days=0),
             [
                 RuleGroupHistory(
                     group=self.group,
-                    count=4,  # 4 from the original data
-                    last_triggered=before_now(days=1),  # Most recent from RuleFireHistory
-                    event_id="rule_event_0",
+                    count=2,
+                    last_triggered=before_now(days=3),
+                    event_id="workflow_event_0",
                 ),
                 RuleGroupHistory(
                     group=group_2,
-                    count=2,  # 2 from both Rule and WorkflowFireHistory
+                    count=1,
                     last_triggered=before_now(days=2),
                     event_id="workflow_event_group2",
                 ),
@@ -264,27 +246,27 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
 
         # Test pagination
         result = self.run_test(
-            rule,
+            workflow,
             before_now(days=6),
             before_now(days=0),
             [
                 RuleGroupHistory(
                     group=self.group,
-                    count=4,
-                    last_triggered=before_now(days=1),
-                    event_id="rule_event_0",
+                    count=2,
+                    last_triggered=before_now(days=3),
+                    event_id="workflow_event_0",
                 ),
             ],
             per_page=1,
         )
         self.run_test(
-            rule,
+            workflow,
             before_now(days=6),
             before_now(days=0),
             [
                 RuleGroupHistory(
                     group=group_2,
-                    count=2,
+                    count=1,
                     last_triggered=before_now(days=2),
                     event_id="workflow_event_group2",
                 ),
@@ -332,32 +314,13 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         assert len(results) == 24
         assert [r.count for r in results[-5:]] == [0, 0, 1, 1, 0]
 
-    def test_combined_rule_and_workflow_history(self) -> None:
-        """Test combining RuleFireHistory and WorkflowFireHistory for hourly stats when feature flag is enabled"""
-        rule = self.create_project_rule(project=self.event.project)
-        workflow = Workflow.objects.get(
-            id=AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow_id
-        )
-
-        rule_history = []
-        # Hour 1: 2 rule fire entries
-        for _ in range(2):
-            rule_history.append(
-                RuleFireHistory(
-                    project=rule.project,
-                    rule=rule,
-                    group=self.group,
-                    date_added=before_now(hours=1),
-                )
-            )
-        # Hour 2: 1 rule fire entry
-        rule_history.append(
-            RuleFireHistory(
-                project=rule.project,
-                rule=rule,
-                group=self.group,
-                date_added=before_now(hours=2),
-            )
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_single_written_workflow_history(self) -> None:
+        """Test using WorkflowFireHistory when feature flag is enabled"""
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
         )
 
         # Hour 1: 1 workflow fire entry
@@ -376,15 +339,13 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
             )
             wfh.update(date_added=before_now(hours=3))
 
-        RuleFireHistory.objects.bulk_create(rule_history)
-
-        results = self.backend.fetch_rule_hourly_stats(rule, before_now(hours=24), before_now())
+        results = self.backend.fetch_rule_hourly_stats(workflow, before_now(hours=24), before_now())
         assert len(results) == 24
 
         # Check the last 5 hours (from most recent to oldest)
         # Hour 0: 0 total
-        # Hour 1: 2 (rule) + 1 (workflow) = 3 total
-        # Hour 2: 1 (rule) + 0 (workflow) = 1 total
-        # Hour 3: 0 (rule) + 2 (workflow) = 2 total
+        # Hour 1: 1 (workflow)
+        # Hour 2: 0 (workflow)
+        # Hour 3: 2 (workflow)
         # Hour 4: 0 total
-        assert [r.count for r in results[-5:]] == [0, 2, 1, 3, 0]
+        assert [r.count for r in results[-5:]] == [0, 2, 0, 1, 0]


### PR DESCRIPTION
Redo of https://github.com/getsentry/sentry/pull/110282 to make the rule stats and group history endpoints backwards compatible by being flexible enough to handle either a `Rule` or a `Workflow`. The previous PR was reverted because I incorrectly assumed `Rule` objects were using `RuleFireHistory`, but it is correct to continue to combine those results with `WorkflowFireHistory` for now.

For both methods the basic logic is as follows:
- If passed a workflow, try to fetch the rule ID via `AlertRuleWorkflow` and fetch combined results. If the workflow was single written, fetch `WorkflowFireHistory` results only.
- If passed a rule, try to fetch the workflow via `AlertRuleWorkflow` and fetch combined results. If the rule for some reason doesn't have a workflow, fetch `RuleFireHistory` results only (this maintains the existing behavior).