### PR TITLE
fix(autofix): Remove broken docs link from GitHub Copilot CTA

### DIFF
--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -2,12 +2,11 @@ import {useCallback} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {organizationIntegrationsCodingAgents} from 'sentry/components/events/autofix/useAutofix';
 import {Placeholder} from 'sentry/components/placeholder';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useQuery} from 'sentry/utils/queryClient';
@@ -75,13 +74,8 @@ export function GithubCopilotIntegrationCta() {
             </Flex>
           </Heading>
           <Text>
-            {tct(
-              'Connect GitHub Copilot to hand off Seer root cause analysis to GitHub Copilot coding agent for seamless code fixes. [docsLink:Read the docs] to learn more.',
-              {
-                docsLink: (
-                  <ExternalLink href="https://docs.sentry.io/organization/integrations/github-copilot/" />
-                ),
-              }
+            {t(
+              'Connect GitHub Copilot to hand off Seer root cause analysis to GitHub Copilot coding agent for seamless code fixes.'
             )}
           </Text>
           <div>
@@ -114,13 +108,8 @@ export function GithubCopilotIntegrationCta() {
           </Flex>
         </Heading>
         <Text>
-          {tct(
-            'GitHub Copilot integration is installed. You can trigger GitHub Copilot from Issue Fix to create pull requests. [docsLink:Read the docs] to learn more.',
-            {
-              docsLink: (
-                <ExternalLink href="https://docs.sentry.io/organization/integrations/github-copilot/" />
-              ),
-            }
+          {t(
+            'GitHub Copilot integration is installed. You can trigger GitHub Copilot from Issue Fix to create pull requests.'
           )}
         </Text>
       </Flex>


### PR DESCRIPTION
The "Read the docs" link in the GitHub Copilot integration CTA points to
`docs.sentry.io/organization/integrations/github-copilot/` which returns a 404.

Removes the link from both the installed and not-installed states. The rest of the
CTA copy and functionality is unchanged. The link can be re-added once the docs page exists.


Agent transcript: https://claudescope.sentry.dev/share/vG5lStfoMBbmZcJ3VliZion_bLqDYH39Gfq96F-HFBA