### PR TITLE
fix(metrics): Prevent trigger refocus after pointer metric selection

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -4,6 +4,7 @@ import {
 } from 'sentry-fixture/tracemetrics';
 
 import {
+  fireEvent,
   render,
   screen,
   userEvent,
@@ -167,6 +168,31 @@ describe('MetricSelector', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       expect(trigger).not.toHaveFocus();
+    });
+
+    it('restores focus after keyboard selection even after non-selecting pointer down', async () => {
+      const onChange = jest.fn();
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={onChange} />, {
+        organization,
+      });
+
+      const trigger = screen.getByRole('button', {name: 'bar'});
+      await userEvent.click(trigger);
+      const listbox = await screen.findByRole('listbox');
+
+      // Simulate pointer interaction that does not lead to a selection.
+      fireEvent.pointerDown(listbox);
+
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('{Enter}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+      expect(onChange).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      });
     });
 
     describe('empty state', () => {

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -151,6 +151,24 @@ describe('MetricSelector', () => {
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({name: 'foo'}));
     });
 
+    it('does not restore focus to trigger after pointer selection', async () => {
+      render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
+        organization: {
+          ...organization,
+          features: [...organization.features, 'tracemetrics-ui-refresh'],
+        },
+      });
+
+      const trigger = screen.getByRole('button', {name: 'bar'});
+      await userEvent.click(trigger);
+      await userEvent.click(await screen.findByRole('option', {name: 'foo'}));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+      expect(trigger).not.toHaveFocus();
+    });
+
     describe('empty state', () => {
       beforeEach(() => {
         setupEventsMock(

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -110,6 +110,8 @@ export function MetricSelector({
   const searchRef = useRef<HTMLInputElement>(null);
   const listElementRef = useRef<HTMLUListElement>(null);
   const scrollElementRef = useRef<HTMLDivElement>(null);
+  const isPointerSelectingRef = useRef(false);
+  const skipTriggerFocusRestoreRef = useRef(false);
 
   const [searchInputValue, setSearchInputValue] = useState('');
   const debouncedSearch = useDebouncedValue(searchInputValue, DEFAULT_DEBOUNCE_DURATION);
@@ -136,6 +138,8 @@ export function MetricSelector({
     onOpenChange: open => {
       nextFrameCallback(() => {
         if (open) {
+          isPointerSelectingRef.current = false;
+          skipTriggerFocusRestoreRef.current = false;
           updateOverlay?.();
           if (searchRef.current) {
             searchRef.current.focus();
@@ -155,6 +159,10 @@ export function MetricSelector({
         }
 
         setSearchInputValue('');
+        if (skipTriggerFocusRestoreRef.current) {
+          skipTriggerFocusRestoreRef.current = false;
+          return;
+        }
         if (
           document.activeElement === document.body ||
           wrapperRef.current?.contains(document.activeElement)
@@ -295,6 +303,8 @@ export function MetricSelector({
         type: option.metricType,
         unit: hasMetricUnitsUI ? option.metricUnit : undefined,
       });
+      skipTriggerFocusRestoreRef.current = isPointerSelectingRef.current;
+      isPointerSelectingRef.current = false;
       overlayState.close();
     },
     [onChange, hasMetricUnitsUI, overlayState]
@@ -534,6 +544,9 @@ export function MetricSelector({
                         >
                           <ListWrap
                             {...listBoxProps}
+                            onPointerDownCapture={() => {
+                              isPointerSelectingRef.current = true;
+                            }}
                             style={{
                               ...listBoxProps.style,
                               padding: 0,

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -544,8 +544,15 @@ export function MetricSelector({
                         >
                           <ListWrap
                             {...listBoxProps}
-                            onPointerDownCapture={() => {
-                              isPointerSelectingRef.current = true;
+                            onPointerDownCapture={event => {
+                              isPointerSelectingRef.current =
+                                event.target instanceof Element &&
+                                !!event.target.closest('li[role="option"]');
+                            }}
+                            onKeyDownCapture={() => {
+                              // If a prior pointer-down did not lead to selection, don't let that
+                              // stale pointer intent leak into a keyboard-driven selection.
+                              isPointerSelectingRef.current = false;
                             }}
                             style={{
                               ...listBoxProps.style,


### PR DESCRIPTION
Prevent the metric selector trigger from being re-focused when a metric is chosen via pointer interaction.

Refs LOGS-616

Made with [Cursor](https://cursor.com)