### PR TITLE
feat(preprod): Add solo/diff toggle button to snapshot dev tools

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
@@ -17,6 +17,8 @@ import {
 
 interface SnapshotDevToolsProps {
   hasBaseArtifact: boolean;
+  isSoloView: boolean;
+  onToggleView: () => void;
   organizationSlug: string;
   refetch: () => void;
   snapshotId: string;
@@ -29,6 +31,8 @@ export function SnapshotDevTools({
   comparisonRunInfo,
   hasBaseArtifact,
   refetch,
+  isSoloView,
+  onToggleView,
 }: SnapshotDevToolsProps) {
   const comparisonState = comparisonRunInfo?.state;
   const comparisonCompletedAt = comparisonRunInfo?.completed_at;
@@ -187,6 +191,16 @@ export function SnapshotDevTools({
           {hasBaseArtifact && (
             <Button size="xs" onClick={handleRecompare} disabled={recompareLoading}>
               {recompareLoading ? t('Queuing...') : t('Re-run Comparison')}
+            </Button>
+          )}
+          {hasBaseArtifact && (
+            <Text size="xs" variant="muted">
+              {'|'}
+            </Text>
+          )}
+          {hasBaseArtifact && (
+            <Button size="xs" onClick={onToggleView}>
+              {isSoloView ? t('View as diff') : t('View as solo')}
             </Button>
           )}
         </Flex>

--- a/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
@@ -200,7 +200,7 @@ export function SnapshotDevTools({
           )}
           {hasBaseArtifact && (
             <Button size="xs" onClick={onToggleView}>
-              {isSoloView ? t('View as diff') : t('View as solo')}
+              {isSoloView ? 'View as diff' : 'View as solo'}
             </Button>
           )}
         </Flex>

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -1,4 +1,4 @@
-import {useDeferredValue, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -12,6 +12,8 @@ import {IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
@@ -78,8 +80,22 @@ export default function SnapshotsPage() {
     sizeStorageKey: 'snapshot-sidebar-width',
   });
 
-  const comparisonType = data?.comparison_type ?? 'solo';
+  const location = useLocation();
+  const navigate = useNavigate();
+  const typeOverride = location.query.type;
+  const comparisonType =
+    typeOverride === 'solo' ? 'solo' : (data?.comparison_type ?? 'solo');
   const comparisonRunInfo = data?.comparison_run_info;
+
+  const isSoloView = comparisonType === 'solo';
+  const handleToggleView = useCallback(() => {
+    const {type: _type, ...restQuery} = location.query;
+    if (isSoloView) {
+      navigate({...location, query: restQuery}, {replace: true});
+    } else {
+      navigate({...location, query: {...location.query, type: 'solo'}}, {replace: true});
+    }
+  }, [location, navigate, isSoloView]);
 
   const sidebarItems = useMemo(() => {
     if (!data) {
@@ -298,6 +314,8 @@ export default function SnapshotsPage() {
               comparisonRunInfo={comparisonRunInfo}
               hasBaseArtifact={data.base_artifact_id !== null}
               refetch={refetch}
+              isSoloView={isSoloView}
+              onToggleView={handleToggleView}
             />
           </Layout.HeaderActions>
         </Layout.Header>

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -82,18 +82,18 @@ export default function SnapshotsPage() {
 
   const location = useLocation();
   const navigate = useNavigate();
-  const typeOverride = location.query.type;
+  const viewOverride = location.query.view;
   const comparisonType =
-    typeOverride === 'solo' ? 'solo' : (data?.comparison_type ?? 'solo');
+    viewOverride === 'solo' ? 'solo' : (data?.comparison_type ?? 'solo');
   const comparisonRunInfo = data?.comparison_run_info;
 
   const isSoloView = comparisonType === 'solo';
   const handleToggleView = useCallback(() => {
-    const {type: _type, ...restQuery} = location.query;
+    const {view: _view, ...restQuery} = location.query;
     if (isSoloView) {
       navigate({...location, query: restQuery}, {replace: true});
     } else {
-      navigate({...location, query: {...location.query, type: 'solo'}}, {replace: true});
+      navigate({...location, query: {...location.query, view: 'solo'}}, {replace: true});
     }
   }, [location, navigate, isSoloView]);
 


### PR DESCRIPTION
Add a toggle button in the snapshot dev tools panel that lets developers
switch between solo and diff views on snapshots that have diff data.

The button toggles the `?type=solo` URL query parameter — when viewing
a diff snapshot, clicking "View as solo" adds `?type=solo` to show the
raw images without comparison overlay. Clicking "View as diff" removes
the parameter to restore the diff view. The button only renders when
the snapshot has a base artifact (i.e., diff data exists).

This is an admin/dev-only feature, scoped to the temporary dev tools
panel rather than the main header UI.