### PR TITLE
ref(dashboards): Widen GroupBy value type to include number and boolean

### DIFF
--- a/static/app/views/dashboards/widgetCard/matchTimeSeriesToTableRowValue.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/matchTimeSeriesToTableRowValue.spec.tsx
@@ -82,6 +82,21 @@ describe('matchTimeSeriesToTableRowValue', () => {
     expect(result).toBe(50);
   });
 
+  it('matches numeric table values to numeric groupBy values', () => {
+    const result = matchTimeSeriesToTableRowValue({
+      tableDataRows: [
+        {id: '1', 'http.response_status_code': 200, 'count()': 50},
+        {id: '2', 'http.response_status_code': 404, 'count()': 3},
+      ],
+      timeSeries: TimeSeriesFixture({
+        yAxis: 'count()',
+        groupBy: [{key: 'http.response_status_code', value: 200}],
+      }),
+    });
+
+    expect(result).toBe(50);
+  });
+
   it('matches array groupBy values using Python str() format', () => {
     const result = matchTimeSeriesToTableRowValue({
       tableDataRows: [

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -306,7 +306,7 @@ export function getMenuOptions(
         const search = new MutableSearch(baseQuery);
         for (const group of timeSeries.groupBy ?? []) {
           if (group.value !== null && !Array.isArray(group.value)) {
-            search.addFilterValue(group.key, group.value);
+            search.addFilterValue(group.key, String(group.value));
           }
         }
 

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatCategoricalSeriesLabel.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatCategoricalSeriesLabel.tsx
@@ -19,7 +19,7 @@ export function formatCategoricalSeriesLabel(series: CategoricalSeries): string 
           return t('(no value)');
         }
 
-        return groupBy.value;
+        return String(groupBy.value);
       })
       .join(',');
   }

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -78,7 +78,7 @@ type IncompleteReason = 'INCOMPLETE_BUCKET';
  */
 type GroupBy = {
   key: string;
-  value: string | null | Array<string | null> | Array<number | null>;
+  value: string | number | boolean | null | Array<string | null> | Array<number | null>;
 };
 
 // Aliases - allows divergence later if unique cases arise

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel.tsx
@@ -19,7 +19,7 @@ export function formatTimeSeriesLabel(timeSeries: TimeSeries): string {
           return JSON.stringify(groupBy.value);
         }
 
-        if (groupBy.key === 'release' && groupBy.value) {
+        if (groupBy.key === 'release' && typeof groupBy.value === 'string') {
           return formatVersion(groupBy.value);
         }
 
@@ -27,7 +27,7 @@ export function formatTimeSeriesLabel(timeSeries: TimeSeries): string {
           return t('(no value)');
         }
 
-        return groupBy.value;
+        return String(groupBy.value);
       })
       .join(',');
   }

--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -131,8 +131,10 @@ function getResponseCode(series: TimeSeries) {
   return responseCodeGroupBy.value;
 }
 
-function isNumeric(maybeNumber: string | number | null | undefined) {
-  if (!maybeNumber) {
+function isNumeric(
+  maybeNumber: string | number | boolean | null | undefined
+): maybeNumber is string | number {
+  if (!maybeNumber || typeof maybeNumber === 'boolean') {
     return false;
   }
   if (typeof maybeNumber === 'number') {

--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -134,11 +134,14 @@ function getResponseCode(series: TimeSeries) {
 function isNumeric(
   maybeNumber: string | number | boolean | null | undefined
 ): maybeNumber is string | number {
-  if (!maybeNumber || typeof maybeNumber === 'boolean') {
+  if (typeof maybeNumber === 'boolean') {
     return false;
   }
   if (typeof maybeNumber === 'number') {
     return true;
+  }
+  if (!maybeNumber) {
+    return false;
   }
   return /^\d+$/.test(maybeNumber);
 }


### PR DESCRIPTION
## Summary

- Widens the `GroupBy.value` type in the timeseries widget types to accept `number` and `boolean` in addition to the existing `string | null | Array<...>` types
- Prepares the frontend for a backend change that will return real typed values from the `events-timeseries` endpoint instead of always stringifying groupBy values

All existing consumers already handle these types safely — `toPythonString` normalizes bools/numbers, formatters have null/array guards, and no direct `===` string comparisons exist against `groupBy.value`.

Fixes BROWSE-468