### PR TITLE
fix(dashboards): Stop table rows inflating to fill widget

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -991,7 +991,6 @@ const ChartWrapper = styled('div')<{autoHeightResize: boolean; noPadding?: boole
 const TableWrapper = styled('div')`
   margin-top: ${p => p.theme.space.lg};
   min-height: 0;
-  flex: 1;
   border-bottom-left-radius: ${p => p.theme.radius.md};
   border-bottom-right-radius: ${p => p.theme.radius.md};
 `;


### PR DESCRIPTION
Remove `flex: 1` from `TableWrapper` so table rows keep their natural height when there are few items, instead of stretching to fill the entire widget card.

The `flex: 1` was added so the empty state would be vertically centered, but it caused the wrapper to grow to fill its parent, which combined with `height: 100%` and `grid-template-rows: auto 1fr` in the underlying `GridEditable`, made data rows inflate to distribute the extra vertical space. Removing it fixes the row inflation at the cost of the empty state no longer being vertically centered — a follow-up can address that separately.