### PR TITLE
feat(scm): Add `create_review` GitLab impl

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -347,6 +347,15 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
             GitLabApiClientPath.merge_request_notes.format(project_id=project_id, pr_key=pr_key)
         )
 
+    def approve_merge_request(self, project_id: str, pr_key: str) -> Any:
+        """Approve a merge request.
+
+        See https://docs.gitlab.com/ee/api/merge_request_approvals.html#approve-merge-request
+        """
+        return self.post(
+            GitLabApiClientPath.merge_request_approve.format(project_id=project_id, pr_key=pr_key),
+        )
+
     def get_merge_request_versions(self, project_id: str, pr_key: str) -> Any:
         return self.get(
             GitLabApiClientPath.merge_request_versions.format(project_id=project_id, pr_key=pr_key)

--- a/src/sentry/integrations/gitlab/utils.py
+++ b/src/sentry/integrations/gitlab/utils.py
@@ -46,6 +46,7 @@ class GitLabApiClientPath:
     )
     merge_requests = "/projects/{project_id}/merge_requests"
     merge_request = "/projects/{project_id}/merge_requests/{pr_key}"
+    merge_request_approve = "/projects/{project_id}/merge_requests/{pr_key}/approve"
     merge_request_commits = "/projects/{project_id}/merge_requests/{pr_key}/commits"
     merge_request_awards = "/projects/{project_id}/merge_requests/{pr_key}/award_emoji"
     merge_request_award = "/projects/{project_id}/merge_requests/{pr_key}/award_emoji/{award_id}"

--- a/src/sentry/scm/private/providers/gitlab.py
+++ b/src/sentry/scm/private/providers/gitlab.py
@@ -577,6 +577,7 @@ class GitLabProvider:
             versions = self.client.get_merge_request_versions(self._repo_id, pull_request_id)
 
         for comment in comments:
