### PR TITLE
fix(dashboards): Set breakdown legend widget limit to 3 in prebuilt configs

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
@@ -90,6 +90,7 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
           orderby: '',
         },
       ],
+      limit: 3,
     },
   ],
   0,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -189,7 +189,7 @@ export const BACKEND_OVERVIEW_SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
           orderby: `-equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
         },
       ],
-      limit: 4,
+      limit: 3,
       widgetType: WidgetType.SPANS,
     },
   ],

--- a/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
@@ -110,7 +110,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       widgetType: WidgetType.SPANS,
       legendType: 'breakdown',
       interval: '5m',
-      limit: 4,
+      limit: 3,
       queries: [
         {
           name: '',


### PR DESCRIPTION
Ensure all prebuilt dashboard widgets with `legendType: 'breakdown'` have a limit of 3, so broken out legends show a maximum of 3 items. This is just for consistency
Fixes DAIN-1380