### PR TITLE
feat(aci): Add issue preview to the metric monitor form

### DIFF
--- a/static/app/views/detectors/components/forms/common/detectorIssuePreview.tsx
+++ b/static/app/views/detectors/components/forms/common/detectorIssuePreview.tsx
@@ -1,19 +1,18 @@
-import {useTheme} from '@emotion/react';
-
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {ActorAvatar} from '@sentry/scraps/avatar';
+import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {ErrorLevel} from 'sentry/components/events/errorLevel';
 import {ShortId} from 'sentry/components/group/inboxBadges/shortId';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
-import {Container} from 'sentry/components/workflowEngine/ui/container';
-import {Section} from 'sentry/components/workflowEngine/ui/section';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
+import type {Actor} from 'sentry/types/core';
 import type {AvatarProject} from 'sentry/types/project';
 
 interface DetectorIssuePreviewProps {
   issueTitle: string;
   subtitle: string;
+  assignee?: Actor;
   project?: AvatarProject;
 }
 
@@ -21,77 +20,44 @@ export function DetectorIssuePreview({
   issueTitle,
   project,
   subtitle,
+  assignee,
 }: DetectorIssuePreviewProps) {
-  const theme = useTheme();
   const projectSlug = project?.slug ?? 'project';
   const shortId = `${projectSlug.toUpperCase()}-D3M0`;
-  return (
-    <Container>
-      <Section
-        title={t('Preview')}
-        description={t(
-          'Given your configurations, this is a sample of the kind of issue you can expect this Monitor to produce.'
-        )}
-      >
-        <Grid
-          radius="lg"
-          columns="1fr repeat(5, auto)"
-          border="primary"
-          justify="center"
-          align="center"
-        >
-          <Flex
-            style={{borderTopLeftRadius: theme.radius.lg}}
-            borderBottom="primary"
-            padding="md"
-            background="secondary"
-          >
-            <Flex marginLeft="2xl">
-              <Text bold>{t('Issue')}</Text>
-            </Flex>
-          </Flex>
-          <Flex borderBottom="primary" padding="md" background="secondary">
-            <Text bold>{t('Last Seen')}</Text>
-          </Flex>
-          <Flex borderBottom="primary" padding="md" background="secondary">
-            <Text bold>{t('Age')}</Text>
-          </Flex>
-          <Flex borderBottom="primary" padding="md" background="secondary">
-            <Text bold>{t('Events')}</Text>
-          </Flex>
-          <Flex borderBottom="primary" padding="md" background="secondary">
-            <Text bold>{t('Users')}</Text>
-          </Flex>
-          <Flex
-            style={{borderTopRightRadius: theme.radius.lg}}
-            borderBottom="primary"
-            padding="md"
-            background="secondary"
-          >
-            <Text bold>{t('Assignee')}</Text>
-          </Flex>
 
-          <Flex align="start" gap="md" marginLeft="2xl" padding="md">
-            <Flex direction="column" gap="sm">
-              <Text bold>{issueTitle}</Text>
-              <Flex align="center" gap="xs">
-                <ErrorLevel level="error" />
-                {subtitle}
-              </Flex>
-              <Flex align="center" gap="xs">
-                {project && <ProjectBadge project={project} avatarSize={14} hideName />}
-                <Text size="sm" variant="muted">
-                  <ShortId shortId={shortId} />
-                </Text>
-              </Flex>
+  return (
+    <SimpleTable style={{gridTemplateColumns: '1fr auto auto auto auto auto'}}>
+      <SimpleTable.Header>
+        <SimpleTable.HeaderCell>{t('Issue')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Last Seen')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Age')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Events')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Users')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Assignee')}</SimpleTable.HeaderCell>
+      </SimpleTable.Header>
+      <SimpleTable.Row>
+        <SimpleTable.RowCell>
+          <Flex direction="column" gap="xs">
+            <Text bold size="lg">
+              {issueTitle}
+            </Text>
+            <Text size="md">{subtitle}</Text>
+            <Flex align="center" gap="xs">
+              {project && <ProjectBadge project={project} avatarSize={14} hideName />}
+              <Text size="sm" variant="muted">
+                <ShortId shortId={shortId} />
+              </Text>
             </Flex>
           </Flex>
-          <Text align="center">4hr ago</Text>
-          <Text align="center">2min</Text>
-          <Text align="center">1</Text>
-          <Text align="center">1.2k</Text>
-        </Grid>
-      </Section>
-    </Container>
+        </SimpleTable.RowCell>
+        <SimpleTable.RowCell justify="end">2min ago</SimpleTable.RowCell>
+        <SimpleTable.RowCell justify="end">4h</SimpleTable.RowCell>
+        <SimpleTable.RowCell justify="end">1.2k</SimpleTable.RowCell>
+        <SimpleTable.RowCell justify="end">620</SimpleTable.RowCell>
+        <SimpleTable.RowCell justify="center">
+          {assignee && <ActorAvatar actor={assignee} size={20} />}
+        </SimpleTable.RowCell>
+      </SimpleTable.Row>
+    </SimpleTable>
   );
 }

