### PR TITLE
perf(nodestore): Increase cache TTL from 5 minutes to 4 hours

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2528,10 +2528,12 @@ register(
 
 # TTL in seconds for nodestore cache entries. Event bodies are immutable
 # so longer TTLs are safe and improve cache hit rates for batch reads
-# (e.g. group events list endpoint).
+# (e.g. group events list endpoint). The ingestion path populates the
+# cache on write (set_subkeys), so a longer TTL means recently ingested
+# events stay warm in cache when users first view an issue's event list.
 register(
     "nodestore.cache-ttl",
-    default=300,
+    default=14400,  # 4 hours
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
Follow-up to #111283 which added cache observability and configurable TTL.

Production metrics from the last 7 days show:
- **86% of `get_multi` calls are full cache hits** (61.4M / 71.6M)
- **p99 pain is all cold misses**: `get_multi` p99 = 4.6s, `SimpleEventSerializer` p99 = 11.5s
- Worst offenders: `sentry.tasks.unmerge` (42.8s/500 IDs), GroupEventsEndpoint (15-24s/100 IDs)

The 300s default TTL was the previous implicit default — it didn't change anything. This PR bumps it to 4 hours (14400s).

### Why this helps

The ingestion path already populates the `nodedata` cache on write (`set_subkeys` → `_set_cache_item`). So when an event is ingested, its full body is cached. With a 5-minute TTL, that cache entry expires before anyone views the issue. With a 4-hour TTL, events ingested in the last 4 hours stay warm — and for **active issues** (the ones people actually click on), most of the 100 latest events will have been ingested recently.

### Why this is safe

Event bodies are **immutable** — they never change after ingestion. There's no invalidation concern. The only cost is cache memory, which is bounded by the natural eviction of least-recently-used entries in the Redis/Memcached backend.

Can be tuned at runtime via `nodestore.cache-ttl` without a deploy if we need to roll back.