### PR TITLE
feat(processing_errors): Add native/proguard configuration issue detection

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -247,6 +247,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:processing-error-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     manager.add("organizations:processing-errors-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:sourcemap-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:native-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enabled for those orgs who participated in the profiling Beta program

--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -11,7 +11,6 @@ from django.utils import timezone
 from sentry import features, ratelimits
 from sentry.issues.grouptype import GroupType
 from sentry.processing_errors.grouptype import (
-    NATIVE_ERROR_TYPES,
     NativeConfigurationType,
     ProcessingErrorDetectorHandler,
     ProcessingErrorPacketValue,

--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -11,6 +11,8 @@ from django.utils import timezone
 from sentry import features, ratelimits
 from sentry.issues.grouptype import GroupType
 from sentry.processing_errors.grouptype import (
+    NATIVE_ERROR_TYPES,
+    NativeConfigurationType,
     ProcessingErrorDetectorHandler,
     ProcessingErrorPacketValue,
     SourcemapConfigurationType,
@@ -65,6 +67,10 @@ DETECTOR_CONFIGS: list[DetectorConfig] = [
     DetectorConfig(
         config_type=SourcemapConfigurationType,
         feature_flag="organizations:sourcemap-issue-detection",
+    ),
+    DetectorConfig(
+        config_type=NativeConfigurationType,
+        feature_flag="organizations:native-issue-detection",
     ),
 ]
 

--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -71,6 +71,18 @@ JS_SOURCEMAP_ERROR_TYPES = frozenset(
 )
 
 
+NATIVE_ERROR_TYPES = frozenset(
+    {
+        EventErrorType.NATIVE_MISSING_DSYM,
+        EventErrorType.NATIVE_BAD_DSYM,
+        EventErrorType.NATIVE_UNSUPPORTED_DSYM,
+        EventErrorType.NATIVE_MISSING_OPTIONALLY_BUNDLED_DSYM,
+        EventErrorType.PROGUARD_MISSING_MAPPING,
+        EventErrorType.PROGUARD_MISSING_LINENO,
+    }
+)
+
+
 class ProcessingErrorDetectorHandler(
     StatefulDetectorHandler[ProcessingErrorPacketValue, ProcessingErrorCheckStatus],
     abc.ABC,
@@ -270,4 +282,38 @@ class SourcemapConfigurationType(GroupType):
     enable_status_change_workflow_notifications = False
     enable_workflow_notifications = False
     # We want to show these separately to normal issue types
+    in_default_search = False
+
+
+class NativeDetectorHandler(ProcessingErrorDetectorHandler):
+    error_types = NATIVE_ERROR_TYPES
+    fingerprint_key = "native"
+    issue_title = "Broken debug symbols detected"
+    issue_subtitle = (
+        "Debug symbols or Proguard mappings are not configured correctly for this project"
+    )
+    group_type_id = 13002
+
+
+@dataclass(frozen=True)
+class NativeConfigurationType(GroupType):
+    type_id = 13002
+    slug = "native_configuration"
+    description = "Native Configuration Issue"
+    category = GroupCategory.CONFIGURATION.value
+    category_v2 = GroupCategory.CONFIGURATION.value
+    released = False
+    default_priority = PriorityLevel.LOW
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+    creation_quota = Quota(3600, 60, 100)
+    notification_config = NotificationConfig(context=[])
+    detector_settings = DetectorSettings(
+        handler=NativeDetectorHandler,
+        validator=None,
+        config_schema={},
+    )
+    enable_user_status_and_priority_changes = False
+    enable_status_change_workflow_notifications = False
+    enable_workflow_notifications = False
     in_default_search = False

--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -292,7 +292,6 @@ class NativeDetectorHandler(ProcessingErrorDetectorHandler):
     issue_subtitle = (
         "Debug symbols or Proguard mappings are not configured correctly for this project"
     )
-    group_type_id = 13002
 
 
 @dataclass(frozen=True)

--- a/tests/sentry/processing_errors/test_detection.py
+++ b/tests/sentry/processing_errors/test_detection.py
@@ -10,7 +10,7 @@ from sentry.processing_errors.detection import (
     _cache_key_triggered,
     detect_processing_issues,
 )
-from sentry.processing_errors.grouptype import SourcemapConfigurationType
+from sentry.processing_errors.grouptype import NativeConfigurationType, SourcemapConfigurationType
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models import DetectorState
 
@@ -38,6 +38,10 @@ def _make_job(event, is_reprocessed=False):
 
 def _sourcemap_config():
     return DETECTOR_CONFIGS[0]
+
+
+def _native_config():
+    return DETECTOR_CONFIGS[1]
 
 
 class TestDetectSourcemapIssues(TestCase):
@@ -183,3 +187,102 @@ class TestDetectSourcemapIssues(TestCase):
 
         state.refresh_from_db()
         assert state.date_updated == original_date_updated
+
+
+class TestDetectNativeIssues(TestCase):
+    def setUp(self):
+        super().setUp()
+        config = _native_config()
+        cache.delete(_cache_key_triggered(config.slug, self.project.id))
+
+    def test_native_errors_trigger_detector(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "native_missing_dsym", "image": "libfoo.so"}],
+            platform="cocoa",
+        )
+
+        with self.feature("organizations:native-issue-detection"):
+            detect_processing_issues(_make_job(event))
+
+        state = DetectorState.objects.get(
+            detector__type=NativeConfigurationType.slug,
+            detector__project=self.project,
+        )
+        assert state.is_triggered is True
+
+        config = _native_config()
+        assert cache.get(_cache_key_triggered(config.slug, self.project.id)) is not None
+
+    def test_proguard_errors_trigger_detector(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "proguard_missing_mapping"}],
+            platform="java",
+        )
+
+        with self.feature("organizations:native-issue-detection"):
+            detect_processing_issues(_make_job(event))
+
+        state = DetectorState.objects.get(
+            detector__type=NativeConfigurationType.slug,
+            detector__project=self.project,
+        )
+        assert state.is_triggered is True
+
+    def test_js_errors_do_not_trigger_native(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "js_no_source", "url": "https://example.com/app.js"}],
+        )
+
+        with self.feature("organizations:native-issue-detection"):
+            detect_processing_issues(_make_job(event))
+
+        assert not DetectorState.objects.filter(
+            detector__type=NativeConfigurationType.slug,
+            detector__project=self.project,
+        ).exists()
+
+    def test_feature_flag_off_does_not_trigger(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "native_missing_dsym", "image": "libfoo.so"}],
+            platform="cocoa",
+        )
+
+        detect_processing_issues(_make_job(event))
+
+        assert not DetectorState.objects.filter(
+            detector__type=NativeConfigurationType.slug,
+            detector__project=self.project,
+        ).exists()
+
+    def test_sourcemap_and_native_trigger_independently(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[
+                {"type": "js_no_source", "url": "https://example.com/app.js"},
+                {"type": "native_missing_dsym", "image": "libfoo.so"},
+            ],
+        )
+
+        with self.feature(
+            {
+                "organizations:sourcemap-issue-detection": True,
+                "organizations:native-issue-detection": True,
+            }
+        ):
+            detect_processing_issues(_make_job(event))
+
+        sourcemap_state = DetectorState.objects.get(
+            detector__type=SourcemapConfigurationType.slug,
+            detector__project=self.project,
+        )
+        assert sourcemap_state.is_triggered is True
+
+        native_state = DetectorState.objects.get(
+            detector__type=NativeConfigurationType.slug,
+            detector__project=self.project,
+        )
+        assert native_state.is_triggered is True

