### PR TITLE
ref(onboarding): Replace useEffect with derived state in ScmConnect

### DIFF
--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -7,17 +7,22 @@ import {Text} from '@sentry/scraps/text';
 import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {Integration} from 'sentry/types/integrations';
 
 import {useScmRepoSearch} from './useScmRepoSearch';
 import {useScmRepoSelection} from './useScmRepoSelection';
 
-export function ScmRepoSelector() {
-  const {selectedIntegration, selectedRepository, setSelectedRepository} =
-    useOnboardingContext();
+interface ScmRepoSelectorProps {
+  integration: Integration;
+}
+
+export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
+  const {selectedRepository, setSelectedRepository} = useOnboardingContext();
   const {reposByIdentifier, dropdownItems, isFetching, debouncedSearch, setSearch} =
-    useScmRepoSearch(selectedIntegration?.id ?? '', selectedRepository);
+    useScmRepoSearch(integration.id, selectedRepository);
 
   const {busy, handleSelect, handleRemove} = useScmRepoSelection({
+    integration,
     onSelect: setSelectedRepository,
     reposByIdentifier,
   });

--- a/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
@@ -84,12 +84,11 @@ describe('useScmRepoSelection', () => {
     });
 
     const {result} = renderHookWithProviders(
-      () => useScmRepoSelection({onSelect, reposByIdentifier}),
+      () =>
+        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
       {
         organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedIntegration: mockIntegration,
-        }),
+        additionalWrapper: makeOnboardingWrapper({}),
       }
     );
 
@@ -132,12 +131,11 @@ describe('useScmRepoSelection', () => {
     });
 
     const {result} = renderHookWithProviders(
-      () => useScmRepoSelection({onSelect, reposByIdentifier}),
+      () =>
+        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
       {
         organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedIntegration: mockIntegration,
-        }),
+        additionalWrapper: makeOnboardingWrapper({}),
       }
     );
 
@@ -163,12 +161,11 @@ describe('useScmRepoSelection', () => {
     });
 
     const {result} = renderHookWithProviders(
-      () => useScmRepoSelection({onSelect, reposByIdentifier}),
+      () =>
+        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
       {
         organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedIntegration: mockIntegration,
-        }),
+        additionalWrapper: makeOnboardingWrapper({}),
       }
     );
 
@@ -202,12 +199,11 @@ describe('useScmRepoSelection', () => {
     });
 
     const {result} = renderHookWithProviders(
-      () => useScmRepoSelection({onSelect, reposByIdentifier}),
+      () =>
+        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
       {
         organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedIntegration: mockIntegration,
-        }),
+        additionalWrapper: makeOnboardingWrapper({}),
       }
     );
 
