### PR TITLE
fix(knip): enable official mdx plugin

### DIFF
--- a/build-utils/remark-unwrap-mdx-paragraphs.ts
+++ b/build-utils/remark-unwrap-mdx-paragraphs.ts
@@ -1,4 +1,4 @@
-import type {Literal, Node, Parent} from 'hast';
+import type {Literal, Node, Parent} from 'unist';
 import {visit} from 'unist-util-visit';
 
 /**
@@ -51,7 +51,7 @@ export function remarkUnwrapMdxParagraphs() {
 function isParagraph(node?: Node): node is Parent {
   return node?.type === 'paragraph';
 }
-function isText(node: Node): node is Literal {
+function isText(node: Node): node is Literal & {value: string} {
   return node.type === 'text';
 }
 function isMdxJsxNode(node: Node): node is Parent {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,4 +1,3 @@
-import {compile} from '@mdx-js/mdx';
 import type {KnipConfig} from 'knip';
 
 const isProductionMode = process.argv.includes('--production');
@@ -62,9 +61,6 @@ const config: KnipConfig = {
     // ignore eslint plugins in production
     '!static/eslint/**/*.ts!',
   ],
-  compilers: {
-    mdx: async text => String(await compile(text)),
-  },
   ignoreExportsUsedInFile: isProductionMode,
   ignoreDependencies: [
     'core-js',
@@ -87,6 +83,9 @@ const config: KnipConfig = {
     unlisted: 'off',
   },
   include: ['nsExports', 'nsTypes'],
+  mdx: {
+    config: 'tsconfig.mdx.json',
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mdx-js/loader": "^3.1.0",
-    "@mdx-js/mdx": "^3.1.0",
     "@popperjs/core": "^2.11.5",
     "@r4ai/remark-callout": "^0.6.2",
     "@react-aria/button": "3.14.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       '@mdx-js/loader':
         specifier: ^3.1.0
         version: 3.1.0(acorn@8.16.0)(webpack@5.99.6(esbuild@0.25.10))
-      '@mdx-js/mdx':
-        specifier: ^3.1.0
-        version: 3.1.0(acorn@8.16.0)
       '@popperjs/core':
         specifier: ^2.11.5
         version: 2.11.5


### PR DESCRIPTION
Previously, we used `@mdx-js/mdx` to compile `.mdx` files for Knip.
Now, we use the [official `mdx` plugin](https://knip.dev/reference/plugins/mdx) and point it at our `tsconfig.mdx.json` file.