### PR TITLE
feat(settings): Add Integrations nav section with MCP & CLI page

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1139,6 +1139,11 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/settings/dynamicSampling')),
     },
     {
+      path: 'mcp-cli/',
+      name: t('MCP & CLI'),
+      component: make(() => import('sentry/views/settings/organizationMcpCli')),
+    },
+    {
       path: 'feature-flags/',
       name: t('Feature Flags'),
       children: [

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -148,15 +148,6 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           id: 'repos',
         },
         {
-          path: `${organizationSettingsPathPrefix}/integrations/`,
-          title: t('Integrations'),
-          description: t(
-            'Manage organization-level integrations, including: Slack, GitHub, Bitbucket, Jira, and Azure DevOps'
-          ),
-          id: 'integrations',
-          recordAnalytics: true,
-        },
-        {
           path: `${organizationSettingsPathPrefix}/early-features/`,
           title: t('Early Features'),
           description: t('Manage early access features'),
@@ -198,6 +189,33 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
       ],
     },
     {
+      id: 'settings-integrations',
+      name: t('Integrations'),
+      items: [
+        {
+          path: `${organizationSettingsPathPrefix}/mcp-cli/`,
+          title: t('MCP & CLI'),
+          description: t('Connect to Sentry via MCP server or the Sentry CLI'),
+          id: 'mcp-cli',
+        },
+        {
+          path: `${organizationSettingsPathPrefix}/integrations/`,
+          title: t('Integrations'),
+          description: t(
+            'Manage organization-level integrations, including: Slack, GitHub, Bitbucket, Jira, and Azure DevOps'
+          ),
+          id: 'integrations',
+          recordAnalytics: true,
+        },
+        {
+          path: `${organizationSettingsPathPrefix}/developer-settings/`,
+          title: t('Custom Integrations'),
+          description: t('Manage custom integrations'),
+          id: 'developer-settings',
+        },
+      ],
+    },
+    {
       id: 'settings-developer',
       name: t('Developer Settings'),
       items: [
@@ -215,14 +233,8 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           ),
         },
         {
-          path: `${organizationSettingsPathPrefix}/developer-settings/`,
-          title: t('Custom Integrations'),
-          description: t('Manage custom integrations'),
-          id: 'developer-settings',
-        },
-        {
           path: `${userSettingsPathPrefix}/api/applications/`,
-          title: t('Applications'),
+          title: t('OAuth Applications'),
           description: t('Add and configure OAuth2 applications'),
         },
       ],

--- a/static/app/views/settings/organizationMcpCli/index.tsx
+++ b/static/app/views/settings/organizationMcpCli/index.tsx
@@ -1,0 +1,71 @@
+import {Fragment} from 'react';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {TextCopyInput} from 'sentry/components/textCopyInput';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
+import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
+
+export default function OrganizationMcpCli() {
+  const organization = useOrganization();
+
+  return (
+    <Fragment>
+      <SentryDocumentTitle title={t('MCP & CLI')} orgSlug={organization.slug} />
+      <SettingsPageHeader title={t('MCP & CLI')} />
+      <TextBlock>
+        {t('Connect to Sentry from AI-powered development tools and your terminal.')}
+      </TextBlock>
+
+      <Flex direction="column" gap="xl">
+        <Container padding="xl" border="primary" radius="md">
+          <Flex direction="column" gap="lg">
+            <Heading as="h3">{t('MCP Server')}</Heading>
+            <Text variant="muted" size="lg">
+              {t(
+                'Add this URL as a streamable HTTP MCP server in your client. Authentication happens automatically via your browser.'
+              )}
+            </Text>
+            <TextCopyInput>https://mcp.sentry.dev/mcp</TextCopyInput>
+            <Text variant="muted">
+              {t(
+                'You can scope the connection to a specific organization or project by appending query parameters to the URL:'
+              )}
+            </Text>
+            <TextCopyInput>
+              https://mcp.sentry.dev/mcp/example-org/example-project
+            </TextCopyInput>
+            <div>
+              <LinkButton href="https://mcp.sentry.dev" external priority="default">
+                {t('MCP Documentation')}
+              </LinkButton>
+            </div>
+          </Flex>
+        </Container>
+
+        <Container padding="xl" border="primary" radius="md">
+          <Flex direction="column" gap="lg">
+            <Heading as="h3">{t('Sentry CLI')}</Heading>
+            <Text variant="muted" size="lg">
+              {t(
+                'Install the Sentry CLI and authenticate to manage releases, source maps, debug symbols, and more from your terminal.'
+              )}
+            </Text>
+            <TextCopyInput>curl https://cli.sentry.dev/install -fsS | bash</TextCopyInput>
+            <TextCopyInput>sentry auth login</TextCopyInput>
+            <div>
+              <LinkButton href="https://cli.sentry.dev" external priority="default">
+                {t('CLI Documentation')}
+              </LinkButton>
+            </div>
+          </Flex>
+        </Container>
+      </Flex>
+    </Fragment>
+  );
+}

