### PR TITLE
fix(aci): Fix detection_type in the serializer for detectors which have conflicting properties

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -172,6 +172,16 @@ class DetectorSerializer(Serializer):
 
         return attrs
 
+    @staticmethod
+    def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+        # XXX: There are some migrated metric alerts which have `detection_type: "static"`,
+        # a defined `comparison_delta`. These are treated as `detection_type: "percent"` in the backend,
+        # so this is a temporary fix to ensure that the frontend displays the correct detection type.
+        # Remove this once ISWF-2272 backfills the correct `detection_type`.
+        if config.get("detection_type") == "static" and config.get("comparison_delta"):
+            return {**config, "detection_type": "percent"}
+        return config
+
     def serialize(
         self, obj: Detector, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> DetectorSerializerResponse:
@@ -189,7 +199,9 @@ class DetectorSerializer(Serializer):
             "dateUpdated": obj.date_updated,
             "dataSources": attrs.get("data_sources"),
             "conditionGroup": attrs.get("condition_group"),
-            "config": convert_dict_key_case(attrs.get("config"), snake_to_camel_case),
+            "config": convert_dict_key_case(
+                self._normalize_config(attrs.get("config", {})), snake_to_camel_case
+            ),
             "enabled": obj.enabled,
             "alertRuleId": alert_rule_mapping.get("alert_rule_id"),
             "ruleId": alert_rule_mapping.get("rule_id"),

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_detector_serializer.py
@@ -206,6 +206,30 @@ class TestDetectorSerializer(TestCase):
 
         assert result["latestGroup"]["id"] == str(group2.id)
 
+    def test_serialize_normalizes_migrated_detection_type(self) -> None:
+        detector = self.create_detector(
+            project_id=self.project.id,
+            name="Migrated Detector",
+            type=MetricIssue.slug,
+            config={
+                "threshold_period": 1,
+                "detection_type": "static",
+                "comparison_delta": 3600,
+            },
+        )
+        result = serialize(detector)
+        assert result["config"]["detectionType"] == "percent"
+        assert result["config"]["comparisonDelta"] == 3600
+
+    def test_serialize_does_not_normalize_static_without_comparison_delta(self) -> None:
+        detector = self.create_detector(
+            project_id=self.project.id,
+            name="Static Detector",
+            type=MetricIssue.slug,
+        )
+        result = serialize(detector)
+        assert result["config"]["detectionType"] == "static"
+
     def test_serialize_bulk(self) -> None:
         detectors = [
             self.create_detector(


### PR DESCRIPTION
Fixes ISWF-2273

There is an issue where some (~5k) old metric alerts have `detection_type: "static"` but a defined `comparison_delta`. The backend (and old frontend) code treats these as `detection_type: "percent"`, but the new UI code looks at `detection_type` to determine this.

Instead of modifying all the frontend callsites to check for `comparisonDelta`, it is a little cleaner if we fix this on the serializer. This will be easier to remove once we get the migration run.