### PR TITLE
feat: Add EAP double read for release health data

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -570,7 +570,9 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/dynamic_sampling/                                                    @getsentry/telemetry-experience
 /tests/sentry/dynamic_sampling/                                                  @getsentry/telemetry-experience
 /src/sentry/release_health/metrics_sessions_v2.py                                @getsentry/telemetry-experience
+/src/sentry/release_health/eap_sessions_rollout.py                               @getsentry/telemetry-experience
 /tests/sentry/release_health/test_metrics_sessions_v2.py                         @getsentry/telemetry-experience
+/tests/sentry/release_health/test_eap_sessions_rollout.py                        @getsentry/telemetry-experience
 /src/sentry/utils/platform_categories.py                                         @getsentry/telemetry-experience
 /src/sentry/sentry_metrics/querying/                                             @getsentry/telemetry-experience
 /tests/sentry/sentry_metrics/querying/                                           @getsentry/telemetry-experience

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -324,6 +324,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable GitLab as a supported SCM provider for Seer
     manager.add("organizations:seer-gitlab-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disable select orgs from ingesting mobile replay events.
+    # Enable double-read from EAP for session health data validation
+    manager.add("organizations:session-health-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:session-replay-video-disabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable data scrubbing of replay recording payloads in Relay.
     manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)

--- a/src/sentry/release_health/eap_sessions_rollout.py
+++ b/src/sentry/release_health/eap_sessions_rollout.py
@@ -1,0 +1,633 @@
+"""Double-read rollout for session health data from EAP.
+
+Queries EAP in parallel with existing metrics and compares results.
+Always returns the control (metrics) data. User-facing behavior never changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
+    AttributeConditionalAggregation,
+)
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    Expression,
+    TimeSeriesRequest,
+    TimeSeriesResponse,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    AttributeValue,
+    Function,
+    StrArray,
+)
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    AndFilter,
+    ComparisonFilter,
+    TraceItemFilter,
+)
+
+from sentry.snuba.sessions_v2 import isoformat_z
+from sentry.utils import metrics
+from sentry.utils.snuba_rpc import timeseries_rpc
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from sentry.snuba.metrics.query import DeprecatingMetricsQuery
+
+logger = logging.getLogger(__name__)
+
+_SESSION_STATUSES = ("healthy", "crashed", "errored", "abnormal", "unhandled")
+
+# All status values used in conditional aggregations for session counts
+_SESSION_COUNT_STATUSES = ("init", "crashed", "errored_preaggr", "abnormal", "unhandled")
+
+
+@dataclass(frozen=True)
+class _FieldSpec:
+    """Describes what a session MRI field needs from EAP."""
+
+    kind: str  # "session_count", "user_count", "session_rate", "user_rate"
+    status: str = ""
+    inverted: bool = False
+
+
+_MRI_TO_FIELD: dict[str, _FieldSpec] = {
+    "e:sessions/all@none": _FieldSpec("session_count"),
+    "e:sessions/crash_free_rate@ratio": _FieldSpec("session_rate", "crashed", True),
+    "s:sessions/user@none": _FieldSpec("user_count"),
+    "e:sessions/user.all@none": _FieldSpec("user_count"),
+    "e:sessions/user.crash_free_rate@ratio": _FieldSpec("user_rate", "crashed", True),
+}
+
+_GROUPBY_TO_EAP: dict[str, tuple[str, AttributeKey.Type.ValueType]] = {
+    "project_id": ("sentry.project_id", AttributeKey.Type.TYPE_INT),
+    "project": ("sentry.project_id", AttributeKey.Type.TYPE_INT),
+    "release": ("release", AttributeKey.Type.TYPE_STRING),
+    "environment": ("environment", AttributeKey.Type.TYPE_STRING),
+}
+
+_EAP_ATTR_TO_OUTPUT_KEY: dict[str, str] = {
+    "sentry.project_id": "project_id",
+    "release": "release",
+    "environment": "environment",
+}
+
+_FILTER_COLUMNS: dict[str, AttributeKey.Type.ValueType] = {
+    "release": AttributeKey.Type.TYPE_STRING,
+    "environment": AttributeKey.Type.TYPE_STRING,
+}
+
+
+def _eq_filter(
+    attr_name: str, attr_type: AttributeKey.Type.ValueType, value: str
+) -> TraceItemFilter:
+    return TraceItemFilter(
+        comparison_filter=ComparisonFilter(
+            key=AttributeKey(name=attr_name, type=attr_type),
+            op=ComparisonFilter.OP_EQUALS,
+            value=AttributeValue(val_str=value),
+        )
+    )
+
+
+def _in_filter(
+    attr_name: str, attr_type: AttributeKey.Type.ValueType, values: list[str]
+) -> TraceItemFilter:
+    return TraceItemFilter(
+        comparison_filter=ComparisonFilter(
+            key=AttributeKey(name=attr_name, type=attr_type),
+            op=ComparisonFilter.OP_IN,
+            value=AttributeValue(val_str_array=StrArray(values=values)),
+        )
+    )
+
+
+def _agg_expr(
+    func: Function.ValueType,
+    attr_name: str,
+    attr_type: AttributeKey.Type.ValueType,
+    label: str,
+    filt: TraceItemFilter | None = None,
+) -> Expression:
+    if filt is not None:
+        return Expression(
+            conditional_aggregation=AttributeConditionalAggregation(
+                aggregate=func,
+                key=AttributeKey(name=attr_name, type=attr_type),
+                filter=filt,
+                label=label,
+            ),
+            label=label,
+        )
+    return Expression(
+        aggregation=AttributeAggregation(
+            aggregate=func,
+            key=AttributeKey(name=attr_name, type=attr_type),
+            label=label,
+        ),
+        label=label,
+    )
+
+
+def _translate_where(where: Sequence) -> list[TraceItemFilter]:
+    """Translate snuba_sdk conditions to TraceItemFilters."""
+    filters: list[TraceItemFilter] = []
+    try:
+        from snuba_sdk import Column, Condition, Op
+
+        for cond in where:
+            if not isinstance(cond, Condition) or not isinstance(cond.lhs, Column):
+                continue
+            attr_type = _FILTER_COLUMNS.get(cond.lhs.name)
+            if attr_type is None:
+                continue
+            if cond.op == Op.EQ:
+                filters.append(_eq_filter(cond.lhs.name, attr_type, str(cond.rhs)))
+            elif cond.op == Op.IN:
+                filters.append(_in_filter(cond.lhs.name, attr_type, [str(v) for v in cond.rhs]))
+    except Exception:
+        logger.exception("eap_sessions.filter_translation_failed")
+    return filters
+
+
+def _build_eap_timeseries_request(
+    org_id: int,
+    project_ids: Sequence[int],
+    fields: list[_FieldSpec],
+    raw_groupby: list[str],
+    start: datetime,
+    end: datetime,
+    rollup: int,
+    where: Sequence,
+) -> TimeSeriesRequest:
+    """Build a TimeSeriesRequest protobuf from explicit parameters."""
+    start_timestamp = Timestamp()
+    start_timestamp.FromDatetime(start)
+    end_timestamp = Timestamp()
+    end_timestamp.FromDatetime(end)
+
+    kinds = {f.kind for f in fields}
+    has_status_groupby = "session.status" in raw_groupby
+    need_session_counts = has_status_groupby or kinds & {"session_count", "session_rate"}
+    need_user_counts = has_status_groupby or kinds & {"user_count", "user_rate"}
+
+    expressions: list[Expression] = []
+
+    if need_session_counts:
+        for status in _SESSION_COUNT_STATUSES:
+            label = f"sum_session_{status}"
+            expressions.append(
+                _agg_expr(
+                    Function.FUNCTION_SUM,
+                    "session_count",
+                    AttributeKey.Type.TYPE_INT,
+                    label,
+                    _eq_filter("status", AttributeKey.Type.TYPE_STRING, status),
+                )
+            )
+        expressions.append(
+            _agg_expr(
+                Function.FUNCTION_UNIQ,
+                "errored_session_id_hash",
+                AttributeKey.Type.TYPE_ARRAY,
+                "errored_set_count",
+            )
+        )
+
+    if need_user_counts:
+        expressions.append(
+            _agg_expr(
+                Function.FUNCTION_UNIQ,
+                "user_id_hash",
+                AttributeKey.Type.TYPE_ARRAY,
+                "uniq_user_all",
+            )
+        )
+        for status in ("errored", "crashed", "abnormal", "unhandled"):
+            label = f"uniq_user_{status}"
+            expressions.append(
+                _agg_expr(
+                    Function.FUNCTION_UNIQ,
+                    "user_id_hash",
+                    AttributeKey.Type.TYPE_ARRAY,
+                    label,
+                    _eq_filter("status", AttributeKey.Type.TYPE_STRING, status),
+                )
+            )
+
+    # Group-by translation
+    group_by: list[AttributeKey] = []
+    for gb in raw_groupby:
+        eap = _GROUPBY_TO_EAP.get(gb)
+        if eap:
+            group_by.append(AttributeKey(name=eap[0], type=eap[1]))
+
+    # Filter translation
+    filters = _translate_where(where)
+    query_filter = None
+    if filters:
+        query_filter = (
+            filters[0]
+            if len(filters) == 1
+            else TraceItemFilter(and_filter=AndFilter(filters=filters))
+        )
+
+    request = TimeSeriesRequest(
+        meta=RequestMeta(
+            organization_id=org_id,
+            project_ids=list(project_ids),
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_USER_SESSION,
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
+        ),
+        expressions=expressions,
+        granularity_secs=rollup,
+        group_by=group_by,
+    )
+    if query_filter is not None:
+        request.filter.CopyFrom(query_filter)
+
+    return request
+
+
+def _safe_rate(
+    numerator: float | None, denominator: float | None, invert: bool = False
+) -> float | None:
+    """Compute a rate, returning None for division by zero."""
+    if denominator is None or denominator == 0 or numerator is None:
+        return None
+    rate = numerator / denominator
+    if invert:
+        rate = 1.0 - rate
+    if not math.isfinite(rate):
+        return None
+    return rate
+
+
+def _extract(
+    spec: _FieldSpec,
+    label_data: dict[str, list[float]],
+    n: int,
+) -> tuple[list[float | None], float | None]:
+    """Extract series and total for a non-status-grouped field."""
+    zeros = [0.0] * n
+
+    if spec.kind == "session_count":
+        values = label_data.get("sum_session_init", zeros)
+        result: list[float | None] = [int(v) for v in values]
+        return result, int(sum(values))
+
+    if spec.kind == "user_count":
+        values = label_data.get("uniq_user_all", zeros)
+        result_u: list[float | None] = [int(v) for v in values]
+        return result_u, int(sum(values))
+
+    if spec.kind == "session_rate":
+        init_values = label_data.get("sum_session_init", zeros)
+        if spec.status == "errored":
+            preaggr = label_data.get("sum_session_errored_preaggr", zeros)
+            eset = label_data.get("errored_set_count", zeros)
+            status_values = [preaggr[i] + eset[i] for i in range(n)]
+        else:
+            status_values = label_data.get(f"sum_session_{spec.status}", zeros)
+        series = [_safe_rate(status_values[i], init_values[i], spec.inverted) for i in range(n)]
+        total = _safe_rate(sum(status_values), sum(init_values), spec.inverted)
+        return series, total
+
+    if spec.kind == "user_rate":
+        all_values = label_data.get("uniq_user_all", zeros)
+        status_values = label_data.get(f"uniq_user_{spec.status}", zeros)
+        series = [_safe_rate(status_values[i], all_values[i], spec.inverted) for i in range(n)]
+        total = _safe_rate(sum(status_values), sum(all_values), spec.inverted)
+        return series, total
+
+    fallback: list[float | None] = [0.0] * n
+    return fallback, 0.0
+
+
+def _extract_for_status(
+    spec: _FieldSpec,
+    status: str,
+    label_data: dict[str, list[float]],
+    n: int,
+) -> tuple[list[float | None], float | None]:
+    """Extract series/total for a field within a session.status group."""
+    if spec.kind == "session_count":
+        return _session_count_for_status(status, label_data, n)
+    if spec.kind == "user_count":
+        return _user_count_for_status(status, label_data, n)
+    # Rates are not status-dependent
+    return _extract(spec, label_data, n)
+
+
+def _session_count_for_status(
+    status: str,
+    label_data: dict[str, list[float]],
+    n: int,
+) -> tuple[list[float | None], float | None]:
+    """Get session count for a specific status."""
+    zeros = [0.0] * n
+    if status == "healthy":
+        init = label_data.get("sum_session_init", zeros)
+        errored_preaggr = label_data.get("sum_session_errored_preaggr", zeros)
+        errored_set = label_data.get("errored_set_count", zeros)
+        result: list[float | None] = [
+            int(max(init[i] - errored_preaggr[i] - errored_set[i], 0)) for i in range(n)
+        ]
+        return result, sum(v for v in result if v is not None)
+
+    if status == "errored":
+        errored_preaggr = label_data.get("sum_session_errored_preaggr", zeros)
+        errored_set = label_data.get("errored_set_count", zeros)
+        crashed = label_data.get("sum_session_crashed", zeros)
+        abnormal = label_data.get("sum_session_abnormal", zeros)
+        result_e: list[float | None] = [
+            int(max(errored_preaggr[i] + errored_set[i] - crashed[i] - abnormal[i], 0))
+            for i in range(n)
+        ]
+        return result_e, sum(v for v in result_e if v is not None)
+
+    key = f"sum_session_{status}"
+    raw = label_data.get(key, zeros)
+    result_s: list[float | None] = [int(v) for v in raw]
+    return result_s, int(sum(raw))
+
+
+def _user_count_for_status(
+    status: str,
+    label_data: dict[str, list[float]],
+    n: int,
+) -> tuple[list[float | None], float | None]:
+    """Get user count for a specific status."""
+    zeros = [0.0] * n
+    if status == "healthy":
+        all_users = label_data.get("uniq_user_all", zeros)
+        errored = label_data.get("uniq_user_errored", zeros)
+        result: list[float | None] = [int(max(all_users[i] - errored[i], 0)) for i in range(n)]
+        return result, sum(v for v in result if v is not None)
+
+    if status == "errored":
+        errored = label_data.get("uniq_user_errored", zeros)
+        crashed = label_data.get("uniq_user_crashed", zeros)
+        abnormal = label_data.get("uniq_user_abnormal", zeros)
+        result_e: list[float | None] = [
+            int(max(errored[i] - crashed[i] - abnormal[i], 0)) for i in range(n)
+        ]
+        return result_e, sum(v for v in result_e if v is not None)
+
+    key = f"uniq_user_{status}"
+    raw = label_data.get(key, zeros)
+    result_s: list[float | None] = [int(v) for v in raw]
+    return result_s, int(sum(raw))
+
+
+def _transform_eap_response(
+    response: TimeSeriesResponse,
+    fields: list[_FieldSpec],
+    field_alias_map: dict[_FieldSpec, str],
+    raw_groupby: list[str],
+    start: datetime,
+    end: datetime,
+    rollup: int,
+    include_totals: bool,
+    include_series: bool,
+) -> dict:
+    """Convert a TimeSeriesResponse into the final get_series output format."""
+    start_ts = int(start.timestamp())
+    end_ts = int(end.timestamp())
+    intervals = [
+        isoformat_z(start.fromtimestamp(ts, tz=start.tzinfo))
+        for ts in range(start_ts, end_ts, rollup)
+    ]
+    num_buckets = len(intervals)
+    has_status_groupby = "session.status" in raw_groupby
+
+    # Collect timeseries data by (group_key, label)
+    grouped: dict[frozenset[tuple[str, str]], dict[str, list[float]]] = {}
+
+    for ts in response.result_timeseries:
+        group_key = frozenset(ts.group_by_attributes.items())
+        label = ts.label
+        if group_key not in grouped:
+            grouped[group_key] = {}
+
+        values: list[float] = []
+        for dp in ts.data_points:
+            values.append(dp.data if dp.data_present else 0.0)
+        while len(values) < num_buckets:
+            values.append(0.0)
+        grouped[group_key][label] = values[:num_buckets]
+
+    result_groups: list[dict] = []
+
+    other_groupbys = [gb for gb in raw_groupby if gb != "session.status"]
+    if not grouped and has_status_groupby and not other_groupbys:
+        grouped[frozenset()] = {}
+
+    for group_key, label_data in grouped.items():
+        by: dict[str, str | int] = {}
+        for attr_name, attr_value in group_key:
+            out_key = _EAP_ATTR_TO_OUTPUT_KEY.get(attr_name)
+            if out_key:
+                by[out_key] = int(attr_value) if out_key == "project_id" else attr_value
+
+        statuses = _SESSION_STATUSES if has_status_groupby else (None,)
+        for status in statuses:
+            series_data: dict[_FieldSpec, list[float | None]] = {}
+            totals_data: dict[_FieldSpec, float | None] = {}
+            for spec in fields:
+                if status is not None:
+                    s, t = _extract_for_status(spec, status, label_data, num_buckets)
+                else:
+                    s, t = _extract(spec, label_data, num_buckets)
+                series_data[spec] = s
+                totals_data[spec] = t
+
+            group: dict = {}
+            if include_series:
+                group["series"] = {
+                    field_alias_map[spec]: [float(v) if v is not None else None for v in vals]
+                    for spec, vals in series_data.items()
+                }
+            if include_totals:
+                group["totals"] = {
+                    field_alias_map[spec]: float(v) if v is not None else None
+                    for spec, v in totals_data.items()
+                }
+            group["by"] = {**by, "session.status": status} if status is not None else by
+            result_groups.append(group)
+
+    return {
+        "start": isoformat_z(start),
+        "end": isoformat_z(end),
+        "intervals": intervals,
+        "groups": result_groups,
+        "query": "",
+    }
+
+
+def is_session_metrics_query(metrics_query: DeprecatingMetricsQuery) -> bool:
+    """Check if a DeprecatingMetricsQuery targets session metrics."""
+    return any(field.metric_mri in _MRI_TO_FIELD for field in metrics_query.select)
+
+
+def get_series_eap(
+    metrics_query: DeprecatingMetricsQuery,
+    org_id: int,
+) -> dict | None:
+    """Query EAP for session data matching a metrics/data endpoint query.
+
+    Returns the result in the same format as get_series() with field names
+    matching the metric aliases, or None if the query can't be translated.
+    """
+    fields: list[_FieldSpec] = []
+    field_alias_map: dict[_FieldSpec, str] = {}
+
+    for field in metrics_query.select:
+        spec = _MRI_TO_FIELD.get(field.metric_mri)
+        if spec is None:
+            return None
+        if spec not in field_alias_map:
+            fields.append(spec)
+            field_alias_map[spec] = field.alias
+
+    raw_groupby: list[str] = []
+    if metrics_query.groupby:
+        for gb in metrics_query.groupby:
+            gb_name = gb.name if hasattr(gb, "name") else str(gb.field)
+            if gb_name == "session.status":
+                raw_groupby.append("session.status")
+            elif gb_name in _GROUPBY_TO_EAP:
+                raw_groupby.append(gb_name)
+            else:
+                return None
+
+    project_ids = list(metrics_query.project_ids)
+    where = list(metrics_query.where) if metrics_query.where else []
+    rollup = metrics_query.granularity.granularity
+
+    if metrics_query.start is None or metrics_query.end is None:
+        return None
+
+    start = metrics_query.start
+    end = metrics_query.end
+
+    request = _build_eap_timeseries_request(
+        org_id=org_id,
+        project_ids=project_ids,
+        fields=fields,
+        raw_groupby=raw_groupby,
+        start=start,
+        end=end,
+        rollup=rollup,
+        where=where,
+    )
+    responses = timeseries_rpc([request])
+    assert len(responses) == 1
+
+    return _transform_eap_response(
+        response=responses[0],
+        fields=fields,
+        field_alias_map=field_alias_map,
+        raw_groupby=raw_groupby,
+        start=start,
+        end=end,
+        rollup=rollup,
+        include_totals=metrics_query.include_totals,
+        include_series=metrics_query.include_series,
+    )
+
+
+_FRESHNESS_BUFFER = timedelta(minutes=30)
+
+
+def _safe_bucket_cutoff(intervals: list[str | datetime]) -> int:
+    """Return the number of leading buckets old enough to compare."""
+    cutoff = datetime.now(timezone.utc) - _FRESHNESS_BUFFER
+    count = 0
+    for ts in intervals:
+        if isinstance(ts, str):
+            bucket_time = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        else:
+            bucket_time = ts
+        if bucket_time >= cutoff:
+            break
+        count += 1
+    return count
+
+
+def _groups_match(
+    control_groups: list[dict],
+    exp_groups: list[dict],
+    cutoff: int,
+) -> bool:
+    """Compare groups, only looking at the first ``cutoff`` series values."""
+    if len(control_groups) != len(exp_groups):
+        return False
+
+    def _sort_key(g: dict) -> list[tuple[str, str]]:
+        return sorted((k, str(v)) for k, v in g.get("by", {}).items())
+
+    control_sorted = sorted(control_groups, key=_sort_key)
+    exp_sorted = sorted(exp_groups, key=_sort_key)
+
+    for cg, eg in zip(control_sorted, exp_sorted):
+        if cg.get("by") != eg.get("by"):
+            return False
+        c_series = cg.get("series", {})
+        e_series = eg.get("series", {})
+        if c_series.keys() != e_series.keys():
+            return False
+        for field in c_series:
+            if c_series[field][:cutoff] != e_series[field][:cutoff]:
+                return False
+    return True
+
+
+def compare_get_series_results(control: dict, experimental: dict) -> None:
+    """Shadow-compare get_series results from legacy metrics and EAP."""
+    control_groups = control.get("groups", [])
+    exp_groups = experimental.get("groups", [])
+    intervals = control.get("intervals", [])
+    is_null = len(exp_groups) == 0
+
+    cutoff = _safe_bucket_cutoff(intervals)
+    if cutoff == 0:
+        metrics.incr(
+            "eap_sessions.get_series_compare",
+            tags={"match": "skipped", "is_null_result": str(is_null)},
+            sample_rate=1.0,
+        )
+        return
+
+    match = _groups_match(control_groups, exp_groups, cutoff)
+
+    if not match:
+        logger.warning(
+            "eap_sessions.get_series_mismatch",
+            extra={
+                "control_groups": control_groups,
+                "eap_groups": exp_groups,
+                "cutoff": cutoff,
+                "total_buckets": len(intervals),
+            },
+        )
+
+    metrics.incr(
+        "eap_sessions.get_series_compare",
+        tags={
+            "match": str(match),
+            "is_null_result": str(is_null),
+        },
+        sample_rate=1.0,
+    )

--- a/src/sentry/release_health/eap_sessions_rollout.py
+++ b/src/sentry/release_health/eap_sessions_rollout.py
@@ -1,6 +1,6 @@
 """Double-read rollout for session health data from EAP.
 
-Queries EAP in parallel with existing metrics and compares results.
+Queries EAP in addition to existing metrics and compares results.
 Always returns the control (metrics) data. User-facing behavior never changes.
 """
 

--- a/src/sentry/releases/endpoints/organization_release_health_data.py
+++ b/src/sentry/releases/endpoints/organization_release_health_data.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -17,6 +19,8 @@ from sentry.snuba.metrics.query_builder import parse_field
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
 from sentry.utils.cursors import Cursor, CursorResult
+
+logger = logging.getLogger(__name__)
 
 
 @cell_silo_endpoint
@@ -93,9 +97,10 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
                     allow_mri=True,
                     paginator_kwargs={"limit": limit, "offset": offset},
                 )
+                metrics_query = query.to_metrics_query()
                 data = get_series(
                     projects,
-                    metrics_query=query.to_metrics_query(),
+                    metrics_query=metrics_query,
                     use_case_id=get_use_case_id(request),
                     tenant_ids={"organization_id": organization.id},
                 )
@@ -109,6 +114,25 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
                 )
 
                 data["query"] = query.query
+
+                # EAP shadow read for session metrics
+                try:
+                    from sentry import features
+                    from sentry.release_health.eap_sessions_rollout import (
+                        compare_get_series_results,
+                        get_series_eap,
+                        is_session_metrics_query,
+                    )
+
+                    if features.has(
+                        "organizations:session-health-eap", organization
+                    ) and is_session_metrics_query(metrics_query):
+                        eap_result = get_series_eap(metrics_query, organization.id)
+                        if eap_result is not None:
+                            compare_get_series_results(data, eap_result)
+                except Exception:
+                    logger.exception("eap_sessions.get_series_double_read_failed")
+
             except (
                 InvalidParams,
                 DerivedMetricException,

--- a/tests/sentry/release_health/test_eap_sessions_rollout.py
+++ b/tests/sentry/release_health/test_eap_sessions_rollout.py
@@ -1,0 +1,715 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    DataPoint,
+    TimeSeries,
+    TimeSeriesResponse,
+)
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeKey,
+    Function,
+)
+
+from sentry.release_health.eap_sessions_rollout import (
+    _FRESHNESS_BUFFER,
+    _build_eap_timeseries_request,
+    _FieldSpec,
+    _transform_eap_response,
+    compare_get_series_results,
+    get_series_eap,
+    is_session_metrics_query,
+)
+from sentry.snuba.sessions_v2 import isoformat_z
+from sentry.testutils.cases import TestCase
+
+NOW = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+ONE_HOUR_AGO = NOW - timedelta(hours=1)
+
+# Commonly used field specs
+_SESSION_COUNT = _FieldSpec("session_count")
+_USER_COUNT = _FieldSpec("user_count")
+_CRASH_FREE_SESSION = _FieldSpec("session_rate", "crashed", True)
+
+
+def _make_timestamp(dt: datetime) -> Timestamp:
+    ts = Timestamp()
+    ts.FromDatetime(dt)
+    return ts
+
+
+def _make_timeseries(
+    label: str,
+    values: list[float],
+    group_by: dict[str, str] | None = None,
+    start: datetime | None = None,
+    rollup: int = 3600,
+) -> TimeSeries:
+    base_time = start or ONE_HOUR_AGO
+    buckets = [
+        _make_timestamp(base_time + timedelta(seconds=rollup * i)) for i in range(len(values))
+    ]
+    data_points = [DataPoint(data=v, data_present=True) for v in values]
+    return TimeSeries(
+        label=label,
+        group_by_attributes=group_by or {},
+        buckets=buckets,
+        data_points=data_points,
+    )
+
+
+def _default_request_kwargs(**overrides: object) -> dict[str, Any]:
+    """Build default kwargs for _build_eap_timeseries_request."""
+    defaults = {
+        "org_id": 1,
+        "project_ids": [1],
+        "fields": [_SESSION_COUNT],
+        "raw_groupby": [],
+        "start": ONE_HOUR_AGO,
+        "end": NOW,
+        "rollup": 3600,
+        "where": [],
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+class TestBuildEapRequest(TestCase):
+    def test_session_count(self) -> None:
+        request = _build_eap_timeseries_request(**_default_request_kwargs())
+
+        labels = [expr.label for expr in request.expressions]
+        assert "sum_session_init" in labels
+        assert "sum_session_crashed" in labels
+        assert "errored_set_count" in labels
+
+        for expr in request.expressions:
+            if expr.label == "sum_session_init":
+                agg = expr.conditional_aggregation
+                assert agg.aggregate == Function.FUNCTION_SUM
+                assert agg.key.name == "session_count"
+                assert agg.key.type == AttributeKey.Type.TYPE_INT
+
+    def test_user_count(self) -> None:
+        request = _build_eap_timeseries_request(**_default_request_kwargs(fields=[_USER_COUNT]))
+
+        labels = [expr.label for expr in request.expressions]
+        assert "uniq_user_all" in labels
+        assert "uniq_user_init" not in labels
+
+        for expr in request.expressions:
+            if expr.label == "uniq_user_all":
+                agg = expr.aggregation
+                assert agg.aggregate == Function.FUNCTION_UNIQ
+                assert agg.key.name == "user_id_hash"
+                assert agg.key.type == AttributeKey.Type.TYPE_ARRAY
+
+    def test_crash_free_rate(self) -> None:
+        request = _build_eap_timeseries_request(
+            **_default_request_kwargs(fields=[_CRASH_FREE_SESSION])
+        )
+
+        labels = [expr.label for expr in request.expressions]
+        assert "sum_session_init" in labels
+        assert "sum_session_crashed" in labels
+
+    def test_with_groupby(self) -> None:
+        request = _build_eap_timeseries_request(
+            **_default_request_kwargs(raw_groupby=["project", "release", "environment"])
+        )
+
+        group_by_names = [gb.name for gb in request.group_by]
+        assert "sentry.project_id" in group_by_names
+        assert "release" in group_by_names
+        assert "environment" in group_by_names
+
+    def test_with_status_groupby(self) -> None:
+        request = _build_eap_timeseries_request(
+            **_default_request_kwargs(raw_groupby=["session.status"])
+        )
+
+        labels = [expr.label for expr in request.expressions]
+        for status in ["init", "crashed", "errored_preaggr", "abnormal", "unhandled"]:
+            assert f"sum_session_{status}" in labels
+        assert "errored_set_count" in labels
+
+        group_by_names = [gb.name for gb in request.group_by]
+        assert "session.status" not in group_by_names
+        assert "status" not in group_by_names
+
+
+def _default_transform_kwargs(**overrides: object) -> dict[str, Any]:
+    """Build default kwargs for _transform_eap_response."""
+    defaults = {
+        "fields": [_SESSION_COUNT],
+        "field_alias_map": {_SESSION_COUNT: "sum(session)"},
+        "raw_groupby": [],
+        "start": ONE_HOUR_AGO,
+        "end": NOW,
+        "rollup": 3600,
+        "include_totals": True,
+        "include_series": True,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+class TestTransformResponse(TestCase):
+    def test_basic_sum_session(self) -> None:
+        response = TimeSeriesResponse(
+            result_timeseries=[
+                _make_timeseries("sum_session_init", [100.0]),
+            ]
+        )
+
+        result = _transform_eap_response(response, **_default_transform_kwargs())
+        assert len(result["groups"]) == 1
+        group = result["groups"][0]
+        assert group["series"]["sum(session)"] == [100.0]
+        assert group["totals"]["sum(session)"] == 100.0
+
+    def test_crash_free_rate(self) -> None:
+        response = TimeSeriesResponse(
+            result_timeseries=[
+                _make_timeseries("sum_session_init", [100.0]),
+                _make_timeseries("sum_session_crashed", [5.0]),
+                _make_timeseries("sum_session_errored_preaggr", [0.0]),
+                _make_timeseries("errored_set_count", [0.0]),
+                _make_timeseries("sum_session_abnormal", [0.0]),
+                _make_timeseries("sum_session_unhandled", [0.0]),
+            ]
+        )
+
+        result = _transform_eap_response(
+            response,
+            **_default_transform_kwargs(
+                fields=[_CRASH_FREE_SESSION],
+                field_alias_map={_CRASH_FREE_SESSION: "crash_free_rate(session)"},
+            ),
+        )
+        group = result["groups"][0]
+        assert group["totals"]["crash_free_rate(session)"] == pytest.approx(0.95)
+        assert group["series"]["crash_free_rate(session)"] == [pytest.approx(0.95)]
+
+    def test_healthy_computation(self) -> None:
+        response = TimeSeriesResponse(
+            result_timeseries=[
+                _make_timeseries("sum_session_init", [100.0]),
+                _make_timeseries("sum_session_crashed", [3.0]),
+                _make_timeseries("sum_session_errored_preaggr", [7.0]),
+                _make_timeseries("errored_set_count", [4.0]),
+                _make_timeseries("sum_session_abnormal", [2.0]),
+                _make_timeseries("sum_session_unhandled", [5.0]),
+            ]
+        )
+
+        result = _transform_eap_response(
+            response,
+            **_default_transform_kwargs(raw_groupby=["session.status"]),
+        )
+        groups_by_status = {g["by"]["session.status"]: g for g in result["groups"]}
+
+        assert groups_by_status["healthy"]["totals"]["sum(session)"] == 89.0
+        assert groups_by_status["crashed"]["totals"]["sum(session)"] == 3.0
+        assert groups_by_status["errored"]["totals"]["sum(session)"] == 6.0
+        assert groups_by_status["abnormal"]["totals"]["sum(session)"] == 2.0
+        assert groups_by_status["unhandled"]["totals"]["sum(session)"] == 5.0
+
+    def test_empty_response(self) -> None:
+        response = TimeSeriesResponse(result_timeseries=[])
+        result = _transform_eap_response(response, **_default_transform_kwargs())
+        assert result["groups"] == []
+
+    def test_grouped_response(self) -> None:
+        response = TimeSeriesResponse(
+            result_timeseries=[
+                _make_timeseries(
+                    "sum_session_init",
+                    [50.0],
+                    group_by={"release": "1.0"},
+                ),
+                _make_timeseries(
+                    "sum_session_init",
+                    [30.0],
+                    group_by={"release": "2.0"},
+                ),
+            ]
+        )
+        for status in ["crashed", "errored_preaggr", "abnormal", "unhandled"]:
+            response.result_timeseries.append(
+                _make_timeseries(
+                    f"sum_session_{status}",
+                    [0.0],
+                    group_by={"release": "1.0"},
+                )
+            )
+            response.result_timeseries.append(
+                _make_timeseries(
+                    f"sum_session_{status}",
+                    [0.0],
+                    group_by={"release": "2.0"},
+                )
+            )
+        for release in ["1.0", "2.0"]:
+            response.result_timeseries.append(
+                _make_timeseries(
+                    "errored_set_count",
+                    [0.0],
+                    group_by={"release": release},
+                )
+            )
+
+        result = _transform_eap_response(
+            response,
+            **_default_transform_kwargs(raw_groupby=["release"]),
+        )
+        assert len(result["groups"]) == 2
+        groups_by_release = {g["by"]["release"]: g for g in result["groups"]}
+        assert groups_by_release["1.0"]["totals"]["sum(session)"] == 50.0
+        assert groups_by_release["2.0"]["totals"]["sum(session)"] == 30.0
+
+
+class TestDoubleRead(TestCase):
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_flag_off_no_eap_query(self, mock_rpc: MagicMock) -> None:
+        """When feature flag is off, EAP query is never called."""
+        from sentry.release_health.metrics import MetricsReleaseHealthBackend
+
+        backend = MetricsReleaseHealthBackend()
+        query = _make_query(["sum(session)"])
+
+        control_result = {
+            "start": ONE_HOUR_AGO,
+            "end": NOW,
+            "intervals": [],
+            "groups": [
+                {"by": {}, "series": {"sum(session)": [100.0]}, "totals": {"sum(session)": 100.0}}
+            ],
+            "query": "",
+        }
+
+        with patch("sentry.release_health.metrics.run_sessions_query", return_value=control_result):
+            with self.feature({"organizations:session-health-eap": False}):
+                result = backend.run_sessions_query(self.organization.id, query, "test")
+
+        assert result == control_result
+        mock_rpc.assert_not_called()
+
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_flag_on_returns_control(self, mock_rpc: MagicMock) -> None:
+        """When flag is on, always returns control data."""
+        from sentry.release_health.metrics import MetricsReleaseHealthBackend
+
+        backend = MetricsReleaseHealthBackend()
+        query = _make_query(["sum(session)"])
+
+        control_result = {
+            "start": ONE_HOUR_AGO,
+            "end": NOW,
+            "intervals": [],
+            "groups": [
+                {"by": {}, "series": {"sum(session)": [100.0]}, "totals": {"sum(session)": 100.0}}
+            ],
+            "query": "",
+        }
+
+        mock_rpc.return_value = [TimeSeriesResponse(result_timeseries=[])]
+
+        with patch("sentry.release_health.metrics.run_sessions_query", return_value=control_result):
+            with self.feature({"organizations:session-health-eap": True}):
+                result = backend.run_sessions_query(self.organization.id, query, "test")
+
+        assert result == control_result
+
+    @patch(
+        "sentry.release_health.eap_sessions_rollout.timeseries_rpc",
+        side_effect=Exception("EAP is down"),
+    )
+    def test_eap_failure_returns_control(self, mock_rpc: MagicMock) -> None:
+        """EAP failure does not affect response — control data is returned."""
+        from sentry.release_health.metrics import MetricsReleaseHealthBackend
+
+        backend = MetricsReleaseHealthBackend()
+        query = _make_query(["sum(session)"])
+
+        control_result = {
+            "start": ONE_HOUR_AGO,
+            "end": NOW,
+            "intervals": [],
+            "groups": [
+                {"by": {}, "series": {"sum(session)": [100.0]}, "totals": {"sum(session)": 100.0}}
+            ],
+            "query": "",
+        }
+
+        with patch("sentry.release_health.metrics.run_sessions_query", return_value=control_result):
+            with self.feature({"organizations:session-health-eap": True}):
+                result = backend.run_sessions_query(self.organization.id, query, "test")
+
+        assert result == control_result
+
+
+def _make_query(
+    raw_fields: list[str],
+    raw_groupby: list[str] | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    rollup: int = 3600,
+    project_ids: list[int] | None = None,
+    query: str = "",
+) -> MagicMock:
+    """Create a mock QueryDefinition for tests that go through the backend."""
+    mock = MagicMock()
+    mock.raw_fields = raw_fields
+    mock.raw_groupby = raw_groupby or []
+    mock.start = start or ONE_HOUR_AGO
+    mock.end = end or NOW
+    mock.rollup = rollup
+    mock.params = {"project_id": project_ids or [1]}
+    mock.query = query
+    mock.get_filter_conditions.return_value = []
+    return mock
+
+
+def _make_metrics_query(
+    fields: list[tuple[str | None, str]],
+    groupby: list[str] | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    rollup: int = 3600,
+    project_ids: list[int] | None = None,
+) -> MagicMock:
+    """Create a mock DeprecatingMetricsQuery for testing.
+
+    fields: list of (op, metric_mri) tuples
+    """
+    mock = MagicMock()
+    mock_fields = []
+    for op, mri in fields:
+        field = MagicMock()
+        field.op = op
+        field.metric_mri = mri
+        if op:
+            name_parts = mri.split("/")[-1].split("@")[0]
+            field.alias = f"{op}(session.{name_parts})" if "session" in mri else f"{op}({mri})"
+        else:
+            name_parts = mri.split("/")[-1].split("@")[0]
+            field.alias = f"session.{name_parts}" if "session" in mri else mri
+        mock_fields.append(field)
+    mock.select = mock_fields
+
+    mock_groupby = []
+    for gb_name in groupby or []:
+        gb = MagicMock()
+        gb.name = gb_name
+        gb.field = gb_name
+        mock_groupby.append(gb)
+    mock.groupby = mock_groupby
+
+    mock.start = start or ONE_HOUR_AGO
+    mock.end = end or NOW
+
+    granularity = MagicMock()
+    granularity.granularity = rollup
+    mock.granularity = granularity
+
+    mock.project_ids = project_ids or [1]
+    mock.where = []
+    mock.include_totals = True
+    mock.include_series = True
+
+    return mock
+
+
+class TestIsSessionMetricsQuery(TestCase):
+    def test_session_all_is_session_query(self) -> None:
+        query = _make_metrics_query([("sum", "e:sessions/all@none")])
+        assert is_session_metrics_query(query) is True
+
+    def test_crash_free_rate_is_session_query(self) -> None:
+        query = _make_metrics_query([(None, "e:sessions/crash_free_rate@ratio")])
+        assert is_session_metrics_query(query) is True
+
+    def test_non_session_metric_is_not_session_query(self) -> None:
+        query = _make_metrics_query([("avg", "d:transactions/duration@millisecond")])
+        assert is_session_metrics_query(query) is False
+
+    def test_mixed_fields_with_session(self) -> None:
+        query = _make_metrics_query(
+            [
+                ("sum", "e:sessions/all@none"),
+                ("avg", "d:transactions/duration@millisecond"),
+            ]
+        )
+        assert is_session_metrics_query(query) is True
+
+
+class TestGetSeriesEap(TestCase):
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_returns_result_with_metric_field_names(self, mock_rpc: MagicMock) -> None:
+        query = _make_metrics_query([("sum", "e:sessions/all@none")])
+        query.select[0].alias = "sum(session.all)"
+
+        mock_rpc.return_value = [
+            TimeSeriesResponse(
+                result_timeseries=[
+                    _make_timeseries("sum_session_init", [100.0]),
+                ]
+            )
+        ]
+
+        result = get_series_eap(query, org_id=1)
+        assert result is not None
+        assert len(result["groups"]) == 1
+        group = result["groups"][0]
+        assert "sum(session.all)" in group["series"]
+        assert "sum(session.all)" in group["totals"]
+
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_remaps_project_groupby(self, mock_rpc: MagicMock) -> None:
+        query = _make_metrics_query(
+            [("sum", "e:sessions/all@none")],
+            groupby=["project_id"],
+        )
+        query.select[0].alias = "sum(session.all)"
+
+        mock_rpc.return_value = [
+            TimeSeriesResponse(
+                result_timeseries=[
+                    _make_timeseries(
+                        "sum_session_init",
+                        [50.0],
+                        group_by={"sentry.project_id": "1"},
+                    ),
+                ]
+            )
+        ]
+
+        result = get_series_eap(query, org_id=1)
+        assert result is not None
+        group = result["groups"][0]
+        assert "project_id" in group["by"]
+        assert "project" not in group["by"]
+
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_strips_totals_when_include_totals_false(self, mock_rpc: MagicMock) -> None:
+        query = _make_metrics_query([("sum", "e:sessions/all@none")])
+        query.select[0].alias = "sum(session.all)"
+        query.include_totals = False
+
+        mock_rpc.return_value = [
+            TimeSeriesResponse(result_timeseries=[_make_timeseries("sum_session_init", [100.0])])
+        ]
+
+        result = get_series_eap(query, org_id=1)
+        assert result is not None
+        group = result["groups"][0]
+        assert "totals" not in group
+        assert "series" in group
+
+    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
+    def test_returns_float_values(self, mock_rpc: MagicMock) -> None:
+        """get_series returns floats, so EAP results should too."""
+        query = _make_metrics_query([("sum", "e:sessions/all@none")])
+        query.select[0].alias = "sum(session.all)"
+
+        mock_rpc.return_value = [
+            TimeSeriesResponse(result_timeseries=[_make_timeseries("sum_session_init", [5.0])])
+        ]
+
+        result = get_series_eap(query, org_id=1)
+        assert result is not None
+        group = result["groups"][0]
+        assert group["series"]["sum(session.all)"] == [5.0]
+        assert isinstance(group["series"]["sum(session.all)"][0], float)
+        assert group["totals"]["sum(session.all)"] == 5.0
+        assert isinstance(group["totals"]["sum(session.all)"], float)
+
+    def test_returns_none_for_non_session_query(self) -> None:
+        query = _make_metrics_query([("avg", "d:transactions/duration@millisecond")])
+        result = get_series_eap(query, org_id=1)
+        assert result is None
+
+
+class TestCompareGetSeriesResults(TestCase):
+    """Tests use timestamps from 2025 (well in the past), so all buckets are old enough to compare."""
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_matching_results(self, mock_metrics: MagicMock) -> None:
+        intervals = [isoformat_z(ONE_HOUR_AGO)]
+        control = {
+            "intervals": intervals,
+            "groups": [
+                {
+                    "by": {},
+                    "series": {"sum(session.all)": [100]},
+                    "totals": {"sum(session.all)": 100},
+                }
+            ],
+        }
+        experimental = {
+            "intervals": intervals,
+            "groups": [
+                {
+                    "by": {},
+                    "series": {"sum(session.all)": [100]},
+                    "totals": {"sum(session.all)": 100},
+                }
+            ],
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"match": "True", "is_null_result": "False"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_mismatched_results(self, mock_metrics: MagicMock) -> None:
+        intervals = [isoformat_z(ONE_HOUR_AGO)]
+        control = {
+            "intervals": intervals,
+            "groups": [
+                {
+                    "by": {},
+                    "series": {"sum(session.all)": [100]},
+                    "totals": {"sum(session.all)": 100},
+                }
+            ],
+        }
+        experimental = {
+            "intervals": intervals,
+            "groups": [
+                {"by": {}, "series": {"sum(session.all)": [50]}, "totals": {"sum(session.all)": 50}}
+            ],
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"match": "False", "is_null_result": "False"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_null_eap_result(self, mock_metrics: MagicMock) -> None:
+        intervals = [isoformat_z(ONE_HOUR_AGO)]
+        control = {
+            "intervals": intervals,
+            "groups": [
+                {
+                    "by": {},
+                    "series": {"sum(session.all)": [100]},
+                    "totals": {"sum(session.all)": 100},
+                }
+            ],
+        }
+        experimental: dict[str, list[object]] = {"groups": []}
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"match": "False", "is_null_result": "True"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_structural_mismatch_is_detected(self, mock_metrics: MagicMock) -> None:
+        """Series key mismatch between control and experimental should be detected."""
+        intervals = [isoformat_z(ONE_HOUR_AGO)]
+        control = {
+            "intervals": intervals,
+            "groups": [{"by": {}, "series": {"session.all": [5.0]}}],
+        }
+        experimental = {
+            "intervals": intervals,
+            "groups": [{"by": {}, "series": {"session.all": [5.0], "extra_field": [1.0]}}],
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"match": "False", "is_null_result": "False"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_skips_comparison_when_all_data_recent(self, mock_metrics: MagicMock) -> None:
+        """When all intervals are within the freshness buffer, comparison is skipped."""
+        now = datetime.now(timezone.utc)
+        recent_intervals = [
+            isoformat_z(now - timedelta(minutes=10)),
+            isoformat_z(now - timedelta(minutes=5)),
+            isoformat_z(now),
+        ]
+        control = {
+            "intervals": recent_intervals,
+            "groups": [{"by": {}, "series": {"sum(session.all)": [100, 200, 300]}}],
+        }
+        experimental = {
+            "intervals": recent_intervals,
+            "groups": [{"by": {}, "series": {"sum(session.all)": [999, 999, 999]}}],
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"match": "skipped", "is_null_result": "False"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_only_compares_old_buckets(self, mock_metrics: MagicMock) -> None:
+        """Old buckets match but recent ones differ — should report match."""
+        now = datetime.now(timezone.utc)
+        old_ts = now - _FRESHNESS_BUFFER - timedelta(hours=1)
+        recent_ts = now - timedelta(minutes=5)
+        intervals = [isoformat_z(old_ts), isoformat_z(recent_ts)]
+        control = {
+            "intervals": intervals,
+            "groups": [{"by": {}, "series": {"sum(session.all)": [100, 200]}}],
+        }
+        experimental = {
+            "intervals": intervals,
+            "groups": [{"by": {}, "series": {"sum(session.all)": [100, 999]}}],
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"match": "True", "is_null_result": "False"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_mismatch_in_old_buckets(self, mock_metrics: MagicMock) -> None:
+        """Old buckets differ — should report mismatch."""
+        now = datetime.now(timezone.utc)
+        old_ts = now - _FRESHNESS_BUFFER - timedelta(hours=1)
+        recent_ts = now - timedelta(minutes=5)
+        intervals = [isoformat_z(old_ts), isoformat_z(recent_ts)]
+        control = {
+            "intervals": intervals,
+            "groups": [{"by": {}, "series": {"sum(session.all)": [100, 200]}}],
+        }
+        experimental = {
+            "intervals": intervals,
+            "groups": [{"by": {}, "series": {"sum(session.all)": [999, 200]}}],
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"match": "False", "is_null_result": "False"},
+        )
+
+    @patch("sentry.release_health.eap_sessions_rollout.metrics")
+    def test_datetime_intervals(self, mock_metrics: MagicMock) -> None:
+        """Intervals passed as datetime objects (from metrics pipeline) should work."""
+        intervals = [ONE_HOUR_AGO]
+        control = {
+            "intervals": intervals,
+            "groups": [{"by": {}, "series": {"sum(session.all)": [100]}}],
+        }
+        experimental = {
+            "intervals": intervals,
+            "groups": [{"by": {}, "series": {"sum(session.all)": [100]}}],
+        }
+        compare_get_series_results(control, experimental)
+        mock_metrics.incr.assert_called_once_with(
+            "eap_sessions.get_series_compare",
+            tags={"match": "True", "is_null_result": "False"},
+        )

--- a/tests/sentry/release_health/test_eap_sessions_rollout.py
+++ b/tests/sentry/release_health/test_eap_sessions_rollout.py
@@ -274,108 +274,6 @@ class TestTransformResponse(TestCase):
         assert groups_by_release["2.0"]["totals"]["sum(session)"] == 30.0
 
 
-class TestDoubleRead(TestCase):
-    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
-    def test_flag_off_no_eap_query(self, mock_rpc: MagicMock) -> None:
-        """When feature flag is off, EAP query is never called."""
-        from sentry.release_health.metrics import MetricsReleaseHealthBackend
-
-        backend = MetricsReleaseHealthBackend()
-        query = _make_query(["sum(session)"])
-
-        control_result = {
-            "start": ONE_HOUR_AGO,
-            "end": NOW,
-            "intervals": [],
-            "groups": [
-                {"by": {}, "series": {"sum(session)": [100.0]}, "totals": {"sum(session)": 100.0}}
-            ],
-            "query": "",
-        }
-
-        with patch("sentry.release_health.metrics.run_sessions_query", return_value=control_result):
-            with self.feature({"organizations:session-health-eap": False}):
-                result = backend.run_sessions_query(self.organization.id, query, "test")
-
-        assert result == control_result
-        mock_rpc.assert_not_called()
-
-    @patch("sentry.release_health.eap_sessions_rollout.timeseries_rpc")
-    def test_flag_on_returns_control(self, mock_rpc: MagicMock) -> None:
-        """When flag is on, always returns control data."""
-        from sentry.release_health.metrics import MetricsReleaseHealthBackend
-
-        backend = MetricsReleaseHealthBackend()
-        query = _make_query(["sum(session)"])
-
-        control_result = {
-            "start": ONE_HOUR_AGO,
-            "end": NOW,
-            "intervals": [],
-            "groups": [
-                {"by": {}, "series": {"sum(session)": [100.0]}, "totals": {"sum(session)": 100.0}}
-            ],
-            "query": "",
-        }
-
-        mock_rpc.return_value = [TimeSeriesResponse(result_timeseries=[])]
-
-        with patch("sentry.release_health.metrics.run_sessions_query", return_value=control_result):
-            with self.feature({"organizations:session-health-eap": True}):
-                result = backend.run_sessions_query(self.organization.id, query, "test")
-
-        assert result == control_result
-
-    @patch(
-        "sentry.release_health.eap_sessions_rollout.timeseries_rpc",
-        side_effect=Exception("EAP is down"),
-    )
-    def test_eap_failure_returns_control(self, mock_rpc: MagicMock) -> None:
-        """EAP failure does not affect response — control data is returned."""
-        from sentry.release_health.metrics import MetricsReleaseHealthBackend
-
-        backend = MetricsReleaseHealthBackend()
-        query = _make_query(["sum(session)"])
-
-        control_result = {
-            "start": ONE_HOUR_AGO,
-            "end": NOW,
-            "intervals": [],
-            "groups": [
-                {"by": {}, "series": {"sum(session)": [100.0]}, "totals": {"sum(session)": 100.0}}
-            ],
-            "query": "",
-        }
-
-        with patch("sentry.release_health.metrics.run_sessions_query", return_value=control_result):
-            with self.feature({"organizations:session-health-eap": True}):
-                result = backend.run_sessions_query(self.organization.id, query, "test")
-
-        assert result == control_result
-
-
-def _make_query(
-    raw_fields: list[str],
-    raw_groupby: list[str] | None = None,
-    start: datetime | None = None,
-    end: datetime | None = None,
-    rollup: int = 3600,
-    project_ids: list[int] | None = None,
-    query: str = "",
-) -> MagicMock:
-    """Create a mock QueryDefinition for tests that go through the backend."""
-    mock = MagicMock()
-    mock.raw_fields = raw_fields
-    mock.raw_groupby = raw_groupby or []
-    mock.start = start or ONE_HOUR_AGO
-    mock.end = end or NOW
-    mock.rollup = rollup
-    mock.params = {"project_id": project_ids or [1]}
-    mock.query = query
-    mock.get_filter_conditions.return_value = []
-    return mock
-
-
 def _make_metrics_query(
     fields: list[tuple[str | None, str]],
     groupby: list[str] | None = None,
@@ -566,6 +464,7 @@ class TestCompareGetSeriesResults(TestCase):
         mock_metrics.incr.assert_called_once_with(
             "eap_sessions.get_series_compare",
             tags={"match": "True", "is_null_result": "False"},
+            sample_rate=1.0,
         )
 
     @patch("sentry.release_health.eap_sessions_rollout.metrics")
@@ -591,6 +490,7 @@ class TestCompareGetSeriesResults(TestCase):
         mock_metrics.incr.assert_called_once_with(
             "eap_sessions.get_series_compare",
             tags={"match": "False", "is_null_result": "False"},
+            sample_rate=1.0,
         )
 
     @patch("sentry.release_health.eap_sessions_rollout.metrics")
@@ -611,6 +511,7 @@ class TestCompareGetSeriesResults(TestCase):
         mock_metrics.incr.assert_called_once_with(
             "eap_sessions.get_series_compare",
             tags={"match": "False", "is_null_result": "True"},
+            sample_rate=1.0,
         )
 
     @patch("sentry.release_health.eap_sessions_rollout.metrics")
@@ -629,6 +530,7 @@ class TestCompareGetSeriesResults(TestCase):
         mock_metrics.incr.assert_called_once_with(
             "eap_sessions.get_series_compare",
             tags={"match": "False", "is_null_result": "False"},
+            sample_rate=1.0,
         )
 
     @patch("sentry.release_health.eap_sessions_rollout.metrics")
@@ -652,6 +554,7 @@ class TestCompareGetSeriesResults(TestCase):
         mock_metrics.incr.assert_called_once_with(
             "eap_sessions.get_series_compare",
             tags={"match": "skipped", "is_null_result": "False"},
+            sample_rate=1.0,
         )
 
     @patch("sentry.release_health.eap_sessions_rollout.metrics")
@@ -673,6 +576,7 @@ class TestCompareGetSeriesResults(TestCase):
         mock_metrics.incr.assert_called_once_with(
             "eap_sessions.get_series_compare",
             tags={"match": "True", "is_null_result": "False"},
+            sample_rate=1.0,
         )
 
     @patch("sentry.release_health.eap_sessions_rollout.metrics")
@@ -694,6 +598,7 @@ class TestCompareGetSeriesResults(TestCase):
         mock_metrics.incr.assert_called_once_with(
             "eap_sessions.get_series_compare",
             tags={"match": "False", "is_null_result": "False"},
+            sample_rate=1.0,
         )
 
     @patch("sentry.release_health.eap_sessions_rollout.metrics")
@@ -712,4 +617,5 @@ class TestCompareGetSeriesResults(TestCase):
         mock_metrics.incr.assert_called_once_with(
             "eap_sessions.get_series_compare",
             tags={"match": "True", "is_null_result": "False"},
+            sample_rate=1.0,
         )


### PR DESCRIPTION
Migrates the `OrganizationReleaseHealthDataEndpoint` to use the EAP sessions data. This is one of two places session data is queried. The other is `OrganizationSessionsEndpoint`. I'm not sure why there is this split (the list of queries that go to sessions is [here](https://github.com/getsentry/sentry/blob/fcb7dbdfcc89644d75ee15ec1aa4288dd34472b6/static/app/views/dashboards/widgetCard/hooks/utils/releases.tsx#L20)), but `OrganizationReleaseHealthDataEndpoint` handles a subset of the queries, for example it handles `crash_free_rate` but not `crash_rate`.

This PR adds support just for the queries that are handled by `OrganizationReleaseHealthDataEndpoint`. The EAP data is never returned, only used as a shadow read. When testing locally I'd find the EAP data available faster than the legacy pipeline, so I only compare data more than 30 minutes old to give time for both paths to catch up