### PR TITLE
ref(spans): add tests and small clean up for spans buffer

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -148,7 +148,6 @@ class FlushedSegment(NamedTuple):
         0.0  # Queue score at flush time, used for conditional cleanup in done_flush_segments
     )
     ingested_count: int = 0  # Ingested count at flush time, used for conditional data cleanup
-    distributed_payload_keys: list[DistributedPayloadKey] = []  # For cleanup
 
 
 class SpansBuffer:
@@ -166,7 +165,6 @@ class SpansBuffer:
         self._buffer_logger = BufferLogger()
         self._flusher_logger = FlusherLogger()
         self._debug_trace_logger: DebugTraceLogger | None = None
-        self._distributed_payload_keys_map: dict[SegmentKey, list[bytes]] = {}
 
     @cached_property
     def client(self) -> RedisCluster[bytes] | StrictRedis[bytes]:
@@ -187,21 +185,6 @@ class SpansBuffer:
     def _get_payload_key_index(self, segment_key: SegmentKey) -> bytes:
         project_id, trace_id, span_id = parse_segment_key(segment_key)
         return b"span-buf:mk:{%s:%s}:%s" % (project_id, trace_id, span_id)
-
-    def _cleanup_distributed_keys(self, segment_keys: set[SegmentKey]) -> None:
-        """Delete member-keys tracking sets and distributed payload keys for the
-        given segments, and remove them from the payload keys map so
-        done_flush_segments doesn't try again."""
-        with self.client.pipeline(transaction=False) as p:
-            for key in segment_keys:
-                payload_keys = self._distributed_payload_keys_map.get(key, [])
-                if payload_keys:
-                    mk_key = self._get_payload_key_index(key)
-                    p.delete(mk_key)
-                    for distributed_key in payload_keys:
-                        p.unlink(distributed_key)
-                self._distributed_payload_keys_map.pop(key, None)
-            p.execute()
 
     @metrics.wraps("spans.buffer.process_spans")
     def process_spans(self, spans: Sequence[Span], now: int):
@@ -642,7 +625,6 @@ class SpansBuffer:
                 project_id=int(project_id.decode("ascii")),
                 score=score,
                 ingested_count=ingested_counts.get(segment_key, 0),
-                distributed_payload_keys=self._distributed_payload_keys_map.get(segment_key, []),
             )
             num_has_root_spans += int(has_root_span)
 
@@ -686,46 +668,6 @@ class SpansBuffer:
         self.any_shard_at_limit = any_shard_at_limit
         return return_segments
 
