### PR TITLE
feat(scm): Add `get_git_commit` and `get_tree` for GitLab

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -690,6 +690,18 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         path = GitLabApiClientPath.build_pr_diffs(project=project_id, pr_key=pr.key, unidiff=True)
         return self.get(path)
 
+    def get_repository_tree(
+        self, project_id: str, ref: str, recursive: bool = True
+    ) -> list[dict[str, Any]]:
+        """List repository tree at a given ref.
+
+        See https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree
+        """
+        params: dict[str, str] = {"ref": ref, "per_page": "100"}
+        if recursive:
+            params["recursive"] = "true"
+        return self.get(GitLabApiClientPath.tree.format(project=project_id), params=params)
+
     def get_merge_request_diffs(self, project_id: str, pr_key: str) -> list[dict[str, Any]]:
         return self.get(GitLabApiClientPath.pr_diffs.format(project=project_id, pr_key=pr_key))
 

--- a/src/sentry/integrations/gitlab/utils.py
+++ b/src/sentry/integrations/gitlab/utils.py
@@ -74,6 +74,7 @@ class GitLabApiClientPath:
     statuses = "/projects/{project}/statuses/{sha}"
     commit_statuses = "/projects/{project}/repository/commits/{sha}/statuses"
     archive = "/projects/{project}/repository/archive{format}"
+    tree = "/projects/{project}/repository/tree"
     branches = "/projects/{project_id}/repository/branches"
     branch = "/projects/{project_id}/repository/branches/{branch}"
     user = "/user"

--- a/src/sentry/scm/private/providers/gitlab.py
+++ b/src/sentry/scm/private/providers/gitlab.py
@@ -337,6 +337,7 @@ class GitLabProvider:
         self,
         tree_sha: SHA,
         recursive: bool = True,
