### PR TITLE
fix(forms): Reset form after successful mutation for forms that stay on page

### DIFF
--- a/.agents/skills/generate-frontend-forms/SKILL.md
+++ b/.agents/skills/generate-frontend-forms/SKILL.md
@@ -732,6 +732,20 @@ function MyForm() {
 }
 ```
 
+### Resetting After Save
+
+When a form stays on the page after submission (e.g., settings pages), call `form.reset()` after a successful mutation. This re-syncs the form with updated `defaultValues` so it becomes pristine again — any UI that depends on the form being dirty (like conditionally shown Save/Cancel buttons) will update correctly.
+
+```tsx
+onSubmit: ({value}) =>
+  mutation
+    .mutateAsync(value)
+    .then(() => form.reset())
+    .catch(() => {}),
+```
+
+> **Note**: `AutoSaveForm` handles this automatically. You only need to add this when using `useScrapsForm`.
+
 ### Submit Button
 
 ```tsx
@@ -828,7 +842,11 @@ onSubmit: ({value}) => {
   // Return the promise to keep form.isSubmitting working
   // Add .catch(() => {}) to avoid unhandled rejection - error handling
   // is done by TanStack Query (onError callback, mutation.isError state)
-  return mutation.mutateAsync(value).catch(() => {});
+  // Add .then(() => form.reset()) if the form stays on the page after save
+  return mutation
+    .mutateAsync(value)
+    .then(() => form.reset())
+    .catch(() => {});
 };
 ```
 
@@ -915,6 +933,23 @@ const opts = mutationOptions({
 
 Make sure the zod schema's types are compatible with the API type. For example, if the API expects a string union like `'off' | 'low' | 'high'`, use `z.enum(['off', 'low', 'high'])` instead of `z.string()`.
 
+### Form Reset After Save
+
+```tsx
+// ❌ Don't forget to reset forms that stay on the page after save
+onSubmit: ({value}) => {
+  return mutation.mutateAsync(value).catch(() => {});
+};
+
+// ✅ Call form.reset() after successful save to sync with updated defaultValues
+onSubmit: ({value}) => {
+  return mutation
+    .mutateAsync(value)
+    .then(() => form.reset())
+    .catch(() => {});
+};
+```
+
 ### Layout Choice
 
 ```tsx
@@ -941,6 +976,7 @@ When creating a new form:
 - [ ] Choose appropriate layout (Stack or Row)
 - [ ] Handle server errors with `setFieldErrors`
 - [ ] Add `<form.SubmitButton>` for submission
+- [ ] Call `form.reset()` after successful mutation if the form stays on the page
 
 When creating auto-save fields:
 

--- a/.agents/skills/migrate-frontend-forms/SKILL.md
+++ b/.agents/skills/migrate-frontend-forms/SKILL.md
@@ -9,22 +9,23 @@ This skill helps migrate forms from Sentry's legacy form system (JsonForm, FormM
 
 ## Feature Mapping
 
