### PR TITLE
fix: selective dispatch should target backend-selective.yml

### DIFF
--- a/.github/workflows/backend-selective.yml
+++ b/.github/workflows/backend-selective.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
 # hack for https://github.com/actions/cache/issues/810#issuecomment-1222550359
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
@@ -62,6 +66,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+
           CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --paginate --jq '.[].filename' | tr '\n' ' ')
           echo "Changed files: $CHANGED_FILES"
           echo "files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
@@ -83,7 +88,7 @@ jobs:
       - name: Download coverage database
         id: download-coverage
         run: |
-          set -euo pipefail
+
           mkdir -p .artifacts/coverage
 
           GCS_PATH="gs://getsentry-coverage-data/latest/.coverage.combined"
@@ -106,7 +111,7 @@ jobs:
           COVERAGE_DB: ${{ steps.download-coverage.outputs.coverage-file }}
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: |
-          set -euo pipefail
+
 
           python3 .github/workflows/scripts/compute-sentry-selected-tests.py \
             --coverage-db "$COVERAGE_DB" \

--- a/.github/workflows/getsentry-dispatch-selective.yml
+++ b/.github/workflows/getsentry-dispatch-selective.yml
@@ -96,4 +96,5 @@ jobs:
               mergeCommitSha: '${{ steps.mergecommit.outputs.mergeCommitSha }}',
               fileChanges: ${{ toJson(steps.changes.outputs) }},
               sentryChangedFiles: process.env.SENTRY_CHANGED_FILES,
+              targetWorkflow: 'backend-selective.yml',
             });

--- a/.github/workflows/scripts/getsentry-dispatch.js
+++ b/.github/workflows/scripts/getsentry-dispatch.js
@@ -20,11 +20,16 @@ export async function dispatch({
   fileChanges,
   mergeCommitSha,
   sentryChangedFiles,
+  targetWorkflow,
 }) {
   core.startGroup('Dispatching request to getsentry.');
 
+  const dispatches = targetWorkflow !== undefined
+    ? [{workflow: targetWorkflow, pathFilterName: 'backend_all'}]
+    : DISPATCHES;
+
   await Promise.all(
-    DISPATCHES.map(({workflow, pathFilterName}) => {
+    dispatches.map(({workflow, pathFilterName}) => {
       const inputs = {
         pull_request_number: `${context.payload.pull_request.number}`, // needs to be string
         skip: `${fileChanges[pathFilterName] !== 'true'}`, // even though this is a boolean, it must be cast to a string

--- a/.github/workflows/scripts/getsentry-dispatch.js
+++ b/.github/workflows/scripts/getsentry-dispatch.js
@@ -24,9 +24,10 @@ export async function dispatch({
 }) {
   core.startGroup('Dispatching request to getsentry.');
 
-  const dispatches = targetWorkflow !== undefined
-    ? [{workflow: targetWorkflow, pathFilterName: 'backend_all'}]
-    : DISPATCHES;
+  const dispatches =
+    targetWorkflow !== undefined
+      ? [{workflow: targetWorkflow, pathFilterName: 'backend_all'}]
+      : DISPATCHES;
 
   await Promise.all(
     dispatches.map(({workflow, pathFilterName}) => {


### PR DESCRIPTION
requires https://github.com/getsentry/getsentry/pull/19634

forgot about this because we're now dual testing, so we need to be dual dispatching as well

currently we're dispatching backend.yml twice: https://github.com/getsentry/sentry/pull/111229/checks?check_run_id=67968779491 and https://github.com/getsentry/sentry/pull/111229/checks?check_run_id=67968785958
