### PR TITLE
ref(seer): Add title prop to ScmRepoTreeModal to help guide users when intent changes

### DIFF
--- a/static/app/components/repositories/scmRepoTreeModal.tsx
+++ b/static/app/components/repositories/scmRepoTreeModal.tsx
@@ -8,16 +8,20 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {ScmIntegrationTree} from 'sentry/components/repositories/scmIntegrationTree/scmIntegrationTree';
 import {ScmTreeFilters} from 'sentry/components/repositories/scmIntegrationTree/scmTreeFilters';
 import type {RepoFilter} from 'sentry/components/repositories/scmIntegrationTree/types';
-import {t, tct} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 
-export function ScmRepoTreeModal({Header, Body}: ModalRenderProps) {
+interface Props extends ModalRenderProps {
+  title: string;
+}
+
+export function ScmRepoTreeModal({Header, Body, title}: Props) {
   const [search, setSearch] = useState('');
   const [repoFilter, setRepoFilter] = useState<RepoFilter>('all');
 
   return (
     <Fragment>
       <Header closeButton>
-        <Heading as="h4">{t('Add Repository')}</Heading>
+        <Heading as="h4">{title}</Heading>
       </Header>
       <Body>
         <Stack gap="2xl">

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -158,14 +158,17 @@ export function SeerRepoTable() {
           priority="primary"
           icon={<IconAdd />}
           onClick={() => {
-            openModal(deps => <ScmRepoTreeModal {...deps} />, {
-              modalCss: css`
-                width: 700px;
-              `,
-              onClose: () => {
-                queryClient.invalidateQueries({queryKey: queryOptions.queryKey});
-              },
-            });
+            openModal(
+              deps => <ScmRepoTreeModal {...deps} title={t('Add Repository')} />,
+              {
+                modalCss: css`
+                  width: 700px;
+                `,
+                onClose: () => {
+                  queryClient.invalidateQueries({queryKey: queryOptions.queryKey});
+                },
+              }
+            );
           }}
         >
           {t('Add Repository')}


### PR DESCRIPTION
This modal could be used for a few reasons: To prompt users to connect their providers, or to connect exposed repos from a previously connected provider.

By making the title a prop we can remind the user what their job is in a context-specific way.