### PR TITLE
ref(cells): Remove bogus default value on rpc region_name

### DIFF
--- a/src/sentry/hybridcloud/services/organization_mapping/model.py
+++ b/src/sentry/hybridcloud/services/organization_mapping/model.py
@@ -16,7 +16,7 @@ from sentry.organizations.services.organization import (
 
 
 class RpcOrganizationMapping(RpcOrganizationSummary):
-    region_name: str = ""
+    region_name: str
     date_created: datetime = Field(default_factory=timezone.now)
     verified: bool = False
     customer_id: str | None = None
@@ -32,7 +32,7 @@ class RpcOrganizationMappingUpdate(RpcModel):
     name: str = ""
     status: int = 0
     slug: str = ""
-    region_name: str = ""
+    region_name: str
     # When not set, no change to customer id performed,
     # when set with a CustomerId, the customer_id set to either None or string
     customer_id: CustomerId | None = None


### PR DESCRIPTION
A real region name must be provided, do not allow the default of "" which is a bogus value.
