### PR TITLE
chore(csp): allow to iframe `demo.arcade.software`

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -539,6 +539,9 @@ CSP_CONNECT_SRC = [
 CSP_FRAME_ANCESTORS = [
     "'none'",
 ]
+CSP_FRAME_SRC = [
+    "demo.arcade.software",
+]
 CSP_OBJECT_SRC = [
     "'none'",
 ]


### PR DESCRIPTION
Fixes this CSP violation on local dev and self-hosted:

<img width="1217" height="783" alt="image" src="https://github.com/user-attachments/assets/cfa82e34-86f3-445f-be44-5bce818e4160" />
