### PR TITLE
fix(dashboards): Default to 10 dashboards when planDetails is null

### DIFF
--- a/static/gsApp/hooks/dashboardsLimit.spec.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.spec.tsx
@@ -58,33 +58,31 @@ describe('useDashboardsLimit', () => {
     expect(dashboardsRequest).not.toHaveBeenCalled();
   });
 
-  it('handles no subscription data (defaults to 0)', () => {
+  it('handles no subscription data (defaults to 10)', async () => {
     SubscriptionStore.set(mockOrganization.slug, null as any);
 
     const dashboardsRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dashboards/',
       body: [],
+      match: [MockApiClient.matchQuery({per_page: 10, filter: 'excludePrebuilt'})],
     });
 
     const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
       organization: mockOrganization,
     });
 
-    expect(result.current.hasReachedDashboardLimit).toBe(true);
-    expect(result.current.dashboardsLimit).toBe(0);
-    expect(result.current.isLoading).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
 
-    render(<div>{result.current.limitMessage}</div>);
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          'You have reached the maximum number of Dashboards available on your plan. To add more, upgrade your plan'
-        )
-      )
-    ).toBeInTheDocument();
+    expect(result.current).toEqual({
+      hasReachedDashboardLimit: false,
+      dashboardsLimit: 10,
+      isLoading: false,
+      limitMessage: null,
+    });
 
-    // Should not make the dashboards request when no subscription
-    expect(dashboardsRequest).not.toHaveBeenCalled();
+    expect(dashboardsRequest).toHaveBeenCalledTimes(1);
   });
 
   it('returns under limit when dashboards count is below limit', async () => {
@@ -293,7 +291,7 @@ describe('useDashboardsLimit', () => {
     });
   });
 
-  it('handles missing subscription planDetails gracefully (defaults to 0)', () => {
+  it('handles missing subscription planDetails gracefully (defaults to 10)', async () => {
     const subscription = SubscriptionFixture({
       organization: mockOrganization,
       planDetails: undefined as any,
@@ -304,27 +302,24 @@ describe('useDashboardsLimit', () => {
     const dashboardsRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dashboards/',
       body: [],
+      match: [MockApiClient.matchQuery({per_page: 10, filter: 'excludePrebuilt'})],
     });
 
     const {result} = renderHookWithProviders(() => useDashboardsLimit(), {
       organization: mockOrganization,
     });
 
-    // Should default to 0 when planDetails is missing
-    expect(result.current.hasReachedDashboardLimit).toBe(true);
-    expect(result.current.dashboardsLimit).toBe(0);
-    expect(result.current.isLoading).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
 
-    render(<div>{result.current.limitMessage}</div>);
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          'You have reached the maximum number of Dashboards available on your plan. To add more, upgrade your plan'
-        )
-      )
-    ).toBeInTheDocument();
+    expect(result.current).toEqual({
+      hasReachedDashboardLimit: false,
+      dashboardsLimit: 10,
+      isLoading: false,
+      limitMessage: null,
+    });
 
-    // Should not make dashboards request for unlimited plans
-    expect(dashboardsRequest).not.toHaveBeenCalled();
+    expect(dashboardsRequest).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/gsApp/hooks/dashboardsLimit.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.tsx
@@ -17,13 +17,15 @@ interface UseDashboardsLimitResult {
 }
 
 const UNLIMITED_DASHBOARDS_LIMIT = -1;
+const DEFAULT_DASHBOARDS_LIMIT = 10;
 
 export function useDashboardsLimit(): UseDashboardsLimitResult {
   const organization = useOrganization();
   const subscription = useSubscription();
 
   // If there is no subscription, block dashboard creation
-  const dashboardsLimit = subscription?.planDetails?.dashboardLimit ?? 0;
+  const dashboardsLimit =
+    subscription?.planDetails?.dashboardLimit ?? DEFAULT_DASHBOARDS_LIMIT;
 
   const isUnlimitedPlan = dashboardsLimit === UNLIMITED_DASHBOARDS_LIMIT;
 

--- a/static/gsApp/hooks/dashboardsLimit.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.tsx
@@ -17,6 +17,7 @@ interface UseDashboardsLimitResult {
 }
 
 const UNLIMITED_DASHBOARDS_LIMIT = -1;
+// 10 is the lowest plan limit, used as a fallback if plan details don't come back
 const DEFAULT_DASHBOARDS_LIMIT = 10;
 
 export function useDashboardsLimit(): UseDashboardsLimitResult {


### PR DESCRIPTION
When `planDetails` is null (e.g. subscription data hasn't loaded yet), the dashboard limit was defaulting to `0`, which incorrectly blocked dashboard creation. This changes the fallback to `10`, matching the minimum plan allowance so users aren't locked out of dashboards while subscription data is loading.

Refs DAIN-1384