### PR TITLE
fix(seer): Update no-repo warning to error severity

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -176,10 +176,12 @@ export function SeerProjectTableRow({
         {autofixSettings ? (
           autofixSettings.reposCount === 0 ? (
             <Tooltip
-              title={t('Seer works best on projects with at least one connected repo.')}
+              title={t(
+                'Seer Autofix only works on projects with at least one connected repo.'
+              )}
             >
               <Flex align="center" gap="sm">
-                <IconWarning variant="warning" />
+                <IconWarning variant="error" />
                 <Text tabular>{0}</Text>
               </Flex>
             </Tooltip>


### PR DESCRIPTION
Update the Seer project table row to better communicate when a project has no connected repos:

- Change tooltip text from "works best" to "only works" to clarify that Autofix requires at least one connected repo
- Change icon variant from `warning` to `error` to better reflect the severity


Agent transcript: https://claudescope.sentry.dev/share/SXLU5YuIYvIViM8lhChIb7CvP6DRkzg2u9sC3MGaAO8