### PR TITLE
fix(users): Default theme preference to system instead of light

### DIFF
--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -206,7 +206,7 @@ class UserSerializer(Serializer):
             )
 
             d["options"] = {
-                "theme": options.get("theme") or "light",
+                "theme": options.get("theme") or "system",
                 "language": options.get("language") or settings.SENTRY_DEFAULT_LANGUAGE,
                 "stacktraceOrder": stacktrace_order,
                 "defaultIssueEvent": options.get("default_issue_event") or "recommended",

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -46,7 +46,7 @@ class UserDetailsGetTest(UserDetailsTest):
         resp = self.get_success_response("me")
 
         assert resp.data["id"] == str(self.user.id)
-        assert resp.data["options"]["theme"] == "light"
+        assert resp.data["options"]["theme"] == "system"
         assert resp.data["options"]["defaultIssueEvent"] == "recommended"
         assert resp.data["options"]["timezone"] == "UTC"
         assert resp.data["options"]["language"] == "en"


### PR DESCRIPTION
The user serializer (`src/sentry/users/api/serializers/user.py`) falls back to `"light"` when no theme is stored in `UserOption`, causing new users and users who never touched the setting to get light mode instead of respecting their OS preference.

The frontend (`useColorscheme.tsx`) already handles `"system"` correctly — it defers to `prefers-color-scheme` — so the fix is changing the serializer fallback from `"light"` to `"system"`.

**Backfill note**: Existing users who were assigned `"light"` by this default (and never explicitly chose it) will keep `"light"` until they manually change it, since we can't distinguish intentional light-mode users from defaulted ones. A data migration could address this but is ambiguous — recommend a follow-up ticket to evaluate.


Agent transcript: https://claudescope.sentry.dev/share/rLWJco0bbwz8pSH4WJbFx29aDC_juNgEnkXarhUjshA