### PR TITLE
feat(tracemetrics): Add trace metric bytes DataCategory to stats page

### DIFF
--- a/static/app/constants/index.spec.tsx
+++ b/static/app/constants/index.spec.tsx
@@ -12,7 +12,11 @@ describe('DATA_CATEGORY_INFO', () => {
     });
 
     it('byte categories have correct formatting', () => {
-      const byteCategories = [DataCategoryExact.ATTACHMENT, DataCategoryExact.LOG_BYTE];
+      const byteCategories = [
+        DataCategoryExact.ATTACHMENT,
+        DataCategoryExact.LOG_BYTE,
+        DataCategoryExact.TRACE_METRIC_BYTE,
+      ];
 
       for (const category of byteCategories) {
         const {formatting} = DATA_CATEGORY_INFO[category];
@@ -72,7 +76,11 @@ describe('DATA_CATEGORY_INFO', () => {
     });
 
     it('formatting unitType matches expected categories', () => {
-      const bytesCategories = [DataCategoryExact.ATTACHMENT, DataCategoryExact.LOG_BYTE];
+      const bytesCategories = [
+        DataCategoryExact.ATTACHMENT,
+        DataCategoryExact.LOG_BYTE,
+        DataCategoryExact.TRACE_METRIC_BYTE,
+      ];
       const durationHoursCategories = [
         DataCategoryExact.PROFILE_DURATION,
         DataCategoryExact.PROFILE_DURATION_UI,

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -645,6 +645,22 @@ export const DATA_CATEGORY_INFO = {
     },
     formatting: DEFAULT_COUNT_FORMATTING,
   },
+  [DataCategoryExact.TRACE_METRIC_BYTE]: {
+    name: DataCategoryExact.TRACE_METRIC_BYTE,
+    plural: DataCategory.TRACE_METRIC_BYTE,
+    singular: 'traceMetricByte',
+    displayName: 'metric byte',
+    titleName: t('Metrics (Bytes)'),
+    productName: t('Metrics'),
+    uid: 37,
+    isBilledCategory: false,
+    statsInfo: {
+      ...DEFAULT_STATS_INFO,
+      showExternalStats: true,
+      yAxisMinInterval: 1 * KILOBYTE,
+    },
+    formatting: BYTES_FORMATTING,
+  },
   [DataCategoryExact.SEER_USER]: {
     name: DataCategoryExact.SEER_USER,
     plural: DataCategory.SEER_USER,

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -98,6 +98,7 @@ export enum DataCategory {
   SEER_USER = 'seerUsers',
   USER_REPORT_V2 = 'feedback',
   TRACE_METRICS = 'traceMetrics',
+  TRACE_METRIC_BYTE = 'traceMetricBytes',
   SIZE_ANALYSIS = 'sizeAnalyses',
   INSTALLABLE_BUILD = 'installableBuilds',
 }
@@ -132,6 +133,7 @@ export enum DataCategoryExact {
   SEER_USER = 'seer_user',
   USER_REPORT_V2 = 'feedback',
   TRACE_METRIC = 'trace_metric',
+  TRACE_METRIC_BYTE = 'trace_metric_byte',
   SIZE_ANALYSIS = 'size_analysis',
   INSTALLABLE_BUILD = 'installable_build',
 }

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -34,3 +34,10 @@ export const canUseMetricsUIRefresh = (organization: Organization) => {
     organization.features.includes('tracemetrics-ui-refresh')
   );
 };
+
+export const canUseMetricsStatsBytesUI = (organization: Organization) => {
+  return (
+    canUseMetricsUI(organization) &&
+    organization.features.includes('tracemetrics-stats-bytes-ui')
+  );
+};

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -31,7 +31,10 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate, type ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {canUseMetricsStatsUI} from 'sentry/views/explore/metrics/metricsFlags';
+import {
+  canUseMetricsStatsBytesUI,
+  canUseMetricsStatsUI,
+} from 'sentry/views/explore/metrics/metricsFlags';
 import {StatsHeader as HeaderTabs} from 'sentry/views/organizationStats/header';
 import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
@@ -276,6 +279,9 @@ export class OrganizationStatsInner extends Component<OrganizationStatsProps> {
       }
       if ([DataCategory.TRACE_METRICS].includes(opt.value)) {
         return canUseMetricsStatsUI(organization);
+      }
+      if ([DataCategory.TRACE_METRIC_BYTE].includes(opt.value)) {
+        return canUseMetricsStatsBytesUI(organization);
       }
       if (
         [DataCategory.PROFILE_DURATION, DataCategory.PROFILE_DURATION_UI].includes(

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -34,7 +34,8 @@ export function formatUsageWithUnits(
 ): string {
   if (
     dataCategory === DATA_CATEGORY_INFO.attachment.plural ||
-    dataCategory === DATA_CATEGORY_INFO.log_byte.plural
+    dataCategory === DATA_CATEGORY_INFO.log_byte.plural ||
+    dataCategory === DATA_CATEGORY_INFO.trace_metric_byte.plural
   ) {
     if (options.useUnitScaling) {
       return formatBytesBase10(usageQuantity);
@@ -70,10 +71,12 @@ export function getFormatUsageOptions(dataCategory: DataCategory): FormatOptions
   return {
     isAbbreviated:
       dataCategory !== DATA_CATEGORY_INFO.attachment.plural &&
-      dataCategory !== DATA_CATEGORY_INFO.log_byte.plural,
+      dataCategory !== DATA_CATEGORY_INFO.log_byte.plural &&
+      dataCategory !== DATA_CATEGORY_INFO.trace_metric_byte.plural,
     useUnitScaling:
       dataCategory === DATA_CATEGORY_INFO.attachment.plural ||
-      dataCategory === DATA_CATEGORY_INFO.log_byte.plural,
+      dataCategory === DATA_CATEGORY_INFO.log_byte.plural ||
+      dataCategory === DATA_CATEGORY_INFO.trace_metric_byte.plural,
   };
 }
 


### PR DESCRIPTION
Add TRACE_METRIC_BYTE to DataCategory enums, DATA_CATEGORY_INFO with bytes formatting, and gate visibility behind canUseMetricsStatsBytesUI
