### PR TITLE
fix(dashboards): Handle null/undefined at top level in toPythonString

### DIFF
--- a/static/app/utils/string/toPythonString.spec.tsx
+++ b/static/app/utils/string/toPythonString.spec.tsx
@@ -1,0 +1,34 @@
+import {toPythonString} from 'sentry/utils/string/toPythonString';
+
+describe('toPythonString', () => {
+  it('converts strings', () => {
+    expect(toPythonString('hello')).toBe('hello');
+    expect(toPythonString('')).toBe('');
+  });
+
+  it('converts booleans to Python format', () => {
+    expect(toPythonString(true)).toBe('True');
+    expect(toPythonString(false)).toBe('False');
+  });
+
+  it('converts null and undefined to None', () => {
+    expect(toPythonString(null)).toBe('None');
+    expect(toPythonString(undefined)).toBe('None');
+  });
+
+  it('converts numbers', () => {
+    expect(toPythonString(42)).toBe('42');
+    expect(toPythonString(0)).toBe('0');
+    expect(toPythonString(-3.14)).toBe('-3.14');
+  });
+
+  it('converts arrays with mixed types', () => {
+    expect(toPythonString([1, 'two', null, true, undefined])).toBe(
+      "[1, 'two', None, True, None]"
+    );
+  });
+
+  it('converts empty arrays', () => {
+    expect(toPythonString([])).toBe('[]');
+  });
+});

--- a/static/app/utils/string/toPythonString.spec.tsx
+++ b/static/app/utils/string/toPythonString.spec.tsx
@@ -1,34 +1,34 @@
-import {toPythonString} from 'sentry/utils/string/toPythonString';
+import { toPythonString } from "sentry/utils/string/toPythonString";
 
