### PR TITLE
feat(snapshots): backend changes to make renames use SnapshotDiffPair

### DIFF
--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -27,7 +27,6 @@ class SnapshotImageResponse(BaseModel):
     image_file_name: str
     width: int
     height: int
-    previous_image_file_name: str | None = None
 
     class Config:
         extra = "allow"
@@ -65,7 +64,7 @@ class SnapshotDetailsApiResponse(BaseModel):
     removed: list[SnapshotImageResponse] = []
     removed_count: int = 0
 
-    renamed: list[SnapshotImageResponse] = []
+    renamed: list[SnapshotDiffPair] = []
     renamed_count: int = 0
 
     changed: list[SnapshotDiffPair] = []

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -19,7 +19,7 @@ class CategorizedComparison(BaseModel):
     added: list[SnapshotImageResponse] = []
     removed: list[SnapshotImageResponse] = []
     unchanged: list[SnapshotImageResponse] = []
-    renamed: list[SnapshotImageResponse] = []
+    renamed: list[SnapshotDiffPair] = []
     errored: list[SnapshotDiffPair] = []
 
 
@@ -83,8 +83,14 @@ def categorize_comparison_images(
             result.removed.append(base_img or _base_image_from_comparison(name, img))
         elif img.status == "renamed":
             if head_img:
-                head_img.previous_image_file_name = img.previous_image_file_name
-                result.renamed.append(head_img)
+                old_name = img.previous_image_file_name
+                base = base_images_by_file_name.get(old_name) if old_name else None
+                result.renamed.append(
+                    SnapshotDiffPair(
+                        base_image=base or _base_image_from_comparison(old_name or name, img),
+                        head_image=head_img,
+                    )
+                )
         elif img.status == "unchanged":
             if head_img:
                 result.unchanged.append(head_img)

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Text} from '@sentry/scraps/text';
 
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -43,7 +43,7 @@ export function SnapshotHeaderContent({projectId, data}: SnapshotHeaderContentPr
         </Flex>
         <Layout.Title>
           {/* TODO: Replace with app-id/version when available */}
-          <Heading as="h2">{t('Snapshots')}</Heading>
+          {t('Snapshots')}
           <Flex align="center" gap="md" wrap="wrap">
             {prUrl && vcs_info.pr_number && (
               <ExternalLink href={prUrl}>

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -148,7 +148,56 @@ export function SnapshotMainContent({
     );
   }
 
-  // added, removed, renamed, unchanged
+  if (selectedItem.type === 'renamed') {
+    const currentPair = selectedItem.pairs[variantIndex];
+    if (!currentPair) {
+      return null;
+    }
+    const totalVariants = selectedItem.pairs.length;
+    const imageUrl = `${imageBaseUrl}${currentPair.head_image.key}/`;
+    const displayName = getImageName(currentPair.head_image);
+
+    return (
+      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+        <Flex align="center" gap="md" padding="xl">
+          {totalVariants > 1 && (
+            <VariantNavigation
+              variantIndex={variantIndex}
+              totalVariants={totalVariants}
+              onVariantChange={onVariantChange}
+            />
+          )}
+          <Stack gap="md">
+            <Flex align="center" gap="md">
+              {currentPair.head_image.display_name && (
+                <Text size="lg" bold>
+                  {currentPair.head_image.display_name}
+                </Text>
+              )}
+              <ImageFileName
+                fileName={currentPair.head_image.image_file_name}
+                previousFileName={currentPair.base_image.image_file_name}
+              />
+            </Flex>
+            <Flex align="center" gap="sm">
+              <Text variant="muted" size="sm">
+                ({t('Renamed')})
+              </Text>
+              {totalVariants > 1 && (
+                <Text variant="muted" size="sm">
+                  {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+                </Text>
+              )}
+            </Flex>
+          </Stack>
+        </Flex>
+        <Separator orientation="horizontal" />
+        <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
+      </Flex>
+    );
+  }
+
+  // added, removed, unchanged
   const currentImage = selectedItem.images[variantIndex];
   if (!currentImage) {
     return null;
@@ -159,7 +208,6 @@ export function SnapshotMainContent({
   const STATUS_LABELS: Record<string, string> = {
     added: t('Added'),
     removed: t('Removed'),
-    renamed: t('Renamed'),
   };
   const statusLabel = STATUS_LABELS[selectedItem.type] ?? t('Unchanged');
 
@@ -180,24 +228,7 @@ export function SnapshotMainContent({
                 {currentImage.display_name}
               </Text>
             )}
-            {currentImage.image_file_name &&
-              (selectedItem.type === 'renamed' &&
-              currentImage.previous_image_file_name ? (
-                <Tooltip
-                  title={
-                    <span>
-                      <InlineCode>{currentImage.previous_image_file_name}</InlineCode>
-                      {' → '}
-                      <InlineCode>{currentImage.image_file_name}</InlineCode>
-                    </span>
-                  }
-                  maxWidth={2000}
-                >
-                  <InlineCode>{currentImage.image_file_name}</InlineCode>
-                </Tooltip>
-              ) : (
-                <InlineCode variant="neutral">{currentImage.image_file_name}</InlineCode>
-              ))}
+            <ImageFileName fileName={currentImage.image_file_name} />
           </Flex>
           <Flex align="center" gap="sm">
             <Text variant="muted" size="sm">
@@ -246,6 +277,32 @@ function VariantNavigation({
       />
     </Flex>
   );
+}
+
+function ImageFileName({
+  fileName,
+  previousFileName,
+}: {
+  fileName: string;
+  previousFileName?: string;
+}) {
+  if (previousFileName) {
+    return (
+      <Tooltip
+        title={
+          <span>
+            <InlineCode>{previousFileName}</InlineCode>
+            {' → '}
+            <InlineCode>{fileName}</InlineCode>
+          </span>
+        }
+        maxWidth={2000}
+      >
+        <InlineCode>{fileName}</InlineCode>
+      </Tooltip>
+    );
+  }
+  return <InlineCode variant="neutral">{fileName}</InlineCode>;
 }
 
 function OverlayControls({

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -76,11 +76,7 @@ export function SnapshotMainContent({
                     {currentPair.head_image.display_name}
                   </Text>
                 )}
-                {currentPair.head_image.image_file_name && (
-                  <InlineCode variant="neutral">
-                    {currentPair.head_image.image_file_name}
-                  </InlineCode>
-                )}
+                <ImageFileName fileName={currentPair.head_image.image_file_name} />
               </Flex>
               {totalVariants > 1 && (
                 <Text variant="muted" size="sm">
@@ -286,6 +282,9 @@ function ImageFileName({
   fileName: string;
   previousFileName?: string;
 }) {
+  if (!fileName) {
+    return null;
+  }
   if (previousFileName) {
     return (
       <Tooltip

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -7,6 +7,7 @@ import {InlineCode} from '@sentry/scraps/code';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -179,9 +180,24 @@ export function SnapshotMainContent({
                 {currentImage.display_name}
               </Text>
             )}
-            {currentImage.image_file_name && (
-              <InlineCode variant="neutral">{currentImage.image_file_name}</InlineCode>
-            )}
+            {currentImage.image_file_name &&
+              (selectedItem.type === 'renamed' &&
+              currentImage.previous_image_file_name ? (
+                <Tooltip
+                  title={
+                    <span>
+                      <InlineCode>{currentImage.previous_image_file_name}</InlineCode>
+                      {' → '}
+                      <InlineCode>{currentImage.image_file_name}</InlineCode>
+                    </span>
+                  }
+                  maxWidth={2000}
+                >
+                  <InlineCode>{currentImage.image_file_name}</InlineCode>
+                </Tooltip>
+              ) : (
+                <InlineCode variant="neutral">{currentImage.image_file_name}</InlineCode>
+              ))}
           </Flex>
           <Flex align="center" gap="sm">
             <Text variant="muted" size="sm">

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -126,9 +126,30 @@ export default function SnapshotsPage() {
         });
       }
 
+      const renamedGroups = new Map<string, SnapshotDiffPair[]>();
+      for (const pair of data.renamed ?? []) {
+        const group = getImageGroup(pair.head_image);
+        const existing = renamedGroups.get(group);
+        if (existing) {
+          existing.push(pair);
+        } else {
+          renamedGroups.set(group, [pair]);
+        }
+      }
+      for (const [groupKey, pairs] of renamedGroups) {
+        const label = pairs[0]!.head_image.group ?? pairs[0]!.head_image.image_file_name;
+        items.push({
+          type: 'renamed',
+          key: `renamed:${groupKey}`,
+          name: label,
+          badge: null,
+          pairs,
+        });
+      }
+
       const groupImages = (
         imgs: SnapshotImage[],
-        type: 'added' | 'removed' | 'renamed' | 'unchanged'
+        type: 'added' | 'removed' | 'unchanged'
       ) => {
         const groups = new Map<string, SnapshotImage[]>();
         for (const img of imgs) {
@@ -154,7 +175,6 @@ export default function SnapshotsPage() {
 
       groupImages(data.added, 'added');
       groupImages(data.removed, 'removed');
-      groupImages(data.renamed ?? [], 'renamed');
       groupImages(data.unchanged, 'unchanged');
 
       computeSidebarBadges(items);
@@ -203,7 +223,7 @@ export default function SnapshotsPage() {
   // Clamp variantIndex to valid range when the selected item changes implicitly
   // (e.g. search filtering selects a new item with fewer variants)
   const variantCount = currentItem
-    ? currentItem.type === 'changed'
+    ? currentItem.type === 'changed' || currentItem.type === 'renamed'
       ? currentItem.pairs.length
       : currentItem.images.length
     : 0;

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -7,7 +7,6 @@ export interface SnapshotImage {
   group?: string | null;
   height: number;
   key: string;
-  previous_image_file_name?: string;
   width: number;
 }
 
@@ -43,7 +42,7 @@ export interface SnapshotDetailsApiResponse {
   changed_count: number;
   removed: SnapshotImage[];
   removed_count: number;
-  renamed?: SnapshotImage[];
+  renamed?: SnapshotDiffPair[];
   renamed_count?: number;
   unchanged: SnapshotImage[];
   unchanged_count: number;
@@ -80,8 +79,8 @@ interface SidebarItemBase {
 
 export type SidebarItem =
   | (SidebarItemBase & {type: 'solo'; images: SnapshotImage[]})
-  | (SidebarItemBase & {type: 'changed'; pairs: SnapshotDiffPair[]})
+  | (SidebarItemBase & {type: 'changed' | 'renamed'; pairs: SnapshotDiffPair[]})
   | (SidebarItemBase & {
-      type: 'added' | 'removed' | 'renamed' | 'unchanged';
+      type: 'added' | 'removed' | 'unchanged';
       images: SnapshotImage[];
     });

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -79,7 +79,8 @@ interface SidebarItemBase {
 
 export type SidebarItem =
   | (SidebarItemBase & {type: 'solo'; images: SnapshotImage[]})
-  | (SidebarItemBase & {type: 'changed' | 'renamed'; pairs: SnapshotDiffPair[]})
+  | (SidebarItemBase & {type: 'changed'; pairs: SnapshotDiffPair[]})
+  | (SidebarItemBase & {type: 'renamed'; pairs: SnapshotDiffPair[]})
   | (SidebarItemBase & {
       type: 'added' | 'removed' | 'unchanged';
       images: SnapshotImage[];

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -7,6 +7,7 @@ export interface SnapshotImage {
   group?: string | null;
   height: number;
   key: string;
+  previous_image_file_name?: string;
   width: number;
 }
 

--- a/static/app/views/preprod/utils/sidebarUtils.ts
+++ b/static/app/views/preprod/utils/sidebarUtils.ts
@@ -21,6 +21,13 @@ export function computeSidebarBadges(items: SidebarItem[]): void {
       continue;
     }
 
+    if (item.type === 'renamed') {
+      if (item.pairs.length > 1) {
+        item.badge = String(item.pairs.length);
+      }
+      continue;
+    }
+
     if (item.images.length > 1) {
       item.badge = String(item.images.length);
     }


### PR DESCRIPTION
## Summary

Follow-up to #111325 — refactors renamed snapshot items to use `SnapshotDiffPair` instead of a flat `SnapshotImageResponse` with a `previous_image_file_name` field.

A rename is conceptually a diff from old image → new image, so the pair structure naturally models this:
- `base_image` = old filename (looked up by `previous_image_file_name`)
- `head_image` = new filename
- `diff` / `diff_image_key` remain `None` (no visual diff for renames)

### Changes

- **`SnapshotImageResponse`**: Remove `previous_image_file_name` field (no longer needed in API response)
- **`SnapshotDetailsApiResponse`**: Change `renamed` from `list[SnapshotImageResponse]` to `list[SnapshotDiffPair]`
- **`CategorizedComparison`**: Same type change for `renamed`
- **`categorize_comparison_images`**: Build `SnapshotDiffPair` for renamed items by looking up base image by old filename from `base_images_by_file_name`

Note: `previous_image_file_name` is kept on `ComparisonImageResult` in `manifest.py` — that's internal transport from tasks → categorizer, not part of the API response.

## Test plan

- [ ] Existing backend snapshot tests pass
- [ ] Frontend PR (#111325) updated to consume renamed as `SnapshotDiffPair[]`
- [ ] Manual: renamed items show tooltip with old → new filename