### PR TITLE
feat(onboarding): Implement SCM project details step

### DIFF
--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -6,10 +6,12 @@ import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 type OnboardingContextProps = {
+  setCreatedProjectSlug: (slug?: string) => void;
   setSelectedFeatures: (features?: ProductSolution[]) => void;
   setSelectedIntegration: (integration?: Integration) => void;
   setSelectedPlatform: (selectedSDK?: OnboardingSelectedSDK) => void;
   setSelectedRepository: (repo?: Repository) => void;
+  createdProjectSlug?: string;
   selectedFeatures?: ProductSolution[];
   selectedIntegration?: Integration;
   selectedPlatform?: OnboardingSelectedSDK;
@@ -17,6 +19,7 @@ type OnboardingContextProps = {
 };
 
 export type OnboardingSessionState = {
+  createdProjectSlug?: string;
   selectedFeatures?: ProductSolution[];
   selectedIntegration?: Integration;
   selectedPlatform?: OnboardingSelectedSDK;
@@ -35,6 +38,8 @@ const OnboardingContext = createContext<OnboardingContextProps>({
   setSelectedRepository: () => {},
   selectedFeatures: undefined,
   setSelectedFeatures: () => {},
+  createdProjectSlug: undefined,
+  setCreatedProjectSlug: () => {},
 });
 
 type ProviderProps = {
@@ -72,6 +77,10 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
       selectedFeatures: onboarding?.selectedFeatures,
       setSelectedFeatures: (selectedFeatures?: ProductSolution[]) => {
         setOnboarding(prev => ({...prev, selectedFeatures}));
+      },
+      createdProjectSlug: onboarding?.createdProjectSlug,
+      setCreatedProjectSlug: (createdProjectSlug?: string) => {
+        setOnboarding(prev => ({...prev, createdProjectSlug}));
       },
     }),
     [onboarding, setOnboarding, removeOnboarding]

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -690,39 +690,12 @@ describe('Onboarding', () => {
       });
     });
 