-    def _apply_per_trace_limit(
-        self,
-        segment_keys: list[tuple[int, QueueKey, SegmentKey]],
-        max_per_trace: int,
-        now: int,
-    ) -> list[tuple[int, QueueKey, SegmentKey]]:
-        """
-        Limits how many segments a single trace can be flushed in one cycle.
-        Prevents a trace from monopolizing the cycle and concentrating all
-        operations on one Redis node.
-
-        Deferred segments have their score set to ``now`` so they no longer
-        sit at the front of the sorted set.  This avoids head-of-line
-        blocking where a hot trace's overdue segments are re-fetched and
-        re-discarded every cycle.
-        """
-        if max_per_trace <= 0:
-            return segment_keys
-        trace_counts: dict[bytes, int] = {}
-        accepted: list[tuple[int, QueueKey, SegmentKey]] = []
-        deferred: list[tuple[int, QueueKey, SegmentKey]] = []
-        for shard, queue_key, segment_key in segment_keys:
-            _, trace_id, _ = parse_segment_key(segment_key)
-            count = trace_counts.get(trace_id, 0)
-            if count < max_per_trace:
-                accepted.append((shard, queue_key, segment_key))
-                trace_counts[trace_id] = count + 1
-            else:
-                deferred.append((shard, queue_key, segment_key))
-
-        if deferred:
-            num_deferred = len(deferred)
-            metrics.incr("spans.buffer.flush_segments.deferred", amount=num_deferred)
-            with self.client.pipeline(transaction=False) as p:
-                for shard, queue_key, segment_key in deferred:
-                    p.zadd(queue_key, {segment_key: now})
-                p.execute()
-
-        return accepted
-
     def _load_segment_data(
         self,
         segment_keys: list[SegmentKey],
@@ -764,27 +706,22 @@ class SpansBuffer:
                 scan_key_to_segment[key] = key
                 cursors[key] = 0
 
-        self._distributed_payload_keys_map = {}
-
         if write_distributed_payloads:
             with self.client.pipeline(transaction=False) as p:
                 for key in segment_keys:
                     p.smembers(self._get_payload_key_index(key))
                 mk_results = p.execute()
 
-            for key, sub_span_ids in zip(segment_keys, mk_results):
+            for key, payload_key_span_ids in zip(segment_keys, mk_results):
                 project_id, trace_id, _ = parse_segment_key(key)
-                pat = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
-                distributed_keys: list[bytes] = []
-                for sub_span_id in sub_span_ids:
+                project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
+                for payload_key_span_id in payload_key_span_ids:
                     distributed_key = self._get_distributed_payload_key(
-                        pat, sub_span_id.decode("ascii")
+                        project_and_trace, payload_key_span_id.decode("ascii")
                     )
-                    distributed_keys.append(distributed_key)
                     if read_distributed_payloads:
                         scan_key_to_segment[distributed_key] = key
                         cursors[distributed_key] = 0
-                self._distributed_payload_keys_map[key] = distributed_keys
 
         dropped_segments: set[SegmentKey] = set()
 
@@ -838,9 +775,6 @@ class SpansBuffer:
                     del cursors[key]
                 else:
                     cursors[key] = cursor
-
-        if dropped_segments:
-            self._cleanup_distributed_keys(dropped_segments)
 
         # Fetch ingested counts for all segments to calculate dropped spans
         with self.client.pipeline(transaction=False) as p:
@@ -936,6 +870,7 @@ class SpansBuffer:
         metrics.timing("spans.buffer.done_flush_segments.num_segments", len(segment_keys))
         with metrics.timer("spans.buffer.done_flush_segments"):
             use_conditional_cleanup = options.get("spans.buffer.done-flush-conditional-zrem")
+            write_distributed_payloads = options.get("spans.buffer.write-distributed-payloads")
 
             segments_to_skip: set[SegmentKey] = set()
             if use_conditional_cleanup:
@@ -994,6 +929,18 @@ class SpansBuffer:
                         amount=skipped,
                     )
 
+            distributed_payload_key_spans: dict[SegmentKey, set[bytes]] = {}
+            if write_distributed_payloads:
+                active_keys = [sk for sk in segment_keys if sk not in segments_to_skip]
+                if active_keys:
+                    with self.client.pipeline(transaction=False) as p:
+                        for segment_key in active_keys:
+                            p.smembers(self._get_payload_key_index(segment_key))
+                        mk_results = p.execute()
+                    for segment_key, payload_key_span_ids in zip(active_keys, mk_results):
+                        if payload_key_span_ids:
+                            distributed_payload_key_spans[segment_key] = payload_key_span_ids
+
             queue_removals: dict[bytes, list[SegmentKey]] = {}
             with self.client.pipeline(transaction=False) as p:
                 for segment_key, flushed_segment in segment_keys.items():
@@ -1028,11 +975,19 @@ class SpansBuffer:
 
                         queue_removals.setdefault(flushed_segment.queue_key, []).append(segment_key)
 
