### PR TITLE
ref(snapshots): Move temp prefix to suffix on metric tags

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -387,9 +387,9 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         has_vcs = commit_comparison is not None
 
         metric_tags = {
-            "temp_org_id": str(project.organization_id),
-            "temp_project_id": str(project.id),
-            "temp_app_id": artifact.app_id or "",
+            "org_id_temp": str(project.organization_id),
+            "project_id_temp": str(project.id),
+            "app_id_temp": artifact.app_id or "",
         }
 
         metrics.distribution(

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -518,9 +518,9 @@ def compare_snapshots(
         time_now = timezone.now()
 
         metric_tags = {
-            "temp_org_id": str(org_id),
-            "temp_project_id": str(project_id),
-            "temp_app_id": head_artifact.app_id or "",
+            "org_id_temp": str(org_id),
+            "project_id_temp": str(project_id),
+            "app_id_temp": head_artifact.app_id or "",
         }
 
         diff_duration_s = (time_now - task_start_time).total_seconds()


### PR DESCRIPTION
The metrics middleware (`src/sentry/metrics/middleware.py`) rejects any tag
ending with `_id` to prevent high-cardinality metric tags. PR #111354
renamed snapshot metric tags with a `temp_` prefix (`temp_org_id`, etc.),
but they still ended with `_id` and were still being filtered.

This moves `temp` to the suffix instead (`org_id_temp`, `project_id_temp`,
`app_id_temp`) so the tags no longer match the `_id` suffix check.