### PR TITLE
fix(search): Render negated multi-value filters with and

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
@@ -40,6 +40,14 @@ describe('FormattedQuery', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders negated filters with multiple values using and', () => {
+    render(<FormattedQuery {...defaultProps} query="!browser.name:[Firefox,Chrome]" />);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher('browser.name is not Firefox and Chrome'))
+    ).toBeInTheDocument();
+  });
+
   it('renders "is" filter correctly', () => {
     render(<FormattedQuery {...defaultProps} query="is:unresolved" />);
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2638,6 +2638,24 @@ describe('SearchQueryBuilder', () => {
         expect(within(valueButton).getAllByText('or')).toHaveLength(2);
       });
 
+      it('renders and between negated multi-value filters', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="!browser.name:[one,two,three]"
+          />
+        );
+
+        const valueButton = await screen.findByRole('button', {
+          name: 'Edit value for filter: browser.name',
+        });
+        expect(within(valueButton).getByText('one')).toBeInTheDocument();
+        expect(within(valueButton).getByText('two')).toBeInTheDocument();
+        expect(within(valueButton).getByText('three')).toBeInTheDocument();
+        expect(within(valueButton).getAllByText('and')).toHaveLength(2);
+        expect(within(valueButton).queryByText('or')).not.toBeInTheDocument();
+      });
+
       it('moves selected values to the top when opening a predefined multi-select', async () => {
         render(
           <SearchQueryBuilder

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -64,6 +64,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
     case Token.VALUE_TEXT_LIST:
     case Token.VALUE_NUMBER_LIST: {
       const items = token.value.items;
+      const multiValueJoiner = token.negated ? 'and' : 'or';
 
       if (items.length === 1 && items[0]!.value) {
         return (
@@ -83,7 +84,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
                 {formatFilterValue({token: item.value!})}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
-                <FilterValueOr> or </FilterValueOr>
+                <FilterValueJoiner> {multiValueJoiner} </FilterValueJoiner>
               ) : null}
             </Fragment>
           ))}
@@ -334,7 +335,7 @@ const DeleteButton = styled(UnstyledButton)`
   }
 `;
 
-const FilterValueOr = styled('span')`
+const FilterValueJoiner = styled('span')`
   color: ${p => p.theme.tokens.content.secondary};
 `;
 


### PR DESCRIPTION
Render negated multi-value filters with an `and` joiner in the shared search UI renderer, so that we correctly follow [De Morgan's laws](https://en.wikipedia.org/wiki/De_Morgan's_laws) (thanks @wmak)



Refs EXP-784 and https://github.com/getsentry/sentry/issues/108195

Made with [Cursor](https://cursor.com)