### PR TITLE
ref(workflow engine): Add assert_serializer_parity, use it for API delta tests

### DIFF
--- a/src/sentry/incidents/endpoints/utils.py
+++ b/src/sentry/incidents/endpoints/utils.py
@@ -41,7 +41,7 @@ def translate_threshold(alert_rule: AlertRule, threshold: float | None) -> float
 
 
 def translate_data_condition_type(
-    comparison_delta: int, condition_type: str, threshold: float | None
+    comparison_delta: int | None, condition_type: str, threshold: float | int | None
 ) -> float | None:
     """
     Translates our internal percent representation into a delta percentage.
@@ -51,8 +51,6 @@ def translate_data_condition_type(
     if threshold is None:
         return threshold
 
-    # DataCondition.comparison is a JSONField, so integer values come back as int
-    # rather than float. Coerce here to match AlertRuleTrigger.alert_threshold (FloatField).
     if comparison_delta is None:
         return float(threshold)
 

--- a/src/sentry/incidents/endpoints/utils.py
+++ b/src/sentry/incidents/endpoints/utils.py
@@ -48,7 +48,12 @@ def translate_data_condition_type(
     For ABOVE: A percentage like 170% would become 70% increase
     For BELOW: A percentage like 40% would become 60% decrease.
     """
-    if comparison_delta is None or threshold is None:
+    if threshold is None:
         return threshold
+
+    # DataCondition.comparison is a JSONField, so integer values come back as int
+    # rather than float. Coerce here to match AlertRuleTrigger.alert_threshold (FloatField).
+    if comparison_delta is None:
+        return float(threshold)
 
     return data_condition_type_translators[condition_type](threshold)