-| Old System           | New System          | Notes                                        |
-| -------------------- | ------------------- | -------------------------------------------- |
-| `saveOnBlur: true`   | `AutoSaveForm`      | Default behavior                             |
-| `confirm`            | `confirm` prop      | `string \| ((value) => string \| undefined)` |
-| `showHelpInTooltip`  | `variant="compact"` | On layout components                         |
-| `disabledReason`     | `disabled="reason"` | String shows tooltip                         |
-| `extraHelp`          | JSX in layout       | Render `<Text>` below field                  |
-| `getData`            | `mutationFn`        | Transform data in mutation function          |
-| `mapFormErrors`      | `setFieldErrors`    | Transform API errors in catch block          |
-| `saveMessage`        | `onSuccess`         | Show toast in mutation onSuccess callback    |
-| `formatMessageValue` | `onSuccess`         | Control toast content in onSuccess callback  |
-| `resetOnError`       | `onError`           | Call form.reset() in mutation onError        |
-| `saveOnBlur: false`  | `useScrapsForm`     | Use regular form with explicit Save button   |
-| `help`               | `hintText`          | On layout components                         |
-| `label`              | `label`             | On layout components                         |
-| `required`           | `required`          | On layout + Zod schema                       |
+| Old System           | New System          | Notes                                                |
+| -------------------- | ------------------- | ---------------------------------------------------- |
+| `saveOnBlur: true`   | `AutoSaveForm`      | Default behavior                                     |
+| `confirm`            | `confirm` prop      | `string \| ((value) => string \| undefined)`         |
+| `showHelpInTooltip`  | `variant="compact"` | On layout components                                 |
+| `disabledReason`     | `disabled="reason"` | String shows tooltip                                 |
+| `extraHelp`          | JSX in layout       | Render `<Text>` below field                          |
+| `getData`            | `mutationFn`        | Transform data in mutation function                  |
+| `mapFormErrors`      | `setFieldErrors`    | Transform API errors in catch block                  |
+| `saveMessage`        | `onSuccess`         | Show toast in mutation onSuccess callback            |
+| `formatMessageValue` | `onSuccess`         | Control toast content in onSuccess callback          |
+| `resetOnError`       | `onError`           | Call form.reset() in mutation onError                |
+| `saveOnBlur: false`  | `useScrapsForm`     | Use regular form with explicit Save button           |
+| (automatic)          | `form.reset()`      | Call after successful mutation if form stays on page |
+| `help`               | `hintText`          | On layout components                                 |
+| `label`              | `label`             | On layout components                                 |
+| `required`           | `required`          | On layout + Zod schema                               |
 
 ## Feature Details
 
@@ -410,6 +411,20 @@ const form = useScrapsForm({
 
 > **Note**: AutoSaveForm with TanStack Query already handles error states gracefully - the mutation's `isError` state is reflected in the UI. Manual reset is typically only needed for specific UX requirements like password fields.
 
+### Resetting After Save
+
+When using `useScrapsForm` for a form that stays on the page after save, call `form.reset()` after a successful mutation. This re-syncs the form with updated `defaultValues` so it becomes pristine again — any UI that depends on the form being dirty (like conditionally shown Save/Cancel buttons) will update correctly.
+
+```tsx
+onSubmit: ({value}) =>
+  mutation
+    .mutateAsync(value)
+    .then(() => form.reset())
+    .catch(() => {}),
+```
+
+> **Note**: `AutoSaveForm` handles this automatically. You only need to add this when using `useScrapsForm`.
+
 ### saveOnBlur: false → `useScrapsForm`
 
 Fields with `saveOnBlur: false` showed an inline alert with Save/Cancel buttons instead of auto-saving. This was used for dangerous operations (slug changes) or large text edits (fingerprint rules).
@@ -597,6 +612,7 @@ This pattern is necessary whenever a required field has no meaningful initial va
 - [ ] Handle `mapFormErrors` with setFieldErrors in catch
 - [ ] Handle `saveMessage` in onSuccess callback
 - [ ] Convert `saveOnBlur: false` fields to regular forms with Save button
+- [ ] Call `form.reset()` after successful mutation (for forms that stay on page)
 - [ ] Verify `onSuccess` cache updates merge with existing data (use updater function) — some API endpoints may return partial objects
 - [ ] Wrap the migrated form with `<FormSearch route="...">` if the old form was searchable in SettingsSearch
 - [ ] Run `pnpm run extract-form-fields` and commit the updated `generatedFieldRegistry.ts`

--- a/static/app/components/backendJsonFormAdapter/projectMapperAdapter.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/projectMapperAdapter.spec.tsx
@@ -266,15 +266,17 @@ describe('ProjectMapperAdapter', () => {
       expect(pendingMutationOptions.mutationFn).toHaveBeenCalled();
     });
 
-    // Remaining delete button should be disabled during mutation
-    expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
+    // Delete buttons should be disabled during mutation
+    const disabledButtons = screen.getAllByRole('button', {name: 'Delete'});
+    expect(disabledButtons.every(btn => btn.hasAttribute('disabled'))).toBe(true);
 
     // Resolve the mutation
     resolveMutation();
 
-    // Controls should be re-enabled
+    // Controls should be re-enabled after mutation resolves
     await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Delete'})).toBeEnabled();
+      const enabledButtons = screen.getAllByRole('button', {name: 'Delete'});
+      expect(enabledButtons.some(btn => !btn.hasAttribute('disabled'))).toBe(true);
     });
   });
 });

