### PR TITLE
feat(preprod): Link artifact ID tags to build detail page

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -32,6 +32,7 @@ import {
   TraceDrawerActionKind,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
+import {getSizeBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
@@ -396,6 +397,21 @@ function EventTagsTreeValue({
           </Link>
         </TagLinkText>
       );
+      break;
+    }
+    case 'head.artifact_id':
+    case 'base.artifact_id': {
+      const buildPath = getSizeBuildPath({
+        organizationSlug: organization.slug,
+        baseArtifactId: content.value,
+      });
+      if (buildPath) {
+        tagValue = (
+          <TagLinkText>
+            <Link to={buildPath}>{content.value}</Link>
+          </TagLinkText>
+        );
+      }
       break;
     }
     default:


### PR DESCRIPTION
Make `head.artifact_id` and `base.artifact_id` tags clickable on the issue detail page, linking to the preprod size build detail page (`/preprod/size/{id}/`).

These tags were added in #110854 but rendered as plain text. This adds them to the existing tag-key switch in `EventTagsTreeValue`, following the same `Link` + `TagLinkText` pattern used by `transaction` and `replayId` tags. Uses the existing `getSizeBuildPath` utility.