--- a/static/app/views/settings/organizationMcpCli/index.tsx
+++ b/static/app/views/settings/organizationMcpCli/index.tsx
@@ -54,7 +54,7 @@ export default function OrganizationMcpCli() {
             <Heading as="h3">{t('Sentry CLI')}</Heading>
             <Text variant="muted" size="lg">
               {t(
-                'Install the Sentry CLI and authenticate to manage releases, source maps, debug symbols, and more from your terminal.'
+                'A command-line tool for developers and agents. Browse issues, get AI-powered root cause analysis, autodetect your project, and pipe structured output to your favorite tools.'
               )}
             </Text>
             <TextCopyInput>curl https://cli.sentry.dev/install -fsS | bash</TextCopyInput>

--- a/static/app/views/settings/organizationMcpCli/index.tsx
+++ b/static/app/views/settings/organizationMcpCli/index.tsx
@@ -28,17 +28,18 @@ export default function OrganizationMcpCli() {
             <Heading as="h3">{t('MCP Server')}</Heading>
             <Text variant="muted" size="lg">
               {t(
-                'Add this URL as a streamable HTTP MCP server in your client. Authentication happens automatically via your browser.'
+                'Connect AI assistants to Sentry for searching errors, analyzing performance, triaging issues, and managing projects via the Model Context Protocol. Add this URL as a streamable HTTP MCP server in your client.'
               )}
             </Text>
             <TextCopyInput>https://mcp.sentry.dev/mcp</TextCopyInput>
             <Text variant="muted">
               {t(
-                'You can scope the connection to a specific organization or project by appending query parameters to the URL:'
+                'You can scope the connection to a specific organization or project. Scoping to a project is recommended when possible — it sets defaults automatically and hides unnecessary discovery tools.'
               )}
             </Text>
+            <TextCopyInput>https://mcp.sentry.dev/mcp/your-org</TextCopyInput>
             <TextCopyInput>
-              https://mcp.sentry.dev/mcp/example-org/example-project
+              https://mcp.sentry.dev/mcp/your-org/your-project
             </TextCopyInput>
             <div>
               <LinkButton href="https://mcp.sentry.dev" external priority="default">


### PR DESCRIPTION
Adds a new **Integrations** section to the organization settings sidebar, positioned between Organization and Developer Settings. This groups integration-related items together and adds a quick-start page for Sentry's MCP server and CLI.

**Navigation changes:**
- New "Integrations" section with: MCP & CLI, Integrations, Custom Integrations
- "Integrations" removed from the Organization section
- "Custom Integrations" moved from Developer Settings
- "Applications" renamed to "OAuth Applications" in Developer Settings

**MCP & CLI page:**
- Copyable MCP connection string (`https://mcp.sentry.dev/mcp`)
- Org/project scoping example
- CLI install and auth commands as copyable inputs
- Links out to mcp.sentry.dev and cli.sentry.dev for full docs