### PR TITLE
fix(workflows): Make TTL a definitional part of CacheMapping rather than an optional param

### DIFF
--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -28,6 +28,7 @@ class _CacheResults(NamedTuple):
 _action_filters_cache = CacheMapping[_ActionFilterCacheKey, list[DataConditionGroup]](
     lambda key: f"{key.workflow_id}",
     namespace=f"workflow:{ACTION_FILTER_CACHE_NAME}",
+    ttl_seconds=CACHE_TTL,
 )
 
 
@@ -73,7 +74,7 @@ def _populate_cache(action_filters_by_workflow: ActionFiltersByWorkflow) -> None
         for workflow_id, action_filters in action_filters_by_workflow.items()
     }
 
-    _action_filters_cache.set_many(cache_items, CACHE_TTL)
+    _action_filters_cache.set_many(cache_items)
 
 
 @scopedstats.timer()

--- a/src/sentry/workflow_engine/caches/detector.py
+++ b/src/sentry/workflow_engine/caches/detector.py
@@ -15,6 +15,7 @@ class _DetectorCacheKey(NamedTuple):
 _detectors_by_data_source = CacheMapping[_DetectorCacheKey, list[Detector]](
     lambda key: f"{key.source_type}:{key.source_id}",
     namespace="detector:detectors_by_data_source",
+    ttl_seconds=CACHE_TTL,
 )
 
 
@@ -29,7 +30,7 @@ def get_detectors_by_data_source(source_id: str, query_type: str) -> list[Detect
         if detectors is None:
             metrics_tags["cache_hit"] = "false"
             detectors = _query_detectors(source_id, query_type)
-            _detectors_by_data_source.set(cache_key, detectors, CACHE_TTL)
+            _detectors_by_data_source.set(cache_key, detectors)
         else:
             metrics_tags["cache_hit"] = "true"
 

--- a/src/sentry/workflow_engine/caches/mapping.py
+++ b/src/sentry/workflow_engine/caches/mapping.py
@@ -20,11 +20,12 @@ class CacheMapping[K, V]:
         _user_cache = CacheMapping[int, UserData](
             lambda uid: str(uid),
             namespace="user",
+            ttl_seconds=300,
         )
         # Keys will be "user:{uid}"
 
     Example without namespace:
-        _user_cache = CacheMapping[int, UserData](lambda uid: f"user:{uid}")
+        _user_cache = CacheMapping[int, UserData](lambda uid: f"user:{uid}", ttl_seconds=300)
     """
 
     def __init__(
@@ -32,9 +33,11 @@ class CacheMapping[K, V]:
         key_func: Callable[[K], str],
         *,
         namespace: str | None = None,
+        ttl_seconds: float,
     ):
         self._key_func = key_func
         self._namespace = namespace
+        self._ttl_seconds = ttl_seconds
         if namespace is not None:
             if namespace in _registered_namespaces:
                 raise ValueError(f"Cache namespace '{namespace}' is already registered")
@@ -49,8 +52,8 @@ class CacheMapping[K, V]:
     def get(self, input: K) -> V | None:
         return cache.get(self.key(input))
 
-    def set(self, input: K, value: V, timeout: float | None = None) -> None:
-        cache.set(self.key(input), value, timeout)
+    def set(self, input: K, value: V) -> None:
+        cache.set(self.key(input), value, self._ttl_seconds)
 
     def delete(self, input: K) -> bool:
         return cache.delete(self.key(input))
@@ -69,7 +72,7 @@ class CacheMapping[K, V]:
         values = cache.get_many(key_to_input.keys())
         return {key_to_input[k]: values.get(k) for k in key_to_input}
 
-    def set_many(self, data: Mapping[K, V], timeout: float | None = None) -> list[K]:
+    def set_many(self, data: Mapping[K, V]) -> list[K]:
         """
         Set multiple cache values at once.
 
@@ -81,7 +84,7 @@ class CacheMapping[K, V]:
         keyed_data = {self.key(inp): (inp, val) for inp, val in data.items()}
         failed_keys = cache.set_many(
             {k: val for k, (_, val) in keyed_data.items()},
-            timeout,
+            self._ttl_seconds,
         )
         failed = set(failed_keys or [])
         return [inp for k, (inp, _) in keyed_data.items() if k in failed]

--- a/src/sentry/workflow_engine/caches/workflow.py
+++ b/src/sentry/workflow_engine/caches/workflow.py
@@ -26,6 +26,7 @@ class _WorkflowCacheKey(NamedTuple):
 _workflow_cache = CacheMapping[_WorkflowCacheKey, set[Workflow]](
     lambda key: f"{key.detector_id}:{key.env_id}",
     namespace=WORKFLOW_CACHE_PREFIX,
+    ttl_seconds=CACHE_TTL,
 )
 
 
@@ -216,7 +217,7 @@ def _populate_detector_caches(
             }
         )
 
