### PR TITLE
feat(trace): Make trace ID clickable in span attributes table

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -141,6 +141,7 @@ export function Attributes({
       const target = getTraceDetailsUrl({
         organization,
         traceSlug,
+        spanId: node.value.event_id,
         timestamp: node.value.start_timestamp,
         dateSelection: normalizeDateTimeParams(selection),
         location: {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -143,7 +143,7 @@ export function Attributes({
         traceSlug,
         spanId: node.value.event_id,
         timestamp: node.value.start_timestamp,
-        dateSelection: normalizeDateTimeParams(selection),
+        dateSelection: normalizeDateTimeParams(selection.datetime),
         location: {
           ...currentLocation,
           query: {},

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -7,6 +7,8 @@ import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SearchBar as BaseSearchBar} from 'sentry/components/searchBar';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
@@ -20,6 +22,7 @@ import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {looksLikeAJSONArray} from 'sentry/utils/string/looksLikeAJSONArray';
 import {looksLikeAJSONObject} from 'sentry/utils/string/looksLikeAJSONObject';
+import {useLocation} from 'sentry/utils/useLocation';
 import {AssertionFailureTree} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/assertionFailureTree';
 import type {AttributesFieldRendererProps} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
@@ -37,6 +40,7 @@ import {
 import type {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
 import type {UptimeCheckNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckNode';
 import {useTraceState} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 
 type CustomRenderersProps = AttributesFieldRendererProps<RenderFunctionBaggage>;
@@ -72,6 +76,8 @@ export function Attributes({
   theme: Theme;
 }) {
   const [searchQuery, setSearchQuery] = useState('');
+  const {selection} = usePageFilters();
+  const currentLocation = useLocation();
   const traceState = useTraceState();
   const columnCount =
     traceState.preferences.layout === 'drawer left' ||
@@ -129,6 +135,20 @@ export function Attributes({
           {props.item.value}
         </StyledLink>
       );
+    },
+    [FieldKey.TRACE]: (props: CustomRenderersProps) => {
+      const traceSlug = String(props.item.value);
+      const target = getTraceDetailsUrl({
+        organization,
+        traceSlug,
+        timestamp: node.value.start_timestamp,
+        dateSelection: normalizeDateTimeParams(selection),
+        location: {
+          ...currentLocation,
+          query: {},
+        },
+      });
+      return <StyledLink to={target}>{props.item.value}</StyledLink>;
     },
     [FieldKey.REPLAY_ID]: (props: CustomRenderersProps) => {
       const target: LocationDescriptorObject = {


### PR DESCRIPTION
Add a custom renderer for the trace attribute in the span attributes table so clicking the trace ID navigates to the full trace waterfall view. Uses getTraceDetailsUrl for consistent URL generation, matching the pattern used by profile.id and replay.id renderers.

[Slack thread](https://sentry.slack.com/archives/C08SBFDKBKJ/p1774357825165989).

Closes TET-2136