### PR TITLE
ref(dashboards): Hide breakdown legend in full screen widget view

### DIFF
--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -631,6 +631,7 @@ function DataWidgetViewerModal(props: Props) {
                 widget={primaryWidget}
                 tableItemLimit={widget.limit}
                 onZoom={onZoom}
+                isFullScreen
                 showConfidenceWarning={
                   widget.widgetType === WidgetType.SPANS ||
                   widget.widgetType === WidgetType.TRACEMETRICS ||

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -59,6 +59,7 @@ interface VisualizationWidgetProps {
   selection: PageFilters;
   widget: Widget;
   dashboardFilters?: DashboardFilters;
+  isFullScreen?: boolean;
   legendSelection?: LegendSelection;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: {
@@ -94,6 +95,7 @@ export function VisualizationWidget({
   onZoom,
   legendSelection,
   onLegendSelectionChange,
+  isFullScreen,
 }: VisualizationWidgetProps) {
   const {releases: releasesWithDate} = useReleaseStats(selection, {
     enabled: showReleaseAs !== 'none',
@@ -148,6 +150,7 @@ export function VisualizationWidget({
             onZoom={onZoom}
             legendSelection={legendSelection}
             onLegendSelectionChange={onLegendSelectionChange}
+            isFullScreen={isFullScreen}
           />
         );
       }}
@@ -165,6 +168,7 @@ interface VisualizationWidgetContentProps {
   dashboardFilters?: DashboardFilters;
   dataScanned?: 'full' | 'partial';
   errorMessage?: string;
+  isFullScreen?: boolean;
   isSampled?: boolean | null;
   legendSelection?: LegendSelection;
   onLegendSelectionChange?: (selection: LegendSelection) => void;
@@ -197,6 +201,7 @@ function VisualizationWidgetContent({
   onZoom,
   legendSelection,
   onLegendSelectionChange,
+  isFullScreen,
 }: VisualizationWidgetContentProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -257,6 +262,7 @@ function VisualizationWidgetContent({
       : [];
 
   const showBreakdownData =
+    !isFullScreen &&
     widget.legendType === 'breakdown' &&
     usesTimeSeriesData(widget.displayType) &&
     tableResults &&


### PR DESCRIPTION
The breakdown legend table is redundant in full screen mode since there is already a full data table rendered below the chart. THis is a regression from moving to the new timeseries visualizations in the widget viewer

Adds an `isFullScreen` prop to `VisualizationWidget` and passes it from the widget viewer modal to suppress the duplicate breakdown.

### Before
<img width="1153" height="647" alt="image" src="https://github.com/user-attachments/assets/fd7d9051-2de4-4778-80d4-f2f5a96f3481" />

### After
<img width="1162" height="651" alt="image" src="https://github.com/user-attachments/assets/be2e7054-f97b-477f-84f7-ef8b170651b1" />
