### PR TITLE
ref(seer): Refactor seer settings overview page to use the new form system

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -65,6 +65,8 @@ export interface Organization extends OrganizationSummary {
   dataScrubberDefaults: boolean;
   debugFilesRole: string;
   defaultCodeReviewTriggers: CodeReviewTrigger[];
+  defaultCodingAgent: string | null;
+  defaultCodingAgentIntegrationId: number | null;
   defaultRole: string;
   enhancedPrivacy: boolean;
   eventsMemberAdmin: boolean;

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -65,8 +65,6 @@ export interface Organization extends OrganizationSummary {
   dataScrubberDefaults: boolean;
   debugFilesRole: string;
   defaultCodeReviewTriggers: CodeReviewTrigger[];
-  defaultCodingAgent: string | null;
-  defaultCodingAgentIntegrationId: number | null;
   defaultRole: string;
   enhancedPrivacy: boolean;
   eventsMemberAdmin: boolean;

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -1,14 +1,18 @@
+import {mutationOptions} from '@tanstack/react-query';
+import {z} from 'zod';
+
 import {Alert} from '@sentry/scraps/alert';
+import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 
-import {Form} from 'sentry/components/forms/form';
-import JsonForm from 'sentry/components/forms/jsonForm';
+import {updateOrganization} from 'sentry/actionCreators/organizations';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {DEFAULT_CODE_REVIEW_TRIGGERS} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
@@ -16,9 +20,39 @@ import {SeerSettingsPageContent} from 'getsentry/views/seerAutomation/components
 import {SeerSettingsPageWrapper} from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
+const seerOrgSchema = z.object({
+  defaultAutofixAutomationTuning: z.boolean(), // The API stores this as an enum, but it is displayed as a boolean toggle.
+  autoOpenPrs: z.boolean(),
+  autoEnableCodeReview: z.boolean(),
+  defaultCodeReviewTriggers: z.array(z.enum(['on_new_commit', 'on_ready_for_review'])),
+  enableSeerEnhancedAlerts: z.boolean(),
+  enableSeerCoding: z.boolean(),
+});
+
 export function SeerAutomationSettings() {
   const organization = useOrganization();
   const canWrite = useCanWriteSettings();
+
+  const orgEndpoint = `/organizations/${organization.slug}/`;
+  const orgMutationOpts = mutationOptions({
+    mutationFn: (data: Partial<Organization>) =>
+      fetchMutation<Organization>({method: 'PUT', url: orgEndpoint, data}),
+    onSuccess: updateOrganization,
+  });
+  const autofixTuningMutationOpts = mutationOptions({
+    mutationFn: (data: {defaultAutofixAutomationTuning: boolean}) =>
+      fetchMutation<Organization>({
+        method: 'PUT',
+        url: orgEndpoint,
+        data: {
+          // All values other than 'off' are converted to 'medium'
+          defaultAutofixAutomationTuning: data.defaultAutofixAutomationTuning
+            ? 'medium'
+            : 'off',
+        },
+      }),
+    onSuccess: updateOrganization,
+  });
 
   return (
     <SeerSettingsPageWrapper>
@@ -41,190 +75,228 @@ export function SeerAutomationSettings() {
         )}
       />
       <SeerSettingsPageContent>
-        <Form
-          saveOnBlur
-          apiMethod="PUT"
-          apiEndpoint={`/organizations/${organization.slug}/`}
-          allowUndo
-          initialData={{
-            // Project<->Repo settings:
-            defaultAutofixAutomationTuning: organization.defaultAutofixAutomationTuning,
-            autoOpenPrs: organization.autoOpenPrs ?? false,
-
-            // Second section
-            autoEnableCodeReview: organization.autoEnableCodeReview ?? true,
-            defaultCodeReviewTriggers:
-              organization.defaultCodeReviewTriggers ?? DEFAULT_CODE_REVIEW_TRIGGERS,
-
-            // Third section
-            enableSeerEnhancedAlerts: organization.enableSeerEnhancedAlerts ?? true,
-            enableSeerCoding: organization.enableSeerCoding ?? true,
-          }}
+        <FieldGroup
+          title={
+            <Flex gap="md">
+              <span>{t('Default automations for new projects')}</span>
+              <QuestionTooltip
+                isHoverable
+                title={tct(
+                  'These settings apply as new projects are created. Any [link:existing projects] will not be affected.',
+                  {
+                    link: <Link to={`/settings/${organization.slug}/seer/projects/`} />,
+                  }
+                )}
+                size="xs"
+                icon="info"
+              />
+            </Flex>
+          }
         >
-          <JsonForm
-            disabled={!canWrite}
-            forms={[
-              {
-                title: (
-                  <Flex gap="md">
-                    <span>{t('Default automations for new projects')}</span>
-                    <QuestionTooltip
-                      isHoverable
-                      title={tct(
-                        'These settings apply as new projects are created. Any [link:existing projects] will not be affected.',
+          <AutoSaveForm
+            name="defaultAutofixAutomationTuning"
+            schema={seerOrgSchema}
+            initialValue={Boolean(
+              organization.defaultAutofixAutomationTuning &&
+              organization.defaultAutofixAutomationTuning !== 'off'
+            )}
+            mutationOptions={autofixTuningMutationOpts}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('Auto-Trigger Fixes by Default')}
+                hintText={t(
+                  'For all new projects, Seer will automatically create a root cause analysis for highly actionable issues and propose a solution without a user needing to prompt it.'
+                )}
+              >
+                <field.Switch
+                  checked={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={!canWrite}
+                />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+          <AutoSaveForm
+            name="autoOpenPrs"
+            schema={seerOrgSchema}
+            initialValue={
+              organization.enableSeerCoding === false
+                ? false
+                : (organization.autoOpenPrs ?? false)
+            }
+            mutationOptions={orgMutationOpts}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('Allow Autofix to create PRs by Default')}
+                hintText={
+                  <Stack gap="sm">
+                    {t(
+                      'For all new projects with connected repos, Seer will be able to make pull requests for highly actionable issues.'
+                    )}
+                    {organization.enableSeerCoding === false && (
+                      <Alert variant="warning">
+                        {tct(
+                          '[settings:"Enable Code Generation"] must be enabled for Seer to create pull requests.',
+                          {
+                            settings: (
+                              <Link
+                                to={`/settings/${organization.slug}/seer/#enableSeerCoding`}
+                              />
+                            ),
+                          }
+                        )}
+                      </Alert>
+                    )}
+                  </Stack>
+                }
+              >
+                <field.Switch
+                  checked={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={
+                    organization.enableSeerCoding === false
+                      ? t('Enable Code Generation to allow Autofix to create PRs.')
+                      : !canWrite
+                  }
+                />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+        </FieldGroup>
+        <FieldGroup
+          title={
+            <Flex gap="md">
+              <span>{t('Default Code Review for New Repos')}</span>
+              <QuestionTooltip
+                isHoverable
+                title={tct(
+                  'These settings apply as repos are newly connected. Any [link:existing repos] will not be affected.',
+                  {
+                    link: <Link to={`/settings/${organization.slug}/seer/repos/`} />,
+                  }
+                )}
+                size="xs"
+                icon="info"
+              />
+            </Flex>
+          }
+        >
+          <AutoSaveForm
+            name="autoEnableCodeReview"
+            schema={seerOrgSchema}
+            initialValue={organization.autoEnableCodeReview ?? true}
+            mutationOptions={orgMutationOpts}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('Enable Code Review by Default')}
+                hintText={t(
+                  'For all new repos connected, Seer will review your PRs and flag potential bugs.'
+                )}
+              >
+                <field.Switch
+                  checked={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={!canWrite}
+                />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+          <AutoSaveForm
+            name="defaultCodeReviewTriggers"
+            schema={seerOrgSchema}
+            initialValue={
+              organization.defaultCodeReviewTriggers ?? DEFAULT_CODE_REVIEW_TRIGGERS
+            }
+            mutationOptions={orgMutationOpts}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('Code Review Triggers')}
+                hintText={tct(
+                  'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
+                  {code: <code />}
+                )}
+              >
+                <field.Select
+                  multiple
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={!canWrite}
+                  options={[
+                    {value: 'on_ready_for_review', label: t('On Ready for Review')},
+                    {value: 'on_new_commit', label: t('On New Commit')},
+                  ]}
+                />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+        </FieldGroup>
+        <FieldGroup title={t('Advanced Settings')}>
+          <AutoSaveForm
+            name="enableSeerEnhancedAlerts"
+            schema={seerOrgSchema}
+            initialValue={organization.enableSeerEnhancedAlerts ?? true}
+            mutationOptions={orgMutationOpts}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('Enable Seer Context in Alerts')}
+                hintText={t('Seer will provide extra context in supported alerts.')}
+              >
+                <field.Switch
+                  checked={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={!canWrite}
+                />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+          <AutoSaveForm
+            name="enableSeerCoding"
+            schema={seerOrgSchema}
+            initialValue={organization.enableSeerCoding ?? true}
+            mutationOptions={orgMutationOpts}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('Enable Code Generation')}
+                hintText={
+                  <Flex gap="sm">
+                    <span>
+                      {tct(
+                        'Enable Seer workflows that streamline creating code changes for your review, such as the ability to create pull requests or branches. [docs:Read the docs] to learn more.',
                         {
-                          link: (
-                            <Link to={`/settings/${organization.slug}/seer/projects/`} />
+                          docs: (
+                            <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#code-generation" />
                           ),
                         }
                       )}
-                      size="xs"
-                      icon="info"
-                    />
-                  </Flex>
-                ),
-                fields: [
-                  {
-                    name: 'defaultAutofixAutomationTuning',
-                    label: t('Auto-Trigger Fixes by Default'),
-                    help: t(
-                      'For all new projects, Seer will automatically create a root cause analysis for highly actionable issues and propose a solution without a user needing to prompt it.'
-                    ),
-                    type: 'boolean',
-                    // Convert from between enum and boolean
-                    // All values other than 'off' are converted to 'medium'
-                    setValue: (
-                      value: Organization['defaultAutofixAutomationTuning']
-                    ): boolean => Boolean(value && value !== 'off'),
-                    getValue: (
-                      value: boolean
-                    ): Organization['defaultAutofixAutomationTuning'] =>
-                      value ? 'medium' : 'off',
-                  },
-                  {
-                    name: 'autoOpenPrs',
-                    label: t('Allow Autofix to create PRs by Default'),
-                    help: (
-                      <Stack gap="sm">
-                        {t(
-                          'For all new projects with connected repos, Seer will be able to make pull requests for highly actionable issues.'
-                        )}
-                        {organization.enableSeerCoding === false && (
-                          <Alert variant="warning">
-                            {tct(
-                              '[settings:"Enable Code Generation"] must be enabled for Seer to create pull requests.',
-                              {
-                                settings: (
-                                  <Link
-                                    to={`/settings/${organization.slug}/seer/#enableSeerCoding`}
-                                  />
-                                ),
-                              }
-                            )}
-                          </Alert>
-                        )}
-                      </Stack>
-                    ),
-                    type: 'boolean',
-                    disabled: !canWrite || organization.enableSeerCoding === false,
-                    setValue: (value: boolean): boolean =>
-                      organization.enableSeerCoding === false ? false : value,
-                  },
-                ],
-              },
-              {
-                title: (
-                  <Flex gap="md">
-                    <span>{t('Default Code Review for New Repos')}</span>
+                    </span>
                     <QuestionTooltip
-                      isHoverable
-                      title={tct(
-                        'These settings apply as repos are newly connected. Any [link:existing repos] will not be affected.',
-                        {
-                          link: (
-                            <Link to={`/settings/${organization.slug}/seer/repos/`} />
-                          ),
-                        }
-                      )}
                       size="xs"
-                      icon="info"
+                      title={t(
+                        'This does not impact chat sessions where the agent will always be able to emit code snippets and examples while responding to your input.'
+                      )}
                     />
                   </Flex>
-                ),
-                fields: [
-                  {
-                    name: 'autoEnableCodeReview',
-                    label: t('Enable Code Review by Default'),
-                    help: t(
-                      'For all new repos connected, Seer will review your PRs and flag potential bugs.'
-                    ),
-                    type: 'boolean',
-                  },
-                  {
-                    name: 'defaultCodeReviewTriggers',
-                    label: t('Code Review Triggers'),
-                    help: tct(
-                      'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
-                      {code: <code />}
-                    ),
-                    type: 'choice',
-                    multiple: true,
-                    choices: [
-                      ['on_ready_for_review', t('On Ready for Review')],
-                      ['on_new_commit', t('On New Commit')],
-                    ],
-                    formatMessageValue: false,
-                  },
-                ],
-              },
-              {
-                title: t('Advanced Settings'),
-                fields: [
-                  {
-                    name: 'enableSeerEnhancedAlerts',
-                    label: t('Enable Seer Context in Alerts'),
-                    help: t('Seer will provide extra context in supported alerts.'),
-                    type: 'boolean',
-                  },
-                  {
-                    name: 'enableSeerCoding',
-                    label: t('Enable Code Generation'),
-                    help: (
-                      <Flex gap="sm">
-                        <span>
-                          {tct(
-                            'Enable Seer workflows that streamline creating code changes for your review, such as the ability to create pull requests or branches. [docs:Read the docs] to learn more.',
-                            {
-                              docs: (
-                                <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#code-generation" />
-                              ),
-                            }
-                          )}
-                        </span>
-                        <QuestionTooltip
-                          size="xs"
-                          title={t(
-                            'This does not impact chat sessions where the agent will always be able to emit code snippets and examples while responding to your input.'
-                          )}
-                        />
-                      </Flex>
-                    ),
-                    type: 'boolean',
-                    defaultValue: true, // See ENABLE_SEER_CODING_DEFAULT in sentry/src/sentry/constants.py
-                    disabled:
-                      !canWrite ||
-                      organization.features.includes('seer-disable-coding-setting'),
-                    disabledReason: organization.features.includes(
-                      'seer-disable-coding-setting'
-                    )
+                }
+              >
+                <field.Switch
+                  checked={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={
+                    organization.features.includes('seer-disable-coding-setting')
                       ? t('Code generation is managed by your organization.')
-                      : undefined,
-                  },
-                ],
-              },
-            ]}
-          />
-        </Form>
+                      : !canWrite
+                  }
+                />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+        </FieldGroup>
       </SeerSettingsPageContent>
     </SeerSettingsPageWrapper>
   );

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -20,7 +20,7 @@ import {SeerSettingsPageContent} from 'getsentry/views/seerAutomation/components
 import {SeerSettingsPageWrapper} from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
-const seerOrgSchema = z.object({
+const schema = z.object({
   defaultAutofixAutomationTuning: z.boolean(), // The API stores this as an enum, but it is displayed as a boolean toggle.
   autoOpenPrs: z.boolean(),
   autoEnableCodeReview: z.boolean(),
@@ -95,7 +95,7 @@ export function SeerAutomationSettings() {
         >
           <AutoSaveForm
             name="defaultAutofixAutomationTuning"
-            schema={seerOrgSchema}
+            schema={schema}
             initialValue={Boolean(
               organization.defaultAutofixAutomationTuning &&
               organization.defaultAutofixAutomationTuning !== 'off'
@@ -119,7 +119,7 @@ export function SeerAutomationSettings() {
           </AutoSaveForm>
           <AutoSaveForm
             name="autoOpenPrs"
-            schema={seerOrgSchema}
+            schema={schema}
             initialValue={
               organization.enableSeerCoding === false
                 ? false
@@ -185,7 +185,7 @@ export function SeerAutomationSettings() {
         >
           <AutoSaveForm
             name="autoEnableCodeReview"
-            schema={seerOrgSchema}
+            schema={schema}
             initialValue={organization.autoEnableCodeReview ?? true}
             mutationOptions={orgMutationOpts}
           >
@@ -206,7 +206,7 @@ export function SeerAutomationSettings() {
           </AutoSaveForm>
           <AutoSaveForm
             name="defaultCodeReviewTriggers"
-            schema={seerOrgSchema}
+            schema={schema}
             initialValue={
               organization.defaultCodeReviewTriggers ?? DEFAULT_CODE_REVIEW_TRIGGERS
             }
@@ -237,7 +237,7 @@ export function SeerAutomationSettings() {
         <FieldGroup title={t('Advanced Settings')}>
           <AutoSaveForm
             name="enableSeerEnhancedAlerts"
-            schema={seerOrgSchema}
+            schema={schema}
             initialValue={organization.enableSeerEnhancedAlerts ?? true}
             mutationOptions={orgMutationOpts}
           >
@@ -256,7 +256,7 @@ export function SeerAutomationSettings() {
           </AutoSaveForm>
           <AutoSaveForm
             name="enableSeerCoding"
-            schema={seerOrgSchema}
+            schema={schema}
             initialValue={organization.enableSeerCoding ?? true}
             mutationOptions={orgMutationOpts}
           >

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -120,11 +120,7 @@ export function SeerAutomationSettings() {
           <AutoSaveForm
             name="autoOpenPrs"
             schema={schema}
-            initialValue={
-              organization.enableSeerCoding === false
-                ? false
-                : (organization.autoOpenPrs ?? false)
-            }
+            initialValue={organization.autoOpenPrs ?? false}
             mutationOptions={orgMutationOpts}
           >
             {field => (
@@ -153,7 +149,9 @@ export function SeerAutomationSettings() {
                 }
               >
                 <field.Switch
-                  checked={field.state.value}
+                  checked={
+                    organization.enableSeerCoding === false ? false : field.state.value
+                  }
                   onChange={field.handleChange}
                   disabled={
                     organization.enableSeerCoding === false

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -105,8 +105,13 @@ export function SeerAutomationSettings() {
             {field => (
               <field.Layout.Row
                 label={t('Auto-Trigger Fixes by Default')}
-                hintText={t(
-                  'For all new projects, Seer will automatically create a root cause analysis for highly actionable issues and propose a solution without a user needing to prompt it.'
+                hintText={tct(
+                  'For all new projects, Seer will automatically create a root cause analysis for [docs:highly actionable] issues and propose a solution without a user needing to prompt it.',
+                  {
+                    docs: (
+                      <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#how-issue-autofix-works" />
+                    ),
+                  }
                 )}
               >
                 <field.Switch
@@ -128,8 +133,13 @@ export function SeerAutomationSettings() {
                 label={t('Allow Autofix to create PRs by Default')}
                 hintText={
                   <Stack gap="sm">
-                    {t(
-                      'For all new projects with connected repos, Seer will be able to make pull requests for highly actionable issues.'
+                    {tct(
+                      'For all new projects with connected repos, Seer will be able to make pull requests for [docs:highly actionable] issues.',
+                      {
+                        docs: (
+                          <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#how-issue-autofix-works" />
+                        ),
+                      }
                     )}
                     {organization.enableSeerCoding === false && (
                       <Alert variant="warning">
@@ -242,7 +252,19 @@ export function SeerAutomationSettings() {
             {field => (
               <field.Layout.Row
                 label={t('Enable Seer Context in Alerts')}
-                hintText={t('Seer will provide extra context in supported alerts.')}
+                hintText={
+                  <Flex gap="sm">
+                    <span>
+                      {t('Seer will provide extra context in supported alerts.')}
+                    </span>
+                    <QuestionTooltip
+                      size="xs"
+                      title={t(
+                        'Enable Seer to include Agent output in alerts when available. Agent output may include code snippets, explanations, and more.'
+                      )}
+                    />
+                  </Flex>
+                }
               >
                 <field.Switch
                   checked={field.state.value}


### PR DESCRIPTION
This was auto-converted using the LLM skill

I tested that the toggles are still sending their expected values, usually a true/false, but sometimes a `medium` or `off`. Looking good!