### PR TITLE
ref(dashboards): Remove span.op global filter from Screen Rendering

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads.ts
@@ -326,15 +326,6 @@ export const MOBILE_VITALS_SCREEN_LOADS_PREBUILT_CONFIG: PrebuiltDashboard = {
         },
         value: '',
       },
-      {
-        dataset: WidgetType.SPANS,
-        tag: {
-          key: SpanFields.SPAN_OP,
-          name: SpanFields.SPAN_OP,
-          kind: FieldKind.TAG,
-        },
-        value: '',
-      },
     ],
   },
   onboarding: {type: 'module', moduleName: ModuleName.SCREEN_LOAD},


### PR DESCRIPTION
The Screen Rendering dashboard only has a single table widget on it, and that widget already has a `span.op` filter on it restricting it to a limited list of relevant ops:

https://github.com/getsentry/sentry/blob/f893223c5d5caa610067ec48a1fd035fc220075f/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads.ts#L9

It doesn't really make sense to have a global filter on this page that can only conflict with the widget's existing filter.

_If_ we could filter the global filter to only ops already in the table then it might make sense, but as is, it's just an invitation to break the page.

If a user really wants to change the filter, they can use the fullscreen button on the widget to do so.

Note that this does make this the only dashboard without a `span.op` filter, but I think the inconsistency is better than inviting confusion with the filter on this screen.