### PR TITLE
meta(oxfmt): Update vscode config to recommend oxfmt instead of prettier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,12 +2,12 @@
   // See https://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
+    "charliermarsh.ruff",
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
     "lextudio.restructuredtext",
     "mkhl.direnv",
-    "charliermarsh.ruff",
     "ms-python.python",
+    "oxc.oxc-vscode",
     "timonwong.shellcheck",
     "tyriar.sort-lines",
     "webpro.vscode-knip",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
     "editor.formatOnSave": true,
     "editor.tabSize": 2,
     "editor.insertSpaces": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.defaultFormatter": "oxc.oxc-vscode",
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"
     }
@@ -60,7 +60,7 @@
     "editor.detectIndentation": false,
     "editor.tabSize": 2,
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   },
 
   "[yaml]": {
@@ -68,7 +68,7 @@
     "editor.detectIndentation": false,
     "editor.tabSize": 2,
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   },
 
   "[markdown]": {
@@ -99,7 +99,6 @@
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
   "python.testing.pytestArgs": ["tests"],
   "python.analysis.autoImportCompletions": true,
-  "prettier.configPath": "prettier.config.js",
   "biome.enabled": false,
   "cursorpyright.analysis.autoImportCompletions": true,
   "mypy-type-checker.path": ["${workspaceFolder}/.venv/bin/mypy"],


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/111205