--- a/src/sentry/testutils/helpers/serializer_parity.py
+++ b/src/sentry/testutils/helpers/serializer_parity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -33,93 +34,85 @@ def assert_serializer_parity(
             {"resolveThreshold", "triggers.resolveThreshold"},
         )
     """
-    known_diffs = known_differences or set()
-    mismatches: list[str] = []
-    fired: set[str] = set()
-    unnecessary_candidates: set[str] = set()
-    _collect_mismatches(old, new, known_diffs, mismatches, fired, unnecessary_candidates, "", "")
-    unnecessary = (unnecessary_candidates - fired) | (known_diffs - fired - unnecessary_candidates)
-    assert not mismatches, f"{label} serializer differences:\n" + "\n".join(mismatches)
+    known_diffs = frozenset(known_differences or ())
+    checker = _ParityChecker()
+    checker.collect(old, new, known_diffs)
+    unnecessary = (checker.unnecessary_candidates - checker.fired) | (
+        known_diffs - checker.fired - checker.unnecessary_candidates
+    )
+    assert not checker.mismatches, f"{label} serializer differences:\n" + "\n".join(
+        checker.mismatches
+    )
     assert not unnecessary, (
         f"{label} unnecessary known_differences (no actual difference found):\n"
         + "\n".join(sorted(unnecessary))
     )
 
 
-def _collect_mismatches(
-    old: Mapping[str, Any],
-    new: Mapping[str, Any],
-    known_differences: set[str],
-    mismatches: list[str],
-    fired: set[str],
-    unnecessary_candidates: set[str],
-    path: str,
-    kd_prefix: str,
-) -> None:
-    def _fp(field: str) -> str:
-        return f"{path}.{field}" if path else field
+@dataclass
+class _ParityChecker:
+    mismatches: list[str] = field(default_factory=list)
+    fired: set[str] = field(default_factory=set)
+    unnecessary_candidates: set[str] = field(default_factory=set)
 
-    def _kd_key(field: str) -> str:
-        return f"{kd_prefix}.{field}" if kd_prefix else field
+    def collect(
+        self,
+        old: Mapping[str, Any],
+        new: Mapping[str, Any],
+        known_diffs: frozenset[str],
+        path: str = "",
+        kd_prefix: str = "",
+    ) -> None:
+        def fp(key: str) -> str:
+            return f"{path}.{key}" if path else key
 
-    def _nested_diffs(field: str) -> set[str]:
-        prefix = field + "."
-        return {entry[len(prefix) :] for entry in known_differences if entry.startswith(prefix)}
+        def kd_key(key: str) -> str:
+            return f"{kd_prefix}.{key}" if kd_prefix else key
 
-    for field in set(list(old.keys()) + list(new.keys())):
-        if field in known_differences:
-            kd_key = _kd_key(field)
-            if field not in new or field not in old or old[field] != new[field]:
-                fired.add(kd_key)
-            else:
-                unnecessary_candidates.add(kd_key)
-            continue
+        def nested_diffs(key: str) -> frozenset[str]:
+            prefix = key + "."
+            return frozenset(e[len(prefix) :] for e in known_diffs if e.startswith(prefix))
 
-        fp = _fp(field)
+        for key in set(list(old.keys()) + list(new.keys())):
+            if key in known_diffs:
+                full_kd_key = kd_key(key)
+                if key not in new or key not in old or old[key] != new[key]:
+                    self.fired.add(full_kd_key)
+                else:
+                    self.unnecessary_candidates.add(full_kd_key)
+                continue
 
-        if field not in new:
-            mismatches.append(f"Missing from new: {fp}")
-            continue
-        if field not in old:
-            mismatches.append(f"Extra in new: {fp}")
-            continue
+            full_path = fp(key)
 
-        old_val = old[field]
-        new_val = new[field]
-        nested = _nested_diffs(field)
+            if key not in new:
+                self.mismatches.append(f"Missing from new: {full_path}")
+                continue
+            if key not in old:
+                self.mismatches.append(f"Extra in new: {full_path}")
+                continue
 
-        if nested:
-            new_kd_prefix = _kd_key(field)
-            if isinstance(old_val, list) and isinstance(new_val, list):
-                if len(old_val) != len(new_val):
-                    mismatches.append(f"{fp} count: old={len(old_val)}, new={len(new_val)}")
-                for i, (old_item, new_item) in enumerate(zip(old_val, new_val)):
-                    item_path = f"{fp}[{i}]"
-                    if isinstance(old_item, Mapping) and isinstance(new_item, Mapping):
-                        _collect_mismatches(
-                            old_item,
-                            new_item,
-                            nested,
-                            mismatches,
-                            fired,
-                            unnecessary_candidates,
-                            item_path,
-                            new_kd_prefix,
+            old_val = old[key]
+            new_val = new[key]
+            nested = nested_diffs(key)
+
+            if nested:
+                child_kd_prefix = kd_key(key)
+                if isinstance(old_val, list) and isinstance(new_val, list):
+                    if len(old_val) != len(new_val):
+                        self.mismatches.append(
+                            f"{full_path} count: old={len(old_val)}, new={len(new_val)}"
                         )
-                    elif old_item != new_item:
-                        mismatches.append(f"{item_path}: old={old_item!r}, new={new_item!r}")
-            elif isinstance(old_val, Mapping) and isinstance(new_val, Mapping):
-                _collect_mismatches(
-                    old_val,
-                    new_val,
-                    nested,
-                    mismatches,
-                    fired,
-                    unnecessary_candidates,
-                    fp,
-                    new_kd_prefix,
-                )
+                    for i, (old_item, new_item) in enumerate(zip(old_val, new_val)):
+                        item_path = f"{full_path}[{i}]"
+                        if isinstance(old_item, Mapping) and isinstance(new_item, Mapping):
+                            self.collect(old_item, new_item, nested, item_path, child_kd_prefix)
+                        elif old_item != new_item:
+                            self.mismatches.append(
+                                f"{item_path}: old={old_item!r}, new={new_item!r}"
+                            )
+                elif isinstance(old_val, Mapping) and isinstance(new_val, Mapping):
+                    self.collect(old_val, new_val, nested, full_path, child_kd_prefix)
+                elif old_val != new_val:
+                    self.mismatches.append(f"{full_path}: old={old_val!r}, new={new_val!r}")
             elif old_val != new_val:
-                mismatches.append(f"{fp}: old={old_val!r}, new={new_val!r}")
-        elif old_val != new_val:
-            mismatches.append(f"{fp}: old={old_val!r}, new={new_val!r}")
+                self.mismatches.append(f"{full_path}: old={old_val!r}, new={new_val!r}")

--- a/src/sentry/testutils/helpers/serializer_parity.py
+++ b/src/sentry/testutils/helpers/serializer_parity.py
@@ -35,11 +35,12 @@ def assert_serializer_parity(
     """
     known_diffs = frozenset(known_differences or ())
     checker = _ParityChecker()
