### PR TITLE
feat(dashboards): Disable lazy loading generated dashboards

### DIFF
--- a/static/app/components/lazyRender.tsx
+++ b/static/app/components/lazyRender.tsx
@@ -24,6 +24,10 @@ const DEFAULT_OPTIONS: IntersectionObserverInit = {
 export interface LazyRenderProps {
   children: React.ReactNode;
   containerHeight?: number;
+  /**
+   * When true, skips lazy loading and renders children immediately.
+   */
+  disabled?: boolean;
   observerOptions?: Partial<IntersectionObserverInit>;
   /**
    * Removes the wrapping div once visible
@@ -39,8 +43,10 @@ export interface LazyRenderProps {
  * @param props.children
  */
 export function LazyRender(props: LazyRenderProps) {
-  // If the browser doesn't support IntersectionObserver, render the children immediately.
-  const [visible, setVisible] = useState<boolean>(!supportsIntersectionObserver());
+  // If disabled or the browser doesn't support IntersectionObserver, render the children immediately.
+  const [visible, setVisible] = useState<boolean>(
+    !!props.disabled || !supportsIntersectionObserver()
+  );
   const observerRef = useRef<IntersectionObserver | null>(null);
 
   const onRefNode = useCallback(

--- a/static/app/views/dashboards/createFromSeer.spec.tsx
+++ b/static/app/views/dashboards/createFromSeer.spec.tsx
@@ -98,6 +98,16 @@ describe('CreateFromSeer', () => {
       method: 'POST',
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      method: 'GET',
+      body: [],
+    });
   });
 
   it('shows loading state while session is processing', () => {

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -133,6 +133,7 @@ export function Dashboard({
   const [isMobile, setIsMobile] = useState(false);
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const forceCheckTimeout = useRef<number | undefined>(undefined);
+  const isGeneratedDashboard = location.query.seerRunId !== undefined;
 
   const debouncedHandleResize = useMemo(
     () =>
@@ -444,6 +445,7 @@ export function Dashboard({
               isEmbedded={isEmbedded}
               isPreview={isPreview}
               isPrebuiltDashboard={defined(dashboard.prebuiltId)}
+              isGeneratedDashboard={isGeneratedDashboard}
               dashboardFilters={getDashboardFiltersFromURL(location) ?? dashboard.filters}
               dashboardPermissions={dashboard.permissions}
               dashboardCreator={dashboard.createdBy}

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -43,6 +43,7 @@ type Props = {
   dashboardFilters?: DashboardFilters;
   dashboardPermissions?: DashboardPermissions;
   isEmbedded?: boolean;
+  isGeneratedDashboard?: boolean;
   isMobile?: boolean;
   isPrebuiltDashboard?: boolean;
   isPreview?: boolean;
@@ -156,7 +157,11 @@ export function SortableWidget(props: Props) {
       data-test-id="sortable-widget"
     >
       <DashboardsMEPProvider>
-        <LazyRender containerHeight={200} withoutContainer disabled={props.isPreview}>
+        <LazyRender
+          containerHeight={200}
+          withoutContainer
+          disabled={props.isGeneratedDashboard}
+        >
           <WidgetCard {...widgetProps} />
           {props.isEditingDashboard && (
             <Toolbar

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -156,7 +156,7 @@ export function SortableWidget(props: Props) {
       data-test-id="sortable-widget"
     >
       <DashboardsMEPProvider>
-        <LazyRender containerHeight={200} withoutContainer>
+        <LazyRender containerHeight={200} withoutContainer disabled={props.isPreview}>
           <WidgetCard {...widgetProps} />
           {props.isEditingDashboard && (
             <Toolbar


### PR DESCRIPTION
Disables widgets from lazy loading when viewing an ai generated dashboard preview. This is to reduce issues with new widgets being inserted during generation but not loading due to lazy load. Also makes it easier to detect failed queries by loading all widgets.