### PR TITLE
ref(code_review): Do not emit enqueued_at

### DIFF
--- a/src/sentry/seer/code_review/webhooks/check_run.py
+++ b/src/sentry/seer/code_review/webhooks/check_run.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import enum
 import logging
 from collections.abc import Mapping
-from datetime import datetime, timezone
 from enum import StrEnum
 from typing import Any
 
@@ -126,7 +125,6 @@ def handle_check_run_event(
         seer_path=SeerEndpoint.PR_REVIEW_RERUN.value,
         # A reduced payload is enough for the task to process.
         event_payload={"original_run_id": validated_event.check_run.external_id},
-        enqueued_at_str=datetime.now(timezone.utc).isoformat(),
         tags=tags,
     )
     record_webhook_enqueued(github_event, action)

--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from datetime import datetime, timezone
 from typing import Any
 
 import sentry_sdk
 from taskbroker_client.retry import Retry
-from taskbroker_client.state import current_task
 from urllib3.exceptions import HTTPError
 
 from sentry.integrations.github.webhook_types import GithubWebhookType
@@ -38,7 +36,6 @@ PREFIX = "seer.code_review.task"
 MAX_RETRIES = 5
 DELAY_BETWEEN_RETRIES = 60  # 1 minute
 RETRYABLE_ERRORS = (HTTPError,)
