### PR TITLE
feat(dashboards): Add category params to SeerExplorerClient in dashboard generate

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -75,7 +75,11 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
 
         try:
             client = SeerExplorerClient(
-                organization, request.user, on_completion_hook=DashboardOnCompletionHook
+                organization,
+                request.user,
+                on_completion_hook=DashboardOnCompletionHook,
+                category_key="dashboard_generate",
+                category_value=str(organization.id),
             )
             run_id = client.start_run(
                 prompt=prompt,

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -43,7 +43,11 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         assert response.data == {"run_id": 789}
 
         mock_client_class.assert_called_once_with(
-            self.organization, ANY, on_completion_hook=DashboardOnCompletionHook
+            self.organization,
+            ANY,
+            on_completion_hook=DashboardOnCompletionHook,
+            category_key="dashboard_generate",
+            category_value=str(self.organization.id),
         )
         mock_client.start_run.assert_called_once_with(
             prompt="Show me error rates by project",


### PR DESCRIPTION
Pass `category_key` and `category_value` to `SeerExplorerClient` in the dashboard generate endpoint so that runs are properly categorized by use case and organization. This enables cost / usage tracking of dashboard generation requests


Agent transcript: https://claudescope.sentry.dev/share/IyJKW8mCxA7WRfW26AW3In8LsGwl3OjMG_FCj72aAsA