### PR TITLE
chore(ACI): Add error to response if multiple if/then blocks used in workflow

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -629,10 +629,8 @@ class WorkflowEngineRuleSerializer(Serializer):
             )
             serialized_actions = []
             errors = []
-            wdcgs_with_conditions = [
-                wdcg for wdcg in prefetched_wdcgs if list(wdcg.condition_group.conditions.all())
-            ]
-            if len(wdcgs_with_conditions) > 1:
+
+            if len(prefetched_wdcgs) > 1:
                 errors.append(
                     {
                         "detail": "Multiple if/then blocks are not supported in this view. Only the first if/then block is displayed."

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -629,6 +629,15 @@ class WorkflowEngineRuleSerializer(Serializer):
             )
             serialized_actions = []
             errors = []
+            wdcgs_with_conditions = [
+                wdcg for wdcg in prefetched_wdcgs if list(wdcg.condition_group.conditions.all())
+            ]
+            if len(wdcgs_with_conditions) > 1:
+                errors.append(
+                    {
+                        "detail": "Multiple if/then blocks are not supported in this view. Only the first if/then block is displayed."
+                    }
+                )
             for action in actions_with_handlers:
                 action_data = action_to_action_data[action]
                 action_data["name"] = action_to_handler[action].render_label(

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -284,13 +284,34 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
         )
         # Second if/then block: action DCG with filter condition + action
         action_group2, _ = self.create_workflow_action(workflow)
-        self.create_data_condition(
+        dc2 = self.create_data_condition(
             condition_group=action_group2,
             type=Condition.EVENT_ATTRIBUTE,
             comparison={"attribute": "platform", "match": "eq", "value": "java"},
             condition_result=True,
         )
 
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=status.HTTP_200_OK,
+        )
+
+        multiple_action_filter_resp = None
+        for resp in response.data:
+            if resp["name"] == workflow.name:
+                multiple_action_filter_resp = resp
+
+        assert multiple_action_filter_resp
+        # only the first if/then block's filter is rendered
+        assert len(multiple_action_filter_resp["filters"]) == 1
+        assert (
+            multiple_action_filter_resp["errors"][0]["detail"]
+            == "Multiple if/then blocks are not supported in this view. Only the first if/then block is displayed."
+        )
+
+        # remove the 2nd data condition so the if/then is just an action - this should still show the error
+        dc2.delete()
         response = self.get_success_response(
             self.organization.slug,
             self.project.slug,

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -249,6 +249,68 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
         )
 
     @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_multiple_action_filters(self) -> None:
+        """
+        Test that if a workflow has multiple action filters (uses an if/then block) we only render 1 in the old UI and add to the error response
+        """
+
+        detector = self.create_detector(project=self.project)
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=detector.project.organization,
+            name="Issue resolved trigger workflow",
+        )
+        self.create_detector_workflow(detector=detector, workflow=workflow)
+        self.create_data_condition(  # trigger condition
+            condition_group=workflow_triggers,
+            type=Condition.ISSUE_RESOLVED_TRIGGER,
+            comparison=True,
+            condition_result=True,
+        )
+        self.create_data_condition(  # trigger condition
+            condition_group=workflow_triggers,
+            type=Condition.EXISTING_HIGH_PRIORITY_ISSUE,
+            comparison=True,
+            condition_result=True,
+        )
+        # First if/then block: action DCG with filter condition + action
+        action_group1, _ = self.create_workflow_action(workflow)
+        self.create_data_condition(
+            condition_group=action_group1,
+            type=Condition.EVENT_ATTRIBUTE,
+            comparison={"attribute": "platform", "match": "eq", "value": "python"},
+            condition_result=True,
+        )
+        # Second if/then block: action DCG with filter condition + action
+        action_group2, _ = self.create_workflow_action(workflow)
+        self.create_data_condition(
+            condition_group=action_group2,
+            type=Condition.EVENT_ATTRIBUTE,
+            comparison={"attribute": "platform", "match": "eq", "value": "java"},
+            condition_result=True,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=status.HTTP_200_OK,
+        )
+
+        multiple_action_filter_resp = None
+        for resp in response.data:
+            if resp["name"] == workflow.name:
+                multiple_action_filter_resp = resp
+
+        assert multiple_action_filter_resp
+        # only the first if/then block's filter is rendered
+        assert len(multiple_action_filter_resp["filters"]) == 1
+        assert (
+            multiple_action_filter_resp["errors"][0]["detail"]
+            == "Multiple if/then blocks are not supported in this view. Only the first if/then block is displayed."
+        )
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
     def test_workflow_engine_only_fetch_workflows_in_project(self) -> None:
         another_rule = self.create_project_rule(
             project=self.create_project(), name="other project rule"

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -209,17 +209,13 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
             comparison=True,
             condition_result=True,
         )
-        workflow_filters = self.create_data_condition_group()
-        self.create_workflow_data_condition_group(
-            workflow=workflow, condition_group=workflow_filters
-        )
+        action_group, _ = self.create_workflow_action(workflow)
         self.create_data_condition(  # filter condition
-            condition_group=workflow_filters,
+            condition_group=action_group,
             type=Condition.EVENT_ATTRIBUTE,
             comparison={"attribute": "platform", "match": "eq", "value": "python"},
             condition_result=True,
         )
-        self.create_workflow_action(workflow)
         response = self.get_success_response(
             self.organization.slug,
             self.project.slug,


### PR DESCRIPTION
If multiple if/then blocks are used in a workflow we're only able to render one of them in the legacy issue alerts UI. This PR adds an item to the `errors` response so that we can render a warning on the front end. See https://github.com/getsentry/sentry/pull/111344 which will be updated to read this error.