### PR TITLE
fix(insights): Right-align perf score empty state in transactions table

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -928,7 +928,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
     renderFunc: data => {
       const score = data['performance_score(measurements.score.total)'];
       if (typeof score !== 'number') {
-        return <Container>{emptyValue}</Container>;
+        return <RightAlignedContainer>{emptyValue}</RightAlignedContainer>;
       }
       return (
         <RightAlignedContainer>


### PR DESCRIPTION
**Before:**
<img width="308" height="157" alt="Screenshot 2026-03-20 at 11 15 56 AM" src="https://github.com/user-attachments/assets/41ff0ac1-dc37-4547-bcf9-eae8aad22884" />

**After:**
<img width="189" height="150" alt="Screenshot 2026-03-20 at 1 58 01 PM" src="https://github.com/user-attachments/assets/ad7bddd2-f856-4339-a40e-5612f3e287de" />

Fixes DAIN-1382