-describe('toPythonString', () => {
-  it('converts strings', () => {
-    expect(toPythonString('hello')).toBe('hello');
-    expect(toPythonString('')).toBe('');
+describe("toPythonString", () => {
+  it("converts strings", () => {
+    expect(toPythonString("hello")).toBe("hello");
+    expect(toPythonString("")).toBe("");
   });
 
-  it('converts booleans to Python format', () => {
-    expect(toPythonString(true)).toBe('True');
-    expect(toPythonString(false)).toBe('False');
+  it("converts booleans to Python format", () => {
+    expect(toPythonString(true)).toBe("True");
+    expect(toPythonString(false)).toBe("False");
   });
 
-  it('converts null and undefined to None', () => {
-    expect(toPythonString(null)).toBe('None');
-    expect(toPythonString(undefined)).toBe('None');
+  it("converts null and undefined to None", () => {
+    expect(toPythonString(null)).toBe("None");
+    expect(toPythonString(undefined)).toBe("None");
   });
 
-  it('converts numbers', () => {
-    expect(toPythonString(42)).toBe('42');
-    expect(toPythonString(0)).toBe('0');
-    expect(toPythonString(-3.14)).toBe('-3.14');
+  it("converts numbers", () => {
+    expect(toPythonString(42)).toBe("42");
+    expect(toPythonString(0)).toBe("0");
+    expect(toPythonString(-3.14)).toBe("-3.14");
   });
 
-  it('converts arrays with mixed types', () => {
-    expect(toPythonString([1, 'two', null, true, undefined])).toBe(
-      "[1, 'two', None, True, None]"
+  it("converts arrays with mixed types", () => {
+    expect(toPythonString([1, "two", null, true, undefined])).toBe(
+      "[1, 'two', None, True, None]",
     );
   });
 
-  it('converts empty arrays', () => {
-    expect(toPythonString([])).toBe('[]');
+  it("converts empty arrays", () => {
+    expect(toPythonString([])).toBe("[]");
   });
 });

--- a/static/app/utils/string/toPythonString.spec.tsx
+++ b/static/app/utils/string/toPythonString.spec.tsx
@@ -1,34 +1,34 @@
-import { toPythonString } from "sentry/utils/string/toPythonString";
+import {toPythonString} from 'sentry/utils/string/toPythonString';
 
-describe("toPythonString", () => {
-  it("converts strings", () => {
-    expect(toPythonString("hello")).toBe("hello");
-    expect(toPythonString("")).toBe("");
+describe('toPythonString', () => {
+  it('converts strings', () => {
+    expect(toPythonString('hello')).toBe('hello');
+    expect(toPythonString('')).toBe('');
   });
 
-  it("converts booleans to Python format", () => {
-    expect(toPythonString(true)).toBe("True");
-    expect(toPythonString(false)).toBe("False");
+  it('converts booleans to Python format', () => {
+    expect(toPythonString(true)).toBe('True');
+    expect(toPythonString(false)).toBe('False');
   });
 
-  it("converts null and undefined to None", () => {
-    expect(toPythonString(null)).toBe("None");
-    expect(toPythonString(undefined)).toBe("None");
+  it('converts null and undefined to None', () => {
+    expect(toPythonString(null)).toBe('None');
+    expect(toPythonString(undefined)).toBe('None');
   });
 
-  it("converts numbers", () => {
-    expect(toPythonString(42)).toBe("42");
-    expect(toPythonString(0)).toBe("0");
-    expect(toPythonString(-3.14)).toBe("-3.14");
+  it('converts numbers', () => {
+    expect(toPythonString(42)).toBe('42');
+    expect(toPythonString(0)).toBe('0');
+    expect(toPythonString(-3.14)).toBe('-3.14');
   });
 
-  it("converts arrays with mixed types", () => {
-    expect(toPythonString([1, "two", null, true, undefined])).toBe(
-      "[1, 'two', None, True, None]",
+  it('converts arrays with mixed types', () => {
+    expect(toPythonString([1, 'two', null, true, undefined])).toBe(
+      "[1, 'two', None, True, None]"
     );
   });
 
-  it("converts empty arrays", () => {
-    expect(toPythonString([])).toBe("[]");
+  it('converts empty arrays', () => {
+    expect(toPythonString([])).toBe('[]');
   });
 });

--- a/static/app/utils/string/toPythonString.tsx
+++ b/static/app/utils/string/toPythonString.tsx
@@ -19,5 +19,8 @@ export function toPythonString(value: unknown): string {
     });
     return `[${items.join(', ')}]`;
   }
-  return String(value);
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return value.toString();
+  }
+  return typeof value === 'string' ? value : JSON.stringify(value) ?? 'None';
 }

--- a/static/app/utils/string/toPythonString.tsx
+++ b/static/app/utils/string/toPythonString.tsx
@@ -4,23 +4,23 @@
  * match that behavior for comparisons.
  */
 export function toPythonString(value: unknown): string {
-  if (typeof value === "boolean") {
-    return value ? "True" : "False";
+  if (typeof value === 'boolean') {
+    return value ? 'True' : 'False';
   }
   if (value === null || value === undefined) {
-    return "None";
+    return 'None';
   }
   if (Array.isArray(value)) {
-    const items = value.map((item) => {
-      if (typeof item === "string") {
+    const items = value.map(item => {
+      if (typeof item === 'string') {
         return `'${item}'`;
       }
       return toPythonString(item);
     });
-    return `[${items.join(", ")}]`;
+    return `[${items.join(', ')}]`;
   }
-  if (typeof value === "number" || typeof value === "bigint") {
+  if (typeof value === 'number' || typeof value === 'bigint') {
     return value.toString();
   }
-  return typeof value === "string" ? value : (JSON.stringify(value) ?? "None");
+  return typeof value === 'string' ? value : (JSON.stringify(value) ?? 'None');
 }

--- a/static/app/utils/string/toPythonString.tsx
+++ b/static/app/utils/string/toPythonString.tsx
@@ -7,15 +7,15 @@ export function toPythonString(value: unknown): string {
   if (typeof value === 'boolean') {
     return value ? 'True' : 'False';
   }
+  if (value === null || value === undefined) {
+    return 'None';
+  }
   if (Array.isArray(value)) {
     const items = value.map(item => {
-      if (item === null || item === undefined) {
-        return 'None';
-      }
       if (typeof item === 'string') {
         return `'${item}'`;
       }
-      return String(item);
+      return toPythonString(item);
     });
     return `[${items.join(', ')}]`;
   }

--- a/static/app/utils/string/toPythonString.tsx
+++ b/static/app/utils/string/toPythonString.tsx
@@ -4,23 +4,23 @@
  * match that behavior for comparisons.
  */
 export function toPythonString(value: unknown): string {
-  if (typeof value === 'boolean') {
-    return value ? 'True' : 'False';
+  if (typeof value === "boolean") {
+    return value ? "True" : "False";
   }
   if (value === null || value === undefined) {
-    return 'None';
+    return "None";
   }
   if (Array.isArray(value)) {
-    const items = value.map(item => {
-      if (typeof item === 'string') {
+    const items = value.map((item) => {
+      if (typeof item === "string") {
         return `'${item}'`;
       }
       return toPythonString(item);
     });
-    return `[${items.join(', ')}]`;
+    return `[${items.join(", ")}]`;
   }
-  if (typeof value === 'number' || typeof value === 'bigint') {
+  if (typeof value === "number" || typeof value === "bigint") {
     return value.toString();
   }
-  return typeof value === 'string' ? value : JSON.stringify(value) ?? 'None';
+  return typeof value === "string" ? value : (JSON.stringify(value) ?? "None");
 }


### PR DESCRIPTION
`toPythonString` converted `null`/`undefined` inside arrays to `'None'` but fell through to `String(null)` → `"null"` at the top level. Python's `str(None)` returns `"None"`, so when a `groupBy` value is `null`, the JS-side string didn't match the backend's `"None"`, causing the breakdown legend to fail to find matching table rows.

Adds a `null`/`undefined` check before the array branch, and refactors the array item mapping to use recursive `toPythonString` calls so boolean/null handling is consistent at all nesting levels. Adds unit tests covering strings, booleans, null, undefined, numbers, and mixed arrays.