-    _workflow_cache.set_many(data, CACHE_TTL)
+    _workflow_cache.set_many(data)
 
 
 @scopedstats.timer()

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -17,6 +17,8 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
+CACHE_TTL_SECONDS = 600
+
 
 class _LatestReleaseCacheKey(NamedTuple):
     project_id: int
@@ -31,11 +33,15 @@ class _LatestAdoptedReleaseCacheKey(NamedTuple):
 # Cache mappings for latest release lookups.
 # Values are Release objects, or False if no release exists (to cache negative lookups).
 _latest_release_cache = CacheMapping[_LatestReleaseCacheKey, Release | Literal[False]](
-    lambda key: latest_release_cache_key(key.project_id, key.environment_id)
+    lambda key: latest_release_cache_key(key.project_id, key.environment_id),
+    ttl_seconds=CACHE_TTL_SECONDS,
 )
 _latest_adopted_release_cache = CacheMapping[
     _LatestAdoptedReleaseCacheKey, Release | Literal[False]
-](lambda key: latest_adopted_release_cache_key(key.project_id, key.environment_id))
+](
+    lambda key: latest_adopted_release_cache_key(key.project_id, key.environment_id),
+    ttl_seconds=CACHE_TTL_SECONDS,
+)
 
 
 def get_latest_adopted_release_for_env(
@@ -110,12 +116,12 @@ def _get_latest_release_for_env_impl[K](
         record_get_latest_release_result("success")
     except Release.DoesNotExist:
         record_get_latest_release_result("does_not_exist")
-        mapping.set(cache_key, False, 600)
+        mapping.set(cache_key, False)
         return None
     latest_release = Release.objects.get(
         version=latest_release_version, organization_id=organization_id
     )
-    mapping.set(cache_key, latest_release or False, 600)
+    mapping.set(cache_key, latest_release or False)
     return latest_release
 
 

--- a/tests/sentry/workflow_engine/caches/test_mapping.py
+++ b/tests/sentry/workflow_engine/caches/test_mapping.py
@@ -10,7 +10,7 @@ from sentry.workflow_engine.caches.mapping import (
 class TestCacheMapping(TestCase):
     def setUp(self) -> None:
         test_only_clear_registered_namespaces()
-        self.mapping = CacheMapping[int, str](lambda x: str(x))
+        self.mapping = CacheMapping[int, str](lambda x: str(x), ttl_seconds=60)
 
     def test_key(self) -> None:
         assert self.mapping.key(123) == "123"
@@ -19,20 +19,20 @@ class TestCacheMapping(TestCase):
         assert self.mapping.get(1) is None
 
     def test_get__returns_value_when_set(self) -> None:
-        self.mapping.set(1, "test_value", 60)
+        self.mapping.set(1, "test_value")
         assert self.mapping.get(1) == "test_value"
 
     def test_set__stores_value(self) -> None:
-        self.mapping.set(42, "stored_value", 60)
+        self.mapping.set(42, "stored_value")
         assert self.mapping.get(42) == "stored_value"
 
     def test_set__overwrites_existing_value(self) -> None:
-        self.mapping.set(1, "first_value", 60)
-        self.mapping.set(1, "second_value", 60)
+        self.mapping.set(1, "first_value")
+        self.mapping.set(1, "second_value")
         assert self.mapping.get(1) == "second_value"
 
     def test_delete__removes_value(self) -> None:
-        self.mapping.set(1, "value_to_delete", 60)
+        self.mapping.set(1, "value_to_delete")
         assert self.mapping.get(1) == "value_to_delete"
 
         result = self.mapping.delete(1)
@@ -67,7 +67,7 @@ class TestCacheMapping(TestCase):
 
     def test_set_many__sets_values(self) -> None:
         data = {i: f"value_{i}" for i in range(5)}
-        failed = self.mapping.set_many(data, 60)
+        failed = self.mapping.set_many(data)
 
         assert failed == []
         for i in range(5):
@@ -75,7 +75,7 @@ class TestCacheMapping(TestCase):
 
     def test_delete_many__deletes_values(self) -> None:
         for i in range(4):
-            self.mapping.set(i, f"value_{i}", 60)
+            self.mapping.set(i, f"value_{i}")
 
         self.mapping.delete_many([0, 1, 2, 3])
 
@@ -86,14 +86,14 @@ class TestCacheMapping(TestCase):
         self.mapping.delete_many([])
 
     def test_namespace__prefixes_key(self) -> None:
-        mapping = CacheMapping[int, str](lambda x: str(x), namespace="test_ns")
+        mapping = CacheMapping[int, str](lambda x: str(x), namespace="test_ns", ttl_seconds=60)
         assert mapping.key(123) == "test_ns:123"
 
     def test_namespace__collision_raises(self) -> None:
-        CacheMapping[int, str](lambda x: str(x), namespace="unique_ns")
+        CacheMapping[int, str](lambda x: str(x), namespace="unique_ns", ttl_seconds=60)
         with pytest.raises(ValueError, match="already registered"):
-            CacheMapping[int, str](lambda x: str(x), namespace="unique_ns")
+            CacheMapping[int, str](lambda x: str(x), namespace="unique_ns", ttl_seconds=60)
 
     def test_namespace__none_does_not_prefix(self) -> None:
-        mapping = CacheMapping[int, str](lambda x: f"raw:{x}")
+        mapping = CacheMapping[int, str](lambda x: f"raw:{x}", ttl_seconds=60)
         assert mapping.key(123) == "raw:123"

--- a/tests/sentry/workflow_engine/caches/test_workflow.py
+++ b/tests/sentry/workflow_engine/caches/test_workflow.py
@@ -51,8 +51,8 @@ class TestProcessingWorkflowCacheInvaliadation(TestCase):
 
         # warm the cache for the invalidation tests
         self.cache_value = {self.workflow}
-        _workflow_cache.set(self.cache_key, self.cache_value, 60)
-        _workflow_cache.set(self.cache_key_no_env, self.cache_value, 60)
+        _workflow_cache.set(self.cache_key, self.cache_value)
+        _workflow_cache.set(self.cache_key_no_env, self.cache_value)
 
         assert _workflow_cache.get(self.cache_key) == self.cache_value
         assert _workflow_cache.get(self.cache_key_no_env) == self.cache_value
@@ -80,7 +80,7 @@ class TestProcessingWorkflowCacheInvaliadation(TestCase):
         env, workflow = self._env_and_workflow()
 
         env_key = _WorkflowCacheKey(self.detector.id, env.id)
-        _workflow_cache.set(env_key, {workflow}, 60)
+        _workflow_cache.set(env_key, {workflow})
 
         invalidate_processing_workflows(self.detector.id)
 
@@ -147,17 +147,15 @@ class TestGetWorkflowsByDetectors(TestCase):
     def test_hot_cache_no_db_query(self) -> None:
         env_id = self.environment.id
         # Pre-populate both global and env caches
-        _workflow_cache.set(_WorkflowCacheKey(self.detector1.id, None), set(), 60)
-        _workflow_cache.set(_WorkflowCacheKey(self.detector2.id, None), set(), 60)
+        _workflow_cache.set(_WorkflowCacheKey(self.detector1.id, None), set())
+        _workflow_cache.set(_WorkflowCacheKey(self.detector2.id, None), set())
         _workflow_cache.set(
             _WorkflowCacheKey(self.detector1.id, env_id),
             {self.workflow1, self.shared_workflow},
-            60,
         )
         _workflow_cache.set(
             _WorkflowCacheKey(self.detector2.id, env_id),
             {self.workflow2, self.shared_workflow},
-            60,
         )
 
         # Call the function - should return cached values from both caches
@@ -170,11 +168,10 @@ class TestGetWorkflowsByDetectors(TestCase):
         env_key2 = _WorkflowCacheKey(self.detector2.id, env_id)
 
         # Pre-populate only detector1's caches (both global and env)
-        _workflow_cache.set(_WorkflowCacheKey(self.detector1.id, None), set(), 60)
+        _workflow_cache.set(_WorkflowCacheKey(self.detector1.id, None), set())
         _workflow_cache.set(
             _WorkflowCacheKey(self.detector1.id, env_id),
             {self.workflow1, self.shared_workflow},
-            60,
         )
         assert _workflow_cache.get(global_key2) is None
         assert _workflow_cache.get(env_key2) is None
@@ -273,8 +270,8 @@ class TestCheckCachesForDetectors(TestCase):
 
     def test_all_cache_hits(self) -> None:
         env_id = self.environment.id
-        _workflow_cache.set(_WorkflowCacheKey(self.detector1.id, env_id), {self.workflow1}, 60)
-        _workflow_cache.set(_WorkflowCacheKey(self.detector2.id, env_id), {self.workflow2}, 60)
+        _workflow_cache.set(_WorkflowCacheKey(self.detector1.id, env_id), {self.workflow1})
+        _workflow_cache.set(_WorkflowCacheKey(self.detector2.id, env_id), {self.workflow2})
 
         result = _check_caches_for_detectors([self.detector1, self.detector2], env_id)
 
@@ -284,7 +281,7 @@ class TestCheckCachesForDetectors(TestCase):
 
     def test_partial_cache_hit(self) -> None:
         env_id = self.environment.id
-        _workflow_cache.set(_WorkflowCacheKey(self.detector1.id, env_id), {self.workflow1}, 60)
+        _workflow_cache.set(_WorkflowCacheKey(self.detector1.id, env_id), {self.workflow1})
 
         result = _check_caches_for_detectors([self.detector1, self.detector2], env_id)
 


### PR DESCRIPTION
When we set up a caching scheme, TTL is a core part of the design.
We don't really want to just use some unspecified default or apply our TTL inconsistently.
By making it a required part of the CacheMapping constructor, we simplify the API and ensure consistency.