+            assert versions is not None
             position: dict[str, Any] = {
                 "base_sha": versions[0]["base_commit_sha"],
                 "head_sha": versions[0]["head_commit_sha"],

--- a/src/sentry/scm/private/providers/gitlab.py
+++ b/src/sentry/scm/private/providers/gitlab.py
@@ -8,7 +8,6 @@ Unsupported actions:
     * create_git_commit
     * create_git_tree
     * create_pull_request_draft
-    * create_review
     * get_check_run
     * get_git_commit
     * get_pull_request_diff
@@ -22,9 +21,12 @@ Unsupported actions:
 
 import datetime
 import functools
+import logging
 from collections.abc import Callable
 from typing import Any, Iterable
 from urllib.parse import urlencode
+
+logger = logging.getLogger(__name__)
 
 from sentry.integrations.gitlab.client import GitLabApiClient
 from sentry.integrations.gitlab.utils import GitLabApiClientPath
@@ -54,7 +56,10 @@ from sentry.scm.types import (
     Referrer,
     Repository,
     RequestOptions,
+    Review,
     ReviewComment,
+    ReviewCommentInput,
+    ReviewEvent,
     ReviewSide,
 )
 from sentry.shared_integrations.exceptions import ApiError
@@ -539,6 +544,83 @@ class GitLabProvider:
         return make_result(
             map_review_comment(discussion_id),
             raw,
+        )
+
+    @catch_provider_exception
+    def create_review(
+        self,
+        pull_request_id: str,
+        commit_sha: SHA,
+        event: ReviewEvent,
+        comments: list[ReviewCommentInput],
+        body: str | None = None,
+    ) -> ActionResult[Review]:
+        """Submit a review with optional inline comments and an approval.
+
+        GitLab does not support this as a single atomic operation.  Each inline
+        comment is posted as a separate merge-request discussion, followed by
+        the body (as a note) and the approval.  If any individual request
+        fails the exception propagates immediately.
+        """
+        if event == "change_request":
+            raise SCMProviderException("GitLab does not support REQUEST_CHANGES reviews")
+
+        if len(comments) > 10:
+            logger.warning(
+                "gitlab.create_review: %d inline comments in a single review",
+                len(comments),
+            )
+
+        # Fetch MR version info once for positioning all inline comments.
+        versions = None
+        if comments:
+            versions = self.client.get_merge_request_versions(self._repo_id, pull_request_id)
+
+        for comment in comments:
+            position: dict[str, Any] = {
+                "base_sha": versions[0]["base_commit_sha"],
+                "head_sha": versions[0]["head_commit_sha"],
+                "start_sha": versions[0]["start_commit_sha"],
+                "new_path": comment["path"],
+                "old_path": comment["path"],
+            }
+
+            if "line" in comment:
+                position["position_type"] = "text"
+                side = comment.get("side", "RIGHT")
+                if side == "LEFT":
+                    position["old_line"] = str(comment["line"])
+                else:
+                    position["new_line"] = str(comment["line"])
+            else:
+                position["position_type"] = "file"
+
+            self.client.create_merge_request_discussion(
+                self._repo_id,
+                pull_request_id,
+                {"body": comment["body"], "position": position},
+            )
+
+        # Post the review body as a general MR note.
+        note_raw = None
+        if body:
+            note_raw = self.client.create_merge_request_note(
+                self._repo_id, pull_request_id, {"body": body}
+            )
+
+        # Approve the MR when requested.
+        approval_raw = None
+        if event == "approve":
+            approval_raw = self.client.approve_merge_request(self._repo_id, pull_request_id)
+
+        raw = approval_raw or note_raw or {}
+        review_id = str(raw.get("id", "")) if isinstance(raw, dict) else ""
+
+        return ActionResult(
+            data=Review(id=review_id, html_url=""),
+            type="gitlab",
+            raw=raw,
+            meta={},
         )
 
 

--- a/tests/sentry/scm/unit/test_gitlab_provider.py
+++ b/tests/sentry/scm/unit/test_gitlab_provider.py
@@ -6,6 +6,7 @@ from typing import Any, NamedTuple
 import pytest
 
 from sentry.integrations.gitlab.client import GitLabApiClient
+from sentry.scm.errors import SCMProviderException
 from sentry.scm.private.providers.gitlab import GitLabProvider
 from sentry.scm.types import Repository
 
@@ -13049,6 +13050,281 @@ class ForwardToClientTest(NamedTuple):
                 "meta": {"next_cursor": None},
             },
         ),
