### PR TITLE
chore(flags): Remove organizations:sdk-crash-detection feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -274,8 +274,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:semver-ordering-with-build-code", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable revocation of org auth keys when a user renames an org slug
     manager.add("organizations:revoke-org-auth-on-slug-rename", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable detecting SDK crashes during event processing
-    manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the Seer Config Reminder in the primary nav
     manager.add("organizations:seer-config-reminder", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer panel for AI-powered data exploration

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1291,9 +1291,6 @@ def sdk_crash_monitoring(job: PostProcessJob):
 
     event = job["event"]
 
-    if not features.has("organizations:sdk-crash-detection", event.project.organization):
-        return
-
     with sentry_sdk.start_span(op="post_process.build_sdk_crash_config"):
         configs = build_sdk_crash_detection_configs()
         if not configs or len(configs) == 0:

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1968,7 +1968,6 @@ class SnoozeTestMixin(BasePostProcessGroupMixin):
 
 @patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection")
 class SDKCrashMonitoringTestMixin(BasePostProcessGroupMixin):
-    @with_feature("organizations:sdk-crash-detection")
     @override_options(
         {
             "issues.sdk_crash_detection.cocoa.project_id": 1234,
@@ -2009,7 +2008,6 @@ class SDKCrashMonitoringTestMixin(BasePostProcessGroupMixin):
         assert react_native_config.sample_rate == 1.0
         assert react_native_config.organization_allowlist == [1]
 
-    @with_feature("organizations:sdk-crash-detection")
     @override_options(
         {
             "issues.sdk_crash_detection.cocoa.project_id": 1234,
@@ -2033,29 +2031,11 @@ class SDKCrashMonitoringTestMixin(BasePostProcessGroupMixin):
 
         mock_sdk_crash_detection.detect_sdk_crash.assert_not_called()
 
-    def test_sdk_crash_monitoring_is_not_called_with_disabled_feature(
-        self, mock_sdk_crash_detection
-    ):
-        event = self.create_event(
-            data={"message": "testing"},
-            project_id=self.project.id,
-        )
-
-        self.call_post_process_group(
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            event=event,
-        )
-
-        mock_sdk_crash_detection.detect_sdk_crash.assert_not_called()
-
     @override_options(
         {
             "issues.sdk_crash_detection.cocoa.project_id": None,
         }
     )
-    @with_feature("organizations:sdk-crash-detection")
     def test_sdk_crash_monitoring_is_not_called_without_project_id(
         self, mock_sdk_crash_detection: MagicMock
     ) -> None:


### PR DESCRIPTION
## Summary

- Remove the `organizations:sdk-crash-detection` feature flag gate from `post_process.py`
- Remove the flag registration from `temporary.py`
- Remove the test for disabled-feature behavior (no longer applicable)

## Why

SDK crash detection is controlled by an option-backed rollout handler in getsentry with three rollout options (`la-rollout`, `ea-rollout`, `ga-rollout`). Currently:

- **US**: `ga-rollout: 1.0` (fully enabled)
- **s4s2**: `ga-rollout: 1.0` (fully enabled)
- **DE**: `ga-rollout: 0.0` (disabled — appears to be an oversight)

Rather than enabling DE separately, we're graduating the flag entirely so SDK crash detection runs everywhere. The option-backed rollout handler and LA org list in getsentry will be cleaned up in a follow-up PR after this deploys.

## Merge order

1. **This PR** (sentry) — remove the flag check and registration
2. getsentry PR — remove `ROLLOUT_FEATURES` entry, `SDK_CRASH_DETECTION_LA_ORGS`
3. sentry-options-automator PR — remove regional option values

cc @getsentry/ingest @getsentry/issue-detection-backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)