### PR TITLE
fix(seer): Handle missing OrganizationMember in collect_user_org_context

### DIFF
--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -205,7 +205,13 @@ def collect_user_org_context(
             "all_org_projects": all_org_projects,
         }
 
-    member = OrganizationMember.objects.get(organization=organization, user_id=user.id)
+    try:
+        member = OrganizationMember.objects.get(organization=organization, user_id=user.id)
+    except OrganizationMember.DoesNotExist:
+        return {
+            "org_slug": organization.slug,
+            "all_org_projects": all_org_projects,
+        }
     user_teams = [{"id": t.id, "slug": t.slug} for t in member.get_teams()]
     my_projects = (
         Project.objects.filter(

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -208,6 +208,15 @@ def collect_user_org_context(
     try:
         member = OrganizationMember.objects.get(organization=organization, user_id=user.id)
     except OrganizationMember.DoesNotExist:
+        # User is not a member of this organization (e.g., superuser accessing foreign org)
+        logger.warning(
+            "User attempted to access Seer Explorer for organization they are not a member of",
+            extra={
+                "user_id": user.id,
+                "organization_id": organization.id,
+                "organization_slug": organization.slug,
+            },
+        )
         return {
             "org_slug": organization.slug,
             "all_org_projects": all_org_projects,

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -1,12 +1,8 @@
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
-from sentry.models.organizationmember import OrganizationMember
-from sentry.seer.explorer.client_utils import collect_user_org_context
-from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.requests import make_request
 
 
 @with_feature("organizations:seer-explorer")
@@ -228,105 +224,3 @@ class OrganizationSeerExplorerChatContextEngineTest(APITestCase):
         assert response.status_code == 200
         body = mock_chat_request.call_args[0][0]
         assert body.get("is_context_engine_enabled") is not False
-
-
-class CollectUserOrgContextTest(APITestCase):
-    """Test the collect_user_org_context helper function"""
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.project1 = self.create_project(
-            organization=self.organization, teams=[self.team], slug="project-1"
-        )
-        self.project2 = self.create_project(
-            organization=self.organization, teams=[self.team], slug="project-2"
-        )
-        self.other_team = self.create_team(organization=self.organization, slug="other-team")
-        self.other_project = self.create_project(
-            organization=self.organization, teams=[self.other_team], slug="other-project"
-        )
-
-    def test_collect_context_with_member(self):
-        """Test context collection for a user who is an organization member"""
-        context = collect_user_org_context(self.user, self.organization)
-
-        assert context is not None
-        assert context["org_slug"] == self.organization.slug
-        assert context.get("user_id") == self.user.id
-        assert context.get("user_name") == self.user.name
-        assert context.get("user_email") == self.user.email
-        assert context.get("user_timezone") is None  # No timezone set by default
-        assert context.get("user_ip") is None  # No IP address set by default
-
-        # Should have exactly one team
-        assert "user_teams" in context
-        assert len(context["user_teams"]) == 1
-        assert context["user_teams"][0]["slug"] == self.team.slug
-
-        # User projects should include project1 and project2 (both on self.team)
-        assert "user_projects" in context
-        user_project_slugs = {p["slug"] for p in context["user_projects"]}
-        assert user_project_slugs == {"project-1", "project-2"}
-
-        # All org projects should include all 3 projects
-        assert "all_org_projects" in context
-        all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
-        assert all_project_slugs == {"project-1", "project-2", "other-project"}
-        all_project_ids = {p["id"] for p in context["all_org_projects"]}
-        assert all_project_ids == {self.project1.id, self.project2.id, self.other_project.id}
-
-    def test_collect_context_with_multiple_teams(self):
-        """Test context collection for a user in multiple teams"""
-        team2 = self.create_team(organization=self.organization, slug="team-2")
-        member = OrganizationMember.objects.get(
-            organization=self.organization, user_id=self.user.id
-        )
-        with unguarded_write(using="default"):
-            member.teams.add(team2)
-
-        context = collect_user_org_context(self.user, self.organization)
-
-        assert context is not None
-        assert "user_teams" in context
-        team_slugs = {t["slug"] for t in context["user_teams"]}
-        assert team_slugs == {self.team.slug, "team-2"}
-
-    def test_collect_context_with_no_teams(self):
-        """Test context collection for a member with no team membership"""
-        member = OrganizationMember.objects.get(
-            organization=self.organization, user_id=self.user.id
-        )
-        # Remove user from all teams
-        with unguarded_write(using="default"):
-            member.teams.clear()
-
-        context = collect_user_org_context(self.user, self.organization)
-
-        assert context is not None
-        assert context.get("user_teams") == []
-        assert context.get("user_projects") == []
-        # All org projects should still be present
-        assert "all_org_projects" in context
-        all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
-        assert all_project_slugs == {"project-1", "project-2", "other-project"}
-
-    def test_collect_context_with_timezone(self):
-        """Test context collection includes user's timezone setting"""
-        from sentry.users.services.user_option import user_option_service
-
-        user_option_service.set_option(
-            user_id=self.user.id, key="timezone", value="America/Los_Angeles"
-        )
-
-        context = collect_user_org_context(self.user, self.organization)
-
-        assert context is not None
-        assert context.get("user_timezone") == "America/Los_Angeles"
-
-    def test_collect_context_with_request(self):
-        """Test context collection includes request metadata like IP address"""
-        request, _ = make_request()
-        context = collect_user_org_context(self.user, self.organization, request=request)
-
-        assert context is not None
-        assert context.get("user_ip") == request.META.get("REMOTE_ADDR")

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -1,8 +1,11 @@
+from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
     has_seer_explorer_access_with_detail,
 )
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
+from sentry.testutils.requests import make_request
 
 
 class TestHasSeerExplorerAccessWithDetail(TestCase):
@@ -78,16 +81,115 @@ class TestHasSeerExplorerAccessWithDetail(TestCase):
         )
 
 
-class TestCollectUserOrgContext(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.org = self.create_organization(owner=self.user)
-        self.project = self.create_project(organization=self.org)
+class CollectUserOrgContextTest(TestCase):
+    """Test the collect_user_org_context helper function"""
 
-    def test_user_not_org_member_returns_default(self):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project1 = self.create_project(
+            organization=self.organization, teams=[self.team], slug="project-1"
+        )
+        self.project2 = self.create_project(
+            organization=self.organization, teams=[self.team], slug="project-2"
+        )
+        self.other_team = self.create_team(organization=self.organization, slug="other-team")
+        self.other_project = self.create_project(
+            organization=self.organization, teams=[self.other_team], slug="other-project"
+        )
+
+    def test_collect_context_with_member(self):
+        """Test context collection for a user who is an organization member"""
+        context = collect_user_org_context(self.user, self.organization)
+
+        assert context is not None
+        assert context["org_slug"] == self.organization.slug
+        assert context.get("user_id") == self.user.id
+        assert context.get("user_name") == self.user.name
+        assert context.get("user_email") == self.user.email
+        assert context.get("user_timezone") is None  # No timezone set by default
+        assert context.get("user_ip") is None  # No IP address set by default
+
+        # Should have exactly one team
+        assert "user_teams" in context
+        assert len(context["user_teams"]) == 1
+        assert context["user_teams"][0]["slug"] == self.team.slug
+
+        # User projects should include project1 and project2 (both on self.team)
+        assert "user_projects" in context
+        user_project_slugs = {p["slug"] for p in context["user_projects"]}
+        assert user_project_slugs == {"project-1", "project-2"}
+
+        # All org projects should include all 3 projects
+        assert "all_org_projects" in context
+        all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
+        assert all_project_slugs == {"project-1", "project-2", "other-project"}
+        all_project_ids = {p["id"] for p in context["all_org_projects"]}
+        assert all_project_ids == {self.project1.id, self.project2.id, self.other_project.id}
+
+    def test_collect_context_with_multiple_teams(self):
+        """Test context collection for a user in multiple teams"""
+        team2 = self.create_team(organization=self.organization, slug="team-2")
+        member = OrganizationMember.objects.get(
+            organization=self.organization, user_id=self.user.id
+        )
+        with unguarded_write(using="default"):
+            member.teams.add(team2)
+
+        context = collect_user_org_context(self.user, self.organization)
+
+        assert context is not None
+        assert "user_teams" in context
+        team_slugs = {t["slug"] for t in context["user_teams"]}
+        assert team_slugs == {self.team.slug, "team-2"}
+
+    def test_collect_context_with_no_teams(self):
+        """Test context collection for a member with no team membership"""
+        member = OrganizationMember.objects.get(
+            organization=self.organization, user_id=self.user.id
+        )
+        # Remove user from all teams
+        with unguarded_write(using="default"):
+            member.teams.clear()
+
+        context = collect_user_org_context(self.user, self.organization)
+
+        assert context is not None
+        assert context.get("user_teams") == []
+        assert context.get("user_projects") == []
+        # All org projects should still be present
+        assert "all_org_projects" in context
+        all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
+        assert all_project_slugs == {"project-1", "project-2", "other-project"}
+
+    def test_collect_context_with_non_member_returns_default(self):
+        """Test context collection for a user who is not an organization member"""
         other_user = self.create_user()
-        result = collect_user_org_context(other_user, self.org)
-        assert result == {
-            "org_slug": self.org.slug,
-            "all_org_projects": [{"id": self.project.id, "slug": self.project.slug}],
+        context = collect_user_org_context(other_user, self.organization)
+
+        all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
+        assert context == {
+            "org_slug": self.organization.slug,
+            "all_org_projects": context["all_org_projects"],
         }
+        assert all_project_slugs == {"project-1", "project-2", "other-project"}
+
+    def test_collect_context_with_timezone(self):
+        """Test context collection includes user's timezone setting"""
+        from sentry.users.services.user_option import user_option_service
+
+        user_option_service.set_option(
+            user_id=self.user.id, key="timezone", value="America/Los_Angeles"
+        )
+
+        context = collect_user_org_context(self.user, self.organization)
+
+        assert context is not None
+        assert context.get("user_timezone") == "America/Los_Angeles"
+
+    def test_collect_context_with_request(self):
+        """Test context collection includes request metadata like IP address"""
+        request, _ = make_request()
+        context = collect_user_org_context(self.user, self.organization, request=request)
+
+        assert context is not None
+        assert context.get("user_ip") == request.META.get("REMOTE_ADDR")

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -1,4 +1,7 @@
-from sentry.seer.explorer.client_utils import has_seer_explorer_access_with_detail
+from sentry.seer.explorer.client_utils import (
+    collect_user_org_context,
+    has_seer_explorer_access_with_detail,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -73,3 +76,18 @@ class TestHasSeerExplorerAccessWithDetail(TestCase):
             False,
             "Organization does not have open team membership enabled. Seer requires this to aggregate context across all projects and allow members to ask questions freely.",
         )
+
+
+class TestCollectUserOrgContext(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+
+    def test_user_not_org_member_returns_default(self):
+        other_user = self.create_user()
+        result = collect_user_org_context(other_user, self.org)
+        assert result == {
+            "org_slug": self.org.slug,
+            "all_org_projects": [{"id": self.project.id, "slug": self.project.slug}],
+        }


### PR DESCRIPTION
Guard against `OrganizationMember.DoesNotExist` in `collect_user_org_context` when the user is not a member of the organization. Previously this would raise an unhandled exception; now it returns the same default context (org slug + all org projects) as the anonymous user path.