--- a/tests/sentry/processing_errors/test_grouptype.py
+++ b/tests/sentry/processing_errors/test_grouptype.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.processing_errors.grouptype import (
+    NativeConfigurationType,
+    NativeDetectorHandler,
     ProcessingErrorCheckStatus,
     ProcessingErrorPacketValue,
     SourcemapConfigurationType,
@@ -145,3 +147,123 @@ class TestSourcemapDetectorHandler(TestCase):
         assert isinstance(result.result, IssueOccurrence)
         state = DetectorState.objects.get(detector=detector)
         assert state.is_triggered is True
+
+
+class TestNativeDetectorHandler(TestCase):
+    def create_native_detector(
+        self,
+        detector_state: DetectorPriorityLevel = DetectorPriorityLevel.OK,
+    ) -> Detector:
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            comparison=ProcessingErrorCheckStatus.FAILURE,
+            type=Condition.EQUAL,
+            condition_result=DetectorPriorityLevel.HIGH,
+            condition_group=condition_group,
+        )
+        self.create_data_condition(
+            comparison=ProcessingErrorCheckStatus.SUCCESS,
+            type=Condition.EQUAL,
+            condition_result=DetectorPriorityLevel.OK,
+            condition_group=condition_group,
+        )
+        detector = self.create_detector(
+            type=NativeConfigurationType.slug,
+            project=self.project,
+            name="Native Configuration",
+            config={},
+            workflow_condition_group=condition_group,
+        )
+        self.create_detector_state(
+            detector=detector,
+            state=detector_state,
+            is_triggered=detector_state == DetectorPriorityLevel.HIGH,
+        )
+        return detector
+
+    def make_packet(
+        self,
+        errors: list | None = None,
+        event_id: str = "abc123",
+        platform: str = "cocoa",
+    ) -> DataPacket[ProcessingErrorPacketValue]:
+        if errors is None:
+            errors = []
+        event_data: dict[str, Any] = {
+            "errors": errors,
+            "platform": platform,
+            "sdk": {"name": "sentry.cocoa", "version": "8.0.0"},
+        }
+        return DataPacket(
+            source_id=str(self.project.id),
+            packet=ProcessingErrorPacketValue(
+                event_id=event_id,
+                event_data=event_data,
+            ),
+        )
+
+    def handle_result(
+        self, detector: Detector, data_packet: DataPacket[ProcessingErrorPacketValue]
+    ) -> DetectorEvaluationResult | None:
+        handler = NativeDetectorHandler(detector)
+        evaluation = handler.evaluate(data_packet)
+        if None not in evaluation:
+            return None
+        return evaluation[None]
+
+    def test_native_missing_dsym_triggers(self) -> None:
+        detector = self.create_native_detector()
+        result = self.handle_result(
+            detector,
+            self.make_packet(
+                errors=[{"type": "native_missing_dsym", "image": "libfoo.so"}],
+                event_id="native-event-1",
+            ),
+        )
+
+        assert result is not None
+        assert result.priority == DetectorPriorityLevel.HIGH
+        assert isinstance(result.result, IssueOccurrence)
+        assert result.result.issue_title == "Broken debug symbols detected"
+        assert result.result.evidence_data["error_types"] == ["native_missing_dsym"]
+        assert result.result.evidence_data["sample_event_id"] == "native-event-1"
+
+        state = DetectorState.objects.get(detector=detector)
+        assert state.is_triggered is True
+
+    def test_proguard_missing_mapping_triggers(self) -> None:
+        detector = self.create_native_detector()
+        result = self.handle_result(
+            detector,
+            self.make_packet(
+                errors=[{"type": "proguard_missing_mapping"}],
+                platform="java",
+            ),
+        )
+
+        assert result is not None
+        assert result.priority == DetectorPriorityLevel.HIGH
+
+    def test_js_errors_do_not_trigger_native(self) -> None:
+        detector = self.create_native_detector()
+        result = self.handle_result(
+            detector,
+            self.make_packet(
+                errors=[{"type": "js_no_source", "url": "https://example.com/app.js"}],
+            ),
+        )
+        assert result is None
+
+    def test_duplicate_failure_does_not_trigger(self) -> None:
+        detector = self.create_native_detector()
+        packet = self.make_packet(
+            errors=[{"type": "native_bad_dsym", "image": "libbar.so"}],
+        )
+
+        result = self.handle_result(detector, packet)
+        assert result is not None
+
+        result = self.handle_result(detector, packet)
+        assert result is None