--- a/static/app/components/core/form/__stories__/formDemos.tsx
+++ b/static/app/components/core/form/__stories__/formDemos.tsx
@@ -267,7 +267,9 @@ export function BasicAutoSaveDemo() {
       await sleep(1000);
       return data;
     },
-    onSuccess: setServerState,
+    onSuccess: data => {
+      setServerState({displayName: data.displayName.toUpperCase()});
+    },
   });
 
   return (

--- a/static/app/components/core/form/autoSaveForm.spec.tsx
+++ b/static/app/components/core/form/autoSaveForm.spec.tsx
@@ -1,5 +1,8 @@
+import {useState} from 'react';
 import {expectTypeOf} from 'expect-type';
 import {z} from 'zod';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {AutoSaveForm} from '@sentry/scraps/form';
 
@@ -43,6 +46,52 @@ describe('AutoSaveForm', () => {
         );
       }
       void TypeTestField;
+    });
+  });
+
+  describe('reset after save', () => {
+    it('shows server-transformed value after successful save', async () => {
+      // Simulates a server that uppercases the value
+      function TestComponent() {
+        const [serverState, setServerState] = useState('initial');
+
+        return (
+          <AutoSaveForm
+            name="testField"
+            schema={testSchema}
+            initialValue={serverState}
+            mutationOptions={{
+              mutationFn: (data: {testField: string}) => {
+                return Promise.resolve({testField: data.testField.toUpperCase()});
+              },
+              onSuccess: data => {
+                setServerState(data.testField);
+              },
+            }}
+          >
+            {field => (
+              <field.Layout.Row label="Name">
+                <field.Input value={field.state.value} onChange={field.handleChange} />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+        );
+      }
+
+      render(<TestComponent />);
+
+      const input = screen.getByRole('textbox', {name: 'Name'});
+      expect(input).toHaveValue('initial');
+
+      // Type a lowercase value and blur to trigger auto-save
+      await userEvent.clear(input);
+      await userEvent.type(input, 'hello');
+      await userEvent.tab();
+
+      // After save, the form should reset and show the server's uppercased value
+      await waitFor(() => {
+        expect(input).toHaveValue('HELLO');
+      });
     });
   });
 });

--- a/static/app/components/core/form/autoSaveForm.tsx
+++ b/static/app/components/core/form/autoSaveForm.tsx
@@ -199,6 +199,10 @@ export function AutoSaveForm<
         setFieldErrors(formApi, {[name]: {message: t('Failed to save')}} as never);
       };
 
+      const onSuccess = () => {
+        formApi.reset();
+      };
+
       const fieldValue = value[name];
 
       // Determine confirmation message
@@ -215,7 +219,9 @@ export function AutoSaveForm<
               pendingConfirmRef.current = false;
               // Resolve on both success and failure - error handling is done by
               // TanStack Query (onError callback, mutation.isError state)
-              mutation.mutateAsync(value, {onError}).then(() => resolve(), resolve);
+              mutation.mutateAsync(value, {onError, onSuccess}).then(() => {
+                resolve();
+              }, resolve);
             },
             onClose: () => {
               // onClose is always called, even after confirming,
@@ -233,7 +239,7 @@ export function AutoSaveForm<
 
       // Resolve on both success and failure - error handling is done by
       // TanStack Query (onError callback, mutation.isError state)
-      return mutation.mutateAsync(value, {onError}).catch(() => {});
+      return mutation.mutateAsync(value, {onError, onSuccess}).catch(() => {});
     },
   });
 

