### PR TITLE
fix(seer): Fix tab normalization so Seer Settings tab hrefs are correct

### DIFF
--- a/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
+++ b/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
@@ -11,18 +11,19 @@ export function SettingsPageTabs() {
   const organization = useOrganization();
   const {pathname} = useLocation();
 
+  const prefix = `/settings/${organization.slug}`;
   const tabs = (
     showNewSeer(organization)
       ? [
-          [t('Overview'), `/settings/${organization.slug}/seer/`],
-          [t('Source Code Management'), `/settings/${organization.slug}/seer/scm/`],
-          [t('Autofix'), `/settings/${organization.slug}/seer/projects/`],
-          [t('Code Review'), `/settings/${organization.slug}/seer/repos/`],
+          [t('Overview'), '/seer/'],
+          [t('Source Code Management'), '/seer/scm/'],
+          [t('Autofix'), '/seer/projects/'],
+          [t('Code Review'), '/seer/repos/'],
         ]
       : [
-          [t('Autofix'), `/settings/${organization.slug}/seer/`],
-          [t('Code Review'), `/settings/${organization.slug}/seer/repos/`],
-          [t('Source Code Management'), `/settings/${organization.slug}/seer/scm/`],
+          [t('Autofix'), '/seer/'],
+          [t('Code Review'), '/seer/repos/'],
+          [t('Source Code Management'), '/seer/scm/'],
         ]
   ) satisfies Array<[string, string]>;
 
@@ -30,11 +31,23 @@ export function SettingsPageTabs() {
     <Container borderBottom="primary">
       <Tabs value={pathname}>
         <TabList>
-          {tabs.map(([label, to]) => (
-            <TabList.Item key={normalizeUrl(to)} to={normalizeUrl(to)}>
-              {label}
-            </TabList.Item>
-          ))}
+          {tabs.map(([label, to]) => {
+            const tabPath = prefix + to;
+            const normalized = normalizeUrl(tabPath);
+            // We need to normalize the `key` prop because that value is used to
+            // identify which tab to highlight, the value needs to match the
+            // value of the `value` prop on the `Tabs` component.
+            // The Tab component will render `TabLink` which extends `Link`and
+            // normalizes the url for us.
+            //
+            // If we manually make the call then it'll be double-normalized,
+            // we'd have `/settings/repos/` instead of `/settings/seer/repos/`.
+            return (
+              <TabList.Item key={normalized} to={{pathname: tabPath}}>
+                {label}
+              </TabList.Item>
+            );
+          })}
         </TabList>
       </Tabs>
     </Container>


### PR DESCRIPTION
**Before**
<img width="590" height="201" alt="Screenshot 2026-03-22 at 3 57 58 PM" src="https://github.com/user-attachments/assets/ef39b787-ffd1-4eea-a547-95265ea68bed" />


**After**

| Tab | Url |
| --- | --- |
| Overview | <img width="590" height="201" alt="Screenshot 2026-03-22 at 3 57 42 PM" src="https://github.com/user-attachments/assets/40bf7392-6a95-45f2-b832-76338da26e95" />
| SCM | <img width="590" height="201" alt="Screenshot 2026-03-22 at 3 57 48 PM" src="https://github.com/user-attachments/assets/63a6537e-9f5d-4fdf-8e5e-c640084a629c" />
| Autofix | <img width="590" height="201" alt="Screenshot 2026-03-22 at 3 57 50 PM" src="https://github.com/user-attachments/assets/dd689499-7816-449d-95ac-c88be529c2e6" />
| Code Review | <img width="590" height="201" alt="Screenshot 2026-03-22 at 3 57 52 PM" src="https://github.com/user-attachments/assets/85d36f87-cd8e-4cbc-92e6-8b87399ee52a" />