+        pagination: PaginationParams | None = None,
         request_options: RequestOptions | None = None,
     ) -> ActionResult[GitTree]:
         """List the repository tree at a given ref.

--- a/src/sentry/scm/private/providers/gitlab.py
+++ b/src/sentry/scm/private/providers/gitlab.py
@@ -10,9 +10,7 @@ Unsupported actions:
     * create_pull_request_draft
     * create_review
     * get_check_run
-    * get_git_commit
     * get_pull_request_diff
-    * get_tree
     * minimize_comment
     * request_review
     * resolve_review_thread
@@ -22,9 +20,12 @@ Unsupported actions:
 
 import datetime
 import functools
+import logging
 from collections.abc import Callable
 from typing import Any, Iterable
 from urllib.parse import urlencode
+
+logger = logging.getLogger(__name__)
 
 from sentry.integrations.gitlab.client import GitLabApiClient
 from sentry.integrations.gitlab.utils import GitLabApiClientPath
@@ -40,7 +41,10 @@ from sentry.scm.types import (
     Commit,
     CommitAuthor,
     FileContent,
+    GitCommitObject,
+    GitCommitTree,
     GitRef,
+    GitTree,
     PaginatedActionResult,
     PaginatedResponseMeta,
     PaginationParams,
@@ -56,6 +60,7 @@ from sentry.scm.types import (
     RequestOptions,
     ReviewComment,
     ReviewSide,
+    TreeEntry,
 )
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -329,6 +334,46 @@ class GitLabProvider:
     def create_branch(self, branch: BranchName, sha: SHA) -> ActionResult[GitRef]:
         raw = self.client.create_branch(self._repo_id, branch, sha)
         return make_result(map_git_ref, raw)
+
+    @catch_provider_exception
+    def get_tree(
+        self,
+        tree_sha: SHA,
+        recursive: bool = True,
+        request_options: RequestOptions | None = None,
+    ) -> ActionResult[GitTree]:
+        """List the repository tree at a given ref.
+
+        GitLab's tree API takes a ref (commit SHA, branch, tag) rather than a
+        tree-object SHA.  We treat ``tree_sha`` as a ref so callers can pass a
+        commit SHA obtained from ``get_git_commit``.
+        """
+        raw = self.client.get_repository_tree(self._repo_id, ref=tree_sha, recursive=recursive)
+        return ActionResult(
+            data=GitTree(
+                sha=tree_sha,
+                tree=[map_tree_entry(e) for e in raw],
+                truncated=False,
+            ),
+            type="gitlab",
+            raw=raw,
+            meta={},
+        )
+
+    @catch_provider_exception
+    def get_git_commit(
+        self,
+        sha: SHA,
+        request_options: RequestOptions | None = None,
+    ) -> ActionResult[GitCommitObject]:
+        """Get a commit as a git object.
+
+        GitLab's commit endpoint does not expose the tree-object SHA.  We set
+        ``tree.sha`` to the commit SHA so that downstream code can pass it to
+        ``get_tree`` (which accepts any ref).
+        """
+        raw = self.client.get_commit(self._repo_id, sha)
+        return make_result(map_git_commit_object, raw)
 
     @catch_provider_exception
     def get_archive_link(
@@ -664,6 +709,26 @@ def map_reaction_result(raw: dict[str, Any]) -> ReactionResult:
         id=str(raw["id"]),
         content=REACTION_BY_AWARD_NAME[raw["name"]],
         author=map_author(raw["user"]),
+    )
+
+
+def map_git_commit_object(raw: dict[str, Any]) -> GitCommitObject:
+    return GitCommitObject(
+        sha=raw["id"],
+        # GitLab's commit API does not return a tree-object SHA.  We use the
+        # commit SHA so callers can pass it to get_tree (which accepts any ref).
+        tree=GitCommitTree(sha=raw["id"]),
+        message=raw["message"],
+    )
+
+
+def map_tree_entry(raw: dict[str, Any]) -> TreeEntry:
+    return TreeEntry(
+        path=raw["path"],
+        mode=raw["mode"],
+        type=raw["type"],
+        sha=raw["id"],
+        size=None,
     )
 
 

--- a/src/sentry/scm/private/providers/gitlab.py
+++ b/src/sentry/scm/private/providers/gitlab.py
@@ -20,12 +20,9 @@ Unsupported actions:
 
 import datetime
 import functools
-import logging
 from collections.abc import Callable
 from typing import Any, Iterable
 from urllib.parse import urlencode
-
-logger = logging.getLogger(__name__)
 
 from sentry.integrations.gitlab.client import GitLabApiClient
 from sentry.integrations.gitlab.utils import GitLabApiClientPath

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -339,7 +339,9 @@ class GitlabRefreshAuthTest(GitLabClientTest):
             url=f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/tree",
             json=tree_response,
         )
-        resp = self.gitlab_client.get_repository_tree(self.gitlab_id, ref="main", recursive=True)
+        resp = self.gitlab_client.get_repository_tree(
+            str(self.gitlab_id), ref="main", recursive=True
+        )
         assert resp == tree_response
         assert "ref=main" in responses.calls[0].request.url
         assert "recursive=true" in responses.calls[0].request.url

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -324,6 +324,27 @@ class GitlabRefreshAuthTest(GitLabClientTest):
         assert resp == orjson.loads(GET_COMMIT_RESPONSE)
 
     @responses.activate
+    def test_get_repository_tree(self) -> None:
+        tree_response = [
+            {
+                "id": "a1e8f8d7",
+                "name": "html",
+                "type": "tree",
+                "path": "files/html",
+                "mode": "040000",
+            },
+        ]
+        responses.add(
+            method=responses.GET,
+            url=f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/tree",
+            json=tree_response,
+        )
+        resp = self.gitlab_client.get_repository_tree(self.gitlab_id, ref="main", recursive=True)
+        assert resp == tree_response
+        assert "ref=main" in responses.calls[0].request.url
+        assert "recursive=true" in responses.calls[0].request.url
+
+    @responses.activate
     def test_get_rate_limit_info_from_response(self) -> None:
         """
         When rate limit headers present, parse them and return a GitLabRateLimitInfo object

