### PR TITLE
chore(codeowners): move explore-related files from data-browsing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -256,31 +256,33 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/api/endpoints/organization_events_histogram.py                  @getsentry/data-browsing
 /src/sentry/api/endpoints/organization_events_facets_performance.py         @getsentry/data-browsing
 /src/sentry/api/endpoints/organization_events_spans_performance.py          @getsentry/data-browsing
-/src/sentry/api/endpoints/organization_events_trace.py                      @getsentry/data-browsing
-/src/sentry/api/endpoints/organization_events_trends.py                     @getsentry/data-browsing
-/src/sentry/api/endpoints/organization_events_trends_v2.py                  @getsentry/data-browsing
+/src/sentry/api/endpoints/organization_events_trace.py                      @getsentry/explore
+/src/sentry/api/endpoints/organization_events_trends.py                     @getsentry/explore
+/src/sentry/api/endpoints/organization_events_trends_v2.py                  @getsentry/explore
 /src/sentry/api/endpoints/organization_events_vitals.py                     @getsentry/data-browsing
 /src/sentry/api/endpoints/organization_tagkey_values.py                     @getsentry/data-browsing
-/src/sentry/api/endpoints/organization_event_details.py                     @getsentry/data-browsing
+/src/sentry/api/endpoints/organization_event_details.py                     @getsentry/explore
 /src/sentry/api/endpoints/organization_events.py                            @getsentry/data-browsing
 /src/sentry/api/endpoints/organization_events_facets.py                     @getsentry/data-browsing
-/src/sentry/api/endpoints/organization_events_meta.py                       @getsentry/data-browsing
+/src/sentry/api/endpoints/organization_events_meta.py                       @getsentry/explore
 /src/sentry/api/endpoints/organization_events_stats.py                      @getsentry/data-browsing
 /src/sentry/api/endpoints/organization_events_timeseries.py                 @getsentry/data-browsing
 /src/sentry/api/endpoints/organization_measurements_meta.py                 @getsentry/data-browsing
-src/sentry/api/endpoints/organization_attribute_mappings.py                 @getsentry/data-browsing
+src/sentry/api/endpoints/organization_attribute_mappings.py                 @getsentry/explore
 
 /tests/snuba/api/endpoints/*                                                @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_tags.py                        @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_events_histogram.py            @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_events_facets_performance.py   @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_events_spans_performance.py    @getsentry/data-browsing
-/tests/snuba/api/endpoints/test_organization_events_trace.py                @getsentry/data-browsing
-/tests/snuba/api/endpoints/test_organization_events_trends.py               @getsentry/data-browsing
-/tests/sentry/api/endpoints/test_organization_events_trends_v2.py           @getsentry/data-browsing
+/tests/snuba/api/endpoints/test_organization_event_details.py               @getsentry/explore
+/tests/snuba/api/endpoints/test_organization_events_meta.py                 @getsentry/explore
+/tests/snuba/api/endpoints/test_organization_events_trace.py                @getsentry/explore
+/tests/snuba/api/endpoints/test_organization_events_trends.py               @getsentry/explore
+/tests/sentry/api/endpoints/test_organization_events_trends_v2.py           @getsentry/explore
 /tests/snuba/api/endpoints/test_organization_events_vitals.py               @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_tagkey_values.py               @getsentry/data-browsing
-tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @getsentry/data-browsing
+tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @getsentry/explore
 
 /src/sentry/api/serializers/snuba.py                                        @getsentry/data-browsing
 
@@ -310,7 +312,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/dashboards/                                                   @getsentry/dashboards
 
 /src/sentry/api/serializers/models/dashboard*                        @getsentry/dashboards
-/src/sentry/api/serializers/models/discoversavedquery.py             @getsentry/data-browsing
+/src/sentry/api/serializers/models/discoversavedquery.py             @getsentry/explore
 /src/sentry/api/serializers/rest_framework/dashboard.py              @getsentry/dashboards
 
 /src/sentry/discover/                                                @getsentry/explore
@@ -319,12 +321,12 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/api/event_search.py                                      @getsentry/data-browsing
 /tests/sentry/api/test_event_search.py                               @getsentry/data-browsing
 
-/src/sentry/data_export/                                             @getsentry/data-browsing
-/tests/sentry/data_export/                                           @getsentry/data-browsing
+/src/sentry/data_export/                                             @getsentry/explore
+/tests/sentry/data_export/                                           @getsentry/explore
 
 
-/src/sentry/api/endpoints/organization_spans_fields.py                              @getsentry/data-browsing
-/tests/sentry/api/endpoints/test_organization_spans_fields.py                       @getsentry/data-browsing
+/src/sentry/api/endpoints/organization_spans_fields.py                              @getsentry/explore
+/tests/sentry/api/endpoints/test_organization_spans_fields.py                       @getsentry/explore
 
 /src/sentry/api/endpoints/organization_traces.py                                    @getsentry/explore
 /tests/sentry/api/endpoints/test_organization_traces.py                             @getsentry/explore

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -336,12 +336,13 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/quickTrace/                                        @getsentry/explore
 /src/sentry/insights/                                                     @getsentry/data-browsing
 /static/app/views/performance/                                            @getsentry/data-browsing
+/static/app/views/performance/newTraceDetails/                            @getsentry/explore
 /static/app/components/performance/                                       @getsentry/data-browsing
 /static/app/utils/performance/                                            @getsentry/data-browsing
 /static/app/components/events/interfaces/spans/                           @getsentry/data-browsing
 /static/app/components/events/viewHierarchy/*                             @getsentry/data-browsing
-/static/app/components/searchQueryBuilder/                                @getsentry/data-browsing
-/static/app/components/arithmeticBuilder/                                 @getsentry/data-browsing
+/static/app/components/searchQueryBuilder/                                @getsentry/explore
+/static/app/components/arithmeticBuilder/                                 @getsentry/explore
 
 /static/app/components/charts/                                            @getsentry/data-browsing
 


### PR DESCRIPTION
Some files are under data-browsing when they can be more specific to explore.