### PR TITLE
feat(grouping): Add replacement callback option to parameterizer

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -19,6 +19,8 @@ class ParameterizationRegex:
     raw_pattern_experimental: str | None = None
     lookbehind: str | None = None  # positive lookbehind prefix if needed
     lookahead: str | None = None  # positive lookahead postfix if needed
+    # Function which takes the matched value and returns the replacement value.
+    replacement_callback: ParameterizationReplacementFunction | None = None
 
     # These need to be used with `(?x)`, to tell the regex compiler to ignore comments
     # and unescaped whitespace, so we can use newlines and indentation for better legibility.

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -2,8 +2,14 @@ import dataclasses
 import re
 from collections import defaultdict
 from collections.abc import Sequence
+from typing import Callable
 
 from sentry.utils import metrics
+
+# Function parameterization regexes can specify to provide a customized replacement string. Can also
+# be used to do conditional replacement, by returning the original value in cases where replacement
+# shouldn't happen.
+ParameterizationReplacementFunction = Callable[[str], str]
 
 
 @dataclasses.dataclass

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -363,7 +363,11 @@ class Parameterizer:
                 replacement_callback(orig_value) if replacement_callback else f"<{matched_key}>"
             )
 
-            matches_counter[matched_key] += 1
+            # The replacement callback might return the original value, if it determines it's not
+            # something which should be replaced, and we don't want to count that
+            if replacement_string != orig_value:
+                matches_counter[matched_key] += 1
+
             return replacement_string
 
         with metrics.timer(

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -328,6 +328,11 @@ class Parameterizer:
             rf"(?x){'|'.join(pattern_strings)}"
         )
 
+        # Collect replacement callbacks, if any
+        self.replacement_functions = {
+            r.name: r.replacement_callback for r in regexes if r.replacement_callback
+        }
+
     def parameterize(self, input_str: str) -> str:
         """
         Replace all regex matches in the input string with placeholder strings, using the regexes

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -341,7 +341,7 @@ class Parameterizer:
         For example, turn "Error with order #1231" into "Error with order #<int>".
         """
 
-        matches_counter: defaultdict[str, int] = defaultdict(int)
+        replacement_counts: defaultdict[str, int] = defaultdict(int)
 
         def _handle_regex_match(match: re.Match[str]) -> str:
             # Since
@@ -366,7 +366,7 @@ class Parameterizer:
             # The replacement callback might return the original value, if it determines it's not
             # something which should be replaced, and we don't want to count that
             if replacement_string != orig_value:
-                matches_counter[matched_key] += 1
+                replacement_counts[matched_key] += 1
 
             return replacement_string
 
@@ -376,7 +376,7 @@ class Parameterizer:
             parameterized = self.combined_regex.sub(_handle_regex_match, input_str)
             metric_tags["changed"] = parameterized != input_str
 
-        for regex_key, count in matches_counter.items():
+        for regex_key, count in replacement_counts.items():
             # Track the kinds of replacements being made
             metrics.incr("grouping.value_parameterized", amount=count, tags={"key": regex_key})
 

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -293,6 +293,7 @@ class Parameterizer:
         # List of `ParameterizationRegex` objects defining the regexes to use. If nothing is passed,
         # the default set will be used.
         regexes: Sequence[ParameterizationRegex] = DEFAULT_PARAMETERIZATION_REGEXES,
+        *,
         # List of `ParameterizationRegex.name` values, used to selectively enable pattern types. To
         # use all available parameterization, omit this argument.
         regex_keys: Sequence[str] | None = None,

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -358,8 +358,13 @@ class Parameterizer:
             if not matched_key or not orig_value:  # Insurance - shouldn't happen IRL
                 return ""
 
+            replacement_callback = self.replacement_functions.get(matched_key)
+            replacement_string = (
+                replacement_callback(orig_value) if replacement_callback else f"<{matched_key}>"
+            )
+
             matches_counter[matched_key] += 1
-            return f"<{matched_key}>"
+            return replacement_string
 
         with metrics.timer(
             "grouping.parameterize", tags={"experimental": self.is_experimental}

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -11,6 +11,8 @@ from sentry.grouping.component import (
 )
 from sentry.grouping.context import GroupingContext
 from sentry.grouping.parameterization import (
+    ParameterizationRegex,
+    Parameterizer,
     experimental_parameterizer,
     parameterizer,
 )
@@ -591,3 +593,22 @@ def test_runs_parameterizer_on_fingerprint_constant_matching_chained_error_messa
         "That's ball number <int> that Charlie hasn't brought back!",
         "Dogs are great!",
     ]
+
+
+def test_uses_callback_for_replacement_value() -> None:
+    input_str = "Dog number 1, #1 dog"
+    callback_parameterizer = Parameterizer(
+        [
+            ParameterizationRegex(
+                name="int",
+                raw_pattern=r"""-\d+\b | \b\d+\b""",
+                replacement_callback=lambda _: "<callback_result>",
+            )
+        ]
+    )
+
+    assert parameterizer.parameterize(input_str) == "Dog number <int>, #<int> dog"
+    assert (
+        callback_parameterizer.parameterize(input_str)
+        == "Dog number <callback_result>, #<callback_result> dog"  # Callback function was used
+    )


### PR DESCRIPTION
This adds the ability to specify a replacement callback when defining a regex for the parameterizer. For example, a regex can now be defined like this:

```python
ParameterizationRegex(
    name="dog",
    raw_pattern=r"some pattern",
    replacement_callback=lambda orig_value: "<dog>" if some_condition else orig_value,
)
```

When the parameterizer finds a matching value, instead of just reflexively replacing it with the regex's name, it'll pass the original value to the callback, and let it decide what the replacement value will be. (This is going to be necessary for us to fix our IPv6 parameterization.)