### PR TITLE
perf(dashboards): Measure re-render duration on full-screen widget view

### DIFF
--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -204,6 +204,24 @@ function DataWidgetViewerModal(props: Props) {
   const location = useLocation();
   const {projects} = useProjects();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    for (const path of ['navigate', 'modal'] as const) {
+      const mark = `dashboard.widget.fullScreenViewClick.${path}`;
+      try {
+        const measure = performance.measure('dashboard.widget.onFullScreenView', mark);
+        Sentry.metrics.distribution(
+          'dashboards.widget.onFullScreenView',
+          measure.duration,
+          {unit: 'millisecond', attributes: {path}}
+        );
+        performance.clearMarks(mark);
+        break;
+      } catch {
+        // performance.measure throws if the mark doesn't exist, try the next one
+      }
+    }
+  }, []);
   // Get widget zoom from location
   // We use the start and end query params for just the initial state
   const start = decodeScalar(location.query[WidgetViewerQueryField.START]);

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -301,7 +301,7 @@ class DashboardDetail extends Component<Props, State> {
             Sentry.metrics.distribution(
               'dashboards.widget.onFullScreenView',
               measure.duration,
-              {unit: 'millisecond'}
+              {unit: 'millisecond', attributes: {path: 'navigate'}}
             );
             performance.clearMarks('dashboard.widget.fullScreenViewClick');
           } catch {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -290,6 +290,23 @@ class DashboardDetail extends Component<Props, State> {
     if (isWidgetViewerPath(location.pathname)) {
       const widget = (modifiedDashboard ?? dashboard).widgets[Number(widgetId)];
       if (widget) {
+        // Measure how long it takes to open the full-screen view from when the
+        // user clicked the button.
+        scheduleMicroTask(() => {
+          try {
+            const measure = performance.measure(
+              'dashboard.widget.onFullScreenView',
+              'dashboard.widget.fullScreenViewClick'
+            );
+            Sentry.metrics.distribution(
+              'dashboards.widget.onFullScreenView',
+              measure.duration,
+              {unit: 'millisecond'}
+            );
+          } catch {
+            // performance.measure throws if the start mark doesn't exist
+          }
+        });
         openWidgetViewerModal({
           organization,
           widget,

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -290,24 +290,6 @@ class DashboardDetail extends Component<Props, State> {
     if (isWidgetViewerPath(location.pathname)) {
       const widget = (modifiedDashboard ?? dashboard).widgets[Number(widgetId)];
       if (widget) {
-        // Measure how long it takes to open the full-screen view from when the
-        // user clicked the button.
-        scheduleMicroTask(() => {
-          try {
-            const measure = performance.measure(
-              'dashboard.widget.onFullScreenView',
-              'dashboard.widget.fullScreenViewClick'
-            );
-            Sentry.metrics.distribution(
-              'dashboards.widget.onFullScreenView',
-              measure.duration,
-              {unit: 'millisecond', attributes: {path: 'navigate'}}
-            );
-            performance.clearMarks('dashboard.widget.fullScreenViewClick');
-          } catch {
-            // performance.measure throws if the start mark doesn't exist
-          }
-        });
         openWidgetViewerModal({
           organization,
           widget,

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -303,6 +303,7 @@ class DashboardDetail extends Component<Props, State> {
               measure.duration,
               {unit: 'millisecond'}
             );
+            performance.clearMarks('dashboard.widget.fullScreenViewClick');
           } catch {
             // performance.measure throws if the start mark doesn't exist
           }

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -265,6 +265,7 @@ function WidgetCard(props: Props) {
         const duration = performance.now() - start;
         Sentry.metrics.distribution('dashboards.widget.onFullScreenView', duration, {
           unit: 'millisecond',
+          attributes: {path: 'modal'},
         });
       });
       openWidgetViewerModal({

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import type {LegendComponentOption} from 'echarts';
 import type {Location} from 'history';
 import omit from 'lodash/omit';
@@ -30,6 +31,7 @@ import {getFieldDefinition} from 'sentry/utils/fields';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import {useExtractionStatus} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import {scheduleMicroTask} from 'sentry/utils/scheduleMicroTask';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -242,8 +244,8 @@ function WidgetCard(props: Props) {
     if (isWidgetViewerPath(location.pathname)) {
       return;
     }
-    performance.mark('dashboard.widget.fullScreenViewClick');
     if (currentDashboardId) {
+      performance.mark('dashboard.widget.fullScreenViewClick');
       navigate(
         normalizeUrl({
           pathname: `/organizations/${organization.slug}/dashboard/${currentDashboardId}/widget/${props.index}/`,
@@ -258,6 +260,13 @@ function WidgetCard(props: Props) {
         {preventScrollReset: true}
       );
     } else {
+      const start = performance.now();
+      scheduleMicroTask(() => {
+        const duration = performance.now() - start;
+        Sentry.metrics.distribution('dashboards.widget.onFullScreenView', duration, {
+          unit: 'millisecond',
+        });
+      });
       openWidgetViewerModal({
         organization,
         widget,

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -1,6 +1,5 @@
 import {useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import type {LegendComponentOption} from 'echarts';
 import type {Location} from 'history';
 import omit from 'lodash/omit';
@@ -31,7 +30,6 @@ import {getFieldDefinition} from 'sentry/utils/fields';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import {useExtractionStatus} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
-import {scheduleMicroTask} from 'sentry/utils/scheduleMicroTask';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -245,7 +243,7 @@ function WidgetCard(props: Props) {
       return;
     }
     if (currentDashboardId) {
-      performance.mark('dashboard.widget.fullScreenViewClick');
+      performance.mark('dashboard.widget.fullScreenViewClick.navigate');
       navigate(
         normalizeUrl({
           pathname: `/organizations/${organization.slug}/dashboard/${currentDashboardId}/widget/${props.index}/`,
@@ -260,14 +258,7 @@ function WidgetCard(props: Props) {
         {preventScrollReset: true}
       );
     } else {
-      const start = performance.now();
-      scheduleMicroTask(() => {
-        const duration = performance.now() - start;
-        Sentry.metrics.distribution('dashboards.widget.onFullScreenView', duration, {
-          unit: 'millisecond',
-          attributes: {path: 'modal'},
-        });
-      });
+      performance.mark('dashboard.widget.fullScreenViewClick.modal');
       openWidgetViewerModal({
         organization,
         widget,

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -242,6 +242,7 @@ function WidgetCard(props: Props) {
     if (isWidgetViewerPath(location.pathname)) {
       return;
     }
+    performance.mark('dashboard.widget.fullScreenViewClick');
     if (currentDashboardId) {
       navigate(
         normalizeUrl({


### PR DESCRIPTION
We want to measure the performance of the dashboard widget full screen viewer. 


This will set  a performance.mark on click, then measure the duration in detail.tsx when it opens the widget viewer modal — emitting a `dashboards.widget.onFullScreenView` distribution metric. 

This covers both the dashboards that have an id, and dashboards that are prebuilt (insights).

If the user navigates directly to the widget viewer URL without clicking the button, no metric is emitted.

Refs DAIN-1371

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
