### PR TITLE
feat(scm): Show repos from other/unknown providers in the treeview component

### DIFF
--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
@@ -11,7 +11,10 @@ import {addRepository, hideRepository} from 'sentry/actionCreators/integrations'
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
-import {buildIntegrationTreeNodes} from 'sentry/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes';
+import {
+  buildIntegrationTreeNodes,
+  DISCONNECTED_SECTION_KEY,
+} from 'sentry/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes';
 import {ScmIntegrationTreeRow} from 'sentry/components/repositories/scmIntegrationTree/scmIntegrationTreeRow';
 import type {
   ProviderFilter,
@@ -48,6 +51,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
   const {
     scmProviders,
     scmIntegrations,
+    connectedRepos,
     connectedIdentifiers,
     refetchIntegrations,
     reposByIntegrationId,
@@ -63,12 +67,14 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
     new Set()
   );
 
-  // Expand all providers once data first loads
+  // Expand all providers (and disconnected section) once data first loads
   const providersInitialized = useRef(false);
   useEffect(() => {
     if (!providersInitialized.current && scmProviders.length > 0) {
       providersInitialized.current = true;
-      setExpandedProviders(new Set(scmProviders.map(p => p.key)));
+      setExpandedProviders(
+        new Set([...scmProviders.map(p => p.key), DISCONNECTED_SECTION_KEY])
+      );
     }
   }, [scmProviders]);
 
@@ -105,6 +111,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
       buildIntegrationTreeNodes({
         scmProviders,
         scmIntegrations,
+        connectedRepos,
         reposByIntegrationId,
         reposPendingByIntegrationId,
         connectedIdentifiers,
@@ -118,6 +125,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
     [
       scmProviders,
       scmIntegrations,
+      connectedRepos,
       reposByIntegrationId,
       reposPendingByIntegrationId,
       connectedIdentifiers,
@@ -140,6 +148,8 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
       if (node.type === 'integration') return `integration:${node.integration.id}`;
       if (node.type === 'add-config') return `add-config:${node.provider.key}`;
       if (node.type === 'no-match') return `no-match:${node.integrationId}`;
+      if (node.type === 'disconnected-section') return 'disconnected-section';
+      if (node.type === 'disconnected-repo') return `disconnected-repo:${node.repo.id}`;
       return `repo:${node.repo.identifier}`;
     },
   });
@@ -148,6 +158,33 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
     refetchIntegrations();
   }, [refetchIntegrations]);
 
+  // Optimistically remove a repo from cache and call the API
+  const removeRepo = useCallback(
+    async (repo: Repository) => {
+      const previousData = queryClient.getQueryData(reposQueryKey as any);
+      queryClient.setQueryData(
+        reposQueryKey as any,
+        (old: InfiniteData<{json: Repository[]}> | undefined) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map(page => ({
+              ...page,
+              json: page.json.filter(r => r.id !== repo.id),
+            })),
+          };
+        }
+      );
+      try {
+        await hideRepository(api, organization.slug, repo.id);
+        addSuccessMessage(t('Removed %s', repo.name));
+      } catch {
+        queryClient.setQueryData(reposQueryKey as any, previousData);
+      }
+    },
+    [api, organization.slug, queryClient, reposQueryKey]
+  );
+
   const handleToggleRepo = useCallback(
     async (
       repo: IntegrationRepository,
@@ -155,39 +192,14 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
       isConnected: boolean
     ) => {
       setTogglingRepos(prev => new Set(prev).add(repo.identifier));
-
       try {
         if (isConnected) {
           const connectedRepo = queryClient
             .getQueryData<InfiniteData<{json: Repository[]}>>(reposQueryKey as any)
             ?.pages.flatMap(p => p.json)
             .find(r => r.name === repo.identifier);
-
-          if (!connectedRepo) {
-            return;
-          }
-
-          // Optimistically remove repo from cache so the UI updates immediately
-          const previousData = queryClient.getQueryData(reposQueryKey as any);
-          queryClient.setQueryData(
-            reposQueryKey as any,
-            (old: InfiniteData<{json: Repository[]}> | undefined) => {
-              if (!old) return old;
-              return {
-                ...old,
-                pages: old.pages.map(page => ({
-                  ...page,
-                  json: page.json.filter(r => r.id !== connectedRepo.id),
-                })),
-              };
-            }
-          );
-
-          try {
-            await hideRepository(api, organization.slug, connectedRepo.id);
-            addSuccessMessage(t('Removed %s', repo.name));
-          } catch {
-            queryClient.setQueryData(reposQueryKey as any, previousData);
+          if (connectedRepo) {
+            await removeRepo(connectedRepo);
           }
         } else {
           const newRepo = await addRepository(
@@ -219,7 +231,23 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
         });
       }
     },
-    [api, organization.slug, queryClient, reposQueryKey]
+    [api, organization.slug, queryClient, removeRepo, reposQueryKey]
+  );
+
+  const handleRemoveDisconnectedRepo = useCallback(
+    async (repo: Repository) => {
+      setTogglingRepos(prev => new Set(prev).add(repo.id));
+      try {
+        await removeRepo(repo);
+      } finally {
+        setTogglingRepos(prev => {
+          const next = new Set(prev);
+          next.delete(repo.id);
+          return next;
+        });
+      }
+    },
+    [removeRepo]
   );
 
   // Dynamic height: fill remaining viewport
@@ -291,6 +319,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
                 onToggleProvider={toggleProvider}
                 onToggleIntegration={toggleIntegration}
                 onToggleRepo={handleToggleRepo}
+                onRemoveDisconnectedRepo={handleRemoveDisconnectedRepo}
               />
             );
           })}

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
@@ -56,7 +56,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
     refetchIntegrations,
     reposByIntegrationId,
     reposPendingByIntegrationId,
