### PR TITLE
fix(nav): Cap list item height for page-frame secondary nav variants

### DIFF
--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -1072,6 +1072,9 @@ const StyledPageFrameReorderableFakeLink = styled('div')<{
   align-items: center;
   position: relative;
   color: ${p => p.theme.tokens.interactive.link.neutral.rest};
+  /* We need to cap the height at sm size as some items like the reorderable link with icons
+   * will otherwise cause the links to be taller, visually standing out when they are laid out in a list */
+  height: ${p => p.theme.form.sm.height};
   padding: ${p => `${p.theme.space.md} ${p.theme.space.lg}`};
   border-radius: ${p => p.theme.radius.md};
   border: 1px solid transparent;
@@ -1192,6 +1195,9 @@ const PageFrameSidebarNavigationLink = styled(Link)`
   align-items: center;
   position: relative;
   color: ${p => p.theme.tokens.interactive.link.neutral.rest};
+  /* We need to cap the height at sm size as some items like the reorderable link with icons
+   * will otherwise cause the links to be taller, visually standing out when they are laid out in a list */
+  height: ${p => p.theme.form.sm.height};
   padding: ${p => `${p.theme.space.md} ${p.theme.space.lg}`};
   border-radius: ${p => p.theme.radius.md};
   border: 1px solid transparent;


### PR DESCRIPTION
The `page-frame` nav variants (`PageFrameSidebarNavigationLink` and `StyledPageFrameReorderableFakeLink`) were missing the `height: form.sm.height` cap that exists on their non-page-frame counterparts, causing items with icons to appear taller than regular items in the list.