### PR TITLE
fix(ui): Preserve Seer paths in URL normalization

### DIFF
--- a/static/app/utils/url/normalizeUrl.spec.tsx
+++ b/static/app/utils/url/normalizeUrl.spec.tsx
@@ -74,6 +74,11 @@ describe('normalizeUrl', () => {
       ['/settings/stats/issues/', '/settings/stats/issues/'],
       ['/settings/stats/health/', '/settings/stats/health/'],
 
+      // Seer org settings: strip org slug but keep /settings/seer/... paths
+      ['/settings/acme/seer/', '/settings/seer/'],
+      ['/settings/acme/seer/repos/', '/settings/seer/repos/'],
+      ['/settings/seer/repos/', '/settings/seer/repos/'],
+
       ['/join-request/acme', '/join-request/'],
       ['/join-request/acme/', '/join-request/'],
       ['/onboarding/acme/', '/onboarding/'],
@@ -155,6 +160,9 @@ describe('normalizeUrl', () => {
 
     result = normalizeUrl({pathname: '/settings/sentry/members'}, location);
     expect(result.pathname).toBe('/settings/members');
+
+    result = normalizeUrl({pathname: '/settings/acme/seer/repos/'}, location);
+    expect(result.pathname).toBe('/settings/seer/repos/');
 
     result = normalizeUrl({pathname: '/organizations/albertos-apples/issues'}, location);
     expect(result.pathname).toBe('/issues');

--- a/static/app/utils/url/normalizeUrl.tsx
+++ b/static/app/utils/url/normalizeUrl.tsx
@@ -8,13 +8,13 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   [/\/organizations\/(?!new)[^/]+\/(.*)/, '/$1'],
   // For /settings/:orgId/ -> /settings/organization/
   [
-    /\/settings\/(?!account\/|billing\/|projects\/|teams\/|stats\/)[^/]+\/?$/,
+    /\/settings\/(?!account\/|billing\/|projects\/|teams\/|stats|seer\/)[^/]+\/?$/,
     '/settings/organization/',
   ],
   // Move /settings/:orgId/:section -> /settings/:section
   // but not /settings/organization or /settings/projects which is a new URL
   [
-    /^\/?settings\/(?!account\/|billing\/|projects\/|teams\/|stats\/)[^/]+\/(.*)/,
+    /^\/?settings\/(?!account\/|billing\/|projects\/|teams\/|stats\/|seer\/)[^/]+\/(.*)/,
     '/settings/$1',
   ],
   [/^\/?join-request\/[^/]+\/?.*/, '/join-request/'],

--- a/static/app/utils/url/normalizeUrl.tsx
+++ b/static/app/utils/url/normalizeUrl.tsx
@@ -8,7 +8,7 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   [/\/organizations\/(?!new)[^/]+\/(.*)/, '/$1'],
   // For /settings/:orgId/ -> /settings/organization/
   [
-    /\/settings\/(?!account\/|billing\/|projects\/|teams\/|stats|seer\/)[^/]+\/?$/,
+    /\/settings\/(?!account\/|billing\/|projects\/|teams\/|stats\/|seer\/)[^/]+\/?$/,
     '/settings/organization/',
   ],
   // Move /settings/:orgId/:section -> /settings/:section

--- a/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
+++ b/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
@@ -34,16 +34,8 @@ export function SettingsPageTabs() {
           {tabs.map(([label, to]) => {
             const tabPath = prefix + to;
             const normalized = normalizeUrl(tabPath);
-            // We need to normalize the `key` prop because that value is used to
-            // identify which tab to highlight, the value needs to match the
-            // value of the `value` prop on the `Tabs` component.
-            // The Tab component will render `TabLink` which extends `Link`and
-            // normalizes the url for us.
-            //
-            // If we manually make the call then it'll be double-normalized,
-            // we'd have `/settings/repos/` instead of `/settings/seer/repos/`.
             return (
-              <TabList.Item key={normalized} to={{pathname: tabPath}}>
+              <TabList.Item key={normalized} to={normalized}>
                 {label}
               </TabList.Item>
             );


### PR DESCRIPTION
Normalization treated the first segment after /settings/ as the org slug, which dropped /seer/ from org Seer settings and broke tab links. Exclude seer
