### PR TITLE
fix(dashboards): Skip conflict warning for inactive global filters

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -14,10 +14,15 @@ import {
 import * as modal from 'sentry/actionCreators/modal';
 import * as LineChart from 'sentry/components/charts/lineChart';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {FieldKind} from 'sentry/utils/fields';
 import {MINUTE, SECOND} from 'sentry/utils/formatters';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import type {Widget} from 'sentry/views/dashboards/types';
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import {
+  DashboardFilterKeys,
+  DisplayType,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import {ReleaseWidgetQueries} from 'sentry/views/dashboards/widgetCard/releaseWidgetQueries';
 import WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
@@ -882,5 +887,87 @@ describe('Dashboards > WidgetCard', () => {
     );
 
     expect(await screen.findByLabelText('Widget warnings')).toBeInTheDocument();
+  });
+
+  describe('conflicting filter warning', () => {
+    const spanWidget: Widget = {
+      title: 'Span Operations',
+      description: '',
+      interval: '5m',
+      displayType: DisplayType.TABLE,
+      widgetType: WidgetType.SPANS,
+      queries: [
+        {
+          conditions: 'span.op:[http.client,db]',
+          fields: ['span.op', 'count()'],
+          aggregates: ['count()'],
+          columns: ['span.op'],
+          name: '',
+          orderby: '',
+        },
+      ],
+    };
+
+    function renderWithDashboardFilters(dashboardFilters: DashboardFilters) {
+      renderWithProviders(
+        <WidgetCard
+          api={api}
+          widget={spanWidget}
+          selection={selection}
+          isEditingDashboard={false}
+          onDelete={() => undefined}
+          onEdit={() => undefined}
+          onDuplicate={() => undefined}
+          showContextMenu
+          widgetLimitReached={false}
+          widgetLegendState={widgetLegendState}
+          dashboardFilters={dashboardFilters}
+        />
+      );
+    }
+
+    it('does not show conflict warning when global filter has empty value', async () => {
+      renderWithDashboardFilters({
+        [DashboardFilterKeys.GLOBAL_FILTER]: [
+          {
+            dataset: WidgetType.SPANS,
+            tag: {key: 'span.op', name: 'span.op', kind: FieldKind.TAG},
+            value: '',
+          },
+        ],
+      });
+
+      await screen.findByLabelText('Widget actions');
+      expect(screen.queryByLabelText('Widget warnings')).not.toBeInTheDocument();
+    });
+
+    it('shows conflict warning when global filter has non-empty value overlapping widget condition', async () => {
+      renderWithDashboardFilters({
+        [DashboardFilterKeys.GLOBAL_FILTER]: [
+          {
+            dataset: WidgetType.SPANS,
+            tag: {key: 'span.op', name: 'span.op', kind: FieldKind.TAG},
+            value: 'span.op:http.client',
+          },
+        ],
+      });
+
+      expect(await screen.findByLabelText('Widget warnings')).toBeInTheDocument();
+    });
+
+    it('does not show conflict warning when global filter key does not overlap widget conditions', async () => {
+      renderWithDashboardFilters({
+        [DashboardFilterKeys.GLOBAL_FILTER]: [
+          {
+            dataset: WidgetType.SPANS,
+            tag: {key: 'os.name', name: 'os.name', kind: FieldKind.TAG},
+            value: 'os.name:android',
+          },
+        ],
+      });
+
+      await screen.findByLabelText('Widget actions');
+      expect(screen.queryByLabelText('Widget warnings')).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -531,7 +531,7 @@ function useConflictingFilterWarning({
     });
     const globalFilterKeys =
       dashboardFilters?.[DashboardFilterKeys.GLOBAL_FILTER]
-        ?.filter(filter => filter.dataset === widget.widgetType)
+        ?.filter(filter => filter.dataset === widget.widgetType && filter.value !== '')
         .map(filter => filter.tag.key) ?? [];
 
     const widgetFilterKeySet = new Set(widgetFilterKeys);


### PR DESCRIPTION
The `useConflictingFilterWarning` hook was flagging conflicts between widget conditions and global filters even when the global filter had no active value. Empty global filters are just placeholders in the filter bar and produce no query condition, so they cannot conflict. Only consider global filters with non-empty values when checking for overlaps with widget-level conditions.

This was happening with the Sentry Built Mobile Vitals App Starts and Screen Loads widgets out of the box (which have a global filter on `span.op`), where we'd always show a warning on their Span Operations tables (which have default filters on `span.op`), making the dashboard look jank out of the box. Only warn when an op is actually selected (i.e. when the conflict is relevant).

<img width="1437" height="237" alt="Screenshot 2026-03-23 at 21 16 51" src="https://github.com/user-attachments/assets/51a4b259-440f-4791-92ee-1c11e4f141de" />
