### PR TITLE
ref(trends): remove v1 trends from releases page

### DIFF
--- a/static/app/components/discover/transactionsList.spec.tsx
+++ b/static/app/components/discover/transactionsList.spec.tsx
@@ -128,21 +128,6 @@ describe('TransactionsList', () => {
         },
         match: [MockApiClient.matchQuery({sort: '-count'})],
       });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events-trends/`,
-        headers: {Link: pageLinks},
-        body: {
-          meta: {
-            transaction: 'string',
-            trend_percentage: 'percentage',
-            trend_difference: 'number',
-          },
-          data: [
-            {transaction: '/a', 'trend_percentage()': 1.25, 'trend_difference()': 25},
-            {transaction: '/b', 'trend_percentage()': 1.05, 'trend_difference()': 5},
-          ],
-        },
-      });
     });
 
     it('renders basic UI components', async () => {
@@ -174,69 +159,6 @@ describe('TransactionsList', () => {
 
       const gridCells = screen.getAllByTestId('grid-cell');
       expect(gridCells.map(e => e.textContent)).toEqual(['/a', '100', '/b', '1,000']);
-    });
-
-    it('renders a trend view', async () => {
-      options.push({
-        sort: {kind: 'desc', field: 'trend_percentage()'},
-        value: 'regression',
-        label: 'Trending Regressions',
-        trendType: 'regression',
-      });
-      render(
-        <WrapperComponent
-          api={api}
-          location={location}
-          organization={organization}
-          trendView={eventView}
-          selected={options[2]}
-          options={options}
-          handleDropdownChange={handleDropdownChange}
-        />
-      );
-
-      expect(await screen.findByTestId('transactions-table')).toBeInTheDocument();
-
-      const filterDropdown = screen.getByRole('button', {
-        name: 'Filter Trending Regressions',
-      });
-      expect(filterDropdown).toBeInTheDocument();
-      await userEvent.click(filterDropdown);
-
-      const menuOptions = await screen.findAllByRole('option');
-      expect(menuOptions.map(e => e.textContent)).toEqual([
-        'Transactions',
-        'Failing Transactions',
-        'Trending Regressions',
-      ]);
-
-      expect(
-        screen.queryByRole('button', {
-          name: 'Open in Discover',
-        })
-      ).not.toBeInTheDocument();
-
-      expect(screen.getByRole('button', {name: 'Previous'})).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Next'})).toBeInTheDocument();
-
-      const gridCells = screen.getAllByTestId('grid-cell');
-      expect(gridCells.map(e => e.textContent)).toEqual(
-        expect.arrayContaining([
-          '/a',
-          '(no value)',
-          '(no value)',
-          '/b',
-          '(no value)',
-          '(no value)',
-        ])
-      );
-
-      const tableHeadings = screen.getAllByTestId('table-header');
-      expect(tableHeadings.map(e => e.textContent)).toEqual([
-        'transaction',
-        'percentage',
-        'difference',
-      ]);
     });
 
     it('renders default titles', async () => {

--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -19,20 +19,18 @@ import {DiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
-import {TrendsEventsDiscoverQuery} from 'sentry/utils/performance/trends/trendsDiscoverQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import type {Actions} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
-import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import type {DomainView, DomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import type {SpanOperationBreakdownFilter} from 'sentry/views/performance/transactionSummary/filter';
 import {mapShowTransactionToPercentile} from 'sentry/views/performance/transactionSummary/transactionEvents/utils';
 import {PerformanceAtScaleContext} from 'sentry/views/performance/transactionSummary/transactionOverview/performanceAtScaleContext';
 import type {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
 import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
-import type {TrendChangeType, TrendView} from 'sentry/views/performance/trends/types';
+import type {TrendChangeType} from 'sentry/views/performance/trends/types';
 
 import {TransactionsTable} from './transactionsTable';
 
@@ -128,7 +126,6 @@ type Props = {
    * A list of preferred table headers to use over the field names.
    */
   titles?: string[];
-  trendView?: TrendView;
 };
 
 type TableRenderProps = Omit<React.ComponentProps<typeof Pagination>, 'size'> &
@@ -290,8 +287,7 @@ class _TransactionsList extends Component<Props> {
             onChange={opt => handleDropdownChange(opt.value)}
           />
         </div>
-        {!this.isTrend() &&
-          (handleOpenAllEventsClick ? (
+        {handleOpenAllEventsClick ? (
             <GuideAnchor target="release_transactions_open_in_transaction_events">
               <LinkButton
                 onClick={handleOpenAllEventsClick}
@@ -326,7 +322,7 @@ class _TransactionsList extends Component<Props> {
                 {t('Open in Discover')}
               </DiscoverButton>
             </GuideAnchor>
-          ))}
+          )}
       </Fragment>
     );
   }
@@ -399,71 +395,8 @@ class _TransactionsList extends Component<Props> {
     );
   }
 
-  renderTrendsTable(): React.ReactNode {
-    const {
-      trendView,
-      location,
-      selected,
-      organization,
-      cursorName,
-      generateLink,
-      domainViewFilters,
-    } = this.props;
-
-    const sortedEventView: TrendView = trendView!.clone();
-    sortedEventView.sorts = [selected.sort];
-    sortedEventView.trendType = selected.trendType;
-    if (selected.query) {
-      const query = new MutableSearch(sortedEventView.query);
-      selected.query.forEach(item => query.setFilterValues(item[0], [item[1]]));
-      sortedEventView.query = query.formatString();
-    }
-    const cursor = decodeScalar(location.query?.[cursorName]);
-
-    return (
-      <TrendsEventsDiscoverQuery
-        eventView={sortedEventView}
-        orgSlug={organization.slug}
-        location={location}
-        cursor={cursor}
-        limit={5}
-      >
-        {({isLoading, trendsData, pageLinks}) => (
-          <TableRender
-            organization={organization}
-            eventView={sortedEventView}
-            location={location}
-            isLoading={isLoading}
-            tableData={trendsData}
-            pageLinks={pageLinks}
-            onCursor={this.handleCursor}
-            paginationCursorSize="sm"
-            header={this.renderHeader({view: domainViewFilters?.view})}
-            titles={['transaction', 'percentage', 'difference']}
-            columnOrder={decodeColumnOrder([
-              {field: 'transaction'},
-              {field: 'trend_percentage()'},
-              {field: 'trend_difference()'},
-            ])}
-            generateLink={generateLink}
-            useAggregateAlias
-          />
-        )}
-      </TrendsEventsDiscoverQuery>
-    );
-  }
-
-  isTrend(): boolean {
-    const {selected} = this.props;
-    return selected.trendType !== undefined;
-  }
-
   render() {
-    return (
-      <Fragment>
-        {this.isTrend() ? this.renderTrendsTable() : this.renderTransactionTable()}
-      </Fragment>
-    );
+    return <Fragment>{this.renderTransactionTable()}</Fragment>;
   }
 }
 

--- a/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
+++ b/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
@@ -9,7 +9,6 @@ import type {
   TrendChangeType,
   TrendFunctionField,
   TrendsData,
-  TrendsDataEvents,
   TrendsQuery,
   TrendView,
 } from 'sentry/views/performance/trends/types';
@@ -39,14 +38,6 @@ export type TrendDiscoveryChildrenProps = Omit<
 
 type Props = RequestProps & {
   children: (props: TrendDiscoveryChildrenProps) => React.ReactNode;
-};
-
-type EventChildrenProps = Omit<GenericChildrenProps<TrendsDataEvents>, 'tableData'> & {
-  trendsData: TrendsDataEvents | null;
-};
-
-type EventProps = RequestProps & {
-  children: (props: EventChildrenProps) => React.ReactNode;
 };
 
 function getTrendsRequestPayload(props: RequestProps) {
@@ -85,22 +76,6 @@ export function TrendsDiscoverQuery(props: Omit<Props, 'projects'>) {
       {...props}
       projects={projects}
       route={route}
-      getRequestPayload={getTrendsRequestPayload}
-    >
-      {({tableData, ...rest}) => {
-        return props.children({trendsData: tableData, ...rest});
-      }}
-    </GenericDiscoverQuery>
-  );
-}
-
-export function TrendsEventsDiscoverQuery(props: Omit<EventProps, 'projects'>) {
-  const {projects} = useProjects();
-  return (
-    <GenericDiscoverQuery<TrendsDataEvents, TrendsRequest>
-      {...props}
-      projects={projects}
-      route="events-trends"
       getRequestPayload={getTrendsRequestPayload}
     >
       {({tableData, ...rest}) => {

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -40,8 +40,6 @@ import {
   DisplayModes,
   transactionSummaryRouteWithQuery,
 } from 'sentry/views/performance/transactionSummary/utils';
-import type {TrendView} from 'sentry/views/performance/trends/types';
-import {TrendChangeType} from 'sentry/views/performance/trends/types';
 import {
   getReleaseParams,
   isReleaseArchived,
@@ -68,8 +66,6 @@ export enum TransactionsListOption {
   TPM = 'tpm',
   SLOW = 'slow',
   SLOW_LCP = 'slow_lcp',
-  REGRESSION = 'regression',
-  IMPROVEMENT = 'improved',
 }
 
 type RouteParams = {
@@ -207,30 +203,6 @@ function ReleaseOverview() {
     }
   };
 
-  const getReleaseTrendView = (projectId: number, versionDate: string): EventView => {
-    const {environments} = selection;
-
-    const {start, end, statsPeriod} = getReleaseParams({
-      location,
-      releaseBounds,
-    });
-
-    const trendView = EventView.fromSavedQuery({
-      id: undefined,
-      version: 2,
-      name: `Release ${formatVersion(version)}`,
-      fields: ['transaction'],
-      query: 'tpm():>0.01 trend_percentage():>0%',
-      range: statsPeriod || undefined,
-      environment: environments,
-      projects: [projectId],
-      start: start ? getUtcDateString(start) : undefined,
-      end: end ? getUtcDateString(end) : undefined,
-    }) as TrendView;
-    trendView.middle = versionDate;
-    return trendView;
-  };
-
   const handleTransactionsListSortChange = (value: string) => {
     const target = {
       pathname: location.pathname,
@@ -280,7 +252,6 @@ function ReleaseOverview() {
     selectedSort.value === TransactionsListOption.SLOW_LCP
       ? [t('transaction'), t('failure_count()'), t('tpm()'), t('p75(lcp)')]
       : [t('transaction'), t('failure_count()'), t('tpm()'), t('p50()')];
-  const releaseTrendView = getReleaseTrendView(project.id, releaseMeta.released);
 
   const generateLink = {
     transaction: generateTransactionLink(
@@ -397,7 +368,6 @@ function ReleaseOverview() {
               location={location}
               organization={organization}
               eventView={releaseEventView}
-              trendView={releaseTrendView}
               selected={selectedSort}
               options={sortOptions}
               handleDropdownChange={handleTransactionsListSortChange}
@@ -481,7 +451,7 @@ function generateTransactionLink(
   version: string,
   projectId: number,
   selection: PageFilters,
-  value: string
+  _value: string
 ) {
   return (
     organization: Organization,
@@ -489,7 +459,6 @@ function generateTransactionLink(
     _location: Location
   ): LocationDescriptor => {
     const {transaction} = tableRow;
-    const trendTransaction = ['regression', 'improved'].includes(value);
     const {environments, datetime} = selection;
     const {start, end, period} = datetime;
 
@@ -497,14 +466,14 @@ function generateTransactionLink(
       organization,
       transaction: transaction! as string,
       query: {
-        query: trendTransaction ? '' : `release:${version}`,
+        query: `release:${version}`,
         environment: environments,
         start: start ? getUtcDateString(start) : undefined,
         end: end ? getUtcDateString(end) : undefined,
         statsPeriod: period,
       },
       projectID: projectId.toString(),
-      display: trendTransaction ? DisplayModes.TREND : DisplayModes.DURATION,
+      display: DisplayModes.DURATION,
     });
   };
 }
@@ -530,20 +499,6 @@ function getDropdownOptions(): DropdownOption[] {
       sort: {kind: 'desc', field: 'p75_measurements_lcp'},
       value: TransactionsListOption.SLOW_LCP,
       label: t('Slow LCP'),
-    },
-    {
-      sort: {kind: 'desc', field: 'trend_percentage()'},
-      query: [['confidence()', '>6']],
-      trendType: TrendChangeType.REGRESSION,
-      value: TransactionsListOption.REGRESSION,
-      label: t('Trending Regressions'),
-    },
-    {
-      sort: {kind: 'asc', field: 'trend_percentage()'},
-      query: [['confidence()', '>6']],
-      trendType: TrendChangeType.IMPROVED,
-      value: TransactionsListOption.IMPROVEMENT,
-      label: t('Trending Improvements'),
     },
   ];
 }


### PR DESCRIPTION
The releases overview page had 'Trending Regressions' and 'Trending Improvements' dropdown options that used the v1 /events-trends/ endpoint with in-database statistics (confidence, t-test). These have no v2 equivalent since v2 uses Seer ML breakpoint detection. Remove these vestigial v1-only options and delete TrendsEventsDiscoverQuery which was their sole consumer.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