--- a/tests/sentry/scm/unit/test_gitlab_provider.py
+++ b/tests/sentry/scm/unit/test_gitlab_provider.py
@@ -13049,6 +13049,120 @@ class ForwardToClientTest(NamedTuple):
                 "meta": {"next_cursor": None},
             },
         ),
+        ForwardToClientTest(
+            provider_method=GitLabProvider.get_git_commit,
+            provider_args={"sha": "6104942438c14ec7bd21c6cd5bd995272b3faff6"},
+            client_calls=[
+                ClientForwardedCall(
+                    client_method="get_commit",
+                    client_args=(
+                        "79787061",
+                        "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+                    ),
+                    client_kwds={},
+                    client_return_value={
+                        "id": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+                        "short_id": "6104942438c",
+                        "title": "Sanitize for network graph",
+                        "message": "Sanitize for network graph",
+                        "author_name": "randx",
+                        "author_email": "user@example.com",
+                        "created_at": "2021-09-20T09:06:12.300+03:00",
+                    },
+                ),
+            ],
+            provider_return_value={
+                "data": {
+                    "sha": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+                    "tree": {"sha": "6104942438c14ec7bd21c6cd5bd995272b3faff6"},
+                    "message": "Sanitize for network graph",
+                },
+                "type": "gitlab",
+                "raw": {
+                    "id": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+                    "short_id": "6104942438c",
+                    "title": "Sanitize for network graph",
+                    "message": "Sanitize for network graph",
+                    "author_name": "randx",
+                    "author_email": "user@example.com",
+                    "created_at": "2021-09-20T09:06:12.300+03:00",
+                },
+                "meta": {},
+            },
+        ),
+        ForwardToClientTest(
+            provider_method=GitLabProvider.get_tree,
+            provider_args={
+                "tree_sha": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+                "recursive": True,
+            },
+            client_calls=[
+                ClientForwardedCall(
+                    client_method="get_repository_tree",
+                    client_args=("79787061",),
+                    client_kwds={
+                        "ref": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+                        "recursive": True,
+                    },
+                    client_return_value=[
+                        {
+                            "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+                            "name": "html",
+                            "type": "tree",
+                            "path": "files/html",
+                            "mode": "040000",
+                        },
+                        {
+                            "id": "4535904260b1082e14f867f7a24fd8c21495bde3",
+                            "name": "images",
+                            "type": "tree",
+                            "path": "files/images",
+                            "mode": "040000",
+                        },
+                    ],
+                ),
+            ],
+            provider_return_value={
+                "data": {
+                    "sha": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+                    "tree": [
+                        {
+                            "path": "files/html",
+                            "mode": "040000",
+                            "type": "tree",
+                            "sha": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+                            "size": None,
+                        },
+                        {
+                            "path": "files/images",
+                            "mode": "040000",
+                            "type": "tree",
+                            "sha": "4535904260b1082e14f867f7a24fd8c21495bde3",
+                            "size": None,
+                        },
+                    ],
+                    "truncated": False,
+                },
+                "type": "gitlab",
+                "raw": [
+                    {
+                        "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+                        "name": "html",
+                        "type": "tree",
+                        "path": "files/html",
+                        "mode": "040000",
+                    },
+                    {
+                        "id": "4535904260b1082e14f867f7a24fd8c21495bde3",
+                        "name": "images",
+                        "type": "tree",
+                        "path": "files/images",
+                        "mode": "040000",
+                    },
+                ],
+                "meta": {},
+            },
+        ),
     ],
     ids=lambda param: param.provider_method.__name__,
 )


### PR DESCRIPTION
This implements `get_git_commit` and `get_tree` for GitLab.

The GitLab implementation has 3 intentional differences from GitHub due to API limitations:

1. `tree.sha` in commits reuses the commit SHA instead of a real tree object SHA
2. `truncated` is hardcoded to `False`
3. `size` on tree entries is always `None`

