### PR TITLE
ref(metrics): Refactor AggregateDropdown to use CompositeSelect

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -1,7 +1,13 @@
 import {useState, type ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
@@ -407,5 +413,100 @@ describe('AggregateDropdown', () => {
     const callArgs = setQueryParams.mock.calls[setQueryParams.mock.calls.length - 1]![0];
     expect(callArgs.aggregateFields).toHaveLength(1);
     expect(callArgs.aggregateFields[0].parsedFunction?.name).toBe('per_second');
+  });
+
+  it('shows selected name in trigger for a single selection', () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled'],
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [new VisualizeFunction('p50(value,test_metric,distribution,-)')],
+      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+    });
+
+    render(
+      <AggregateDropdown traceMetric={{name: 'test_metric', type: 'distribution'}} />,
+      {organization, additionalWrapper: createWrapper({queryParams})}
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    expect(within(trigger).getByText('p50')).toBeInTheDocument();
+    expect(within(trigger).queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+
+  it('shows first name and +N badge in trigger for multiple selections', () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled'],
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [
+        new VisualizeFunction('p50(value,test_metric,distribution,-)'),
+        new VisualizeFunction('p75(value,test_metric,distribution,-)'),
+        new VisualizeFunction('p90(value,test_metric,distribution,-)'),
+      ],
+      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+    });
+
+    render(
+      <AggregateDropdown traceMetric={{name: 'test_metric', type: 'distribution'}} />,
+      {organization, additionalWrapper: createWrapper({queryParams})}
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    expect(within(trigger).getByText('p50')).toBeInTheDocument();
+    expect(within(trigger).getByText('+2')).toBeInTheDocument();
+  });
+
+  it('updates trigger label after selecting an additional option', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled'],
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [new VisualizeFunction('p50(value,test_metric,distribution,-)')],
+      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+    });
+
+    render(
+      <AggregateDropdown traceMetric={{name: 'test_metric', type: 'distribution'}} />,
+      {
+        organization,
+        additionalWrapper: createWrapper({queryParams, stateful: true}),
+      }
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    expect(within(trigger).getByText('p50')).toBeInTheDocument();
+    expect(within(trigger).queryByText(/^\+/)).not.toBeInTheDocument();
+
+    await userEvent.click(trigger);
+    await userEvent.click(screen.getByRole('option', {name: 'p75'}));
+
+    await waitFor(() => {
+      expect(within(trigger).getByText('+1')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -376,10 +376,7 @@ describe('AggregateDropdown', () => {
       fields: ['id', 'timestamp'],
       sortBys: [{field: 'timestamp', kind: 'desc'}],
       aggregateCursor: '',
-      aggregateFields: [
-        new VisualizeFunction('sum(value,test_metric,distribution,-)'),
-        new VisualizeFunction('count(value,test_metric,distribution,-)'),
-      ],
+      aggregateFields: [new VisualizeFunction('sum(value,test_metric,distribution,-)')],
       aggregateSortBys: [{field: 'sum(value,test_metric,distribution,-)', kind: 'desc'}],
     });
 
@@ -396,12 +393,6 @@ describe('AggregateDropdown', () => {
 
     await waitFor(() =>
       expect(screen.getByRole('option', {name: 'sum'})).toHaveAttribute(
-        'aria-selected',
-        'true'
-      )
-    );
-    await waitFor(() =>
-      expect(screen.getByRole('option', {name: 'count'})).toHaveAttribute(
         'aria-selected',
         'true'
       )

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -51,6 +51,7 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
 
   return (
     <CompositeSelect
+      disabled={groups.length === 0}
       style={{width: '100%'}}
       trigger={triggerProps => (
         <OverlayTrigger.Button

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -1,4 +1,11 @@
-import {CompositeSelect, type SelectOption} from '@sentry/scraps/compactSelect';
+import {Fragment} from 'react';
+
+import {Badge} from '@sentry/scraps/badge';
+import {
+  CompositeSelect,
+  type SelectOption,
+  TriggerLabel,
+} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {t} from 'sentry/locale';
@@ -40,7 +47,7 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
     }
   }
 
-  const triggerLabel = [...selectedNames].filter(Boolean).join(', ') || t('None');
+  const selectedList = [...selectedNames].filter(Boolean);
 
   return (
     <CompositeSelect
@@ -51,7 +58,21 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
           prefix={t('Agg')}
           style={{width: '100%'}}
         >
-          {triggerLabel}
+          {selectedList.length === 0 ? (
+            <TriggerLabel>{t('None')}</TriggerLabel>
+          ) : (
+            <Fragment>
+              <TriggerLabel>{selectedList[0]}</TriggerLabel>
+              {selectedList.length > 1 && (
+                <Badge
+                  variant="muted"
+                  style={{marginLeft: 4, flexShrink: 0, top: 'auto'}}
+                >
+                  {`+${selectedList.length - 1}`}
+                </Badge>
+              )}
+            </Fragment>
+          )}
         </OverlayTrigger.Button>
       )}
     >

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -1,4 +1,4 @@
-import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
+import {CompositeSelect, type SelectOption} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {t} from 'sentry/locale';
@@ -14,78 +14,77 @@ import {
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {updateVisualizeYAxis} from 'sentry/views/explore/metrics/utils';
 
-function findGroupKey(
-  metricType: string,
-  aggregateValue: string | undefined
-): string | number | undefined {
-  const groups = GROUPED_OPTIONS_BY_TYPE[metricType];
-
-  if (!aggregateValue || !groups) {
-    return undefined;
-  }
-
-  for (const group of groups) {
-    if (group.options.some(opt => String(opt.value) === aggregateValue)) {
-      return group.key;
-    }
-  }
-
-  return undefined;
-}
+const MULTI_SELECT_GROUP_KEYS = new Set(['percentiles', 'stats']);
 
 export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
   const visualize = useMetricVisualize();
-
   const visualizes = useMetricVisualizes();
   const setMetricVisualizes = useSetMetricVisualizes();
 
+  const groups = GROUPED_OPTIONS_BY_TYPE[traceMetric.type] ?? [];
+  const selectedNames = new Set(visualizes.map(v => v.parsedFunction?.name ?? ''));
+
+  function handleChange(selectedOptions: Array<SelectOption<string>>) {
+    if (selectedOptions.length === 0) {
+      setMetricVisualizes([
+        updateVisualizeYAxis(
+          visualize,
+          DEFAULT_YAXIS_BY_TYPE[traceMetric.type]!,
+          traceMetric
+        ),
+      ]);
+    } else {
+      setMetricVisualizes(
+        selectedOptions.map(o => updateVisualizeYAxis(visualize, o.value, traceMetric))
+      );
+    }
+  }
+
+  const triggerLabel = [...selectedNames].filter(Boolean).join(', ') || t('None');
+
   return (
-    <CompactSelect
-      multiple
+    <CompositeSelect
       style={{width: '100%'}}
       trigger={triggerProps => (
         <OverlayTrigger.Button
           {...triggerProps}
           prefix={t('Agg')}
           style={{width: '100%'}}
-        />
+        >
+          {triggerLabel}
+        </OverlayTrigger.Button>
       )}
-      options={GROUPED_OPTIONS_BY_TYPE[traceMetric.type] ?? []}
-      value={visualizes.map(v => v.parsedFunction?.name ?? '')}
-      onChange={(option: Array<SelectOption<string>>) => {
-        if (option.length === 0) {
-          setMetricVisualizes([
-            updateVisualizeYAxis(
-              visualize,
-              DEFAULT_YAXIS_BY_TYPE[traceMetric.type]!,
-              traceMetric
-            ),
-          ]);
-        } else {
-          // Find the newly selected aggregate by comparing with current selection
-          const currentValues = new Set(
-            visualizes.map(v => v.parsedFunction?.name ?? '')
-          );
-          const newlySelected = option.find(o => !currentValues.has(o.value));
+    >
+      {groups.map(group => {
+        const groupKey = String(group.key);
+        const isMulti = MULTI_SELECT_GROUP_KEYS.has(groupKey);
+        const activeValues = group.options
+          .map(opt => String(opt.value))
+          .filter(v => selectedNames.has(v));
 
-          // If something new was selected, use its group; otherwise keep existing group
-          const targetGroup = newlySelected
-            ? findGroupKey(traceMetric.type, newlySelected.value)
-            : findGroupKey(traceMetric.type, visualizes?.[0]?.parsedFunction?.name ?? '');
-
-          // Filter to only keep aggregates from the same group
-          // This auto-deselects incompatible aggregates when switching groups
-          const compatibleOptions = option.filter(
-            o => findGroupKey(traceMetric.type, o.value) === targetGroup
-          );
-
-          setMetricVisualizes(
-            compatibleOptions.map(o =>
-              updateVisualizeYAxis(visualize, o.value, traceMetric)
-            )
+        if (isMulti) {
+          return (
+            <CompositeSelect.Region
+              key={groupKey}
+              label={group.label as string}
+              multiple
+              options={group.options}
+              value={activeValues}
+              onChange={(opts: Array<SelectOption<string>>) => handleChange(opts)}
+            />
           );
         }
-      }}
-    />
+
+        return (
+          <CompositeSelect.Region
+            key={groupKey}
+            label={group.label as string}
+            options={group.options}
+            value={activeValues[0] as string}
+            onChange={(opt: SelectOption<string>) => handleChange([opt])}
+          />
+        );
+      })}
+    </CompositeSelect>
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -122,7 +122,7 @@ export function GroupBySelector({traceMetric}: GroupBySelectorProps) {
       options={enabledOptions}
       value={[...groupBys]}
       loading={isLoading}
-      disabled={enabledOptions.length === 0}
+      disabled={!traceMetricFilter}
       onChange={handleChange}
       style={{width: '100%'}}
     />


### PR DESCRIPTION
Replaces the `CompactSelect` in `AggregateDropdown` with `CompositeSelect`, where each option group gets its own `Region`. This removes the manual `findGroupKey` helper and the hand-rolled cross-group filtering logic that lived in the `onChange` handler.

**Group modes:**
- `percentiles` and `stats` → multi-select regions (users commonly compare e.g. p50 + p75 + p90)
- `rate` and `math` → single-select regions

Cross-group enforcement is now automatic: `handleChange` always replaces the full `visualizes` array, so selecting from a new group clears the previous group's selections on re-render without any explicit filtering.

The trigger label is manually constructed to match `CompactSelect`'s built-in behaviour — first selected name in a `TriggerLabel` span, with a muted `+N` badge when more than one aggregate is active (`CompositeSelect` does not inject a trigger label the way `CompactSelect` does).

Ticket: LOGS-628

Example:
<img width="273" height="567" alt="Screenshot 2026-03-23 at 11 14 33" src="https://github.com/user-attachments/assets/df6159cd-b6f8-4fce-a972-133d858689b8" />