@@ -251,11 +247,11 @@ describe('useScmRepoSelection', () => {
     });
 
     const {result} = renderHookWithProviders(
-      () => useScmRepoSelection({onSelect, reposByIdentifier}),
+      () =>
+        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
       {
         organization,
         additionalWrapper: makeOnboardingWrapper({
-          selectedIntegration: mockIntegration,
           selectedRepository: {
             id: '99',
             name: 'sentry',

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -12,6 +12,7 @@ import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface UseScmRepoSelectionOptions {
+  integration: Integration;
   onSelect: (repo?: Repository) => void;
   reposByIdentifier: Map<string, IntegrationRepository>;
 }
@@ -37,11 +38,12 @@ function buildOptimisticRepo(
 }
 
 export function useScmRepoSelection({
+  integration,
   onSelect,
   reposByIdentifier,
 }: UseScmRepoSelectionOptions) {
   const organization = useOrganization();
-  const {selectedIntegration, selectedRepository} = useOnboardingContext();
+  const {selectedRepository} = useOnboardingContext();
   const [busy, setBusy] = useState(false);
 
   // Fetch repos already registered in Sentry for this integration, so we
@@ -53,9 +55,9 @@ export function useScmRepoSelection({
       getApiUrl('/organizations/$organizationIdOrSlug/repos/', {
         path: {organizationIdOrSlug: organization.slug},
       }),
-      {query: {status: 'active', integration_id: selectedIntegration?.id ?? ''}},
+      {query: {status: 'active', integration_id: integration.id}},
     ],
-    {staleTime: 0, enabled: !!selectedIntegration}
+    {staleTime: 0}
   );
 
   const existingReposBySlug = useMemo(
@@ -82,13 +84,13 @@ export function useScmRepoSelection({
 
   const handleSelect = async (selection: {value: string}) => {
     const repo = reposByIdentifier.get(selection.value);
-    if (!repo || !selectedIntegration) {
+    if (!repo) {
       return;
     }
 
     cleanupPreviousAdd();
 
-    const optimistic = buildOptimisticRepo(repo, selectedIntegration);
+    const optimistic = buildOptimisticRepo(repo, integration);
     onSelect(optimistic);
 
     if (repo.isInstalled) {
@@ -108,9 +110,9 @@ export function useScmRepoSelection({
         url: `/organizations/${organization.slug}/repos/`,
         method: 'POST',
         data: {
-          installation: selectedIntegration.id,
+          installation: integration.id,
           identifier: repo.identifier,
-          provider: `integrations:${selectedIntegration.provider.key}`,
+          provider: `integrations:${integration.provider.key}`,
         },
       });
       onSelect({...optimistic, ...created});

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect} from 'react';
+import {useCallback} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -35,15 +35,8 @@ export function ScmConnect({onComplete}: StepProps) {
     activeIntegrationExisting,
   } = useScmProviders();
 
-  // If an existing SCM integration is detected and context doesn't have one
-  // yet, persist it to context so downstream steps and child components can
-  // read it without prop drilling.
-  const hasSelectedIntegration = !!selectedIntegration;
-  useEffect(() => {
-    if (!hasSelectedIntegration && activeIntegrationExisting) {
-      setSelectedIntegration(activeIntegrationExisting);
-    }
-  }, [hasSelectedIntegration, setSelectedIntegration, activeIntegrationExisting]);
+  // Derive integration from explicit selection, falling back to existing
+  const effectiveIntegration = selectedIntegration ?? activeIntegrationExisting;
 
   const handleInstall = useCallback(
     (data: Integration) => {
@@ -81,7 +74,7 @@ export function ScmConnect({onComplete}: StepProps) {
       </Stack>
 
       <Stack gap="lg" width="100%" maxWidth="600px">
-        {selectedIntegration ? (
+        {effectiveIntegration ? (
           <Stack gap="lg">
             <Flex align="center" justify="between">
               <Flex align="center" gap="sm">
@@ -89,7 +82,7 @@ export function ScmConnect({onComplete}: StepProps) {
                 <Text bold variant="success">
                   {t(
                     'Connected to %s',
-                    selectedIntegration.domainName || selectedIntegration.provider.name
+                    effectiveIntegration.domainName || effectiveIntegration.provider.name
                   )}
                 </Text>
               </Flex>
@@ -97,7 +90,7 @@ export function ScmConnect({onComplete}: StepProps) {
                 {t('Manage in Settings')}
               </Link>
             </Flex>
-            <ScmRepoSelector />
+            <ScmRepoSelector integration={effectiveIntegration} />
           </Stack>
         ) : (
           <ScmProviderPills providers={scmProviders} onInstall={handleInstall} />
@@ -108,7 +101,12 @@ export function ScmConnect({onComplete}: StepProps) {
         <Button onClick={() => onComplete()}>{t('Skip for now')}</Button>
         <Button
           priority="primary"
-          onClick={() => onComplete()}
+          onClick={() => {
+            if (effectiveIntegration && !selectedIntegration) {
+              setSelectedIntegration(effectiveIntegration);
+            }
+            onComplete();
+          }}
           disabled={!selectedRepository?.id}
         >
           {t('Continue')}


### PR DESCRIPTION
Replace the useEffect that synced `activeIntegrationExisting` to onboarding context with a derived `effectiveIntegration` value. This eliminates a state-sync effect and makes the component's data flow more predictable.

To support this, `ScmRepoSelector` and `useScmRepoSelection` now receive the integration as a prop instead of reading `selectedIntegration` from context directly. The derived integration is persisted to context in the Continue handler when the user accepts the auto-detected default.