### PR TITLE
feat(pipeline): Add frontend pipeline framework

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -595,6 +595,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/js/fixtures/detectedPlatform.ts                                           @getsentry/value-discovery
 /static/app/views/projectInstall/                                                @getsentry/value-discovery
 /src/sentry/onboarding_tasks/                                                    @getsentry/value-discovery
+/static/app/components/pipeline/                                                 @getsentry/value-discovery
 ## End of Value Discovery
 
 ## ML & AI

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -19,6 +19,8 @@ const productionEntryPoints = [
   'static/app/icons/**/*.{js,ts,tsx}',
   // todo find out how chartcuterie works
   'static/app/chartcuterie/**/*.{js,ts,tsx}',
+  // TODO: Remove when used
+  'static/app/components/pipeline/**/*.{js,ts,tsx}',
 ];
 
 const testingEntryPoints = [

--- a/static/app/components/pipeline/index.stories.tsx
+++ b/static/app/components/pipeline/index.stories.tsx
@@ -1,0 +1,199 @@
+import {Fragment, useState} from 'react';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {StructuredEventData} from 'sentry/components/structuredEventData';
+import * as Storybook from 'sentry/stories';
+
+import {openPipelineModal} from './modal';
+import {PIPELINE_REGISTRY} from './registry';
+import type {ProvidersByType, RegisteredPipelineType} from './registry';
+import {usePipeline} from './usePipeline';
+
+const pipelineMenuItems = PIPELINE_REGISTRY.map(p => ({
+  key: `${p.type}:${p.provider}`,
+  label: (
+    <Fragment>
+      {p.provider} <Tag variant="muted">{p.type}</Tag>
+    </Fragment>
+  ),
+}));
+
+function UsePipelineDemo() {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const parsed = selected
+    ? {
+        type: selected.split(':')[0] as RegisteredPipelineType,
+        provider: selected.split(':')[1] as ProvidersByType[RegisteredPipelineType],
+      }
+    : null;
+
+  return (
+    <Flex direction="column" gap="lg">
+      <DropdownMenu
+        triggerLabel={parsed ? `${parsed.type} / ${parsed.provider}` : 'Select pipeline'}
+        items={pipelineMenuItems}
+        onAction={key => setSelected(key.toString())}
+      />
+      {parsed && (
+        <PipelineRunner key={selected} type={parsed.type} provider={parsed.provider} />
+      )}
+    </Flex>
+  );
+}
+
+function PipelineRunner({
+  type,
+  provider,
+}: {
+  provider: ProvidersByType[RegisteredPipelineType];
+  type: RegisteredPipelineType;
+}) {
+  const pipeline = usePipeline(type, provider);
+
+  function getStatus(): string {
+    if (pipeline.isComplete) {
+      return 'complete';
+    }
+    if (pipeline.error) {
+      return 'error';
+    }
+    if (pipeline.isInitializing) {
+      return 'initializing';
+    }
+    if (pipeline.isAdvancing) {
+      return 'advancing';
+    }
+    if (pipeline.stepDefinition) {
+      return 'active';
+    }
+    return 'idle';
+  }
+
+  return (
+    <Flex direction="column" gap="md">
+      <Container border="primary" padding="md">
+        <Flex direction="column" gap="sm">
+          <Flex gap="lg" align="center">
+            <Flex gap="sm" align="center">
+              <Text bold>Status:</Text>
+              <Text>{getStatus()}</Text>
+            </Flex>
+            {pipeline.stepDefinition && (
+              <Flex gap="sm" align="center">
+                <Text bold>Step:</Text>
+                <Text>{pipeline.stepDefinition.stepId}</Text>
+              </Flex>
+            )}
+            {pipeline.totalSteps > 0 && (
+              <Flex gap="sm" align="center">
+                <Text bold>Progress:</Text>
+                <Text>
+                  {pipeline.stepIndex + 1} / {pipeline.totalSteps}
+                </Text>
+              </Flex>
+            )}
+          </Flex>
+          <Flex gap="lg" align="center">
+            <Text size="sm" variant="muted">
+              initializing={String(pipeline.isInitializing)} advancing=
+              {String(pipeline.isAdvancing)} complete={String(pipeline.isComplete)} error=
+              {String(!!pipeline.error)}
+            </Text>
+          </Flex>
+        </Flex>
+      </Container>
+
+      {pipeline.error && <Text variant="muted">Error: {pipeline.error.message}</Text>}
+
+      {pipeline.view}
+
+      {pipeline.isComplete && (
+        <Fragment>
+          <Text bold>Pipeline complete!</Text>
+          <StructuredEventData data={pipeline.completionData} />
+        </Fragment>
+      )}
+    </Flex>
+  );
+}
+
+function PipelineModalDemo() {
+  const [result, setResult] = useState<Record<string, unknown> | null>(null);
+
+  return (
+    <Flex direction="column" gap="lg">
+      <DropdownMenu
+        triggerLabel="Open pipeline modal"
+        items={pipelineMenuItems}
+        onAction={key => {
+          const [type, provider] = key.toString().split(':');
+          setResult(null);
+          openPipelineModal({
+            type: type as RegisteredPipelineType,
+            provider: provider as ProvidersByType[RegisteredPipelineType],
+            onComplete: data => setResult(data),
+          });
+        }}
+      />
+      {result && (
+        <Fragment>
+          <Text bold>Pipeline completed with:</Text>
+          <StructuredEventData data={result} />
+        </Fragment>
+      )}
+    </Flex>
+  );
+}
+
+export default Storybook.story('Pipeline', story => {
+  story('usePipeline', () => {
+    return (
+      <Fragment>
+        <p>
+          <Storybook.JSXNode name="usePipeline" /> is the core state machine for driving
+          backend pipelines from React. It manages initialization, step transitions, error
+          handling, and completion — but does not render any UI itself beyond the step
+          components registered in the pipeline definition.
+        </p>
+        <p>
+          The hook communicates with the backend pipeline system via the organization
+          pipeline REST API. Each pipeline provider (e.g. GitHub, Slack, SAML) registers a
+          definition with ordered step components. The hook matches the backend's current
+          step to the corresponding frontend component and renders it via the{' '}
+          <code>view</code> property.
+        </p>
+        <p>
+          Select a pipeline below to initialize it and step through interactively. The
+          debug panel shows the hook's full state as it transitions.
+        </p>
+        <UsePipelineDemo />
+      </Fragment>
+    );
+  });
+
+  story('PipelineModal', () => {
+    return (
+      <Fragment>
+        <p>
+          <Storybook.JSXNode name="openPipelineModal" /> opens a modal that wraps{' '}
+          <Storybook.JSXNode name="usePipeline" /> with standard modal chrome — a header
+          showing the provider name and step progress, a body rendering the current step,
+          and automatic close on completion.
+        </p>
+        <p>
+          It accepts typed <code>onComplete</code> and <code>onClose</code> callbacks. The
+          completion data type is inferred from the pipeline definition, so{' '}
+          <code>{'openPipelineModal({type: "integration", provider: "github"})'}</code>{' '}
+          will type the callback data as <code>GitHubCompletionData</code>.
+        </p>
+        <p>Select a pipeline below to open it in a modal.</p>
+        <PipelineModalDemo />
+      </Fragment>
+    );
+  });
+});

--- a/static/app/components/pipeline/modal.tsx
+++ b/static/app/components/pipeline/modal.tsx
@@ -1,0 +1,145 @@
+import {Fragment} from 'react';
+import {AnimatePresence, motion} from 'framer-motion';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {openModal} from 'sentry/actionCreators/modal';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ProgressRing} from 'sentry/components/progressRing';
+import {IconRefresh} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+import type {
+  CompletionDataFor,
+  ProvidersByType,
+  RegisteredPipelineType,
+} from './registry';
+import {usePipeline} from './usePipeline';
+
+interface PipelineModalProps<
+  T extends RegisteredPipelineType,
+  P extends ProvidersByType[T] = ProvidersByType[T],
+> extends ModalRenderProps {
+  provider: P;
+  type: T;
+  onComplete?: (data: CompletionDataFor<T, P>) => void;
+}
+
+function PipelineModal<
+  T extends RegisteredPipelineType,
+  P extends ProvidersByType[T] = ProvidersByType[T],
+>({Header, Body, closeModal, type, provider, onComplete}: PipelineModalProps<T, P>) {
+  const handleComplete = (data: CompletionDataFor<T, P>) => {
+    onComplete?.(data);
+    closeModal();
+  };
+
+  const pipeline = usePipeline(type, provider, {onComplete: handleComplete});
+  const {stepDefinition} = pipeline;
+
+  const stepText = (
+    <Text variant="muted">
+      {t(
+        'Step %s of %s: %s',
+        pipeline.stepIndex + 1,
+        pipeline.totalSteps,
+        stepDefinition?.shortDescription
+      )}
+    </Text>
+  );
+
+  const loading = pipeline.isInitializing || pipeline.isAdvancing;
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Text size="lg">{pipeline.definition.actionTitle}</Text>
+      </Header>
+      <Body>
+        <Stack gap="2xl">
+          <Grid columns="1fr max-content">
+            <Flex gap="md" align="center">
+              <ProgressRing
+                maxValue={pipeline.totalSteps}
+                value={pipeline.stepIndex + 1}
+                text={pipeline.stepIndex + 1}
+                animate
+              />
+              <Grid>
+                <AnimatePresence>
+                  <motion.div
+                    key={stepDefinition?.stepId}
+                    initial={pipeline.stepIndex === 0 ? {} : {y: -15, opacity: 0}}
+                    animate={{y: 0, opacity: 1}}
+                    exit={{y: 15, opacity: 0}}
+                    transition={{duration: 0.2}}
+                    style={{gridColumn: 1, gridRow: 1}}
+                  >
+                    {stepText}
+                  </motion.div>
+                </AnimatePresence>
+              </Grid>
+            </Flex>
+            <Flex gap="md" align="center">
+              {loading && (
+                <LoadingIndicator
+                  mini
+                  size={20}
+                  style={{margin: 0, height: 20, width: 20}}
+                />
+              )}
+              {pipeline.stepIndex !== 0 && (
+                <Button
+                  size="zero"
+                  priority="transparent"
+                  onClick={pipeline.restart}
+                  icon={<IconRefresh size="xs" variant="muted" />}
+                  tooltipProps={{title: t('Restart flow')}}
+                  aria-label={t('Restart flow')}
+                />
+              )}
+            </Flex>
+          </Grid>
+
+          {pipeline.error && (
+            <Alert
+              variant="danger"
+              trailingItems={
+                <Alert.Button onClick={pipeline.restart}>{t('Start over')}</Alert.Button>
+              }
+            >
+              {pipeline.error.message}
+            </Alert>
+          )}
+          {pipeline.view}
+        </Stack>
+      </Body>
+    </Fragment>
+  );
+}
+
+interface OpenPipelineModalOptions<
+  T extends RegisteredPipelineType,
+  P extends ProvidersByType[T] = ProvidersByType[T],
+> {
+  provider: P;
+  type: T;
+  onClose?: () => void;
+  onComplete?: (data: CompletionDataFor<T, P>) => void;
+}
+
+export function openPipelineModal<
+  T extends RegisteredPipelineType,
+  P extends ProvidersByType[T] = ProvidersByType[T],
+>({type, provider, onComplete, onClose}: OpenPipelineModalOptions<T, P>) {
+  openModal(
+    deps => (
+      <PipelineModal {...deps} type={type} provider={provider} onComplete={onComplete} />
+    ),
+    {onClose, closeEvents: 'none'}
+  );
+}

