### PR TITLE
feat(tracemetrics): Allow brush selection to scope metric table time ranges

### DIFF
--- a/static/app/components/charts/useChartXRangeSelection.spec.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.spec.tsx
@@ -521,8 +521,7 @@ describe('useChartXRangeSelection', () => {
           areas: [
             expect.objectContaining({
               brushType: 'lineX',
-              coordRange: [20, 80],
-              panelId: 'initial-panel-id',
+              range: [100, 100],
             }),
           ],
         });
@@ -580,7 +579,8 @@ describe('useChartXRangeSelection', () => {
           type: 'brush',
           areas: [
             expect.objectContaining({
-              coordRange: [20, 80],
+              brushType: 'lineX',
+              range: [100, 100],
             }),
           ],
         });
@@ -643,7 +643,8 @@ describe('useChartXRangeSelection', () => {
           type: 'brush',
           areas: [
             expect.objectContaining({
-              coordRange: [20, 80],
+              brushType: 'lineX',
+              range: [100, 100],
             }),
           ],
         });
@@ -662,7 +663,8 @@ describe('useChartXRangeSelection', () => {
           type: 'brush',
           areas: [
             expect.objectContaining({
-              coordRange: [30, 70],
+              brushType: 'lineX',
+              range: [100, 100],
             }),
           ],
         });

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -403,6 +403,10 @@ export function useChartXRangeSelection({
         selectionState.selection.range[1]
       );
 
+      if (pixelMin === null || pixelMax === null) {
+        return;
+      }
+
       chartInstance.dispatchAction({
         type: 'brush',
         areas: [

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -390,16 +390,25 @@ export function useChartXRangeSelection({
     }
 
     // Re-draw the box in the chart whenever state.selection changes,
-    // enforcing persistence.
+    // enforcing persistence. We use pixel-based `range` instead of
+    // `coordRange` + `panelId` because the panelId may not be valid
+    // (e.g. when restoring selection from URL params).
     if (selectionState?.selection) {
+      const pixelMin = chartInstance.convertToPixel(
+        {xAxisIndex: 0},
+        selectionState.selection.range[0]
+      );
+      const pixelMax = chartInstance.convertToPixel(
+        {xAxisIndex: 0},
+        selectionState.selection.range[1]
+      );
+
       chartInstance.dispatchAction({
         type: 'brush',
         areas: [
           {
             brushType: 'lineX',
-            coordRange: selectionState.selection.range,
-            coordRanges: [selectionState.selection.range],
-            panelId: selectionState.selection.panelId,
+            range: [pixelMin, pixelMax],
           },
         ],
       });

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.spec.tsx
@@ -7,6 +7,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {MockMetricQueryParamsContext} from 'sentry/views/explore/metrics/hooks/testUtils';
 import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMetricAggregatesTable';
+import {MetricsFrozenContextProvider} from 'sentry/views/explore/metrics/metricsFrozenContext';
 import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
@@ -203,6 +204,53 @@ describe('useMetricAggregatesTable', () => {
             // The count aggregate includes metric details: count(metric.name,<name>,<type>,-)
             expect.stringMatching(/^count\(metric\.name,test-metric,distribution,-\)$/),
           ]),
+        }),
+      })
+    );
+  });
+
+  it('uses the frozen trace period when present', async () => {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{id: '1'}],
+        meta: {fields: {}},
+      },
+      method: 'GET',
+    });
+
+    renderHookWithProviders(useMetricAggregatesTable, {
+      initialProps: {
+        traceMetric: {name: 'test.metric', type: 'counter'},
+        limit: 50,
+        enabled: true,
+      },
+      additionalWrapper: ({children}) => (
+        <MockMetricQueryParamsContext>
+          <MetricsFrozenContextProvider
+            traceIds={[]}
+            tracePeriod={{
+              start: '2025-03-24T18:31:00',
+              end: '2025-03-24T18:35:00',
+              period: null,
+            }}
+          >
+            {children}
+          </MetricsFrozenContextProvider>
+        </MockMetricQueryParamsContext>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          start: '2025-03-24T18:31:00.000',
+          end: '2025-03-24T18:35:00.000',
         }),
       })
     );

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
@@ -11,6 +11,7 @@ import {
   type RPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {useMetricsFrozenTracePeriod} from 'sentry/views/explore/metrics/metricsFrozenContext';
 import {useMetricVisualizes} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
@@ -81,6 +82,7 @@ function useMetricAggregatesTableImp({
   queryExtras,
 }: UseMetricAggregatesTableOptions): MetricAggregatesTableResult {
   const {selection} = usePageFilters();
+  const frozenTracePeriod = useMetricsFrozenTracePeriod();
   const visualizes = useMetricVisualizes();
 
   const groupBys = useQueryParamsGroupBys();
@@ -107,6 +109,22 @@ function useMetricAggregatesTableImp({
     return allFields.filter(Boolean);
   }, [groupBys, visualizes]);
 
+  const pageFilters = useMemo(() => {
+    if (frozenTracePeriod) {
+      return {
+        ...selection,
+        datetime: {
+          start: frozenTracePeriod.start ?? null,
+          end: frozenTracePeriod.end ?? null,
+          period: frozenTracePeriod.period ?? null,
+          utc: selection.datetime.utc,
+        },
+      };
+    }
+
+    return selection;
+  }, [selection, frozenTracePeriod]);
+
   const eventView = useMemo(() => {
     const discoverQuery: NewQuery = {
       id: undefined,
@@ -118,8 +136,8 @@ function useMetricAggregatesTableImp({
       dataset: DiscoverDatasets.TRACEMETRICS,
     };
 
-    return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
-  }, [fields, query, selection, sortBys, traceMetric]);
+    return EventView.fromNewQueryWithPageFilters(discoverQuery, pageFilters);
+  }, [fields, pageFilters, query, sortBys, traceMetric]);
 
   const result = useSpansQuery({
     enabled: enabled && Boolean(traceMetric.name) && fields.length > 0,

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.spec.tsx
@@ -6,6 +6,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {MockMetricQueryParamsContext} from 'sentry/views/explore/metrics/hooks/testUtils';
 import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
+import {MetricsFrozenContextProvider} from 'sentry/views/explore/metrics/metricsFrozenContext';
 
 jest.mock('sentry/components/pageFilters/usePageFilters');
 
@@ -150,6 +151,62 @@ describe('useMetricSamplesTable', () => {
           referrer: 'api.explore.metric-samples-table',
           sampling: SAMPLING_MODE.NORMAL,
           sort: '-timestamp',
+        }),
+      })
+    );
+  });
+
+  it('uses the frozen trace period when present', async () => {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [],
+        meta: {
+          fields: {},
+        },
+      },
+      method: 'GET',
+    });
+
+    renderHookWithProviders(
+      () =>
+        useMetricSamplesTable({
+          traceMetric: {
+            name: 'test.metric',
+            type: 'counter',
+          },
+          fields: ['trace', 'timestamp'],
+          limit: 50,
+          ingestionDelaySeconds: 0,
+        }),
+      {
+        additionalWrapper: ({children}) => (
+          <MockMetricQueryParamsContext>
+            <MetricsFrozenContextProvider
+              traceIds={[]}
+              tracePeriod={{
+                start: '2025-03-24T18:31:00',
+                end: '2025-03-24T18:35:00',
+                period: null,
+              }}
+            >
+              {children}
+            </MetricsFrozenContextProvider>
+          </MockMetricQueryParamsContext>
+        ),
+      }
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          start: '2025-03-24T18:31:00.000',
+          end: '2025-03-24T18:35:00.000',
         }),
       })
     );

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -1,13 +1,15 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
-import {IconClock, IconGraph} from 'sentry/icons';
+import type {Selection} from 'sentry/components/charts/useChartXRangeSelection';
+import {IconClock, IconClose, IconGraph} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {parseFunction} from 'sentry/utils/discover/fields';
@@ -21,6 +23,7 @@ import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVis
 import {ConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
 import type {TableOrientation} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
 import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
+import type {TracePeriod} from 'sentry/views/explore/metrics/metricsFrozenContext';
 import {
   useMetricLabel,
   useMetricName,
@@ -31,6 +34,7 @@ import {
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {METRICS_CHART_GROUP} from 'sentry/views/explore/metrics/metricsTab';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {getTracePeriodFromSelection} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsQuery,
   useQueryParamsTopEventsLimit,
@@ -60,7 +64,12 @@ interface MetricsGraphProps {
   additionalActions?: React.ReactNode;
   infoContentHidden?: boolean;
   isMetricOptionsEmpty?: boolean;
+  onTableSelectionChange?: (
+    selection: Selection | null,
+    tracePeriod?: TracePeriod
+  ) => void;
   queryIndex?: number;
+  tableSelection?: Selection | null;
 }
 
 export function MetricsGraph({
@@ -70,6 +79,8 @@ export function MetricsGraph({
   additionalActions,
   infoContentHidden,
   isMetricOptionsEmpty,
+  tableSelection,
+  onTableSelectionChange,
 }: MetricsGraphProps) {
   const metricQueries = useMultiMetricsQueryParams();
   const visualize = useMetricVisualize();
@@ -97,6 +108,8 @@ export function MetricsGraph({
       infoContentHidden={infoContentHidden}
       isMetricOptionsEmpty={isMetricOptionsEmpty}
       queryIndex={queryIndex}
+      tableSelection={tableSelection}
+      onTableSelectionChange={onTableSelectionChange}
     />
   );
 }
@@ -117,8 +130,11 @@ function Graph({
   additionalActions,
   isMetricOptionsEmpty,
   queryIndex = 0,
+  tableSelection,
+  onTableSelectionChange,
 }: GraphProps) {
   const organization = useOrganization();
+  const hasMetricsUIRefresh = canUseMetricsUIRefresh(organization);
   const aggregate = visualize.yAxis;
   const topEventsLimit = useQueryParamsTopEventsLimit();
   const metricLabel = useMetricLabel();
@@ -187,7 +203,7 @@ function Graph({
     return metricLabel ?? prettifyAggregation(aggregate) ?? aggregate;
   }, [aggregate, metricLabel, metricName, visualizes.length]);
 
-  const Title = canUseMetricsUIRefresh(organization) ? (
+  const Title = hasMetricsUIRefresh ? (
     <Flex align="center" gap="xs">
       <VisualizeLabel
         justify="center"
@@ -253,6 +269,15 @@ function Graph({
         menuTitle="Interval"
         options={intervalOptions}
       />
+      {hasMetricsUIRefresh && tableSelection ? (
+        <Button
+          aria-label={t('Clear table time range')}
+          icon={<IconClose />}
+          priority="transparent"
+          size="xs"
+          onClick={() => onTableSelectionChange?.(null)}
+        />
+      ) : null}
       {additionalActions}
     </Fragment>
   );
@@ -264,7 +289,7 @@ function Graph({
   if (visualize.visible) {
     if (orientation === 'bottom' || infoContentHidden) {
       height = STACKED_GRAPH_HEIGHT;
-    } else if (canUseMetricsUIRefresh(organization)) {
+    } else if (hasMetricsUIRefresh) {
       height = STACKED_GRAPH_HEIGHT;
     } else {
       height = undefined;
@@ -272,9 +297,7 @@ function Graph({
   }
 
   return (
-    <WidgetWrapper
-      hideFooterBorder={orientation === 'bottom' || canUseMetricsUIRefresh(organization)}
-    >
+    <WidgetWrapper hideFooterBorder={orientation === 'bottom' || hasMetricsUIRefresh}>
       <Widget
         Title={Title}
         Actions={Actions}
@@ -293,7 +316,30 @@ function Graph({
               )}
             />
           ) : showChart ? (
-            <ChartVisualization chartInfo={chartInfo} />
+            <ChartVisualization
+              chartInfo={chartInfo}
+              chartXRangeSelection={
+                hasMetricsUIRefresh
+                  ? {
+                      disabled: false,
+                      initialSelection: tableSelection ?? undefined,
+                      onSelectionEnd: ({selectionState}) => {
+                        if (!selectionState) {
+                          return;
+                        }
+
+                        onTableSelectionChange?.(
+                          selectionState.selection,
+                          getTracePeriodFromSelection(selectionState.selection)
+                        );
+                      },
+                      onClearSelection: () => {
+                        onTableSelectionChange?.(null);
+                      },
+                    }
+                  : undefined
+              }
+            />
           ) : undefined
         }
         Footer={

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
@@ -36,6 +36,7 @@ import {
 } from 'sentry/views/explore/metrics/metricInfoTabs/metricInfoTabStyles';
 import {StyledTimestampWrapper} from 'sentry/views/explore/metrics/metricInfoTabs/styles';
 import {stripMetricParamsFromLocation} from 'sentry/views/explore/metrics/metricQuery';
+import {useMetricsFrozenTracePeriod} from 'sentry/views/explore/metrics/metricsFrozenContext';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
 import {
   TraceMetricKnownFieldKey,
@@ -117,6 +118,7 @@ export function SampleTableRow({
 }: SampleTableRowProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
+  const frozenTracePeriod = useMetricsFrozenTracePeriod();
   const location = useLocation();
   const theme = useTheme();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -151,15 +153,22 @@ export function SampleTableRow({
 
     const hasSpans = (telemetry?.spansCount ?? 0) > 0;
     const shouldGoToSpans = spanIdToUse && hasSpans;
+    const dateSelection = frozenTracePeriod
+      ? {
+          start: frozenTracePeriod.start ?? null,
+          end: frozenTracePeriod.end ?? null,
+          statsPeriod: frozenTracePeriod.period ?? null,
+        }
+      : {
+          start: selection.datetime.start,
+          end: selection.datetime.end,
+          statsPeriod: selection.datetime.period,
+        };
 
     const target = getTraceDetailsUrl({
       organization,
       traceSlug: traceId,
-      dateSelection: {
-        start: selection.datetime.start,
-        end: selection.datetime.end,
-        statsPeriod: selection.datetime.period,
-      },
+      dateSelection,
       timestamp,
       location: strippedLocation,
       source: TraceViewSources.TRACE_METRICS,

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -1,7 +1,8 @@
-import {useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 
 import {Stack} from '@sentry/scraps/layout';
 
+import type {Selection} from 'sentry/components/charts/useChartXRangeSelection';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
@@ -20,6 +21,10 @@ import {SideBySideOrientation} from 'sentry/views/explore/metrics/metricPanel/si
 import {StackedOrientation} from 'sentry/views/explore/metrics/metricPanel/stackedOrientation';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
+import {
+  MetricsFrozenContextProvider,
+  type TracePeriod,
+} from 'sentry/views/explore/metrics/metricsFrozenContext';
 import {getMetricTableColumnType} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsAggregateSortBys,
@@ -43,6 +48,10 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
     canChangeOrientation,
   } = useTableOrientationControl();
   const [infoContentHidden, setInfoContentHidden] = useState(false);
+  const [selectedTableRange, setSelectedTableRange] = useState<Selection | null>(null);
+  const [tableTracePeriod, setTableTracePeriod] = useState<TracePeriod | undefined>(
+    undefined
+  );
   const {isMetricOptionsEmpty} = useMetricOptions({enabled: Boolean(traceMetric.name)});
   const {result: timeseriesResult} = useMetricTimeseries({
     traceMetric,
@@ -87,25 +96,42 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
     panelIndex: queryIndex,
   });
 
+  useEffect(() => {
+    setSelectedTableRange(null);
+    setTableTracePeriod(undefined);
+  }, [traceMetric.name, traceMetric.type, traceMetric.unit]);
+
+  const handleTableSelectionChange = useCallback(
+    (selection: Selection | null, tracePeriod?: TracePeriod) => {
+      setSelectedTableRange(selection);
+      setTableTracePeriod(tracePeriod);
+    },
+    []
+  );
+
   if (hasMetricsUIRefresh) {
     return (
       <Panel data-test-id="metric-panel">
         <PanelBody>
-          <Stack gap="sm">
-            <MetricsGraph
-              timeseriesResult={timeseriesResult}
-              orientation={orientation}
-              isMetricOptionsEmpty={isMetricOptionsEmpty}
-              queryIndex={queryIndex}
-            />
-            <MetricInfoTabs
-              traceMetric={traceMetric}
-              additionalActions={undefined}
-              contentsHidden={infoContentHidden}
-              orientation={orientation}
-              isMetricOptionsEmpty={isMetricOptionsEmpty}
-            />
-          </Stack>
+          <MetricsFrozenContextProvider traceIds={[]} tracePeriod={tableTracePeriod}>
+            <Stack gap="sm">
+              <MetricsGraph
+                timeseriesResult={timeseriesResult}
+                orientation={orientation}
+                isMetricOptionsEmpty={isMetricOptionsEmpty}
+                queryIndex={queryIndex}
+                tableSelection={selectedTableRange}
+                onTableSelectionChange={handleTableSelectionChange}
+              />
+              <MetricInfoTabs
+                traceMetric={traceMetric}
+                additionalActions={undefined}
+                contentsHidden={infoContentHidden}
+                orientation={orientation}
+                isMetricOptionsEmpty={isMetricOptionsEmpty}
+              />
+            </Stack>
+          </MetricsFrozenContextProvider>
         </PanelBody>
       </Panel>
     );

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 import {Stack} from '@sentry/scraps/layout';
 
@@ -25,7 +25,10 @@ import {
   MetricsFrozenContextProvider,
   type TracePeriod,
 } from 'sentry/views/explore/metrics/metricsFrozenContext';
-import {getMetricTableColumnType} from 'sentry/views/explore/metrics/utils';
+import {
+  getMetricTableColumnType,
+  getTracePeriodFromSelection,
+} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsAggregateSortBys,
   useQueryParamsMode,
@@ -38,9 +41,16 @@ const TWO_MINUTE_DELAY = 120;
 interface MetricPanelProps {
   queryIndex: number;
   traceMetric: TraceMetric;
+  selection?: [number, number];
+  setSelection?: (selection: [number, number] | null) => void;
 }
 
-export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
+export function MetricPanel({
+  traceMetric,
+  queryIndex,
+  selection: selectionRange,
+  setSelection,
+}: MetricPanelProps) {
   const organization = useOrganization();
   const {
     orientation,
@@ -48,10 +58,20 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
     canChangeOrientation,
   } = useTableOrientationControl();
   const [infoContentHidden, setInfoContentHidden] = useState(false);
-  const [selectedTableRange, setSelectedTableRange] = useState<Selection | null>(null);
-  const [tableTracePeriod, setTableTracePeriod] = useState<TracePeriod | undefined>(
-    undefined
-  );
+
+  const selectedTableRange: Selection | null = useMemo(() => {
+    if (!selectionRange) {
+      return null;
+    }
+    return {panelId: 'url', range: selectionRange};
+  }, [selectionRange]);
+
+  const tableTracePeriod: TracePeriod | undefined = useMemo(() => {
+    if (!selectedTableRange) {
+      return undefined;
+    }
+    return getTracePeriodFromSelection(selectedTableRange);
+  }, [selectedTableRange]);
   const {isMetricOptionsEmpty} = useMetricOptions({enabled: Boolean(traceMetric.name)});
   const {result: timeseriesResult} = useMetricTimeseries({
     traceMetric,
@@ -96,17 +116,11 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
     panelIndex: queryIndex,
   });
 
-  useEffect(() => {
-    setSelectedTableRange(null);
-    setTableTracePeriod(undefined);
-  }, [traceMetric.name, traceMetric.type, traceMetric.unit]);
-
   const handleTableSelectionChange = useCallback(
-    (selection: Selection | null, tracePeriod?: TracePeriod) => {
-      setSelectedTableRange(selection);
-      setTableTracePeriod(tracePeriod);
+    (selection: Selection | null, _tracePeriod?: TracePeriod) => {
+      setSelection?.(selection ? selection.range : null);
     },
-    []
+    [setSelection]
   );
 
   if (hasMetricsUIRefresh) {

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -213,8 +213,8 @@ function parseSelection(value: unknown): [number, number] | undefined {
   if (
     !Array.isArray(value) ||
     value.length !== 2 ||
-    typeof value[0] !== 'number' ||
-    typeof value[1] !== 'number'
+    !Number.isFinite(value[0]) ||
+    !Number.isFinite(value[1])
   ) {
     return undefined;
   }

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -36,11 +36,13 @@ function isTraceMetric(value: unknown): value is TraceMetric {
 export interface BaseMetricQuery {
   metric: TraceMetric;
   queryParams: ReadableQueryParams;
+  selection?: [number, number];
 }
 
 export interface MetricQuery extends BaseMetricQuery {
   removeMetric: () => void;
   setQueryParams: (queryParams: ReadableQueryParams) => void;
+  setSelection: (selection: [number, number] | null) => void;
   setTraceMetric: (traceMetric: TraceMetric) => void;
 }
 
@@ -68,6 +70,8 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
   const aggregateFields = [...visualizes, ...groupBys];
   const aggregateSortBys = parseAggregateSortBys(json.aggregateSortBys, aggregateFields);
 
+  const selection = parseSelection(json.selection);
+
   return {
     metric,
     queryParams: new ReadableQueryParams({
@@ -83,6 +87,7 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
       aggregateFields,
       aggregateSortBys,
     }),
+    selection,
   };
 }
 
@@ -100,6 +105,7 @@ export function encodeMetricQueryParams(metricQuery: BaseMetricQuery): string {
     }),
     aggregateSortBys: metricQuery.queryParams.aggregateSortBys,
     mode: metricQuery.queryParams.mode,
+    ...(metricQuery.selection ? {selection: metricQuery.selection} : {}),
   });
 }
 
@@ -201,6 +207,18 @@ function parseGroupBys(value: unknown): GroupBy[] {
   }
 
   return value.filter<GroupBy>(isGroupBy);
+}
+
+function parseSelection(value: unknown): [number, number] | undefined {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 2 ||
+    typeof value[0] !== 'number' ||
+    typeof value[1] !== 'number'
+  ) {
+    return undefined;
+  }
+  return [value[0], value[1]];
 }
 
 function parseAggregateSortBys(

--- a/static/app/views/explore/metrics/metricsFrozenContext.tsx
+++ b/static/app/views/explore/metrics/metricsFrozenContext.tsx
@@ -48,6 +48,13 @@ export function MetricsFrozenContextProvider(props: MetricsFrozenForTracesProvid
       };
     }
 
+    if (props.tracePeriod) {
+      return {
+        frozen: true,
+        tracePeriod: props.tracePeriod,
+      };
+    }
+
     return {frozen: false};
   }, [props]);
 

--- a/static/app/views/explore/metrics/metricsFrozenContext.tsx
+++ b/static/app/views/explore/metrics/metricsFrozenContext.tsx
@@ -56,7 +56,7 @@ export function MetricsFrozenContextProvider(props: MetricsFrozenForTracesProvid
     }
 
     return {frozen: false};
-  }, [props]);
+  }, [props.traceIds, props.tracePeriod]);
 
   return <MetricsFrozenContext value={value}>{props.children}</MetricsFrozenContext>;
 }

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -250,7 +250,12 @@ function MetricsTabBodySection({
                   setTraceMetric={metricQuery.setTraceMetric}
                   removeMetric={metricQuery.removeMetric}
                 >
-                  <MetricPanel traceMetric={metricQuery.metric} queryIndex={index} />
+                  <MetricPanel
+                    traceMetric={metricQuery.metric}
+                    queryIndex={index}
+                    selection={metricQuery.selection}
+                    setSelection={metricQuery.setSelection}
+                  />
                 </MetricsQueryParamsProvider>
               );
             })}
@@ -275,7 +280,12 @@ function MetricsTabBodySection({
                   setTraceMetric={metricQuery.setTraceMetric}
                   removeMetric={metricQuery.removeMetric}
                 >
-                  <MetricPanel traceMetric={metricQuery.metric} queryIndex={index} />
+                  <MetricPanel
+                    traceMetric={metricQuery.metric}
+                    queryIndex={index}
+                    selection={metricQuery.selection}
+                    setSelection={metricQuery.setSelection}
+                  />
                 </MetricsQueryParamsProvider>
               );
             })}

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -38,6 +38,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
         }),
         removeMetric: expect.any(Function),
         setQueryParams: expect.any(Function),
+        setSelection: expect.any(Function),
         setTraceMetric: expect.any(Function),
       },
     ]);

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -62,6 +62,31 @@ export function MultiMetricsQueryParamsProvider({
             return {
               metric: metricQuery.metric,
               queryParams: newQueryParams,
+              selection: metricQuery.selection,
+            };
+          })
+          .map((metricQuery: BaseMetricQuery) => encodeMetricQueryParams(metricQuery))
+          .filter(defined)
+          .filter(Boolean);
+        target.query.metric = newMetricQueries;
+
+        navigate(target);
+      };
+    }
+
+    function setSelectionForIndex(i: number) {
+      return function (selection: [number, number] | null) {
+        const target = {...location, query: {...location.query}};
+
+        const newMetricQueries = metricQueries
+          .map((metricQuery: BaseMetricQuery, j: number) => {
+            if (i !== j) {
+              return metricQuery;
+            }
+            return {
+              metric: metricQuery.metric,
+              queryParams: metricQuery.queryParams,
+              selection: selection ?? undefined,
             };
           })
           .map((metricQuery: BaseMetricQuery) => encodeMetricQueryParams(metricQuery))
@@ -113,6 +138,7 @@ export function MultiMetricsQueryParamsProvider({
             return {
               queryParams: metricQuery.queryParams.replace({aggregateFields}),
               metric: newTraceMetric,
+              selection: undefined,
             };
           })
           .map((metric: BaseMetricQuery) => encodeMetricQueryParams(metric))
@@ -148,6 +174,7 @@ export function MultiMetricsQueryParamsProvider({
         return {
           ...metric,
           setQueryParams: setQueryParamsForIndex(index),
+          setSelection: setSelectionForIndex(index),
           setTraceMetric: setTraceMetricForIndex(index),
           removeMetric: removeMetricQueryForIndex(index),
         };

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -1,4 +1,7 @@
-import {mapMetricUnitToFieldType} from 'sentry/views/explore/metrics/utils';
+import {
+  mapMetricUnitToFieldType,
+  getTracePeriodFromSelection,
+} from 'sentry/views/explore/metrics/utils';
 
 describe('mapMetricUnitToFieldType', () => {
   it.each([
@@ -16,5 +19,36 @@ describe('mapMetricUnitToFieldType', () => {
     ['custom_unit', {fieldType: 'number', unit: undefined}],
   ])('maps %s to the correct field type', (unit, expected) => {
     expect(mapMetricUnitToFieldType(unit)).toEqual(expected);
+  });
+});
+
+describe('getTracePeriodFromSelection', () => {
+  it('rounds the selected range to minute boundaries', () => {
+    expect(
+      getTracePeriodFromSelection({
+        panelId: 'panel-id',
+        range: [
+          Date.UTC(2025, 2, 24, 18, 31, 52, 345),
+          Date.UTC(2025, 2, 24, 18, 34, 59, 999),
+        ],
+      })
+    ).toEqual({
+      start: '2025-03-24T18:31:00',
+      end: '2025-03-24T18:35:00',
+      period: null,
+    });
+  });
+
+  it('ensures the selected range spans at least one minute', () => {
+    expect(
+      getTracePeriodFromSelection({
+        panelId: 'panel-id',
+        range: [Date.UTC(2025, 2, 24, 18, 24, 1, 0), Date.UTC(2025, 2, 24, 18, 24, 2, 0)],
+      })
+    ).toEqual({
+      start: '2025-03-24T18:24:00',
+      end: '2025-03-24T18:25:00',
+      period: null,
+    });
   });
 });

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -1,8 +1,10 @@
 import qs from 'query-string';
 
+import type {Selection} from 'sentry/components/charts/useChartXRangeSelection';
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
+import {getUtcDateString} from 'sentry/utils/dates';
 import type {EventsMetaType, MetaType} from 'sentry/utils/discover/eventView';
 import {
   DurationUnit,
@@ -24,6 +26,7 @@ import {
   encodeMetricQueryParams,
   type BaseMetricQuery,
 } from 'sentry/views/explore/metrics/metricQuery';
+import type {TracePeriod} from 'sentry/views/explore/metrics/metricsFrozenContext';
 import {
   TraceMetricKnownFieldKey,
   VirtualTableSampleColumnKey,
@@ -199,6 +202,19 @@ export function makeMetricsAggregate({
     traceMetric.unit ?? '-',
   ];
   return `${aggregate}(${args.join(',')})`;
+}
+
+export function getTracePeriodFromSelection(selection: Selection): TracePeriod {
+  let startTimestamp = Math.floor(selection.range[0] / 60_000) * 60_000;
+  const endTimestamp = Math.ceil(selection.range[1] / 60_000) * 60_000;
+
+  startTimestamp = Math.min(startTimestamp, endTimestamp - 60_000);
+
+  return {
+    start: getUtcDateString(startTimestamp),
+    end: getUtcDateString(endTimestamp),
+    period: null,
+  };
 }
 
 export function updateVisualizeYAxis(


### PR DESCRIPTION
Adds the ability to brush-select a time range on a metric chart, which then filters the tables (aggregates and samples) below to show only data from that selected window.

When a user selects a range on the chart, the selection is converted into a minute-boundary-aligned `TracePeriod` and stored as panel-scoped state. This period is injected into the `MetricsFrozenContext`, which the table hooks already read to override the default page filters for their queries. A clear button appears in the chart header when a selection is active.

https://github.com/user-attachments/assets/b28f2c1b-3df6-463c-be75-8c5abcb87869

Refs LOGS-622