### PR TITLE
fix(explore): Confidence footer messages should pluralize zero

### DIFF
--- a/static/app/views/explore/logs/confidenceFooter.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.tsx
@@ -78,6 +78,9 @@ function ConfidenceMessage({
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
   const usePluralSampleCount = sampleCount > 1 || sampleCount === 0;
+  const usePluralNormalLogsCount =
+    defined(rawLogCounts.normal.count) &&
+    (rawLogCounts.normal.count > 1 || rawLogCounts.normal.count === 0);
   const usePluralTotalLogsCount =
     defined(rawLogCounts.total.count) &&
     (rawLogCounts.total.count > 1 || rawLogCounts.total.count === 0);
@@ -214,7 +217,7 @@ function ConfidenceMessage({
       : t('%s match', <Count value={sampleCount} />);
 
     const scannedLogsCount = defined(rawLogCounts.normal.count) ? (
-      usePluralTotalLogsCount ? (
+      usePluralNormalLogsCount ? (
         t('%s samples', <Count value={rawLogCounts.normal.count} />)
       ) : (
         t('%s sample', <Count value={rawLogCounts.normal.count} />)

--- a/static/app/views/explore/logs/confidenceFooter.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.tsx
@@ -77,14 +77,17 @@ function ConfidenceMessage({
 
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
+  const usePluralSampleCount = sampleCount > 1 || sampleCount === 0;
+  const usePluralTotalLogsCount =
+    defined(rawLogCounts.total.count) &&
+    (rawLogCounts.total.count > 1 || rawLogCounts.total.count === 0);
 
   // No sampling happened, so don't mention estimations.
   if (noSampling) {
     if (!hasUserQuery) {
-      const matchingLogsCount =
-        sampleCount > 1
-          ? t('%s logs', <Count value={sampleCount} />)
-          : t('%s log', <Count value={sampleCount} />);
+      const matchingLogsCount = usePluralSampleCount
+        ? t('%s logs', <Count value={sampleCount} />)
+        : t('%s log', <Count value={sampleCount} />);
 
       if (isTopN) {
         return tct('[matchingLogsCount] for top [topEvents] groups', {
@@ -96,13 +99,12 @@ function ConfidenceMessage({
       return matchingLogsCount;
     }
 
-    const matchingLogsCount =
-      sampleCount > 1
-        ? t('%s matches', <Count value={sampleCount} />)
-        : t('%s match', <Count value={sampleCount} />);
+    const matchingLogsCount = usePluralSampleCount
+      ? t('%s matches', <Count value={sampleCount} />)
+      : t('%s match', <Count value={sampleCount} />);
 
     const totalLogsCount = defined(rawLogCounts.total.count) ? (
-      rawLogCounts.total.count > 1 ? (
+      usePluralTotalLogsCount ? (
         t('%s logs', <Count value={rawLogCounts.total.count} />)
       ) : (
         t('%s log', <Count value={rawLogCounts.total.count} />)
@@ -136,13 +138,12 @@ function ConfidenceMessage({
     // partial scans means that we didnt scan all the data so it's useful
     // to mention the total number of logs available
     if (dataScanned === 'partial') {
-      const matchingLogsCount =
-        sampleCount > 1
-          ? t('%s samples', <Count value={sampleCount} />)
-          : t('%s sample', <Count value={sampleCount} />);
+      const matchingLogsCount = usePluralSampleCount
+        ? t('%s samples', <Count value={sampleCount} />)
+        : t('%s sample', <Count value={sampleCount} />);
 
       const totalLogsCount = defined(rawLogCounts.total.count) ? (
-        rawLogCounts.total.count > 1 ? (
+        usePluralTotalLogsCount ? (
           t('%s logs', <Count value={rawLogCounts.total.count} />)
         ) : (
           t('%s log', <Count value={rawLogCounts.total.count} />)
@@ -178,10 +179,9 @@ function ConfidenceMessage({
     // otherwise, a full scan was done
     // full scan means we scanned all the data available so no need to repeat that information twice
 
-    const matchingLogsCount =
-      sampleCount > 1
-        ? t('%s logs', <Count value={sampleCount} />)
-        : t('%s log', <Count value={sampleCount} />);
+    const matchingLogsCount = usePluralSampleCount
+      ? t('%s logs', <Count value={sampleCount} />)
+      : t('%s log', <Count value={sampleCount} />);
 
     if (isTopN) {
       return tct(
@@ -209,13 +209,12 @@ function ConfidenceMessage({
   // partial scans means that we didnt scan all the data so it's useful
   // to mention the total number of logs available
   if (dataScanned === 'partial') {
-    const matchingLogsCount =
-      sampleCount > 1
-        ? t('%s matches', <Count value={sampleCount} />)
-        : t('%s match', <Count value={sampleCount} />);
+    const matchingLogsCount = usePluralSampleCount
+      ? t('%s matches', <Count value={sampleCount} />)
+      : t('%s match', <Count value={sampleCount} />);
 
     const scannedLogsCount = defined(rawLogCounts.normal.count) ? (
-      rawLogCounts.normal.count > 1 ? (
+      usePluralTotalLogsCount ? (
         t('%s samples', <Count value={rawLogCounts.normal.count} />)
       ) : (
         t('%s sample', <Count value={rawLogCounts.normal.count} />)
@@ -225,7 +224,7 @@ function ConfidenceMessage({
     );
 
     const totalLogsCount = defined(rawLogCounts.total.count) ? (
-      rawLogCounts.total.count > 1 ? (
+      usePluralTotalLogsCount ? (
         t('%s logs', <Count value={rawLogCounts.total.count} />)
       ) : (
         t('%s log', <Count value={rawLogCounts.total.count} />)
@@ -263,13 +262,12 @@ function ConfidenceMessage({
   // otherwise, a full scan was done
   // full scan means we scanned all the data available so no need to repeat that information twice
 
-  const matchingLogsCount =
-    sampleCount > 1
-      ? t('%s matches', <Count value={sampleCount} />)
-      : t('%s match', <Count value={sampleCount} />);
+  const matchingLogsCount = usePluralSampleCount
+    ? t('%s matches', <Count value={sampleCount} />)
+    : t('%s match', <Count value={sampleCount} />);
 
   const totalLogsCount = defined(rawLogCounts.total.count) ? (
-    rawLogCounts.total.count > 1 ? (
+    usePluralTotalLogsCount ? (
       t('%s logs', <Count value={rawLogCounts.total.count} />)
     ) : (
       t('%s log', <Count value={rawLogCounts.total.count} />)

--- a/static/app/views/explore/logs/confidenceFooter.tsx
+++ b/static/app/views/explore/logs/confidenceFooter.tsx
@@ -77,13 +77,11 @@ function ConfidenceMessage({
 
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
-  const usePluralSampleCount = sampleCount > 1 || sampleCount === 0;
+  const usePluralSampleCount = sampleCount !== 1;
   const usePluralNormalLogsCount =
-    defined(rawLogCounts.normal.count) &&
-    (rawLogCounts.normal.count > 1 || rawLogCounts.normal.count === 0);
+    defined(rawLogCounts.normal.count) && rawLogCounts.normal.count !== 1;
   const usePluralTotalLogsCount =
-    defined(rawLogCounts.total.count) &&
-    (rawLogCounts.total.count > 1 || rawLogCounts.total.count === 0);
+    defined(rawLogCounts.total.count) && rawLogCounts.total.count !== 1;
 
   // No sampling happened, so don't mention estimations.
   if (noSampling) {

--- a/static/app/views/explore/metrics/confidenceFooter.tsx
+++ b/static/app/views/explore/metrics/confidenceFooter.tsx
@@ -77,13 +77,11 @@ function ConfidenceMessage({
 
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
-  const usePluralSampleCount = sampleCount > 1 || sampleCount === 0;
+  const usePluralSampleCount = sampleCount !== 1;
   const usePluralNormalMetricsCount =
-    defined(rawMetricCounts.normal.count) &&
-    (rawMetricCounts.normal.count > 1 || rawMetricCounts.normal.count === 0);
+    defined(rawMetricCounts.normal.count) && rawMetricCounts.normal.count !== 1;
   const usePluralTotalMetricsCount =
-    defined(rawMetricCounts.total.count) &&
-    (rawMetricCounts.total.count > 1 || rawMetricCounts.total.count === 0);
+    defined(rawMetricCounts.total.count) && rawMetricCounts.total.count !== 1;
 
   // No sampling happened, so don't mention estimations.
   if (noSampling) {

--- a/static/app/views/explore/metrics/confidenceFooter.tsx
+++ b/static/app/views/explore/metrics/confidenceFooter.tsx
@@ -77,14 +77,17 @@ function ConfidenceMessage({
 
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
+  const usePluralSampleCount = sampleCount > 1 || sampleCount === 0;
+  const usePluralTotalMetricsCount =
+    defined(rawMetricCounts.total.count) &&
+    (rawMetricCounts.total.count > 1 || rawMetricCounts.total.count === 0);
 
   // No sampling happened, so don't mention estimations.
   if (noSampling) {
     if (!hasUserQuery) {
-      const matchingMetricsCount =
-        sampleCount > 1
-          ? t('%s data points', <Count value={sampleCount} />)
-          : t('%s data point', <Count value={sampleCount} />);
+      const matchingMetricsCount = usePluralSampleCount
+        ? t('%s data points', <Count value={sampleCount} />)
+        : t('%s data point', <Count value={sampleCount} />);
 
       if (isTopN) {
         return tct('[matchingMetricsCount] for top [topEvents] groups', {
@@ -96,13 +99,12 @@ function ConfidenceMessage({
       return matchingMetricsCount;
     }
 
-    const matchingMetricsCount =
-      sampleCount > 1
-        ? t('%s matches', <Count value={sampleCount} />)
-        : t('%s match', <Count value={sampleCount} />);
+    const matchingMetricsCount = usePluralSampleCount
+      ? t('%s matches', <Count value={sampleCount} />)
+      : t('%s match', <Count value={sampleCount} />);
 
     const totalMetricsCount = defined(rawMetricCounts.total.count) ? (
-      rawMetricCounts.total.count > 1 ? (
+      usePluralTotalMetricsCount ? (
         t('%s data points', <Count value={rawMetricCounts.total.count} />)
       ) : (
         t('%s data point', <Count value={rawMetricCounts.total.count} />)
@@ -141,13 +143,12 @@ function ConfidenceMessage({
     // partial scans means that we didnt scan all the data so it's useful
     // to mention the total number of metrics available
     if (dataScanned === 'partial') {
-      const matchingMetricsCount =
-        sampleCount > 1
-          ? t('%s samples', <Count value={sampleCount} />)
-          : t('%s sample', <Count value={sampleCount} />);
+      const matchingMetricsCount = usePluralSampleCount
+        ? t('%s samples', <Count value={sampleCount} />)
+        : t('%s sample', <Count value={sampleCount} />);
 
       const totalMetricsCount = defined(rawMetricCounts.total.count) ? (
-        rawMetricCounts.total.count > 1 ? (
+        usePluralTotalMetricsCount ? (
           t('%s data points', <Count value={rawMetricCounts.total.count} />)
         ) : (
           t('%s data point', <Count value={rawMetricCounts.total.count} />)
@@ -183,10 +184,9 @@ function ConfidenceMessage({
     // otherwise, a full scan was done
     // full scan means we scanned all the data available so no need to repeat that information twice
 
-    const matchingMetricsCount =
-      sampleCount > 1
-        ? t('%s data points', <Count value={sampleCount} />)
-        : t('%s data point', <Count value={sampleCount} />);
+    const matchingMetricsCount = usePluralSampleCount
+      ? t('%s data points', <Count value={sampleCount} />)
+      : t('%s data point', <Count value={sampleCount} />);
 
     if (isTopN) {
       return tct(
@@ -214,13 +214,12 @@ function ConfidenceMessage({
   // partial scans means that we didnt scan all the data so it's useful
   // to mention the total number of metrics available
   if (dataScanned === 'partial') {
-    const matchingMetricsCount =
-      sampleCount > 1
-        ? t('%s matches', <Count value={sampleCount} />)
-        : t('%s match', <Count value={sampleCount} />);
+    const matchingMetricsCount = usePluralSampleCount
+      ? t('%s matches', <Count value={sampleCount} />)
+      : t('%s match', <Count value={sampleCount} />);
 
     const scannedMetricsCount = defined(rawMetricCounts.normal.count) ? (
-      rawMetricCounts.normal.count > 1 || rawMetricCounts.normal.count === 0 ? (
+      usePluralTotalMetricsCount ? (
         t('%s samples', <Count value={rawMetricCounts.normal.count} />)
       ) : (
         t('%s sample', <Count value={rawMetricCounts.normal.count} />)
@@ -230,7 +229,7 @@ function ConfidenceMessage({
     );
 
     const totalMetricsCount = defined(rawMetricCounts.total.count) ? (
-      rawMetricCounts.total.count > 1 ? (
+      usePluralTotalMetricsCount ? (
         t('%s data points', <Count value={rawMetricCounts.total.count} />)
       ) : (
         t('%s data point', <Count value={rawMetricCounts.total.count} />)
@@ -268,13 +267,12 @@ function ConfidenceMessage({
   // otherwise, a full scan was done
   // full scan means we scanned all the data available so no need to repeat that information twice
 
-  const matchingMetricsCount =
-    sampleCount > 1
-      ? t('%s matches', <Count value={sampleCount} />)
-      : t('%s match', <Count value={sampleCount} />);
+  const matchingMetricsCount = usePluralSampleCount
+    ? t('%s matches', <Count value={sampleCount} />)
+    : t('%s match', <Count value={sampleCount} />);
 
   const totalMetricsCount = defined(rawMetricCounts.total.count) ? (
-    rawMetricCounts.total.count > 1 ? (
+    usePluralTotalMetricsCount ? (
       t('%s data points', <Count value={rawMetricCounts.total.count} />)
     ) : (
       t('%s data point', <Count value={rawMetricCounts.total.count} />)

--- a/static/app/views/explore/metrics/confidenceFooter.tsx
+++ b/static/app/views/explore/metrics/confidenceFooter.tsx
@@ -78,6 +78,9 @@ function ConfidenceMessage({
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
   const usePluralSampleCount = sampleCount > 1 || sampleCount === 0;
+  const usePluralNormalMetricsCount =
+    defined(rawMetricCounts.normal.count) &&
+    (rawMetricCounts.normal.count > 1 || rawMetricCounts.normal.count === 0);
   const usePluralTotalMetricsCount =
     defined(rawMetricCounts.total.count) &&
     (rawMetricCounts.total.count > 1 || rawMetricCounts.total.count === 0);
@@ -219,7 +222,7 @@ function ConfidenceMessage({
       : t('%s match', <Count value={sampleCount} />);
 
     const scannedMetricsCount = defined(rawMetricCounts.normal.count) ? (
-      usePluralTotalMetricsCount ? (
+      usePluralNormalMetricsCount ? (
         t('%s samples', <Count value={rawMetricCounts.normal.count} />)
       ) : (
         t('%s sample', <Count value={rawMetricCounts.normal.count} />)

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -302,7 +302,7 @@ function Graph({
           showChart && (
             <ConfidenceFooter
               chartInfo={chartInfo}
-              isLoading={timeseriesResult.isFetching}
+              isLoading={timeseriesResult.isPending || timeseriesResult.isFetching}
               hasUserQuery={!!userQuery}
               rawMetricCounts={rawMetricCounts}
             />

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -47,6 +47,9 @@ function confidenceMessage({
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
   const usePluralSampleCount = sampleCount > 1 || sampleCount === 0;
+  const usePluralNormalSpansCount =
+    defined(rawSpanCounts?.normal.count) &&
+    (rawSpanCounts.normal.count > 1 || rawSpanCounts.normal.count === 0);
   const usePluralTotalSpansCount =
     defined(rawSpanCounts?.total.count) &&
     (rawSpanCounts.total.count > 1 || rawSpanCounts.total.count === 0);
@@ -219,7 +222,7 @@ function confidenceMessage({
       : t('%s match', <Count value={sampleCount} />);
 
     const scannedSpansCount = defined(rawSpanCounts.normal.count) ? (
-      usePluralTotalSpansCount ? (
+      usePluralNormalSpansCount ? (
         t('%s samples', <Count value={rawSpanCounts.normal.count} />)
       ) : (
         t('%s sample', <Count value={rawSpanCounts.normal.count} />)

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -46,13 +46,11 @@ function confidenceMessage({
 
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
-  const usePluralSampleCount = sampleCount > 1 || sampleCount === 0;
+  const usePluralSampleCount = sampleCount !== 1;
   const usePluralNormalSpansCount =
-    defined(rawSpanCounts?.normal.count) &&
-    (rawSpanCounts.normal.count > 1 || rawSpanCounts.normal.count === 0);
+    defined(rawSpanCounts?.normal.count) && rawSpanCounts.normal.count !== 1;
   const usePluralTotalSpansCount =
-    defined(rawSpanCounts?.total.count) &&
-    (rawSpanCounts.total.count > 1 || rawSpanCounts.total.count === 0);
+    defined(rawSpanCounts?.total.count) && rawSpanCounts.total.count !== 1;
 
   const maybeWarning =
     confidence === 'low' ? tct('[warning] ', {warning: <WarningIcon />}) : null;

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -69,8 +69,8 @@ function confidenceMessage({
   // so make sure to have a backup when this happens.
   if (!defined(rawSpanCounts)) {
     const matchingSpansCount = usePluralSampleCount
-      ? t('%s span', <Count value={sampleCount} />)
-      : t('%s spans', <Count value={sampleCount} />);
+      ? t('%s spans', <Count value={sampleCount} />)
+      : t('%s span', <Count value={sampleCount} />);
 
     if (isTopN) {
       return tct(

--- a/static/app/views/explore/spans/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/spans/charts/confidenceFooter.tsx
@@ -46,6 +46,10 @@ function confidenceMessage({
 
   const isTopN = defined(topEvents) && topEvents > 1;
   const noSampling = defined(isSampled) && !isSampled;
+  const usePluralSampleCount = sampleCount > 1 || sampleCount === 0;
+  const usePluralTotalSpansCount =
+    defined(rawSpanCounts?.total.count) &&
+    (rawSpanCounts.total.count > 1 || rawSpanCounts.total.count === 0);
 
   const maybeWarning =
     confidence === 'low' ? tct('[warning] ', {warning: <WarningIcon />}) : null;
@@ -61,10 +65,9 @@ function confidenceMessage({
   // The multi query mode does not fetch the raw span counts
   // so make sure to have a backup when this happens.
   if (!defined(rawSpanCounts)) {
-    const matchingSpansCount =
-      sampleCount === 1
-        ? t('%s span', <Count value={sampleCount} />)
-        : t('%s spans', <Count value={sampleCount} />);
+    const matchingSpansCount = usePluralSampleCount
+      ? t('%s span', <Count value={sampleCount} />)
+      : t('%s spans', <Count value={sampleCount} />);
 
     if (isTopN) {
       return tct(
@@ -92,10 +95,9 @@ function confidenceMessage({
     noSampling
   ) {
     if (!userQuery) {
-      const matchingSpansCount =
-        sampleCount > 1
-          ? t('%s spans', <Count value={sampleCount} />)
-          : t('%s span', <Count value={sampleCount} />);
+      const matchingSpansCount = usePluralSampleCount
+        ? t('%s spans', <Count value={sampleCount} />)
+        : t('%s span', <Count value={sampleCount} />);
 
       if (isTopN) {
         return tct('[matchingSpansCount] for top [topEvents] groups', {
@@ -107,13 +109,12 @@ function confidenceMessage({
       return matchingSpansCount;
     }
 
-    const matchingSpansCount =
-      sampleCount > 1
-        ? t('%s matches', <Count value={sampleCount} />)
-        : t('%s match', <Count value={sampleCount} />);
+    const matchingSpansCount = usePluralSampleCount
+      ? t('%s matches', <Count value={sampleCount} />)
+      : t('%s match', <Count value={sampleCount} />);
 
     const totalSpansCount = defined(rawSpanCounts.total.count) ? (
-      rawSpanCounts.total.count > 1 ? (
+      usePluralTotalSpansCount ? (
         t('%s spans', <Count value={rawSpanCounts.total.count} />)
       ) : (
         t('%s span', <Count value={rawSpanCounts.total.count} />)
@@ -142,13 +143,12 @@ function confidenceMessage({
     // partial scans means that we didnt scan all the data so it's useful
     // to mention the total number of spans available
     if (dataScanned === 'partial') {
-      const matchingSpansCount =
-        sampleCount > 1
-          ? t('%s samples', <Count value={sampleCount} />)
-          : t('%s sample', <Count value={sampleCount} />);
+      const matchingSpansCount = usePluralSampleCount
+        ? t('%s samples', <Count value={sampleCount} />)
+        : t('%s sample', <Count value={sampleCount} />);
 
       const totalSpansCount = defined(rawSpanCounts.total.count) ? (
-        rawSpanCounts.total.count > 1 ? (
+        usePluralTotalSpansCount ? (
           t('%s spans', <Count value={rawSpanCounts.total.count} />)
         ) : (
           t('%s span', <Count value={rawSpanCounts.total.count} />)
@@ -184,10 +184,9 @@ function confidenceMessage({
     // otherwise, a full scan was done
     // full scan means we scanned all the data available so no need to repeat that information twice
 
-    const matchingSpansCount =
-      sampleCount > 1
-        ? t('%s spans', <Count value={sampleCount} />)
-        : t('%s span', <Count value={sampleCount} />);
+    const matchingSpansCount = usePluralSampleCount
+      ? t('%s spans', <Count value={sampleCount} />)
+      : t('%s span', <Count value={sampleCount} />);
 
     if (isTopN) {
       return tct(
@@ -215,13 +214,12 @@ function confidenceMessage({
   // partial scans means that we didnt scan all the data so it's useful
   // to mention the total number of spans available
   if (dataScanned === 'partial') {
-    const matchingSpansCount =
-      sampleCount > 1
-        ? t('%s matches', <Count value={sampleCount} />)
-        : t('%s match', <Count value={sampleCount} />);
+    const matchingSpansCount = usePluralSampleCount
+      ? t('%s matches', <Count value={sampleCount} />)
+      : t('%s match', <Count value={sampleCount} />);
 
     const scannedSpansCount = defined(rawSpanCounts.normal.count) ? (
-      rawSpanCounts.normal.count > 1 ? (
+      usePluralTotalSpansCount ? (
         t('%s samples', <Count value={rawSpanCounts.normal.count} />)
       ) : (
         t('%s sample', <Count value={rawSpanCounts.normal.count} />)
@@ -231,7 +229,7 @@ function confidenceMessage({
     );
 
     const totalSpansCount = defined(rawSpanCounts.total.count) ? (
-      rawSpanCounts.total.count > 1 ? (
+      usePluralTotalSpansCount ? (
         t('%s spans', <Count value={rawSpanCounts.total.count} />)
       ) : (
         t('%s span', <Count value={rawSpanCounts.total.count} />)
@@ -269,13 +267,12 @@ function confidenceMessage({
   // otherwise, a full scan was done
   // full scan means we scanned all the data available so no need to repeat that information twice
 
-  const matchingSpansCount =
-    sampleCount > 1
-      ? t('%s matches', <Count value={sampleCount} />)
-      : t('%s match', <Count value={sampleCount} />);
+  const matchingSpansCount = usePluralSampleCount
+    ? t('%s matches', <Count value={sampleCount} />)
+    : t('%s match', <Count value={sampleCount} />);
 
   const totalSpansCount = defined(rawSpanCounts.total.count) ? (
-    rawSpanCounts.total.count > 1 ? (
+    usePluralTotalSpansCount ? (
       t('%s spans', <Count value={rawSpanCounts.total.count} />)
     ) : (
       t('%s span', <Count value={rawSpanCounts.total.count} />)


### PR DESCRIPTION
When there was no data, the confidence footer message would read "0 data point" or "0 log", etc instead of "0 data points"

This PR changes it so when we look at the sample count, or normal count, or total count, we include `0` in the criteria for displaying a plural message.