### PR TITLE
feat(pipeline): Add API mode support to base Pipeline

### DIFF
--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -19,8 +19,8 @@ from sentry.web.helpers import render_to_response
 from ..models import Organization
 from .constants import PIPELINE_STATE_TTL
 from .store import PipelineSessionStore
-from .types import PipelineRequestState
-from .views.base import PipelineView
+from .types import PipelineRequestState, PipelineStepAction, PipelineStepResult
+from .views.base import ApiPipelineEndpoint, ApiPipelineStep, ApiPipelineSteps, PipelineView
 from .views.nested import NestedPipelineView
 
 ERR_MISMATCHED_USER = "Current user does not match user that started the pipeline."
@@ -256,6 +256,70 @@ class Pipeline[M: Model, S: PipelineSessionStore](abc.ABC):
             )
             return nested_pipeline.fetch_state(key)
         return self._fetch_state(key)
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[Self]:
+        """
+        Return API step objects for this pipeline, or None if API mode is not
+        supported. Steps may be callables for late binding (resolved when the
+        step is reached). Subclasses override this to enable API mode.
+        """
+        return None
+
+    def _resolve_api_step(self, step: ApiPipelineStep[Self]) -> ApiPipelineEndpoint[Self]:
+        return step() if callable(step) else step
+
+    def is_api_ready(self) -> bool:
+        """Returns True if this pipeline supports API mode."""
+        return self.get_pipeline_api_steps() is not None
+
+    def _assert_user_authorization(self) -> None:
+        assert not (self.state.uid is not None and self.state.uid != self.request.user.id), (
+            ERR_MISMATCHED_USER
+        )
+
+    def get_current_step_info(self) -> dict[str, Any]:
+        """Returns structured data describing the current pipeline step for API consumers."""
+        self._assert_user_authorization()
+        api_steps = self.get_pipeline_api_steps()
+        assert api_steps is not None
+        step_index = self.step_index
+        api_step = self._resolve_api_step(api_steps[step_index])
+        return {
+            "step": api_step.step_name,
+            "stepIndex": step_index,
+            "totalSteps": len(api_steps),
+            "provider": self.provider.key,
+            "data": api_step.get_step_data(self, self.request),
+        }
+
+    def api_advance(self, request: HttpRequest, data: Mapping[str, Any]) -> PipelineStepResult:
+        """Validates and processes the current step in API mode, advancing the pipeline."""
+        self._assert_user_authorization()
+        api_steps = self.get_pipeline_api_steps()
+        assert api_steps is not None
+        step_index = self.step_index
+        api_step = self._resolve_api_step(api_steps[step_index])
+
+        serializer_cls = api_step.get_serializer_cls()
+        if serializer_cls is not None:
+            serializer = serializer_cls(data=data)
+            serializer.is_valid(raise_exception=True)
+            validated_data = serializer.validated_data
+        else:
+            validated_data = data
+
+        result = api_step.handle_post(validated_data, self, request)
+
+        if result.action == PipelineStepAction.ADVANCE:
+            self.state.step_index = step_index + 1
+            if self.step_index >= len(api_steps):
+                return self.api_finish_pipeline()
+
+        return result
+
+    def api_finish_pipeline(self) -> PipelineStepResult:
+        """Called when all pipeline steps complete in API mode. Subclasses must override."""
+        raise NotImplementedError
 
     def get_logger(self) -> logging.Logger:
         return logging.getLogger(f"sentry.integration.{self.provider.key}")

--- a/src/sentry/pipeline/provider.py
+++ b/src/sentry/pipeline/provider.py
@@ -4,7 +4,7 @@ import abc
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 
 
 class PipelineProvider[P](abc.ABC):
@@ -35,6 +35,13 @@ class PipelineProvider[P](abc.ABC):
         interface. Each view will be dispatched in order.
         >>> return [OAuthInitView(), OAuthCallbackView()]
         """
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[P]:
+        """
+        Return API step objects for this provider's pipeline, or None if API
+        mode is not supported. Override to enable the pipeline API.
+        """
+        return None
 
     def update_config(self, config: Mapping[str, Any]) -> None:
         """