--- a/static/app/views/detectors/components/forms/common/issuePreviewSection.tsx
+++ b/static/app/views/detectors/components/forms/common/issuePreviewSection.tsx
@@ -1,0 +1,18 @@
+import {Container} from 'sentry/components/workflowEngine/ui/container';
+import {Section} from 'sentry/components/workflowEngine/ui/section';
+import {t} from 'sentry/locale';
+
+export function IssuePreviewSection({children}: {children: React.ReactNode}) {
+  return (
+    <Container data-test-id="issue-preview-section">
+      <Section
+        title={t('Preview')}
+        description={t(
+          'Given your configurations, this is a sample of the kind of issue you can expect this Monitor to produce.'
+        )}
+      >
+        {children}
+      </Section>
+    </Container>
+  );
+}

--- a/static/app/views/detectors/components/forms/common/ownerToActor.tsx
+++ b/static/app/views/detectors/components/forms/common/ownerToActor.tsx
@@ -1,0 +1,15 @@
+import type {Actor} from 'sentry/types/core';
+
+/**
+ * Converts an owner string (e.g. "user:123" or "team:456") to an Actor object.
+ */
+export function ownerToActor(owner: string | undefined): Actor | undefined {
+  if (!owner) {
+    return undefined;
+  }
+  const [type, id] = owner.split(':');
+  if (!id || (type !== 'team' && type !== 'user')) {
+    return undefined;
+  }
+  return {type, id, name: ''};
+}

--- a/static/app/views/detectors/components/forms/metric/metric.spec.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.spec.tsx
@@ -1,9 +1,11 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
+import {MemberListStore} from 'sentry/stores/memberListStore';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {DetectorFormProvider} from 'sentry/views/detectors/components/forms/context';
 import {NewMetricDetectorForm} from 'sentry/views/detectors/components/forms/metric/metric';
