### PR TITLE
perf(dashboards): Measure re-render duration on edit dashboard click

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -429,11 +429,19 @@ class DashboardDetail extends Component<Props, State> {
 
   onEdit = () => {
     const {dashboard, organization} = this.props;
+    const start = performance.now();
     trackAnalytics('dashboards2.edit.start', {organization});
 
     this.setState({
       dashboardState: DashboardState.EDIT,
       modifiedDashboard: cloneDashboard(dashboard),
+    });
+
+    scheduleMicroTask(() => {
+      const duration = performance.now() - start;
+      Sentry.metrics.distribution('dashboards.dashboard.onEdit', duration, {
+        unit: 'millisecond',
+      });
     });
   };
 


### PR DESCRIPTION
Use the `scheduleMicroTask` pattern — already in use for `onEditWidget` — to measure the duration between the edit dashboard button click and the next re-render, emitting a `dashboards.dashboard.onEdit` distribution metric.

Refs DAIN-1372