### PR TITLE
feat(ai-insights): add param change analytics event

### DIFF
--- a/static/app/utils/analytics/agentMonitoringAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/agentMonitoringAnalyticsEvents.tsx
@@ -8,6 +8,9 @@ export type AgentMonitoringEventParameters = {
   'agent-monitoring.drawer.open': Record<string, unknown>;
   'agent-monitoring.drawer.span-select': Record<string, unknown>;
   'agent-monitoring.drawer.view-full-trace-click': Record<string, unknown>;
+  'agent-monitoring.page-filter-change': {
+    filter: 'project' | 'environment' | 'date' | 'agent' | 'search';
+  };
   'agent-monitoring.page-view': {
     isOnboarding: boolean;
   };
@@ -27,6 +30,7 @@ export const agentMonitoringEventMap: Record<
   string
 > = {
   'agent-monitoring.copy-llm-prompt-click': 'Agent Monitoring: Copy LLM Prompt Click',
+  'agent-monitoring.page-filter-change': 'Agent Monitoring: Page Filter Change',
   'agent-monitoring.page-view': 'Agent Monitoring: Page View',
   'agent-monitoring.table-switch': 'Agent Monitoring: Table Switch',
   'agent-monitoring.column-sort': 'Agent Monitoring: Column Sort',

--- a/static/app/views/insights/common/components/agentSelector.tsx
+++ b/static/app/views/insights/common/components/agentSelector.tsx
@@ -7,6 +7,7 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -161,6 +162,10 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
         setQueryStates({
           [AGENT_URL_PARAM]: values.length > 0 ? values : null,
           [TableUrlParams.CURSOR]: null,
+        });
+        trackAnalytics('agent-monitoring.page-filter-change', {
+          organization,
+          filter: 'agent',
         });
       }}
     />

--- a/static/app/views/insights/pages/agents/hooks/useAgentSpanSearchProps.tsx
+++ b/static/app/views/insights/pages/agents/hooks/useAgentSpanSearchProps.tsx
@@ -5,6 +5,7 @@ import {
   useSpanSearchQueryBuilderProps,
   type UseSpanSearchQueryBuilderProps,
 } from 'sentry/components/performance/spanSearchQueryBuilder';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 
@@ -26,6 +27,10 @@ export function useAgentSpanSearchProps() {
       onSearch: (newQuery: string) => {
         setSearchQuery(newQuery);
         unsetCursor();
+        trackAnalytics('agent-monitoring.page-filter-change', {
+          organization,
+          filter: 'search',
+        });
       },
       searchSource: 'agent-monitoring',
 
@@ -37,7 +42,7 @@ export function useAgentSpanSearchProps() {
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
       ],
     }),
-    [hasRawSearchReplacement, searchQuery, setSearchQuery, unsetCursor]
+    [hasRawSearchReplacement, organization, searchQuery, setSearchQuery, unsetCursor]
   );
 
   const {spanSearchQueryBuilderProviderProps, spanSearchQueryBuilderProps} =

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -13,6 +13,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {IconClose} from 'sentry/icons';
 import {DataCategory} from 'sentry/types/core';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
@@ -81,6 +82,7 @@ function AgentsOverviewPage({datePageFilterProps}: AgentsOverviewPageProps) {
 }
 
 function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
+  const organization = useOrganization();
   const showOnboarding = useShowAgentOnboarding();
   useDefaultToAllProjects();
 
@@ -111,13 +113,31 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
                 <PageFilterBar condensed>
                   <InsightsProjectSelector
                     resetParamsOnChange={[TableUrlParams.CURSOR]}
+                    onChange={() => {
+                      trackAnalytics('agent-monitoring.page-filter-change', {
+                        organization,
+                        filter: 'project',
+                      });
+                    }}
                   />
                   <InsightsEnvironmentSelector
                     resetParamsOnChange={[TableUrlParams.CURSOR]}
+                    onChange={() => {
+                      trackAnalytics('agent-monitoring.page-filter-change', {
+                        organization,
+                        filter: 'environment',
+                      });
+                    }}
                   />
                   <DatePageFilter
                     {...datePageFilterProps}
                     resetParamsOnChange={[TableUrlParams.CURSOR]}
+                    onChange={() => {
+                      trackAnalytics('agent-monitoring.page-filter-change', {
+                        organization,
+                        filter: 'date',
+                      });
+                    }}
                   />
                 </PageFilterBar>
                 <AgentSelector


### PR DESCRIPTION
Part of [TET-2108: Make sure engagement score events are still firing](https://linear.app/getsentry/issue/TET-2108/make-sure-engagement-score-events-are-still-firing)