### PR TITLE
fix(aci): Translate percent threshold value correctly for metric monitors

### DIFF
--- a/static/app/views/detectors/components/details/metric/detect.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.spec.tsx
@@ -5,6 +5,12 @@ import {
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {
+  DataConditionGroupLogicType,
+  DataConditionType,
+  DetectorPriorityLevel,
+} from 'sentry/types/workflowEngine/dataConditions';
+
 import {MetricDetectorDetailsDetect} from './detect';
 
 describe('MetricDetectorDetailsDetect', () => {
@@ -49,6 +55,26 @@ describe('MetricDetectorDetailsDetect', () => {
   it('renders percent change description with delta window', () => {
     const detector = MetricDetectorFixture({
       config: {detectionType: 'percent', comparisonDelta: 60},
+      // Percent thresholds are stored as absolute percentages internally:
+      // 108 = "8% higher" (108% of baseline), 92 for resolution = "8% lower" (100 - 92)
+      conditionGroup: {
+        conditions: [
+          {
+            id: '1',
+            type: DataConditionType.GREATER,
+            comparison: 108,
+            conditionResult: DetectorPriorityLevel.HIGH,
+          },
+          {
+            id: '2',
+            type: DataConditionType.LESS_OR_EQUAL,
+            comparison: 92,
+            conditionResult: DetectorPriorityLevel.OK,
+          },
+        ],
+        id: '1',
+        logicType: DataConditionGroupLogicType.ANY,
+      },
     });
 
     render(<MetricDetectorDetailsDetect detector={detector} />);
@@ -59,6 +85,37 @@ describe('MetricDetectorDetailsDetect', () => {
     expect(screen.getByText('Resolved')).toBeInTheDocument();
     expect(
       screen.getByText(/Below or equal to 8% lower than the previous 1 minute/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders percent change description when resolution comparison matches alert', () => {
+    const detector = MetricDetectorFixture({
+      config: {detectionType: 'percent', comparisonDelta: 604800},
+      conditionGroup: {
+        conditions: [
+          {
+            id: '1',
+            type: DataConditionType.GREATER,
+            comparison: 110,
+            conditionResult: DetectorPriorityLevel.HIGH,
+          },
+          {
+            id: '2',
+            type: DataConditionType.LESS_OR_EQUAL,
+            comparison: 110,
+            conditionResult: DetectorPriorityLevel.OK,
+          },
+        ],
+        id: '1',
+        logicType: DataConditionGroupLogicType.ANY,
+      },
+    });
+
+    render(<MetricDetectorDetailsDetect detector={detector} />);
+
+    expect(screen.getByText('10% higher than the previous 1 week')).toBeInTheDocument();
+    expect(
+      screen.getByText('Below or equal to 10% higher than the previous 1 week')
     ).toBeInTheDocument();
   });
 

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -76,19 +76,6 @@ function makeDirectionText(condition: MetricCondition) {
   }
 }
 
-function convertComparisonValue(
-  comparison: MetricCondition['comparison'],
-  config: MetricDetector['config']
-) {
-  if (typeof comparison !== 'number') {
-    return '';
-  }
-  if (config.detectionType === 'percent') {
-    return String(percentThresholdAbsoluteToDelta(comparison));
-  }
-  return String(comparison);
-}
-
 export function getConditionDescription({
   aggregate,
   config,
@@ -149,7 +136,7 @@ export function getConditionDescription({
     );
   }
 
-  return `${makeDirectionText(condition)} ${convertComparisonValue(condition.comparison, config)}${unit}`;
+  return `${makeDirectionText(condition)} ${condition.comparison}${unit}`;
 }
 
 function DetectorPriorities({detector}: {detector: MetricDetector}) {

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -30,6 +30,7 @@ import {
   isAnomalyDetectionComparison,
 } from 'sentry/views/detectors/utils/anomalyDetectionLabels';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
+import {percentThresholdAbsoluteToDelta} from 'sentry/views/detectors/utils/percentThreshold';
 
 function getDetectorTypeLabel(detector: MetricDetector) {
   if (detector.config.detectionType === 'dynamic') {
@@ -75,6 +76,19 @@ function makeDirectionText(condition: MetricCondition) {
   }
 }
 
+function convertComparisonValue(
+  comparison: MetricCondition['comparison'],
+  config: MetricDetector['config']
+) {
+  if (typeof comparison !== 'number') {
+    return '';
+  }
+  if (config.detectionType === 'percent') {
+    return String(percentThresholdAbsoluteToDelta(comparison));
+  }
+  return String(comparison);
+}
+
 export function getConditionDescription({
   aggregate,
   config,
@@ -84,8 +98,6 @@ export function getConditionDescription({
   condition: MetricCondition;
   config: MetricDetector['config'];
 }) {
-  const comparisonValue =
-    typeof condition.comparison === 'number' ? String(condition.comparison) : '';
   const unit = getMetricDetectorSuffix(config.detectionType, aggregate);
 
   if (config.detectionType === 'dynamic') {
@@ -104,17 +116,21 @@ export function getConditionDescription({
     return t('Dynamic threshold');
   }
 
+  // This should never happen, but we need to narrow the type
+  if (typeof condition.comparison !== 'number') {
+    return t('Invalid comparison value');
+  }
+
   if (config.detectionType === 'percent') {
-    const direction =
-      condition.type === DataConditionType.GREATER ? t('higher') : t('lower');
-    const delta = config.comparisonDelta;
-    const timeRange = getExactDuration(delta);
+    const direction = condition.comparison >= 100 ? t('higher') : t('lower');
+    const deltaComparison = percentThresholdAbsoluteToDelta(condition.comparison);
+    const timeRange = getExactDuration(config.comparisonDelta);
 
     if (condition.conditionResult === DetectorPriorityLevel.OK) {
       return t(
         `Below or equal to %(comparisonValue)s%(unit)s %(direction)s than the previous %(timeRange)s`,
         {
-          comparisonValue,
+          comparisonValue: deltaComparison,
           unit,
           direction,
           timeRange,
@@ -125,7 +141,7 @@ export function getConditionDescription({
     return t(
       `%(comparisonValue)s%(unit)s %(direction)s than the previous %(timeRange)s`,
       {
-        comparisonValue,
+        comparisonValue: deltaComparison,
         unit,
         direction,
         timeRange,
@@ -133,7 +149,7 @@ export function getConditionDescription({
     );
   }
 
-  return `${makeDirectionText(condition)} ${comparisonValue}${unit}`;
+  return `${makeDirectionText(condition)} ${convertComparisonValue(condition.comparison, config)}${unit}`;
 }
 
 function DetectorPriorities({detector}: {detector: MetricDetector}) {

--- a/static/app/views/detectors/components/detectorLink.spec.tsx
+++ b/static/app/views/detectors/components/detectorLink.spec.tsx
@@ -2,7 +2,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataConditionGroupLogicType,
+  DataConditionType,
+  DetectorPriorityLevel,
+} from 'sentry/types/workflowEngine/dataConditions';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {DetectorLink} from 'sentry/views/detectors/components/detectorLink';
@@ -108,5 +112,44 @@ describe('DetectorLink', () => {
 
     expect(screen.getByText(/all issues in/i)).toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders percent thresholds using delta values in details', () => {
+    const percentDetector: MetricDetector = {
+      ...mockDetector,
+      config: {
+        detectionType: 'percent',
+        comparisonDelta: 3600,
+      },
+      conditionGroup: {
+        id: 'cg-1',
+        logicType: DataConditionGroupLogicType.ALL,
+        conditions: [
+          {
+            id: 'c-1',
+            type: DataConditionType.GREATER,
+            comparison: 108,
+            conditionResult: DetectorPriorityLevel.HIGH,
+          },
+          {
+            id: 'c-2',
+            type: DataConditionType.GREATER,
+            comparison: 115,
+            conditionResult: DetectorPriorityLevel.MEDIUM,
+          },
+          {
+            id: 'c-ok',
+            type: DataConditionType.LESS_OR_EQUAL,
+            comparison: 108,
+            conditionResult: DetectorPriorityLevel.OK,
+          },
+        ],
+      },
+    };
+
+    render(<DetectorLink detector={percentDetector} />, {organization});
+
+    expect(screen.getByText(/8% higher than previous 1 hour/)).toBeInTheDocument();
+    expect(screen.getByText(/15% higher than previous 1 hour/)).toBeInTheDocument();
   });
 });

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -34,6 +34,7 @@ import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetect
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 import {getDetectorSystemCreatedNotice} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
+import {percentThresholdAbsoluteToDelta} from 'sentry/views/detectors/utils/percentThreshold';
 import {scheduleAsText} from 'sentry/views/insights/crons/utils/scheduleAsText';
 
 type DetectorLinkProps = {
@@ -79,6 +80,32 @@ function formatCondition({condition, unit}: {condition: DataCondition; unit: str
   return `${comparison}${threshold} ${priority}`;
 }
 
+function formatPercentCondition({
+  condition,
+  timeRange,
+  unit,
+}: {
+  condition: DataCondition;
+  timeRange: string;
+  unit: string;
+}) {
+  if (
+    !condition.conditionResult ||
+    condition.conditionResult === DetectorPriorityLevel.OK ||
+    typeof condition.comparison !== 'number'
+  ) {
+    return null;
+  }
+
+  const threshold = `${percentThresholdAbsoluteToDelta(condition.comparison)}${unit}`;
+  const direction = condition.comparison >= 100 ? t('higher') : t('lower');
+  return t('%(threshold)s %(direction)s than previous %(timeRange)s', {
+    threshold,
+    direction,
+    timeRange,
+  });
+}
+
 function DetailItem({children}: {children: React.ReactNode}) {
   if (!children) {
     return null;
@@ -115,8 +142,10 @@ function MetricDetectorConfigDetails({detector}: {detector: MetricDetector}) {
       return <DetailItem>{text}</DetailItem>;
     }
     case 'percent': {
+      const comparisonDelta = detector.config.comparisonDelta ?? 3600;
+      const timeRange = getDuration(comparisonDelta);
       const text = conditions
-        .map(condition => formatCondition({condition, unit}))
+        .map(condition => formatPercentCondition({condition, timeRange, unit}))
         .filter(defined)
         .join(', ');
       if (!text) {

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -26,6 +26,10 @@ import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetC
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {getDetectorEnvironment} from 'sentry/views/detectors/utils/getDetectorEnvironment';
+import {
+  percentThresholdAbsoluteToDelta,
+  percentThresholdDeltaToAbsolute,
+} from 'sentry/views/detectors/utils/percentThreshold';
 
 /**
  * Snuba query types that correspond to the backend SnubaQuery.Type enum.
@@ -342,6 +346,19 @@ export function metricDetectorFormDataToEndpointPayload(
       ? createAnomalyDetectionCondition(data)
       : createConditions(data);
 
+  // For percent detection, translate user-facing delta percentages (e.g. 10 for "10% higher")
+  // to the internal absolute-percentage format (e.g. 110) that the backend expects.
+  if (data.detectionType === 'percent') {
+    for (const condition of conditions) {
+      if (typeof condition.comparison === 'number') {
+        condition.comparison = percentThresholdDeltaToAbsolute(
+          condition.comparison,
+          condition.type
+        );
+      }
+    }
+  }
+
   const dataSource = createDataSource(data);
 
   // Create config based on detection type
@@ -394,6 +411,7 @@ function processDetectorConditions(
   > {
   // Get conditions from the condition group
   const conditions = detector.conditionGroup?.conditions || [];
+  const isPercent = detector.config.detectionType === 'percent';
 
   // Find HIGH priority condition
   const highCondition = conditions.find(
@@ -428,6 +446,13 @@ function processDetectorConditions(
     conditionType = mainCondition.type;
   }
 
+  // Helper to translate a comparison value from internal absolute-percentage form
+  // to the user-facing delta form when in percent detection mode.
+  const toFormValue = (comparison: number): string =>
+    isPercent
+      ? percentThresholdAbsoluteToDelta(comparison).toString()
+      : comparison.toString();
+
   // Determine resolution strategy: automatic if OK threshold matches warning or critical
   const resolutionValue = okCondition?.comparison ?? undefined;
   const computedResolutionStrategy =
@@ -440,19 +465,19 @@ function processDetectorConditions(
     initialPriorityLevel,
     highThreshold:
       typeof highCondition?.comparison === 'number'
-        ? highCondition.comparison.toString()
+        ? toFormValue(highCondition.comparison)
         : typeof mainCondition?.comparison === 'number'
-          ? mainCondition.comparison.toString()
+          ? toFormValue(mainCondition.comparison)
           : '',
     conditionType,
     mediumThreshold:
       typeof mediumCondition?.comparison === 'number'
-        ? mediumCondition.comparison.toString()
+        ? toFormValue(mediumCondition.comparison)
         : '',
     resolutionStrategy: computedResolutionStrategy,
     resolutionValue:
       typeof okCondition?.comparison === 'number'
-        ? okCondition.comparison.toString()
+        ? toFormValue(okCondition.comparison)
         : '',
   };
 }

--- a/static/app/views/detectors/components/forms/metric/previewChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/previewChart.tsx
@@ -9,6 +9,7 @@ import {
   useMetricDetectorFormField,
 } from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
+import {percentThresholdDeltaToAbsolute} from 'sentry/views/detectors/utils/percentThreshold';
 
 interface MetricDetectorPreviewChartProps {
   detector?: MetricDetector;
@@ -64,13 +65,27 @@ export function MetricDetectorPreviewChart({
       return [];
     }
 
-    return createConditions({
+    const rawConditions = createConditions({
       conditionType,
       highThreshold,
       mediumThreshold,
       resolutionStrategy,
       resolutionValue,
     });
+
+    if (detectionType !== 'percent') {
+      return rawConditions;
+    }
+
+    // The shared threshold chart hook expects backend-style absolute percent comparisons
+    // (e.g. 110), while the form state stores user-facing deltas (e.g. 10% higher).
+    return rawConditions.map(condition => ({
+      ...condition,
+      comparison:
+        typeof condition.comparison === 'number'
+          ? percentThresholdDeltaToAbsolute(condition.comparison, condition.type)
+          : condition.comparison,
+    }));
   }, [
     conditionType,
     highThreshold,

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -522,8 +522,10 @@ describe('DetectorEdit', () => {
         );
       });
       const updateBody = updateRequest.mock.calls[0][1];
+      // Percent thresholds are reverse-translated to internal absolute-percentage form:
+      // user enters 22 (meaning "22% higher") → stored as 122 (122% of baseline)
       expect(updateBody.data.conditionGroup.conditions[0]).toEqual({
-        comparison: Number(newThresholdValue),
+        comparison: Number(newThresholdValue) + 100,
         conditionResult: 75,
         type: 'gt',
       });

--- a/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.spec.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.spec.tsx
@@ -1,0 +1,187 @@
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {
+  DataConditionType,
+  DetectorPriorityLevel,
+} from 'sentry/types/workflowEngine/dataConditions';
+import type {MetricCondition} from 'sentry/types/workflowEngine/detectors';
+
+import {useMetricDetectorThresholdSeries} from './useMetricDetectorThresholdSeries';
+
+function makeConditions(
+  overrides: Array<Partial<Omit<MetricCondition, 'id'>>>
+): Array<Omit<MetricCondition, 'id'>> {
+  return overrides.map(c => ({
+    type: c.type ?? DataConditionType.GREATER,
+    comparison: c.comparison ?? 0,
+    conditionResult: c.conditionResult ?? DetectorPriorityLevel.HIGH,
+  }));
+}
+
+describe('useMetricDetectorThresholdSeries', () => {
+  describe('percent detection with session percentage aggregates', () => {
+    it('computes correct delta for crash_free_rate (comparison=110 → 10% higher)', () => {
+      const comparisonSeries = [
+        {
+          seriesName: 'Previous crash_free_rate(session)',
+          data: [{name: 1609459200000, value: 0.95}],
+        },
+      ];
+
+      const conditions = makeConditions([
+        {
+          type: DataConditionType.GREATER,
+          comparison: 110,
+          conditionResult: DetectorPriorityLevel.HIGH,
+        },
+      ]);
+
+      const {result} = renderHookWithProviders(() =>
+        useMetricDetectorThresholdSeries({
+          conditions,
+          detectionType: 'percent',
+          aggregate: 'crash_free_rate(session)',
+          comparisonSeries,
+        })
+      );
+
+      expect(result.current.additionalSeries).toHaveLength(1);
+      expect(result.current.additionalSeries[0]?.name).toBe('10% Higher Threshold');
+      // 0.95 * (1 + 10/100) = 1.045
+      expect(result.current.maxValue).toBeCloseTo(1.045);
+    });
+
+    it('computes correct delta for crash_free_rate (comparison=60 → 40% lower)', () => {
+      const comparisonSeries = [
+        {
+          seriesName: 'Previous crash_free_rate(session)',
+          data: [{name: 1609459200000, value: 0.95}],
+        },
+      ];
+
+      const conditions = makeConditions([
+        {
+          type: DataConditionType.LESS,
+          comparison: 60,
+          conditionResult: DetectorPriorityLevel.HIGH,
+        },
+      ]);
+
+      const {result} = renderHookWithProviders(() =>
+        useMetricDetectorThresholdSeries({
+          conditions,
+          detectionType: 'percent',
+          aggregate: 'crash_free_rate(session)',
+          comparisonSeries,
+        })
+      );
+
+      expect(result.current.additionalSeries).toHaveLength(1);
+      expect(result.current.additionalSeries[0]?.name).toBe('40% Lower Threshold');
+      // 0.95 * (1 - 40/100) = 0.57
+      expect(result.current.maxValue).toBeCloseTo(0.57);
+    });
+
+    it('computes correct resolution delta for crash_free_rate', () => {
+      const comparisonSeries = [
+        {
+          seriesName: 'Previous crash_free_rate(session)',
+          data: [{name: 1609459200000, value: 0.95}],
+        },
+      ];
+
+      const conditions = makeConditions([
+        {
+          type: DataConditionType.GREATER,
+          comparison: 110,
+          conditionResult: DetectorPriorityLevel.HIGH,
+        },
+        {
+          type: DataConditionType.LESS_OR_EQUAL,
+          comparison: 105,
+          conditionResult: DetectorPriorityLevel.OK,
+        },
+      ]);
+
+      const {result} = renderHookWithProviders(() =>
+        useMetricDetectorThresholdSeries({
+          conditions,
+          detectionType: 'percent',
+          aggregate: 'crash_free_rate(session)',
+          comparisonSeries,
+        })
+      );
+
+      // The alert threshold should be 10% (from 110)
+      expect(result.current.additionalSeries[0]?.name).toBe('10% Higher Threshold');
+    });
+  });
+
+  describe('percent detection with non-session aggregates', () => {
+    it('computes correct delta for count() (comparison=110 → 10% higher)', () => {
+      const comparisonSeries = [
+        {
+          seriesName: 'Previous count()',
+          data: [{name: 1609459200000, value: 100}],
+        },
+      ];
+
+      const conditions = makeConditions([
+        {
+          type: DataConditionType.GREATER,
+          comparison: 110,
+          conditionResult: DetectorPriorityLevel.HIGH,
+        },
+      ]);
+
+      const {result} = renderHookWithProviders(() =>
+        useMetricDetectorThresholdSeries({
+          conditions,
+          detectionType: 'percent',
+          aggregate: 'count()',
+          comparisonSeries,
+        })
+      );
+
+      expect(result.current.additionalSeries[0]?.name).toBe('10% Higher Threshold');
+      // 100 * (1 + 10/100) = 110
+      expect(result.current.maxValue).toBeCloseTo(110);
+    });
+  });
+
+  describe('static detection with session percentage aggregates', () => {
+    it('normalizes crash_free_rate threshold to 0-1 scale', () => {
+      const conditions = makeConditions([
+        {
+          type: DataConditionType.GREATER,
+          comparison: 95,
+          conditionResult: DetectorPriorityLevel.HIGH,
+        },
+      ]);
+
+      const {result} = renderHookWithProviders(() =>
+        useMetricDetectorThresholdSeries({
+          conditions,
+          detectionType: 'static',
+          aggregate: 'crash_free_rate(session)',
+        })
+      );
+
+      // Static threshold for crash_free_rate(session) 95 should normalize to 0.95
+      expect(result.current.maxValue).toBeCloseTo(0.95);
+    });
+  });
+
+  it('returns empty series when conditions are undefined', () => {
+    const {result} = renderHookWithProviders(() =>
+      useMetricDetectorThresholdSeries({
+        conditions: undefined,
+        detectionType: 'static',
+        aggregate: 'count()',
+      })
+    );
+
+    expect(result.current.additionalSeries).toHaveLength(0);
+    expect(result.current.maxValue).toBeUndefined();
+  });
+});

--- a/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
@@ -122,9 +122,11 @@ function extractThresholdsFromConditions(
         typeof condition.comparison === 'number'
     )
     .map(condition => {
-      let value = normalizePercentageThreshold(aggregate, Number(condition.comparison));
+      let value = Number(condition.comparison);
       if (detectionType === 'percent') {
         value = percentThresholdAbsoluteToDelta(value);
+      } else {
+        value = normalizePercentageThreshold(aggregate, value);
       }
       return {
         value,
@@ -144,12 +146,7 @@ function extractThresholdsFromConditions(
           type: resolutionCondition.type,
           value:
             detectionType === 'percent'
-              ? percentThresholdAbsoluteToDelta(
-                  normalizePercentageThreshold(
-                    aggregate,
-                    Number(resolutionCondition.comparison)
-                  )
-                )
+              ? percentThresholdAbsoluteToDelta(Number(resolutionCondition.comparison))
               : normalizePercentageThreshold(
                   aggregate,
                   Number(resolutionCondition.comparison)

--- a/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorThresholdSeries.tsx
@@ -18,6 +18,7 @@ import type {
 } from 'sentry/types/workflowEngine/detectors';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {isSessionPercentageOperation} from 'sentry/views/detectors/utils/metricDetectorSuffix';
+import {percentThresholdAbsoluteToDelta} from 'sentry/views/detectors/utils/percentThreshold';
 
 function createThresholdMarkLine(lineColor: string, threshold: number) {
   return MarkLine({
@@ -104,7 +105,8 @@ function normalizePercentageThreshold(aggregate: string, value: number): number 
 
 function extractThresholdsFromConditions(
   conditions: Array<Omit<MetricCondition, 'id'>>,
-  aggregate: string
+  aggregate: string,
+  detectionType: MetricDetectorConfig['detectionType']
 ): {
   thresholds: Array<{
     priority: DetectorPriorityLevel;
@@ -119,11 +121,17 @@ function extractThresholdsFromConditions(
         condition.conditionResult !== DetectorPriorityLevel.OK &&
         typeof condition.comparison === 'number'
     )
-    .map(condition => ({
-      value: normalizePercentageThreshold(aggregate, Number(condition.comparison)),
-      priority: condition.conditionResult || DetectorPriorityLevel.MEDIUM,
-      type: condition.type,
-    }))
+    .map(condition => {
+      let value = normalizePercentageThreshold(aggregate, Number(condition.comparison));
+      if (detectionType === 'percent') {
+        value = percentThresholdAbsoluteToDelta(value);
+      }
+      return {
+        value,
+        priority: condition.conditionResult || DetectorPriorityLevel.MEDIUM,
+        type: condition.type,
+      };
+    })
     .sort((a, b) => a.value - b.value);
 
   const resolutionCondition = conditions.find(
@@ -134,10 +142,18 @@ function extractThresholdsFromConditions(
     resolutionCondition && typeof resolutionCondition.comparison === 'number'
       ? {
           type: resolutionCondition.type,
-          value: normalizePercentageThreshold(
-            aggregate,
-            Number(resolutionCondition.comparison)
-          ),
+          value:
+            detectionType === 'percent'
+              ? percentThresholdAbsoluteToDelta(
+                  normalizePercentageThreshold(
+                    aggregate,
+                    Number(resolutionCondition.comparison)
+                  )
+                )
+              : normalizePercentageThreshold(
+                  aggregate,
+                  Number(resolutionCondition.comparison)
+                ),
         }
       : undefined;
 
@@ -180,7 +196,8 @@ export function useMetricDetectorThresholdSeries({
 
     const {thresholds, resolution} = extractThresholdsFromConditions(
       conditions,
-      aggregate
+      aggregate,
+      detectionType
     );
     const additional: LineSeriesOption[] = [];
 

--- a/static/app/views/detectors/list/allMonitors.spec.tsx
+++ b/static/app/views/detectors/list/allMonitors.spec.tsx
@@ -59,7 +59,7 @@ describe('DetectorsList', () => {
             logicType: DataConditionGroupLogicType.ALL,
             conditions: [
               {
-                comparison: 10,
+                comparison: 110,
                 conditionResult: DetectorPriorityLevel.HIGH,
                 type: DataConditionType.GREATER,
                 id: '1',
@@ -106,7 +106,9 @@ describe('DetectorsList', () => {
     expect(within(row).getByText('production')).toBeInTheDocument();
     expect(within(row).getByText('count()')).toBeInTheDocument();
     expect(within(row).getByText('event.type:error')).toBeInTheDocument();
-    expect(within(row).getByText('>10% high')).toBeInTheDocument();
+    expect(
+      within(row).getByText('10% higher than previous 10 seconds')
+    ).toBeInTheDocument();
 
     // Last issue
     expect(within(row).getByText('RequestError')).toBeInTheDocument();

--- a/static/app/views/detectors/utils/percentThreshold.tsx
+++ b/static/app/views/detectors/utils/percentThreshold.tsx
@@ -1,0 +1,38 @@
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+
+/**
+ * Converts a percent-change condition's absolute-percentage (e.g. 110) value to the
+ * user-facing delta percentage value (e.g. 10% higher).
+ *
+ * The backend stores percent-change thresholds as absolute percentages of the baseline:
+ *   - 110 means "the value is 110% of the baseline" → 10% higher
+ *   - 60  means "the value is 60% of the baseline"  → 40% lower
+ */
+export function percentThresholdAbsoluteToDelta(comparison: number): number {
+  if (comparison >= 100) {
+    return comparison - 100;
+  }
+  return 100 - comparison;
+}
+
+/**
+ * Converts a user-facing form value (delta percentage) to the backend
+ * absolute-percentage condition comparison value.
+ *
+ * This is the inverse of {@link percentThresholdAbsoluteToDelta}.
+ *
+ *   - GREATER / LESS_OR_EQUAL: 10 → 110  (10% higher → value is 110% of baseline)
+ *   - LESS / GREATER_OR_EQUAL: 40 → 60   (40% lower  → value is 60% of baseline)
+ */
+export function percentThresholdDeltaToAbsolute(
+  delta: number,
+  conditionType: DataConditionType
+): number {
+  if (
+    conditionType === DataConditionType.GREATER ||
+    conditionType === DataConditionType.LESS_OR_EQUAL
+  ) {
+    return delta + 100;
+  }
+  return 100 - delta;
+}


### PR DESCRIPTION
Fixes ISWF-2278

Metric monitors with percent change thresholds were translating the value incorrectly. `110` should display as `10% higher`, not `110% higher`.

See this for an example: https://sentry.sentry.io/monitors/2809101/

Before:
<img width="1600" height="456" alt="CleanShot 2026-03-20 at 15 10 34@2x" src="https://github.com/user-attachments/assets/b258f96b-7f40-4140-90a9-147d08c7e343" />
<img width="656" height="316" alt="CleanShot 2026-03-20 at 15 10 44@2x" src="https://github.com/user-attachments/assets/3b941078-dfe5-41d3-a602-5421579dac03" />

After:
<img width="1602" height="454" alt="CleanShot 2026-03-20 at 15 10 52@2x" src="https://github.com/user-attachments/assets/613df9ab-8494-49a5-8e55-d1d5c670fc7b" />
<img width="688" height="338" alt="CleanShot 2026-03-20 at 15 11 01@2x" src="https://github.com/user-attachments/assets/5e1444ad-046f-4f81-876c-d16231c10c9d" />