@@ -18,6 +20,8 @@ describe('NewMetricDetectorForm', () => {
     MockApiClient.clearMockResponses();
     OrganizationStore.reset();
     OrganizationStore.onUpdate(organization);
+    MemberListStore.init();
+    MemberListStore.loadInitialData([UserFixture()]);
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
@@ -63,6 +67,76 @@ describe('NewMetricDetectorForm', () => {
       url: '/organizations/org-slug/projects/',
       body: [project],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/user-teams/',
+      body: [],
+    });
+  });
+
+  it('shows default issue preview and updates subtitle when threshold changes', async () => {
+    render(
+      <DetectorFormProvider detectorType="metric_issue" project={project}>
+        <NewMetricDetectorForm />
+      </DetectorFormProvider>,
+      {organization}
+    );
+
+    // Default title and subtitle
+    expect(await screen.findByText('Monitor title')).toBeInTheDocument();
+    expect(
+      screen.getByText('Critical: Number of errors above ... in 1 hour')
+    ).toBeInTheDocument();
+
+    // Change the monitor name and verify it updates the preview
+    await userEvent.click(screen.getByTestId('editable-text-label'));
+    await userEvent.clear(screen.getByRole('textbox', {name: 'Monitor Name'}));
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Monitor Name'}),
+      'My Custom Monitor'
+    );
+    await userEvent.keyboard('{Enter}');
+    const preview = screen.getByTestId('issue-preview-section');
+    expect(within(preview).getByText('My Custom Monitor')).toBeInTheDocument();
+
+    // Change the high threshold
+    await userEvent.type(screen.getByRole('spinbutton', {name: 'High threshold'}), '100');
+
+    expect(
+      within(preview).getByText('Critical: Number of errors above 100 in 1 hour')
+    ).toBeInTheDocument();
+
+    // Switch to percent change detection type — threshold value carries over
+    await userEvent.click(screen.getByRole('radio', {name: /Change/i}));
+
+    expect(
+      within(preview).getByText(
+        'Critical: Number of errors higher by 100% compared to past 1 hour'
+      )
+    ).toBeInTheDocument();
+
+    // Clear and set a new percent threshold
+    await userEvent.clear(screen.getByRole('spinbutton', {name: 'High threshold'}));
+    await userEvent.type(screen.getByRole('spinbutton', {name: 'High threshold'}), '50');
+
+    expect(
+      within(preview).getByText(
+        'Critical: Number of errors higher by 50% compared to past 1 hour'
+      )
+    ).toBeInTheDocument();
+
+    // Switch to dynamic (anomaly) detection type
+    await userEvent.click(screen.getByRole('radio', {name: /Dynamic/i}));
+
+    expect(
+      within(preview).getByText('Detected an anomaly in the query for Number of errors')
+    ).toBeInTheDocument();
+
+    // Change the assignee and verify it shows in the preview
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Default assignee'}),
+      'Foo Bar'
+    );
+    expect(within(preview).getByText('FB')).toBeInTheDocument();
   });
 
   it('removes is filters when switching away from the errors dataset', async () => {

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -44,6 +44,7 @@ import {
   metricSavedDetectorToFormData,
   useMetricDetectorFormField,
 } from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {MetricIssuePreview} from 'sentry/views/detectors/components/forms/metric/metricIssuePreview';
 import {MetricDetectorPreviewChart} from 'sentry/views/detectors/components/forms/metric/previewChart';
 import {DetectorQueryFilterBuilder} from 'sentry/views/detectors/components/forms/metric/queryFilterBuilder';
 import {ResolveSection} from 'sentry/views/detectors/components/forms/metric/resolveSection';
@@ -77,6 +78,7 @@ function MetricDetectorForm() {
       <DetectSection />
       <AssignSection />
       <DescribeSection />
+      <MetricIssuePreview />
       <AutomateSection />
     </Stack>
   );

--- a/static/app/views/detectors/components/forms/metric/metricIssuePreview.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricIssuePreview.tsx
@@ -1,0 +1,96 @@
+import {t} from 'sentry/locale';
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {getDuration} from 'sentry/utils/duration/getDuration';
+import {DetectorIssuePreview} from 'sentry/views/detectors/components/forms/common/detectorIssuePreview';
+import {IssuePreviewSection} from 'sentry/views/detectors/components/forms/common/issuePreviewSection';
+import {ownerToActor} from 'sentry/views/detectors/components/forms/common/ownerToActor';
+import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/context';
+import {
+  METRIC_DETECTOR_FORM_FIELDS,
+  useMetricDetectorFormField,
+} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
+import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
+
+function useMetricIssuePreviewSubtitle() {
+  const detectionType = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.detectionType
+  );
+  const aggregate = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
+  );
+  const dataset = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.dataset);
+  const interval = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.interval);
+  const highThreshold = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.highThreshold
+  );
+  const conditionType = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.conditionType
+  );
+  const conditionComparisonAgo = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.conditionComparisonAgo
+  );
+
+  const datasetConfig = getDatasetConfig(dataset);
+  const formattedAggregate =
+    datasetConfig.formatAggregateForTitle?.(aggregate) ?? aggregate;
+  const intervalLabel = getDuration(interval);
+  const thresholdLabel = highThreshold || t('...');
+
+  switch (detectionType) {
+    case 'static': {
+      const direction =
+        conditionType === DataConditionType.LESS ? t('below') : t('above');
+      const suffix = getMetricDetectorSuffix('static', aggregate);
+      return t(
+        'Critical: %(aggregate)s %(direction)s %(threshold)s%(suffix)s in %(interval)s',
+        {
+          aggregate: formattedAggregate,
+          direction,
+          threshold: thresholdLabel,
+          suffix,
+          interval: intervalLabel,
+        }
+      );
+    }
+    case 'percent': {
+      const direction =
+        conditionType === DataConditionType.LESS ? t('lower') : t('higher');
+      return t(
+        'Critical: %(aggregate)s %(direction)s by %(threshold)s%% compared to past %(interval)s',
+        {
+          aggregate: formattedAggregate,
+          direction,
+          threshold: thresholdLabel,
+          interval: getDuration(conditionComparisonAgo ?? interval),
+        }
+      );
+    }
+    case 'dynamic': {
+      return t('Detected an anomaly in the query for %(aggregate)s', {
+        aggregate: formattedAggregate,
+      });
+    }
+    default:
+      return t('Critical issue condition met');
+  }
+}
+
+export function MetricIssuePreview() {
+  const name = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.name);
+  const owner = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.owner);
+  const subtitle = useMetricIssuePreviewSubtitle();
+  const assignee = ownerToActor(owner);
+  const {project} = useDetectorFormContext();
+
+  return (
+    <IssuePreviewSection>
+      <DetectorIssuePreview
+        issueTitle={name || t('Monitor title')}
+        subtitle={subtitle}
+        assignee={assignee}
+        project={project}
+      />
+    </IssuePreviewSection>
+  );
+}

