### PR TITLE
fix(dashboards): Fixes Create Dashboard with Seer button styling clashing with experimental badge

### DIFF
--- a/static/app/components/modals/generateDashboardFromSeerModal.tsx
+++ b/static/app/components/modals/generateDashboardFromSeerModal.tsx
@@ -76,7 +76,7 @@ function GenerateDashboardFromSeerModal({
   return (
     <Fragment>
       <Header closeButton>
-        <h4>{t('Generate Dashboard with Seer')}</h4>
+        <h4>{t('Create Dashboard with Seer')}</h4>
       </Header>
       <Body>
         <p>{t('Describe the dashboard you would like Seer to generate for you.')}</p>
@@ -92,7 +92,7 @@ function GenerateDashboardFromSeerModal({
         />
       </Body>
       <Footer>
-        <Flex justify="end">
+        <Flex justify="end" gap="sm">
           <Button onClick={closeModal} disabled={isGenerating}>
             {t('Cancel')}
           </Button>

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -9,7 +9,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Grid} from '@sentry/scraps/layout';
+import {Flex, Grid} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Switch} from '@sentry/scraps/switch';
@@ -684,11 +684,13 @@ function ManageDashboards() {
                             });
                           }}
                           size="sm"
-                          priority="primary"
+                          priority="default"
                           icon={<IconSeer />}
                         >
-                          {t('Create Dashboard with Seer')}
-                          <FeatureBadge type="experimental" />
+                          <Flex gap="sm" align="center">
+                            {t('Create Dashboard with Seer')}
+                            <FeatureBadge type="experimental" />
+                          </Flex>
                         </Button>
                       </Feature>
                       <Feature features="dashboards-import">

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -687,7 +687,7 @@ function ManageDashboards() {
                           priority="default"
                           icon={<IconSeer />}
                         >
-                          <Flex gap="sm" align="center">
+                          <Flex gap="sm" align="center" as="span">
                             {t('Create Dashboard with Seer')}
                             <FeatureBadge type="experimental" />
                           </Flex>


### PR DESCRIPTION
- Use default priority on the Create Dashboard with Seer button to prevent visual clashing with the experimental badge
- Also makes a slight change to modal title to match button and adds a gap between modal buttons