### PR TITLE
fix(dashboards): Pass widget and dashboardFilters to getFieldRenderer in all dataset configs

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -20,7 +20,7 @@ import {
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import type {AggregationKey} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
+import type {DashboardFilters, Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
 import {transformEventsResponseToSeries} from 'sentry/views/dashboards/utils/transformEventsResponseToSeries';
@@ -148,7 +148,13 @@ function getEventsTableFieldOptions(
   });
 }
 
-function getCustomEventsFieldRenderer(field: string, meta: MetaType, widget?: Widget) {
+function getCustomEventsFieldRenderer(
+  field: string,
+  meta: MetaType,
+  widget?: Widget,
+  _organization?: Organization,
+  dashboardFilters?: DashboardFilters
+) {
   if (field === 'id') {
     return renderEventIdAsLinkable;
   }
@@ -157,7 +163,7 @@ function getCustomEventsFieldRenderer(field: string, meta: MetaType, widget?: Wi
     return renderTraceAsLinkable(widget);
   }
 
-  return getFieldRenderer(field, meta, false);
+  return getFieldRenderer(field, meta, false, widget, dashboardFilters);
 }
 
 // The y-axis options are a strict set of available aggregates

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -46,7 +46,7 @@ import {FieldKey} from 'sentry/utils/fields';
 import {getMeasurements} from 'sentry/utils/measurements/measurements';
 import type {DatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {handleOrderByReset} from 'sentry/views/dashboards/datasetConfig/base';
-import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
+import type {DashboardFilters, Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {transformEventsResponseToSeries} from 'sentry/views/dashboards/utils/transformEventsResponseToSeries';
@@ -386,7 +386,9 @@ export function renderTraceAsLinkable(widget?: Widget) {
 export function getCustomEventsFieldRenderer(
   field: string,
   meta: MetaType,
-  widget?: Widget
+  widget?: Widget,
+  _organization?: Organization,
+  dashboardFilters?: DashboardFilters
 ): FieldFormatterRenderFunctionPartial {
   if (field === 'id') {
     return renderEventIdAsLinkable;
@@ -414,10 +416,16 @@ export function getCustomEventsFieldRenderer(
           </Container>
         );
       }
-      return getFieldRenderer(field, meta, false)(data, baggage);
+      return getFieldRenderer(
+        field,
+        meta,
+        false,
+        widget,
+        dashboardFilters
+      )(data, baggage);
     };
   }
-  return getFieldRenderer(field, meta, false);
+  return getFieldRenderer(field, meta, false, widget, dashboardFilters);
 }
 
 export async function doOnDemandMetricsRequest(

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -212,8 +212,8 @@ export const LogsConfig: DatasetConfig<
   transformTable: transformEventsResponseToTable,
   transformSeries: transformEventsResponseToSeries,
   filterAggregateParams,
-  getCustomFieldRenderer: (field, meta, _organization) => {
-    return getFieldRenderer(field, meta, false);
+  getCustomFieldRenderer: (field, meta, widget, _organization, dashboardFilters) => {
+    return getFieldRenderer(field, meta, false, widget, dashboardFilters);
   },
 };
 

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -77,7 +77,8 @@ export const ReleasesConfig: DatasetConfig<SessionApiResponse, SessionApiRespons
   filterYAxisAggregateParams: (_fieldValue: QueryFieldValue, _displayType: DisplayType) =>
     filterAggregateParams,
   filterYAxisOptions,
-  getCustomFieldRenderer: (field, meta) => getFieldRenderer(field, meta, false),
+  getCustomFieldRenderer: (field, meta, widget, _organization, dashboardFilters) =>
+    getFieldRenderer(field, meta, false, widget, dashboardFilters),
   SearchBar: ReleaseSearchBar,
   useSearchBarDataProvider: useReleasesSearchBarDataProvider,
   getTableFieldOptions: getReleasesTableFieldOptions,

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -325,8 +325,8 @@ export const TraceMetricsConfig: DatasetConfig<
       };
     });
   },
-  getCustomFieldRenderer: (field, meta, _organization) => {
-    return getFieldRenderer(field, meta, false);
+  getCustomFieldRenderer: (field, meta, widget, _organization, dashboardFilters) => {
+    return getFieldRenderer(field, meta, false, widget, dashboardFilters);
   },
   getFieldHeaderMap: widgetQuery => {
     return (


### PR DESCRIPTION
Ensure `getCustomFieldRenderer` passes `widget` and `dashboardFilters` through to `getFieldRenderer` across all dataset configs that support global filters. Previously only `errors` and `spans` forwarded these parameters, causing linked dashboards to not work correctly for the other datasets.

**Updated datasets:**
- `releases` — was ignoring both params
- `errorsAndTransactions` — was ignoring both params
- `logs` — was ignoring both params
- `traceMetrics` — was ignoring both params

No behavior change for `errors` and `spans` which already passed them correctly.

Fixes BROWSE-458