### PR TITLE
fix(snapshots): Use explicit HEAD rather than merge commit for frontend snapshots

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # Checkout the HEAD of the PR (or the commit if not a PR)
+          # Explicitly need to do this to avoid cases where the merge commit is used instead of the PR head,
+          # which can introduce diffs that aren't explicitly caused by the PR changes.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:


### PR DESCRIPTION
We found a bug yesterday where an unsuspecting PR showed a large "Added" diff. This led to an investigation where I discovered the checkout action is checking out the merge commit (https://github.com/actions/checkout/issues/504) rather than the HEAD commit.

In the case of the PR that showed this diff (https://github.com/getsentry/sentry/pull/110780), the base has 12 snapshots as it's from a few days ago. His HEAD has no snapshot changes, so should only be diffing 12 images. Instead, it used the merge commit, so his changes+master (which has 132 new snapshots), therefore showing 132 incorrectly "added" snapshots.

The fix here is simple, explicitly checkout the HEAD commit of the PR rather than the merge commit (https://github.com/actions/checkout?tab=readme-ov-file#checkout-pull-request-head-commit-instead-of-merge-commit). This ensures the snapshot changes only diff changes on that branch rather than against the master+branch merge commit. 