### PR TITLE
Communicate SourceCodeManager's capabilities through RPC

### DIFF
--- a/src/sentry/scm/actions.py
+++ b/src/sentry/scm/actions.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Self
+from typing import Iterable, Self
 
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
@@ -14,6 +14,7 @@ from sentry.scm.private.helpers import (
 )
 from sentry.scm.private.ipc import record_count_metric
 from sentry.scm.private.provider import (
+    ALL_PROTOCOLS,
     CompareCommitsProtocol,
     CreateBranchProtocol,
     CreateCheckRunProtocol,
@@ -155,6 +156,16 @@ class SourceCodeManager(Facade):
         )
 
         return cls(provider, referrer=referrer, record_count=record_count)
+
+
+def get_capabilities(scm: SourceCodeManager) -> Iterable[str]:
+    """
+    Get the names of the capabilities implemented by the given SourceCodeManager.
+    Names correspond to the protocol class names, minus the "Protocol" suffix.
+    """
+    for protocol in ALL_PROTOCOLS:
+        if isinstance(scm, protocol):
+            yield protocol.__name__.removesuffix("Protocol")
 
 
 def get_issue_comments(

--- a/src/sentry/scm/actions.py
+++ b/src/sentry/scm/actions.py
@@ -159,13 +159,10 @@ class SourceCodeManager(Facade):
 
 
 def get_capabilities(scm: SourceCodeManager) -> Iterable[str]:
-    """
-    Get the names of the capabilities implemented by the given SourceCodeManager.
-    Names correspond to the protocol class names, minus the "Protocol" suffix.
-    """
+    """Get the names of the protocols implemented by the given SourceCodeManager."""
     for protocol in ALL_PROTOCOLS:
         if isinstance(scm, protocol):
-            yield protocol.__name__.removesuffix("Protocol")
+            yield protocol.__name__
 
 
 def get_issue_comments(

--- a/src/sentry/scm/private/rpc.py
+++ b/src/sentry/scm/private/rpc.py
@@ -29,6 +29,7 @@ from sentry.scm.actions import (
     delete_pull_request_reaction,
     get_archive_link,
     get_branch,
+    get_capabilities,
     get_check_run,
     get_commit,
     get_commits,
@@ -133,6 +134,7 @@ scm_action_registry: dict[str, Callable] = {
     # If a method of SourceCodeManager accepts only JSON-serializable arguments, by names, and
     # returns a JSON-serializable type, then it can be listed here directly.
     # Else, an adapter function must be used.
+    "get_capabilities_v1": lambda scm: sorted(get_capabilities(scm)),
     "compare_commits_v1": compare_commits,
     "create_branch_v1": create_branch,
     "create_check_run_v1": create_check_run,

--- a/tests/sentry/scm/unit/test_scm_actions.py
+++ b/tests/sentry/scm/unit/test_scm_actions.py
@@ -30,6 +30,7 @@ from sentry.scm.actions import (
     delete_pull_request_comment_reaction,
     delete_pull_request_reaction,
     get_branch,
+    get_capabilities,
     get_check_run,
     get_commit,
     get_commits,
@@ -774,3 +775,64 @@ def test_exec_passes_custom_record_count():
         {"provider": "BaseTestProvider"},
     )
     assert calls[1] == ("sentry.scm.actions.success_by_referrer", 1, {"referrer": "shared"})
+
+
+def test_get_capabilities():
+    assert list(get_capabilities(SourceCodeManager(BaseTestProvider()))) == [
+        "CompareCommitsProtocol",
+        "CreateBranchProtocol",
+        "CreateCheckRunProtocol",
+        "CreateGitBlobProtocol",
+        "CreateGitCommitProtocol",
+        "CreateGitTreeProtocol",
+        "CreateIssueCommentProtocol",
+        "CreateIssueCommentReactionProtocol",
+        "CreateIssueReactionProtocol",
+        "CreatePullRequestCommentProtocol",
+        "CreatePullRequestCommentReactionProtocol",
+        "CreatePullRequestDraftProtocol",
+        "CreatePullRequestProtocol",
+        "CreatePullRequestReactionProtocol",
+        "CreateReviewCommentFileProtocol",
+        "CreateReviewCommentReplyProtocol",
+        "CreateReviewProtocol",
+        "DeleteIssueCommentProtocol",
+        "DeleteIssueCommentReactionProtocol",
+        "DeleteIssueReactionProtocol",
+        "DeletePullRequestCommentProtocol",
+        "DeletePullRequestCommentReactionProtocol",
+        "DeletePullRequestReactionProtocol",
+        "GetBranchProtocol",
+        "GetCheckRunProtocol",
+        "GetCommitProtocol",
+        "GetCommitsByPathProtocol",
+        "GetCommitsProtocol",
+        "GetFileContentProtocol",
+        "GetGitCommitProtocol",
+        "GetIssueCommentReactionsProtocol",
+        "GetIssueCommentsProtocol",
+        "GetIssueReactionsProtocol",
+        "GetPullRequestCommentReactionsProtocol",
+        "GetPullRequestCommentsProtocol",
+        "GetPullRequestCommitsProtocol",
+        "GetPullRequestDiffProtocol",
+        "GetPullRequestFilesProtocol",
+        "GetPullRequestProtocol",
+        "GetPullRequestReactionsProtocol",
+        "GetPullRequestsProtocol",
+        "GetTreeProtocol",
+        "MinimizeCommentProtocol",
+        "RequestReviewProtocol",
+        "UpdateBranchProtocol",
+        "UpdateCheckRunProtocol",
+        "UpdatePullRequestProtocol",
+    ]
+
+    class IncapableProvider:
+        organization_id: int
+        repository: Repository
+
+        def is_rate_limited(self, referrer: Referrer) -> bool:
+            return False
+
+    assert list(get_capabilities(SourceCodeManager(IncapableProvider()))) == []


### PR DESCRIPTION
This exposes the capabilities of a given provider through the SCM RPC. It's used in https://github.com/getsentry/seer/pull/5393.