### PR TITLE
test(metrics): Add fallback events mock for sidebar toggle test

### DIFF
--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -614,6 +614,14 @@ describe('MetricsTabContent (tracemetrics-ui-refresh)', () => {
 
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
     setupTraceItemsMock(metricFixtures.detailedFixtures);
+    // Fallback for background /events/ queries from the refreshed panel that this
+    // sidebar toggle test doesn't assert on directly.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [], meta: {fields: {}, units: {}, dataScanned: 'full'}},
+    });
+
     setupEventsMock(metricFixtures.detailedFixtures, [
       MockApiClient.matchQuery({
         dataset: 'tracemetrics',


### PR DESCRIPTION
Add a fallback `/events/` mock to the refreshed metrics tab sidebar toggle test.

The refreshed metrics panel can issue background events queries while this test is only trying to assert the collapse and expand behavior. Without a generic fallback response, those unrelated requests bubble up through the mocked API client and fail the spec via the console-error guard.

I considered tightening this to the exact background referrer, but the current test does not care which secondary panel request fires. A low-priority fallback keeps the test focused on the sidebar interaction while preserving the more specific mocks used by the rest of the suite.

Made with [Cursor](https://cursor.com)