### PR TITLE
ref(grouping): Simplify parameterizer code

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -296,7 +296,7 @@ class Parameterizer:
             # Only mark the parameterizer as experimental if there are actually any experiments
             # running. If there aren't, then both parameterizers use the default regex patterns, so
             # the "experimental" parameterizer isn't actually experimental.
-            and EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP != DEFAULT_PARAMETERIZATION_REGEXES_MAP
+            and any(r.experimental_pattern is not None for r in regexes)
         )
         self._parameterization_regex = self._make_regex_from_patterns(
             regex_pattern_keys or DEFAULT_PARAMETERIZATION_REGEXES_MAP.keys()

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -326,14 +326,20 @@ class Parameterizer:
         matches_counter: defaultdict[str, int] = defaultdict(int)
 
         def _handle_regex_match(match: re.Match[str]) -> str:
-            # Find the first (should be only) non-None match entry, and sub in the placeholder. For
-            # example, given the groupdict item `('hex', '0x40000015')`, this returns '<hex>' as a
-            # replacement for the original value in the string.
-            for key, value in match.groupdict().items():
-                if value is not None:
-                    matches_counter[key] += 1
-                    return f"<{key}>"
-            return ""
+            # Since
+            #   a) our regex consists of a bunch of named capturing groups separated by `|`,
+            #   b) no other capturing groups in the regex are named, and
+            #   c) there's nothing else in the regex,
+            # there should be exactly one named matching group, making the last matching group also
+            # the only matching group.
+            key = match.lastgroup
+            value = match.groupdict().get(key or "")  # Empty string for mypy appeasment
+
+            if not key or not value:  # Insurance - shouldn't happen IRL
+                return ""
+
+            matches_counter[key] += 1
+            return f"<{key}>"
 
         with metrics.timer(
             "grouping.parameterize", tags={"experimental": self._experimental}

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 
 from sentry.utils import metrics
 
@@ -298,29 +298,21 @@ class Parameterizer:
             # the "experimental" parameterizer isn't actually experimental.
             and any(r.experimental_pattern is not None for r in regexes)
         )
-        self._parameterization_regex = self._make_regex_from_patterns(
-            regex_pattern_keys or DEFAULT_PARAMETERIZATION_REGEXES_MAP.keys()
+
+        if self._experimental:
+            pattern_strings = [
+                r.experimental_pattern if r.experimental_pattern else r.pattern for r in regexes
+            ]
+        else:
+            pattern_strings = [r.pattern for r in regexes]
+
+        # Combine the individual patterns into one giant regex to check against. (This is faster
+        # than checking each pattern individually because it entails less overhead.)
+        self._parameterization_regex = re.compile(
+            # The `(?x)` tells the regex compiler to ignore comments and unescaped whitespace, so we
+            # can use newlines and indentation for better legibility when defining regexes
+            rf"(?x){'|'.join(pattern_strings)}"
         )
-
-    def _make_regex_from_patterns(self, pattern_keys: Iterable[str]) -> re.Pattern[str]:
-        """
-        Takes list of pattern keys and returns a compiled regex pattern that matches any of them.
-
-        @param pattern_keys: A list of keys to match in the _parameterization_regex_components dict.
-        @returns: A compiled regex pattern that matches any of the given keys.
-        @raises: KeyError on pattern key not in the _parameterization_regex_components dict
-
-        The `(?x)` tells the regex compiler to ignore comments and unescaped whitespace,
-        so we can use newlines and indentation for better legibility in patterns above.
-        """
-
-        regexes_map = (
-            EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP
-            if self._experimental
-            else DEFAULT_PARAMETERIZATION_REGEXES_MAP
-        )
-
-        return re.compile(rf"(?x){'|'.join(regexes_map[k] for k in pattern_keys)}")
 
     def parameterize(self, input_str: str) -> str:
         """

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -263,17 +263,6 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
 ]
 
 
-# Patterns to use for each match type when not in experimental mode.
-DEFAULT_PARAMETERIZATION_REGEXES_MAP = {r.name: r.pattern for r in DEFAULT_PARAMETERIZATION_REGEXES}
-
-# Patterns to use when in experimental mode. If no experimental pattern exists for a given type of
-# match, falls back to the default pattern.
-EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP = {
-    r.name: r.experimental_pattern if r.experimental_pattern else r.pattern
-    for r in DEFAULT_PARAMETERIZATION_REGEXES
-}
-
-
 class Parameterizer:
     def __init__(
         self,

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -277,6 +277,9 @@ EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP = {
 class Parameterizer:
     def __init__(
         self,
+        # List of `ParameterizationRegex` objects defining the regexes to use. If nothing is passed,
+        # the default set will be used.
+        regexes: Sequence[ParameterizationRegex] = DEFAULT_PARAMETERIZATION_REGEXES,
         # List of `ParameterizationRegex.name` values, used to selectively enable pattern types. To
         # use all available parameterization, omit this argument.
         regex_pattern_keys: Sequence[str] | None = None,
@@ -284,6 +287,10 @@ class Parameterizer:
         # pattern will fall back to the standard pattern.)
         use_experimental_regexes: bool = False,
     ):
+        # Filter regexes by the specified keys, if given
+        if regex_pattern_keys:
+            regexes = [r for r in regexes if r.name in regex_pattern_keys]
+
         self._experimental = (
             use_experimental_regexes
             # Only mark the parameterizer as experimental if there are actually any experiments

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -321,9 +321,11 @@ class Parameterizer:
             # there should be exactly one named matching group, making the last matching group also
             # the only matching group.
             matched_key = match.lastgroup
-            value = match.groupdict().get(matched_key or "")  # Empty string for mypy appeasment
+            orig_value = match.groupdict().get(
+                matched_key or ""  # Empty string for mypy appeasment
+            )
 
-            if not matched_key or not value:  # Insurance - shouldn't happen IRL
+            if not matched_key or not orig_value:  # Insurance - shouldn't happen IRL
                 return ""
 
             matches_counter[matched_key] += 1

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -337,9 +337,9 @@ class Parameterizer:
             parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
             metric_tags["changed"] = parameterized != input_str
 
-        for key, value in matches_counter.items():
+        for regex_key, value in matches_counter.items():
             # Track the kinds of replacements being made
-            metrics.incr("grouping.value_parameterized", amount=value, tags={"key": key})
+            metrics.incr("grouping.value_parameterized", amount=value, tags={"key": regex_key})
 
         return parameterized
 

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -337,9 +337,9 @@ class Parameterizer:
             parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
             metric_tags["changed"] = parameterized != input_str
 
-        for regex_key, value in matches_counter.items():
+        for regex_key, count in matches_counter.items():
             # Track the kinds of replacements being made
-            metrics.incr("grouping.value_parameterized", amount=value, tags={"key": regex_key})
+            metrics.incr("grouping.value_parameterized", amount=count, tags={"key": regex_key})
 
         return parameterized
 

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -297,7 +297,7 @@ class Parameterizer:
 
         # Combine the individual patterns into one giant regex to check against. (This is faster
         # than checking each pattern individually because it entails less overhead.)
-        self._parameterization_regex = re.compile(
+        self.combined_regex = re.compile(
             # The `(?x)` tells the regex compiler to ignore comments and unescaped whitespace, so we
             # can use newlines and indentation for better legibility when defining regexes
             rf"(?x){'|'.join(pattern_strings)}"
@@ -334,7 +334,7 @@ class Parameterizer:
         with metrics.timer(
             "grouping.parameterize", tags={"experimental": self.is_experimental}
         ) as metric_tags:
-            parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
+            parameterized = self.combined_regex.sub(_handle_regex_match, input_str)
             metric_tags["changed"] = parameterized != input_str
 
         for regex_key, count in matches_counter.items():

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -271,14 +271,14 @@ class Parameterizer:
         regexes: Sequence[ParameterizationRegex] = DEFAULT_PARAMETERIZATION_REGEXES,
         # List of `ParameterizationRegex.name` values, used to selectively enable pattern types. To
         # use all available parameterization, omit this argument.
-        regex_pattern_keys: Sequence[str] | None = None,
+        regex_keys: Sequence[str] | None = None,
         # Whether to use experimental patterns, if available. (Pattern types without an experimental
         # pattern will fall back to the standard pattern.)
         use_experimental_regexes: bool = False,
     ):
         # Filter regexes by the specified keys, if given
-        if regex_pattern_keys:
-            regexes = [r for r in regexes if r.name in regex_pattern_keys]
+        if regex_keys:
+            regexes = [r for r in regexes if r.name in regex_keys]
 
         self._experimental = (
             use_experimental_regexes

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -320,14 +320,14 @@ class Parameterizer:
             #   c) there's nothing else in the regex,
             # there should be exactly one named matching group, making the last matching group also
             # the only matching group.
-            key = match.lastgroup
-            value = match.groupdict().get(key or "")  # Empty string for mypy appeasment
+            matched_key = match.lastgroup
+            value = match.groupdict().get(matched_key or "")  # Empty string for mypy appeasment
 
-            if not key or not value:  # Insurance - shouldn't happen IRL
+            if not matched_key or not value:  # Insurance - shouldn't happen IRL
                 return ""
 
-            matches_counter[key] += 1
-            return f"<{key}>"
+            matches_counter[matched_key] += 1
+            return f"<{matched_key}>"
 
         with metrics.timer(
             "grouping.parameterize", tags={"experimental": self._experimental}

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -280,7 +280,7 @@ class Parameterizer:
         if regex_keys:
             regexes = [r for r in regexes if r.name in regex_keys]
 
-        self._experimental = (
+        self.is_experimental = (
             use_experimental_regexes
             # Only mark the parameterizer as experimental if there are actually any experiments
             # running. If there aren't, then both parameterizers use the default regex patterns, so
@@ -288,7 +288,7 @@ class Parameterizer:
             and any(r.experimental_pattern is not None for r in regexes)
         )
 
-        if self._experimental:
+        if self.is_experimental:
             pattern_strings = [
                 r.experimental_pattern if r.experimental_pattern else r.pattern for r in regexes
             ]
@@ -332,7 +332,7 @@ class Parameterizer:
             return f"<{matched_key}>"
 
         with metrics.timer(
-            "grouping.parameterize", tags={"experimental": self._experimental}
+            "grouping.parameterize", tags={"experimental": self.is_experimental}
         ) as metric_tags:
             parameterized = self._parameterization_regex.sub(_handle_regex_match, input_str)
             metric_tags["changed"] = parameterized != input_str

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -11,8 +11,6 @@ from sentry.grouping.component import (
 )
 from sentry.grouping.context import GroupingContext
 from sentry.grouping.parameterization import (
-    DEFAULT_PARAMETERIZATION_REGEXES_MAP,
-    EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP,
     experimental_parameterizer,
     parameterizer,
 )
@@ -219,8 +217,7 @@ def test_default_parameterizer_misses_experimental_cases(
 
 
 @pytest.mark.skipif(
-    EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP == DEFAULT_PARAMETERIZATION_REGEXES_MAP,
-    reason="no experimental regexes to test",
+    not experimental_parameterizer._experimental, reason="no experimental regexes to test"
 )
 @pytest.mark.parametrize(("name", "input", "expected"), standard_cases + experimental_cases)
 def test_experimental_parameterization(name: str, input: str, expected: str) -> None:

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -217,7 +217,7 @@ def test_default_parameterizer_misses_experimental_cases(
 
 
 @pytest.mark.skipif(
-    not experimental_parameterizer._experimental, reason="no experimental regexes to test"
+    not experimental_parameterizer.is_experimental, reason="no experimental regexes to test"
 )
 @pytest.mark.parametrize(("name", "input", "expected"), standard_cases + experimental_cases)
 def test_experimental_parameterization(name: str, input: str, expected: str) -> None:


### PR DESCRIPTION
This is handful of refactors to the parameterization code, to make it a bit simpler and more testable.

- Allow `ParameterizationRegex` objects to be passed directly to parameterizer during initialization rather than always using the default set. (This should make it easier to test, so we don't have to do a bunch of mocking.) If none are passed, the default set will still be used.

- Create the final regex directly in `__init__` rather than in a separate method.

- When deciding if the experimental parameterizer is actually experimental, look at the regexes themselves rather than at the regex maps.

- When deciding whether to skip testing the experimental parameterizer, look directly at it rather than comparing the regex maps.

- Use `lastgroup` to get matched key/original value directly rather than iterating over `groupdict`.

- Remove the now-unused regex maps.

- Rename a number of things.