### PR TITLE
ref(trends): remove v1 trends code paths behind GA feature flag

### DIFF
--- a/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
+++ b/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
@@ -25,7 +25,6 @@ type TrendsRequest = {
   projects: Project[];
   trendChangeType?: TrendChangeType;
   trendFunctionField?: TrendFunctionField;
-  withBreakpoint?: boolean;
 };
 
 type RequestProps = DiscoverQueryProps & TrendsRequest;
@@ -79,12 +78,11 @@ function getTrendsRequestPayload(props: RequestProps) {
 
 export function TrendsDiscoverQuery(props: Omit<Props, 'projects'>) {
   const {projects} = useProjects();
-  const route = props.withBreakpoint ? 'events-trends-statsv2' : 'events-trends-stats';
   return (
     <GenericDiscoverQuery<TrendsData, TrendsRequest>
       {...props}
       projects={projects}
-      route={route}
+      route="events-trends-statsv2"
       getRequestPayload={getTrendsRequestPayload}
     >
       {({tableData, ...rest}) => {

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -9,10 +9,8 @@ import {t, tct} from 'sentry/locale';
 import type {NewQuery, Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import EventView from 'sentry/utils/discover/eventView';
-import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {getCurrentTrendParameter} from 'sentry/views/performance/trends/utils';
 
 import {getCurrentLandingDisplay, LandingDisplayField} from './landing/utils';
 
@@ -182,7 +180,7 @@ export function prepareQueryForLandingPage(searchQuery: any, withStaticFilters: 
 export function generateGenericPerformanceEventView(
   location: Location,
   withStaticFilters: boolean,
-  organization: Organization
+  _organization: Organization
 ): EventView {
   const {query} = location;
 
@@ -224,19 +222,6 @@ export function generateGenericPerformanceEventView(
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
-
-  if (query.trendParameter) {
-    // projects and projectIds are not necessary here since trendParameter will always
-    // be present in location and will not be determined based on the project type
-    const trendParameter = getCurrentTrendParameter(location, [], []);
-    if (
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      WEB_VITAL_DETAILS[trendParameter.column] &&
-      !organization.features.includes('performance-new-trends')
-    ) {
-      eventView.additionalConditions.addFilterValues('has', [trendParameter.column]);
-    }
-  }
 
   return eventView;
 }

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -109,7 +109,7 @@ describe('Performance > Widgets > WidgetContainer', () => {
 
     eventsTrendsStats = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trends-stats/',
+      url: '/organizations/org-slug/events-trends-statsv2/',
       body: [],
     });
 
@@ -255,12 +255,11 @@ describe('Performance > Widgets > WidgetContainer', () => {
           noPagination: true,
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
-          query:
-            'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
-          sort: 'trend_percentage()',
+          query: 'transaction.op:pageload tpm():>0.1',
+          sort: '-trend_percentage()',
           statsPeriod: '14d',
           trendFunction: 'p95(transaction.duration)',
-          trendType: 'improved',
+          trendType: 'any',
         }),
       })
     );
@@ -712,12 +711,11 @@ describe('Performance > Widgets > WidgetContainer', () => {
           middle: undefined,
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
-          query:
-            'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
-          sort: 'trend_percentage()',
+          query: 'transaction.op:pageload tpm():>0.1',
+          sort: '-trend_percentage()',
           statsPeriod: '7d',
           trendFunction: 'p95(transaction.duration)',
-          trendType: 'improved',
+          trendType: 'any',
         }),
       })
     );
@@ -1000,12 +998,11 @@ describe('Performance > Widgets > WidgetContainer', () => {
           middle: undefined,
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
-          query:
-            'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
+          query: 'transaction.op:pageload tpm():>0.1',
           sort: '-trend_percentage()',
           statsPeriod: '7d',
           trendFunction: 'p95(transaction.duration)',
-          trendType: 'regression',
+          trendType: 'any',
         }),
       })
     );

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -31,7 +31,6 @@ import {
   QUERY_LIMIT_PARAM,
   TOTAL_EXPANDABLE_ROWS_HEIGHT,
 } from 'sentry/views/performance/landing/widgets/utils';