-    reposQueryKey,
+    reposQueryOptions,
     isPending,
     isError,
   } = useScmIntegrationTreeData();
@@ -161,9 +161,9 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
   // Optimistically remove a repo from cache and call the API
   const removeRepo = useCallback(
     async (repo: Repository) => {
-      const previousData = queryClient.getQueryData(reposQueryKey as any);
+      const previousData = queryClient.getQueryData(reposQueryOptions.queryKey);
       queryClient.setQueryData(
-        reposQueryKey as any,
+        reposQueryOptions.queryKey,
         (old: InfiniteData<{json: Repository[]}> | undefined) => {
           if (!old) return old;
           return {
@@ -179,10 +179,10 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
         await hideRepository(api, organization.slug, repo.id);
         addSuccessMessage(t('Removed %s', repo.name));
       } catch {
-        queryClient.setQueryData(reposQueryKey as any, previousData);
+        queryClient.setQueryData(reposQueryOptions.queryKey, previousData);
       }
     },
-    [api, organization.slug, queryClient, reposQueryKey]
+    [api, organization.slug, queryClient, reposQueryOptions.queryKey]
   );
 
   const handleToggleRepo = useCallback(
@@ -195,7 +195,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
       try {
         if (isConnected) {
           const connectedRepo = queryClient
-            .getQueryData<InfiniteData<{json: Repository[]}>>(reposQueryKey as any)
+            .getQueryData<InfiniteData<{json: Repository[]}>>(reposQueryOptions.queryKey)
             ?.pages.flatMap(p => p.json)
             .find(r => r.name === repo.identifier);
           if (connectedRepo) {
@@ -209,7 +209,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
             integration
           );
           queryClient.setQueryData(
-            reposQueryKey as any,
+            reposQueryOptions.queryKey,
             (old: InfiniteData<{json: Repository[]}> | undefined) => {
               if (!old) return old;
               return {
@@ -231,7 +231,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
         });
       }
     },
-    [api, organization.slug, queryClient, removeRepo, reposQueryKey]
+    [api, organization.slug, queryClient, removeRepo, reposQueryOptions.queryKey]
   );
 
   const handleRemoveDisconnectedRepo = useCallback(

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
@@ -162,19 +162,16 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
   const removeRepo = useCallback(
     async (repo: Repository) => {
       const previousData = queryClient.getQueryData(reposQueryOptions.queryKey);
-      queryClient.setQueryData(
-        reposQueryOptions.queryKey,
-        (old: InfiniteData<{json: Repository[]}> | undefined) => {
-          if (!old) return old;
-          return {
-            ...old,
-            pages: old.pages.map(page => ({
-              ...page,
-              json: page.json.filter(r => r.id !== repo.id),
-            })),
-          };
-        }
-      );
+      queryClient.setQueryData(reposQueryOptions.queryKey, old => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map(page => ({
+            ...page,
+            json: page.json.filter(r => r.id !== repo.id),
+          })),
+        };
+      });
       try {
         await hideRepository(api, organization.slug, repo.id);
         addSuccessMessage(t('Removed %s', repo.name));
@@ -208,19 +205,21 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
             repo.identifier,
             integration
           );
-          queryClient.setQueryData(
-            reposQueryOptions.queryKey,
-            (old: InfiniteData<{json: Repository[]}> | undefined) => {
-              if (!old) return old;
-              return {
-                ...old,
-                pages: [
-                  {...old.pages[0]!, json: [newRepo, ...(old.pages[0]?.json ?? [])]},
-                  ...old.pages.slice(1),
-                ],
-              };
+          queryClient.setQueryData(reposQueryOptions.queryKey, old => {
+            if (!old) {
+              return old;
             }
-          );
+            return {
+              ...old,
+              pages: [
+                {
+                  ...old.pages[0]!,
+                  json: [{...newRepo, settings: null}, ...(old.pages[0]?.json ?? [])],
+                },
+                ...old.pages.slice(1),
+              ],
+            };
+          });
           addSuccessMessage(t('Added %s', repo.name));
         }
       } finally {

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
@@ -8,10 +8,14 @@ import type {
   IntegrationProvider,
   IntegrationRepository,
   OrganizationIntegration,
+  Repository,
 } from 'sentry/types/integrations';
+
+export const DISCONNECTED_SECTION_KEY = '__disconnected__';
 
 type Props = {
   connectedIdentifiers: Set<string>;
+  connectedRepos: Repository[];
   expandedIntegrations: Set<string>;
   expandedProviders: Set<string>;
   providerFilter: ProviderFilter;
@@ -27,6 +31,7 @@ type Props = {
 export function buildIntegrationTreeNodes({
   scmProviders,
   scmIntegrations,
+  connectedRepos,
   reposByIntegrationId,
   reposPendingByIntegrationId,
   connectedIdentifiers,
@@ -105,6 +110,37 @@ export function buildIntegrationTreeNodes({
             }
           }
         }
+      }
+    }
+  }
+
+  // Disconnected repos: connected to the org but no matching SCM integration
+  const scmIntegrationIds = new Set(scmIntegrations.map(i => i.id));
+  const disconnectedRepos =
+    providerFilter === 'seer-supported' || repoFilter === 'not-connected'
+      ? []
+      : connectedRepos.filter(
+          r =>
+            r.url &&
+            (!r.integrationId || !scmIntegrationIds.has(r.integrationId)) &&
+            (!query || r.name.toLowerCase().includes(query))
+        );
+
+  if (disconnectedRepos.length > 0) {
+    const isExpanded = expandedProviders.has(DISCONNECTED_SECTION_KEY);
+    nodes.push({
+      type: 'disconnected-section',
+      isExpanded,
+      repoCount: disconnectedRepos.length,
+    });
+
+    if (isExpanded) {
+      for (const repo of disconnectedRepos) {
+        nodes.push({
+          type: 'disconnected-repo',
+          repo,
+          isToggling: togglingRepos.has(repo.id),
+        });
       }
     }
   }

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -441,8 +441,8 @@ function RemoveButton({
       onClick={() => setIsConfirming(true)}
       aria-label={t('Remove %s', repoName)}
       tooltipProps={{
-				disabled: canAccess,
-    		title: t('You must be an organization owner, manager or admin to uninstall'),
+        disabled: canAccess,
+        title: t('You must be an organization owner, manager or admin to uninstall'),
       }}
     >
       {t('Remove')}

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -365,7 +365,7 @@ function DisconnectedRepoRow({
   style: CSSProperties;
 }) {
   return (
-    <RowContainer style={style} role="row" aria-level={3}>
+    <RowContainer style={style} role="row" aria-level={2}>
       <Flex align="center" gap="sm" height="100%" paddingRight="lg">
         <Flex
           flex={1}

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -434,20 +434,19 @@ function RemoveButton({
   }
 
   return (
-    <Tooltip
-      disabled={canAccess}
-      title={t('You must be an organization owner, manager or admin to uninstall')}
+    <Button
+      size="xs"
+      icon={<IconDelete />}
+      disabled={!canAccess || isToggling}
+      onClick={() => setIsConfirming(true)}
+      aria-label={t('Remove %s', repoName)}
+      tooltipProps={{
+				disabled: canAccess,
+    		title: t('You must be an organization owner, manager or admin to uninstall'),
+      }}
     >
-      <Button
-        size="xs"
-        icon={<IconDelete />}
-        disabled={!canAccess || isToggling}
-        onClick={() => setIsConfirming(true)}
-        aria-label={t('Remove %s', repoName)}
-      >
-        {t('Remove')}
-      </Button>
-    </Tooltip>
+      {t('Remove')}
+    </Button>
   );
 }
 

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -13,6 +13,7 @@ import {hasEveryAccess} from 'sentry/components/acl/access';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {ProviderConfigLink} from 'sentry/components/repositories/scmIntegrationTree/providerConfigLink';
+import {DISCONNECTED_SECTION_KEY} from 'sentry/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes';
 import type {TreeNode} from 'sentry/components/repositories/scmIntegrationTree/types';
 import {IconAdd, IconChevron, IconClose, IconDelete, IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -244,7 +245,7 @@ export function ScmIntegrationTreeRow({
     return (
       <RowContainer style={style} role="row" aria-level={1}>
         <RowButton
-          onClick={() => onToggleProvider('__disconnected__')}
+          onClick={() => onToggleProvider(DISCONNECTED_SECTION_KEY)}
           aria-expanded={node.isExpanded}
           aria-label={t('Other repositories')}
         >

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -16,7 +16,11 @@ import {ProviderConfigLink} from 'sentry/components/repositories/scmIntegrationT
 import type {TreeNode} from 'sentry/components/repositories/scmIntegrationTree/types';
 import {IconAdd, IconChevron, IconClose, IconDelete, IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {Integration, IntegrationRepository} from 'sentry/types/integrations';
+import type {
+  Integration,
+  IntegrationRepository,
+  Repository,
+} from 'sentry/types/integrations';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTimeout} from 'sentry/utils/useTimeout';
@@ -29,6 +33,7 @@ import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegratio
 type Props = {
   node: TreeNode;
   onAddIntegration: () => void;
+  onRemoveDisconnectedRepo: (repo: Repository) => void;
   onToggleIntegration: (integrationId: string) => void;
   onToggleProvider: (providerKey: string) => void;
   onToggleRepo: (
@@ -45,6 +50,7 @@ export function ScmIntegrationTreeRow({
   onToggleProvider,
   onToggleIntegration,
   onToggleRepo,
+  onRemoveDisconnectedRepo,
   style,
 }: Props) {
   const organization = useOrganization();
@@ -234,6 +240,40 @@ export function ScmIntegrationTreeRow({
     );
   }
 
+  if (node.type === 'disconnected-section') {
+    return (
+      <RowContainer style={style} role="row" aria-level={1}>
+        <RowButton
+          onClick={() => onToggleProvider('__disconnected__')}
+          aria-expanded={node.isExpanded}
+          aria-label={t('Other repositories')}
+        >
+          <InteractionStateLayer hasSelectedBackground={false} />
+          <Flex align="center" gap="lg" flex={1}>
+            <IconChevron direction={node.isExpanded ? 'down' : 'right'} size="xs" />
+            <Flex align="center" gap="sm" flex={1} justify="between">
+              <Text bold size="md">
+                {t('Other')}
+              </Text>
+              <Badge variant="muted">{t('%s repos', node.repoCount)}</Badge>
+            </Flex>
+          </Flex>
+        </RowButton>
+      </RowContainer>
+    );
+  }
+
+  if (node.type === 'disconnected-repo') {
+    return (
+      <DisconnectedRepoRow
+        node={node}
+        style={style}
+        canAccess={canAccess}
+        onRemoveDisconnectedRepo={onRemoveDisconnectedRepo}
+      />
+    );
+  }
+
   // node.type === 'repo'
   return (
     <RepoRow
@@ -256,8 +296,6 @@ function RepoRow({
   onToggleRepo: Props['onToggleRepo'];
   style: CSSProperties;
 }) {
-  const [isConfirming, setIsConfirming] = useState(false);
-
   return (
     <RowContainer style={style} role="row" aria-level={3}>
       <Flex align="center" gap="sm" height="100%" paddingRight="lg">
@@ -269,17 +307,7 @@ function RepoRow({
           marginLeft="2xl"
           paddingLeft="3xl"
         >
-          {isConfirming ? (
-            <Text size="xs" variant="muted">
-              {tct(
-                'Are you sure you want to remove [repoName]?[break]All associated commit data will be removed in addition to the repository.',
-                {
-                  repoName: <Text monospace>{node.repo.name}</Text>,
-                  break: <br />,
-                }
-              )}
-            </Text>
-          ) : node.integration.domainName ? (
+          {node.integration.domainName ? (
             <ExternalLink
               href={`https://${node.integration.domainName}/${node.repo.name}`}
             >
@@ -298,46 +326,12 @@ function RepoRow({
           )}
         </Flex>
         {node.isConnected ? (
-          isConfirming ? (
-            <Flex align="center" gap="sm">
-              <Button
-                size="xs"
-                priority="danger"
-                disabled={node.isToggling}
-                onClick={() => {
-                  onToggleRepo(node.repo, node.integration, true);
-                  setIsConfirming(false);
-                }}
-                aria-label={t('Confirm remove %s', node.repo.name)}
-              >
-                {t('Confirm')}
-              </Button>
-              <Button
-                size="xs"
-                icon={<IconClose size="xs" />}
-                disabled={node.isToggling}
-                onClick={() => setIsConfirming(false)}
-                aria-label={t('Cancel')}
-              />
-            </Flex>
-          ) : (
-            <Tooltip
-              disabled={canAccess}
-              title={t(
-                'You must be an organization owner, manager or admin to uninstall'
-              )}
-            >
-              <Button
-                size="xs"
-                icon={<IconDelete />}
-                disabled={!canAccess || node.isToggling}
-                onClick={() => setIsConfirming(true)}
-                aria-label={t('Remove %s', node.repo.name)}
-              >
-                {t('Remove')}
-              </Button>
-            </Tooltip>
-          )
+          <RemoveButton
+            repoName={node.repo.name}
+            isToggling={node.isToggling}
+            canAccess={canAccess}
+            onRemove={() => onToggleRepo(node.repo, node.integration, true)}
+          />
         ) : (
           <Tooltip
             disabled={canAccess}
@@ -356,6 +350,103 @@ function RepoRow({
         )}
       </Flex>
     </RowContainer>
+  );
+}
+
+function DisconnectedRepoRow({
+  node,
+  style,
+  canAccess,
+  onRemoveDisconnectedRepo,
+}: {
+  canAccess: boolean;
+  node: Extract<TreeNode, {type: 'disconnected-repo'}>;
+  onRemoveDisconnectedRepo: Props['onRemoveDisconnectedRepo'];
+  style: CSSProperties;
+}) {
+  return (
+    <RowContainer style={style} role="row" aria-level={3}>
+      <Flex align="center" gap="sm" height="100%" paddingRight="lg">
+        <Flex
+          flex={1}
+          align="center"
+          gap="sm"
+          height="100%"
+          marginLeft="2xl"
+          paddingLeft="3xl"
+        >
+          <ExternalLink href={node.repo.url}>
+            <Flex align="center" gap="sm">
+              {node.repo.name}
+              <IconOpen size="xs" />
+            </Flex>
+          </ExternalLink>
+        </Flex>
+        <RemoveButton
+          repoName={node.repo.name}
+          isToggling={node.isToggling}
+          canAccess={canAccess}
+          onRemove={() => onRemoveDisconnectedRepo(node.repo)}
+        />
+      </Flex>
+    </RowContainer>
+  );
+}
+
+function RemoveButton({
+  repoName,
+  isToggling,
+  canAccess,
+  onRemove,
+}: {
+  canAccess: boolean;
+  isToggling: boolean;
+  onRemove: () => void;
+  repoName: string;
+}) {
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  if (isConfirming) {
+    return (
+      <Flex align="center" gap="sm">
+        <Button
+          size="xs"
+          priority="danger"
+          disabled={isToggling}
+          onClick={() => {
+            onRemove();
+            setIsConfirming(false);
+          }}
+          aria-label={t('Confirm remove %s', repoName)}
+        >
+          {t('Confirm')}
+        </Button>
+        <Button
+          size="xs"
+          icon={<IconClose size="xs" />}
+          disabled={isToggling}
+          onClick={() => setIsConfirming(false)}
+          aria-label={t('Cancel')}
+        />
+      </Flex>
+    );
+  }
+
+  return (
+    <Tooltip
+      disabled={canAccess}
+      title={t('You must be an organization owner, manager or admin to uninstall')}
+    >
+      <Button
+        size="xs"
+        icon={<IconDelete />}
+        disabled={!canAccess || isToggling}
+        onClick={() => setIsConfirming(true)}
+        aria-label={t('Remove %s', repoName)}
+      >
+        {t('Remove')}
+      </Button>
+    </Tooltip>
   );
 }
 

--- a/static/app/components/repositories/scmIntegrationTree/types.ts
+++ b/static/app/components/repositories/scmIntegrationTree/types.ts
@@ -3,6 +3,7 @@ import type {
   IntegrationProvider,
   IntegrationRepository,
   OrganizationIntegration,
+  Repository,
 } from 'sentry/types/integrations';
 
 export type ProviderNode = {
@@ -41,12 +42,26 @@ export type NoMatchNode = {
   type: 'no-match';
 };
 
+export type DisconnectedSectionNode = {
+  isExpanded: boolean;
+  repoCount: number;
+  type: 'disconnected-section';
+};
+
+export type DisconnectedRepoNode = {
+  isToggling: boolean;
+  repo: Repository;
+  type: 'disconnected-repo';
+};
+
 export type TreeNode =
   | ProviderNode
   | IntegrationNode
   | RepoNode
   | AddConfigNode
-  | NoMatchNode;
+  | NoMatchNode
+  | DisconnectedSectionNode
+  | DisconnectedRepoNode;
 
 export type RepoFilter = 'all' | 'connected' | 'not-connected';
 export type ProviderFilter = 'seer-supported' | 'all';

--- a/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
+++ b/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
@@ -19,7 +19,7 @@ type ScmIntegrationTreeData = {
   refetchIntegrations: () => void;
   reposByIntegrationId: Record<string, IntegrationRepository[]>;
   reposPendingByIntegrationId: Record<string, boolean>;
-  reposQueryKey: unknown;
+  reposQueryOptions: ReturnType<typeof organizationRepositoriesInfiniteOptions>;
   scmIntegrations: OrganizationIntegration[];
   scmProviders: IntegrationProvider[];
 };
@@ -146,7 +146,7 @@ export function useScmIntegrationTreeData(): ScmIntegrationTreeData {
     refetchIntegrations: integrationsQuery.refetch,
     reposByIntegrationId,
     reposPendingByIntegrationId,
-    reposQueryKey: reposQueryOptions.queryKey,
+    reposQueryOptions,
     isPending,
     isError,
   };


### PR DESCRIPTION
It's possible to get into a state where repo's exist in sentry but the integration that added them is removed. I believe we keep the repo's around because removing them could destroy release related data, or some other data that we might want to keep. (we should take a closer look at this though)

Recently we added a tree-view component at `/settings/repos/` which groups repo's by provider, but it was hiding repos where the provider is unknown. Before this was a list and everything was visible. This PR aims to restore that visibility.

If there are extra repo's on the org we'll see them at `/settings/repos/` in the `Other` section

**Other Section**
<img width="1121" height="606" alt="SCR-20260322-ozmy" src="https://github.com/user-attachments/assets/7a680282-87aa-4d57-8d92-9c10465b43b1" />

**Not shown in Seer settings (other is not supported by seer)**
<img width="1124" height="433" alt="SCR-20260322-oznq" src="https://github.com/user-attachments/assets/214ffdd6-be8c-4490-8589-867e285be97f" />

**When the section is empty, it is not shown**
<img width="1119" height="546" alt="SCR-20260322-ozoq" src="https://github.com/user-attachments/assets/37d385e4-ff94-4b87-a589-2df99ffedbce" />
