### PR TITLE
Scope get_latest_issue_event ID query to the organization

### DIFF
--- a/src/sentry/seer/fetch_issues/utils.py
+++ b/src/sentry/seer/fetch_issues/utils.py
@@ -152,7 +152,9 @@ def get_latest_issue_event(group_id: int | str, organization_id: int) -> dict[st
     if isinstance(group_id, str) and not group_id.isdigit():
         group = _group_by_short_id(group_id, organization_id)
     else:
-        group = Group.objects.filter(id=int(group_id)).first()
+        group = Group.objects.filter(
+            id=int(group_id), project__organization_id=organization_id
+        ).first()
 
     if not group:
         logger.warning(

--- a/tests/sentry/seer/fetch_issues/test_utils.py
+++ b/tests/sentry/seer/fetch_issues/test_utils.py
@@ -289,6 +289,18 @@ class TestGetLatestIssueEvent(TestCase):
         results = get_latest_issue_event(group.id, self.organization.id + 1)
         assert results == {}
 
+    def test_get_latest_issue_event_numeric_id_cross_org(self):
+        """Numeric group ID from another org must not be returned."""
+        other_org = self.create_organization(owner=self.create_user())
+        other_project = self.create_project(organization=other_org)
+        data = load_data("python", timestamp=before_now(minutes=1))
+        other_event = self.store_event(data=data, project_id=other_project.id)
+        other_group = other_event.group
+        assert other_group is not None
+
+        result = get_latest_issue_event(other_group.id, self.organization.id)
+        assert result == {}
+
 
 class TestHandleFetchIssuesExceptions(TestCase):
     def test_handle_fetch_issues_exceptions_success(self):


### PR DESCRIPTION
Defense in depth and save us from loading data in memory we don't need. 

The group_id param is (indirectly) user controlled since seer pulls those issue IDs from PR descriptions. _group_by_short_id scoped the organization, but the ID path didn't have an org filter. We have a post-query check so i's already not a problem in the response, but there's no reason to query for this at all when we can pre-filter. Prevents loading that data in memory and makes both paths consistent. 