-                    if flushed_segment.distributed_payload_keys:
-                        mk_key = self._get_payload_key_index(segment_key)
-                        p.delete(mk_key)
-                        for distributed_key in flushed_segment.distributed_payload_keys:
-                            p.unlink(distributed_key)
+                    payload_key_span_ids = distributed_payload_key_spans.get(segment_key)
+                    if payload_key_span_ids:
+                        project_id, trace_id, _ = parse_segment_key(segment_key)
+                        project_and_trace = (
+                            f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
+                        )
+                        p.delete(self._get_payload_key_index(segment_key))
+                        for span_id in payload_key_span_ids:
+                            p.unlink(
+                                self._get_distributed_payload_key(
+                                    project_and_trace, span_id.decode("ascii")
+                                )
+                            )
 
                 for queue_key, keys in queue_removals.items():
                     for key_batch in itertools.batched(keys, 100):

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -93,7 +93,7 @@ from sentry.spans.buffer_logger import (
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.spans.debug_trace_logger import DebugTraceLogger
 from sentry.spans.segment_key import (
-    DistributedPayloadKey,
+    PayloadKey,
     SegmentKey,
     parse_segment_key,
     segment_key_to_span_id,
@@ -148,6 +148,7 @@ class FlushedSegment(NamedTuple):
         0.0  # Queue score at flush time, used for conditional cleanup in done_flush_segments
     )
     ingested_count: int = 0  # Ingested count at flush time, used for conditional data cleanup
+    payload_keys: list[PayloadKey] = []  # For cleanup
 
 
 class SpansBuffer:
@@ -177,9 +178,7 @@ class SpansBuffer:
     def _get_span_key(self, project_and_trace: str, span_id: str) -> bytes:
         return f"span-buf:s:{{{project_and_trace}}}:{span_id}".encode("ascii")
 
-    def _get_distributed_payload_key(
-        self, project_and_trace: str, span_id: str
-    ) -> DistributedPayloadKey:
+    def _get_payload_key(self, project_and_trace: str, span_id: str) -> PayloadKey:
         return f"span-buf:s:{{{project_and_trace}:{span_id}}}:{span_id}".encode("ascii")
 
     def _get_payload_key_index(self, segment_key: SegmentKey) -> bytes:
@@ -238,10 +237,7 @@ class SpansBuffer:
                     for (project_and_trace, parent_span_id), subsegment in batch:
                         set_members = self._prepare_payloads(subsegment)
                         if write_distributed_payloads:
-                            # Write to distributed key.
-                            dist_key = self._get_distributed_payload_key(
-                                project_and_trace, parent_span_id
-                            )
+                            dist_key = self._get_payload_key(project_and_trace, parent_span_id)
                             p.sadd(dist_key, *set_members)
                             p.expire(dist_key, redis_ttl)
 
@@ -573,7 +569,7 @@ class SpansBuffer:
             segment_to_queue = {
                 segment_key: queue_key for _, queue_key, segment_key, _ in segment_keys
             }
-            segments, ingested_counts = self._load_segment_data(
+            segments, payload_keys_map, ingested_counts = self._load_segment_data(
                 [k for _, _, k, _ in segment_keys],
                 segment_to_queue,
                 now,
@@ -625,6 +621,7 @@ class SpansBuffer:
                 project_id=int(project_id.decode("ascii")),
                 score=score,
                 ingested_count=ingested_counts.get(segment_key, 0),
+                payload_keys=payload_keys_map.get(segment_key, []),
             )
             num_has_root_spans += int(has_root_span)
 
@@ -673,7 +670,9 @@ class SpansBuffer:
         segment_keys: list[SegmentKey],
         segment_to_queue: dict[SegmentKey, QueueKey],
         now: int,
-    ) -> tuple[dict[SegmentKey, list[bytes]], dict[SegmentKey, int]]:
+    ) -> tuple[
+        dict[SegmentKey, list[bytes]], dict[SegmentKey, list[PayloadKey]], dict[SegmentKey, int]
+    ]:
         """
         Loads the segments from Redis, given a list of segment keys. Segments
         exceeding a certain size are skipped, and an error is logged.
@@ -690,13 +689,14 @@ class SpansBuffer:
         write_distributed_payloads = options.get("spans.buffer.write-distributed-payloads")
 
         payloads: dict[SegmentKey, list[bytes]] = {key: [] for key in segment_keys}
+        payload_keys_map: dict[SegmentKey, list[PayloadKey]] = {key: [] for key in segment_keys}
         sizes: dict[SegmentKey, int] = {key: 0 for key in segment_keys}
         self._last_decompress_latency_ms = 0
         decompress_latency_ms = 0.0
 
         # Maps each scan key back to the segment it belongs to. For merged
         # keys these are the same; for distributed keys many map to one segment.
-        scan_key_to_segment: dict[SegmentKey | DistributedPayloadKey, SegmentKey] = {}
+        scan_key_to_segment: dict[SegmentKey | PayloadKey, SegmentKey] = {}
 
         # When read_distributed_payloads is off, scan merged segment keys directly.
         # When on, skip them — all data lives in distributed keys.
@@ -715,13 +715,16 @@ class SpansBuffer:
             for key, payload_key_span_ids in zip(segment_keys, mk_results):
                 project_id, trace_id, _ = parse_segment_key(key)
                 project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
+                segment_payload_keys: list[PayloadKey] = []
                 for payload_key_span_id in payload_key_span_ids:
-                    distributed_key = self._get_distributed_payload_key(
+                    payload_key = self._get_payload_key(
                         project_and_trace, payload_key_span_id.decode("ascii")
                     )
+                    segment_payload_keys.append(payload_key)
                     if read_distributed_payloads:
-                        scan_key_to_segment[distributed_key] = key
-                        cursors[distributed_key] = 0
+                        scan_key_to_segment[payload_key] = key
+                        cursors[payload_key] = 0
+                payload_keys_map[key] = segment_payload_keys
 
         dropped_segments: set[SegmentKey] = set()
 
@@ -864,13 +867,12 @@ class SpansBuffer:
 
         self._last_decompress_latency_ms = int(decompress_latency_ms)
 
-        return payloads, ingested_counts
+        return payloads, payload_keys_map, ingested_counts
 
     def done_flush_segments(self, segment_keys: dict[SegmentKey, FlushedSegment]):
         metrics.timing("spans.buffer.done_flush_segments.num_segments", len(segment_keys))
         with metrics.timer("spans.buffer.done_flush_segments"):
             use_conditional_cleanup = options.get("spans.buffer.done-flush-conditional-zrem")
-            write_distributed_payloads = options.get("spans.buffer.write-distributed-payloads")
 
             segments_to_skip: set[SegmentKey] = set()
             if use_conditional_cleanup:
@@ -929,18 +931,6 @@ class SpansBuffer:
                         amount=skipped,
                     )
 
-            distributed_payload_key_spans: dict[SegmentKey, set[bytes]] = {}
-            if write_distributed_payloads:
-                active_keys = [sk for sk in segment_keys if sk not in segments_to_skip]
-                if active_keys:
-                    with self.client.pipeline(transaction=False) as p:
-                        for segment_key in active_keys:
-                            p.smembers(self._get_payload_key_index(segment_key))
-                        mk_results = p.execute()
-                    for segment_key, payload_key_span_ids in zip(active_keys, mk_results):
-                        if payload_key_span_ids:
-                            distributed_payload_key_spans[segment_key] = payload_key_span_ids
-
             queue_removals: dict[bytes, list[SegmentKey]] = {}
             with self.client.pipeline(transaction=False) as p:
                 for segment_key, flushed_segment in segment_keys.items():
@@ -975,19 +965,11 @@ class SpansBuffer:
 
                         queue_removals.setdefault(flushed_segment.queue_key, []).append(segment_key)
 
-                    payload_key_span_ids = distributed_payload_key_spans.get(segment_key)
-                    if payload_key_span_ids:
-                        project_id, trace_id, _ = parse_segment_key(segment_key)
-                        project_and_trace = (
-                            f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
-                        )
-                        p.delete(self._get_payload_key_index(segment_key))
-                        for span_id in payload_key_span_ids:
-                            p.unlink(
-                                self._get_distributed_payload_key(
-                                    project_and_trace, span_id.decode("ascii")
-                                )
-                            )
+                    if flushed_segment.payload_keys:
+                        mk_key = self._get_payload_key_index(segment_key)
+                        p.delete(mk_key)
+                        for payload_key in flushed_segment.payload_keys:
+                            p.unlink(payload_key)
 
                 for queue_key, keys in queue_removals.items():
                     for key_batch in itertools.batched(keys, 100):

--- a/src/sentry/spans/segment_key.py
+++ b/src/sentry/spans/segment_key.py
@@ -6,10 +6,10 @@
 # The segment ID in the Kafka protocol is only the span ID.
 SegmentKey = bytes
 
-# DistributedPayloadKey is a Redis key for a payload set that uses a per-span
+# PayloadKey is a Redis key for a payload set that uses a per-span
 # hash tag: "span-buf:s:{project_id:trace_id:span_id}:span_id". This distributes
 # payloads across Redis cluster nodes instead of merging by trace in a single key.
-DistributedPayloadKey = bytes
+PayloadKey = bytes
 
 
 def parse_segment_key(segment_key: SegmentKey) -> tuple[bytes, bytes, bytes]:

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -9,7 +9,7 @@ import orjson
 import pytest
 import sentry_kafka_schemas
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
-from sentry_redis_tools.clients import StrictRedis
+from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.spans.buffer import FlushedSegment, OutputSpan, Span, SpansBuffer
@@ -118,7 +118,7 @@ def buffer(request):
             yield buf
 
 
-def assert_ttls(client: StrictRedis[bytes]):
+def assert_ttls(client: StrictRedis[bytes] | RedisCluster[bytes]):
     """
     Check that all keys have a TTL, because if the consumer dies before
     flushing, we should not leak memory.