--- a/static/app/components/pipeline/pipelineDummyProvider.tsx
+++ b/static/app/components/pipeline/pipelineDummyProvider.tsx
@@ -1,0 +1,83 @@
+import {useState} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {InputGroup} from '@sentry/scraps/input';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+function DummyStepOne({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<{message: string}, {name: string}>) {
+  const [name, setName] = useState('');
+
+  return (
+    <Stack gap="md">
+      <Text>{stepData.message ?? t('Enter your name to continue')}</Text>
+      <InputGroup>
+        <InputGroup.Input
+          aria-label={t('Your name')}
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+      </InputGroup>
+      <Button
+        size="sm"
+        priority="primary"
+        onClick={() => advance({name})}
+        disabled={isAdvancing || !name}
+      >
+        {t('Continue')}
+      </Button>
+    </Stack>
+  );
+}
+
+function DummyStepTwo({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<{greeting: string}>) {
+  return (
+    <Stack gap="md">
+      <Text>{stepData.greeting ?? t('Dummy step two')}</Text>
+      <Button
+        size="sm"
+        priority="primary"
+        onClick={() => advance()}
+        disabled={isAdvancing}
+      >
+        {t('Finish')}
+      </Button>
+    </Stack>
+  );
+}
+
+type DummyCompletionData = {
+  result: string;
+};
+
+export const dummyIntegrationPipeline = {
+  type: 'integration',
+  provider: 'dummy',
+  actionTitle: t('Dummy Integration Pipeline'),
+  getCompletionData: pipelineComplete<DummyCompletionData>,
+  steps: [
+    {
+      stepId: 'step_one',
+      shortDescription: t('Enter Name'),
+      component: DummyStepOne,
+    },
+    {
+      stepId: 'step_two',
+      shortDescription: t('Confirmation'),
+      component: DummyStepTwo,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,0 +1,52 @@
+import {dummyIntegrationPipeline} from './pipelineDummyProvider';
+
+/**
+ * All registered pipeline definitions.
+ */
+export const PIPELINE_REGISTRY = [dummyIntegrationPipeline] as const;
+
+type AllPipelines = (typeof PIPELINE_REGISTRY)[number];
+
+/**
+ * Union of all registered pipeline types.
+ */
+export type RegisteredPipelineType = AllPipelines['type'];
+
+/**
+ * Maps each registered pipeline type to its available providers.
+ */
+export type ProvidersByType = {
+  [T in RegisteredPipelineType]: Extract<AllPipelines, {type: T}>['provider'];
+};
+
+/**
+ * Resolves the provider definition for a given type + provider combo.
+ */
+type ProviderDefintionFor<
+  T extends RegisteredPipelineType,
+  P extends ProvidersByType[T],
+> = Extract<AllPipelines, {provider: P; type: T}>;
+
+/**
+ * Resolves the completion data type for a given type + provider combo.
+ */
+export type CompletionDataFor<
+  T extends RegisteredPipelineType,
+  P extends ProvidersByType[T],
+> = ReturnType<ProviderDefintionFor<T, P>['getCompletionData']>;
+
+/**
+ * Look up a pipeline definition by type and provider.
+ */
+export function getPipelineDefinition<
+  T extends RegisteredPipelineType,
+  P extends ProvidersByType[T],
+>(type: T, provider: P): ProviderDefintionFor<T, P> {
+  const match = PIPELINE_REGISTRY.find(p => p.type === type && p.provider === provider);
+
+  if (!match) {
+    throw new Error(`No pipeline definition registered for ${type}/${provider}`);
+  }
+
+  return match as ProviderDefintionFor<T, P>;
+}

--- a/static/app/components/pipeline/types.tsx
+++ b/static/app/components/pipeline/types.tsx
@@ -1,0 +1,98 @@
+const PIPELINE_NAME_MAP = {
+  integration: 'integration_pipeline',
+  identity: 'identity_provider',
+} as const;
+
+type PipelineType = keyof typeof PIPELINE_NAME_MAP;
+
+export function getBackendPipelineType(type: PipelineType): string {
+  return PIPELINE_NAME_MAP[type];
+}
+
+/**
+ * A single step in a pipeline definition.
+ */
+export interface PipelineStepDefinition<StepId extends string = string> {
+  component: React.ComponentType<PipelineStepProps<any, any>>;
+  shortDescription: string;
+  stepId: StepId;
+}
+
+/**
+ * Defines a complete pipeline with its type, provider, and ordered steps.
+ */
+export interface PipelineDefinition<
+  T extends PipelineType = PipelineType,
+  P extends string = string,
+> {
+  actionTitle: string;
+  getCompletionData: (data: Record<string, unknown>) => unknown;
+  provider: P;
+  steps: readonly PipelineStepDefinition[];
+  type: T;
+}
+
+/**
+ * Props passed to each pipeline step component.
+ * The step component should NOT interact with pipeline APIs directly.
+ */
+export interface PipelineStepProps<
+  D = Record<string, unknown>,
+  A = Record<string, unknown>,
+> {
+  advance: (data?: A) => void;
+  advanceError: Error | null;
+  isAdvancing: boolean;
+  stepData: D;
+  stepIndex: number;
+  totalSteps: number;
+}
+
+/**
+ * Identity function that casts the raw completion data to a typed shape.
+ * Avoids the verbose `(data: Record<string, unknown>) => data as unknown as T`
+ * boilerplate in every pipeline definition.
+ */
+export function pipelineComplete<T>(data: Record<string, unknown>): T {
+  return data as unknown as T;
+}
+
+/**
+ * Response from the pipeline API for step info (GET or after initialize).
+ */
+export interface PipelineStepResponse {
+  data: Record<string, unknown>;
+  provider: string;
+  step: string;
+  stepIndex: number;
+  totalSteps: number;
+}
+
+/**
+ * Response from the pipeline API after advancing a step.
+ */
+export interface PipelineAdvanceResponse {
+  status: 'advance' | 'stay' | 'error' | 'complete';
+  data?: Record<string, unknown>;
+  provider?: string;
+  step?: string;
+  stepIndex?: number;
+  totalSteps?: number;
+}
+
+/**
+ * Return type of the usePipeline hook.
+ */
+export interface ApiPipeline<C = Record<string, unknown>> {
+  completionData: C | null;
+  definition: PipelineDefinition;
+  error: Error | null;
+  isAdvancing: boolean;
+  isComplete: boolean;
+  isInitializing: boolean;
+  restart: () => void;
+  stepDefinition: PipelineStepDefinition | null;
+  stepIndex: number;
+  totalSteps: number;
+  view: React.ReactNode;
+}

--- a/static/app/components/pipeline/usePipeline.spec.tsx
+++ b/static/app/components/pipeline/usePipeline.spec.tsx
@@ -1,0 +1,271 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {usePipeline} from './usePipeline';
+
+const organization = OrganizationFixture();
+const API_URL = `/organizations/${organization.slug}/pipeline/integration_pipeline/`;
+
+function TestHarness() {
+  const pipeline = usePipeline('integration', 'dummy');
+
+  return (
+    <div>
+      <div data-test-id="step">{pipeline.stepDefinition?.stepId ?? 'none'}</div>
+      <div data-test-id="step-index">{pipeline.stepIndex}</div>
+      <div data-test-id="total-steps">{pipeline.totalSteps}</div>
+      <div data-test-id="is-initializing">{String(pipeline.isInitializing)}</div>
+      <div data-test-id="is-advancing">{String(pipeline.isAdvancing)}</div>
+      <div data-test-id="is-complete">{String(pipeline.isComplete)}</div>
+      <div data-test-id="error">{pipeline.error?.message ?? 'none'}</div>
+      <div data-test-id="completion-data">
+        {pipeline.completionData ? JSON.stringify(pipeline.completionData) : 'none'}
+      </div>
+      <div data-test-id="view">{pipeline.view}</div>
+      <button data-test-id="restart" onClick={pipeline.restart}>
+        Restart
+      </button>
+    </div>
+  );
+}
+
+describe('usePipeline', () => {
+  it('initializes the pipeline on mount and renders the first step', async () => {
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Hello!'},
+      },
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    render(<TestHarness />, {organization});
+
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+    expect(screen.getByTestId('step')).toHaveTextContent('step_one');
+    expect(screen.getByTestId('step-index')).toHaveTextContent('0');
+    expect(screen.getByTestId('total-steps')).toHaveTextContent('2');
+    expect(screen.getByTestId('is-complete')).toHaveTextContent('false');
+  });
+
+  it('advances through steps and completes the pipeline', async () => {
+    const initializeRequest = MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Enter your name'},
+      },
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    const advanceToStepTwo = MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        status: 'advance',
+        step: 'step_two',
+        stepIndex: 1,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {greeting: 'Hello, Test User!'},
+      },
+      match: [MockApiClient.matchData({name: 'Test User'})],
+    });
+
+    render(<TestHarness />, {organization});
+
+    // Wait for initialization
+    expect(await screen.findByText('Enter your name')).toBeInTheDocument();
+    expect(initializeRequest).toHaveBeenCalledTimes(1);
+
+    // Fill in the input and advance
+    await userEvent.type(screen.getByRole('textbox', {name: 'Your name'}), 'Test User');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    expect(await screen.findByText('Hello, Test User!')).toBeInTheDocument();
+    expect(advanceToStepTwo).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('step')).toHaveTextContent('step_two');
+    expect(screen.getByTestId('step-index')).toHaveTextContent('1');
+
+    // Set up complete mock now that we're past initialization to avoid matching the init POST
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        status: 'complete',
+        data: {result: 'success'},
+      },
+    });
+
+    // Complete the pipeline
+    await userEvent.click(screen.getByRole('button', {name: 'Finish'}));
+
+    expect(await screen.findByText('{"result":"success"}')).toBeInTheDocument();
+    expect(screen.getByTestId('is-complete')).toHaveTextContent('true');
+  });
+
+  it('handles stay responses by merging data into step data', async () => {
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Hello!'},
+      },
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    render(<TestHarness />, {organization});
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+
+    // Override mock for advance — return stay with redirect data
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        status: 'stay',
+        data: {redirectUrl: 'https://example.com/auth'},
+      },
+      match: [MockApiClient.matchData({name: 'Test'})],
+    });
+
+    await userEvent.type(screen.getByRole('textbox', {name: 'Your name'}), 'Test');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    // Should stay on same step — wait for the mutation to settle,
+    // then verify step didn't change
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+    expect(screen.getByTestId('step')).toHaveTextContent('step_one');
+  });
+
+  it('handles error responses from the API', async () => {
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Hello!'},
+      },
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    render(<TestHarness />, {organization});
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+
+    // Override mock — return pipeline error
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        status: 'error',
+        data: {detail: 'Something went wrong'},
+      },
+      match: [MockApiClient.matchData({name: 'Test'})],
+    });
+
+    await userEvent.type(screen.getByRole('textbox', {name: 'Your name'}), 'Test');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+
+    // Restart should recover from the error and re-initialize
+    await userEvent.click(screen.getByTestId('restart'));
+
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+    expect(screen.getByTestId('error')).toHaveTextContent('none');
+    expect(screen.getByTestId('step')).toHaveTextContent('step_one');
+  });
+
+  it('restarts the pipeline from the beginning', async () => {
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Hello!'},
+      },
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    const advanceToStepTwo = MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        status: 'advance',
+        step: 'step_two',
+        stepIndex: 1,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {greeting: 'Are you sure?'},
+      },
+      match: [MockApiClient.matchData({name: 'Test'})],
+    });
+
+    render(<TestHarness />, {organization});
+
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+
+    // Type a name and advance to step two
+    await userEvent.type(screen.getByRole('textbox', {name: 'Your name'}), 'Test');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+    expect(await screen.findByText('Are you sure?')).toBeInTheDocument();
+    expect(advanceToStepTwo).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('step')).toHaveTextContent('step_two');
+
+    // Restart — should re-initialize and go back to step one
+    await userEvent.click(screen.getByTestId('restart'));
+
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+    expect(screen.getByTestId('step')).toHaveTextContent('step_one');
+    expect(screen.getByTestId('step-index')).toHaveTextContent('0');
+  });
+
+  it('does not initialize when enabled is false', async () => {
+    const initRequest = MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Hello!'},
+      },
+    });
+
+    function DisabledHarness() {
+      const pipeline = usePipeline('integration', 'dummy', {enabled: false});
+      return (
+        <div>
+          <div data-test-id="is-initializing">{String(pipeline.isInitializing)}</div>
+          <div data-test-id="step">{pipeline.stepDefinition?.stepId ?? 'none'}</div>
+        </div>
+      );
+    }
+
+    render(<DisabledHarness />, {organization});
+
+    // Give it a tick to potentially fire
+    expect(await screen.findByText('none')).toBeInTheDocument();
+    expect(initRequest).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/components/pipeline/usePipeline.tsx
+++ b/static/app/components/pipeline/usePipeline.tsx
@@ -1,0 +1,291 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+
+import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {getPipelineDefinition} from './registry';
+import type {
+  CompletionDataFor,
+  ProvidersByType,
+  RegisteredPipelineType,
+} from './registry';
+import type {
+  ApiPipeline,
+  PipelineAdvanceResponse,
+  PipelineStepProps,
+  PipelineStepResponse,
+} from './types';
+import {getBackendPipelineType} from './types';
+
+type PipelineState<T extends RegisteredPipelineType, P extends ProvidersByType[T]> =
+  | {status: 'idle'}
+  | {status: 'initializing'}
+  | {
+      status: 'active';
+      stepData: Record<string, unknown>;
+      stepInfo: PipelineStepResponse;
+    }
+  | {data: CompletionDataFor<T, P>; status: 'complete'}
+  | {error: Error; status: 'error'};
+
+interface UsePipelineOptions<
+  T extends RegisteredPipelineType,
+  P extends ProvidersByType[T],
+> {
+  enabled?: boolean;
+  onComplete?: (data: CompletionDataFor<T, P>) => void;
+}
+
+/**
+ * React hook that drives a backend pipeline via the organization pipeline API.
+ *
+ * ## How it maps to the backend
+ *
+ * The backend pipeline system (`sentry.pipeline.base.Pipeline`) manages a
+ * sequence of steps stored in the user's session. There are two pipeline
+ * types: integration pipelines (GitHub, Bitbucket, Jira, Slack, etc.) and
+ * identity association pipelines (Google SSO, SAML, etc.). Each provider
+ * defines its own pipeline subclass with ordered steps.
+ *
+ * When a pipeline is configured for API mode (`get_pipeline_api_steps()`),
+ * the `OrganizationPipelineEndpoint` at
+ * `/api/0/organizations/:org/pipeline/:pipeline_name/` exposes the pipeline
+ * over REST:
+ *
+ *   - **POST {action: 'initialize', provider}** — creates a new pipeline
+ *     session and returns the first step's info (name, index, data).
+ *   - **GET** — returns the current step's info, including step data
+ *     from the step's `get_step_data()` method.
+ *   - **POST {step data}** — validates the posted data via the step's
+ *     serializer, calls `handle_post()`, and returns one of:
+ *       - `advance` — pipeline moved to the next step (response includes
+ *         the new step's info via `get_current_step_info()`).
+ *       - `stay` — same step, updated data (e.g. a redirect URL).
+ *       - `complete` — pipeline finished, response includes completion data.
+ *       - `error` — validation or processing failed.
+ *
+ * ## How this hook works
+ *
+ * On mount (when `enabled`), the hook initializes the pipeline and enters
+ * the `active` state with the first step's data. It looks up the matching
+ * step component from the frontend pipeline definition (registered in
+ * `registry.tsx`) and renders it via the returned `view` property.
+ *
+ * Each step component receives `stepData` (from the backend) and an
+ * `advance` callback. When the step calls `advance(data)`, the hook POSTs
+ * to the pipeline endpoint and transitions based on the response status.
+ *
+ * The hook is provider-typed: `usePipeline('integration', 'github')` infers
+ * the correct completion data type from the pipeline definition's
+ * `onComplete` return type.
+ */
+export function usePipeline<
+  T extends RegisteredPipelineType,
+  P extends ProvidersByType[T],
+>(
+  type: T,
+  provider: P,
+  options: UsePipelineOptions<T, P> = {}
+): ApiPipeline<CompletionDataFor<T, P>> {
+  const organization = useOrganization();
+  const [state, setState] = useState<PipelineState<T, P>>({status: 'idle'});
+  const initializedRef = useRef(false);
+  const onCompleteRef = useRef(options.onComplete);
+  onCompleteRef.current = options.onComplete;
+  const generationRef = useRef(0);
+
+  const {enabled = true} = options;
+
+  const pipelineName = getBackendPipelineType(type);
+  const apiUrl = `/organizations/${organization.slug}/pipeline/${pipelineName}/`;
+
+  const definition = useMemo(
+    () => getPipelineDefinition(type, provider),
+    [type, provider]
+  );
+
+  const {mutate: initializeMutate, ...initializeRest} = useMutation<
+    PipelineStepResponse,
+    Error,
+    void,
+    {generation: number}
+  >({
+    mutationFn: () =>
+      fetchMutation<PipelineStepResponse>({
+        method: 'POST',
+        url: apiUrl,
+        data: {action: 'initialize', provider},
+      }),
+    onMutate: () => ({generation: generationRef.current}),
+    onSuccess: (data: PipelineStepResponse, _variables, context) => {
+      if (context?.generation !== generationRef.current) {
+        return;
+      }
+      setState({status: 'active', stepInfo: data, stepData: data.data});
+    },
+    onError: (error: Error, _variables, context) => {
+      if (context?.generation !== generationRef.current) {
+        return;
+      }
+      setState({status: 'error', error});
+    },
+  });
+
+  const {
+    mutate: advanceMutate,
+    isPending: isAdvancePending,
+    error: advanceError,
+    reset: resetAdvance,
+  } = useMutation<
+    PipelineAdvanceResponse,
+    Error,
+    Record<string, unknown>,
+    {generation: number}
+  >({
+    mutationFn: (data: Record<string, unknown>) =>
+      fetchMutation<PipelineAdvanceResponse>({
+        method: 'POST',
+        url: apiUrl,
+        data,
+      }),
+    onMutate: () => ({generation: generationRef.current}),
+    onSuccess: (response: PipelineAdvanceResponse, _variables, context) => {
+      if (context?.generation !== generationRef.current) {
+        return;
+      }
+      switch (response.status) {
+        case 'advance':
+          if (
+            response.step !== undefined &&
+            response.stepIndex !== undefined &&
+            response.totalSteps !== undefined
+          ) {
+            setState({
+              status: 'active',
+              stepInfo: {
+                step: response.step,
+                stepIndex: response.stepIndex,
+                totalSteps: response.totalSteps,
+                provider: response.provider ?? provider,
+                data: response.data ?? {},
+              },
+              stepData: response.data ?? {},
+            });
+          }
+          break;
+        case 'stay':
+          // Same step, updated data (e.g. redirect URL)
+          setState(prev =>
+            prev.status === 'active'
+              ? {...prev, stepData: {...prev.stepData, ...response.data}}
+              : prev
+          );
+          break;
+        case 'complete': {
+          const rawData = response.data ?? {};
+
+          // Widen from the specific union of completion data types to the specific
+          // completion data.
+          const data = definition.getCompletionData(rawData) as CompletionDataFor<T, P>;
+
+          setState({status: 'complete', data});
+          onCompleteRef.current?.(data);
+          break;
+        }
+        case 'error':
+          setState({
+            status: 'error',
+            error: new Error((response.data?.detail as string) ?? 'Pipeline error'),
+          });
+          break;
+        default:
+          break;
+      }
+    },
+    onError: (error: Error, _variables, context) => {
+      if (context?.generation !== generationRef.current) {
+        return;
+      }
+      setState({status: 'error', error});
+    },
+  });
+
+  const restart = useCallback(() => {
+    generationRef.current += 1;
+    resetAdvance();
+    setState({status: 'initializing'});
+    initializeMutate();
+  }, [initializeMutate, resetAdvance]);
+
+  // Initialize the pipeline on mount when enabled
+  useEffect(() => {
+    if (enabled && !initializedRef.current) {
+      initializedRef.current = true;
+      restart();
+    }
+  }, [enabled, restart]);
+
+  const stepDefinition = useMemo(() => {
+    if (state.status === 'active') {
+      return definition.steps.find(s => s.stepId === state.stepInfo.step) ?? null;
+    }
+
+    // Optimistically return the first step while initializing so the UI
+    // can render the step component immediately (with empty data).
+    if (state.status === 'initializing') {
+      return definition.steps[0] ?? null;
+    }
+
+    return null;
+  }, [state, definition]);
+
+  const view = useMemo(() => {
+    if (!stepDefinition) {
+      return null;
+    }
+
+    const isActive = state.status === 'active';
+
+    // Widen from the specific union of component types to the general
+    // PipelineStepDefinition component type
+    const Component: React.ComponentType<PipelineStepProps<any, any>> =
+      stepDefinition.component;
+
+    return (
+      <Component
+        stepIndex={isActive ? state.stepInfo.stepIndex : 0}
+        totalSteps={isActive ? state.stepInfo.totalSteps : definition.steps.length}
+        stepData={isActive ? state.stepData : {}}
+        advance={advanceMutate}
+        isAdvancing={isAdvancePending}
+        advanceError={advanceError}
+      />
+    );
+  }, [state, stepDefinition, definition, advanceMutate, isAdvancePending, advanceError]);
+
+  const {stepIndex, totalSteps} =
+    state.status === 'active'
+      ? {stepIndex: state.stepInfo.stepIndex, totalSteps: state.stepInfo.totalSteps}
+      : {stepIndex: 0, totalSteps: definition.steps.length};
+
+  const error =
+    state.status === 'error'
+      ? state.error
+      : (advanceError ?? initializeRest.error ?? null);
+
+  const completionData = state.status === 'complete' ? state.data : null;
+
+  return {
+    view,
+    restart,
+    definition,
+    stepDefinition,
+    stepIndex,
+    totalSteps,
+    isInitializing: state.status === 'initializing' || initializeRest.isPending,
+    isAdvancing: isAdvancePending,
+    isComplete: state.status === 'complete',
+    error,
+    completionData,
+  };
+}


### PR DESCRIPTION
Adds the core frontend infrastructure for API-driven integration pipelines: type definitions, the usePipeline hook for managing pipeline state and step advancement, a modal component for rendering pipeline steps, a registry for pipeline definitions, and stories.

Relates to https://github.com/getsentry/sentry/pull/111422

Here's an example driving through the GitLab API Pipeline.

https://github.com/user-attachments/assets/2639db94-21b5-4f38-bf80-b62a1800fa76

Fixes [VDY-34](https://linear.app/getsentry/issue/VDY-34)