### PR TITLE
chore(dev): Add processing errors tests to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -677,6 +677,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/issues/test_search_issues_dataset.py          @getsentry/issue-workflow
 /tests/sentry/issues/test_status_change_consumer.py         @getsentry/issue-detection-backend
 /tests/sentry/issues/test_status_change.py                  @getsentry/issue-detection-backend
+/tests/sentry/processing_errors/                            @getsentry/issue-detection-backend
 /tests/sentry/search/                                       @getsentry/issue-workflow
 /tests/sentry/seer/similarity/                              @getsentry/issue-detection-backend
 /tests/sentry/seer/supergroups/                             @getsentry/issue-detection-backend

--- a/.github/codeowners-coverage-baseline.txt
+++ b/.github/codeowners-coverage-baseline.txt
@@ -2370,12 +2370,6 @@ tests/sentry/processing/backpressure/test_checking.py
 tests/sentry/processing/backpressure/test_monitoring.py
 tests/sentry/processing/backpressure/test_redis.py
 tests/sentry/processing/eventstore/test_processing.py
-tests/sentry/processing_errors/__init__.py
-tests/sentry/processing_errors/eap/__init__.py
-tests/sentry/processing_errors/eap/test_producer.py
-tests/sentry/processing_errors/test_detection.py
-tests/sentry/processing_errors/test_grouptype.py
-tests/sentry/processing_errors/test_provisioning.py
 tests/sentry/projectoptions/__init__.py
 tests/sentry/projectoptions/test_basic.py
 tests/sentry/projects/project_rules/test_creator.py


### PR DESCRIPTION
This adds the `tests/sentry/processing_errors` directory to our codeowners file, assigned to the issue detection team because the corresponding `src/sentry/processing_errors` directory is assigned that way. This should fix the codeowners check which is currently failing in all new PRs.