-    checker.collect(old, new, known_diffs)
-    unnecessary = (checker.unnecessary_candidates - checker.fired) | (
-        known_diffs - checker.fired - checker.unnecessary_candidates
-    )
+    checker.compare(old, new, known_diffs)
+
     assert not checker.mismatches, "Serializer differences:\n" + "\n".join(checker.mismatches)
+
+    # known_diffs entries that were never confirmed as real differences are unnecessary.
+    unnecessary = known_diffs - checker.confirmed
     assert not unnecessary, (
         "Unnecessary known_differences (no actual difference found):\n"
         + "\n".join(sorted(unnecessary))
@@ -53,28 +54,27 @@ def _qualify(prefix: str, name: str) -> str:
 @dataclass
 class _ParityChecker:
     mismatches: list[str] = field(default_factory=list)
-    fired: set[str] = field(default_factory=set)
-    unnecessary_candidates: set[str] = field(default_factory=set)
+
+    # known_diffs entries confirmed to be actual differences.
+    confirmed: set[str] = field(default_factory=set)
 
     def _nested_diffs(self, known_diffs: frozenset[str], key: str) -> frozenset[str]:
         prefix = key + "."
         return frozenset(e[len(prefix) :] for e in known_diffs if e.startswith(prefix))
 
-    def collect(
+    def compare(
         self,
         old: Mapping[str, Any],
         new: Mapping[str, Any],
         known_diffs: frozenset[str],
         path: str = "",
-        kd_prefix: str = "",
+        kd_path: str = "",
     ) -> None:
         for key in set(list(old.keys()) + list(new.keys())):
             if key in known_diffs:
-                full_kd_key = _qualify(kd_prefix, key)
+                full_kd_key = _qualify(kd_path, key)
                 if key not in new or key not in old or old[key] != new[key]:
-                    self.fired.add(full_kd_key)
-                else:
-                    self.unnecessary_candidates.add(full_kd_key)
+                    self.confirmed.add(full_kd_key)
                 continue
 
             full_path = _qualify(path, key)
@@ -91,7 +91,7 @@ class _ParityChecker:
             nested = self._nested_diffs(known_diffs, key)
 
             if nested:
-                child_kd_prefix = _qualify(kd_prefix, key)
+                child_kd_path = _qualify(kd_path, key)
                 if isinstance(old_val, list) and isinstance(new_val, list):
                     if len(old_val) != len(new_val):
                         self.mismatches.append(
@@ -100,13 +100,13 @@ class _ParityChecker:
                     for i, (old_item, new_item) in enumerate(zip(old_val, new_val)):
                         item_path = f"{full_path}[{i}]"
                         if isinstance(old_item, Mapping) and isinstance(new_item, Mapping):
-                            self.collect(old_item, new_item, nested, item_path, child_kd_prefix)
+                            self.compare(old_item, new_item, nested, item_path, child_kd_path)
                         elif old_item != new_item:
                             self.mismatches.append(
                                 f"{item_path}: old={old_item!r}, new={new_item!r}"
                             )
                 elif isinstance(old_val, Mapping) and isinstance(new_val, Mapping):
-                    self.collect(old_val, new_val, nested, full_path, child_kd_prefix)
+                    self.compare(old_val, new_val, nested, full_path, child_kd_path)
                 elif old_val != new_val:
                     self.mismatches.append(f"{full_path}: old={old_val!r}, new={new_val!r}")
             elif old_val != new_val:

--- a/src/sentry/testutils/helpers/serializer_parity.py
+++ b/src/sentry/testutils/helpers/serializer_parity.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def assert_serializer_parity(
+    old: Mapping[str, Any],
+    new: Mapping[str, Any],
+    known_differences: set[str] | None = None,
+    *,
+    label: str = "old vs new",
+) -> None:
+    """Assert that two serializer responses are equal, modulo known differences.
+
+    ``known_differences`` is a set of dot-separated field paths to exclude:
+
+    * ``"field"`` — skip ``field`` at the top level.
+    * ``"parent.field"`` — skip ``field`` inside ``parent``.  If ``parent`` is a
+      list of dicts, the exclusion applies to every element.  Callers must sort
+      any list fields to the same order before calling.
+
+    Raises if any listed known difference is not actually different — unnecessary
+    entries should be removed.
+
+    Examples::
+
+        assert_serializer_parity(old, new, {"resolveThreshold"})
+
+        assert_serializer_parity(
+            old,
+            new,
+            {"resolveThreshold", "triggers.resolveThreshold"},
+        )
+    """
+    known_diffs = known_differences or set()
+    mismatches: list[str] = []
+    fired: set[str] = set()
+    unnecessary_candidates: set[str] = set()
+    _collect_mismatches(old, new, known_diffs, mismatches, fired, unnecessary_candidates, "", "")
+    unnecessary = (unnecessary_candidates - fired) | (known_diffs - fired - unnecessary_candidates)
+    assert not mismatches, f"{label} serializer differences:\n" + "\n".join(mismatches)
+    assert not unnecessary, (
+        f"{label} unnecessary known_differences (no actual difference found):\n"
+        + "\n".join(sorted(unnecessary))
+    )
+
+
+def _collect_mismatches(
+    old: Mapping[str, Any],
+    new: Mapping[str, Any],
+    known_differences: set[str],
+    mismatches: list[str],
+    fired: set[str],
+    unnecessary_candidates: set[str],
+    path: str,
+    kd_prefix: str,
+) -> None:
+    def _fp(field: str) -> str:
+        return f"{path}.{field}" if path else field
+
+    def _kd_key(field: str) -> str:
+        return f"{kd_prefix}.{field}" if kd_prefix else field
+
+    def _nested_diffs(field: str) -> set[str]:
+        prefix = field + "."
+        return {entry[len(prefix) :] for entry in known_differences if entry.startswith(prefix)}
+
+    for field in set(list(old.keys()) + list(new.keys())):
+        if field in known_differences:
+            kd_key = _kd_key(field)
+            if field not in new or field not in old or old[field] != new[field]:
+                fired.add(kd_key)
+            else:
+                unnecessary_candidates.add(kd_key)
+            continue
+
+        fp = _fp(field)
+
+        if field not in new:
+            mismatches.append(f"Missing from new: {fp}")
+            continue
+        if field not in old:
+            mismatches.append(f"Extra in new: {fp}")
+            continue
+
+        old_val = old[field]
+        new_val = new[field]
+        nested = _nested_diffs(field)
+
+        if nested:
+            new_kd_prefix = _kd_key(field)
+            if isinstance(old_val, list) and isinstance(new_val, list):
+                if len(old_val) != len(new_val):
+                    mismatches.append(f"{fp} count: old={len(old_val)}, new={len(new_val)}")
+                for i, (old_item, new_item) in enumerate(zip(old_val, new_val)):
+                    item_path = f"{fp}[{i}]"
+                    if isinstance(old_item, Mapping) and isinstance(new_item, Mapping):
+                        _collect_mismatches(
+                            old_item,
+                            new_item,
+                            nested,
+                            mismatches,
+                            fired,
+                            unnecessary_candidates,
+                            item_path,
+                            new_kd_prefix,
+                        )
+                    elif old_item != new_item:
+                        mismatches.append(f"{item_path}: old={old_item!r}, new={new_item!r}")
+            elif isinstance(old_val, Mapping) and isinstance(new_val, Mapping):
+                _collect_mismatches(
+                    old_val,
+                    new_val,
+                    nested,
+                    mismatches,
+                    fired,
+                    unnecessary_candidates,
+                    fp,
+                    new_kd_prefix,
+                )
+            elif old_val != new_val:
+                mismatches.append(f"{fp}: old={old_val!r}, new={new_val!r}")
+        elif old_val != new_val:
+            mismatches.append(f"{fp}: old={old_val!r}, new={new_val!r}")

--- a/src/sentry/testutils/helpers/serializer_parity.py
+++ b/src/sentry/testutils/helpers/serializer_parity.py
@@ -6,11 +6,10 @@ from typing import Any
 
 
 def assert_serializer_parity(
+    *,
     old: Mapping[str, Any],
     new: Mapping[str, Any],
     known_differences: set[str] | None = None,
-    *,
-    label: str = "old vs new",
 ) -> None:
     """Assert that two serializer responses are equal, modulo known differences.
 
@@ -19,19 +18,19 @@ def assert_serializer_parity(
     * ``"field"`` — skip ``field`` at the top level.
     * ``"parent.field"`` — skip ``field`` inside ``parent``.  If ``parent`` is a
       list of dicts, the exclusion applies to every element.  Callers must sort
-      any list fields to the same order before calling.
+      any list fields to the same order before calling if order should be ignored.
 
     Raises if any listed known difference is not actually different — unnecessary
     entries should be removed.
 
     Examples::
 
-        assert_serializer_parity(old, new, {"resolveThreshold"})
+        assert_serializer_parity(old=old, new=new)
 
         assert_serializer_parity(
-            old,
-            new,
-            {"resolveThreshold", "triggers.resolveThreshold"},
+            old=old,
+            new=new,
+            known_differences={"resolveThreshold", "triggers.resolveThreshold"},
         )
     """
     known_diffs = frozenset(known_differences or ())
@@ -40,13 +39,15 @@ def assert_serializer_parity(
     unnecessary = (checker.unnecessary_candidates - checker.fired) | (
         known_diffs - checker.fired - checker.unnecessary_candidates
     )
-    assert not checker.mismatches, f"{label} serializer differences:\n" + "\n".join(
-        checker.mismatches
-    )
+    assert not checker.mismatches, "Serializer differences:\n" + "\n".join(checker.mismatches)
     assert not unnecessary, (
-        f"{label} unnecessary known_differences (no actual difference found):\n"
+        "Unnecessary known_differences (no actual difference found):\n"
         + "\n".join(sorted(unnecessary))
     )
+
+
+def _qualify(prefix: str, name: str) -> str:
+    return f"{prefix}.{name}" if prefix else name
 
 
 @dataclass
@@ -54,6 +55,10 @@ class _ParityChecker:
     mismatches: list[str] = field(default_factory=list)
     fired: set[str] = field(default_factory=set)
     unnecessary_candidates: set[str] = field(default_factory=set)
+
+    def _nested_diffs(self, known_diffs: frozenset[str], key: str) -> frozenset[str]:
+        prefix = key + "."
+        return frozenset(e[len(prefix) :] for e in known_diffs if e.startswith(prefix))
 
     def collect(
         self,
@@ -63,26 +68,16 @@ class _ParityChecker:
         path: str = "",
         kd_prefix: str = "",
     ) -> None:
-        def fp(key: str) -> str:
-            return f"{path}.{key}" if path else key
-
-        def kd_key(key: str) -> str:
-            return f"{kd_prefix}.{key}" if kd_prefix else key
-
-        def nested_diffs(key: str) -> frozenset[str]:
-            prefix = key + "."
-            return frozenset(e[len(prefix) :] for e in known_diffs if e.startswith(prefix))
-
         for key in set(list(old.keys()) + list(new.keys())):
             if key in known_diffs:
-                full_kd_key = kd_key(key)
+                full_kd_key = _qualify(kd_prefix, key)
                 if key not in new or key not in old or old[key] != new[key]:
                     self.fired.add(full_kd_key)
                 else:
                     self.unnecessary_candidates.add(full_kd_key)
                 continue
 
-            full_path = fp(key)
+            full_path = _qualify(path, key)
 
             if key not in new:
                 self.mismatches.append(f"Missing from new: {full_path}")
@@ -93,10 +88,10 @@ class _ParityChecker:
 
             old_val = old[key]
             new_val = new[key]
-            nested = nested_diffs(key)
+            nested = self._nested_diffs(known_diffs, key)
 
             if nested:
-                child_kd_prefix = kd_key(key)
+                child_kd_prefix = _qualify(kd_prefix, key)
                 if isinstance(old_val, list) and isinstance(new_val, list):
                     if len(old_val) != len(new_val):
                         self.mismatches.append(

--- a/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
@@ -148,9 +148,9 @@ class ProjectAlertRuleTaskDetailsDeltaTest(APITestCase):
         new_data = response_new.data["alertRule"]
 
         assert_serializer_parity(
-            old_data,
-            new_data,
-            {
+            old=old_data,
+            new=new_data,
+            known_differences={
                 # createdBy: Lost during migration when AlertRuleActivity CREATED type wasn't
                 # tracked. Detector.created_by_id is None if user wasn't provided during migration.
                 # Cannot use AlertRuleActivity as it's being phased out.
@@ -161,5 +161,4 @@ class ProjectAlertRuleTaskDetailsDeltaTest(APITestCase):
                 "resolveThreshold",
                 "triggers.resolveThreshold",  # same reason as above
             },
-            label="Task details old vs new",
         )

--- a/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_alert_rule,
     migrate_metric_action,
@@ -146,31 +147,19 @@ class ProjectAlertRuleTaskDetailsDeltaTest(APITestCase):
         assert response_new.status_code == 200
         new_data = response_new.data["alertRule"]
 
-        skip_fields = {"triggers"}
-
-        # Known differences between old and new serializers that are acceptable
-        known_differences = {
-            # createdBy: Lost during migration when AlertRuleActivity CREATED type wasn't
-            # tracked. Detector.created_by_id is None if user wasn't provided during migration.
-            # Cannot use AlertRuleActivity as it's being phased out.
-            "createdBy",
-            # resolveThreshold: Old serializer checked AlertRule.resolve_threshold for None,
-            # but workflow engine always creates a resolve condition during migration.
-            # Cannot distinguish between explicit None vs migrated value without AlertRule.
-            "resolveThreshold",
-        }
-
-        mismatches: list[str] = []
-        for field in set(list(old_data.keys()) + list(new_data.keys())):
-            if field in skip_fields or field in known_differences:
-                continue
-            if field not in new_data:
-                mismatches.append(f"Missing from new: {field}")
-            elif field not in old_data:
-                mismatches.append(f"Extra in new: {field}")
-            elif old_data[field] != new_data[field]:
-                mismatches.append(f"{field}: old={old_data[field]!r}, new={new_data[field]!r}")
-
-        assert not mismatches, "Task details old vs new serializer differences:\n" + "\n".join(
-            mismatches
+        assert_serializer_parity(
+            old_data,
+            new_data,
+            {
+                # createdBy: Lost during migration when AlertRuleActivity CREATED type wasn't
+                # tracked. Detector.created_by_id is None if user wasn't provided during migration.
+                # Cannot use AlertRuleActivity as it's being phased out.
+                "createdBy",
+                # resolveThreshold: Old serializer checked AlertRule.resolve_threshold for None,
+                # but workflow engine always creates a resolve condition during migration.
+                # Cannot distinguish between explicit None vs migrated value without AlertRule.
+                "resolveThreshold",
+                "triggers.resolveThreshold",  # same reason as above
+            },
+            label="Task details old vs new",
         )

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1956,9 +1956,7 @@ class GetProjectRuleDetailsDeltaTest(ProjectRuleDetailsBaseTestCase):
             )
 
         assert legacy_response.data["id"] == str(rule.id)
-        assert_serializer_parity(
-            legacy_response.data, we_response.data, label="Legacy vs workflow engine"
-        )
+        assert_serializer_parity(old=legacy_response.data, new=we_response.data)
 
     def test_dual_written_rule_with_filters_parity(self) -> None:
         rule = self.create_project_rule(
@@ -1997,6 +1995,4 @@ class GetProjectRuleDetailsDeltaTest(ProjectRuleDetailsBaseTestCase):
             )
 
         assert legacy_response.data["id"] == str(rule.id)
-        assert_serializer_parity(
-            legacy_response.data, we_response.data, label="Legacy vs workflow engine"
-        )
+        assert_serializer_parity(old=legacy_response.data, new=we_response.data)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -24,6 +24,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack, with_feature
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
 from sentry.workflow_engine.models import Action, AlertRuleWorkflow
@@ -1915,28 +1916,6 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
 
 
 class GetProjectRuleDetailsDeltaTest(ProjectRuleDetailsBaseTestCase):
-    def assert_serializer_parity(
-        self,
-        legacy: Mapping[str, Any],
-        we: Mapping[str, Any],
-        known_differences: set[str] | None = None,
-    ) -> None:
-        if known_differences is None:
-            known_differences = set()
-        mismatches: list[str] = []
-        for field in set(list(legacy.keys()) + list(we.keys())):
-            if field in known_differences:
-                continue
-            if field not in we:
-                mismatches.append(f"Missing from workflow engine: {field}")
-            elif field not in legacy:
-                mismatches.append(f"Extra in workflow engine: {field}")
-            elif legacy[field] != we[field]:
-                mismatches.append(f"{field}: legacy={legacy[field]!r}, we={we[field]!r}")
-        assert not mismatches, "Legacy vs workflow engine serializer differences:\n" + "\n".join(
-            mismatches
-        )
-
     def test_dual_written_rule_parity(self) -> None:
         rule = self.create_project_rule(
             project=self.project,
@@ -1977,7 +1956,9 @@ class GetProjectRuleDetailsDeltaTest(ProjectRuleDetailsBaseTestCase):
             )
 
         assert legacy_response.data["id"] == str(rule.id)
-        self.assert_serializer_parity(legacy_response.data, we_response.data)
+        assert_serializer_parity(
+            legacy_response.data, we_response.data, label="Legacy vs workflow engine"
+        )
 
     def test_dual_written_rule_with_filters_parity(self) -> None:
         rule = self.create_project_rule(
@@ -2016,4 +1997,6 @@ class GetProjectRuleDetailsDeltaTest(ProjectRuleDetailsBaseTestCase):
             )
 
         assert legacy_response.data["id"] == str(rule.id)
-        self.assert_serializer_parity(legacy_response.data, we_response.data)
+        assert_serializer_parity(
+            legacy_response.data, we_response.data, label="Legacy vs workflow engine"
+        )

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -45,6 +45,7 @@ from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack, with_feature
+from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.models.user import User
 from sentry.workflow_engine.models import (
@@ -1592,19 +1593,4 @@ class GetProjectRulesDeltaTest(APITestCase):
         we_rule = we_response.data[0]
         assert legacy_rule["id"] == str(rule.id)
 
-        known_differences: set[str] = set()
-
-        mismatches: list[str] = []
-        for field in set(list(legacy_rule.keys()) + list(we_rule.keys())):
-            if field in known_differences:
-                continue
-            if field not in we_rule:
-                mismatches.append(f"Missing from workflow engine: {field}")
-            elif field not in legacy_rule:
-                mismatches.append(f"Extra in workflow engine: {field}")
-            elif legacy_rule[field] != we_rule[field]:
-                mismatches.append(f"{field}: legacy={legacy_rule[field]!r}, we={we_rule[field]!r}")
-
-        assert not mismatches, "Legacy vs workflow engine serializer differences:\n" + "\n".join(
-            mismatches
-        )
+        assert_serializer_parity(legacy_rule, we_rule, label="Legacy vs workflow engine")

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -1593,4 +1593,4 @@ class GetProjectRulesDeltaTest(APITestCase):
         we_rule = we_response.data[0]
         assert legacy_rule["id"] == str(rule.id)
 
-        assert_serializer_parity(legacy_rule, we_rule, label="Legacy vs workflow engine")
+        assert_serializer_parity(old=legacy_rule, new=we_rule)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -60,6 +60,7 @@ from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -389,43 +390,27 @@ class AlertRuleListDeltaTest(AlertRuleIndexBase, TestWorkflowEngineSerializer):
         new_data = new_resp.data
         assert len(new_data) == len(old_data)
 
-        # Known differences between old and new serializers
-        known_differences = {
-            # resolveThreshold: Old serializer checked AlertRule.resolve_threshold for None,
-            # but workflow engine always creates a resolve condition during migration.
-            # Cannot distinguish between explicit None vs migrated value without AlertRule.
-            "resolveThreshold",
-        }
-
-        mismatches: list[str] = []
         for old_rule, new_rule in zip(old_data, new_data):
-            for field in set(list(old_rule.keys()) + list(new_rule.keys())):
-                if field == "triggers" or field in known_differences:
-                    continue
-                if field not in new_rule:
-                    mismatches.append(f"Missing from new: {field}")
-                elif field not in old_rule:
-                    mismatches.append(f"Extra in new: {field}")
-                elif old_rule[field] != new_rule[field]:
-                    mismatches.append(f"{field}: old={old_rule[field]!r}, new={new_rule[field]!r}")
-
-            old_triggers = sorted(old_rule.get("triggers", []), key=lambda t: t.get("label", ""))
-            new_triggers = sorted(new_rule.get("triggers", []), key=lambda t: t.get("label", ""))
-            if len(old_triggers) != len(new_triggers):
-                mismatches.append(
-                    f"trigger count: old={len(old_triggers)}, new={len(new_triggers)}"
-                )
-            for old_t, new_t in zip(old_triggers, new_triggers):
-                for tfield in set(list(old_t.keys()) + list(new_t.keys())):
-                    if tfield == "actions" or tfield in known_differences:
-                        continue
-                    if old_t.get(tfield) != new_t.get(tfield):
-                        mismatches.append(
-                            f"trigger[{old_t.get('label')}].{tfield}: "
-                            f"old={old_t.get(tfield)!r}, new={new_t.get(tfield)!r}"
-                        )
-
-        assert not mismatches, "List old vs new serializer differences:\n" + "\n".join(mismatches)
+            old_sorted = {
+                **old_rule,
+                "triggers": sorted(old_rule.get("triggers", []), key=lambda t: t.get("label", "")),
+            }
+            new_sorted = {
+                **new_rule,
+                "triggers": sorted(new_rule.get("triggers", []), key=lambda t: t.get("label", "")),
+            }
+            assert_serializer_parity(
+                old_sorted,
+                new_sorted,
+                {
+                    # resolveThreshold: Old serializer checked AlertRule.resolve_threshold for None,
+                    # but workflow engine always creates a resolve condition during migration.
+                    # Cannot distinguish between explicit None vs migrated value without AlertRule.
+                    "resolveThreshold",
+                    "triggers.resolveThreshold",  # same reason as above
+                },
+                label="List old vs new",
+            )
 
 
 @freeze_time()

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -400,16 +400,15 @@ class AlertRuleListDeltaTest(AlertRuleIndexBase, TestWorkflowEngineSerializer):
                 "triggers": sorted(new_rule.get("triggers", []), key=lambda t: t.get("label", "")),
             }
             assert_serializer_parity(
-                old_sorted,
-                new_sorted,
-                {
+                old=old_sorted,
+                new=new_sorted,
+                known_differences={
                     # resolveThreshold: Old serializer checked AlertRule.resolve_threshold for None,
                     # but workflow engine always creates a resolve condition during migration.
                     # Cannot distinguish between explicit None vs migrated value without AlertRule.
                     "resolveThreshold",
                     "triggers.resolveThreshold",  # same reason as above
                 },
-                label="List old vs new",
             )
 
 


### PR DESCRIPTION
Rather than writing slightly different diff code in each test, we can extract the diffing logic and share it.
There are open source things we could involve here, but it isn't hard to do it ourselves, and by keeping it fairly tightly constrained it should be easy to import something more sophisticated if necessary.

Note: this does include a serializer change to avoid a flagged diff where there was a type difference, but it seemed small enough to not merit a spin-off pr.
