### PR TITLE
feat(agents): add agent monitoring onboarding for Bun

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -842,6 +842,7 @@ export const agentMonitoringPlatforms: ReadonlySet<PlatformKey> = new Set([
   ...platformKeys.filter(id => id.startsWith('javascript')),
   ...platformKeys.filter(id => id.startsWith('node')),
   ...platformKeys.filter(id => id.startsWith('python')),
+  'bun',
 ]);
 
 export const javascriptMetaFrameworks: readonly PlatformKey[] = [

--- a/static/app/gettingStartedDocs/bun/index.tsx
+++ b/static/app/gettingStartedDocs/bun/index.tsx
@@ -1,4 +1,5 @@
 import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
 import {
   feedbackOnboardingJsLoader,
   replayOnboardingJsLoader,
@@ -15,6 +16,9 @@ export const docs: Docs = {
   feedbackOnboardingJsLoader,
   logsOnboarding: getNodeLogsOnboarding({
     docsPlatform: 'bun',
+    packageName: '@sentry/bun',
+  }),
+  agentMonitoringOnboarding: agentMonitoring({
     packageName: '@sentry/bun',
   }),
 };


### PR DESCRIPTION
- Add `'bun'` to `agentMonitoringPlatforms` so Bun projects show the onboarding UI instead of "Auto instrumentation not available"
- Wire up `agentMonitoringOnboarding` in Bun's doc config using `javascript/agentMonitoring` with `@sentry/bun` as the package name

contributes to https://linear.app/getsentry/issue/TET-2103/missing-onboarding-instructions-for-ai-agent-monitoring-in-bun-and