### PR TITLE
fix(search): clarify is:linked/is:unlinked filter descriptions

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -426,8 +426,8 @@ const IsFieldDescriptions: Record<IsFieldValues, string> = {
   [IsFieldValues.ASSIGNED]: t('Issues assigned to a team member'),
   [IsFieldValues.UNASSIGNED]: t('Issues not assigned to anyone'),
   [IsFieldValues.FOR_REVIEW]: t('Issues pending review'),
-  [IsFieldValues.LINKED]: t('Issues linked to other issues'),
-  [IsFieldValues.UNLINKED]: t('Issues not linked to other issues'),
+  [IsFieldValues.LINKED]: t('Issues linked via an integration'),
+  [IsFieldValues.UNLINKED]: t('Issues not linked via an integration'),
 };
 
 export function getIsFieldDescriptionFromValue(


### PR DESCRIPTION
These filters are a bit ambiguous — they don't filter for issues that are 'linked' to other issues (we don't have any linking between issues), these refer to issues linked to external integration tickets.