### PR TITLE
feat(seer): Iterate on the Seer Trial page styles

### DIFF
--- a/static/gsApp/views/seerAutomation/trial.tsx
+++ b/static/gsApp/views/seerAutomation/trial.tsx
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
+import styled from '@emotion/styled';
 import seerConfigBug1 from 'getsentry-images/spot/seer-config-bug-1.svg';
 import seerConfigCheck from 'getsentry-images/spot/seer-config-check.svg';
 import seerConfigConnect2 from 'getsentry-images/spot/seer-config-connect-2.svg';
@@ -8,14 +9,16 @@ import seerConfigMain from 'getsentry-images/spot/seer-config-main.svg';
 
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
+import {Image} from '@sentry/scraps/image';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {AnalyticsArea} from 'sentry/components/analyticsArea';
+import {AnalyticsArea, useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {IconUpgrade} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {showNewSeer} from 'sentry/utils/seer/showNewSeer';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -27,7 +30,7 @@ const BUTTONS = [
   {
     label: t('Triage issues'),
     imageSrc: seerConfigHand2,
-    href: 'https://docs.sentry.io/product/ai-in-sentry/seer/autofix/',
+    href: 'https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#how-issue-autofix-works',
   },
   {
     label: t('Run root cause analysis'),
@@ -73,19 +76,16 @@ export default function SeerAutomationTrial() {
     // Else you don't yet have the new seer plan, then stay here and click to start a trial.
   }, [navigate, organization.features, organization.slug, organization]);
 
+  useRouteAnalyticsParams({
+    showNewSeer: showNewSeer(organization),
+    hasSeatBasedSeer: organization.features.includes('seat-based-seer-enabled'),
+    canVisitSubscriptionPage,
+  });
+
   return (
     <AnalyticsArea name="trial">
       <Flex justify="center">
-        <img
-          src={seerConfigMain}
-          alt="Seer"
-          style={{
-            maxWidth: '90%',
-            marginTop: '-40px',
-            marginBottom: '-77px',
-            transform: 'rotate(1.281deg)',
-          }}
-        />
+        <HeroImage src={seerConfigMain} aspectRatio="1119/526" alt="Seer hero image" />
       </Flex>
 
       <Container
@@ -95,35 +95,42 @@ export default function SeerAutomationTrial() {
         background="secondary"
         maxWidth="600px"
         margin="auto"
+        position="relative"
       >
         <Stack gap="lg">
           <Heading as="h1" align="center">
             {t('Say Hello to a Smarter Sentry')}
           </Heading>
+          <Flex align="center" justify="center" paddingBottom="xl">
+            {canVisitSubscriptionPage ? (
+              <TrySeerNowButton />
+            ) : (
+              <Alert variant="warning">
+                {t(
+                  'You need to be a billing member to try out Seer. Please contact your organization owner to upgrade your plan.'
+                )}
+              </Alert>
+            )}
+          </Flex>
+
           <Text>
             {tct(
-              `Meet Seer: Sentry’s AI agent that helps you troubleshoot and fix
-            problems with your application, review your PRs, propose solutions
-            to your bugs and performance issues, and even partner with coding
-            agents to implement fixes in code. Learn more about Seer [link:here]!`,
+              `With Seer, issues [em:almost] fix themselves. Choose your favorite coding agent and run Autofix on Issues as they're detected, and use Code Review to prevent bugs before they happen. [docs:Read the docs] for more.`,
               {
-                link: (
+                em: <em />,
+                docs: (
                   <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/" />
                 ),
               }
             )}
           </Text>
 
-          <Heading as="h3" align="center">
-            {t('Seer is able to...')}
-          </Heading>
           <Text as="div" bold>
             <Grid
               as="ul"
               columns="repeat(2, 1fr)"
               gap="xl 2xl"
-              padding="lg"
-              style={{listStyle: 'none'}}
+              style={{padding: 0, margin: 0, listStyle: 'none'}}
             >
               {BUTTONS.map(({label, imageSrc, href}) => {
                 return (
@@ -148,25 +155,36 @@ export default function SeerAutomationTrial() {
               })}
             </Grid>
           </Text>
-          <Flex align="center" justify="center" paddingTop="lg">
-            {canVisitSubscriptionPage ? (
-              <LinkButton
-                to={`/settings/${organization.slug}/billing/overview/?product=seer`}
-                priority="primary"
-                icon={<IconUpgrade />}
-              >
-                {t('Try Out Seer Now')}
-              </LinkButton>
-            ) : (
-              <Alert variant="warning">
-                {t(
-                  'You need to be a billing member to try out Seer. Please contact your organization owner to upgrade your plan.'
-                )}
-              </Alert>
-            )}
-          </Flex>
         </Stack>
       </Container>
     </AnalyticsArea>
+  );
+}
+
+const HeroImage = styled(Image)`
+  width: auto;
+  max-width: 90%;
+  max-height: 50vh;
+  margin-top: -40px;
+  margin-bottom: -77px;
+`;
+
+function TrySeerNowButton() {
+  const organization = useOrganization();
+  const surface = useAnalyticsArea();
+
+  return (
+    <LinkButton
+      to={`/settings/${organization.slug}/billing/overview/?product=seer`}
+      priority="primary"
+      icon={<IconUpgrade />}
+      analyticsEventKey="clicked.try_seer_button"
+      analyticsEventName="Clicked: Try Seer Now"
+      analyticsParams={{
+        surface,
+      }}
+    >
+      {t('Try Seer Now')}
+    </LinkButton>
   );
 }


### PR DESCRIPTION
Before the image was tooooo big. 

Here's a side-by side of the page at the same browser-window size, before the bottom was cutoff at this dimension!

| Before | After |
| --- | --- |
| <img width="1512" height="948" alt="SCR-20260322-jslx" src="https://github.com/user-attachments/assets/b69e56c9-b10a-4e7e-a024-ab7e89ec84da" /> | <img width="1512" height="948" alt="SCR-20260322-jsmh" src="https://github.com/user-attachments/assets/2981d2d8-3dc7-452e-ba69-61892daa995f" />


It was always responsive though: narrowing the window width, or shrinking the height scales the image. 

Here's a selection of images to show the page at different approx scales, assuming the image above is the 100% size, these are all smaller:

| Scale | Img |
| --- | --- |
| 3/4 height | <img width="1512" height="725" alt="seer trial - after 3-4 height" src="https://github.com/user-attachments/assets/d85c639e-c34d-4c82-8070-730f8caec8f4" />
| 1/2 height | <img width="1512" height="580" alt="seer trial - after 1-2 height" src="https://github.com/user-attachments/assets/619e0d5e-7895-4c4f-b274-e200483a03ba" />
| 3/4 width | <img width="1170" height="948" alt="seer trial - after 3-4 width" src="https://github.com/user-attachments/assets/a4a08a61-ed7a-4c7b-97f4-72424b054e86" />
| 1/2 width | <img width="784" height="948" alt="seer trial - after 1-2 width" src="https://github.com/user-attachments/assets/58109123-93a1-4480-a41c-eddac3ae6719" />
| 3/4 of total | <img width="1207" height="760" alt="seer trial - after 3-4 size" src="https://github.com/user-attachments/assets/7124abef-28a7-4c34-9e94-b8ebde30824c" />
| 1/2 of total | <img width="790" height="615" alt="seer trial - after 1-2 size" src="https://github.com/user-attachments/assets/e033ace1-a874-4437-b8c3-a3a75cfa556f" />