-METRICS_PREFIX = "seer.code_review.task"
 
 
 def schedule_task(
@@ -95,7 +92,6 @@ def schedule_task(
     process_github_webhook_event.delay(
         seer_path=get_seer_path_for_request(github_event.value, github_event_action),
         event_payload=payload,
-        enqueued_at_str=datetime.now(timezone.utc).isoformat(),
         tags=tags,
     )
     record_webhook_enqueued(github_event, github_event_action)
@@ -109,7 +105,6 @@ def schedule_task(
 )
 def process_github_webhook_event(
     *,
-    enqueued_at_str: str,
     seer_path: str,
     event_payload: Mapping[str, Any],
     tags: Mapping[str, Any] | None = None,
@@ -119,14 +114,13 @@ def process_github_webhook_event(
     Forward a validated code-review payload to Seer.
 
     Args:
-        enqueued_at_str: The timestamp when the task was enqueued
         seer_path: The path to the Seer API endpoint to call
         event_payload: The payload (already validated before scheduling)
         tags: Sentry SDK tags to set on this task's scope for error correlation
         **kwargs: Absorbs legacy serialized task arguments from in-flight work
+            (e.g. removed ``enqueued_at_str``).
     """
     status = "success"
-    should_record_latency = True
     try:
         if tags:
             sentry_sdk.set_tags(tags)
@@ -137,36 +131,7 @@ def process_github_webhook_event(
         make_seer_request(path=seer_path, payload=event_payload, viewer_context=viewer_context)
     except Exception as e:
         status = e.__class__.__name__
-        # Retryable errors are automatically retried by taskworker.
-        if isinstance(e, RETRYABLE_ERRORS):
-            task = current_task()
-            if task and task.retries_remaining:
-                should_record_latency = False
         raise
     finally:
         if status != "success":
             metrics.incr(f"{PREFIX}.error", tags={"error_status": status}, sample_rate=1.0)
-        if should_record_latency:
-            record_latency(status, enqueued_at_str)
-
-
-def record_latency(status: str, enqueued_at_str: str) -> None:
-    latency_ms = calculate_latency_ms(enqueued_at_str)
-    if latency_ms > 0:
-        metrics.timing(f"{PREFIX}.e2e_latency", latency_ms, tags={"status": status})
-
-
-def calculate_latency_ms(timestamp_str: str) -> int:
-    """Calculate the latency in milliseconds between the given timestamp and now."""
-    try:
-        timestamp = datetime.fromisoformat(timestamp_str)
-        now = datetime.now(timezone.utc)
-        return int((now - timestamp).total_seconds() * 1000)
-    except (ValueError, TypeError) as e:
-        # Don't fail the task if timestamp parsing fails
-        logger.warning(
-            "%s.invalid_timestamp",
-            PREFIX,
-            extra={"timestamp": timestamp_str, "error": str(e)},
-        )
-        return 0

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import orjson
@@ -15,12 +15,7 @@ from sentry.seer.code_review.webhooks.issue_comment import (
     is_pr_review_command,
 )
 from sentry.seer.code_review.webhooks.pull_request import PullRequestAction
-from sentry.seer.code_review.webhooks.task import (
-    DELAY_BETWEEN_RETRIES,
-    MAX_RETRIES,
-    PREFIX,
-    process_github_webhook_event,
-)
+from sentry.seer.code_review.webhooks.task import MAX_RETRIES, process_github_webhook_event
 from sentry.testutils.cases import TestCase
 
 
@@ -29,7 +24,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.enqueued_at_str = (datetime.now(timezone.utc) - timedelta(seconds=2)).isoformat()
         self.original_run_id = "4663713"
 
     def test_retry_configuration_includes_http_error(self) -> None:
@@ -88,7 +82,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -115,7 +108,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -142,7 +134,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -167,7 +158,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -197,7 +187,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -226,7 +215,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -255,7 +243,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -284,7 +271,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -313,7 +299,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -343,7 +328,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
             process_github_webhook_event._func(
                 seer_path="/v1/code_review/check/rerun",
                 event_payload={"original_run_id": self.original_run_id},
-                enqueued_at_str=self.enqueued_at_str,
                 tags={},
             )
 
@@ -356,79 +340,67 @@ class ProcessGitHubWebhookEventTest(TestCase):
         outcome_call = outcome_calls[0]
         assert "ValueError" in str(outcome_call)
 
-        mock_metrics.timing.assert_called_once()
+        mock_metrics.timing.assert_not_called()
 
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
-    def test_latency_tracking_on_first_attempt(
+    def test_success_does_not_emit_e2e_latency(
         self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
-        """Test that latency is tracked correctly on the first attempt (base case)."""
+        """E2E latency was removed; success path should not call metrics.timing."""
         mock_request.return_value = self._mock_response(200, b"{}")
 
         process_github_webhook_event._func(
             seer_path="/v1/code_review/check/rerun",
             event_payload={"original_run_id": self.original_run_id},
-            enqueued_at_str=self.enqueued_at_str,
             tags={},
         )
 
-        mock_metrics.timing.assert_called_once()
-        call_args = mock_metrics.timing.call_args[0]
-        assert call_args[0] == f"{PREFIX}.e2e_latency"
-        # 2 seconds base + test overhead, allow wide tolerance (1-5 seconds total)
-        assert 1000 <= call_args[1] <= 5000, f"Expected latency between 1-5s, got {call_args[1]}ms"
+        mock_metrics.timing.assert_not_called()
+
+    @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
+    @patch("sentry.seer.code_review.webhooks.task.metrics")
+    def test_legacy_enqueued_at_str_kwarg_is_absorbed(
+        self, mock_metrics: MagicMock, mock_request: MagicMock
+    ) -> None:
+        """In-flight activations may still pass enqueued_at_str; it must be ignored."""
+        mock_request.return_value = self._mock_response(200, b"{}")
+
+        process_github_webhook_event._func(
+            seer_path="/v1/code_review/check/rerun",
+            event_payload={"original_run_id": self.original_run_id},
+            tags={},
+            enqueued_at_str=datetime.now(timezone.utc).isoformat(),
+        )
+
+        mock_metrics.timing.assert_not_called()
 
     @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
-    def test_latency_tracking_on_max_retries_with_failures(
+    def test_max_retry_attempts_each_record_error_metric(
         self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
     ) -> None:
-        """Test that latency is tracked once on final attempt after max retries with failures."""
+        """Each failed attempt increments the error metric; e2e latency is not emitted."""
         from urllib3.exceptions import MaxRetryError
 
         mock_request.side_effect = MaxRetryError(None, "test", reason="Connection failed")  # type: ignore[arg-type]
 
-        # With MAX_RETRIES=5, there are 4 delays between 5 attempts: (5-1) * 60s = 240s
-        enqueued_at_str = (
-            datetime.now(timezone.utc)
-            - timedelta(seconds=DELAY_BETWEEN_RETRIES * (MAX_RETRIES - 1))
-        ).isoformat()
-
         for retry_count in range(MAX_RETRIES):
-            # On the last retry, retries_remaining is False
             retries_remaining = retry_count < MAX_RETRIES - 1
             mock_current_task.return_value = self._create_mock_task_state(
                 retries_remaining=retries_remaining
             )
 
-            try:
+            with pytest.raises(MaxRetryError):
                 process_github_webhook_event._func(
                     seer_path="/v1/code_review/check/rerun",
                     event_payload={"original_run_id": self.original_run_id},
-                    enqueued_at_str=enqueued_at_str,
                     tags={},
                 )
-                assert False, "Expected MaxRetryError to be raised"
-            except MaxRetryError:
-                pass  # Expected
 
-        # Timing called exactly once on the last attempt only
-        mock_metrics.timing.assert_called_once()
-        call_args = mock_metrics.timing.call_args[0]
-        assert call_args[0] == f"{PREFIX}.e2e_latency"
-
-        call_kwargs = mock_metrics.timing.call_args[1]
-        assert "tags" in call_kwargs
-        assert "status" in call_kwargs["tags"]
-
-        # With MAX_RETRIES=5, there are 4 delays: (5-1) * 60s = 240s
-        # Allow tolerance for test execution time (5 attempts add overhead)
-        expected_latency_ms = (MAX_RETRIES - 1) * DELAY_BETWEEN_RETRIES * 1000  # 240,000ms
-        assert expected_latency_ms - 1000 <= call_args[1] <= expected_latency_ms + 5000, (
-            f"Expected latency ~{expected_latency_ms}ms, got {call_args[1]}ms"
-        )
+        assert mock_metrics.incr.call_count == MAX_RETRIES
+        mock_metrics.timing.assert_not_called()
 
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     def test_check_run_and_pr_events_processed_separately(self, mock_request: MagicMock) -> None:
@@ -438,7 +410,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
         process_github_webhook_event._func(
             seer_path="/v1/code_review/check/rerun",
             event_payload={"original_run_id": self.original_run_id},
-            enqueued_at_str=self.enqueued_at_str,
             tags={},
         )
 
@@ -481,7 +452,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
         process_github_webhook_event._func(
             seer_path="/v1/code_review/review-request",
             event_payload=event_payload,
-            enqueued_at_str=self.enqueued_at_str,
             tags={},
         )
 
@@ -533,7 +503,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
         process_github_webhook_event._func(
             seer_path="/v1/code_review/review-request",
             event_payload=event_payload,
-            enqueued_at_str=self.enqueued_at_str,
             tags={},
         )
 
@@ -591,7 +560,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
         process_github_webhook_event._func(
             seer_path="/v1/code_review/review-request",
             event_payload=event_payload,
-            enqueued_at_str=self.enqueued_at_str,
             tags={},
         )
 
@@ -635,7 +603,6 @@ class ProcessGitHubWebhookEventTest(TestCase):
         process_github_webhook_event._func(
             seer_path="/v1/code_review/pr-closed",
             event_payload=event_payload,
-            enqueued_at_str=self.enqueued_at_str,
             tags={},
         )
 
@@ -660,7 +627,6 @@ class TestProcessGitHubWebhookEventSetsTags:
         process_github_webhook_event._func(
             seer_path="/v1/code_review/check/rerun",
             event_payload={"original_run_id": "123"},
-            enqueued_at_str=datetime.now(timezone.utc).isoformat(),
             tags=tags,
         )
 
@@ -677,7 +643,6 @@ class TestProcessGitHubWebhookEventSetsTags:
         process_github_webhook_event._func(
             seer_path="/v1/code_review/check/rerun",
             event_payload={"original_run_id": "123"},
-            enqueued_at_str=datetime.now(timezone.utc).isoformat(),
         )
 
         mock_sdk.set_tags.assert_not_called()

--- a/tests/sentry/seer/code_review/test_webhooks.py
+++ b/tests/sentry/seer/code_review/test_webhooks.py
@@ -60,23 +60,15 @@ class ProcessGitHubWebhookEventTest(TestCase):
         mock_response.data = data
         return mock_response
 
-    def _create_mock_task_state(self, retries_remaining: bool = True) -> MagicMock:
-        """Helper to create a mock CurrentTaskState object."""
-        mock_state = MagicMock()
-        mock_state.retries_remaining = retries_remaining
-        return mock_state
-
-    @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
     def test_server_error_response_raises_for_retry(
-        self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
+        self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
         """Test that Seer 5xx responses are raised to trigger task retry."""
         mock_request.return_value = self._mock_response(
             500, b'{"detail": "Error handling check_run rerun."}'
         )
-        mock_current_task.return_value = self._create_mock_task_state(retries_remaining=False)
 
         with pytest.raises(HTTPError):
             process_github_webhook_event._func(
@@ -94,15 +86,13 @@ class ProcessGitHubWebhookEventTest(TestCase):
         )
         assert "HTTPError" in str(outcome_calls[0])
 
-    @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
     def test_service_unavailable_response_raises_for_retry(
-        self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
+        self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
         """Test that Seer 503 (service unavailable) responses are raised to trigger task retry."""
         mock_request.return_value = self._mock_response(503, b'{"detail": "Service unavailable"}')
-        mock_current_task.return_value = self._create_mock_task_state(retries_remaining=False)
 
         with pytest.raises(HTTPError):
             process_github_webhook_event._func(
@@ -120,15 +110,13 @@ class ProcessGitHubWebhookEventTest(TestCase):
         )
         assert "HTTPError" in str(outcome_calls[0])
 
-    @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
     def test_rate_limit_response_raises_for_retry(
-        self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
+        self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
         """Test that Seer 429 (rate limit) responses are raised to trigger task retry."""
         mock_request.return_value = self._mock_response(429, b'{"detail": "Rate limit exceeded"}')
-        mock_current_task.return_value = self._create_mock_task_state(retries_remaining=False)
 
         with pytest.raises(HTTPError):
             process_github_webhook_event._func(
@@ -171,17 +159,15 @@ class ProcessGitHubWebhookEventTest(TestCase):
         outcome_call = outcome_calls[0]
         assert "seer.code_review.task.error" in str(outcome_call)
 
-    @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
     def test_network_error_raises_for_retry(
-        self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
+        self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
         """Test that network errors are re-raised to trigger task retry."""
         from urllib3.exceptions import MaxRetryError
 
         mock_request.side_effect = MaxRetryError(None, "test", reason="Connection failed")  # type: ignore[arg-type]
-        mock_current_task.return_value = self._create_mock_task_state(retries_remaining=False)
 
         with pytest.raises(MaxRetryError):
             process_github_webhook_event._func(
@@ -199,17 +185,15 @@ class ProcessGitHubWebhookEventTest(TestCase):
         )
         assert "MaxRetryError" in str(outcome_calls[0])
 
-    @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
     def test_timeout_error_raises_for_retry(
-        self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
+        self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
         """Test that timeout errors are re-raised to trigger task retry."""
         from urllib3.exceptions import TimeoutError
 
         mock_request.side_effect = TimeoutError("Request timed out")
-        mock_current_task.return_value = self._create_mock_task_state(retries_remaining=False)
 
         with pytest.raises(TimeoutError):
             process_github_webhook_event._func(
@@ -227,17 +211,15 @@ class ProcessGitHubWebhookEventTest(TestCase):
         )
         assert "TimeoutError" in str(outcome_calls[0])
 
-    @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
     def test_ssl_error_raises_for_retry(
-        self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
+        self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
         """Test that SSL errors are re-raised to trigger task retry."""
         from urllib3.exceptions import SSLError
 
         mock_request.side_effect = SSLError("Certificate verification failed")
-        mock_current_task.return_value = self._create_mock_task_state(retries_remaining=False)
 
         with pytest.raises(SSLError):
             process_github_webhook_event._func(
@@ -255,17 +237,15 @@ class ProcessGitHubWebhookEventTest(TestCase):
         )
         assert "SSLError" in str(outcome_calls[0])
 
-    @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
     def test_new_connection_error_raises_for_retry(
-        self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
+        self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
         """Test that connection errors are re-raised to trigger task retry."""
         from urllib3.exceptions import NewConnectionError
 
         mock_request.side_effect = NewConnectionError(None, "Failed to establish connection")  # type: ignore[arg-type]
-        mock_current_task.return_value = self._create_mock_task_state(retries_remaining=False)
 
         with pytest.raises(NewConnectionError):
             process_github_webhook_event._func(
@@ -283,17 +263,15 @@ class ProcessGitHubWebhookEventTest(TestCase):
         )
         assert "NewConnectionError" in str(outcome_calls[0])
 
-    @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
     def test_network_error_not_logged_on_early_retry(
-        self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
+        self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
         """Test that network errors are raised on early retry attempts to trigger retry."""
         from urllib3.exceptions import TimeoutError
 
         mock_request.side_effect = TimeoutError("Request timed out")
-        mock_current_task.return_value = self._create_mock_task_state(retries_remaining=True)
 
         with pytest.raises(TimeoutError):
             process_github_webhook_event._func(
@@ -375,23 +353,17 @@ class ProcessGitHubWebhookEventTest(TestCase):
 
         mock_metrics.timing.assert_not_called()
 
-    @patch("sentry.seer.code_review.webhooks.task.current_task")
     @patch("sentry.seer.code_review.utils.make_signed_seer_api_request")
     @patch("sentry.seer.code_review.webhooks.task.metrics")
     def test_max_retry_attempts_each_record_error_metric(
-        self, mock_metrics: MagicMock, mock_request: MagicMock, mock_current_task: MagicMock
+        self, mock_metrics: MagicMock, mock_request: MagicMock
     ) -> None:
         """Each failed attempt increments the error metric; e2e latency is not emitted."""
         from urllib3.exceptions import MaxRetryError
 
         mock_request.side_effect = MaxRetryError(None, "test", reason="Connection failed")  # type: ignore[arg-type]
 
-        for retry_count in range(MAX_RETRIES):
-            retries_remaining = retry_count < MAX_RETRIES - 1
-            mock_current_task.return_value = self._create_mock_task_state(
-                retries_remaining=retries_remaining
-            )
-
+        for _ in range(MAX_RETRIES):
             with pytest.raises(MaxRetryError):
                 process_github_webhook_event._func(
                     seer_path="/v1/code_review/check/rerun",

--- a/tests/sentry/seer/code_review/webhooks/test_check_run.py
+++ b/tests/sentry/seer/code_review/webhooks/test_check_run.py
@@ -28,8 +28,6 @@ class CheckRunEventWebhookTest(GitHubWebhookCodeReviewTestCase):
                 call_kwargs["event_payload"]["original_run_id"]
                 == self.event_dict["check_run"]["external_id"]
             )
-            assert "enqueued_at_str" in call_kwargs
-            assert isinstance(call_kwargs["enqueued_at_str"], str)
 
     @patch("sentry.seer.code_review.webhooks.task.process_github_webhook_event")
     def test_check_run_skips_when_ai_features_disabled(self, mock_task: MagicMock) -> None:


### PR DESCRIPTION
We can use `taskworker.worker.execution_latency` instead.