### PR TITLE
fix(insights): Link trace table on AI agent dashboard to trace view

### DIFF
--- a/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
@@ -1,6 +1,5 @@
 import type {DashboardFilters} from 'sentry/views/dashboards/types';
 import {DEFAULT_TRACES_TABLE_WIDTHS} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview';
-import {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
 import {TracesTable} from 'sentry/views/insights/pages/agents/components/tracesTable';
 
 interface AgentsTracesTableWidgetVisualizationProps {
@@ -16,15 +15,13 @@ export function AgentsTracesTableWidgetVisualization({
   dashboardFilters,
   frameless,
 }: AgentsTracesTableWidgetVisualizationProps) {
-  const {openTraceViewDrawer} = useTraceViewDrawer();
-
   return (
     <TracesTable
-      openTraceViewDrawer={openTraceViewDrawer}
       limit={limit}
       tableWidths={tableWidths}
       dashboardFilters={dashboardFilters}
       frameless={frameless}
+      linkToTraceView
     />
   );
 }

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -9,6 +9,7 @@ import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Pagination} from 'sentry/components/pagination';
 import {Placeholder} from 'sentry/components/placeholder';
@@ -49,6 +50,9 @@ import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
+import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
+import {TraceLayoutTabKeys} from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
+import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
 interface TableData {
   agents: string[];
@@ -92,10 +96,11 @@ const rightAlignColumns = new Set([
 const DEFAULT_LIMIT = 10;
 
 interface TracesTableProps {
-  openTraceViewDrawer: ReturnType<typeof useTraceViewDrawer>['openTraceViewDrawer'];
   dashboardFilters?: DashboardFilters;
   frameless?: boolean;
   limit?: number;
+  linkToTraceView?: boolean;
+  openTraceViewDrawer?: ReturnType<typeof useTraceViewDrawer>['openTraceViewDrawer'];
   tableWidths?: number[];
 }
 
@@ -105,6 +110,7 @@ export function TracesTable({
   dashboardFilters,
   limit = DEFAULT_LIMIT,
   tableWidths,
+  linkToTraceView,
 }: TracesTableProps) {
   const {columns: columnOrder, handleResizeColumn} = useStateBasedColumnResize({
     columns:
@@ -273,10 +279,11 @@ export function TracesTable({
           dataRow={dataRow}
           query={combinedQuery}
           openTraceViewDrawer={openTraceViewDrawer}
+          linkToTraceView={linkToTraceView}
         />
       );
     },
-    [combinedQuery, openTraceViewDrawer]
+    [combinedQuery, openTraceViewDrawer, linkToTraceView]
   );
 
   const additionalGridProps = frameless
@@ -324,23 +331,41 @@ const BodyCell = memo(function BodyCell({
   dataRow,
   query,
   openTraceViewDrawer,
+  linkToTraceView,
 }: {
   column: GridColumnHeader<string>;
   dataRow: TableData;
-  openTraceViewDrawer: (traceSlug: string, spanId?: string, timestamp?: number) => void;
   query: string;
+  linkToTraceView?: boolean;
+  openTraceViewDrawer?: (traceSlug: string, spanId?: string, timestamp?: number) => void;
 }) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
+  const location = useLocation();
 
   switch (column.key) {
     case 'traceId':
+      if (linkToTraceView || !openTraceViewDrawer) {
+        const traceUrl = getTraceDetailsUrl({
+          organization,
+          traceSlug: dataRow.traceId,
+          dateSelection: normalizeDateTimeParams(selection),
+          timestamp: dataRow.timestamp / 1000,
+          location: {
+            ...location,
+            query: {},
+          },
+          source: TraceViewSources.AGENT_MONITORING,
+          tab: TraceLayoutTabKeys.AI_SPANS,
+        });
+        return <Link to={traceUrl}>{dataRow.traceId.slice(0, 8)}</Link>;
+      }
       return (
         <span>
           <TraceIdButton
             priority="link"
             onClick={() =>
-              openTraceViewDrawer(dataRow.traceId, undefined, dataRow.timestamp / 1000)
+              openTraceViewDrawer?.(dataRow.traceId, undefined, dataRow.timestamp / 1000)
             }
           >
             {dataRow.traceId.slice(0, 8)}

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -349,7 +349,7 @@ const BodyCell = memo(function BodyCell({
         const traceUrl = getTraceDetailsUrl({
           organization,
           traceSlug: dataRow.traceId,
-          dateSelection: normalizeDateTimeParams(selection),
+          dateSelection: normalizeDateTimeParams(selection.datetime),
           timestamp: dataRow.timestamp / 1000,
           location: {
             ...location,


### PR DESCRIPTION
## Summary
- On the AI agents prebuilt dashboard, the trace ID in the traces table now links directly to the trace view with the **AI Spans** tab selected, instead of opening a drawer.
- Adds a `linkToTraceView` prop to `TracesTable` to support this behavior while preserving the existing drawer behavior on the agents insights page.

Fixes DAIN-1397

## Test plan
- [ ] Navigate to the AI agents prebuilt dashboard
- [ ] Click a trace ID in the traces table
- [ ] Verify it navigates to the trace view with the AI Spans tab active
- [ ] Navigate to the agents insights page and verify the trace ID still opens the drawer