### PR TITLE
feat(preprod): Show processing state for snapshot comparisons

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -6,7 +6,7 @@ from typing import Any
 import jsonschema
 import orjson
 from django.conf import settings
-from django.db import router, transaction
+from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -448,11 +448,14 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                         preprod_artifact=base_artifact
                     ).first()
                     if base_metrics:
-                        PreprodSnapshotComparison.objects.get_or_create(
-                            head_snapshot_metrics=snapshot_metrics,
-                            base_snapshot_metrics=base_metrics,
-                            defaults={"state": PreprodSnapshotComparison.State.PENDING},
-                        )
+                        try:
+                            PreprodSnapshotComparison.objects.get_or_create(
+                                head_snapshot_metrics=snapshot_metrics,
+                                base_snapshot_metrics=base_metrics,
+                                defaults={"state": PreprodSnapshotComparison.State.PENDING},
+                            )
+                        except IntegrityError:
+                            pass
 
                     compare_snapshots.apply_async(
                         kwargs={

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -444,6 +444,16 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                         },
                     )
 
+                    base_metrics = PreprodSnapshotMetrics.objects.filter(
+                        preprod_artifact=base_artifact
+                    ).first()
+                    if base_metrics:
+                        PreprodSnapshotComparison.objects.get_or_create(
+                            head_snapshot_metrics=snapshot_metrics,
+                            base_snapshot_metrics=base_metrics,
+                            defaults={"state": PreprodSnapshotComparison.State.PENDING},
+                        )
+
                     compare_snapshots.apply_async(
                         kwargs={
                             "project_id": project.id,

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -300,10 +300,69 @@ export default function SnapshotsPage() {
   // while the expensive image rendering catches up
   const deferredItem = useDeferredValue(currentItem);
 
+  const isComparisonProcessing =
+    !!comparisonRunInfo?.state &&
+    [ComparisonState.PENDING, ComparisonState.PROCESSING].includes(
+      comparisonRunInfo.state
+    );
+
   const imageBaseUrl = `/api/0/projects/${organization.slug}/${data?.project_id ?? ''}/files/images/`;
   const diffImageBaseUrl = data
     ? `/api/0/organizations/${organization.slug}/objectstore/v1/objects/preprod/org=${organization.id};project=${data.project_id}/${organization.id}/${data.project_id}/`
     : '';
+
+  const processingContent = (
+    <Flex width="100%" justify="center" align="center">
+      <BuildProcessing
+        title={t('Generating snapshot comparison')}
+        message={t('Hang tight, this may take a few minutes...')}
+      />
+    </Flex>
+  );
+
+  const snapshotContent = (
+    <Flex
+      direction="row"
+      flex="1"
+      minHeight="0"
+      width="100%"
+      overflow="hidden"
+      style={{maxHeight: 'calc(100vh - 205px)'}}
+    >
+      <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
+        <SnapshotSidebarContent
+          items={filteredItems}
+          totalItemCount={sidebarItems.length}
+          currentItemKey={currentItemKey}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          onSelectItem={handleSelectItem}
+        />
+      </Flex>
+      <DragHandle
+        data-is-held={isHeld}
+        onMouseDown={onMouseDown}
+        onDoubleClick={onDoubleClick}
+      >
+        <IconGrabbable size="sm" />
+      </DragHandle>
+      <Flex flex="1" minWidth={0} overflow="hidden">
+        <SnapshotMainContent
+          selectedItem={deferredItem}
+          variantIndex={safeVariantIndex}
+          onVariantChange={setVariantIndex}
+          imageBaseUrl={imageBaseUrl}
+          diffImageBaseUrl={diffImageBaseUrl}
+          showOverlay={showOverlay}
+          onShowOverlayChange={setShowOverlay}
+          overlayColor={overlayColor}
+          onOverlayColorChange={setOverlayColor}
+          diffMode={diffMode}
+          onDiffModeChange={setDiffMode}
+        />
+      </Flex>
+    </Flex>
+  );
 
   if (isPending) {
     return (
@@ -347,59 +406,7 @@ export default function SnapshotsPage() {
           </Layout.HeaderActions>
         </Layout.Header>
 
-        {comparisonRunInfo?.state &&
-        [ComparisonState.PENDING, ComparisonState.PROCESSING].includes(
-          comparisonRunInfo.state
-        ) ? (
-          <Flex width="100%" justify="center" align="center">
-            <BuildProcessing
-              title={t('Generating snapshot comparison')}
-              message={t('Hang tight, this may take a few minutes...')}
-            />
-          </Flex>
-        ) : (
-          <Flex
-            direction="row"
-            flex="1"
-            minHeight="0"
-            width="100%"
-            overflow="hidden"
-            style={{maxHeight: 'calc(100vh - 205px)'}}
-          >
-            <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
-              <SnapshotSidebarContent
-                items={filteredItems}
-                totalItemCount={sidebarItems.length}
-                currentItemKey={currentItemKey}
-                searchQuery={searchQuery}
-                onSearchChange={setSearchQuery}
-                onSelectItem={handleSelectItem}
-              />
-            </Flex>
-            <DragHandle
-              data-is-held={isHeld}
-              onMouseDown={onMouseDown}
-              onDoubleClick={onDoubleClick}
-            >
-              <IconGrabbable size="sm" />
-            </DragHandle>
-            <Flex flex="1" minWidth={0} overflow="hidden">
-              <SnapshotMainContent
-                selectedItem={deferredItem}
-                variantIndex={safeVariantIndex}
-                onVariantChange={setVariantIndex}
-                imageBaseUrl={imageBaseUrl}
-                diffImageBaseUrl={diffImageBaseUrl}
-                showOverlay={showOverlay}
-                onShowOverlayChange={setShowOverlay}
-                overlayColor={overlayColor}
-                onOverlayColorChange={setOverlayColor}
-                diffMode={diffMode}
-                onDiffModeChange={setDiffMode}
-              />
-            </Flex>
-          </Flex>
-        )}
+        {isComparisonProcessing ? processingContent : snapshotContent}
       </Layout.Page>
     </SentryDocumentTitle>
   );

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -17,7 +17,8 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
-import {getImageGroup} from 'sentry/views/preprod/types/snapshotTypes';
+import {BuildProcessing} from 'sentry/views/preprod/components/buildProcessing';
+import {ComparisonState, getImageGroup} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDetailsApiResponse,
@@ -54,6 +55,12 @@ export default function SnapshotsPage() {
     {
       staleTime: 0,
       enabled: !!snapshotId,
+      refetchInterval: query => {
+        const state = query.state.data?.[0]?.comparison_run_info?.state;
+        return state === ComparisonState.PENDING || state === ComparisonState.PROCESSING
+          ? 5_000
+          : false;
+      },
     }
   );
 
@@ -340,47 +347,59 @@ export default function SnapshotsPage() {
           </Layout.HeaderActions>
         </Layout.Header>
 
-        <Flex
-          direction="row"
-          flex="1"
-          minHeight="0"
-          width="100%"
-          overflow="hidden"
-          style={{maxHeight: 'calc(100vh - 205px)'}}
-        >
-          <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
-            <SnapshotSidebarContent
-              items={filteredItems}
-              totalItemCount={sidebarItems.length}
-              currentItemKey={currentItemKey}
-              searchQuery={searchQuery}
-              onSearchChange={setSearchQuery}
-              onSelectItem={handleSelectItem}
+        {comparisonRunInfo?.state &&
+        [ComparisonState.PENDING, ComparisonState.PROCESSING].includes(
+          comparisonRunInfo.state
+        ) ? (
+          <Flex width="100%" justify="center" align="center">
+            <BuildProcessing
+              title={t('Generating snapshot comparison')}
+              message={t('Hang tight, this may take a few minutes...')}
             />
           </Flex>
-          <DragHandle
-            data-is-held={isHeld}
-            onMouseDown={onMouseDown}
-            onDoubleClick={onDoubleClick}
+        ) : (
+          <Flex
+            direction="row"
+            flex="1"
+            minHeight="0"
+            width="100%"
+            overflow="hidden"
+            style={{maxHeight: 'calc(100vh - 205px)'}}
           >
-            <IconGrabbable size="sm" />
-          </DragHandle>
-          <Flex flex="1" minWidth={0} overflow="hidden">
-            <SnapshotMainContent
-              selectedItem={deferredItem}
-              variantIndex={safeVariantIndex}
-              onVariantChange={setVariantIndex}
-              imageBaseUrl={imageBaseUrl}
-              diffImageBaseUrl={diffImageBaseUrl}
-              showOverlay={showOverlay}
-              onShowOverlayChange={setShowOverlay}
-              overlayColor={overlayColor}
-              onOverlayColorChange={setOverlayColor}
-              diffMode={diffMode}
-              onDiffModeChange={setDiffMode}
-            />
+            <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
+              <SnapshotSidebarContent
+                items={filteredItems}
+                totalItemCount={sidebarItems.length}
+                currentItemKey={currentItemKey}
+                searchQuery={searchQuery}
+                onSearchChange={setSearchQuery}
+                onSelectItem={handleSelectItem}
+              />
+            </Flex>
+            <DragHandle
+              data-is-held={isHeld}
+              onMouseDown={onMouseDown}
+              onDoubleClick={onDoubleClick}
+            >
+              <IconGrabbable size="sm" />
+            </DragHandle>
+            <Flex flex="1" minWidth={0} overflow="hidden">
+              <SnapshotMainContent
+                selectedItem={deferredItem}
+                variantIndex={safeVariantIndex}
+                onVariantChange={setVariantIndex}
+                imageBaseUrl={imageBaseUrl}
+                diffImageBaseUrl={diffImageBaseUrl}
+                showOverlay={showOverlay}
+                onShowOverlayChange={setShowOverlay}
+                overlayColor={overlayColor}
+                onOverlayColorChange={setOverlayColor}
+                diffMode={diffMode}
+                onDiffModeChange={setDiffMode}
+              />
+            </Flex>
           </Flex>
-        </Flex>
+        )}
       </Layout.Page>
     </SentryDocumentTitle>
   );


### PR DESCRIPTION

<img width="800" alt="image" src="https://github.com/user-attachments/assets/562b1e51-cbc8-4070-a513-dabc02ebe2af" />

Creates a `PreprodSnapshotComparison` record with PENDING state at upload time, before the async comparison task is dispatched. This lets the frontend immediately detect that a comparison is in progress.

On the frontend, a `BuildProcessing` indicator is shown while the comparison is pending or processing. The page auto-polls every 5 seconds and transitions to the full diff view once the comparison completes. Previously, the page showed an empty or stale diff view until the background task finished, with no indication that work was happening.