### PR TITLE
fix(dashboards): Fix double nested query param when creating dashboard

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -853,9 +853,7 @@ class DashboardDetail extends Component<Props, State> {
                   browserHistory.replace(
                     normalizeUrl({
                       pathname: `/organizations/${organization.slug}/dashboard/${newDashboard.id}/`,
-                      query: {
-                        query: omit(location.query, Object.values(DashboardFilterKeys)),
-                      },
+                      query: omit(location.query, Object.values(DashboardFilterKeys)),
                     })
                   );
                 }


### PR DESCRIPTION
When creating a new dashboard, we navigate the user to the new dashboard url with an incorrect double nested `query` parameter. This causes the new url to contain `query=[object object]`. Removes the unnecessary nest to fix this.