### PR TITLE
feat(metrics): Limit rate aggregates to single selection

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -417,4 +417,55 @@ describe('AggregateDropdown', () => {
     expect(callArgs.aggregateFields).toHaveLength(1);
     expect(callArgs.aggregateFields[0].parsedFunction?.name).toBe('per_second');
   });
+
+  it('only allows one rate aggregate at a time', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled'],
+    });
+
+    const setQueryParams = jest.fn();
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [
+        new VisualizeFunction('per_second(value,test_metric,distribution,-)'),
+      ],
+      aggregateSortBys: [
+        {field: 'per_second(value,test_metric,distribution,-)', kind: 'desc'},
+      ],
+    });
+
+    render(
+      <AggregateDropdown traceMetric={{name: 'test_metric', type: 'distribution'}} />,
+      {
+        organization,
+        additionalWrapper: createWrapper({queryParams, setQueryParams, stateful: true}),
+      }
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    await userEvent.click(trigger);
+
+    await waitFor(() =>
+      expect(screen.getByRole('option', {name: 'per_second'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    );
+
+    await userEvent.click(screen.getByRole('option', {name: 'per_minute'}));
+
+    await waitFor(() => {
+      expect(setQueryParams).toHaveBeenCalled();
+    });
+
+    const callArgs = setQueryParams.mock.calls[setQueryParams.mock.calls.length - 1]![0];
+    expect(callArgs.aggregateFields).toHaveLength(1);
+    expect(callArgs.aggregateFields[0].parsedFunction?.name).toBe('per_minute');
+  });
 });

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -79,10 +79,12 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
             o => findGroupKey(traceMetric.type, o.value) === targetGroup
           );
 
+          // Rate-based aggregates are mutually exclusive — only keep the newly selected one
+          const finalOptions =
+            targetGroup === 'rate' && newlySelected ? [newlySelected] : compatibleOptions;
+
           setMetricVisualizes(
-            compatibleOptions.map(o =>
-              updateVisualizeYAxis(visualize, o.value, traceMetric)
-            )
+            finalOptions.map(o => updateVisualizeYAxis(visualize, o.value, traceMetric))
           );
         }
       }}


### PR DESCRIPTION
Make rate-based aggregates (per_second, per_minute) mutually exclusive in the metrics aggregate dropdown. Selecting one now deselects the other, while non-rate groups (percentiles, stats, math) still allow multi-select.

Refs LOGS-628

Made with [Cursor](https://cursor.com)