### PR TITLE
feat(onboarding): Sync feature selections from context to SetupDocs URL params

### DIFF
--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -256,7 +256,11 @@ export function OnboardingWithoutContext() {
   });
 
   const goNextStep = useCallback(
-    (step: StepDescriptor, platform?: OnboardingSelectedSDK) => {
+    (
+      step: StepDescriptor,
+      platform?: OnboardingSelectedSDK,
+      query?: Record<string, string[]>
+    ) => {
       const currentStepIndex = onboardingSteps.findIndex(s => s.id === step.id);
       const nextStep = onboardingSteps[currentStepIndex + 1]!;
 
@@ -268,7 +272,8 @@ export function OnboardingWithoutContext() {
         return;
       }
 
-      navigate(normalizeUrl(`/onboarding/${organization.slug}/${nextStep.id}/`));
+      const pathname = `/onboarding/${organization.slug}/${nextStep.id}/`;
+      navigate(query ? normalizeUrl({pathname, query}) : normalizeUrl(pathname));
     },
     [organization.slug, navigate, onboardingSteps, onboardingContext.selectedPlatform]
   );
@@ -373,9 +378,9 @@ export function OnboardingWithoutContext() {
               <stepObj.Component
                 data-test-id={`onboarding-step-${stepObj.id}`}
                 stepIndex={stepIndex}
-                onComplete={platform => {
+                onComplete={(platform, query) => {
                   if (stepObj) {
-                    goNextStep(stepObj, platform);
+                    goNextStep(stepObj, platform, query);
                   }
                 }}
                 recentCreatedProject={recentCreatedProject}

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -26,7 +26,8 @@ import {
 import type {StepProps} from './types';
 
 export function ScmProjectDetails({onComplete}: StepProps) {
-  const {selectedPlatform, setCreatedProjectSlug} = useOnboardingContext();
+  const {selectedPlatform, selectedFeatures, setCreatedProjectSlug} =
+    useOnboardingContext();
   const {teams} = useTeams();
   const createProjectAndRules = useCreateProjectAndRules();
 
@@ -86,7 +87,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
       // selectedPlatform.key (which the platform features step needs).
       setCreatedProjectSlug(project.slug);
 
-      onComplete();
+      onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);
     } catch (error) {
       addErrorMessage(t('Failed to create project'));
       Sentry.captureException(error);
@@ -99,6 +100,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     teamSlugResolved,
     alertRuleConfig,
     createNotificationAction,
+    selectedFeatures,
     setCreatedProjectSlug,
     onComplete,
   ]);

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -426,7 +426,7 @@ describe('Onboarding Setup Docs', () => {
     });
   });
 
-  it('syncs feature selections from context to URL params', async () => {
+  it('reads feature selections from URL params', async () => {
     const organization = OrganizationFixture();
     const project = ProjectFixture({
       slug: 'javascript-nextjs',
@@ -439,28 +439,33 @@ describe('Onboarding Setup Docs', () => {
     renderMockRequests({project, orgSlug: organization.slug});
 
     const {router} = render(
-      <OnboardingContextProvider
-        initialValue={{
-          selectedFeatures: [
-            ProductSolution.PERFORMANCE_MONITORING,
-            ProductSolution.SESSION_REPLAY,
-          ],
-        }}
-      >
-        <SetupDocs
-          onComplete={() => {}}
-          stepIndex={2}
-          genSkipOnboardingLink={() => ''}
-          recentCreatedProject={project}
-        />
-      </OnboardingContextProvider>
+      <SetupDocs
+        onComplete={() => {}}
+        stepIndex={2}
+        genSkipOnboardingLink={() => ''}
+        recentCreatedProject={project}
+      />,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/onboarding/setup-docs/',
+            query: {
+              product: [
+                ProductSolution.PERFORMANCE_MONITORING,
+                ProductSolution.SESSION_REPLAY,
+              ],
+            },
+          },
+        },
+      }
     );
 
     expect(
       await screen.findByRole('heading', {name: 'Configure Next.js SDK'})
     ).toBeInTheDocument();
 
-    // Features from context should be synced to URL params
+    // Features should be available from URL params
     expect(router.location.query.product).toEqual([
       ProductSolution.PERFORMANCE_MONITORING,
       ProductSolution.SESSION_REPLAY,

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -425,4 +425,45 @@ describe('Onboarding Setup Docs', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('syncs feature selections from context to URL params', async () => {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({
+      slug: 'javascript-nextjs',
+      platform: 'javascript-nextjs',
+    });
+
+    ProjectsStore.init();
+    ProjectsStore.loadInitialData([project]);
+
+    renderMockRequests({project, orgSlug: organization.slug});
+
+    const {router} = render(
+      <OnboardingContextProvider
+        initialValue={{
+          selectedFeatures: [
+            ProductSolution.PERFORMANCE_MONITORING,
+            ProductSolution.SESSION_REPLAY,
+          ],
+        }}
+      >
+        <SetupDocs
+          onComplete={() => {}}
+          stepIndex={2}
+          genSkipOnboardingLink={() => ''}
+          recentCreatedProject={project}
+        />
+      </OnboardingContextProvider>
+    );
+
+    expect(
+      await screen.findByRole('heading', {name: 'Configure Next.js SDK'})
+    ).toBeInTheDocument();
+
+    // Features from context should be synced to URL params
+    expect(router.location.query.product).toEqual([
+      ProductSolution.PERFORMANCE_MONITORING,
+      ProductSolution.SESSION_REPLAY,
+    ]);
+  });
 });

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -1,11 +1,10 @@
-import {Fragment, useEffect, useMemo, useRef} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
 
 import {SdkDocumentation} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {otherPlatform, allPlatforms as platforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -15,7 +14,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SetupIntroduction} from 'sentry/views/onboarding/components/setupIntroduction';
-import {useOnboardingQueryParams} from 'sentry/views/onboarding/components/useOnboardingQueryParams';
 import {OtherPlatformsInfo} from 'sentry/views/projectInstall/otherPlatformsInfo';
 
 import {FirstEventFooter} from './components/firstEventFooter';
@@ -25,20 +23,6 @@ export function SetupDocs({recentCreatedProject: project}: StepProps) {
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
-  const [, setOnboardingParams] = useOnboardingQueryParams();
-  const {selectedFeatures} = useOnboardingContext();
-  const hasSyncedRef = useRef(false);
-
-  // Sync feature selections from context into URL params on first mount
-  // so the inline ProductSelection checkboxes reflect the user's choices
-  // from the SCM_PLATFORM_FEATURES step.
-  useEffect(() => {
-    if (selectedFeatures && selectedFeatures.length > 0 && !hasSyncedRef.current) {
-      hasSyncedRef.current = true;
-      setOnboardingParams({product: selectedFeatures});
-    }
-  }, [selectedFeatures, setOnboardingParams]);
-
   const products = useMemo<ProductSolution[]>(
     () => decodeList(location.query.product ?? []) as ProductSolution[],
     [location.query.product]

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -1,10 +1,11 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
 
 import {SdkDocumentation} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {otherPlatform, allPlatforms as platforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -14,6 +15,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SetupIntroduction} from 'sentry/views/onboarding/components/setupIntroduction';
+import {useOnboardingQueryParams} from 'sentry/views/onboarding/components/useOnboardingQueryParams';
 import {OtherPlatformsInfo} from 'sentry/views/projectInstall/otherPlatformsInfo';
 
 import {FirstEventFooter} from './components/firstEventFooter';
@@ -23,6 +25,19 @@ export function SetupDocs({recentCreatedProject: project}: StepProps) {
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
+  const [, setOnboardingParams] = useOnboardingQueryParams();
+  const {selectedFeatures} = useOnboardingContext();
+  const hasSyncedRef = useRef(false);
+
+  // Sync feature selections from context into URL params on first mount
+  // so the inline ProductSelection checkboxes reflect the user's choices
+  // from the SCM_PLATFORM_FEATURES step.
+  useEffect(() => {
+    if (selectedFeatures && selectedFeatures.length > 0 && !hasSyncedRef.current) {
+      hasSyncedRef.current = true;
+      setOnboardingParams({product: selectedFeatures});
+    }
+  }, [selectedFeatures, setOnboardingParams]);
 
   const products = useMemo<ProductSolution[]>(
     () => decodeList(location.query.product ?? []) as ProductSolution[],

--- a/static/app/views/onboarding/types.ts
+++ b/static/app/views/onboarding/types.ts
@@ -3,7 +3,10 @@ import type {Project} from 'sentry/types/project';
 
 export type StepProps = {
   genSkipOnboardingLink: () => React.ReactNode;
-  onComplete: (selectedPlatforms?: OnboardingSelectedSDK) => void;
+  onComplete: (
+    selectedPlatforms?: OnboardingSelectedSDK,
+    query?: Record<string, string[]>
+  ) => void;
   stepIndex: number;
   recentCreatedProject?: Project;
 };

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -36,9 +36,7 @@ export function useBackActions({
   const currentStep = onboardingSteps[stepIndex];
 
   const deleteRecentCreatedProject = useCallback(
-    async ({
-      preserveOnboardingState = false,
-    }: {preserveOnboardingState?: boolean} = {}) => {
+    async (preserveOnboardingState = false) => {
       if (!recentCreatedProject) {
         return;
       }
@@ -120,9 +118,7 @@ export function useBackActions({
         // store data and skip project creation.
         // In the SCM flow, preserve context so the user keeps their SCM
         // connection, repo selection, and feature choices.
-        await deleteRecentCreatedProject({
-          preserveOnboardingState: prevStep.id === 'scm-project-details',
-        });
+        await deleteRecentCreatedProject(prevStep.id === 'scm-project-details');
       }
 
       if (!browserBackButton) {


### PR DESCRIPTION
When a user selects features in the SCM_PLATFORM_FEATURES step, those choices are stored in OnboardingContext. The SetupDocs step reads product selections from URL params (used by the inline ProductSelection component). This PR passes feature selections as query params through the `onComplete` -> `goNextStep` -> `navigate` chain so they arrive in the URL when navigating to setup-docs. No mount-time sync effect needed.

The `onComplete` callback and `goNextStep` accept an optional `query` parameter that is forwarded to `navigate()` via `normalizeUrl`. scmProjectDetails passes `{product: selectedFeatures}` when calling `onComplete`, so the URL already contains the correct product selections when SetupDocs mounts. Legacy flow is unaffected since query is only passed when provided.

## PR stack

- [PR 1: SCM platform & features step](https://github.com/getsentry/sentry/pull/111160)
- [PR 2: SCM project details step](https://github.com/getsentry/sentry/pull/111306)
- **PR 3 (this): Sync feature selections to SetupDocs**

Refs VDY-30