### PR TITLE
chore(codeowners): Add processing_errors test coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -614,6 +614,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/api/endpoints/                                  @getsentry/issue-workflow
 /src/sentry/rules/                                          @getsentry/issue-detection-backend
 /src/sentry/processing_errors/                              @getsentry/issue-detection-backend
+/tests/sentry/processing_errors/                             @getsentry/issue-detection-backend
 /src/sentry/api/helpers/group_index/delete.py               @getsentry/issue-detection-backend
 /src/sentry/deletions/defaults/group.py                     @getsentry/issue-detection-backend
 /src/sentry/deletions/tasks/groups.py                       @getsentry/issue-detection-backend

--- a/.github/codeowners-coverage-baseline.txt
+++ b/.github/codeowners-coverage-baseline.txt
@@ -2370,12 +2370,6 @@ tests/sentry/processing/backpressure/test_checking.py
 tests/sentry/processing/backpressure/test_monitoring.py
 tests/sentry/processing/backpressure/test_redis.py
 tests/sentry/processing/eventstore/test_processing.py
-tests/sentry/processing_errors/__init__.py
-tests/sentry/processing_errors/eap/__init__.py
-tests/sentry/processing_errors/eap/test_producer.py
-tests/sentry/processing_errors/test_detection.py
-tests/sentry/processing_errors/test_grouptype.py
-tests/sentry/processing_errors/test_provisioning.py
 tests/sentry/projectoptions/__init__.py
 tests/sentry/projectoptions/test_basic.py
 tests/sentry/projects/project_rules/test_creator.py


### PR DESCRIPTION
Add `/tests/sentry/processing_errors/` to CODEOWNERS under `@getsentry/issue-detection-backend`.

This closes a coverage gap identified by the CODEOWNERS enforcement system — the test directory for processing errors was missing ownership while the corresponding source directory already had it.