### PR TITLE
ref(nav) implement new help menu

### DIFF
--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -46,6 +46,11 @@ function BaseFooter({className}: Props) {
   const secondaryNavigation = useContext(SecondaryNavigationContext);
   const hasPageFrame = useHasPageFrameFeature();
 
+  if (hasPageFrame) {
+    // @TODO(JonasBadalic): Remove ~ footer CSS rules once this flag is GA'd
+    return null;
+  }
+
   return (
     <Container
       as="footer"

--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -336,6 +336,7 @@ function PrimaryNavigationMenu(props: PrimaryNavigationMenuProps) {
       renderWrapAs={PassthroughWrapper}
       position={layout === 'mobile' ? 'bottom' : 'right-end'}
       shouldApplyMinWidth={false}
+      size="sm"
       minMenuWidth={200}
       trigger={triggerProps => {
         return (

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -1,8 +1,26 @@
+import {Flex} from '@sentry/scraps/layout';
+
 import {openHelpSearchModal} from 'sentry/actionCreators/modal';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
-import {IconEllipsis} from 'sentry/icons';
+import {
+  IconBuilding,
+  IconDiscord,
+  IconDocs,
+  IconEllipsis,
+  IconGithub,
+  IconGlobe,
+  IconGroup,
+  IconMegaphone,
+  IconOpen,
+  IconQuestion,
+  IconSearch,
+  IconSentry,
+  IconSupport,
+} from 'sentry/icons';
+import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
@@ -13,12 +31,19 @@ import {
   useNavigationTour,
 } from 'sentry/views/navigation/navigationTour';
 import {PrimaryNavigation} from 'sentry/views/navigation/primary/components';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export function PrimaryNavigationHelpMenu() {
   const organization = useOrganization();
   const contactSupportItem = getContactSupportItem(organization);
   const openForm = useFeedbackForm();
   const {startTour} = useNavigationTour();
+  const {privacyUrl, termsUrl} = useLegacyStore(ConfigStore);
+  const hasPageFrame = useHasPageFrameFeature();
+
+  const items = hasPageFrame
+    ? getPageFrameItems({contactSupportItem, privacyUrl, termsUrl})
+    : getLegacyItems({contactSupportItem});
 
   return (
     <PrimaryNavigation.Menu
@@ -27,49 +52,27 @@ export function PrimaryNavigationHelpMenu() {
         {
           key: 'search',
           label: t('Search support, docs and more'),
+          leadingItems: (
+            <MenuIcon>
+              <IconSearch />
+            </MenuIcon>
+          ),
           onAction() {
             openHelpSearchModal({organization});
           },
         },
-        {
-          key: 'resources',
-          label: t('Resources'),
-          children: [
-            {
-              key: 'help-center',
-              label: t('Help Center'),
-              externalHref: 'https://sentry.zendesk.com/hc/en-us',
-            },
-            {
-              key: 'docs',
-              label: t('Documentation'),
-              externalHref: 'https://docs.sentry.io',
-            },
-          ],
-        },
-        {
-          key: 'help',
-          label: t('Get Help'),
-          children: [
-            ...(contactSupportItem ? [contactSupportItem] : []),
-            {
-              key: 'github',
-              label: t('Sentry on GitHub'),
-              externalHref: 'https://github.com/getsentry/sentry/issues',
-            },
-            {
-              key: 'discord',
-              label: t('Join our Discord'),
-              externalHref: 'https://discord.com/invite/sentry',
-            },
-          ],
-        },
+        ...items,
         {
           key: 'actions',
           children: [
             {
               key: 'give-feedback',
               label: t('Give feedback'),
+              leadingItems: (
+                <MenuIcon>
+                  <IconMegaphone />
+                </MenuIcon>
+              ),
               onAction() {
                 openForm?.({
                   tags: {
@@ -82,6 +85,11 @@ export function PrimaryNavigationHelpMenu() {
             {
               key: 'tour',
               label: t('Tour the new navigation'),
+              leadingItems: (
+                <MenuIcon>
+                  <IconGlobe />
+                </MenuIcon>
+              ),
               onAction() {
                 startTour();
               },
@@ -94,6 +102,211 @@ export function PrimaryNavigationHelpMenu() {
       icon={<IconEllipsis />}
     />
   );
+}
+
+function MenuIcon({children}: {children: React.ReactNode}) {
+  return (
+    <IconDefaultsProvider size="sm">
+      <Flex width="100%" height="100%" align="center">
+        {children}
+      </Flex>
+    </IconDefaultsProvider>
+  );
+}
+
+function getPageFrameItems({
+  contactSupportItem,
+  privacyUrl,
+  termsUrl,
+}: {
+  contactSupportItem: MenuItemProps | null;
+  privacyUrl: string | null;
+  termsUrl: string | null;
+}): MenuItemProps[] {
+  return [
+    {
+      key: 'resources',
+      label: t('Resources'),
+      isSubmenu: true,
+      leadingItems: (
+        <MenuIcon>
+          <IconQuestion />
+        </MenuIcon>
+      ),
+      children: [
+        {
+          key: 'welcome',
+          label: t('Welcome Page'),
+          externalHref: 'https://sentry.io/welcome/',
+          leadingItems: (
+            <MenuIcon>
+              <IconSentry />
+            </MenuIcon>
+          ),
+        },
+        {
+          key: 'docs',
+          label: t('Documentation'),
+          externalHref: 'https://docs.sentry.io',
+          leadingItems: (
+            <MenuIcon>
+              <IconDocs />
+            </MenuIcon>
+          ),
+        },
+        {
+          key: 'api-docs',
+          label: t('API Docs'),
+          externalHref: 'https://docs.sentry.io/api/',
+          leadingItems: (
+            <MenuIcon>
+              <IconDocs />
+            </MenuIcon>
+          ),
+        },
+        {
+          key: 'help-center',
+          label: t('Help Center'),
+          externalHref: 'https://sentry.zendesk.com/hc/en-us',
+          leadingItems: (
+            <MenuIcon>
+              <IconQuestion />
+            </MenuIcon>
+          ),
+        },
+        ...(contactSupportItem
+          ? [
+              {
+                ...contactSupportItem,
+                leadingItems: (
+                  <MenuIcon>
+                    <IconSupport />
+                  </MenuIcon>
+                ),
+              },
+            ]
+          : []),
+      ],
+    },
+    {
+      key: 'community',
+      label: t('Community'),
+      isSubmenu: true,
+      leadingItems: (
+        <MenuIcon>
+          <IconGroup />
+        </MenuIcon>
+      ),
+      children: [
+        {
+          key: 'github',
+          label: t('Sentry on GitHub'),
+          externalHref: 'https://github.com/getsentry/sentry',
+          leadingItems: (
+            <MenuIcon>
+              <IconGithub />
+            </MenuIcon>
+          ),
+        },
+        {
+          key: 'discord',
+          label: t('Join our Discord'),
+          externalHref: 'https://discord.com/invite/sentry',
+          leadingItems: (
+            <MenuIcon>
+              <IconDiscord />
+            </MenuIcon>
+          ),
+        },
+      ],
+    },
+    ...(privacyUrl || termsUrl
+      ? [
+          {
+            key: 'legal',
+            label: t('Legal'),
+            isSubmenu: true,
+            leadingItems: (
+              <MenuIcon>
+                <IconBuilding />
+              </MenuIcon>
+            ),
+            children: [
+              ...(privacyUrl
+                ? [
+                    {
+                      key: 'privacy',
+                      label: t('Privacy Policy'),
+                      externalHref: privacyUrl,
+                      leadingItems: (
+                        <MenuIcon>
+                          <IconOpen />
+                        </MenuIcon>
+                      ),
+                    },
+                  ]
+                : []),
+              ...(termsUrl
+                ? [
+                    {
+                      key: 'terms',
+                      label: t('Terms of Use'),
+                      externalHref: termsUrl,
+                      leadingItems: (
+                        <MenuIcon>
+                          <IconOpen />
+                        </MenuIcon>
+                      ),
+                    },
+                  ]
+                : []),
+            ],
+          },
+        ]
+      : []),
+  ];
+}
+
+function getLegacyItems({
+  contactSupportItem,
+}: {
+  contactSupportItem: MenuItemProps | null;
+}): MenuItemProps[] {
+  return [
+    {
+      key: 'resources',
+      label: t('Resources'),
+      children: [
+        {
+          key: 'help-center',
+          label: t('Help Center'),
+          externalHref: 'https://sentry.zendesk.com/hc/en-us',
+        },
+        {
+          key: 'docs',
+          label: t('Documentation'),
+          externalHref: 'https://docs.sentry.io',
+        },
+      ],
+    },
+    {
+      key: 'help',
+      label: t('Get Help'),
+      children: [
+        ...(contactSupportItem ? [contactSupportItem] : []),
+        {
+          key: 'github',
+          label: t('Sentry on GitHub'),
+          externalHref: 'https://github.com/getsentry/sentry/issues',
+        },
+        {
+          key: 'discord',
+          label: t('Join our Discord'),
+          externalHref: 'https://discord.com/invite/sentry',
+        },
+      ],
+    },
+  ];
 }
 
 function getContactSupportItem(organization: Organization): MenuItemProps | null {

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -52,11 +52,11 @@ export function PrimaryNavigationHelpMenu() {
         {
           key: 'search',
           label: t('Search support, docs and more'),
-          leadingItems: (
+          leadingItems: hasPageFrame ? (
             <MenuIcon>
               <IconSearch />
             </MenuIcon>
-          ),
+          ) : undefined,
           onAction() {
             openHelpSearchModal({organization});
           },
@@ -68,11 +68,11 @@ export function PrimaryNavigationHelpMenu() {
             {
               key: 'give-feedback',
               label: t('Give feedback'),
-              leadingItems: (
+              leadingItems: hasPageFrame ? (
                 <MenuIcon>
                   <IconMegaphone />
                 </MenuIcon>
-              ),
+              ) : undefined,
               onAction() {
                 openForm?.({
                   tags: {
@@ -85,11 +85,11 @@ export function PrimaryNavigationHelpMenu() {
             {
               key: 'tour',
               label: t('Tour the new navigation'),
-              leadingItems: (
+              leadingItems: hasPageFrame ? (
                 <MenuIcon>
                   <IconGlobe />
                 </MenuIcon>
-              ),
+              ) : undefined,
               onAction() {
                 startTour();
               },


### PR DESCRIPTION
Implements the new menu for when page frame is enabled and hides the footer. 

<table>
<tr>
 <td> Before
 <td> After
<tr>
 <td> <img width="678" height="866" alt="CleanShot 2026-03-20 at 17 27 20@2x" src="https://github.com/user-attachments/assets/9873f451-be8f-4e24-a116-bcdb89587edc" />
 <td> <img width="672" height="542" alt="CleanShot 2026-03-20 at 17 27 52@2x" src="https://github.com/user-attachments/assets/db8b5d4b-b53f-4c3b-81aa-b0455b1cbdb1" />
</table>
