### PR TITLE
ref(cells): remove support for `region_name` in ByCellName resolver

### DIFF
--- a/src/sentry/hybridcloud/rpc/resolvers.py
+++ b/src/sentry/hybridcloud/rpc/resolvers.py
@@ -37,17 +37,14 @@ class CellResolutionStrategy(ABC):
 
 @dataclass(frozen=True)
 class ByCellName(CellResolutionStrategy):
-    """Resolve from a `str` parameter representing a cell's name.
-
-    Accepts either ``cell_name`` or ``region_name`` to ease the migration of
-    service method parameters from the old name to the new one.
+    """
+    Resolve from a `str` parameter representing a cell's name.
     """
 
     parameter_name: str = "cell_name"
 
     def resolve(self, arguments: ArgumentDict) -> Cell:
-        # TODO(cells): Temporary fall back to "region_name" while service methods are being migrated.
-        cell_name = arguments.get("region_name") or arguments[self.parameter_name]
+        cell_name = arguments[self.parameter_name]
         return get_cell_by_name(cell_name)
 
 

--- a/tests/sentry/hybridcloud/test_cell.py
+++ b/tests/sentry/hybridcloud/test_cell.py
@@ -29,17 +29,8 @@ class CellResolutionTest(TestCase):
 
     def test_by_cell_name(self) -> None:
         resolver = ByCellName()
-        # Primary path: callers using the new cell_name parameter
         assert resolver.resolve({"cell_name": self.target_cell.name}) == self.target_cell
-        # Fallback: callers still using the old region_name parameter
-        assert resolver.resolve({"region_name": self.target_cell.name}) == self.target_cell
-        # When both are present, region_name takes precedence over cell_name
-        other_cell = _TEST_CELLS[1]
-        assert (
-            resolver.resolve({"cell_name": other_cell.name, "region_name": self.target_cell.name})
-            == self.target_cell
-        )
-        # When neither is passed, raise KeyError
+        # When no cell_name is passed, raise KeyError
         with pytest.raises(KeyError):
             resolver.resolve({})
 


### PR DESCRIPTION
all cell rpc methods that use the ByCellName resolver have been migrated to cell_name. We can drop support for region_name now.
