### PR TITLE
ref(aci): Remove a try/except block for more detailed errors

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -327,7 +327,7 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
                     update_detector_data(instance, validated_data_source)
             except Exception as e:
                 # don't update the snuba query if we failed to send data to Seer
-                raise serializers.ValidationError(e.message)
+                raise serializers.ValidationError(str(e))
 
         extrapolation_mode = format_extrapolation_mode(
             data_source.get("extrapolation_mode", snuba_query.extrapolation_mode)
@@ -367,7 +367,7 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
                 seer_updated = True
             except Exception as e:
                 # Don't update if we failed to send data to Seer
-                raise serializers.ValidationError(e.message)
+                raise serializers.ValidationError(str(e))
 
         elif (
             validated_data.get("config")

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -1,7 +1,10 @@
 from datetime import timedelta
 from typing import Any
 
+from django.core.exceptions import ValidationError
+from parsimonious.exceptions import ParseError
 from rest_framework import serializers
+from urllib3.exceptions import MaxRetryError, TimeoutError
 
 from sentry import features, quotas
 from sentry.constants import ObjectStatus
@@ -325,7 +328,7 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
                 validated_data_source: dict[str, Any] = {"data_sources": [data_source]}
                 if not seer_updated:
                     update_detector_data(instance, validated_data_source)
-            except Exception as e:
+            except (TimeoutError, MaxRetryError, ParseError, ValidationError) as e:
                 # don't update the snuba query if we failed to send data to Seer
                 raise serializers.ValidationError(str(e))
 
@@ -365,7 +368,7 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
             try:
                 update_detector_data(instance, validated_data)
                 seer_updated = True
-            except Exception as e:
+            except (TimeoutError, MaxRetryError, ParseError, ValidationError) as e:
                 # Don't update if we failed to send data to Seer
                 raise serializers.ValidationError(str(e))
 

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -325,11 +325,9 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
                 validated_data_source: dict[str, Any] = {"data_sources": [data_source]}
                 if not seer_updated:
                     update_detector_data(instance, validated_data_source)
-            except Exception:
+            except Exception as e:
                 # don't update the snuba query if we failed to send data to Seer
-                raise serializers.ValidationError(
-                    "Failed to send data to Seer, cannot update detector"
-                )
+                raise serializers.ValidationError(e.message)
 
         extrapolation_mode = format_extrapolation_mode(
             data_source.get("extrapolation_mode", snuba_query.extrapolation_mode)
@@ -367,11 +365,9 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
             try:
                 update_detector_data(instance, validated_data)
                 seer_updated = True
-            except Exception:
+            except Exception as e:
                 # Don't update if we failed to send data to Seer
-                raise serializers.ValidationError(
-                    "Failed to send data to Seer, cannot update detector"
-                )
+                raise serializers.ValidationError(e.message)
 
         elif (
             validated_data.get("config")


### PR DESCRIPTION
# Description
When investigating an issue, it was difficult to determine the source of the issue because we hit the exception block and lost which of the ValidationError was bubbling up.

This will just allow the more specific validation error to bubble up and reformat them to all be ValidationErrors that can be handled in the API.

The code still catches the exception and retriggers it to ensure the control flow is consistent and the validation error types are correct.