### PR TITLE
feat(grouping): Add `raw_message` fingerprint variable

### DIFF
--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -238,7 +238,7 @@ def resolve_fingerprint_variable(
     if variable_key == "transaction":
         return event.data.get("transaction") or "<no-transaction>"
 
-    elif variable_key == "message":
+    elif variable_key in ("message", "raw_message"):
         message = get_canonical_message_from_event(event)
         return message or "<no-message>"
 

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -273,7 +273,20 @@ release:foo                                     -> release-foo
 def test_variable_resolution() -> None:
     # TODO: This should be fleshed out to test way more cases, at which point we'll need to add some
     # actual data here
-    event = Event(project_id=908415, event_id="11211231", data={})
+    event = Event(
+        project_id=908415,
+        event_id="11211231",
+        data={
+            "exception": {
+                "values": [
+                    {
+                        "type": "FailedToFetchError",
+                        "value": "That's ball number 6 that Charlie hasn't brought back!",
+                    }
+                ]
+            },
+        },
+    )
     context = GroupingContext(StrategyConfiguration(), event)
 
     for fingerprint_entry, expected_resolved_value in [
@@ -281,6 +294,8 @@ def test_variable_resolution() -> None:
         ("{{default}}", "{{ default }}"),
         ("{{  default }}", "{{ default }}"),
         ("{{ dog }}", "<unrecognized-variable-dog>"),
+        ("{{ message }}", "That's ball number <int> that Charlie hasn't brought back!"),
+        ("{{ raw_message }}", "That's ball number 6 that Charlie hasn't brought back!"),
     ]:
         assert resolve_fingerprint_values([fingerprint_entry], event, context) == [
             expected_resolved_value


### PR DESCRIPTION
Though in most cases messages in fingerprints should be parameterized just like messages in events are, there are cases where that's not true. For example, if the same stacktrace throws both `APIRequestError: Request failed (response code: 404)` and `APIRequestError: Request failed (response code: 500)`, by default we'd put the events into the same issue, because the stacktraces match. If a user wanted to get around that, [until recently](https://github.com/getsentry/sentry/pull/107808) they could use a fingerprint like `["{{ default }}", "{{ message }}"]`, and the two events would get different hashes because of the difference in their error messages.

However, now that we're parameterizing messages in fingerprints, those two events have gone back to having the same hash, even with the fingerprint rule. To allow users to opt out of that behavior, this PR introduces a (for-now-undocumented*) new fingerprint variable, `{{ raw_message }}`, which does the same thing as `{{ message }}`, but without the parameterization. (Since we only parameterize the `{{ message }}` variable, the new variable automatically has parameterization skipped.)

*For now we're not documenting the variable because the problem this solves is kind of an edge case, and we want to lower the chances of users shooting themselves in the foot by using it when they really shouldn't. If this ends up coming up with other customers, we can always add it to docs then.