### PR TITLE
ref(ui): Replace framer-motion ring animation with CSS transition

### DIFF
--- a/static/app/components/progressRing.tsx
+++ b/static/app/components/progressRing.tsx
@@ -1,4 +1,3 @@
-import {useMemo} from 'react';
 import type {SerializedStyles, Theme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -112,19 +111,6 @@ export function ProgressRing({
     textNode
   );
 
-  const ringCommonProps = useMemo(() => {
-    return {
-      strokeDashoffset: progressOffset,
-      strokeLinecap: progressEndcaps,
-      circumference,
-      r: radius,
-      barWidth,
-      cx: radius + barWidth / 2,
-      cy: radius + barWidth / 2,
-      color: progressColor,
-    };
-  }, [progressOffset, progressEndcaps, circumference, radius, barWidth, progressColor]);
-
   return (
     <RingSvg
       role="img"
@@ -139,16 +125,17 @@ export function ProgressRing({
         cy={radius + barWidth / 2}
         color={backgroundColor}
       />
-      {animate ? (
-        <MotionRingBar
-          {...ringCommonProps}
-          initial={{strokeDashoffset: circumference}}
-          animate={{strokeDashoffset: progressOffset}}
-          transition={{duration: 1.5, ease: 'easeInOut'}}
-        />
-      ) : (
-        <RingBar {...ringCommonProps} />
-      )}
+      <RingBar
+        strokeDashoffset={progressOffset}
+        strokeLinecap={progressEndcaps}
+        circumference={circumference}
+        r={radius}
+        barWidth={barWidth}
+        cx={radius + barWidth / 2}
+        cy={radius + barWidth / 2}
+        color={progressColor}
+        animate={animate}
+      />
       <foreignObject height="100%" width="100%">
         {text !== undefined && textNode}
       </foreignObject>
@@ -171,6 +158,7 @@ const RingBar = styled('circle')<{
   barWidth: number;
   circumference: number;
   color: string;
+  animate?: boolean;
 }>`
   fill: none;
   stroke: ${p => p.color};
@@ -178,9 +166,9 @@ const RingBar = styled('circle')<{
   stroke-dasharray: ${p => p.circumference} ${p => p.circumference};
   transform: rotate(-90deg);
   transform-origin: 50% 50%;
-  transition:
+  ${p =>
+    p.animate &&
+    `transition:
     stroke-dashoffset 200ms,
-    stroke 100ms;
+    stroke 100ms;`}
 `;
-
-const MotionRingBar = motion.create(RingBar);


### PR DESCRIPTION
The progress ring was already animated via CSS transitions on
stroke-dashoffset. Remove the redundant framer-motion MotionRingBar
wrapper and instead gate the existing CSS transition behind the
`animate` prop.