--- a/src/sentry/pipeline/types.py
+++ b/src/sentry/pipeline/types.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
 
 from sentry.db.models.base import Model
 from sentry.organizations.services.organization import RpcOrganization
@@ -24,3 +26,38 @@ class PipelineAnalyticsEntry:
 
     event_type: str
     pipeline_type: str
+
+
+class PipelineStepAction(str, Enum):
+    ADVANCE = "advance"
+    STAY = "stay"
+    ERROR = "error"
+    COMPLETE = "complete"
+
+
+@dataclass
+class PipelineStepResult:
+    action: PipelineStepAction
+    data: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def advance(cls, data: dict[str, Any] | None = None) -> PipelineStepResult:
+        return cls(action=PipelineStepAction.ADVANCE, data=data or {})
+
+    @classmethod
+    def stay(cls, data: dict[str, Any] | None = None) -> PipelineStepResult:
+        return cls(action=PipelineStepAction.STAY, data=data or {})
+
+    @classmethod
+    def error(cls, message: str) -> PipelineStepResult:
+        return cls(action=PipelineStepAction.ERROR, data={"detail": message})
+
+    @classmethod
+    def complete(cls, data: dict[str, Any] | None = None) -> PipelineStepResult:
+        return cls(action=PipelineStepAction.COMPLETE, data=data or {})
+
+    def serialize(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"status": self.action.value}
+        if self.data:
+            result["data"] = self.data
+        return result

--- a/src/sentry/pipeline/views/base.py
+++ b/src/sentry/pipeline/views/base.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Protocol
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 
+from sentry.pipeline.types import PipelineStepResult
 from sentry.utils import json
 from sentry.web.client_config import get_client_config
 from sentry.web.frontend.base import determine_active_organization
@@ -13,7 +14,51 @@ from sentry.web.helpers import render_to_response
 
 
 class PipelineView[P](Protocol):
+    """Legacy protocol for template/redirect-based pipeline steps.
+
+    Deprecated: new pipeline steps should implement ApiPipelineEndpoint instead.
+    Existing PipelineView implementations will be migrated incrementally as each
+    integration adopts API mode. Once all providers have been converted, this
+    protocol and the dispatch-based flow in Pipeline.current_step will be removed.
+    """
+
     def dispatch(self, request: HttpRequest, pipeline: P) -> HttpResponseBase: ...