-import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets/widgetDefinitions';
 import {
   DisplayModes,
   transactionSummaryRouteWithQuery,
@@ -55,7 +54,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
   const location = useLocation();
   const {projects} = useProjects();
 
-  const {isLoading: isCardinalityCheckLoading, outcome} = useMetricsCardinalityContext();
+  const {isLoading: isCardinalityCheckLoading} = useMetricsCardinalityContext();
 
   const {
     eventView: _eventView,
@@ -64,16 +63,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
     InteractiveTitle,
   } = props;
 
-  const withBreakpoint =
-    organization.features.includes('performance-new-trends') &&
-    !isCardinalityCheckLoading &&
-    !outcome?.forceTransactionsOnly;
-
-  const trendChangeType =
-    props.chartSetting === PerformanceWidgetSetting.MOST_IMPROVED
-      ? TrendChangeType.IMPROVED
-      : TrendChangeType.REGRESSION;
-  const derivedTrendChangeType = withBreakpoint ? TrendChangeType.ANY : trendChangeType;
+  const derivedTrendChangeType = TrendChangeType.ANY;
   const trendFunctionField = TrendFunctionField.P95;
 
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
@@ -82,19 +72,12 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
   eventView.fields = fields;
   eventView.sorts = [
     {
-      kind: derivedTrendChangeType === TrendChangeType.IMPROVED ? 'asc' : 'desc',
+      kind: 'desc',
       field: 'trend_percentage()',
     },
   ];
   const rest = {...props, eventView};
-  if (withBreakpoint) {
-    eventView.additionalConditions.addFilterValues('tpm()', ['>0.1']);
-  } else {
-    eventView.additionalConditions.addFilterValues('tpm()', ['>0.01']);
-    eventView.additionalConditions.addFilterValues('count_percentage()', ['>0.25', '<4']);
-    eventView.additionalConditions.addFilterValues('trend_percentage()', ['>0%']);
-    eventView.additionalConditions.addFilterValues('confidence()', ['>6']);
-  }
+  eventView.additionalConditions.addFilterValues('tpm()', ['>0.1']);
 
   const chart = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({
@@ -109,7 +92,6 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
           limit={QUERY_LIMIT_PARAM}
           cursor="0:0:1"
           noPagination
-          withBreakpoint={withBreakpoint}
         />
       ),
       transform: transformTrendsDiscover,

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -236,7 +236,6 @@ export function TransactionSummaryCharts({
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
             projects={project ? [project] : []}
-            withBreakpoint={organization.features.includes('performance-new-trends')}
           />
         )}
         {display === DisplayModes.VITALS && (

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/content.tsx
@@ -34,7 +34,6 @@ type Props = {
     start: number;
   };
   transaction?: NormalizedTrendsTransaction;
-  withBreakpoint?: boolean;
 } & Omit<React.ComponentProps<typeof ReleaseSeries>, 'children' | 'queryExtra'> &
   Pick<LineChartProps, 'onLegendSelectChanged' | 'legend'>;
 
@@ -53,7 +52,6 @@ export function Content({
   legend,
   utc,
   queryExtra,
-  withBreakpoint,
   transaction,
   onLegendSelectChanged,
 }: Props) {
@@ -81,9 +79,13 @@ export function Content({
     : [];
 
   const needsLabel = false;
-  const breakpointSeries = withBreakpoint
-    ? getIntervalLine(theme, data || [], 0.5, needsLabel, transaction)
-    : [];
+  const breakpointSeries = getIntervalLine(
+    theme,
+    data || [],
+    0.5,
+    needsLabel,
+    transaction
+  );
 
   const durationUnit = getDurationUnit(series, legend);
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -40,7 +40,6 @@ type Props = ViewProps & {
   queryExtra: Query;
   trendFunction: TrendFunctionField;
   trendParameter: string;
-  withBreakpoint?: boolean;
 };
 
 export function TrendChart({
@@ -52,7 +51,6 @@ export function TrendChart({
   trendFunction,
   trendParameter,
   queryExtra,
-  withBreakpoint,
   eventView,
   start: propsStart,
   end: propsEnd,
@@ -65,7 +63,7 @@ export function TrendChart({
 
   const {isLoading: isCardinalityCheckLoading, outcome} = useMetricsCardinalityContext();
   const shouldGetBreakpoint =
-    withBreakpoint && !isCardinalityCheckLoading && !outcome?.forceTransactionsOnly;
+    !isCardinalityCheckLoading && !outcome?.forceTransactionsOnly;
 
   function handleLegendSelectChanged(legendChange: {
     name: string;
@@ -172,13 +170,11 @@ export function TrendChart({
     <Fragment>
       {header}
       {shouldGetBreakpoint ? (
-        // queries events-trends-statsv2 for breakpoint data (feature flag only)
         <TrendsDiscoverQuery
           eventView={trendView}
           orgSlug={organization.slug}
           location={location}
           limit={1}
-          withBreakpoint
         >
           {({isLoading, trendsData}) => {
             const events = normalizeTrends(trendsData?.events?.data || []);
@@ -236,7 +232,6 @@ export function TrendChart({
                       loading={loading || isLoading}
                       reloading={reloading}
                       timeFrame={timeframe}
-                      withBreakpoint
                       transaction={selectedTransaction}
                       {...contentCommonProps}
                     />
@@ -250,7 +245,6 @@ export function TrendChart({
                 loading={isLoading || isCardinalityCheckLoading}
                 reloading={isLoading}
                 timeFrame={metricsTimeFrame}
-                withBreakpoint
                 transaction={selectedTransaction}
                 {...contentCommonProps}
               />

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -93,7 +93,7 @@ export function Chart({
   height,
   projects,
   project,
-  organization,
+  organization: _organization,
   additionalSeries,
   applyRegressionFormatToInterval = false,
 }: Props) {
@@ -119,9 +119,7 @@ export function Chart({
     navigate(to);
   };
 
-  const derivedTrendChangeType = organization.features.includes('performance-new-trends')
-    ? transaction?.change
-    : trendChangeType;
+  const derivedTrendChangeType = transaction?.change;
 
   const trendToColor = makeTrendToColorMapping(theme);
   const lineColor =

--- a/static/app/views/performance/trends/utils/index.tsx
+++ b/static/app/views/performance/trends/utils/index.tsx
@@ -29,8 +29,6 @@ import {
   ProjectPerformanceType,
 } from 'sentry/views/performance/utils';
 
-export const DEFAULT_MAX_DURATION = '15min';
-
 export const TRENDS_FUNCTIONS: TrendFunction[] = [
   {
     label: 'p99',

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -28,7 +28,6 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
-import {DEFAULT_MAX_DURATION} from 'sentry/views/performance/trends/utils';
 
 export const QUERY_KEYS = [
   'environment',
@@ -226,32 +225,8 @@ export function trendsTargetRoute({
     ...additionalQuery,
   };
 
-  const query = decodeScalar(location.query.query, '');
-  const conditions = new MutableSearch(query);
-
   const modifiedConditions = initialConditions ?? new MutableSearch([]);
 
-  // Trends on metrics don't need these conditions
-  if (!organization.features.includes('performance-new-trends')) {
-    // No need to carry over tpm filters to transaction summary
-    if (conditions.hasFilter('tpm()')) {
-      modifiedConditions.setFilterValues('tpm()', conditions.getFilterValues('tpm()'));
-    } else {
-      modifiedConditions.setFilterValues('tpm()', ['>0.01']);
-    }
-
-    if (conditions.hasFilter('transaction.duration')) {
-      modifiedConditions.setFilterValues(
-        'transaction.duration',
-        conditions.getFilterValues('transaction.duration')
-      );
-    } else {
-      modifiedConditions.setFilterValues('transaction.duration', [
-        '>0',
-        `<${DEFAULT_MAX_DURATION}`,
-      ]);
-    }
-  }
   newQuery.query = modifiedConditions.formatString();
 
   return {pathname: getPerformanceTrendsUrl(organization, view), query: {...newQuery}};


### PR DESCRIPTION
The `performance-new-trends` feature flag has been 100% rolled out since 2023-07-17. Remove all conditional v1/v2 branching and make v2 (events-trends-statsv2) the unconditional default. This eliminates dead code paths that were only reachable when the flag was off.