### PR TITLE
perf(nodestore): Add cache metrics to get_multi and configurable TTL

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2526,6 +2526,16 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# TTL in seconds for nodestore cache entries. Event bodies are immutable
+# so longer TTLs are safe and improve cache hit rates for batch reads
+# (e.g. group events list endpoint).
+register(
+    "nodestore.cache-ttl",
+    default=300,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # === Backpressure related runtime options ===
 
 # Enables monitoring of services for backpressure management.

--- a/src/sentry/services/nodestore/base.py
+++ b/src/sentry/services/nodestore/base.py
@@ -188,10 +188,15 @@ class NodeStorage(local, Service):
             if subkey is None:
                 cache_items = self._get_cache_items(id_list)
                 if len(cache_items) == len(id_list):
+                    metrics.incr("nodestore.get_multi", amount=len(id_list), tags={"cache": "hit"})
                     span.set_tag("result", "from_cache")
                     return cache_items
 
                 uncached_ids = [id for id in id_list if id not in cache_items]
+                metrics.incr("nodestore.get_multi", amount=len(cache_items), tags={"cache": "hit"})
+                metrics.incr(
+                    "nodestore.get_multi", amount=len(uncached_ids), tags={"cache": "miss"}
+                )
             else:
                 uncached_ids = id_list
 
@@ -288,12 +293,12 @@ class NodeStorage(local, Service):
 
     def _set_cache_item(self, item_id: str, data: Any) -> None:
         if self.cache and data:
-            self.cache.set(item_id, data)
+            self.cache.set(item_id, data, timeout=options.get("nodestore.cache-ttl"))
 
     @sentry_sdk.tracing.trace
     def _set_cache_items(self, items: dict[Any, Any]) -> None:
         if self.cache:
-            self.cache.set_many(items)
+            self.cache.set_many(items, timeout=options.get("nodestore.cache-ttl"))
 
     def _delete_cache_item(self, item_id: str) -> None:
         if self.cache:

--- a/tests/sentry/services/nodestore/test_common.py
+++ b/tests/sentry/services/nodestore/test_common.py
@@ -35,7 +35,9 @@ def ns(request: pytest.FixtureRequest) -> Generator[NodeStorage]:
         yield ns
 
 
-@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
+@override_options(
+    {"nodestore.set-subkeys.enable-set-cache-item": False, "nodestore.cache-ttl": 300}
+)
 def test_get_multi(ns: NodeStorage) -> None:
     nodes = [("a" * 32, {"foo": "a"}), ("b" * 32, {"foo": "b"})]
 
@@ -46,7 +48,9 @@ def test_get_multi(ns: NodeStorage) -> None:
     assert result == {n[0]: n[1] for n in nodes}
 
 
-@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
+@override_options(
+    {"nodestore.set-subkeys.enable-set-cache-item": False, "nodestore.cache-ttl": 300}
+)
 def test_get_multi_with_duplicates(ns: NodeStorage) -> None:
     key = "a" * 32
     value = {"foo": "a"}
@@ -60,7 +64,9 @@ def test_get_multi_with_duplicates(ns: NodeStorage) -> None:
     assert ns.get_multi([key, key]) == {key: value}
 
 
-@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
+@override_options(
+    {"nodestore.set-subkeys.enable-set-cache-item": False, "nodestore.cache-ttl": 300}
+)
 def test_set(ns: NodeStorage) -> None:
     node_id = "d2502ebbd7df41ceba8d3275595cac33"
     data = {"foo": "bar"}
@@ -68,7 +74,9 @@ def test_set(ns: NodeStorage) -> None:
     assert ns.get(node_id) == data
 
 
-@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
+@override_options(
+    {"nodestore.set-subkeys.enable-set-cache-item": False, "nodestore.cache-ttl": 300}
+)
 def test_delete(ns: NodeStorage) -> None:
     node_id = "d2502ebbd7df41ceba8d3275595cac33"
     data = {"foo": "bar"}
@@ -78,7 +86,9 @@ def test_delete(ns: NodeStorage) -> None:
     assert not ns.get(node_id)
 
 
-@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
+@override_options(
+    {"nodestore.set-subkeys.enable-set-cache-item": False, "nodestore.cache-ttl": 300}
+)
 def test_delete_multi(ns: NodeStorage) -> None:
     nodes = [("node_1", {"foo": "a"}), ("node_2", {"foo": "b"})]
 
@@ -90,7 +100,9 @@ def test_delete_multi(ns: NodeStorage) -> None:
     assert not ns.get(nodes[1][0])
 
 
-@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
+@override_options(
+    {"nodestore.set-subkeys.enable-set-cache-item": False, "nodestore.cache-ttl": 300}
+)
 def test_set_subkeys(ns: NodeStorage) -> None:
     """
     Subkeys are used to store multiple JSON payloads under the same main key.


### PR DESCRIPTION
Follow-up to #110981 which batched nodestore fetches for the group events endpoint. The batched `get_multi` call reduced 100 sequential Bigtable RPCs to 1, but the single batch still takes ~8-10s because row keys are MD5-hashed and scattered across ~100 Bigtable tablets.

This PR adds two things to help understand and reduce that cost:

### 1. Cache observability for `get_multi`

The single-event `get()` already emits `nodestore.get` metrics with `cache:hit/miss` tags, but `get_multi` had no cache metrics at all. Now it emits:

```
nodestore.get_multi  cache:hit   amount=<N>
nodestore.get_multi  cache:miss  amount=<N>
```

This lets us measure the actual cache hit rate for batch reads in production and understand whether increasing the TTL would help.

### 2. Configurable cache TTL

Cache entries were written with no explicit `timeout`, relying on the backend's `DEFAULT_TIMEOUT` (typically 300s). Since event bodies are **immutable** — they never change after ingestion — there's no invalidation concern with longer TTLs.

The new `nodestore.cache-ttl` option (default: 300s) can be tuned upward via configoptions without a deploy. If production metrics show low hit rates, increasing to 1-4 hours should improve cache effectiveness for paginated list views where events are often viewed in quick succession.

### Why this helps

The group events endpoint fetches ~100 events per page. With a 5-minute cache TTL, events ingested more than 5 minutes ago won't be cached when the list is first viewed. But once viewed, they'll be cached for subsequent page loads and adjacent page navigations. A longer TTL extends this window significantly.

### Files changed

- `src/sentry/services/nodestore/base.py` — metrics in `get_multi`, explicit TTL in `_set_cache_item`/`_set_cache_items`
- `src/sentry/options/defaults.py` — register `nodestore.cache-ttl` option