--- a/static/app/components/core/form/field/switchField.spec.tsx
+++ b/static/app/components/core/form/field/switchField.spec.tsx
@@ -188,23 +188,24 @@ describe('SwitchField auto-save', () => {
     });
   });
 
-  it('does not trigger mutation when toggling back to initial value', async () => {
+  it('triggers mutation on every toggle because form resets after each save', async () => {
     const mutationFn = jest.fn((data: {enabled: boolean}) => Promise.resolve(data));
 
     render(<AutoSaveTestForm mutationFn={mutationFn} initialValue={false} />);
 
     const checkbox = screen.getByRole('checkbox');
-    // Toggle on then off - ends up at initial value
-    await userEvent.click(checkbox);
-    // First click triggers mutation
-    expect(mutationFn).toHaveBeenCalledTimes(1);
 
-    // Clear mock to check next behavior
+    // First click: OFF → ON, triggers mutation
+    await userEvent.click(checkbox);
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+    expect(mutationFn).toHaveBeenCalledWith({enabled: true});
+
+    // After save succeeds, form.reset() resets to initialValue (false/OFF).
+    // Second click: OFF → ON again, triggers another mutation.
     mutationFn.mockClear();
     await userEvent.click(checkbox);
-
-    // Second click back to initial value should not trigger mutation
-    expect(mutationFn).not.toHaveBeenCalled();
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+    expect(mutationFn).toHaveBeenCalledWith({enabled: true});
   });
 
   it('does not hang when mutation fails', async () => {

--- a/static/app/components/core/form/form.mdx
+++ b/static/app/components/core/form/form.mdx
@@ -355,6 +355,23 @@ function MyForm() {
 
 `SubmitButton` automatically disables while submission is pending and triggers form validation before submitting.
 
+## Resetting After Save
+
+When a form stays on the page after submission (e.g., settings pages), call `form.reset()` after a successful mutation. This is necessary because `defaultValues` are reactive — when the mutation updates the cache or store, `defaultValues` update too. But if the form is dirty, the updated defaults won't be reflected in the UI until you reset.
+
+```jsx
+onSubmit: ({value}) =>
+  mutation
+    .mutateAsync(value)
+    .then(() => form.reset())
+    .catch(() => {}),
+```
+
+After `form.reset()`, the form re-syncs with the (now-updated) `defaultValues`, becoming pristine again. This means any UI that depends on the form being dirty (like conditionally shown Save/Cancel buttons or unsaved-changes warnings) will update correctly.
+
+> [!NOTE]
+> `AutoSaveForm` handles this automatically — it calls `form.reset()` after every successful save. You only need to add this manually when using `useScrapsForm`.
+
 ## Nullable Default Values
 
 When a required field has no meaningful initial value (e.g., a select that starts empty), use `.nullable().refine()` in the schema. This creates a difference between the schema's input type (accepts `null`) and output type (does not). Type `defaultValues` with `z.input<typeof schema>` and call `schema.parse(value)` in `onSubmit` to narrow the type.

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -218,8 +218,6 @@ describe('OrganizationSettingsForm', () => {
         })
       );
     });
-
-    expect(checkbox).toBeChecked();
   });
 
   it('can disable "Show Generative AI Features"', async () => {
@@ -251,8 +249,6 @@ describe('OrganizationSettingsForm', () => {
         expect.objectContaining({data: {hideAiFeatures: true}})
       );
     });
-
-    expect(checkbox).not.toBeChecked();
   });
 
   it('shows hideAiFeatures toggle for DE region', () => {

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -125,6 +125,37 @@ describe('OrganizationSettingsForm', () => {
     );
   });
 
+  it('hides Save/Cancel after successful slug change', async () => {
+    putMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      method: 'PUT',
+      body: {...organization, slug: 'new-slug'},
+    });
+
+    render(
+      <OrganizationSettingsForm initialData={OrganizationFixture()} onSave={onSave} />
+    );
+
+    const input = screen.getByRole('textbox', {name: 'Organization Slug'});
+    await userEvent.clear(input);
+    await userEvent.type(input, 'new-slug');
+
+    expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalled();
+    });
+
+    // After successful save, form.reset() syncs defaults so the form is pristine again
+    await waitFor(() => {
+      expect(screen.queryByRole('button', {name: 'Save'})).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument();
+  });
+
   it('can enable codecov', async () => {
     putMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -437,7 +437,10 @@ export function OrganizationSettingsForm({initialData, onSave}: Props) {
     ...defaultFormOptions,
     defaultValues: {slug: initialData.slug},
     validators: {onDynamic: slugSchema},
-    onSubmit: ({value}) => updateSlug({slug: value.slug}).catch(() => {}),
+    onSubmit: ({value}) =>
+      updateSlug({slug: value.slug})
+        .then(() => slugForm.reset())
+        .catch(() => {}),
   });
 
   return (

--- a/static/app/views/settings/organizationSecurityAndPrivacy/index.spec.tsx
+++ b/static/app/views/settings/organizationSecurityAndPrivacy/index.spec.tsx
@@ -122,6 +122,48 @@ describe('OrganizationSecurityAndPrivacy', () => {
     expect(mock).not.toHaveBeenCalled();
   });
 
+  it('resets form to pristine after successful scrubbing config save', async () => {
+    const mock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      method: 'PUT',
+      body: {
+        ...organization,
+        sensitiveFields: ['email'],
+        safeFields: [],
+      },
+    });
+
+    render(<OrganizationSecurityAndPrivacy />);
+
+    const sensitiveFieldsInput = await screen.findByRole('textbox', {
+      name: 'Global Sensitive Fields',
+    });
+    await userEvent.type(sensitiveFieldsInput, 'email');
+
+    // The changes alert should be visible after typing
+    expect(
+      screen.getByText(
+        'Changes to your scrubbing configuration will apply to all new events.'
+      )
+    ).toBeVisible();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalled();
+    });
+
+    // After successful save, form.reset() syncs defaults so the form is pristine again
+    // The changes alert should become hidden
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Changes to your scrubbing configuration will apply to all new events.'
+        )
+      ).not.toBeVisible();
+    });
+  });
+
   it('enables require2fa with confirm modal', async () => {
     const mock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,

--- a/static/app/views/settings/organizationSecurityAndPrivacy/index.spec.tsx
+++ b/static/app/views/settings/organizationSecurityAndPrivacy/index.spec.tsx
@@ -197,11 +197,5 @@ describe('OrganizationSecurityAndPrivacy', () => {
         })
       );
     });
