### PR TITLE
fix(ai-insights): sort conversation spans by start timestamp

### DIFF
--- a/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
@@ -36,7 +36,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.description': 'AI generation',
+          'span.name': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-1',
@@ -81,7 +81,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.description': 'AI generation',
+          'span.name': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-output',
@@ -123,7 +123,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.description': 'AI generation',
+          'span.name': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-2',
@@ -161,7 +161,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.description': 'AI generation',
+          'span.name': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-3',
@@ -201,7 +201,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.description': 'AI generation',
+          'span.name': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-ts',
@@ -240,18 +240,17 @@ describe('useConversation', () => {
     );
   });
 
-  it('falls back to span.name when span.description is empty', async () => {
+  it('uses span.name for description and name', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-name-fallback/`,
+      url: `/organizations/${organization.slug}/ai-conversations/conv-name/`,
       body: [
         {
-          'gen_ai.conversation.id': 'conv-name-fallback',
+          'gen_ai.conversation.id': 'conv-name',
           parent_span: 'parent-1',
           'precise.finish_ts': 1000.5,
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.description': '',
           'span.name': 'My AI Agent',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
@@ -263,7 +262,7 @@ describe('useConversation', () => {
     });
 
     const {result} = renderHookWithProviders(
-      () => useConversation({conversationId: 'conv-name-fallback'}),
+      () => useConversation({conversationId: 'conv-name'}),
       {organization}
     );
 
@@ -278,44 +277,6 @@ describe('useConversation', () => {
     expect(value?.name).toBe('My AI Agent');
   });
 
-  it('prefers span.description over span.name when both exist', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-both/`,
-      body: [
-        {
-          'gen_ai.conversation.id': 'conv-both',
-          parent_span: 'parent-1',
-          'precise.finish_ts': 1000.5,
-          'precise.start_ts': 1000.0,
-          project: 'test-project',
-          'project.id': 1,
-          'span.description': 'AI generation',
-          'span.name': 'My AI Agent',
-          'span.op': 'gen_ai.generate',
-          'span.status': 'ok',
-          span_id: 'span-both',
-          trace: 'trace-both',
-          'gen_ai.operation.type': 'ai_client',
-        },
-      ],
-    });
-
-    const {result} = renderHookWithProviders(
-      () => useConversation({conversationId: 'conv-both'}),
-      {organization}
-    );
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.nodes).toHaveLength(1);
-    const node = result.current.nodes[0];
-    const value = node?.value as {description?: string; name?: string};
-    expect(value?.description).toBe('AI generation');
-    expect(value?.name).toBe('AI generation');
-  });
-
   it('filters to only gen_ai spans', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-filter/`,
@@ -327,7 +288,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.description': 'AI generation',
+          'span.name': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-ai',
@@ -341,7 +302,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1001.0,
           project: 'test-project',
           'project.id': 1,
-          'span.description': 'HTTP request',
+          'span.name': 'HTTP request',
           'span.op': 'http.client',
           'span.status': 'ok',
           span_id: 'span-http',

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
@@ -316,6 +316,56 @@ describe('useConversation', () => {
     expect(value?.name).toBe('AI generation');
   });
 
+  it('sorts nodes by start timestamp for AI spans list', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-sort/`,
+      body: [
+        {
+          'gen_ai.conversation.id': 'conv-sort',
+          parent_span: 'parent-1',
+          'precise.finish_ts': 1002.0,
+          'precise.start_ts': 1001.0,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'Second by start, first by end',
+          'span.op': 'gen_ai.generate',
+          'span.status': 'ok',
+          span_id: 'span-b',
+          trace: 'trace-sort',
+          'gen_ai.operation.type': 'ai_client',
+        },
+        {
+          'gen_ai.conversation.id': 'conv-sort',
+          parent_span: 'parent-1',
+          'precise.finish_ts': 1003.0,
+          'precise.start_ts': 1000.0,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'First by start, second by end',
+          'span.op': 'gen_ai.generate',
+          'span.status': 'ok',
+          span_id: 'span-a',
+          trace: 'trace-sort',
+          'gen_ai.operation.type': 'ai_client',
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-sort'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes).toHaveLength(2);
+    // Sorted by start timestamp: span-a (1000) before span-b (1001)
+    expect(result.current.nodes[0]?.id).toBe('span-a');
+    expect(result.current.nodes[1]?.id).toBe('span-b');
+  });
+
   it('filters to only gen_ai spans', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-filter/`,

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
@@ -36,7 +36,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.name': 'AI generation',
+          'span.description': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-1',
@@ -81,7 +81,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.name': 'AI generation',
+          'span.description': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-output',
@@ -123,7 +123,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.name': 'AI generation',
+          'span.description': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-2',
@@ -161,7 +161,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.name': 'AI generation',
+          'span.description': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-3',
@@ -201,7 +201,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.name': 'AI generation',
+          'span.description': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-ts',
@@ -240,17 +240,18 @@ describe('useConversation', () => {
     );
   });
 
-  it('uses span.name for description and name', async () => {
+  it('falls back to span.name when span.description is empty', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-name/`,
+      url: `/organizations/${organization.slug}/ai-conversations/conv-name-fallback/`,
       body: [
         {
-          'gen_ai.conversation.id': 'conv-name',
+          'gen_ai.conversation.id': 'conv-name-fallback',
           parent_span: 'parent-1',
           'precise.finish_ts': 1000.5,
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
+          'span.description': '',
           'span.name': 'My AI Agent',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
@@ -262,7 +263,7 @@ describe('useConversation', () => {
     });
 
     const {result} = renderHookWithProviders(
-      () => useConversation({conversationId: 'conv-name'}),
+      () => useConversation({conversationId: 'conv-name-fallback'}),
       {organization}
     );
 
@@ -277,6 +278,44 @@ describe('useConversation', () => {
     expect(value?.name).toBe('My AI Agent');
   });
 
+  it('prefers span.description over span.name when both exist', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-both/`,
+      body: [
+        {
+          'gen_ai.conversation.id': 'conv-both',
+          parent_span: 'parent-1',
+          'precise.finish_ts': 1000.5,
+          'precise.start_ts': 1000.0,
+          project: 'test-project',
+          'project.id': 1,
+          'span.description': 'AI generation',
+          'span.name': 'My AI Agent',
+          'span.op': 'gen_ai.generate',
+          'span.status': 'ok',
+          span_id: 'span-both',
+          trace: 'trace-both',
+          'gen_ai.operation.type': 'ai_client',
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-both'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes).toHaveLength(1);
+    const node = result.current.nodes[0];
+    const value = node?.value as {description?: string; name?: string};
+    expect(value?.description).toBe('AI generation');
+    expect(value?.name).toBe('AI generation');
+  });
+
   it('filters to only gen_ai spans', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-filter/`,
@@ -288,7 +327,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1000.0,
           project: 'test-project',
           'project.id': 1,
-          'span.name': 'AI generation',
+          'span.description': 'AI generation',
           'span.op': 'gen_ai.generate',
           'span.status': 'ok',
           span_id: 'span-ai',
@@ -302,7 +341,7 @@ describe('useConversation', () => {
           'precise.start_ts': 1001.0,
           project: 'test-project',
           'project.id': 1,
-          'span.name': 'HTTP request',
+          'span.description': 'HTTP request',
           'span.op': 'http.client',
           'span.status': 'ok',
           span_id: 'span-http',

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -29,7 +29,7 @@ interface ConversationApiSpan {
   'precise.start_ts': number;
   project: string;
   'project.id': number;
-  'span.description': string;
+  'span.name': string;
   'span.op': string;
   'span.status': string;
   span_id: string;
@@ -46,7 +46,7 @@ interface ConversationApiSpan {
   'gen_ai.response.text'?: string;
   'gen_ai.tool.name'?: string;
   'gen_ai.usage.total_tokens'?: number;
-  'span.name'?: string;
+  'span.description'?: string;
   'user.email'?: string;
   'user.id'?: string;
   'user.ip'?: string;
@@ -87,7 +87,7 @@ function createNodeFromApiSpan(
     event_type: 'span',
     is_transaction: false,
     op: apiSpan['span.op'],
-    description: apiSpan['span.description'] || apiSpan['span.name'],
+    description: apiSpan['span.name'],
     start_timestamp: apiSpan['precise.start_ts'],
     end_timestamp: apiSpan['precise.finish_ts'],
     project_id: apiSpan['project.id'],
@@ -98,7 +98,7 @@ function createNodeFromApiSpan(
     sdk_name: '',
     transaction: '',
     transaction_id: '',
-    name: apiSpan['span.description'] || apiSpan['span.name'] || '',
+    name: apiSpan['span.name'] || '',
     errors: [],
     occurrences: [],
     additional_attributes: {
@@ -229,7 +229,7 @@ export function useConversation(
       return node;
     });
 
-    transformedNodes.sort((a, b) => (a.endTimestamp ?? 0) - (b.endTimestamp ?? 0));
+    transformedNodes.sort((a, b) => (a.startTimestamp ?? 0) - (b.startTimestamp ?? 0));
 
     return {nodes: transformedNodes, nodeTraceMap: traceMap};
   }, [conversationQuery.data]);

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -29,7 +29,7 @@ interface ConversationApiSpan {
   'precise.start_ts': number;
   project: string;
   'project.id': number;
-  'span.name': string;
+  'span.description': string;
   'span.op': string;
   'span.status': string;
   span_id: string;
@@ -46,7 +46,7 @@ interface ConversationApiSpan {
   'gen_ai.response.text'?: string;
   'gen_ai.tool.name'?: string;
   'gen_ai.usage.total_tokens'?: number;
-  'span.description'?: string;
+  'span.name'?: string;
   'user.email'?: string;
   'user.id'?: string;
   'user.ip'?: string;
@@ -87,7 +87,7 @@ function createNodeFromApiSpan(
     event_type: 'span',
     is_transaction: false,
     op: apiSpan['span.op'],
-    description: apiSpan['span.name'],
+    description: apiSpan['span.description'] || apiSpan['span.name'],
     start_timestamp: apiSpan['precise.start_ts'],
     end_timestamp: apiSpan['precise.finish_ts'],
     project_id: apiSpan['project.id'],
@@ -98,7 +98,7 @@ function createNodeFromApiSpan(
     sdk_name: '',
     transaction: '',
     transaction_id: '',
-    name: apiSpan['span.name'] || '',
+    name: apiSpan['span.description'] || apiSpan['span.name'] || '',
     errors: [],
     occurrences: [],
     additional_attributes: {

--- a/static/app/views/insights/pages/conversations/overview.tsx
+++ b/static/app/views/insights/pages/conversations/overview.tsx
@@ -114,7 +114,9 @@ function ConversationsContent({datePageFilterProps}: ConversationsOverviewPagePr
         unsetCursor();
       },
       searchSource: 'conversations',
-      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.name'] : undefined,
+      replaceRawSearchKeys: hasRawSearchReplacement
+        ? ['span.description', 'span.name']
+        : undefined,
       matchKeySuggestions: [
         {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},

--- a/static/app/views/insights/pages/conversations/overview.tsx
+++ b/static/app/views/insights/pages/conversations/overview.tsx
@@ -114,9 +114,7 @@ function ConversationsContent({datePageFilterProps}: ConversationsOverviewPagePr
         unsetCursor();
       },
       searchSource: 'conversations',
-      replaceRawSearchKeys: hasRawSearchReplacement
-        ? ['span.description', 'span.name']
-        : undefined,
+      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.name'] : undefined,
       matchKeySuggestions: [
         {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
@@ -322,23 +322,36 @@ describe('conversationMessages utilities', () => {
       expect(result.toolSpans[0]?.id).toBe('tool-1');
     });
 
-    it('sorts by timestamp', () => {
-      const gen1 = createMockNode({id: 'gen-1', startTimestamp: 2000});
-      const gen2 = createMockNode({id: 'gen-2', startTimestamp: 1000});
+    it('sorts by end timestamp, not start timestamp', () => {
+      // gen-1 starts later but ends first
+      const gen1 = createMockNode({
+        id: 'gen-1',
+        startTimestamp: 2000,
+        endTimestamp: 2100,
+      });
+      // gen-2 starts earlier but ends later
+      const gen2 = createMockNode({
+        id: 'gen-2',
+        startTimestamp: 1000,
+        endTimestamp: 3000,
+      });
       const tool1 = createMockToolNode({
         id: 'tool-1',
         toolName: 'a',
         startTimestamp: 3000,
+        endTimestamp: 3500,
       });
       const tool2 = createMockToolNode({
         id: 'tool-2',
         toolName: 'b',
         startTimestamp: 1500,
+        endTimestamp: 1600,
       });
 
       const result = partitionSpansByType([gen1, gen2, tool1, tool2] as any);
 
-      expect(result.generationSpans.map(s => s.id)).toEqual(['gen-2', 'gen-1']);
+      // Sorted by end_timestamp: gen-1 (2100) before gen-2 (3000)
+      expect(result.generationSpans.map(s => s.id)).toEqual(['gen-1', 'gen-2']);
       expect(result.toolSpans.map(s => s.id)).toEqual(['tool-2', 'tool-1']);
     });
 


### PR DESCRIPTION
Sort spans by `start_timestamp` instead of `end_timestamp` in the conversation hook so the AI Spans list displays spans in the order they began. The Messages panel is unaffected because `extractMessagesFromNodes` applies its own internal sort by `end_timestamp`.