--- a/static/app/views/detectors/components/forms/mobileBuild/previewSection.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/previewSection.tsx
@@ -1,6 +1,7 @@
 import {t} from 'sentry/locale';
 import {useProjects} from 'sentry/utils/useProjects';
 import {DetectorIssuePreview} from 'sentry/views/detectors/components/forms/common/detectorIssuePreview';
+import {IssuePreviewSection} from 'sentry/views/detectors/components/forms/common/issuePreviewSection';
 import {
   PREPROD_DETECTOR_FORM_FIELDS,
   usePreprodDetectorFormField,
@@ -38,10 +39,12 @@ export function MobileBuildPreviewSection() {
   const thresholdDisplay = highThreshold ? `${threshold} ${thresholdUnit}` : '\u2026';
 
   return (
-    <DetectorIssuePreview
-      issueTitle={t('%s threshold exceeded', metricLabel)}
-      project={project}
-      subtitle={t('%s > %s Threshold', actualDisplay, thresholdDisplay)}
-    />
+    <IssuePreviewSection>
+      <DetectorIssuePreview
+        issueTitle={t('%s threshold exceeded', metricLabel)}
+        project={project}
+        subtitle={t('%s > %s Threshold', actualDisplay, thresholdDisplay)}
+      />
+    </IssuePreviewSection>
   );
 }


### PR DESCRIPTION
Closes ISWF-2147

- Adds an issue preview to the metric monitor form
- Refactors the issue preview component to use SimpleTable and thus look more similar to the actual issue stream
- Add support for sending "assignee" to the issue preview
- Add a reusable issue preview section wrapper since should look the same in most detector forms

<img width="2296" height="474" alt="CleanShot 2026-03-24 at 10 42 11@2x" src="https://github.com/user-attachments/assets/86b424d9-b1b6-45af-b290-a1573f1700c0" />
