### PR TITLE
fix(dashboards): Navigate to trace view when clicking trace in fullscreen widget viewer

### DIFF
--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -551,6 +551,7 @@ function DataWidgetViewerModal(props: Props) {
         <AgentsTracesTableWidgetVisualization
           limit={FULL_TABLE_ITEM_LIMIT}
           tableWidths={widget.tableWidths}
+          isFullscreen
         />
       );
     }

--- a/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
@@ -1,11 +1,21 @@
+import {useCallback} from 'react';
+import type {Location} from 'history';
+
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import type {DashboardFilters} from 'sentry/views/dashboards/types';
 import {DEFAULT_TRACES_TABLE_WIDTHS} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview';
 import {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
 import {TracesTable} from 'sentry/views/insights/pages/agents/components/tracesTable';
+import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
+import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
 interface AgentsTracesTableWidgetVisualizationProps {
   dashboardFilters?: DashboardFilters;
   frameless?: boolean;
+  isFullscreen?: boolean;
   limit?: number;
   tableWidths?: number[];
 }
@@ -15,12 +25,32 @@ export function AgentsTracesTableWidgetVisualization({
   tableWidths = DEFAULT_TRACES_TABLE_WIDTHS,
   dashboardFilters,
   frameless,
+  isFullscreen,
 }: AgentsTracesTableWidgetVisualizationProps) {
   const {openTraceViewDrawer} = useTraceViewDrawer();
+  const navigate = useNavigate();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const navigateToTraceView = useCallback(
+    (traceSlug: string, _spanId?: string, timestamp?: number) => {
+      navigate(
+        getTraceDetailsUrl({
+          organization,
+          traceSlug,
+          dateSelection: normalizeDateTimeParams(selection),
+          timestamp,
+          location: {query: {}} as Location,
+          source: TraceViewSources.AGENT_MONITORING,
+        })
+      );
+    },
+    [navigate, organization, selection]
+  );
 
   return (
     <TracesTable
-      openTraceViewDrawer={openTraceViewDrawer}
+      openTraceViewDrawer={isFullscreen ? navigateToTraceView : openTraceViewDrawer}
       limit={limit}
       tableWidths={tableWidths}
       dashboardFilters={dashboardFilters}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -172,16 +172,15 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
   const plottablesByType = groupBy(props.plottables, plottable => plottable.dataType);
 
-  // Count up the field types of all the plottables
-  const fieldTypeCounts = mapValues(plottablesByType, plottables => plottables.length);
-
-  // Sort the field types by how many plottables use each one
-  const axisTypes = Object.keys(fieldTypeCounts)
-    .toSorted(
-      // `dataTypes` is extracted from `dataTypeCounts`, so the counts are guaranteed to exist
-      (a, b) => fieldTypeCounts[b]! - fieldTypeCounts[a]!
-    )
-    .filter(axisType => !!axisType); // `TimeSeries` allows for a `null` data type , though it's not likely
+  // Get unique axis types in order of first appearance, treating the first
+  // aggregate as primary. This avoids axis flipping when thresholds or other
+  // plottables inflate the count of a particular data type.
+  const axisTypes: string[] = [];
+  for (const plottable of props.plottables) {
+    if (plottable.dataType && !axisTypes.includes(plottable.dataType)) {
+      axisTypes.push(plottable.dataType);
+    }
+  }
 
   // Partition the types between the two axes
   let leftYAxisDataTypes: string[] = [];
@@ -195,11 +194,11 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     leftYAxisDataTypes = axisTypes.slice(0, 1);
     rightYAxisDataTypes = axisTypes.slice(1, 2);
   } else if (axisTypes.length > 2 && axisTypes.at(0) === FALLBACK_TYPE) {
-    // There are multiple types, and the most popular one is the fallback. Don't
+    // There are multiple types, and the first one is the fallback. Don't
     // bother creating a second fallback axis, plot everything on the left
     leftYAxisDataTypes = axisTypes;
   } else {
-    // There are multiple types. Assign the most popular type to the left axis,
+    // There are multiple types. Assign the first type to the left axis,
     // the rest to the right axis
     leftYAxisDataTypes = axisTypes.slice(0, 1);
     rightYAxisDataTypes = axisTypes.slice(1);


### PR DESCRIPTION
## Summary
- When clicking a trace ID in the fullscreen widget viewer, the trace preview drawer doesn't open because `GlobalDrawer` context is not available in the modal
- Instead of opening the drawer (which doesn't work), navigate the user directly to the full trace view page when in fullscreen mode
- Adds an `isFullscreen` prop to `AgentsTracesTableWidgetVisualization` that switches the click handler from opening the drawer to navigating to the trace view

Fixes DAIN-1358

## Test plan
- [ ] Open AI Agents dashboard
- [ ] Click expand/fullscreen on the traces table widget
- [ ] Click a trace ID in the fullscreen view — should navigate to the trace view page
- [ ] Close fullscreen and click a trace ID in the normal widget — should still open the drawer as before