### PR TITLE
fix(explore): Disable metric selector highlight scrolling

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -350,17 +350,6 @@ export function MetricSelector({
     overscan: 20,
   });
 
-  const focusedIndex = useMemo(
-    () => collectionItems.findIndex(item => item.key === focusedKey),
-    [collectionItems, focusedKey]
-  );
-
-  useEffect(() => {
-    if (focusedIndex >= 0 && isOpen) {
-      virtualizer.scrollToIndex(focusedIndex, {align: 'auto'});
-    }
-  }, [focusedIndex, isOpen, virtualizer]);
-
   const highlightedOption = focusedKey
     ? (displayedOptionsMap.get(String(focusedKey)) ?? null)
     : null;


### PR DESCRIPTION
The metric selector was calling `scrollToIndex` whenever the focused option changed. That caused the dropdown list to jump while hovering items or moving through highlighted options.

Made with [Cursor](https://cursor.com)