### PR TITLE
fix(seer): Remove noisy capture_exception for expected ObjectDoesNotExist

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -252,8 +252,6 @@ class SeerRpcServiceEndpoint(Endpoint):
             sentry_sdk.capture_exception()
             raise ParseError from e
         except ObjectDoesNotExist as e:
-            # Let this fall through, this is normal.
-            sentry_sdk.capture_exception()
             raise NotFound from e
         except SnubaRPCRateLimitExceeded as e:
             sentry_sdk.capture_exception()


### PR DESCRIPTION
Remove `sentry_sdk.capture_exception()` from the `ObjectDoesNotExist` handler in `SeerRpcServiceEndpoint.post()`. This exception is expected behavior (the comment even says "this is normal") and already results in a proper 404 response via `raise NotFound`. The `capture_exception` call just creates unnecessary noise in Sentry.