### PR TITLE
fix(trace): Improve mobile experience for AI spans view

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -135,6 +135,7 @@ const Wrapper = styled('div')`
   grid-template-rows: 38px 1fr;
   flex: 1 1 100%;
   min-height: 0;
+  overflow-x: auto;
   background-color: ${p => p.theme.tokens.background.primary};
   border-radius: ${p => p.theme.radius.md};
   border: 1px solid ${p => p.theme.tokens.border.primary};

--- a/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
@@ -261,30 +261,32 @@ function AttributesHighlights({
   ];
 
   return (
-    <StyledScrollCarousel gap="xl" aria-label={t('Attributes Highlights')}>
-      {highlights.map(highlight => {
-        const summary = highlight.getSummary();
+    <Flex wrap="wrap" overflow="visible" whiteSpace="normal">
+      {({className}) => (
+        <ScrollCarousel
+          gap="xl"
+          aria-label={t('Attributes Highlights')}
+          className={className}
+        >
+          {highlights.map(highlight => {
+            const summary = highlight.getSummary();
 
-        if (!summary) {
-          return null;
-        }
+            if (!summary) {
+              return null;
+            }
 
-        return (
-          <Flex align="center" gap="md" key={highlight.key}>
-            <HighlightsIconWrapper>{summary.icon}</HighlightsIconWrapper>
-            <HighlightsDescription>{summary.description}</HighlightsDescription>
-          </Flex>
-        );
-      })}
-    </StyledScrollCarousel>
+            return (
+              <Flex align="center" gap="md" key={highlight.key}>
+                <HighlightsIconWrapper>{summary.icon}</HighlightsIconWrapper>
+                <HighlightsDescription>{summary.description}</HighlightsDescription>
+              </Flex>
+            );
+          })}
+        </ScrollCarousel>
+      )}
+    </Flex>
   );
 }
-
-const StyledScrollCarousel = styled(ScrollCarousel)`
-  flex-wrap: wrap;
-  overflow: visible;
-  white-space: normal;
-`;
 
 const HighlightsDescription = styled('div')`
   display: flex;

--- a/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
@@ -261,30 +261,22 @@ function AttributesHighlights({
   ];
 
   return (
-    <Flex wrap="wrap" overflow="visible" whiteSpace="normal">
-      {({className}) => (
-        <ScrollCarousel
-          gap="xl"
-          aria-label={t('Attributes Highlights')}
-          className={className}
-        >
-          {highlights.map(highlight => {
-            const summary = highlight.getSummary();
+    <ScrollCarousel gap="xl" aria-label={t('Attributes Highlights')}>
+      {highlights.map(highlight => {
+        const summary = highlight.getSummary();
 
-            if (!summary) {
-              return null;
-            }
+        if (!summary) {
+          return null;
+        }
 
-            return (
-              <Flex align="center" gap="md" key={highlight.key}>
-                <HighlightsIconWrapper>{summary.icon}</HighlightsIconWrapper>
-                <HighlightsDescription>{summary.description}</HighlightsDescription>
-              </Flex>
-            );
-          })}
-        </ScrollCarousel>
-      )}
-    </Flex>
+        return (
+          <Flex align="center" gap="md" flex="0 0 auto" key={highlight.key}>
+            <HighlightsIconWrapper>{summary.icon}</HighlightsIconWrapper>
+            <HighlightsDescription>{summary.description}</HighlightsDescription>
+          </Flex>
+        );
+      })}
+    </ScrollCarousel>
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
@@ -261,7 +261,7 @@ function AttributesHighlights({
   ];
 
   return (
-    <ScrollCarousel gap="xl" aria-label={t('Attributes Highlights')}>
+    <StyledScrollCarousel gap="xl" aria-label={t('Attributes Highlights')}>
       {highlights.map(highlight => {
         const summary = highlight.getSummary();
 
@@ -276,9 +276,15 @@ function AttributesHighlights({
           </Flex>
         );
       })}
-    </ScrollCarousel>
+    </StyledScrollCarousel>
   );
 }
+
+const StyledScrollCarousel = styled(ScrollCarousel)`
+  flex-wrap: wrap;
+  overflow: visible;
+  white-space: normal;
+`;
 
 const HighlightsDescription = styled('div')`
   display: flex;

--- a/static/app/views/performance/newTraceDetails/traceHeader/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/styles.tsx
@@ -9,6 +9,7 @@ const HeaderLayout = styled('div')`
   padding: ${p => p.theme.space.md} ${p => p.theme.space['2xl']} ${p => p.theme.space.md}
     ${p => p.theme.space['2xl']};
   border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  flex-shrink: 0;
   min-height: 150px;
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/styles.tsx
@@ -22,7 +22,6 @@ const HeaderRow = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     gap: ${p => p.theme.space.md};
     flex-direction: column;
-    align-items: stretch;
   }
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/styles.tsx
@@ -22,6 +22,7 @@ const HeaderRow = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     gap: ${p => p.theme.space.md};
     flex-direction: column;
+    align-items: stretch;
   }
 `;
 


### PR DESCRIPTION
Fix mobile layout issues in the trace details view.

**AI Spans tab**: Add `overflow-x: auto` to the wrapper so the table
scrolls horizontally on narrow screens instead of overflowing.

**Trace header highlights**: On mobile, `HeaderRow` switches to column
layout but children were centered (shrink-wrapped), so the
`ScrollCarousel` had no width constraint and couldn't scroll. Fix by
stretching children to full width. Also prevent highlight items from
shrinking (`flex: 0 0 auto`) so the gap between them is preserved —
the carousel handles overflow by scrolling instead.

**Header layout**: Add `flex-shrink: 0` to prevent the header from
collapsing when the trace content below is tall.


**Before**

https://github.com/user-attachments/assets/7f8c559d-9a59-491e-ac1d-c4a6fd19c953



**After**

https://github.com/user-attachments/assets/5716219f-a733-4370-9683-40864f863130


