### PR TITLE
fix(explore): Contain traces table overflow

### DIFF
--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -68,7 +68,7 @@ export function TracesTable({tracesTableResult}: TracesTableProps) {
   return (
     <Fragment>
       <StyledPanel>
-        <Container width="100%" minWidth={0} overflowY="auto">
+        <Container width="100%" minWidth={0} overflowX="auto">
           <Grid width="100%" columns="116px auto repeat(3, min-content) 95px">
             <StyledPanelHeader justify="start" lightText radius="md 0 0 0">
               {t('Trace ID')}

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -43,7 +43,6 @@ import {
   StyledPanel,
   StyledPanelHeader,
   StyledPanelItem,
-  TracePanelContent,
   WrappingText,
 } from 'sentry/views/explore/tables/tracesTable/styles';
 
@@ -69,71 +68,73 @@ export function TracesTable({tracesTableResult}: TracesTableProps) {
   return (
     <Fragment>
       <StyledPanel>
-        <TracePanelContent>
-          <StyledPanelHeader justify="start" lightText radius="md 0 0 0">
-            {t('Trace ID')}
-          </StyledPanelHeader>
+        <Container width="100%" minWidth={0} overflowY="auto">
+          <Grid width="100%" columns="116px auto repeat(3, min-content) 95px">
+            <StyledPanelHeader justify="start" lightText radius="md 0 0 0">
+              {t('Trace ID')}
+            </StyledPanelHeader>
 
-          <StyledPanelHeader justify="start" lightText>
-            {t('Trace Root')}
-          </StyledPanelHeader>
+            <StyledPanelHeader justify="start" lightText>
+              {t('Trace Root')}
+            </StyledPanelHeader>
 
-          <StyledPanelHeader justify="end" lightText>
-            {query ? t('Matching Spans') : t('Total Spans')}
-          </StyledPanelHeader>
+            <StyledPanelHeader justify="end" lightText>
+              {query ? t('Matching Spans') : t('Total Spans')}
+            </StyledPanelHeader>
 
-          <StyledPanelHeader justify="start" lightText>
-            {t('Timeline')}
-          </StyledPanelHeader>
+            <StyledPanelHeader justify="start" lightText>
+              {t('Timeline')}
+            </StyledPanelHeader>
 
-          <StyledPanelHeader justify="end" lightText>
-            {t('Root Duration')}
-          </StyledPanelHeader>
+            <StyledPanelHeader justify="end" lightText>
+              {t('Root Duration')}
+            </StyledPanelHeader>
 
-          <StyledPanelHeader justify="end" lightText radius="0 md 0 0">
-            <Flex gap="xs">
-              {t('Timestamp')}
-              <IconArrow size="xs" direction="down" />
-            </Flex>
-          </StyledPanelHeader>
+            <StyledPanelHeader justify="end" lightText radius="0 md 0 0">
+              <Flex gap="xs">
+                {t('Timestamp')}
+                <IconArrow size="xs" direction="down" />
+              </Flex>
+            </StyledPanelHeader>
 
-          {isPending && (
-            <StyledPanelItem span={6} overflow>
-              <LoadingIndicator />
-            </StyledPanelItem>
-          )}
-          {showErrorState && (
-            <StyledPanelItem span={6} overflow>
-              <WarningStreamWrapper>
-                <IconWarning data-test-id="error-indicator" variant="muted" size="lg" />
-              </WarningStreamWrapper>
-            </StyledPanelItem>
-          )}
-          {showEmptyState && (
-            <StyledPanelItem span={6} overflow>
-              <EmptyStateWarning withIcon>
-                <EmptyStateText size="xl">{t('No trace results found')}</EmptyStateText>
-                <EmptyStateText size="md">
-                  {tct('Try adjusting your filters or refer to [docSearchProps].', {
-                    docSearchProps: (
-                      <ExternalLink href={SPAN_PROPS_DOCS_URL}>
-                        {t('docs for search properties')}
-                      </ExternalLink>
-                    ),
-                  })}
-                </EmptyStateText>
-              </EmptyStateWarning>
-            </StyledPanelItem>
-          )}
-          {data?.data?.map((trace, i) => (
-            <TraceRow
-              key={trace.trace}
-              trace={trace}
-              defaultExpanded={query && i === 0}
-              query={query}
-            />
-          ))}
-        </TracePanelContent>
+            {isPending && (
+              <StyledPanelItem span={6} overflow>
+                <LoadingIndicator />
+              </StyledPanelItem>
+            )}
+            {showErrorState && (
+              <StyledPanelItem span={6} overflow>
+                <WarningStreamWrapper>
+                  <IconWarning data-test-id="error-indicator" variant="muted" size="lg" />
+                </WarningStreamWrapper>
+              </StyledPanelItem>
+            )}
+            {showEmptyState && (
+              <StyledPanelItem span={6} overflow>
+                <EmptyStateWarning withIcon>
+                  <EmptyStateText size="xl">{t('No trace results found')}</EmptyStateText>
+                  <EmptyStateText size="md">
+                    {tct('Try adjusting your filters or refer to [docSearchProps].', {
+                      docSearchProps: (
+                        <ExternalLink href={SPAN_PROPS_DOCS_URL}>
+                          {t('docs for search properties')}
+                        </ExternalLink>
+                      ),
+                    })}
+                  </EmptyStateText>
+                </EmptyStateWarning>
+              </StyledPanelItem>
+            )}
+            {data?.data?.map((trace, i) => (
+              <TraceRow
+                key={trace.trace}
+                trace={trace}
+                defaultExpanded={query && i === 0}
+                query={query}
+              />
+            ))}
+          </Grid>
+        </Container>
       </StyledPanel>
       <Pagination
         pageLinks={getResponseHeader?.('Link')}

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -11,6 +11,7 @@ import {PanelItem} from 'sentry/components/panels/panelItem';
 
 export const StyledPanel = styled(Panel)`
   margin-bottom: 0px;
+  overflow: hidden;
 `;
 
 interface StyledPanelHeaderProps extends ComponentProps<typeof PanelHeader> {

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -31,19 +31,17 @@ export function StyledPanelHeader({
     <Flex justify={justify} radius={radius} height="100%">
       {flexProps => (
         <Text as="div" wrap="nowrap">
-          <PanelHeader lightText={lightText} {...flexProps} {...props}>
+          <TablePanelHeader lightText={lightText} {...flexProps} {...props}>
             {children}
-          </PanelHeader>
+          </TablePanelHeader>
         </Text>
       )}
     </Flex>
   );
 }
 
-export const TracePanelContent = styled('div')`
-  width: 100%;
-  display: grid;
-  grid-template-columns: 116px auto repeat(3, min-content) 95px;
+const TablePanelHeader = styled(PanelHeader)`
+  border-radius: 0;
 `;
 
 export const StyledPanelItem = styled(PanelItem)<{


### PR DESCRIPTION
Contain the traces table scroll area inside the panel and switch the table layout to Scraps layout primitives.

The overflow regression came from the traces table content escaping its panel boundary when the table needed horizontal scrolling. This keeps the scrollable area inside the panel while preserving the existing table structure.

Also replaced the custom grid wrapper and header styling with `Container`, `Grid`, and a scoped header wrapper so the layout is expressed directly in the component tree. That makes the overflow behavior easier to reason about and avoids depending on a bespoke styled grid container.

Refs EXP-845

Made with [Cursor](https://cursor.com)

Example:

<img width="526" height="301" alt="Screenshot 2026-03-20 at 08 02 35" src="https://github.com/user-attachments/assets/d2c1b278-09cc-492d-b662-aca2136f899b" />