### PR TITLE
fix(tests): add teardown to relay_server fixture to prevent port conflict flake

### DIFF
--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -173,6 +173,10 @@ def relay_server(relay_server_setup, settings):
 
     yield {"url": relay_server_setup["url"]}
 
+    if not environ.get("RELAY_TEST_KEEP_CONTAINER", False):
+        with get_docker_client() as docker_client:
+            _remove_container_if_exists(docker_client, _relay_server_container_name())
+
 
 def adjust_settings_for_relay_tests(settings):
     """


### PR DESCRIPTION
After #111041, the `relay_server` fixture retries `containers.run()` up to 5 times (~8 s) when Docker returns "address already in use." This helped but didn't eliminate the flake — today's CI run (Mar 20) burned through all 5 attempts and still failed on `FilterTests.test_should_not_filter_bad_ip_addresses_when_disabled`.

The retry can't win because the removal and rebind happen back-to-back in the same fixture setup. The fixture has no teardown, so the previous test's container stays running until the *next* test's setup removes it and immediately tries to bind the same port. Under xdist the Docker daemon is under heavier load and its async port cleanup takes longer than the retry window.

Add a teardown after `yield` so the container is stopped at the end of each test, not the start of the next one. This gives Docker the entire between-test gap (fixture teardowns, TransactionTestCase DB flush, next fixture chain setup) to release the port before anyone tries to bind it again. The existing retry from #111041 stays as defense-in-depth, and the `_remove_container_if_exists` at the top of the setup still runs as a no-op fallback.