### PR TITLE
fix(eap): Declare http.response_status_code as integer attribute

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -269,6 +269,11 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="byte",
         ),
         ResolvedAttribute(
+            public_alias="http.response_status_code",
+            internal_name="http.response.status_code",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
             public_alias="sampling_rate",
             internal_name="sentry.sampling_factor",
             search_type="percentage",

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -2639,3 +2639,53 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             {"key": "project.id", "value": str(self.project.id)},
             {"key": "project.name", "value": self.project.slug},
         ]
+
+    def test_group_by_http_response_status_code(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo"},
+                    start_ts=self.start + timedelta(minutes=1),
+                    measurements={"http.response.status_code": {"value": 200}},
+                ),
+                self.create_span(
+                    {"description": "bar"},
+                    start_ts=self.start + timedelta(minutes=1),
+                    measurements={"http.response.status_code": {"value": 200}},
+                ),
+                self.create_span(
+                    {"description": "baz"},
+                    start_ts=self.start + timedelta(minutes=1),
+                    measurements={"http.response.status_code": {"value": 404}},
+                ),
+            ],
+        )
+
+        self.end = self.start + timedelta(minutes=6)
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1m",
+                "yAxis": "count()",
+                "groupBy": ["http.response_status_code", "count()"],
+                "orderby": ["-count()"],
+                "project": self.project.id,
+                "dataset": "spans",
+                "excludeOther": 0,
+                "topEvents": 5,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        time_series_by_status = {
+            ts["groupBy"][0]["value"]: ts
+            for ts in response.data["timeSeries"]
+            if ts["groupBy"] is not None
+        }
+        assert time_series_by_status["200"]["groupBy"] == [
+            {"key": "http.response_status_code", "value": "200"}
+        ]
+        assert time_series_by_status["404"]["groupBy"] == [
+            {"key": "http.response_status_code", "value": "404"}
+        ]


### PR DESCRIPTION
Adds `http.response_status_code` as a resolved attribute with `search_type="integer"` in the EAP spans attribute definitions.

Without this declaration, `http.response_status_code` is treated as a float, so groupBy values in timeseries queries appear as `200.0` instead of `200`. Declaring it as an integer ensures clean, non-fractional values when used as a groupBy key in dashboards and explore.

Includes a test that requests `count()` grouped by `http.response_status_code` and verifies the groupBy values are correct.

Fixes DAIN-1386