### PR TITLE
fix(dashboards): blank visualize fields on tables/big numbers from text widgets

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -167,7 +167,7 @@ describe('TypeSelector', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({
-          field: ['count()'],
+          field: ['count_unique(user)'],
         }),
       }),
       expect.anything()

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -125,4 +125,52 @@ describe('TypeSelector', () => {
       expect.anything()
     );
   });
+
+  it('resets the widget builder state to dataset defaults when display type is changed from text widget', async () => {
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+
+    render(
+      <WidgetBuilderProvider>
+        <TypeSelector />
+      </WidgetBuilderProvider>,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+            query: {displayType: 'text'},
+          },
+        },
+        organization: OrganizationFixture({features: ['dashboards-text-widgets']}),
+      }
+    );
+
+    await userEvent.click(await screen.findByText('Text (Markdown)'));
+    await userEvent.click(await screen.findByText('Table'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          displayType: 'table',
+        }),
+      }),
+      expect.anything()
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          dataset: WidgetType.ERRORS,
+        }),
+      }),
+      expect.anything()
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          field: ['count()'],
+        }),
+      }),
+      expect.anything()
+    );
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -93,6 +93,23 @@ export function WidgetBuilderTypeSelector({
     }
   };
 
+  const handleTextWidgetDisplayTypeChange = (newValue: DisplayType) => {
+    const defaultConfig = getDatasetConfig(undefined);
+    dispatch({
+      type: BuilderStateAction.SET_STATE,
+      payload: convertWidgetToBuilderState({
+        widgetType: state.dataset ?? WidgetType.ERRORS,
+        queries: [
+          (usesTimeSeriesData(newValue) && defaultConfig.defaultSeriesWidgetQuery) ||
+            defaultConfig.defaultWidgetQuery,
+        ],
+        displayType: newValue,
+        interval: '',
+        title: state.title ?? '',
+      }),
+    });
+  };
+
   return (
     <Fragment>
       <SectionHeader
@@ -121,7 +138,12 @@ export function WidgetBuilderTypeSelector({
             }
             setError?.({...error, displayType: undefined});
 
-            if (state.dataset === WidgetType.ISSUE) {
+            if (
+              state.displayType === DisplayType.TEXT &&
+              newValue?.value !== DisplayType.TEXT
+            ) {
+              handleTextWidgetDisplayTypeChange(newValue?.value);
+            } else if (state.dataset === WidgetType.ISSUE) {
               handleIssueWidgetDisplayTypeChange(newValue?.value);
             } else {
               dispatch({

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -94,7 +94,7 @@ export function WidgetBuilderTypeSelector({
   };
 
   const handleTextWidgetDisplayTypeChange = (newValue: DisplayType) => {
-    const defaultConfig = getDatasetConfig(undefined);
+    const defaultConfig = getDatasetConfig(state.dataset ?? WidgetType.ERRORS);
     dispatch({
       type: BuilderStateAction.SET_STATE,
       payload: convertWidgetToBuilderState({


### PR DESCRIPTION
when switching from text widget to big number widgets or table widgets specifically, the visualize fields were not populated with the defaults. I've adjusted the logic so that the default config populates the fields.