### PR TITLE
perf(dashboards): Measure re-render duration on full-screen widget view

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import type {LegendComponentOption} from 'echarts';
 import type {Location} from 'history';
 import omit from 'lodash/omit';
@@ -30,6 +31,7 @@ import {getFieldDefinition} from 'sentry/utils/fields';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import {useExtractionStatus} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import {scheduleMicroTask} from 'sentry/utils/scheduleMicroTask';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -257,6 +259,14 @@ function WidgetCard(props: Props) {
         {preventScrollReset: true}
       );
     } else {
+      const start = performance.now();
+      // Measure how long it takes to open the full-screen modal view.
+      scheduleMicroTask(() => {
+        const duration = performance.now() - start;
+        Sentry.metrics.distribution('dashboards.widget.onFullScreenView', duration, {
+          unit: 'millisecond',
+        });
+      });
       openWidgetViewerModal({
         organization,
         widget,


### PR DESCRIPTION
Set a performance.mark on click, then measure the duration in dataWidgetViewerModal on mount — emitting a `dashboards.widget.onFullScreenView` distribution metric.

Prebuilt insights dashboards (no dashboard ID) are not included for measurement.

Refs DAIN-1371