@@ -128,7 +128,7 @@ def assert_ttls(client: StrictRedis[bytes]):
         assert client.ttl(k) > -1, k
 
 
-def assert_clean(client: StrictRedis[bytes]):
+def assert_clean(client: StrictRedis[bytes] | RedisCluster[bytes]):
     """
     Check that there's no leakage.
 
@@ -1380,16 +1380,36 @@ def _dspan(
     )
 
 
-@pytest.fixture(params=["phase1", "phase2", "phase3"])
+@pytest.fixture(
+    params=[
+        pytest.param(("cluster", phase), id=f"cluster-{phase}")
+        for phase in DISTRIBUTED_PHASE_OPTIONS
+    ]
+    + [pytest.param(("single", phase), id=f"single-{phase}") for phase in DISTRIBUTED_PHASE_OPTIONS]
+)
 def distributed_buffer(request):
-    opts = DISTRIBUTED_PHASE_OPTIONS[request.param]
+    redis_type, phase = request.param
+    opts = DISTRIBUTED_PHASE_OPTIONS[phase]
     with override_options(opts):
-        buf = SpansBuffer(assigned_shards=list(range(32)))
-        buf.client.flushdb()
-        yield buf
+        if redis_type == "cluster":
+            from sentry.testutils.helpers.redis import use_redis_cluster
+            from sentry.utils import redis as redis_utils
+
+            with use_redis_cluster(
+                "span-buffer",
+                with_settings={"SENTRY_SPAN_BUFFER_CLUSTER": "span-buffer"},
+            ):
+                buf = SpansBuffer(assigned_shards=list(range(32)))
+                buf.client.flushall()
+                yield buf
+                redis_utils.redis_clusters._clusters_bytes.pop("span-buffer", None)
+        else:
+            buf = SpansBuffer(assigned_shards=list(range(32)))
+            buf.client.flushdb()
+            yield buf
 
 
-def assert_clean_distributed(client: StrictRedis[bytes]):
+def assert_clean_distributed(client: StrictRedis[bytes] | RedisCluster[bytes]):
     remaining = [x for x in client.keys("*") if b":hrs:" not in x]
     assert not remaining, f"Leaked keys: {remaining}"
 


### PR DESCRIPTION
Small cleanup for spans buffer:
  - Removes `self._distributed_payload_keys_map` from `SpansBuffer` to eliminate coupling between `_load_segment_data` and `done_flush_segments`.
  - Removes `_apply_per_trace_limit` (unused)

Also adds RedisCluster to distributed tests.