### PR TITLE
fix(migrations): Correct dependency in explore migration 0007

### DIFF
--- a/src/sentry/explore/migrations/0007_update_numeric_attrs_to_bools.py
+++ b/src/sentry/explore/migrations/0007_update_numeric_attrs_to_bools.py
@@ -198,7 +198,7 @@ class Migration(CheckedMigration):
     is_post_deployment = True
 
     dependencies = [
-        ("sentry", "1055_rename_regiontombstone_to_celltombstone"),
+        ("sentry", "1041_projectkeymapping"),
         ("explore", "0006_add_changed_reason_field_explore"),
     ]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The explore migration `0007_update_numeric_attrs_to_bools` was causing an `InconsistentMigrationHistory` error:

```
django.db.migrations.exceptions.InconsistentMigrationHistory: Migration explore.0007_update_numeric_attrs_to_bools is applied before its dependency sentry.1055_rename_regiontombstone_to_celltombstone on database 'default'.
```

## Root Cause

The explore migration was originally created on **2026-03-04 20:33** with NO sentry app dependency. Later, PR #111013 added a dependency on sentry migration `1055_rename_regiontombstone_to_celltombstone` which wasn't created until **2026-03-17** (13 days after the explore migration).

This created an inconsistency: databases that ran the explore migration in early March had already applied it before migration 1055 even existed.

## Solution

Changed the dependency to `1041_projectkeymapping`, which was the latest sentry migration when the explore migration was originally generated (March 4, 20:20 - just 13 minutes before the explore migration at 20:33).

The explore migration doesn't actually use anything from either migration 1041 or 1055, so the dependency is just to ensure reasonable migration ordering.

## Testing

Users experiencing this error should be able to resolve it by:
1. Pulling this fix
2. Running migrations normally (no need to reset database)

The migration dependency chain is now consistent with the actual generation timeline.

## CI Note

The `migrations-drift` check is showing differences only in random PostgreSQL `\restrict` / `\unrestrict` session tokens, not actual schema changes. This appears to be a pg_dumpall artifact issue unrelated to the dependency change, as the explore migration performs the same data operations regardless of which sentry migration it depends on.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/CUHS29QJ0/p1774278859630319?thread_ts=1774278859.630319&cid=CUHS29QJ0)

<div><a href="https://cursor.com/agents/bc-2aa4e424-9bbf-5f44-83af-dd9300d5d0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2aa4e424-9bbf-5f44-83af-dd9300d5d0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

