### PR TITLE
feat(nav): Allow Cmd+K to toggle command palette open and closed

### DIFF
--- a/static/app/components/commandPalette/ui/useCommandPaletteState.tsx
+++ b/static/app/components/commandPalette/ui/useCommandPaletteState.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import type Fuse from 'fuse.js';
 
 import {useCommandPaletteActions} from 'sentry/components/commandPalette/context';
@@ -67,8 +67,14 @@ function flattenActions(
   return flattened;
 }
 
+let persistedQuery = '';
+
 export function useCommandPaletteState() {
-  const [query, setQuery] = useState('');
+  const [query, _setQuery] = useState(persistedQuery);
+  const setQuery = useCallback((newQuery: string) => {
+    persistedQuery = newQuery;
+    _setQuery(newQuery);
+  }, []);
   const actions = useCommandPaletteActions();
   const [selectedAction, setSelectedAction] =
     useState<CommandPaletteActionWithKey | null>(null);

--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -1,3 +1,4 @@
+import {useEffect, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -5,6 +6,7 @@ import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {
+  closeModal,
   openCommandPalette,
   openCommandPaletteDeprecated,
 } from 'sentry/actionCreators/modal';
@@ -36,22 +38,32 @@ function UserAndOrganizationNavigation() {
 
   useGlobalCommandPaletteActions();
 
-  useHotkeys(
-    visible
-      ? []
-      : [
-          {
-            match: ['command+shift+p', 'command+k', 'ctrl+shift+p', 'ctrl+k'],
-            callback: () => {
-              if (organization.features.includes('cmd-k-supercharged')) {
-                openCommandPalette();
-              } else {
-                openCommandPaletteDeprecated();
-              }
-            },
-          },
-        ]
-  );
+  const commandPaletteOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!visible) {
+      commandPaletteOpenRef.current = false;
+    }
+  }, [visible]);
+
+  useHotkeys([
+    {
+      match: ['command+shift+p', 'command+k', 'ctrl+shift+p', 'ctrl+k'],
+      includeInputs: true,
+      callback: () => {
+        if (organization.features.includes('cmd-k-supercharged')) {
+          if (visible && commandPaletteOpenRef.current) {
+            closeModal();
+          } else if (!visible) {
+            openCommandPalette();
+            commandPaletteOpenRef.current = true;
+          }
+        } else if (!visible) {
+          openCommandPaletteDeprecated();
+        }
+      },
+    },
+  ]);
 
   return (
     <NavigationLayout>


### PR DESCRIPTION
## Summary
- Cmd+K (and Ctrl+K, Cmd+Shift+P, Ctrl+Shift+P) now **toggles** the new command palette open and closed, instead of only opening it
- Search query is **preserved** across open/close cycles so reopening the palette restores the previous search text
- Only affects the new command palette behind `cmd-k-supercharged` feature flag; the deprecated palette retains its existing open-only behavior

## How it works
- A ref tracks whether the command palette is the currently active modal
- The ref resets when the modal closes by any means (Escape, backdrop click, route change)
- `includeInputs: true` ensures the shortcut fires even while the palette's search input is focused
- A module-level variable in `useCommandPaletteState` persists the search query across mount/unmount cycles

## Test plan
- [ ] Press Cmd+K → palette opens
- [ ] Press Cmd+K again → palette closes
- [ ] Type a search query, press Cmd+K to close, press Cmd+K to reopen → query is preserved
- [ ] Press Escape to close → Cmd+K reopens with preserved query
- [ ] Open a different modal → Cmd+K does nothing (doesn't close unrelated modals)
- [ ] Without `cmd-k-supercharged` flag → old palette opens only, no toggle behavior