### PR TITLE
fix(ci): prevent kafka consumer teardown hang with xdist

### DIFF
--- a/src/sentry/testutils/pytest/kafka.py
+++ b/src/sentry/testutils/pytest/kafka.py
@@ -83,15 +83,49 @@ def scope_consumers():
     for consumer_name, consumer in all_consumers.items():
         if consumer is not None:
             try:
-                # stop the consumer
+                arroyo_consumer = consumer._StreamProcessor__consumer
+                last_run = consumer._StreamProcessor__last_run
+                gap = time.time() - last_run
+
+                member_id = None
+                try:
+                    member_id = arroyo_consumer.member_id
+                except Exception as e:
+                    _log.warning("[teardown-diag] %s: member_id error: %s", consumer_name, e)
+
+                _log.warning(
+                    "[teardown-diag] %s: seconds_since_last_poll=%.1f member_id=%s",
+                    consumer_name,
+                    gap,
+                    member_id,
+                )
+
+                raw = arroyo_consumer._KafkaConsumer__consumer
+                try:
+                    assignment = raw.assignment()
+                    _log.warning("[teardown-diag] %s: assignment=%s", consumer_name, assignment)
+                    if assignment:
+                        committed = raw.committed(assignment, timeout=3.0)
+                        _log.warning(
+                            "[teardown-diag] %s: committed(timeout=3)=%s",
+                            consumer_name,
+                            committed,
+                        )
+                except Exception as e:
+                    _log.warning(
+                        "[teardown-diag] %s: pre-shutdown probe error: %s", consumer_name, e
+                    )
+
                 consumer.signal_shutdown()
                 t = threading.Thread(target=consumer.run, daemon=True)
                 t.start()
-                t.join(timeout=5)
+                t.join(timeout=10)
                 if t.is_alive():
-                    _log.warning("Consumer %s shutdown timed out, skipping", consumer_name)
+                    _log.warning("[teardown-diag] %s: shutdown HUNG (10s timeout)", consumer_name)
+                else:
+                    _log.warning("[teardown-diag] %s: shutdown completed OK", consumer_name)
             except Exception:
-                _log.warning("Failed to cleanup consumer %s", consumer_name)
+                _log.warning("Failed to cleanup consumer %s", consumer_name, exc_info=True)
 
 
 @pytest.fixture(scope="function")

--- a/src/sentry/testutils/pytest/kafka.py
+++ b/src/sentry/testutils/pytest/kafka.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 from collections.abc import MutableMapping
 
@@ -84,7 +85,11 @@ def scope_consumers():
             try:
                 # stop the consumer
                 consumer.signal_shutdown()
-                consumer.run()
+                t = threading.Thread(target=consumer.run, daemon=True)
+                t.start()
+                t.join(timeout=5)
+                if t.is_alive():
+                    _log.warning("Consumer %s shutdown timed out, skipping", consumer_name)
             except Exception:
                 _log.warning("Failed to cleanup consumer %s", consumer_name)
 

--- a/src/sentry/testutils/pytest/kafka.py
+++ b/src/sentry/testutils/pytest/kafka.py
@@ -83,49 +83,15 @@ def scope_consumers():
     for consumer_name, consumer in all_consumers.items():
         if consumer is not None:
             try:
-                arroyo_consumer = consumer._StreamProcessor__consumer
-                last_run = consumer._StreamProcessor__last_run
-                gap = time.time() - last_run
-
-                member_id = None
-                try:
-                    member_id = arroyo_consumer.member_id
-                except Exception as e:
-                    _log.warning("[teardown-diag] %s: member_id error: %s", consumer_name, e)
-
-                _log.warning(
-                    "[teardown-diag] %s: seconds_since_last_poll=%.1f member_id=%s",
-                    consumer_name,
-                    gap,
-                    member_id,
-                )
-
-                raw = arroyo_consumer._KafkaConsumer__consumer
-                try:
-                    assignment = raw.assignment()
-                    _log.warning("[teardown-diag] %s: assignment=%s", consumer_name, assignment)
-                    if assignment:
-                        committed = raw.committed(assignment, timeout=3.0)
-                        _log.warning(
-                            "[teardown-diag] %s: committed(timeout=3)=%s",
-                            consumer_name,
-                            committed,
-                        )
-                except Exception as e:
-                    _log.warning(
-                        "[teardown-diag] %s: pre-shutdown probe error: %s", consumer_name, e
-                    )
-
+                # stop the consumer
                 consumer.signal_shutdown()
                 t = threading.Thread(target=consumer.run, daemon=True)
                 t.start()
-                t.join(timeout=10)
+                t.join(timeout=5)
                 if t.is_alive():
-                    _log.warning("[teardown-diag] %s: shutdown HUNG (10s timeout)", consumer_name)
-                else:
-                    _log.warning("[teardown-diag] %s: shutdown completed OK", consumer_name)
+                    _log.warning("Consumer %s shutdown timed out, skipping", consumer_name)
             except Exception:
-                _log.warning("Failed to cleanup consumer %s", consumer_name, exc_info=True)
+                _log.warning("Failed to cleanup consumer %s", consumer_name)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Observed these [99% completion hang](https://github.com/getsentry/sentry/actions/runs/23306172165/job/67780853966) failures after xdist. Reproduced on a test branch and a thread dump on the hung process showed:

```
File "arroyo/backends/kafka/consumer.py", line 348 in assignment_callback
File "arroyo/backends/kafka/consumer.py", line 719 in close
File "arroyo/processing/processor.py", line 567 in _shutdown
File "arroyo/processing/processor.py", line 353 in run
File "sentry/testutils/pytest/kafka.py", line 87 in scope_consumers
```

Let's run `consumer.run()` on a daemon thread with a 5-second join timeout. This still attempts a graceful shutdown, but bails out if the broker is slow. If the thread outlives the join, it dies on process exit and the broker detects the dead consumer via heartbeat timeout.

Tested that hangs no longer happen with the fix.

We could also potentially just remove `consumer.run()` entirely and skip graceful shutdown as the fixture is  session-scoped so teardown runs right before process exit.