### PR TITLE
chore(issues): Remove duplicate metric

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -133,7 +133,6 @@ def _capture_event_stats(event: Event) -> None:
     platform = format_event_platform(event)
     tags = {"platform": platform}
     metrics.incr("events.processed", tags={"platform": platform}, skip_internal=False)
-    metrics.incr(f"events.processed.{platform}", skip_internal=False)
     metrics.distribution("events.size.data", event.size, tags=tags, unit="byte")
 
 


### PR DESCRIPTION
As far as I can tell this predates the `sentry.events.processed` metric which has a platform tag. The removed metric is not used in any alerts/dashboards/etc as far as I can tell.