### PR TITLE
ref(cmdk): Update new cmd+k's focus to be clearer

### DIFF
--- a/static/app/components/commandPalette/ui/list.tsx
+++ b/static/app/components/commandPalette/ui/list.tsx
@@ -11,6 +11,7 @@ import {Button} from '@sentry/scraps/button';
 import {ListBox} from '@sentry/scraps/compactSelect';
 import {Image} from '@sentry/scraps/image';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {InnerWrap} from '@sentry/scraps/menuListItem';
 import {Text} from '@sentry/scraps/text';
 
 import type {CommandPaletteActionWithKey} from 'sentry/components/commandPalette/types';
@@ -196,5 +197,9 @@ const ResultsList = styled(Flex)`
   ul,
   li {
     scroll-margin: ${p => p.theme.space['3xl']} 0;
+  }
+
+  li[data-focused] > ${InnerWrap} {
+    outline: 2px solid ${p => p.theme.tokens.focus.default};
   }
 `;


### PR DESCRIPTION
Before (note the tiny weird focus state):
<img width="654" height="170" alt="Screenshot 2026-03-23 at 4 55 35 PM" src="https://github.com/user-attachments/assets/761b7ea6-31de-41b5-97af-5f6efe77d498" />


After
<img width="677" height="257" alt="Screenshot 2026-03-23 at 4 55 01 PM" src="https://github.com/user-attachments/assets/fac75c3b-dfe8-4af2-bedd-7db1075d5768" />