+        # --- create_review: approve-only (no comments, no body) ---
+        ForwardToClientTest(
+            provider_method=GitLabProvider.create_review,
+            provider_args={
+                "pull_request_id": "1",
+                "commit_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                "event": "approve",
+                "comments": [],
+                "body": None,
+            },
+            client_calls=[
+                ClientForwardedCall(
+                    client_method="approve_merge_request",
+                    client_args=("79787061", "1"),
+                    client_kwds={},
+                    client_return_value={"id": 100},
+                ),
+            ],
+            provider_return_value={
+                "data": {"id": "100", "html_url": ""},
+                "type": "gitlab",
+                "raw": {"id": 100},
+                "meta": {},
+            },
+        ),
+        # --- create_review: body-only comment (no inline comments, no approval) ---
+        ForwardToClientTest(
+            provider_method=GitLabProvider.create_review,
+            provider_args={
+                "pull_request_id": "1",
+                "commit_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                "event": "comment",
+                "comments": [],
+                "body": "LGTM",
+            },
+            client_calls=[
+                ClientForwardedCall(
+                    client_method="create_merge_request_note",
+                    client_args=("79787061", "1", {"body": "LGTM"}),
+                    client_kwds={},
+                    client_return_value={"id": 99},
+                ),
+            ],
+            provider_return_value={
+                "data": {"id": "99", "html_url": ""},
+                "type": "gitlab",
+                "raw": {"id": 99},
+                "meta": {},
+            },
+        ),
+        # --- create_review: single inline comment on RIGHT side ---
+        ForwardToClientTest(
+            provider_method=GitLabProvider.create_review,
+            provider_args={
+                "pull_request_id": "1",
+                "commit_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                "event": "comment",
+                "comments": [
+                    {"path": "BLAH.md", "body": "fix this", "line": 10, "side": "RIGHT"},
+                ],
+                "body": None,
+            },
+            client_calls=[
+                ClientForwardedCall(
+                    client_method="get_merge_request_versions",
+                    client_args=("79787061", "1"),
+                    client_kwds={},
+                    client_return_value=[
+                        {
+                            "id": 1692137080,
+                            "head_commit_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                            "base_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "start_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "created_at": "2026-03-05T11:16:06.468Z",
+                            "merge_request_id": 459277081,
+                            "state": "collected",
+                            "real_size": "1",
+                            "patch_id_sha": "7e2de654ed21ae09a78ad51592379d8a582e90ff",
+                        },
+                        {
+                            "id": 1682341969,
+                            "head_commit_sha": "6d8ca33dae268d3c5835e721e5702ef9dcb43c8c",
+                            "base_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "start_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "created_at": "2026-02-26T08:48:23.979Z",
+                            "merge_request_id": 459277081,
+                            "state": "collected",
+                            "real_size": "1",
+                            "patch_id_sha": "f86adf0229d6ac6d77ac8d2087cd5fae3cc052d8",
+                        },
+                    ],
+                ),
+                ClientForwardedCall(
+                    client_method="create_merge_request_discussion",
+                    client_args=(
+                        "79787061",
+                        "1",
+                        {
+                            "body": "fix this",
+                            "position": {
+                                "base_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                                "head_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                                "start_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                                "new_path": "BLAH.md",
+                                "old_path": "BLAH.md",
+                                "position_type": "text",
+                                "new_line": "10",
+                            },
+                        },
+                    ),
+                    client_kwds={},
+                    client_return_value={},
+                ),
+            ],
+            provider_return_value={
+                "data": {"id": "", "html_url": ""},
+                "type": "gitlab",
+                "raw": {},
+                "meta": {},
+            },
+        ),
+        # --- create_review: single inline comment on LEFT side ---
+        ForwardToClientTest(
+            provider_method=GitLabProvider.create_review,
+            provider_args={
+                "pull_request_id": "1",
+                "commit_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                "event": "comment",
+                "comments": [
+                    {"path": "BLAH.md", "body": "old code note", "line": 5, "side": "LEFT"},
+                ],
+                "body": None,
+            },
+            client_calls=[
+                ClientForwardedCall(
+                    client_method="get_merge_request_versions",
+                    client_args=("79787061", "1"),
+                    client_kwds={},
+                    client_return_value=[
+                        {
+                            "id": 1692137080,
+                            "head_commit_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                            "base_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "start_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "created_at": "2026-03-05T11:16:06.468Z",
+                            "merge_request_id": 459277081,
+                            "state": "collected",
+                            "real_size": "1",
+                            "patch_id_sha": "7e2de654ed21ae09a78ad51592379d8a582e90ff",
+                        },
+                        {
+                            "id": 1682341969,
+                            "head_commit_sha": "6d8ca33dae268d3c5835e721e5702ef9dcb43c8c",
+                            "base_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "start_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "created_at": "2026-02-26T08:48:23.979Z",
+                            "merge_request_id": 459277081,
+                            "state": "collected",
+                            "real_size": "1",
+                            "patch_id_sha": "f86adf0229d6ac6d77ac8d2087cd5fae3cc052d8",
+                        },
+                    ],
+                ),
+                ClientForwardedCall(
+                    client_method="create_merge_request_discussion",
+                    client_args=(
+                        "79787061",
+                        "1",
+                        {
+                            "body": "old code note",
+                            "position": {
+                                "base_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                                "head_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                                "start_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                                "new_path": "BLAH.md",
+                                "old_path": "BLAH.md",
+                                "position_type": "text",
+                                "old_line": "5",
+                            },
+                        },
+                    ),
+                    client_kwds={},
+                    client_return_value={},
+                ),
+            ],
+            provider_return_value={
+                "data": {"id": "", "html_url": ""},
+                "type": "gitlab",
+                "raw": {},
+                "meta": {},
+            },
+        ),
+        # --- create_review: full review (inline comment + body + approval) ---
+        ForwardToClientTest(
+            provider_method=GitLabProvider.create_review,
+            provider_args={
+                "pull_request_id": "1",
+                "commit_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                "event": "approve",
+                "comments": [
+                    {"path": "BLAH.md", "body": "nice", "line": 3},
+                ],
+                "body": "Approving",
+            },
+            client_calls=[
+                ClientForwardedCall(
+                    client_method="get_merge_request_versions",
+                    client_args=("79787061", "1"),
+                    client_kwds={},
+                    client_return_value=[
+                        {
+                            "id": 1692137080,
+                            "head_commit_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                            "base_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "start_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "created_at": "2026-03-05T11:16:06.468Z",
+                            "merge_request_id": 459277081,
+                            "state": "collected",
+                            "real_size": "1",
+                            "patch_id_sha": "7e2de654ed21ae09a78ad51592379d8a582e90ff",
+                        },
+                        {
+                            "id": 1682341969,
+                            "head_commit_sha": "6d8ca33dae268d3c5835e721e5702ef9dcb43c8c",
+                            "base_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "start_commit_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                            "created_at": "2026-02-26T08:48:23.979Z",
+                            "merge_request_id": 459277081,
+                            "state": "collected",
+                            "real_size": "1",
+                            "patch_id_sha": "f86adf0229d6ac6d77ac8d2087cd5fae3cc052d8",
+                        },
+                    ],
+                ),
+                ClientForwardedCall(
+                    client_method="create_merge_request_discussion",
+                    client_args=(
+                        "79787061",
+                        "1",
+                        {
+                            "body": "nice",
+                            "position": {
+                                "base_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                                "head_sha": "7497e018d01503b6abc3053b7896266115e631f6",
+                                "start_sha": "0941ee0a9eac9914cfddf5adec7a9558a2f1c447",
+                                "new_path": "BLAH.md",
+                                "old_path": "BLAH.md",
+                                "position_type": "text",
+                                "new_line": "3",
+                            },
+                        },
+                    ),
+                    client_kwds={},
+                    client_return_value={},
+                ),
+                ClientForwardedCall(
+                    client_method="create_merge_request_note",
+                    client_args=("79787061", "1", {"body": "Approving"}),
+                    client_kwds={},
+                    client_return_value={"id": 99},
+                ),
+                ClientForwardedCall(
+                    client_method="approve_merge_request",
+                    client_args=("79787061", "1"),
+                    client_kwds={},
+                    client_return_value={"id": 100},
+                ),
+            ],
+            provider_return_value={
+                "data": {"id": "100", "html_url": ""},
+                "type": "gitlab",
+                "raw": {"id": 100},
+                "meta": {},
+            },
+        ),
     ],
     ids=lambda param: param.provider_method.__name__,
 )
@@ -13111,3 +13387,16 @@ class TestGetArchiveLink:
         result = provider.get_archive_link("")
 
         assert "?sha=" not in result["data"]["url"]
+
+
+class TestCreateReview:
+    def test_change_request_raises(self, provider: GitLabProvider, client: unittest.mock.MagicMock):
+        with pytest.raises(SCMProviderException, match="REQUEST_CHANGES"):
+            provider.create_review(
+                pull_request_id="1",
+                commit_sha="abc",
+                event="change_request",
+                comments=[],
+                body=None,
+            )
+        assert client.mock_calls == []


### PR DESCRIPTION
This adds a `create_review` GitLab implementation. It is not 1:1 to GitHub because you cannot approve + post review comments in the same request for GitLab _and_ there is no equivalent to "changes requested".

This GitLab implementation requires an API request per:

- each inline comment review
- overall review comment
- approving merge request
