### PR TITLE
chore(autofix): Add referrer to explorer autofix runs

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -14,6 +14,7 @@ from sentry.seer.autofix.artifact_schemas import (
     SolutionArtifact,
     TriageArtifact,
 )
+from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.prompts import (
     code_changes_prompt,
     impact_assessment_prompt,
@@ -187,6 +188,7 @@ def get_autofix_explorer_client(
 def trigger_autofix_explorer(
     group: Group,
     step: AutofixStep,
+    referrer: AutofixReferrer,
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
     intelligence_level: Literal["low", "medium", "high"] = "low",
@@ -213,12 +215,15 @@ def trigger_autofix_explorer(
     )
 
     prompt = build_step_prompt(step, group, user_context)
-    prompt_metadata = {"step": step.value}
+    prompt_metadata = {
+        "step": step.value,
+        "referrer": referrer.value,
+    }
     artifact_key = step.value if config.artifact_schema else None
     artifact_schema = config.artifact_schema
 
     if run_id is None:
-        metadata = {"group_id": group.id}
+        metadata = {"group_id": group.id, "referrer": referrer.value}
         if stopping_point:
             metadata["stopping_point"] = stopping_point.value
         run_id = client.start_run(

--- a/src/sentry/seer/autofix/constants.py
+++ b/src/sentry/seer/autofix/constants.py
@@ -47,6 +47,7 @@ class AutofixReferrer(enum.StrEnum):
     ISSUE_SUMMARY_ALERT_FIXABILITY = "issue_summary.alert_fixability"
     ISSUE_SUMMARY_POST_PROCESS_FIXABILITY = "issue_summary.post_process_fixability"
     SLACK = "slack"
+    ON_COMPLETION_HOOK = "autofix.on_completion_hook"
     UNKNOWN = "unknown"
 
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -222,6 +222,7 @@ def _trigger_autofix_task(
             run_id = trigger_autofix_explorer(
                 group=group,
                 step=AutofixStep.ROOT_CAUSE,
+                referrer=referrer,
                 run_id=None,
                 stopping_point=stopping_point,
             )

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -11,6 +11,7 @@ from sentry.seer.autofix.autofix_agent import (
     trigger_autofix_explorer,
     trigger_coding_agent_handoff,
 )
+from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.utils import AutofixStoppingPoint, get_project_seer_preferences
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
 from sentry.seer.explorer.client import SeerExplorerClient
@@ -387,7 +388,12 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
                 "stopping_point": stopping_point,
             },
         )
-        trigger_autofix_explorer(group=group, step=next_step, run_id=run_id)
+        trigger_autofix_explorer(
+            group=group,
+            step=next_step,
+            referrer=AutofixReferrer.ON_COMPLETION_HOOK,
+            run_id=run_id,
+        )
 
     @classmethod
     def _push_changes(cls, organization: Organization, run_id: int, state: SeerRunState) -> None:

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -242,6 +242,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             run_id = trigger_autofix_explorer(
                 group=group,
                 step=AutofixStep(step),
+                referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
                 stopping_point=AutofixStoppingPoint(stopping_point) if stopping_point else None,
                 run_id=data.get("run_id"),
                 intelligence_level=data["intelligence_level"],

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -219,6 +219,7 @@ class SeerAutofixOperator[CachePayloadT]:
                     run_id = trigger_autofix_explorer(
                         group=group,
                         step=AutofixStep.ROOT_CAUSE,
+                        referrer=AutofixReferrer.SLACK,
                         run_id=None,
                     )
                 elif stopping_point == AutofixStoppingPoint.OPEN_PR:
@@ -232,6 +233,7 @@ class SeerAutofixOperator[CachePayloadT]:
                     run_id = trigger_autofix_explorer(
                         group=group,
                         step=AutofixStep.from_autofix_stopping_point(stopping_point),
+                        referrer=AutofixReferrer.SLACK,
                         run_id=run_id,
                     )
             except Exception as e:

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -352,7 +352,7 @@ class TestTriggerAutofixExplorer(TestCase):
 
         mock_client.start_run.assert_called_once()
         call_kwargs = mock_client.start_run.call_args.kwargs
-        assert call_kwargs["metadata"] == {"group_id": self.group.id}
+        assert call_kwargs["metadata"] == {"group_id": self.group.id, "referrer": "unknown"}
 
 
 class TestTriggerCodingAgentHandoff(TestCase):

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -7,6 +7,7 @@ from sentry.seer.autofix.autofix_agent import (
     trigger_autofix_explorer,
     trigger_coding_agent_handoff,
 )
+from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.explorer.client_models import (
     Artifact,
     MemoryBlock,
@@ -280,6 +281,7 @@ class TestTriggerAutofixExplorer(TestCase):
             trigger_autofix_explorer(
                 group=self.group,
                 step=step,
+                referrer=AutofixReferrer.UNKNOWN,
                 run_id=None,
             )
             mock_broadcast.assert_called_once()
@@ -299,6 +301,7 @@ class TestTriggerAutofixExplorer(TestCase):
         result = trigger_autofix_explorer(
             group=self.group,
             step=AutofixStep.SOLUTION,
+            referrer=AutofixReferrer.UNKNOWN,
             run_id=67890,
         )
 
@@ -319,7 +322,12 @@ class TestTriggerAutofixExplorer(TestCase):
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = 123
 
-        trigger_autofix_explorer(group=self.group, step=AutofixStep.ROOT_CAUSE, run_id=None)
+        trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+        )
 
         mock_client_class.assert_called_once()
         call_kwargs = mock_client_class.call_args.kwargs
@@ -335,7 +343,12 @@ class TestTriggerAutofixExplorer(TestCase):
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = 123
 
-        trigger_autofix_explorer(group=self.group, step=AutofixStep.ROOT_CAUSE, run_id=None)
+        trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+        )
 
         mock_client.start_run.assert_called_once()
         call_kwargs = mock_client.start_run.call_args.kwargs

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 from sentry.seer.autofix.autofix import TIMEOUT_SECONDS
 from sentry.seer.autofix.autofix_agent import AutofixStep
-from sentry.seer.autofix.constants import AutofixStatus
+from sentry.seer.autofix.constants import AutofixReferrer, AutofixStatus
 from sentry.seer.autofix.utils import AutofixState, AutofixStoppingPoint, CodebaseState
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -913,6 +913,7 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         mock_trigger_explorer.assert_called_once_with(
             group=group,
             step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
             stopping_point=AutofixStoppingPoint.CODE_CHANGES,
             run_id=None,
             intelligence_level="low",


### PR DESCRIPTION
Stores a referrer in the metadata to indicate where the run was triggered from. There is a top level one that indicates where the first step is triggered from and a per prompt one to indicate where next step was triggered.