-    it('renders scm-project-details step and advances to setup-docs when platform is set', async () => {
-      const nextJsProject = ProjectFixture({
-        platform: 'javascript-nextjs',
-        id: '2',
-        slug: 'javascript-nextjs',
-      });
-
-      MockApiClient.addMockResponse({
-        url: `/organizations/${scmOrganization.slug}/sdks/`,
-        body: {},
-      });
-      MockApiClient.addMockResponse({
-        url: `/projects/${scmOrganization.slug}/${nextJsProject.slug}/keys/`,
-        method: 'GET',
-        body: [ProjectKeysFixture()[0]],
-      });
-      MockApiClient.addMockResponse({
-        url: `/projects/${scmOrganization.slug}/${nextJsProject.slug}/issues/`,
-        body: [],
-      });
-
-      jest
-        .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
-        .mockImplementation(() => ({
-          project: nextJsProject,
-          isProjectActive: false,
-        }));
-
-      const {router} = render(
+    it('renders scm-project-details step with project details form', () => {
+      render(
         <OnboardingContextProvider
           initialValue={{
             selectedPlatform: {
-              key: nextJsProject.slug as PlatformKey,
+              key: 'javascript-nextjs' as PlatformKey,
               type: 'framework',
               language: 'javascript',
               category: 'browser',
@@ -745,25 +718,13 @@ describe('Onboarding', () => {
       );
 
       expect(screen.getByText('Project details')).toBeInTheDocument();
-
-      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
-
-      await waitFor(() => {
-        expect(router.location.pathname).toBe(
-          `/onboarding/${scmOrganization.slug}/setup-docs/`
-        );
-      });
+      expect(screen.getByRole('button', {name: 'Create project'})).toBeInTheDocument();
     });
 
-    it('does not advance to setup-docs without a platform selected', async () => {
-      const {router} = renderOnboarding('scm-project-details');
+    it('create project button is disabled without a platform selected', () => {
+      renderOnboarding('scm-project-details');
 
-      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
-
-      // Should stay on the same step
-      expect(router.location.pathname).toBe(
-        `/onboarding/${scmOrganization.slug}/scm-project-details/`
-      );
+      expect(screen.getByRole('button', {name: 'Create project'})).toBeDisabled();
     });
 
     it('navigates back from scm-connect to welcome', async () => {

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -553,6 +553,77 @@ describe('Onboarding', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('clears all context when going back from setup-docs in legacy flow', async () => {
+    const organization = OrganizationFixture();
+    const reactProject = ProjectFixture({
+      platform: 'javascript-react',
+      id: '2',
+      slug: 'javascript-react',
+    });
+
+    jest
+      .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
+      .mockImplementation(() => ({
+        project: reactProject,
+        isProjectActive: false,
+      }));
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sdks/`,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${reactProject.slug}/keys/`,
+      body: [ProjectKeysFixture()[0]],
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${reactProject.slug}/issues/`,
+      body: [],
+    });
+
+    const deleteProjectMock = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${reactProject.slug}/`,
+      method: 'DELETE',
+    });
+
+    const initialContext = {
+      selectedPlatform: {
+        key: reactProject.slug as PlatformKey,
+        type: 'framework',
+        language: 'javascript',
+        category: 'browser',
+        name: 'React',
+        link: 'https://docs.sentry.io/platforms/javascript/guides/react/',
+      },
+    };
+
+    sessionStorage.setItem('onboarding', JSON.stringify(initialContext));
+
+    render(
+      <OnboardingContextProvider initialValue={initialContext}>
+        <OnboardingWithoutContext />
+      </OnboardingContextProvider>,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/onboarding/${organization.slug}/setup-docs/`,
+          },
+          route: '/onboarding/:orgId/:step/',
+        },
+      }
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Back'}));
+
+    await waitFor(() => {
+      expect(deleteProjectMock).toHaveBeenCalled();
+    });
+
+    // Legacy flow should clear all context
+    const stored = sessionStorage.getItem('onboarding');
+    expect(stored).toBeNull();
+  });
+
   describe('SCM onboarding flow', () => {
     const scmOrganization = OrganizationFixture({
       features: ['onboarding-scm'],
@@ -799,6 +870,8 @@ describe('Onboarding', () => {
       const stored = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');
       expect(stored.selectedPlatform).toBeDefined();
       expect(stored.selectedFeatures).toBeDefined();
+      // createdProjectSlug should be cleared so the user can re-create
+      expect(stored.createdProjectSlug).toBeUndefined();
     });
 
     it('navigates back from scm-connect to welcome', async () => {

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -727,6 +727,80 @@ describe('Onboarding', () => {
       expect(screen.getByRole('button', {name: 'Create project'})).toBeDisabled();
     });
 
+    it('preserves SCM context when going back from setup-docs', async () => {
+      const nextJsProject = ProjectFixture({
+        platform: 'javascript-nextjs',
+        id: '2',
+        slug: 'javascript-nextjs',
+      });
+
+      jest
+        .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
+        .mockImplementation(() => ({
+          project: nextJsProject,
+          isProjectActive: false,
+        }));
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${scmOrganization.slug}/sdks/`,
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${scmOrganization.slug}/${nextJsProject.slug}/keys/`,
+        body: [ProjectKeysFixture()[0]],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${scmOrganization.slug}/${nextJsProject.slug}/issues/`,
+        body: [],
+      });
+
+      const deleteProjectMock = MockApiClient.addMockResponse({
+        url: `/projects/${scmOrganization.slug}/${nextJsProject.slug}/`,
+        method: 'DELETE',
+      });
+
+      const initialContext = {
+        selectedPlatform: {
+          key: nextJsProject.slug as PlatformKey,
+          type: 'framework',
+          language: 'javascript',
+          category: 'browser',
+          name: 'Next.js',
+          link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+        },
+        selectedFeatures: [ProductSolution.ERROR_MONITORING],
+      };
+
+      // Seed sessionStorage directly so we can verify it's preserved after back
+      sessionStorage.setItem('onboarding', JSON.stringify(initialContext));
+
+      render(
+        <OnboardingContextProvider initialValue={initialContext}>
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          organization: scmOrganization,
+          initialRouterConfig: {
+            location: {
+              pathname: `/onboarding/${scmOrganization.slug}/setup-docs/`,
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Back'}));
+
+      await waitFor(() => {
+        expect(deleteProjectMock).toHaveBeenCalled();
+      });
+
+      // Context should be preserved — selectedPlatform should not be cleared
+      const stored = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');
+      expect(stored.selectedPlatform).toBeDefined();
+      expect(stored.selectedFeatures).toBeDefined();
+    });
+
     it('navigates back from scm-connect to welcome', async () => {
       const {router} = renderOnboarding('scm-connect');
 

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -615,9 +615,7 @@ describe('Onboarding', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Back'}));
 
-    await waitFor(() => {
-      expect(deleteProjectMock).toHaveBeenCalled();
-    });
+    expect(deleteProjectMock).toHaveBeenCalled();
 
     // Legacy flow should clear all context
     const stored = sessionStorage.getItem('onboarding');

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -160,7 +160,8 @@ export function OnboardingWithoutContext() {
   const {step: stepId} = useParams<{step: string}>();
   const organization = useOrganization();
   const onboardingContext = useOnboardingContext();
-  const selectedProjectSlug = onboardingContext.selectedPlatform?.key;
+  const selectedProjectSlug =
+    onboardingContext.createdProjectSlug ?? onboardingContext.selectedPlatform?.key;
 
   const hasNewWelcomeUI = useHasNewWelcomeUI();
   const hasScmOnboarding = organization.features.includes('onboarding-scm');

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -250,10 +250,12 @@ describe('ScmProjectDetails', () => {
       expect(onComplete).toHaveBeenCalled();
     });
 
-    // Verify the context was updated with the project slug by checking
-    // session storage (OnboardingContext persists there)
+    // Verify the project slug was stored separately in context (not overwriting
+    // selectedPlatform.key) so onboarding.tsx can find the project via
+    // useRecentCreatedProject while preserving the original platform selection.
     const stored = JSON.parse(sessionStorageWrapper.getItem('onboarding') ?? '{}');
-    expect(stored.selectedPlatform?.key).toBe('my-custom-project');
+    expect(stored.createdProjectSlug).toBe('my-custom-project');
+    expect(stored.selectedPlatform?.key).toBe('javascript-nextjs');
   });
 
   it('shows error message on project creation failure', async () => {

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {RepositoryFixture} from 'sentry-fixture/repository';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -9,7 +10,6 @@ import {
   type OnboardingSessionState,
 } from 'sentry/components/onboarding/onboardingContext';
 import {TeamStore} from 'sentry/stores/teamStore';
-import {RepositoryStatus, type Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
@@ -34,17 +34,7 @@ const mockPlatform: OnboardingSelectedSDK = {
   type: 'framework',
 };
 
-const mockRepository: Repository = {
-  id: '42',
-  name: 'getsentry/sentry',
-  externalId: '123',
-  externalSlug: 'getsentry/sentry',
-  url: 'https://github.com/getsentry/sentry',
-  integrationId: '1',
-  status: RepositoryStatus.ACTIVE,
-  dateCreated: '2024-01-01T00:00:00.000Z',
-  provider: {id: 'integrations:github', name: 'GitHub'},
-};
+const mockRepository = RepositoryFixture({id: '42', name: 'getsentry/sentry'});
 
 describe('ScmProjectDetails', () => {
   const organization = OrganizationFixture();

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -53,16 +53,6 @@ describe('ScmProjectDetails', () => {
   beforeEach(() => {
     sessionStorageWrapper.clear();
     TeamStore.loadInitialData([teamWithAccess]);
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/`,
-      body: [],
-      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/config/integrations/`,
-      body: {providers: []},
-    });
   });
 
   afterEach(() => {

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -190,4 +190,36 @@ describe('ScmProjectDetails', () => {
       expect(onComplete).toHaveBeenCalled();
     });
   });
+
+  it('shows error message on project creation failure', async () => {
+    const onComplete = jest.fn();
+
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    render(
+      <ScmProjectDetails
+        onComplete={onComplete}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    const createButton = await screen.findByRole('button', {name: 'Create project'});
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -59,6 +59,10 @@ describe('ScmProjectDetails', () => {
       body: [],
       match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/`,
+      body: {providers: []},
+    });
   });
 
   afterEach(() => {

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -1,0 +1,193 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {TeamFixture} from 'sentry-fixture/team';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {
+  OnboardingContextProvider,
+  type OnboardingSessionState,
+} from 'sentry/components/onboarding/onboardingContext';
+import {TeamStore} from 'sentry/stores/teamStore';
+import {RepositoryStatus, type Repository} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
+
+import {ScmProjectDetails} from './scmProjectDetails';
+
+function makeOnboardingWrapper(initialState?: OnboardingSessionState) {
+  return function OnboardingWrapper({children}: {children?: React.ReactNode}) {
+    return (
+      <OnboardingContextProvider initialValue={initialState}>
+        {children}
+      </OnboardingContextProvider>
+    );
+  };
+}
+
+const mockPlatform: OnboardingSelectedSDK = {
+  key: 'javascript-nextjs',
+  name: 'Next.js',
+  language: 'javascript',
+  category: 'browser',
+  link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+  type: 'framework',
+};
+
+const mockRepository: Repository = {
+  id: '42',
+  name: 'getsentry/sentry',
+  externalId: '123',
+  externalSlug: 'getsentry/sentry',
+  url: 'https://github.com/getsentry/sentry',
+  integrationId: '1',
+  status: RepositoryStatus.ACTIVE,
+  dateCreated: '2024-01-01T00:00:00.000Z',
+  provider: {id: 'integrations:github', name: 'GitHub'},
+};
+
+describe('ScmProjectDetails', () => {
+  const organization = OrganizationFixture();
+  const teamWithAccess = TeamFixture({slug: 'my-team', access: ['team:admin']});
+
+  beforeEach(() => {
+    sessionStorageWrapper.clear();
+    TeamStore.loadInitialData([teamWithAccess]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [],
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders project name defaulted from platform key', async () => {
+    render(
+      <ScmProjectDetails
+        onComplete={jest.fn()}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    const input = await screen.findByPlaceholderText('project-name');
+    expect(input).toHaveValue('javascript-nextjs');
+  });
+
+  it('renders project name defaulted from repository name when SCM connected', async () => {
+    render(
+      <ScmProjectDetails
+        onComplete={jest.fn()}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+          selectedRepository: mockRepository,
+        }),
+      }
+    );
+
+    // slugify('getsentry/sentry') strips the slash -> 'getsentrysentry'
+    const input = await screen.findByPlaceholderText('project-name');
+    expect(input).toHaveValue('getsentrysentry');
+  });
+
+  it('renders alert frequency options', async () => {
+    render(
+      <ScmProjectDetails
+        onComplete={jest.fn()}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    expect(
+      await screen.findByText('Alert me on high priority issues')
+    ).toBeInTheDocument();
+    expect(screen.getByText("I'll create my own alerts later")).toBeInTheDocument();
+  });
+
+  it('create project button is disabled without platform in context', async () => {
+    render(
+      <ScmProjectDetails
+        onComplete={jest.fn()}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper(),
+      }
+    );
+
+    expect(await screen.findByRole('button', {name: 'Create project'})).toBeDisabled();
+  });
+
+  it('create project button calls API and completes on success', async () => {
+    const onComplete = jest.fn();
+
+    const projectCreationRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: ProjectFixture({slug: 'javascript-nextjs', name: 'javascript-nextjs'}),
+    });
+
+    // Mocks for the post-creation organization refetch triggered by ProjectsStore.onCreateSuccess
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [teamWithAccess],
+    });
+
+    render(
+      <ScmProjectDetails
+        onComplete={onComplete}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    const createButton = await screen.findByRole('button', {name: 'Create project'});
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(projectCreationRequest).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+});

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -185,6 +185,77 @@ describe('ScmProjectDetails', () => {
     });
   });
 
+  it('defaults team selector to first admin team', async () => {
+    render(
+      <ScmProjectDetails
+        onComplete={jest.fn()}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    // TeamSelector renders the team slug as the selected value
+    expect(await screen.findByText(`#${teamWithAccess.slug}`)).toBeInTheDocument();
+  });
+
+  it('updates context with project slug after creation', async () => {
+    const createdProject = ProjectFixture({
+      slug: 'my-custom-project',
+      name: 'my-custom-project',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: createdProject,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [teamWithAccess],
+    });
+
+    const onComplete = jest.fn();
+
+    render(
+      <ScmProjectDetails
+        onComplete={onComplete}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    // Verify the context was updated with the project slug by checking
+    // session storage (OnboardingContext persists there)
+    const stored = JSON.parse(sessionStorageWrapper.getItem('onboarding') ?? '{}');
+    expect(stored.selectedPlatform?.key).toBe('my-custom-project');
+  });
+
   it('shows error message on project creation failure', async () => {
     const onComplete = jest.fn();
 

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -68,7 +68,7 @@ describe('ScmProjectDetails', () => {
     expect(input).toHaveValue('javascript-nextjs');
   });
 
-  it('renders project name defaulted from repository name when SCM connected', async () => {
+  it('uses platform key as default name even when repository is in context', async () => {
     render(
       <ScmProjectDetails
         onComplete={jest.fn()}
@@ -84,9 +84,8 @@ describe('ScmProjectDetails', () => {
       }
     );
 
-    // slugify('getsentry/sentry') strips the slash -> 'getsentrysentry'
     const input = await screen.findByPlaceholderText('project-name');
-    expect(input).toHaveValue('getsentrysentry');
+    expect(input).toHaveValue('javascript-nextjs');
   });
 
   it('renders alert frequency options', async () => {

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -31,7 +31,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     useOnboardingContext();
   const {teams} = useTeams();
   const createProjectAndRules = useCreateProjectAndRules();
-  const {createNotificationAction} = useCreateNotificationAction();
+  const {createNotificationAction, notificationProps} = useCreateNotificationAction();
 
   const firstAdminTeam = useMemo(
     () => teams.find((team: Team) => team.access.includes('team:admin')),
@@ -150,7 +150,11 @@ export function ScmProjectDetails({onComplete}: StepProps) {
           <Text variant="muted" size="sm">
             {t('Get notified when things go wrong')}
           </Text>
-          <IssueAlertOptions {...alertRuleConfig} onFieldChange={handleAlertChange} />
+          <IssueAlertOptions
+            {...alertRuleConfig}
+            onFieldChange={handleAlertChange}
+            notificationProps={notificationProps}
+          />
         </Stack>
       </Stack>
 

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -12,6 +12,11 @@ import {t} from 'sentry/locale';
 import type {Team} from 'sentry/types/organization';
 import {slugify} from 'sentry/utils/slugify';
 import {useTeams} from 'sentry/utils/useTeams';
+import {
+  IssueAlertOptions,
+  RuleAction,
+  type AlertRuleOptions,
+} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import type {StepProps} from './types';
 
@@ -25,6 +30,19 @@ export function ScmProjectDetails({onComplete}: StepProps) {
 
   const [projectName, setProjectName] = useState(defaultName);
   const [teamSlug, setTeamSlug] = useState(firstAdminTeam?.slug ?? '');
+  const [alertRuleConfig, setAlertRuleConfig] = useState<AlertRuleOptions>({
+    alertSetting: RuleAction.DEFAULT_ALERT,
+    threshold: '10',
+    metric: 0,
+    interval: '1m',
+  });
+
+  const handleAlertChange = <K extends keyof AlertRuleOptions>(
+    key: K,
+    value: AlertRuleOptions[K]
+  ) => {
+    setAlertRuleConfig(prev => ({...prev, [key]: value}));
+  };
 
   const canSubmit = projectName.length > 0 && teamSlug.length > 0;
 
@@ -67,6 +85,16 @@ export function ScmProjectDetails({onComplete}: StepProps) {
             value={teamSlug}
             onChange={({value}: {value: string}) => setTeamSlug(value)}
           />
+        </Stack>
+
+        <Stack gap="sm">
+          <Flex gap="xs" align="center">
+            <Text bold>{t('Alert frequency')}</Text>
+          </Flex>
+          <Text variant="muted" size="sm">
+            {t('Get notified when things go wrong')}
+          </Text>
+          <IssueAlertOptions {...alertRuleConfig} onFieldChange={handleAlertChange} />
         </Stack>
       </Stack>
 

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Button} from '@sentry/scraps/button';
@@ -18,9 +18,9 @@ import {slugify} from 'sentry/utils/slugify';
 import {useTeams} from 'sentry/utils/useTeams';
 import {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
+  DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
   getRequestDataFragment,
   IssueAlertOptions,
-  RuleAction,
   type AlertRuleOptions,
 } from 'sentry/views/projectInstall/issueAlertOptions';
 
@@ -33,22 +33,22 @@ export function ScmProjectDetails({onComplete}: StepProps) {
   const createProjectAndRules = useCreateProjectAndRules();
   const {createNotificationAction} = useCreateNotificationAction();
 
-  const firstAdminTeam = teams.find((team: Team) => team.access.includes('team:admin'));
+  const firstAdminTeam = useMemo(
+    () => teams.find((team: Team) => team.access.includes('team:admin')),
+    [teams]
+  );
   const defaultName = slugify(selectedRepository?.name ?? selectedPlatform?.key ?? '');
 
-  // Track user overrides separately so derived defaults update if context changes
-  const [projectNameOverride, setProjectNameOverride] = useState<string | null>(null);
-  const [teamSlugOverride, setTeamSlugOverride] = useState<string | null>(null);
+  // State tracks user edits; derived values fall back to defaults from context/teams
+  const [projectName, setProjectName] = useState<string | null>(null);
+  const [teamSlug, setTeamSlug] = useState<string | null>(null);
 
-  const projectName = projectNameOverride ?? defaultName;
-  const teamSlug = teamSlugOverride ?? firstAdminTeam?.slug ?? '';
+  const projectNameResolved = projectName ?? defaultName;
+  const teamSlugResolved = teamSlug ?? firstAdminTeam?.slug ?? '';
 
-  const [alertRuleConfig, setAlertRuleConfig] = useState<AlertRuleOptions>({
-    alertSetting: RuleAction.DEFAULT_ALERT,
-    threshold: '10',
-    metric: 0,
-    interval: '1m',
-  });
+  const [alertRuleConfig, setAlertRuleConfig] = useState<AlertRuleOptions>(
+    DEFAULT_ISSUE_ALERT_OPTIONS_VALUES
+  );
 
   const handleAlertChange = useCallback(
     <K extends keyof AlertRuleOptions>(key: K, value: AlertRuleOptions[K]) => {
@@ -58,8 +58,8 @@ export function ScmProjectDetails({onComplete}: StepProps) {
   );
 
   const canSubmit =
-    projectName.length > 0 &&
-    teamSlug.length > 0 &&
+    projectNameResolved.length > 0 &&
+    teamSlugResolved.length > 0 &&
     !!selectedPlatform &&
     !createProjectAndRules.isPending;
 
@@ -70,9 +70,9 @@ export function ScmProjectDetails({onComplete}: StepProps) {
 
     try {
       const {project} = await createProjectAndRules.mutateAsync({
-        projectName,
+        projectName: projectNameResolved,
         platform: selectedPlatform,
-        team: teamSlug,
+        team: teamSlugResolved,
         alertRuleConfig: getRequestDataFragment(alertRuleConfig),
         createNotificationAction,
       });
@@ -94,8 +94,8 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     selectedPlatform,
     canSubmit,
     createProjectAndRules,
-    projectName,
-    teamSlug,
+    projectNameResolved,
+    teamSlugResolved,
     alertRuleConfig,
     createNotificationAction,
     setSelectedPlatform,
@@ -122,8 +122,8 @@ export function ScmProjectDetails({onComplete}: StepProps) {
           <Input
             type="text"
             placeholder={t('project-name')}
-            value={projectName}
-            onChange={e => setProjectNameOverride(slugify(e.target.value))}
+            value={projectNameResolved}
+            onChange={e => setProjectName(slugify(e.target.value))}
           />
         </Stack>
 
@@ -138,8 +138,8 @@ export function ScmProjectDetails({onComplete}: StepProps) {
             clearable={false}
             placeholder={t('Select a Team')}
             teamFilter={(tm: Team) => tm.access.includes('team:admin')}
-            value={teamSlug}
-            onChange={({value}: {value: string}) => setTeamSlugOverride(value)}
+            value={teamSlugResolved}
+            onChange={({value}: {value: string}) => setTeamSlug(value)}
           />
         </Stack>
 

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -15,7 +15,7 @@ import {t} from 'sentry/locale';
 import type {Team} from 'sentry/types/organization';
 import {slugify} from 'sentry/utils/slugify';
 import {useTeams} from 'sentry/utils/useTeams';
-import {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import type {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
   getRequestDataFragment,

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -26,8 +26,7 @@ import {
 import type {StepProps} from './types';
 
 export function ScmProjectDetails({onComplete}: StepProps) {
-  const {selectedPlatform, selectedRepository, setCreatedProjectSlug} =
-    useOnboardingContext();
+  const {selectedPlatform, setCreatedProjectSlug} = useOnboardingContext();
   const {teams} = useTeams();
   const createProjectAndRules = useCreateProjectAndRules();
 
@@ -45,7 +44,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     () => teams.find((team: Team) => team.access.includes('team:admin')),
     [teams]
   );
-  const defaultName = slugify(selectedRepository?.name ?? selectedPlatform?.key ?? '');
+  const defaultName = slugify(selectedPlatform?.key ?? '');
 
   // State tracks user edits; derived values fall back to defaults from context/teams
   const [projectName, setProjectName] = useState<string | null>(null);

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,18 +1,23 @@
-import {useState} from 'react';
+import {useCallback, useState} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
+import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
 import {TeamSelector} from 'sentry/components/teamSelector';
 import {IconProject} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Team} from 'sentry/types/organization';
 import {slugify} from 'sentry/utils/slugify';
 import {useTeams} from 'sentry/utils/useTeams';
+import {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
+  getRequestDataFragment,
   IssueAlertOptions,
   RuleAction,
   type AlertRuleOptions,
@@ -21,8 +26,11 @@ import {
 import type {StepProps} from './types';
 
 export function ScmProjectDetails({onComplete}: StepProps) {
-  const {selectedPlatform, selectedRepository} = useOnboardingContext();
+  const {selectedPlatform, selectedRepository, setSelectedPlatform} =
+    useOnboardingContext();
   const {teams} = useTeams();
+  const createProjectAndRules = useCreateProjectAndRules();
+  const {createNotificationAction} = useCreateNotificationAction();
 
   const firstAdminTeam = teams.find((team: Team) => team.access.includes('team:admin'));
 
@@ -44,7 +52,48 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     setAlertRuleConfig(prev => ({...prev, [key]: value}));
   };
 
-  const canSubmit = projectName.length > 0 && teamSlug.length > 0;
+  const canSubmit =
+    projectName.length > 0 &&
+    teamSlug.length > 0 &&
+    !!selectedPlatform &&
+    !createProjectAndRules.isPending;
+
+  const handleCreateProject = useCallback(async () => {
+    if (!selectedPlatform || !canSubmit) {
+      return;
+    }
+
+    try {
+      const {project} = await createProjectAndRules.mutateAsync({
+        projectName,
+        platform: selectedPlatform,
+        team: teamSlug,
+        alertRuleConfig: getRequestDataFragment(alertRuleConfig),
+        createNotificationAction,
+      });
+
+      // Update context so SetupDocs can find the project by slug
+      setSelectedPlatform({
+        ...selectedPlatform,
+        key: project.slug,
+      });
+
+      onComplete();
+    } catch (error) {
+      addErrorMessage(t('Failed to create project'));
+      Sentry.captureException(error);
+    }
+  }, [
+    selectedPlatform,
+    canSubmit,
+    createProjectAndRules,
+    projectName,
+    teamSlug,
+    alertRuleConfig,
+    createNotificationAction,
+    setSelectedPlatform,
+    onComplete,
+  ]);
 
   return (
     <Flex direction="column" align="center" gap="xl" flexGrow={1}>
@@ -102,7 +151,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
         <Button onClick={() => onComplete()}>{t('Back')}</Button>
         <Button
           priority="primary"
-          onClick={() => onComplete()}
+          onClick={handleCreateProject}
           disabled={!canSubmit}
           icon={<IconProject />}
         >

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -13,6 +13,7 @@ import {TeamSelector} from 'sentry/components/teamSelector';
 import {IconProject} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Team} from 'sentry/types/organization';
+import type {PlatformKey} from 'sentry/types/project';
 import {slugify} from 'sentry/utils/slugify';
 import {useTeams} from 'sentry/utils/useTeams';
 import {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
@@ -72,10 +73,12 @@ export function ScmProjectDetails({onComplete}: StepProps) {
         createNotificationAction,
       });
 
-      // Update context so SetupDocs can find the project by slug
+      // onboarding.tsx uses selectedPlatform.key as the project slug for
+      // useRecentCreatedProject lookup. The types don't align (PlatformKey vs
+      // string) because the field is overloaded for both purposes.
       setSelectedPlatform({
         ...selectedPlatform,
-        key: project.slug,
+        key: project.slug as PlatformKey,
       });
 
       onComplete();

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,18 +1,86 @@
-import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
-import {Heading} from '@sentry/scraps/text';
+import {useState} from 'react';
 
+import {Button} from '@sentry/scraps/button';
+import {Input} from '@sentry/scraps/input';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
+import {TeamSelector} from 'sentry/components/teamSelector';
+import {IconProject} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {Team} from 'sentry/types/organization';
+import {slugify} from 'sentry/utils/slugify';
+import {useTeams} from 'sentry/utils/useTeams';
 
 import type {StepProps} from './types';
 
 export function ScmProjectDetails({onComplete}: StepProps) {
+  const {selectedPlatform, selectedRepository} = useOnboardingContext();
+  const {teams} = useTeams();
+
+  const firstAdminTeam = teams.find((team: Team) => team.access.includes('team:admin'));
+
+  const defaultName = slugify(selectedRepository?.name ?? selectedPlatform?.key ?? '');
+
+  const [projectName, setProjectName] = useState(defaultName);
+  const [teamSlug, setTeamSlug] = useState(firstAdminTeam?.slug ?? '');
+
+  const canSubmit = projectName.length > 0 && teamSlug.length > 0;
+
   return (
-    <Flex direction="column" align="center" justify="center" gap="lg" flexGrow={1}>
-      <Heading as="h2">{t('Project details')}</Heading>
-      <Button priority="primary" onClick={() => onComplete()}>
-        {t('Continue')}
-      </Button>
+    <Flex direction="column" align="center" gap="xl" flexGrow={1}>
+      <Stack align="center" gap="md">
+        <Heading as="h2">{t('Project details')}</Heading>
+        <Text variant="muted">
+          {t(
+            'Set the project name, assign a team, and configure how you want to receive issue alerts'
+          )}
+        </Text>
+      </Stack>
+
+      <Stack gap="lg" width="100%" maxWidth="600px">
+        <Stack gap="sm">
+          <Flex gap="xs" align="center">
+            <IconProject size="sm" />
+            <Text bold>{t('Give your project a name')}</Text>
+          </Flex>
+          <Input
+            type="text"
+            placeholder={t('project-name')}
+            value={projectName}
+            onChange={e => setProjectName(slugify(e.target.value))}
+          />
+        </Stack>
+
+        <Stack gap="sm">
+          <Flex gap="xs" align="center">
+            <Text bold>{t('Assign a team')}</Text>
+          </Flex>
+          <TeamSelector
+            allowCreate
+            name="team"
+            aria-label={t('Select a Team')}
+            clearable={false}
+            placeholder={t('Select a Team')}
+            teamFilter={(tm: Team) => tm.access.includes('team:admin')}
+            value={teamSlug}
+            onChange={({value}: {value: string}) => setTeamSlug(value)}
+          />
+        </Stack>
+      </Stack>
+
+      <Flex gap="md" align="center">
+        <Button onClick={() => onComplete()}>{t('Back')}</Button>
+        <Button
+          priority="primary"
+          onClick={() => onComplete()}
+          disabled={!canSubmit}
+          icon={<IconProject />}
+        >
+          {t('Create project')}
+        </Button>
+      </Flex>
     </Flex>
   );
 }

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -31,7 +31,16 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     useOnboardingContext();
   const {teams} = useTeams();
   const createProjectAndRules = useCreateProjectAndRules();
-  const {createNotificationAction, notificationProps} = useCreateNotificationAction();
+
+  // Notification actions (Connect to messaging) deferred to VDY-28 UI polish pass.
+  // No-op avoids the API call that useCreateNotificationAction makes on mount.
+  const createNotificationAction = useCallback(
+    () =>
+      undefined as ReturnType<
+        ReturnType<typeof useCreateNotificationAction>['createNotificationAction']
+      >,
+    []
+  );
 
   const firstAdminTeam = useMemo(
     () => teams.find((team: Team) => team.access.includes('team:admin')),
@@ -150,11 +159,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
           <Text variant="muted" size="sm">
             {t('Get notified when things go wrong')}
           </Text>
-          <IssueAlertOptions
-            {...alertRuleConfig}
-            onFieldChange={handleAlertChange}
-            notificationProps={notificationProps}
-          />
+          <IssueAlertOptions {...alertRuleConfig} onFieldChange={handleAlertChange} />
         </Stack>
       </Stack>
 

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Button} from '@sentry/scraps/button';
@@ -40,10 +40,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     []
   );
 
-  const firstAdminTeam = useMemo(
-    () => teams.find((team: Team) => team.access.includes('team:admin')),
-    [teams]
-  );
+  const firstAdminTeam = teams.find((team: Team) => team.access.includes('team:admin'));
   const defaultName = slugify(selectedPlatform?.key ?? '');
 
   // State tracks user edits; derived values fall back to defaults from context/teams

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -34,11 +34,15 @@ export function ScmProjectDetails({onComplete}: StepProps) {
   const {createNotificationAction} = useCreateNotificationAction();
 
   const firstAdminTeam = teams.find((team: Team) => team.access.includes('team:admin'));
-
   const defaultName = slugify(selectedRepository?.name ?? selectedPlatform?.key ?? '');
 
-  const [projectName, setProjectName] = useState(defaultName);
-  const [teamSlug, setTeamSlug] = useState(firstAdminTeam?.slug ?? '');
+  // Track user overrides separately so derived defaults update if context changes
+  const [projectNameOverride, setProjectNameOverride] = useState<string | null>(null);
+  const [teamSlugOverride, setTeamSlugOverride] = useState<string | null>(null);
+
+  const projectName = projectNameOverride ?? defaultName;
+  const teamSlug = teamSlugOverride ?? firstAdminTeam?.slug ?? '';
+
   const [alertRuleConfig, setAlertRuleConfig] = useState<AlertRuleOptions>({
     alertSetting: RuleAction.DEFAULT_ALERT,
     threshold: '10',
@@ -46,12 +50,12 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     interval: '1m',
   });
 
-  const handleAlertChange = <K extends keyof AlertRuleOptions>(
-    key: K,
-    value: AlertRuleOptions[K]
-  ) => {
-    setAlertRuleConfig(prev => ({...prev, [key]: value}));
-  };
+  const handleAlertChange = useCallback(
+    <K extends keyof AlertRuleOptions>(key: K, value: AlertRuleOptions[K]) => {
+      setAlertRuleConfig(prev => ({...prev, [key]: value}));
+    },
+    []
+  );
 
   const canSubmit =
     projectName.length > 0 &&
@@ -119,7 +123,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
             type="text"
             placeholder={t('project-name')}
             value={projectName}
-            onChange={e => setProjectName(slugify(e.target.value))}
+            onChange={e => setProjectNameOverride(slugify(e.target.value))}
           />
         </Stack>
 
@@ -135,7 +139,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
             placeholder={t('Select a Team')}
             teamFilter={(tm: Team) => tm.access.includes('team:admin')}
             value={teamSlug}
-            onChange={({value}: {value: string}) => setTeamSlug(value)}
+            onChange={({value}: {value: string}) => setTeamSlugOverride(value)}
           />
         </Stack>
 

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -155,7 +155,6 @@ export function ScmProjectDetails({onComplete}: StepProps) {
       </Stack>
 
       <Flex gap="md" align="center">
-        <Button onClick={() => onComplete()}>{t('Back')}</Button>
         <Button
           priority="primary"
           onClick={handleCreateProject}

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -13,7 +13,6 @@ import {TeamSelector} from 'sentry/components/teamSelector';
 import {IconProject} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Team} from 'sentry/types/organization';
-import type {PlatformKey} from 'sentry/types/project';
 import {slugify} from 'sentry/utils/slugify';
 import {useTeams} from 'sentry/utils/useTeams';
 import {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
@@ -27,7 +26,7 @@ import {
 import type {StepProps} from './types';
 
 export function ScmProjectDetails({onComplete}: StepProps) {
-  const {selectedPlatform, selectedRepository, setSelectedPlatform} =
+  const {selectedPlatform, selectedRepository, setCreatedProjectSlug} =
     useOnboardingContext();
   const {teams} = useTeams();
   const createProjectAndRules = useCreateProjectAndRules();
@@ -86,13 +85,10 @@ export function ScmProjectDetails({onComplete}: StepProps) {
         createNotificationAction,
       });
 
-      // onboarding.tsx uses selectedPlatform.key as the project slug for
-      // useRecentCreatedProject lookup. The types don't align (PlatformKey vs
-      // string) because the field is overloaded for both purposes.
-      setSelectedPlatform({
-        ...selectedPlatform,
-        key: project.slug as PlatformKey,
-      });
+      // Store the project slug separately so onboarding.tsx can find
+      // the project via useRecentCreatedProject without corrupting
+      // selectedPlatform.key (which the platform features step needs).
+      setCreatedProjectSlug(project.slug);
 
       onComplete();
     } catch (error) {
@@ -107,7 +103,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     teamSlugResolved,
     alertRuleConfig,
     createNotificationAction,
-    setSelectedPlatform,
+    setCreatedProjectSlug,
     onComplete,
   ]);
 

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -36,12 +36,16 @@ export function useBackActions({
   const currentStep = onboardingSteps[stepIndex];
 
   const deleteRecentCreatedProject = useCallback(
-    async ({resetContext = true}: {resetContext?: boolean} = {}) => {
+    async ({
+      preserveOnboardingState = false,
+    }: {preserveOnboardingState?: boolean} = {}) => {
       if (!recentCreatedProject) {
         return;
       }
 
-      if (resetContext) {
+      if (preserveOnboardingState) {
+        onboardingContext.setCreatedProjectSlug(undefined);
+      } else {
         onboardingContext.setSelectedPlatform(undefined);
       }
 
@@ -117,7 +121,7 @@ export function useBackActions({
         // In the SCM flow, preserve context so the user keeps their SCM
         // connection, repo selection, and feature choices.
         await deleteRecentCreatedProject({
-          resetContext: prevStep.id !== 'scm-project-details',
+          preserveOnboardingState: prevStep.id === 'scm-project-details',
         });
       }
 

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -36,7 +36,9 @@ export function useBackActions({
   const currentStep = onboardingSteps[stepIndex];
 
   const deleteRecentCreatedProject = useCallback(
-    async (preserveOnboardingState = false) => {
+    async ({
+      preserveOnboardingState = false,
+    }: {preserveOnboardingState?: boolean} = {}) => {
       if (!recentCreatedProject) {
         return;
       }
@@ -118,7 +120,9 @@ export function useBackActions({
         // store data and skip project creation.
         // In the SCM flow, preserve context so the user keeps their SCM
         // connection, repo selection, and feature choices.
-        await deleteRecentCreatedProject(prevStep.id === 'scm-project-details');
+        await deleteRecentCreatedProject({
+          preserveOnboardingState: prevStep.id === 'scm-project-details',
+        });
       }
 
       if (!browserBackButton) {

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -35,35 +35,40 @@ export function useBackActions({
   const onboardingContext = useOnboardingContext();
   const currentStep = onboardingSteps[stepIndex];
 
-  const deleteRecentCreatedProject = useCallback(async () => {
-    if (!recentCreatedProject) {
-      return;
-    }
+  const deleteRecentCreatedProject = useCallback(
+    async ({resetContext = true}: {resetContext?: boolean} = {}) => {
+      if (!recentCreatedProject) {
+        return;
+      }
 
-    onboardingContext.setSelectedPlatform(undefined);
+      if (resetContext) {
+        onboardingContext.setSelectedPlatform(undefined);
+      }
 
-    try {
-      await removeProject({
-        api,
-        orgSlug: organization.slug,
-        projectSlug: recentCreatedProject.slug,
-        origin: 'onboarding',
-      });
+      try {
+        await removeProject({
+          api,
+          orgSlug: organization.slug,
+          projectSlug: recentCreatedProject.slug,
+          origin: 'onboarding',
+        });
 
-      trackAnalytics('onboarding.data_removed', {
-        organization,
-        date_created: recentCreatedProject.dateCreated,
-        platform: recentCreatedProject.slug,
-        project_id: recentCreatedProject.id,
-      });
-    } catch (error) {
-      handleXhrErrorResponse(
-        'Unable to delete project in onboarding',
-        error as RequestError
-      );
-      // we don't give the user any feedback regarding this error as this shall be silent
-    }
-  }, [api, organization, onboardingContext, recentCreatedProject]);
+        trackAnalytics('onboarding.data_removed', {
+          organization,
+          date_created: recentCreatedProject.dateCreated,
+          platform: recentCreatedProject.slug,
+          project_id: recentCreatedProject.id,
+        });
+      } catch (error) {
+        handleXhrErrorResponse(
+          'Unable to delete project in onboarding',
+          error as RequestError
+        );
+        // we don't give the user any feedback regarding this error as this shall be silent
+      }
+    },
+    [api, organization, onboardingContext, recentCreatedProject]
+  );
 
   const backStepActions = useCallback(
     async ({
@@ -94,7 +99,7 @@ export function useBackActions({
         return;
       }
 
-      // from setup docs to selected platform
+      // from setup docs to previous step
       if (
         currentStep.id === 'setup-docs' &&
         defined(isRecentCreatedProjectActive) &&
@@ -109,7 +114,11 @@ export function useBackActions({
         // Await deletion so the projects store is updated before navigating
         // back. Without this, re-selecting the same platform can see stale
         // store data and skip project creation.
-        await deleteRecentCreatedProject();
+        // In the SCM flow, preserve context so the user keeps their SCM
+        // connection, repo selection, and feature choices.
+        await deleteRecentCreatedProject({
+          resetContext: prevStep.id !== 'scm-project-details',
+        });
       }
 
       if (!browserBackButton) {

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -36,9 +36,7 @@ export function useBackActions({
   const currentStep = onboardingSteps[stepIndex];
 
   const deleteRecentCreatedProject = useCallback(
-    async ({
-      preserveOnboardingState = false,
-    }: {preserveOnboardingState?: boolean} = {}) => {
+    async (preserveOnboardingState = false) => {
       if (!recentCreatedProject) {
         return;
       }
@@ -120,9 +118,7 @@ export function useBackActions({
         // store data and skip project creation.
         // In the SCM flow, preserve context so the user keeps their SCM
         // connection, repo selection, and feature choices.
-        await deleteRecentCreatedProject({
-          preserveOnboardingState: prevStep.id === 'scm-project-details',
-        });
+        await deleteRecentCreatedProject(prevStep.id === 'scm-project-details');
       }
 
       if (!browserBackButton) {

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -62,7 +62,7 @@ const INTERVAL_CHOICES = [
   {value: '30d', label: t('30 days')},
 ];
 
-const DEFAULT_ISSUE_ALERT_OPTIONS_VALUES = {
+export const DEFAULT_ISSUE_ALERT_OPTIONS_VALUES = {
   alertSetting: RuleAction.DEFAULT_ALERT,
   interval: '1m',
   metric: MetricValues.ERRORS,


### PR DESCRIPTION
Implement the `SCM_PROJECT_DETAILS` onboarding step -- the third step in the SCM-first onboarding flow where users configure and create a project after selecting a platform and features.

**Project name:** Defaults from platform key, slugified and editable.

**Team selection:** Uses the existing `TeamSelector` component, defaulting to the first team with admin access.

**Alert frequency:** Reuses the `IssueAlertOptions` component from the project creation page with three radio options -- high priority issues (default), custom threshold/metric/interval, and create alerts later.

**Project creation:** Uses `useCreateProjectAndRules` for atomic project + alert rule creation. After creation, stores the project slug in a separate `createdProjectSlug` context field so `useRecentCreatedProject` in SetupDocs can find it without corrupting `selectedPlatform.key` (which the platform features step still needs).

## PR stack

This PR is stacked on [#111160](https://github.com/getsentry/sentry/pull/111160) (SCM platform & features step).

- [PR 1: SCM platform & features step](https://github.com/getsentry/sentry/pull/111160)
- **PR 2 (this): SCM project details step**
- [PR 3: Sync feature selections to SetupDocs URL params](https://github.com/getsentry/sentry/pull/111334)

Refs VDY-27