### PR TITLE
feat(tracemetrics): Add referrer for raw count normal extrapolated request

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -132,6 +132,9 @@ class Referrer(StrEnum):
     API_EXPLORE_LOGS_RAW_COUNT_NORMAL = "api.explore.logs.raw-count.normal"
     API_EXPLORE_LOGS_RAW_COUNT_HIGH_ACCURACY = "api.explore.logs.raw-count.high-accuracy"
     API_EXPLORE_TRACEMETRICS_RAW_COUNT_NORMAL = "api.explore.tracemetrics.raw-count.normal"
+    API_EXPLORE_TRACEMETRICS_RAW_COUNT_NORMAL_EXTRAPOLATED_TOTAL = (
+        "api.explore.tracemetrics.raw-count.normal-extrapolated-total"
+    )
     API_EXPLORE_TRACEMETRICS_RAW_COUNT_HIGH_ACCURACY = (
         "api.explore.tracemetrics.raw-count.high-accuracy"
     )


### PR DESCRIPTION
We're going to use a normal request with an extrapolated server-only count for the total # of metrics call for a widget. This works because right now metrics are sampled at 100% so the server only count is a close approximation of our stored count. Adds a referrer to make sure this is queryable