### PR TITLE
chore(autofix): Update autofix on explorer analytics

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -529,9 +529,11 @@ function AutofixRootCauseDisplay({
 
     setSolutionText('');
 
-    trackAnalytics('autofix.coding_agent.launch_from_root_cause', {
+    trackAnalytics('autofix.coding_agent.launch', {
       organization,
       group_id: groupId,
+      step: 'root_cause',
+      provider: integration.provider,
     });
     trackAnalytics('coding_integration.send_to_agent_clicked', {
       organization,

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -21,14 +21,16 @@ import {
 } from 'sentry/components/events/autofix/v3/autofixCards';
 import {SeerDrawerNextStep} from 'sentry/components/events/autofix/v3/nextStep';
 import {Placeholder} from 'sentry/components/placeholder';
+import type {Group} from 'sentry/types/group';
 import type {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 
 interface SeerDrawerContentProps {
   aiConfig: ReturnType<typeof useAiConfig>;
   autofix: ReturnType<typeof useExplorerAutofix>;
+  group: Group;
 }
 
-export function SeerDrawerContent({aiConfig, autofix}: SeerDrawerContentProps) {
+export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentProps) {
   const sections = useMemo(
     () => getOrderedAutofixSections(autofix.runState),
     [autofix.runState]
@@ -55,7 +57,7 @@ export function SeerDrawerContent({aiConfig, autofix}: SeerDrawerContentProps) {
     <Flex direction="column" gap="lg">
       <SeerDrawerArtifacts autofix={autofix} sections={sections} />
       {autofix.runState?.status === 'completed' && (
-        <SeerDrawerNextStep autofix={autofix} sections={sections} />
+        <SeerDrawerNextStep group={group} autofix={autofix} sections={sections} />
       )}
     </Flex>
   );

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -119,7 +119,7 @@ function InnerSeerDrawer({
     return <SeerWelcomeScreen group={group} project={project} event={event} />;
   }
 
-  return <SeerDrawerContent autofix={aiAutofix} aiConfig={aiConfig} />;
+  return <SeerDrawerContent group={group} autofix={aiAutofix} aiConfig={aiConfig} />;
 }
 
 function useHandleCopyMarkdown({

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -1,3 +1,5 @@
+import {GroupFixture} from 'sentry-fixture/group';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
@@ -20,6 +22,7 @@ function makeAutofix(
     reset: jest.fn(),
     triggerCodingAgentHandoff: jest.fn(),
     isLoading: false,
+    isPolling: false,
     isReady: true,
     isStreaming: false,
     ...overrides,
@@ -97,13 +100,17 @@ function makeSection(
 describe('SeerDrawerNextStep', () => {
   it('returns null when no runId', () => {
     const autofix = makeAutofix({runState: null});
-    const {container} = render(<SeerDrawerNextStep sections={[]} autofix={autofix} />);
+    const {container} = render(
+      <SeerDrawerNextStep group={GroupFixture()} sections={[]} autofix={autofix} />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
   it('returns null when sections are empty', () => {
     const autofix = makeAutofix();
-    const {container} = render(<SeerDrawerNextStep sections={[]} autofix={autofix} />);
+    const {container} = render(
+      <SeerDrawerNextStep group={GroupFixture()} sections={[]} autofix={autofix} />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -129,7 +136,11 @@ describe('SeerDrawerNextStep', () => {
     it('renders prompt and yes button', () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('root_cause')]}
+          autofix={autofix}
+        />
       );
       expect(screen.getByText('Are you happy with this root cause?')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'No'})).toBeInTheDocument();
@@ -141,7 +152,11 @@ describe('SeerDrawerNextStep', () => {
     it('calls startStep with solution on yes click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('root_cause')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(
         screen.getByRole('button', {name: 'Yes, make an implementation plan'})
@@ -152,7 +167,11 @@ describe('SeerDrawerNextStep', () => {
     it('shows feedback UI on no click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('root_cause')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -167,7 +186,11 @@ describe('SeerDrawerNextStep', () => {
     it('calls startStep with root_cause and feedback on rethink click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('root_cause')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       await userEvent.type(screen.getByRole('textbox'), 'Try a different approach');
@@ -182,7 +205,11 @@ describe('SeerDrawerNextStep', () => {
     it('proceeds like yes on nevermind click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('root_cause')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       await userEvent.click(
@@ -202,7 +229,11 @@ describe('SeerDrawerNextStep', () => {
       });
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('root_cause')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('root_cause')]}
+          autofix={autofix}
+        />
       );
       expect(
         await screen.findByRole('button', {name: 'More code fix options'})
@@ -220,7 +251,11 @@ describe('SeerDrawerNextStep', () => {
     it('returns null when section has no artifacts', () => {
       const autofix = makeAutofix();
       const {container} = render(
-        <SeerDrawerNextStep sections={[makeSection('solution', [])]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('solution', [])]}
+          autofix={autofix}
+        />
       );
       expect(container).toBeEmptyDOMElement();
     });
@@ -228,7 +263,11 @@ describe('SeerDrawerNextStep', () => {
     it('renders prompt and yes button', () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('solution')]}
+          autofix={autofix}
+        />
       );
       expect(
         screen.getByText('Are you happy with this implementation plan?')
@@ -242,7 +281,11 @@ describe('SeerDrawerNextStep', () => {
     it('calls startStep with code_changes on yes click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('solution')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'Yes, write a code fix'}));
       expect(autofix.startStep).toHaveBeenCalledWith('code_changes', 1);
@@ -251,7 +294,11 @@ describe('SeerDrawerNextStep', () => {
     it('shows feedback UI on no click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('solution')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -266,7 +313,11 @@ describe('SeerDrawerNextStep', () => {
     it('calls startStep with solution and feedback on rethink click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('solution')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       await userEvent.type(screen.getByRole('textbox'), 'Consider edge cases');
@@ -283,7 +334,11 @@ describe('SeerDrawerNextStep', () => {
     it('proceeds like yes on nevermind click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('solution')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       await userEvent.click(
@@ -303,7 +358,11 @@ describe('SeerDrawerNextStep', () => {
       });
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('solution')]}
+          autofix={autofix}
+        />
       );
       expect(
         await screen.findByRole('button', {name: 'More code fix options'})
@@ -321,7 +380,11 @@ describe('SeerDrawerNextStep', () => {
       });
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('solution')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('solution')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(
         await screen.findByRole('button', {name: 'More code fix options'})
@@ -351,7 +414,11 @@ describe('SeerDrawerNextStep', () => {
     it('renders prompt and yes button', () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={autofix}
+        />
       );
       expect(
         screen.getByText('Are you happy with these code changes?')
@@ -363,7 +430,11 @@ describe('SeerDrawerNextStep', () => {
     it('calls createPR on yes click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'Yes, draft a PR'}));
       expect(autofix.createPR).toHaveBeenCalledWith(1);
@@ -372,7 +443,11 @@ describe('SeerDrawerNextStep', () => {
     it('shows feedback UI on no click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -387,7 +462,11 @@ describe('SeerDrawerNextStep', () => {
     it('calls startStep with code_changes and feedback on rethink click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       await userEvent.type(screen.getByRole('textbox'), 'Fix the error handling');
@@ -402,7 +481,11 @@ describe('SeerDrawerNextStep', () => {
     it('proceeds like yes on nevermind click', async () => {
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={autofix}
+        />
       );
       await userEvent.click(screen.getByRole('button', {name: 'No'}));
       await userEvent.click(screen.getByRole('button', {name: 'Nevermind, draft a PR'}));
@@ -420,7 +503,11 @@ describe('SeerDrawerNextStep', () => {
       });
       const autofix = makeAutofix();
       render(
-        <SeerDrawerNextStep sections={[makeSection('code_changes')]} autofix={autofix} />
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={autofix}
+        />
       );
       expect(
         screen.queryByRole('button', {name: 'More code fix options'})

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -126,6 +126,7 @@ describe('SeerDrawerNextStep', () => {
       const autofix = makeAutofix();
       const {container} = render(
         <SeerDrawerNextStep
+          group={GroupFixture()}
           sections={[makeSection('root_cause', [])]}
           autofix={autofix}
         />
@@ -404,6 +405,7 @@ describe('SeerDrawerNextStep', () => {
       const autofix = makeAutofix();
       const {container} = render(
         <SeerDrawerNextStep
+          group={GroupFixture()}
           sections={[makeSection('code_changes', [])]}
           autofix={autofix}
         />

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -157,6 +157,7 @@ function SolutionNextStep({autofix, group, runId, section, referrer}: NextStepPr
     runId,
     group,
     step: 'solution',
+    referrer,
   });
 
   const handleYesClick = useCallback(() => {
@@ -371,9 +372,9 @@ function NextStepTemplate({
 interface UseCodingAgentsOptions {
   autofix: ReturnType<typeof useExplorerAutofix>;
   group: Group;
+  referrer: string | undefined;
   runId: number;
   step: 'root_cause' | 'solution';
-  referrer?: string;
 }
 
 function useCodingAgents({

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -21,33 +21,61 @@ import {
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+import type {Group} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface SeerDrawerNextStepProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
+  group: Group;
   sections: AutofixSection[];
 }
 
-export function SeerDrawerNextStep({sections, autofix}: SeerDrawerNextStepProps) {
+export function SeerDrawerNextStep({sections, group, autofix}: SeerDrawerNextStepProps) {
   const runId = autofix.runState?.run_id;
   const section = sections[sections.length - 1];
+  const referrer = autofix.runState?.blocks?.[0]?.message?.metadata?.referrer;
 
   if (!defined(runId) || !defined(section)) {
     return null;
   }
 
   if (isRootCauseSection(section)) {
-    return <RootCauseNextStep autofix={autofix} runId={runId} section={section} />;
+    return (
+      <RootCauseNextStep
+        group={group}
+        autofix={autofix}
+        runId={runId}
+        section={section}
+        referrer={referrer}
+      />
+    );
   }
 
   if (isSolutionSection(section)) {
-    return <SolutionNextStep autofix={autofix} runId={runId} section={section} />;
+    return (
+      <SolutionNextStep
+        group={group}
+        autofix={autofix}
+        runId={runId}
+        section={section}
+        referrer={referrer}
+      />
+    );
   }
 
   if (isCodeChangesSection(section)) {
-    return <CodeChangesNextStep autofix={autofix} runId={runId} section={section} />;
+    return (
+      <CodeChangesNextStep
+        group={group}
+        autofix={autofix}
+        runId={runId}
+        section={section}
+        referrer={referrer}
+      />
+    );
   }
 
   return null;
@@ -55,27 +83,45 @@ export function SeerDrawerNextStep({sections, autofix}: SeerDrawerNextStepProps)
 
 interface NextStepProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
+  group: Group;
   runId: number;
   section: AutofixSection;
+  referrer?: string;
 }
 
-function RootCauseNextStep({autofix, runId, section}: NextStepProps) {
+function RootCauseNextStep({autofix, group, runId, section, referrer}: NextStepProps) {
+  const organization = useOrganization();
   const {isPolling, startStep} = autofix;
 
-  const {codingAgentIntegrations, handleCodingAgentHandoff} = useCodingAgents(
+  const {codingAgentIntegrations, handleCodingAgentHandoff} = useCodingAgents({
     autofix,
-    runId
-  );
+    runId,
+    group,
+    step: 'root_cause',
+    referrer,
+  });
 
   const handleYesClick = useCallback(() => {
     startStep('solution', runId);
-  }, [startStep, runId]);
+    trackAnalytics('autofix.root_cause.find_solution', {
+      organization,
+      group_id: group.id,
+      mode: 'explorer',
+      referrer,
+    });
+  }, [organization, group, startStep, runId, referrer]);
 
   const handleNoClick = useCallback(
     (userContext: string) => {
       startStep('root_cause', runId, userContext);
+      trackAnalytics('autofix.root_cause.re_run', {
+        organization,
+        group_id: group.id,
+        mode: 'explorer',
+        referrer,
+      });
     },
-    [startStep, runId]
+    [organization, group, startStep, runId, referrer]
   );
 
   const artifact = useMemo(() => getAutofixArtifactFromSection(section), [section]);
@@ -102,23 +148,38 @@ function RootCauseNextStep({autofix, runId, section}: NextStepProps) {
   );
 }
 
-function SolutionNextStep({autofix, runId, section}: NextStepProps) {
+function SolutionNextStep({autofix, group, runId, section, referrer}: NextStepProps) {
+  const organization = useOrganization();
   const {isPolling, startStep} = autofix;
 
-  const {codingAgentIntegrations, handleCodingAgentHandoff} = useCodingAgents(
+  const {codingAgentIntegrations, handleCodingAgentHandoff} = useCodingAgents({
     autofix,
-    runId
-  );
+    runId,
+    group,
+    step: 'solution',
+  });
 
   const handleYesClick = useCallback(() => {
     startStep('code_changes', runId);
-  }, [startStep, runId]);
+    trackAnalytics('autofix.solution.code', {
+      organization,
+      group_id: group.id,
+      mode: 'explorer',
+      referrer,
+    });
+  }, [organization, group, startStep, runId, referrer]);
 
   const handleNoClick = useCallback(
     (userContext: string) => {
       startStep('solution', runId, userContext);
+      trackAnalytics('autofix.solution.re_run', {
+        organization,
+        group_id: group.id,
+        mode: 'explorer',
+        referrer,
+      });
     },
-    [startStep, runId]
+    [organization, group, startStep, runId, referrer]
   );
 
   const artifact = useMemo(() => getAutofixArtifactFromSection(section), [section]);
@@ -147,18 +208,31 @@ function SolutionNextStep({autofix, runId, section}: NextStepProps) {
   );
 }
 
-function CodeChangesNextStep({autofix, runId, section}: NextStepProps) {
+function CodeChangesNextStep({autofix, group, runId, section, referrer}: NextStepProps) {
+  const organization = useOrganization();
   const {isPolling, createPR, startStep} = autofix;
 
   const handleYesClick = useCallback(() => {
     createPR(runId);
-  }, [createPR, runId]);
+    trackAnalytics('autofix.create_pr_clicked', {
+      organization,
+      group_id: group.id,
+      mode: 'explorer',
+      referrer,
+    });
+  }, [organization, group, createPR, runId, referrer]);
 
   const handleNoClick = useCallback(
     (userContext: string) => {
       startStep('code_changes', runId, userContext);
+      trackAnalytics('autofix.code_changes.re_run', {
+        organization,
+        group_id: group.id,
+        mode: 'explorer',
+        referrer,
+      });
     },
-    [startStep, runId]
+    [organization, group, startStep, runId, referrer]
   );
 
   const artifact = useMemo(() => getAutofixArtifactFromSection(section), [section]);
@@ -294,7 +368,21 @@ function NextStepTemplate({
   );
 }
 
-function useCodingAgents(autofix: ReturnType<typeof useExplorerAutofix>, runId: number) {
+interface UseCodingAgentsOptions {
+  autofix: ReturnType<typeof useExplorerAutofix>;
+  group: Group;
+  runId: number;
+  step: 'root_cause' | 'solution';
+  referrer?: string;
+}
+
+function useCodingAgents({
+  autofix,
+  group,
+  runId,
+  step,
+  referrer,
+}: UseCodingAgentsOptions) {
   const organization = useOrganization();
   const {triggerCodingAgentHandoff} = autofix;
 
@@ -315,8 +403,16 @@ function useCodingAgents(autofix: ReturnType<typeof useExplorerAutofix>, runId: 
         return;
       }
       triggerCodingAgentHandoff(runId, integration);
+      trackAnalytics('autofix.coding_agent.launch', {
+        organization,
+        group_id: group.id,
+        step,
+        provider: integration.provider,
+        mode: 'explorer',
+        referrer,
+      });
     },
-    [triggerCodingAgentHandoff, runId]
+    [triggerCodingAgentHandoff, organization, runId, group, step, referrer]
   );
 
   return {codingAgentIntegrations, handleCodingAgentHandoff};

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -1,21 +1,55 @@
 import type {Organization} from 'sentry/types/organization';
 
 export type SeerAnalyticsEventsParameters = {
-  'autofix.coding_agent.launch_from_root_cause': {
+  'autofix.code_changes.re_run': {
     group_id: string;
     organization: Organization;
+    instruction_provided?: boolean;
+    mode?: 'explorer' | 'legacy';
+    referrer?: string;
+  };
+  'autofix.coding_agent.launch': {
+    group_id: string;
+    organization: Organization;
+    provider: string;
+    step: 'root_cause' | 'solution';
+    mode?: 'explorer' | 'legacy';
+    referrer?: string;
+  };
+  'autofix.create_pr_clicked': {
+    group_id: string;
+    organization: Organization;
+    instruction_provided?: boolean;
+    mode?: 'explorer' | 'legacy';
+    referrer?: string;
   };
   'autofix.root_cause.find_solution': {
     group_id: string;
-    instruction_provided: boolean;
     organization: Organization;
+    instruction_provided?: boolean;
+    mode?: 'explorer' | 'legacy';
+    referrer?: string;
   };
-  'autofix.setup_modal_viewed': {
-    groupId: string;
-    projectId: string;
-    setup_gen_ai_consent: boolean;
-    setup_integration: boolean;
-    setup_write_integration?: boolean;
+  'autofix.root_cause.re_run': {
+    group_id: string;
+    organization: Organization;
+    instruction_provided?: boolean;
+    mode?: 'explorer' | 'legacy';
+    referrer?: string;
+  };
+  'autofix.solution.code': {
+    group_id: string;
+    organization: Organization;
+    instruction_provided?: boolean;
+    mode?: 'explorer' | 'legacy';
+    referrer?: string;
+  };
+  'autofix.solution.re_run': {
+    group_id: string;
+    organization: Organization;
+    instruction_provided?: boolean;
+    mode?: 'explorer' | 'legacy';
+    referrer?: string;
   };
   'coding_integration.install_clicked': {
     organization: Organization;
@@ -83,13 +117,16 @@ export type SeerAnalyticsEventsParameters = {
 type SeerAnalyticsEventKey = keyof SeerAnalyticsEventsParameters;
 
 export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null> = {
-  'autofix.coding_agent.launch_from_root_cause':
-    'Autofix: Coding Agent Launch From Root Cause',
+  'autofix.coding_agent.launch': 'Autofix: Coding Agent Launch',
+  'autofix.code_changes.re_run': 'Autofix: Code Changes Re-run',
+  'autofix.create_pr_clicked': 'Autofix: Create PR Setup Clicked',
   'coding_integration.install_clicked': 'Coding Integration: Install Clicked',
   'coding_integration.send_to_agent_clicked': 'Coding Integration: Send to Agent Clicked',
   'coding_integration.setup_handoff_clicked': 'Coding Integration: Setup Handoff Clicked',
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
-  'autofix.setup_modal_viewed': 'Autofix: Setup Modal Viewed',
+  'autofix.root_cause.re_run': 'Autofix: Root Cause Re-run',
+  'autofix.solution.code': 'Autofix: Code It Up',
+  'autofix.solution.re_run': 'Autofix: Solution Re-run',
   'seer.autofix.feedback_submitted': 'Seer: Autofix Feedback Submitted',
   'seer.config_reminder.rendered': 'Seer: Config Reminder Rendered',
   'seer.explorer.feedback_submitted': 'Seer Explorer: Feedback Submitted',

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -10,10 +10,14 @@ import {Text} from '@sentry/scraps/text';
 
 import {
   getOrderedAutofixSections,
+  isCodeChangesArtifact,
   isCodeChangesSection,
   isCodingAgentsSection,
+  isPullRequestsArtifact,
   isPullRequestsSection,
+  isRootCauseArtifact,
   isRootCauseSection,
+  isSolutionArtifact,
   isSolutionSection,
   useExplorerAutofix,
   type AutofixSection,
@@ -25,6 +29,7 @@ import {
   RootCausePreview,
   SolutionPreview,
 } from 'sentry/components/events/autofix/v3/autofixPreviews';
+import {useGroupSummaryData} from 'sentry/components/group/groupSummary';
 import {HookOrDefault} from 'sentry/components/hookOrDefault';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconBug} from 'sentry/icons';
@@ -33,7 +38,9 @@ import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSeerOnboardingCheck} from 'sentry/utils/useSeerOnboardingCheck';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
@@ -198,6 +205,8 @@ function AutofixArtifacts({autofix, group, project, event}: AutofixArtifactsProp
     [autofix.runState]
   );
 
+  const referrer = autofix.runState?.blocks?.[0]?.message?.metadata?.referrer;
+
   if (!sections.length) {
     return (
       <AutofixEmptyState
@@ -205,12 +214,19 @@ function AutofixArtifacts({autofix, group, project, event}: AutofixArtifactsProp
         event={event}
         group={group}
         project={project}
+        referrer={referrer}
       />
     );
   }
 
   return (
-    <AutofixPreviews sections={sections} event={event} group={group} project={project} />
+    <AutofixPreviews
+      sections={sections}
+      event={event}
+      group={group}
+      project={project}
+      referrer={referrer}
+    />
   );
 }
 
@@ -219,9 +235,16 @@ interface AutofixEmptyStateProps {
   event: Event;
   group: Group;
   project: Project;
+  referrer?: string;
 }
 
-function AutofixEmptyState({autofix, group, event, project}: AutofixEmptyStateProps) {
+function AutofixEmptyState({
+  autofix,
+  group,
+  event,
+  project,
+  referrer,
+}: AutofixEmptyStateProps) {
   const {openSeerDrawer} = useOpenSeerDrawer({
     group,
     project,
@@ -270,6 +293,9 @@ function AutofixEmptyState({autofix, group, event, project}: AutofixEmptyStatePr
         tooltipProps={{title: t('Fix the Issue')}}
         priority="primary"
         onClick={handleStartRootCause}
+        analyticsEventKey="autofix.start_fix_clicked"
+        analyticsEventName="Autofix: Start Fix Clicked"
+        analyticsParams={{group_id: group.id, mode: 'explorer', referrer}}
       >
         {t('Fix the Issue')}
       </Button>
@@ -282,9 +308,43 @@ interface AutofixPreviewsProps {
   group: Group;
   project: Project;
   sections: AutofixSection[];
+  referrer?: string;
 }
 
-function AutofixPreviews({event, group, project, sections}: AutofixPreviewsProps) {
+function AutofixPreviews({
+  event,
+  group,
+  project,
+  sections,
+  referrer,
+}: AutofixPreviewsProps) {
+  const hasRootCause = defined(
+    sections.findLast(isRootCauseSection)?.artifacts?.some(isRootCauseArtifact)
+  );
+
+  const hasSolution = defined(
+    sections.findLast(isSolutionSection)?.artifacts?.some(isSolutionArtifact)
+  );
+
+  const hasCodeChanges = defined(
+    sections.findLast(isCodeChangesSection)?.artifacts?.some(isCodeChangesArtifact)
+  );
+  const hasPullRequests = defined(
+    sections.findLast(isPullRequestsSection)?.artifacts?.some(isPullRequestsArtifact)
+  );
+
+  // Track autofix features analytics
+  useRouteAnalyticsParams({
+    has_root_cause: hasRootCause,
+    has_solution: hasSolution,
+    has_coded_solution: hasCodeChanges,
+    has_pr: hasPullRequests,
+    autofix_mode: 'explorer',
+    autofix_referrer: referrer,
+  });
+
+  const {data: summaryData, isPending: isSummaryPending} = useGroupSummaryData(group);
+
   const {openSeerDrawer} = useOpenSeerDrawer({
     group,
     project,
@@ -325,6 +385,21 @@ function AutofixPreviews({event, group, project, sections}: AutofixPreviewsProps
         tooltipProps={{title: t('Open Seer')}}
         priority="primary"
         onClick={openSeerDrawer}
+        analyticsEventKey="issue_details.seer_opened"
+        analyticsEventName="Issue Details: Seer Opened"
+        analyticsParams={{
+          group_id: group.id,
+          has_streamlined_ui: true,
+          autofix_exists: true,
+          autofix_step_type: sections[sections.length - 1]?.step ?? null,
+          has_summary: Boolean(summaryData && !isSummaryPending),
+          has_root_cause: hasRootCause,
+          has_solution: hasSolution,
+          has_coded_solution: hasCodeChanges,
+          has_pr: hasPullRequests,
+          mode: 'explorer',
+          referrer,
+        }}
       >
         {t('Open Seer')}
       </Button>

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -38,7 +38,6 @@ import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-import {defined} from 'sentry/utils';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -318,20 +317,18 @@ function AutofixPreviews({
   sections,
   referrer,
 }: AutofixPreviewsProps) {
-  const hasRootCause = defined(
-    sections.findLast(isRootCauseSection)?.artifacts?.some(isRootCauseArtifact)
-  );
+  const hasRootCause =
+    sections.findLast(isRootCauseSection)?.artifacts?.some(isRootCauseArtifact) ?? false;
 
-  const hasSolution = defined(
-    sections.findLast(isSolutionSection)?.artifacts?.some(isSolutionArtifact)
-  );
+  const hasSolution =
+    sections.findLast(isSolutionSection)?.artifacts?.some(isSolutionArtifact) ?? false;
 
-  const hasCodeChanges = defined(
-    sections.findLast(isCodeChangesSection)?.artifacts?.some(isCodeChangesArtifact)
-  );
-  const hasPullRequests = defined(
-    sections.findLast(isPullRequestsSection)?.artifacts?.some(isPullRequestsArtifact)
-  );
+  const hasCodeChanges =
+    sections.findLast(isCodeChangesSection)?.artifacts?.some(isCodeChangesArtifact) ??
+    false;
+  const hasPullRequests =
+    sections.findLast(isPullRequestsSection)?.artifacts?.some(isPullRequestsArtifact) ??
+    false;
 
   // Track autofix features analytics
   useRouteAnalyticsParams({


### PR DESCRIPTION
Adds analytics to autofix on explorer. For the most part, it re-uses existing analytic event names for backwards compatibility with existing pipelines. A few that are renamed/removed have been verified to not be referenced anywhere.