### PR TITLE
ref(scm): Initialize in '__init__' instead of '__new__'

### DIFF
--- a/src/sentry/scm/private/facade.py
+++ b/src/sentry/scm/private/facade.py
@@ -71,11 +71,7 @@ class Facade:
         facade_cls = _facade_type_for_provider_class(
             cast(Hashable, cls), cast(Hashable, type(provider))
         )
-        instance = object.__new__(facade_cls)
-        instance.provider = provider
-        instance.referrer = referrer
-        instance.record_count = record_count
-        return instance
+        return object.__new__(facade_cls)
 
     def __init__(
         self,
@@ -84,4 +80,6 @@ class Facade:
         referrer: Referrer = "shared",
         record_count: Callable[[str, int, dict[str, str]], None] = record_count_metric,
     ) -> None:
-        pass
+        self.provider = provider
+        self.referrer = referrer
+        self.record_count = record_count

--- a/tests/sentry/scm/unit/test_scm_actions.py
+++ b/tests/sentry/scm/unit/test_scm_actions.py
@@ -190,6 +190,15 @@ def test_rate_limited_action(action: Callable[..., Any], kwargs: dict[str, Any])
         action(scm, **kwargs)
 
 
+def test_scm_is_instance_of_scm():
+    # This weird test is justified by the creation of the dynamic Facade subclass in SourceCodeManager.__new__.
+    # In a previous version, it was returning a subclass of Facade, but not of SourceCodeManager.
+    provider = BaseTestProvider()
+    scm = SourceCodeManager(provider)
+    assert isinstance(scm, SourceCodeManager)
+    assert scm.provider is provider
+
+
 def test_repository_not_found():
     with raises_with_code(SCMCodedError, "repository_not_found"):
         SourceCodeManager.make_from_repository_id(


### PR DESCRIPTION
Colton, I was double-checking why you said that initializing the SCM Facade in its `__init__` method did not work, which I felt could be hiding something more serious.

My conclusion is that you observed that behavior on an intermediate version of #111113, when `_facade_type_for_provider_class` was returning a subclass of `Facade`. You then fixed the main issue by making it return a subclass of `cls`, but did not realize this allowed moving the initialization back to `__init__`.

I did that, and added a test.

Reference: [`object.__new__`](https://docs.python.org/3/reference/datamodel.html#object.__new__) and [`object.__init__`](https://docs.python.org/3/reference/datamodel.html#object.__init__).