### PR TITLE
perf(dashboards): Measure re-render duration on full-screen widget view

### DIFF
--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -219,6 +219,7 @@ function DataWidgetViewerModal(props: Props) {
         }
       );
       performance.clearMarks('dashboard.widget.fullScreenViewClick');
+      performance.clearMeasures('dashboard.widget.onFullScreenView');
     } catch {
       // performance.measure throws if the start mark doesn't exist (e.g. direct URL navigation)
     }

--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -28,7 +28,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';
 import {defined} from 'sentry/utils';
-import {trackAnalytics} from 'sentry/utils/analytics';
+import {CAN_MARK, trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
@@ -206,6 +206,9 @@ function DataWidgetViewerModal(props: Props) {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (!CAN_MARK) {
+      return;
+    }
     try {
       const measure = performance.measure(
         'dashboard.widget.onFullScreenView',

--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -204,6 +204,25 @@ function DataWidgetViewerModal(props: Props) {
   const location = useLocation();
   const {projects} = useProjects();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    try {
+      const measure = performance.measure(
+        'dashboard.widget.onFullScreenView',
+        'dashboard.widget.fullScreenViewClick'
+      );
+      Sentry.metrics.distribution(
+        'dashboards.widget.onFullScreenView',
+        measure.duration,
+        {
+          unit: 'millisecond',
+        }
+      );
+      performance.clearMarks('dashboard.widget.fullScreenViewClick');
+    } catch {
+      // performance.measure throws if the start mark doesn't exist (e.g. direct URL navigation)
+    }
+  }, []);
   // Get widget zoom from location
   // We use the start and end query params for just the initial state
   const start = decodeScalar(location.query[WidgetViewerQueryField.START]);

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -295,7 +295,7 @@ export const metric: RecordMetric = (name, value, tags) =>
   HookStore.get('metrics:event').forEach(cb => cb(name, value, tags));
 
 // JSDOM implements window.performance but not window.performance.mark
-const CAN_MARK =
+export const CAN_MARK =
   window.performance &&
   typeof window.performance.mark === 'function' &&
   typeof window.performance.measure === 'function' &&

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -241,7 +241,7 @@ function WidgetCard(props: Props) {
       return;
     }
     if (currentDashboardId) {
-      performance.mark?.('dashboard.widget.fullScreenViewClick');
+      performance?.mark?.('dashboard.widget.fullScreenViewClick');
       navigate(
         normalizeUrl({
           pathname: `/organizations/${organization.slug}/dashboard/${currentDashboardId}/widget/${props.index}/`,

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -241,6 +241,7 @@ function WidgetCard(props: Props) {
       return;
     }
     if (currentDashboardId) {
+      performance.mark('dashboard.widget.fullScreenViewClick');
       navigate(
         normalizeUrl({
           pathname: `/organizations/${organization.slug}/dashboard/${currentDashboardId}/widget/${props.index}/`,

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -241,7 +241,7 @@ function WidgetCard(props: Props) {
       return;
     }
     if (currentDashboardId) {
-      performance.mark('dashboard.widget.fullScreenViewClick');
+      performance.mark?.('dashboard.widget.fullScreenViewClick');
       navigate(
         normalizeUrl({
           pathname: `/organizations/${organization.slug}/dashboard/${currentDashboardId}/widget/${props.index}/`,

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -22,6 +22,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import type {Confidence, Organization} from 'sentry/types/organization';
+import {CAN_MARK} from 'sentry/utils/analytics';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, DataUnit, Sort} from 'sentry/utils/discover/fields';
 import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
@@ -241,7 +242,9 @@ function WidgetCard(props: Props) {
       return;
     }
     if (currentDashboardId) {
-      performance?.mark?.('dashboard.widget.fullScreenViewClick');
+      if (CAN_MARK) {
+        performance.mark('dashboard.widget.fullScreenViewClick');
+      }
       navigate(
         normalizeUrl({
           pathname: `/organizations/${organization.slug}/dashboard/${currentDashboardId}/widget/${props.index}/`,


### PR DESCRIPTION
Set a performance.mark on click, then measure the duration in dataWidgetViewerModal on mount — emitting a
`dashboards.widget.onFullScreenView` distribution metric.

Prebuilt insights dashboards (no dashboard ID) are not included for measurement.

Refs DAIN-1371

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
