### PR TITLE
ref(snapshots): Temporarily rename metrics tag keys with temp_ prefix

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -387,9 +387,9 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         has_vcs = commit_comparison is not None
 
         metric_tags = {
-            "org_id": str(project.organization_id),
-            "project_id": str(project.id),
-            "app_id": artifact.app_id or "",
+            "temp_org_id": str(project.organization_id),
+            "temp_project_id": str(project.id),
+            "temp_app_id": artifact.app_id or "",
         }
 
         metrics.distribution(

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -518,9 +518,9 @@ def compare_snapshots(
         time_now = timezone.now()
 
         metric_tags = {
-            "org_id": str(org_id),
-            "project_id": str(project_id),
-            "app_id": head_artifact.app_id or "",
+            "temp_org_id": str(org_id),
+            "temp_project_id": str(project_id),
+            "temp_app_id": head_artifact.app_id or "",
         }
 
         diff_duration_s = (time_now - task_start_time).total_seconds()


### PR DESCRIPTION
Temporarily renames the snapshot comparison metrics tag keys from `org_id`, `project_id`, `app_id` to `temp_org_id`, `temp_project_id`, `temp_app_id` in both the upload endpoint and the comparison task.

This is to investigate a metrics tagging issue where the current tag names may be conflicting with reserved or existing tag keys in our metrics pipeline. The `temp_` prefix isolates these tags to confirm they're being recorded correctly.

This is a temporary change — once we verify the metrics are flowing properly, we'll rename them back.