### PR TITLE
feat(seer): Add a tooltip explaining Seer Context in Alerts setting

### DIFF
--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -105,8 +105,13 @@ export function SeerAutomationSettings() {
             {field => (
               <field.Layout.Row
                 label={t('Auto-Trigger Fixes by Default')}
-                hintText={t(
-                  'For all new projects, Seer will automatically create a root cause analysis for highly actionable issues and propose a solution without a user needing to prompt it.'
+                hintText={tct(
+                  'For all new projects, Seer will automatically create a root cause analysis for [docs:highly actionable] issues and propose a solution without a user needing to prompt it.',
+                  {
+                    docs: (
+                      <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#how-issue-autofix-works" />
+                    ),
+                  }
                 )}
               >
                 <field.Switch
@@ -128,8 +133,13 @@ export function SeerAutomationSettings() {
                 label={t('Allow Autofix to create PRs by Default')}
                 hintText={
                   <Stack gap="sm">
-                    {t(
-                      'For all new projects with connected repos, Seer will be able to make pull requests for highly actionable issues.'
+                    {tct(
+                      'For all new projects with connected repos, Seer will be able to make pull requests for [docs:highly actionable] issues.',
+                      {
+                        docs: (
+                          <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#how-issue-autofix-works" />
+                        ),
+                      }
                     )}
                     {organization.enableSeerCoding === false && (
                       <Alert variant="warning">

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -242,7 +242,19 @@ export function SeerAutomationSettings() {
             {field => (
               <field.Layout.Row
                 label={t('Enable Seer Context in Alerts')}
-                hintText={t('Seer will provide extra context in supported alerts.')}
+                hintText={
+                  <Flex gap="sm">
+                    <span>
+                      {t('Seer will provide extra context in supported alerts.')}
+                    </span>
+                    <QuestionTooltip
+                      size="xs"
+                      title={t(
+                        'Enable Seer to include Agent output in alerts when available. Agent output may include code snippets, explanations, and more.'
+                      )}
+                    />
+                  </Flex>
+                }
               >
                 <field.Switch
                   checked={field.state.value}


### PR DESCRIPTION
**Tooltip to explain "Seer Context in Alerts"**

<img width="671" height="217" alt="Screenshot 2026-03-22 at 11 03 03 AM" src="https://github.com/user-attachments/assets/43799d7f-66fe-46c9-96b5-3f2f083e8023" />


**Link to docs to explain Highly Actionable**
Requires: https://github.com/getsentry/sentry-docs/pull/17060
<img width="720" height="305" alt="SCR-20260322-kggb" src="https://github.com/user-attachments/assets/92a1fdf0-2d01-4d98-ae60-0022039e24bc" />