--- a/tests/sentry/processing_errors/test_provisioning.py
+++ b/tests/sentry/processing_errors/test_provisioning.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from sentry.processing_errors.grouptype import (
+    NativeConfigurationType,
     ProcessingErrorCheckStatus,
     SourcemapConfigurationType,
 )
@@ -73,3 +74,21 @@ class TestEnsureDetector(TestCase):
     def test_uses_description_as_name(self) -> None:
         detector = ensure_detector(self.project, SourcemapConfigurationType)
         assert detector.name == SourcemapConfigurationType.description
+
+    def test_creates_native_detector(self) -> None:
+        detector = ensure_detector(self.project, NativeConfigurationType)
+
+        assert detector.type == NativeConfigurationType.slug
+        assert detector.name == NativeConfigurationType.description
+        assert detector.project == self.project
+
+        state = DetectorState.objects.get(detector=detector)
+        assert state.is_triggered is False
+
+    def test_separate_detectors_per_config_type(self) -> None:
+        sourcemap = ensure_detector(self.project, SourcemapConfigurationType)
+        native = ensure_detector(self.project, NativeConfigurationType)
+
+        assert sourcemap.id != native.id
+        assert sourcemap.type == SourcemapConfigurationType.slug
+        assert native.type == NativeConfigurationType.slug


### PR DESCRIPTION
Add a new detector for native debug symbol and Proguard mapping configuration issues, using the generalized framework from the previous commit.

Includes:
- NativeDetectorHandler and NativeConfigurationType (type_id=13002)
- NATIVE_ERROR_TYPES covering native_missing_dsym, native_bad_dsym, native_unsupported_dsym, native_optionally_bundled_dsym, proguard_missing_mapping, proguard_missing_lineno
- Feature flag: organizations:native-issue-detection
- Tests for handler, detection, and provisioning

<!-- Describe your PR here. -->