-
-    expect(
-      screen.getByRole('checkbox', {
-        name: 'Enable to require and enforce two-factor authentication for all members',
-      })
-    ).toBeChecked();
   });
 });

--- a/static/app/views/settings/organizationSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/organizationSecurityAndPrivacy/index.tsx
@@ -416,6 +416,7 @@ function ScrubbingConfigurationFieldGroup({hasOrgWrite}: {hasOrgWrite: boolean})
           safeFields: extractMultilineFields(value.safeFields),
         })
         .then(() => {
+          scrubbingConfiguration.reset();
           addSuccessMessage(t('Scrubbing configuration updated'));
         })
         .catch(() => {


### PR DESCRIPTION
for forms where we stay on the same page (no modals that close, no redirects), we should reset the form after the source of `defaultValues` (usually a query or a store) has been updated.

while the defaultValues are reactive by themselves, they only get applied if the form is `pristine`. That means the `value` won’t change. Now that might not be a problem if the server returns the same values, but if it doesn’t, we’d want to see the server values here.

I’ve simulated this in the story where the mutation returns the input as `toUpperCase()`, so that we can see what’s happening.

This also means if you only make a mutation and forget to update the query, or if you don’t return the invalidation from the mutation, the values will “flicker” back to the old initial state. This is intended because it serves as a reminder that the corresponding query / store needs to be updated.

For AutoSaveForms, we’re doing this internally.

Note: The reset is timing sensitive. If it happens too early, there will be a flash of old initialData briefly. That’s why this PR is dependent upon:

- https://github.com/getsentry/sentry/pull/111187