+
+
+class ApiPipelineEndpoint[P, D = Any, V = Any](Protocol):
+    """Protocol for a pipeline step that supports API mode.
+
+    This replaces the legacy PipelineView dispatch() approach. Instead of
+    rendering templates and handling redirects server-side, each step exposes
+    structured data via get_step_data() and accepts validated input via
+    handle_post(), allowing a React frontend to drive the flow through JSON
+    API calls.
+
+    Each provider returns a list of these via get_pipeline_api_steps(), one
+    per pipeline view. The pipeline is considered API-ready when
+    get_pipeline_api_steps() returns any steps (see Pipeline.is_api_ready).
+
+    P: the pipeline type (e.g. IntegrationPipeline)
+    D: the TypedDict returned by get_step_data — typed step data for the frontend
+    V: the type of validated_data passed to handle_post (defaults to Any)
+    """
+
+    step_name: str
+
+    def get_step_data(self, pipeline: P, request: HttpRequest) -> D: ...
+
+    def get_serializer_cls(self) -> type | None: ...
+
+    def handle_post(
+        self,
+        validated_data: V,
+        pipeline: P,
+        request: HttpRequest,
+    ) -> PipelineStepResult: ...
+
+
+type ApiPipelineStep[P] = ApiPipelineEndpoint[P] | Callable[[], ApiPipelineEndpoint[P]]
+type ApiPipelineSteps[P] = Sequence[ApiPipelineStep[P]] | None
 
 
 def render_react_view(

--- a/tests/sentry/pipeline/test_pipeline.py
+++ b/tests/sentry/pipeline/test_pipeline.py
@@ -1,15 +1,20 @@
 from collections.abc import Sequence
 from functools import cached_property
-from typing import Never
+from typing import Any, Never
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.contrib.sessions.backends.base import SessionBase
 from django.http import HttpRequest, HttpResponse
+from django.http.response import HttpResponseBase
+from rest_framework import serializers
 
 from sentry.organizations.services.organization.serial import serialize_rpc_organization
 from sentry.pipeline.base import ERR_MISMATCHED_USER, Pipeline
 from sentry.pipeline.provider import PipelineProvider
 from sentry.pipeline.store import PipelineSessionStore
+from sentry.pipeline.types import PipelineStepAction, PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineEndpoint, ApiPipelineSteps, PipelineView
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -31,6 +36,8 @@ class DummyProvider(PipelineProvider["DummyPipeline"]):
 
 
 class DummyPipeline(Pipeline[Never, PipelineSessionStore]):
+    """A minimal pipeline that does NOT support API mode."""
+
     pipeline_name = "test_pipeline"
 
     def __init__(self, *args, **kwargs):
@@ -50,6 +57,185 @@ class DummyPipeline(Pipeline[Never, PipelineSessionStore]):
 
     def finish_pipeline(self):
         self.finished = True
+
+
+class ChooseThingView:
+    """Step 1 (dispatch): user picks a thing."""
+
+    def dispatch(self, request: HttpRequest, pipeline: Any) -> HttpResponseBase:
+        if "thing" in request.POST:
+            pipeline.bind_state("thing", request.POST["thing"])
+            return pipeline.next_step()
+        return HttpResponse('<form method="POST"><input name="thing" /></form>')
+
+
+class ConfirmView:
+    """Step 2 (dispatch): user confirms their choice."""
+
+    def dispatch(self, request: HttpRequest, pipeline: Any) -> HttpResponseBase:
+        if request.method == "POST":
+            pipeline.bind_state("confirmed", True)
+            return pipeline.next_step()
+        thing = pipeline.fetch_state("thing")
+        return HttpResponse(
+            f"<p>Confirm {thing}?</p><form method='POST'><button>OK</button></form>"
+        )
+
+
+class ChooseThingApiStep[P: Pipeline[Any, Any]]:
+    step_name = "choose_thing"
+
+    def get_step_data(self, pipeline: P, request: HttpRequest) -> dict[str, Any]:
+        return {"available_things": ["thing_a", "thing_b", "thing_c"]}
+
+    def get_serializer_cls(self) -> type | None:
+        return None
+
+    def handle_post(
+        self, validated_data: Any, pipeline: P, request: HttpRequest
+    ) -> PipelineStepResult:
+        thing = validated_data.get("thing", "thing_a")
+        pipeline.bind_state("thing", thing)
+        return PipelineStepResult.advance()
+
+
+class ConfirmApiStep[P: Pipeline[Any, Any]]:
+    step_name = "confirm"
+
+    def get_step_data(self, pipeline: P, request: HttpRequest) -> dict[str, Any]:
+        return {"thing": pipeline.fetch_state("thing")}
+
+    def get_serializer_cls(self) -> type | None:
+        return None
+
+    def handle_post(
+        self, validated_data: Any, pipeline: P, request: HttpRequest
+    ) -> PipelineStepResult:
+        pipeline.bind_state("confirmed", True)
+        return PipelineStepResult.advance()
+
+
+class ApiDummyProvider(PipelineProvider["ApiDummyPipeline"]):
+    key = "dummy"
+    name = "Dummy"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._pipeline_views: list[PipelineView[ApiDummyPipeline]] = [
+            ChooseThingView(),
+            ConfirmView(),
+        ]
+        self._api_steps: list[ApiPipelineEndpoint[ApiDummyPipeline]] = [
+            ChooseThingApiStep(),
+            ConfirmApiStep(),
+        ]
+
+    def get_pipeline_views(self) -> Sequence[PipelineView["ApiDummyPipeline"]]:
+        return self._pipeline_views
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps["ApiDummyPipeline"]:
+        return self._api_steps
+
+
+class ApiDummyPipeline(Pipeline[Never, PipelineSessionStore]):
+    """A pipeline that supports both dispatch-based views and API mode."""
+
+    pipeline_name = "test_api_pipeline"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.finished = False
+        self.finish_data: dict[str, Any] | None = None
+
+    @cached_property
+    def provider(self) -> ApiDummyProvider:
+        ret = {"dummy": ApiDummyProvider()}[self._provider_key]
+        ret.set_pipeline(self)
+        ret.update_config(self.config)
+        return ret
+
+    def get_pipeline_views(self) -> Sequence[PipelineView["ApiDummyPipeline"]]:
+        return self.provider.get_pipeline_views()
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps["ApiDummyPipeline"]:
+        return self.provider.get_pipeline_api_steps()
+
+    def finish_pipeline(self) -> HttpResponseBase:
+        self.finished = True
+        return HttpResponse("done")
+
+    def api_finish_pipeline(self) -> PipelineStepResult:
+        self.finished = True
+        self.finish_data = self.state.data
+        return PipelineStepResult.complete(data={"thing": self.fetch_state("thing")})
+
+
+class LateBoundApiStep:
+    """A step that is constructed at resolution time and reads earlier pipeline state."""
+
+    step_name = "late_bound"
+
+    def __init__(self, config_from_state: str) -> None:
+        self.config_from_state = config_from_state
+
+    def get_step_data(self, pipeline: Any, request: HttpRequest) -> dict[str, Any]:
+        return {"config": self.config_from_state}
+
+    def get_serializer_cls(self) -> type | None:
+        return None
+
+    def handle_post(
+        self, validated_data: Any, pipeline: Any, request: HttpRequest
+    ) -> PipelineStepResult:
+        pipeline.bind_state("late_result", f"processed:{self.config_from_state}")
+        return PipelineStepResult.advance()
+
+
+class LateBoundProvider(PipelineProvider["LateBoundPipeline"]):
+    key = "late_bound"
+    name = "Late Bound"
+
+    def get_pipeline_views(self) -> Sequence[PipelineView["LateBoundPipeline"]]:
+        return [ChooseThingView()]
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps["LateBoundPipeline"]:
+        return [
+            ChooseThingApiStep(),
+            lambda: self._make_late_step(),
+        ]
+
+    def _make_late_step(self) -> LateBoundApiStep:
+        thing = self.pipeline.fetch_state("thing")
+        return LateBoundApiStep(config_from_state=thing or "missing")
+
+
+class LateBoundPipeline(Pipeline[Never, PipelineSessionStore]):
+    pipeline_name = "test_late_bound_pipeline"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.finished = False
+
+    @cached_property
+    def provider(self) -> LateBoundProvider:
+        ret = LateBoundProvider()
+        ret.set_pipeline(self)
+        ret.update_config(self.config)
+        return ret
+
+    def get_pipeline_views(self) -> Sequence[PipelineView["LateBoundPipeline"]]:
+        return self.provider.get_pipeline_views()
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps["LateBoundPipeline"]:
+        return self.provider.get_pipeline_api_steps()
+
+    def finish_pipeline(self) -> HttpResponseBase:
+        self.finished = True
+        return HttpResponse("done")
+
+    def api_finish_pipeline(self) -> PipelineStepResult:
+        self.finished = True
+        return PipelineStepResult.complete(data={"late_result": self.fetch_state("late_result")})
 
 
 @control_silo_test
@@ -126,3 +312,194 @@ class PipelineTestCase(TestCase):
         resp = intercepted_pipeline.next_step()
         assert isinstance(resp, HttpResponse)  # TODO(cathy): fix typing on
         assert ERR_MISMATCHED_USER.encode() in resp.content
+
+
+@control_silo_test
+class PipelineApiModeTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        with assume_test_silo_mode(SiloMode.CELL):
+            self.org = serialize_rpc_organization(self.create_organization())
+        self.request = HttpRequest()
+        self.request.session = SessionBase()
+        self.request.user = self.user
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_non_api_pipeline_is_not_api_ready(self, mock_bind_org_context: MagicMock) -> None:
+        """A pipeline that doesn't override get_pipeline_api_steps is not API ready."""
+        pipeline = DummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        assert pipeline.get_pipeline_api_steps() is None
+        assert not pipeline.is_api_ready()
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_api_pipeline_is_api_ready(self, mock_bind_org_context: MagicMock) -> None:
+        """A pipeline with matching API steps and pipeline views is API ready."""
+        pipeline = ApiDummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        assert pipeline.get_pipeline_api_steps() is not None
+        assert pipeline.is_api_ready()
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_get_current_step_info(self, mock_bind_org_context: MagicMock) -> None:
+        pipeline = ApiDummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        info = pipeline.get_current_step_info()
+        assert info["step"] == "choose_thing"
+        assert info["stepIndex"] == 0
+        assert info["totalSteps"] == 2
+        assert info["provider"] == "dummy"
+        assert info["data"] == {"available_things": ["thing_a", "thing_b", "thing_c"]}
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_get_current_step_info_after_advance(self, mock_bind_org_context: MagicMock) -> None:
+        pipeline = ApiDummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        pipeline.api_advance(self.request, {"thing": "thing_b"})
+
+        info = pipeline.get_current_step_info()
+        assert info["step"] == "confirm"
+        assert info["stepIndex"] == 1
+        assert info["data"] == {"thing": "thing_b"}
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_api_advance_binds_state(self, mock_bind_org_context: MagicMock) -> None:
+        pipeline = ApiDummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        result = pipeline.api_advance(self.request, {"thing": "thing_c"})
+
+        assert result.action == PipelineStepAction.ADVANCE
+        assert pipeline.fetch_state("thing") == "thing_c"
+        assert pipeline.step_index == 1
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_api_full_flow_completes_pipeline(self, mock_bind_org_context: MagicMock) -> None:
+        """Walk through every step and verify the pipeline completes."""
+        pipeline = ApiDummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        # Step 1: choose a thing
+        result = pipeline.api_advance(self.request, {"thing": "thing_b"})
+        assert result.action == PipelineStepAction.ADVANCE
+        assert pipeline.step_index == 1
+
+        # Step 2: confirm — this is the last step, so pipeline finishes
+        result = pipeline.api_advance(self.request, {})
+        assert result.action == PipelineStepAction.COMPLETE
+        assert result.data == {"thing": "thing_b"}
+        assert pipeline.finished
+        assert pipeline.fetch_state("confirmed") is True
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_api_advance_raises_on_validation_error(self, mock_bind_org_context: MagicMock) -> None:
+        """When a serializer is provided and validation fails, a ValidationError is raised."""
+        from rest_framework.exceptions import ValidationError
+
+        class StrictSerializer(serializers.Serializer):
+            thing = serializers.CharField(required=True)
+
+        pipeline = ApiDummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        # Attach a serializer to the first step
+        api_steps = pipeline.get_pipeline_api_steps()
+        assert api_steps is not None
+        step = pipeline._resolve_api_step(api_steps[0])
+        step.get_serializer_cls = lambda: StrictSerializer  # type: ignore[method-assign]
+
+        with pytest.raises(ValidationError) as exc_info:
+            pipeline.api_advance(self.request, {})
+
+        assert "thing" in exc_info.value.detail
+        assert pipeline.step_index == 0
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_api_advance_with_valid_serializer_data(self, mock_bind_org_context: MagicMock) -> None:
+        class StrictSerializer(serializers.Serializer):
+            thing = serializers.CharField(required=True)
+
+        pipeline = ApiDummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        api_steps = pipeline.get_pipeline_api_steps()
+        assert api_steps is not None
+        step = pipeline._resolve_api_step(api_steps[0])
+        step.get_serializer_cls = lambda: StrictSerializer  # type: ignore[method-assign]
+
+        result = pipeline.api_advance(self.request, {"thing": "thing_a"})
+
+        assert result.action == PipelineStepAction.ADVANCE
+        assert pipeline.step_index == 1
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_api_advance_respects_non_advance_result(
+        self, mock_bind_org_context: MagicMock
+    ) -> None:
+        """When handle_post returns a non-ADVANCE result, the step index should not change."""
+        pipeline = ApiDummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        # Make step return a stay with redirect data instead of advance
+        api_steps = pipeline.get_pipeline_api_steps()
+        assert api_steps is not None
+        step = pipeline._resolve_api_step(api_steps[0])
+        step.handle_post = lambda *_a, **_kw: PipelineStepResult.stay(  # type: ignore[method-assign]
+            data={"redirectUrl": "https://github.com/login/oauth"}
+        )
+
+        result = pipeline.api_advance(self.request, {})
+
+        assert result.action == PipelineStepAction.STAY
+        assert result.data == {"redirectUrl": "https://github.com/login/oauth"}
+        assert pipeline.step_index == 0
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_api_finish_pipeline_not_implemented_on_base(
+        self, mock_bind_org_context: MagicMock
+    ) -> None:
+        """The base Pipeline.api_finish_pipeline raises NotImplementedError."""
+        pipeline = DummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        with pytest.raises(NotImplementedError):
+            pipeline.api_finish_pipeline()
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_late_bound_step_reads_state_from_earlier_step(
+        self, mock_bind_org_context: MagicMock
+    ) -> None:
+        """A callable step is resolved at access time and can use state bound by previous steps."""
+        pipeline = LateBoundPipeline(self.request, "late_bound", self.org)
+        pipeline.initialize()
+
+        assert pipeline.is_api_ready()
+
+        # Step 1: choose a thing — binds "thing" to state
+        result = pipeline.api_advance(self.request, {"thing": "thing_b"})
+        assert result.action == PipelineStepAction.ADVANCE
+        assert pipeline.fetch_state("thing") == "thing_b"
+
+        # Step 2 is late-bound: it reads "thing" from state at construction time
+        info = pipeline.get_current_step_info()
+        assert info["step"] == "late_bound"
+        assert info["data"]["config"] == "thing_b"
+
+        # Advance through the late-bound step
+        result = pipeline.api_advance(self.request, {})
+        assert result.action == PipelineStepAction.COMPLETE
+        assert result.data["late_result"] == "processed:thing_b"
+        assert pipeline.finished
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_late_bound_step_counts_in_total_steps(self, mock_bind_org_context: MagicMock) -> None:
+        """Late-bound callables are counted in totalSteps even before resolution."""
+        pipeline = LateBoundPipeline(self.request, "late_bound", self.org)
+        pipeline.initialize()
+
+        info = pipeline.get_current_step_info()
+        assert info["totalSteps"] == 2


### PR DESCRIPTION
Add infrastructure for driving pipelines via JSON APIs instead of the legacy template/redirect-based dispatch flow. This is the first step toward migrating integration setup pipelines to be driven by a React frontend through structured API requests.

New types in pipeline/types.py:
- PipelineStepAction enum (ADVANCE, STAY, ERROR, COMPLETE)
- PipelineStepResult dataclass with factory methods for each action

New ApiPipelineEndpoint protocol in pipeline/views/base.py, replacing the legacy PipelineView dispatch() approach. Each step exposes structured data via get_step_data() and accepts validated input via handle_post(), with optional DRF serializer validation.

New methods on the base Pipeline class:
- get_pipeline_api_steps() — returns API steps or None (opt-in)
- is_api_ready() — True when a pipeline provides any API steps
- get_current_step_info() — structured JSON for the current step
- api_advance() — validates input and processes the current step
- api_finish_pipeline() — called when all steps complete

The legacy PipelineView protocol is marked as deprecated with guidance to implement ApiPipelineEndpoint for new steps. Existing views will be migrated incrementally as each integration adopts API mode.

Fixes [VDY-33](https://linear.app/getsentry/issue/VDY-33)