### PR TITLE
ref(nav) promote search to primary nav

### DIFF
--- a/static/app/views/navigation/navigation.tsx
+++ b/static/app/views/navigation/navigation.tsx
@@ -6,9 +6,12 @@ import {Stack} from '@sentry/scraps/layout';
 import {Flex} from '@sentry/scraps/layout';
 import {SizeProvider} from '@sentry/scraps/sizeContext';
 
+import {openCommandPalette} from 'sentry/actionCreators/modal';
+import {openHelpSearchModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Hook from 'sentry/components/hook';
+import {IconSearch} from 'sentry/icons';
 import {
   IconCompass,
   IconDashboard,
@@ -297,9 +300,23 @@ export function PrimaryNavigationItems({listRef}: PrimaryNavigationItemsProps) {
  */
 export function PrimaryNavigationFooterItems() {
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
 
   return (
     <Fragment>
+      {hasPageFrame ? (
+        <PrimaryNavigation.Button
+          label={t('Search support, docs and more')}
+          analyticsKey="search"
+          buttonProps={{
+            icon: <IconSearch />,
+            onClick: () =>
+              organization.features.includes('cmd-k-supercharged')
+                ? openCommandPalette()
+                : openHelpSearchModal({organization}),
+          }}
+        />
+      ) : null}
       <ErrorBoundary customComponent={null}>
         <PrimaryNavigationOnboarding />
       </ErrorBoundary>

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -49,18 +49,25 @@ export function PrimaryNavigationHelpMenu() {
     <PrimaryNavigation.Menu
       triggerWrap={NavigationTourReminder}
       items={[
-        {
-          key: 'search',
-          label: t('Search support, docs and more'),
-          leadingItems: hasPageFrame ? (
-            <MenuIcon>
-              <IconSearch />
-            </MenuIcon>
-          ) : undefined,
-          onAction() {
-            openHelpSearchModal({organization});
-          },
-        },
+        ...(hasPageFrame
+          ? // When page frame feature flag is enabled, the search menu is
+            // rendered as part of the footer items and is always visible
+            // to the user.
+            []
+          : [
+              {
+                key: 'search',
+                label: t('Search support, docs and more'),
+                leadingItems: hasPageFrame ? (
+                  <MenuIcon>
+                    <IconSearch />
+                  </MenuIcon>
+                ) : undefined,
+                onAction() {
+                  openHelpSearchModal({organization});
+                },
+              },
+            ]),
         ...items,
         {
           key: 'actions',

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -13,7 +13,6 @@ import {
   IconMegaphone,
   IconOpen,
   IconQuestion,
-  IconSearch,
   IconSentry,
   IconSupport,
 } from 'sentry/icons';
@@ -58,11 +57,6 @@ export function PrimaryNavigationHelpMenu() {
               {
                 key: 'search',
                 label: t('Search support, docs and more'),
-                leadingItems: hasPageFrame ? (
-                  <MenuIcon>
-                    <IconSearch />
-                  </MenuIcon>
-                ) : undefined,
                 onAction() {
                   openHelpSearchModal({organization});
                 },


### PR DESCRIPTION
Promotes CMD+K action to primary nav when page-frame is enabled and replaces the help menu search when cmd+k supercharged flag is enabled

<img width="708" height="117" alt="CleanShot 2026-03-24 at 11 12 18" src="https://github.com/user-attachments/assets/3c785256-8d94-4227-91ca-076ec6a333ee" />

<img width="147" height="186" alt="CleanShot 2026-03-24 at 11 12 13" src="https://github.com/user-attachments/assets/8cf2f52e-6a4d-4ce1-a938-ce5668df7d54" />

Pending feature flag release, but this fixes DE-722