### PR TITLE
chore: Add CODEOWNERS for processing errors tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -244,7 +244,6 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/snuba/tasks.py                                @getsentry/alerts-notifications
 /tests/snuba/incidents/                                   @getsentry/alerts-notifications
 /tests/sentry/rules/                                      @getsentry/alerts-notifications
-
 /tests/sentry/snuba/test_query_subscription_consumer.py   @getsentry/alerts-notifications
 /tests/sentry/snuba/test_subscriptions.py                 @getsentry/alerts-notifications
 /tests/sentry/snuba/test_tasks.py                         @getsentry/alerts-notifications

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -244,6 +244,7 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/snuba/tasks.py                                @getsentry/alerts-notifications
 /tests/snuba/incidents/                                   @getsentry/alerts-notifications
 /tests/sentry/rules/                                      @getsentry/alerts-notifications
+
 /tests/sentry/snuba/test_query_subscription_consumer.py   @getsentry/alerts-notifications
 /tests/sentry/snuba/test_subscriptions.py                 @getsentry/alerts-notifications
 /tests/sentry/snuba/test_tasks.py                         @getsentry/alerts-notifications
@@ -614,6 +615,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/api/endpoints/                                  @getsentry/issue-workflow
 /src/sentry/rules/                                          @getsentry/issue-detection-backend
 /src/sentry/processing_errors/                              @getsentry/issue-detection-backend
+/tests/sentry/processing_errors/                              @getsentry/issue-detection-backend
 /src/sentry/api/helpers/group_index/delete.py               @getsentry/issue-detection-backend
 /src/sentry/deletions/defaults/group.py                     @getsentry/issue-detection-backend
 /src/sentry/deletions/tasks/groups.py                       @getsentry/issue-detection-backend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -615,7 +615,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/api/endpoints/                                  @getsentry/issue-workflow
 /src/sentry/rules/                                          @getsentry/issue-detection-backend
 /src/sentry/processing_errors/                              @getsentry/issue-detection-backend
-/tests/sentry/processing_errors/                              @getsentry/issue-detection-backend
+/tests/sentry/processing_errors/                            @getsentry/issue-detection-backend
 /src/sentry/api/helpers/group_index/delete.py               @getsentry/issue-detection-backend
 /src/sentry/deletions/defaults/group.py                     @getsentry/issue-detection-backend
 /src/sentry/deletions/tasks/groups.py                       @getsentry/issue-detection-backend

--- a/.github/codeowners-coverage-baseline.txt
+++ b/.github/codeowners-coverage-baseline.txt
@@ -2370,12 +2370,6 @@ tests/sentry/processing/backpressure/test_checking.py
 tests/sentry/processing/backpressure/test_monitoring.py
 tests/sentry/processing/backpressure/test_redis.py
 tests/sentry/processing/eventstore/test_processing.py
-tests/sentry/processing_errors/__init__.py
-tests/sentry/processing_errors/eap/__init__.py
-tests/sentry/processing_errors/eap/test_producer.py
-tests/sentry/processing_errors/test_detection.py
-tests/sentry/processing_errors/test_grouptype.py
-tests/sentry/processing_errors/test_provisioning.py
 tests/sentry/projectoptions/__init__.py
 tests/sentry/projectoptions/test_basic.py
 tests/sentry/projects/project_rules/test_creator.py


### PR DESCRIPTION
For whatever reason, my [completely unrelated PR is failing with a complaint](https://github.com/getsentry/sentry/actions/runs/23458124009/job/68262156417?pr=111258) that there's no codeowners for this directory of tests. I added one that seemed reasonable. You tell me, though!
