### PR TITLE
ref: Remove dead code after continuous-profiling-beta ff removal

### DIFF
--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -7,7 +7,6 @@ import {Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {DATA_CATEGORY_INFO} from 'sentry/constants';
 import {IconClose, IconInfo, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
@@ -33,7 +32,6 @@ import {
   getProductTrial,
   isAm2Plan,
   isAm3Plan,
-  isEnterprise,
   UsageAction,
 } from 'getsentry/utils/billing';
 import {getCategoryInfoFromPlural} from 'getsentry/utils/dataCategory';
@@ -271,74 +269,6 @@ function ProfilingBetaAlertBannerComponent(props: ProfilingBetaAlertBannerProps)
 export const ProfilingBetaAlertBanner = withSubscription(
   ProfilingBetaAlertBannerComponent,
   {noLoader: true}
-);
-
-interface ContinuousProfilingBetaAlertBannerInner {
-  organization: Organization;
-  subscription: Subscription;
-}
-
-function ContinuousProfilingBetaAlertBannerInner({
-  organization,
-  subscription,
-}: ContinuousProfilingBetaAlertBannerInner) {
-  if (!organization.features.includes('continuous-profiling-beta')) {
-    return null;
-  }
-
-  const eventTypes: EventType[] = [
-    DATA_CATEGORY_INFO.profile_duration.singular as EventType,
-    DATA_CATEGORY_INFO.profile_duration_ui.singular as EventType,
-  ];
-
-  return (
-    <Alert
-      variant="warning"
-      system
-      trailingItems={
-        <AddEventsCTA
-          organization={organization}
-          subscription={subscription}
-          buttonProps={{
-            priority: 'default',
-            size: 'xs',
-            style: {marginBlock: '-2px'},
-          }}
-          eventTypes={eventTypes}
-          notificationType="overage_critical"
-          referrer={`overage-alert-${eventTypes.join('-')}`}
-          source="continuous-profiling-beta-trial-banner"
-        />
-      }
-    >
-      {subscription.isFree
-        ? tct(
-            '[bold:Profiling Beta Ending Soon:] Your free access ends May 19, 2025. Profiling will require a [budgetTerm] after this date. To avoid disruptions, upgrade to a paid plan.',
-            {
-              bold: <b />,
-              budgetTerm: displayBudgetName(subscription.planDetails, {withBudget: true}),
-            }
-          )
-        : isEnterprise(subscription.plan)
-          ? tct(
-              '[bold:Profiling Beta Ending Soon:] Your free access ends May 19, 2025. To avoid disruptions, contact your account manager before then to add it to your plan.',
-              {bold: <b />}
-            )
-          : tct(
-              '[bold:Profiling Beta Ending Soon:] Your free access ends May 19, 2025. Profiling will require a [budgetTerm] after this date.',
-              {
-                bold: <b />,
-                budgetTerm: displayBudgetName(subscription.planDetails, {
-                  withBudget: true,
-                }),
-              }
-            )}
-    </Alert>
-  );
-}
-
-export const ContinuousProfilingBetaAlertBanner = withSubscription(
-  ContinuousProfilingBetaAlertBannerInner
 );
 
 export function ContinuousProfilingBetaSDKAlertBanner() {

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -79,7 +79,6 @@ import {CodecovSettingsLink} from './components/codecovSettingsLink';
 import {PrimaryNavigationQuotaExceeded} from './components/navBillingStatus';
 import {OpenInDiscoverBtn} from './components/openInDiscoverBtn';
 import {
-  ContinuousProfilingBetaAlertBanner,
   ContinuousProfilingBetaSDKAlertBanner,
   ContinuousProfilingBillingRequirementBanner,
   ProfilingBetaAlertBanner,
@@ -212,7 +211,6 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:ai-setup-configuration': () => AiSetupConfiguration,
   'component:ai-setup-data-consent': () => AiSetupDataConsent,
   'component:codecov-integration-settings-link': () => CodecovSettingsLink,
-  'component:continuous-profiling-beta-banner': () => ContinuousProfilingBetaAlertBanner,
   'component:continuous-profiling-beta-sdk-banner': () =>
     ContinuousProfilingBetaSDKAlertBanner,
   'component:continuous-profiling-billing-requirement-banner': () =>


### PR DESCRIPTION
Remove front-end code which will be dead after the no longer used feature flag `organizations:continuous-profiling-beta` is removed in https://github.com/getsentry/sentry/pull/111394.

Ref: [RELAY-192](https://linear.app/getsentry/issue/RELAY-192/remove-organizationscontinuous-profiling-beta-and)