### PR TITLE
fix(ui): Fix ScrollCarousel story crash in production

### DIFF
--- a/static/app/components/scrollCarousel.stories.tsx
+++ b/static/app/components/scrollCarousel.stories.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import * as Storybook from 'sentry/stories';
@@ -7,7 +6,6 @@ import * as Storybook from 'sentry/stories';
 import {ScrollCarousel} from './scrollCarousel';
 
 export default Storybook.story('ScrollCarousel', story => {
-  const theme = useTheme();
   story('Default', () => (
     <Fragment>
       <p>
@@ -15,12 +13,7 @@ export default Storybook.story('ScrollCarousel', story => {
         and show arrows to scroll left and right. Native scrollbars are hidden.
       </p>
       <div style={{width: '375px', display: 'block'}}>
-        <ScrollCarousel
-          aria-label="example"
-          css={css`
-            gap: ${theme.space.md};
-          `}
-        >
+        <ScrollCarousel aria-label="example" gap="md">
           {['one', 'two', 'three', 'four', 'five', 'six'].map(item => (
             <ExampleItem key={item}>{item}</ExampleItem>
           ))}
@@ -36,13 +29,7 @@ export default Storybook.story('ScrollCarousel', story => {
         <Storybook.JSXProperty name="orientation" value="vertical" />.
       </p>
       <div style={{width: '240px', height: '160px', display: 'block'}}>
-        <ScrollCarousel
-          aria-label="vertical-example"
-          orientation="vertical"
-          css={css`
-            gap: ${theme.space.md};
-          `}
-        >
+        <ScrollCarousel aria-label="vertical-example" orientation="vertical" gap="md">
           {['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta'].map(item => (
             <ExampleItem key={item}>{item}</ExampleItem>
           ))}


### PR DESCRIPTION
Replace `useTheme()` called during `Storybook.story()` setup — which
runs at module initialization, outside any React component — with the
built-in `gap` prop that `ScrollCarousel` already supports.

The invalid hook call caused a TDZ error (`Cannot access 'c' before
initialization`) in production builds due to module evaluation order
differences.