### PR TITLE
fix(nav): Restore focus to previous element after closing command palette

### DIFF
--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -39,9 +39,14 @@ function UserAndOrganizationNavigation() {
   useGlobalCommandPaletteActions();
 
   const commandPaletteOpenRef = useRef(false);
+  const previousFocusRef = useRef<Element | null>(null);
 
   useEffect(() => {
-    if (!visible) {
+    if (!visible && commandPaletteOpenRef.current) {
+      if (previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus();
+      }
+      previousFocusRef.current = null;
       commandPaletteOpenRef.current = false;
     }
   }, [visible]);
@@ -55,6 +60,7 @@ function UserAndOrganizationNavigation() {
           if (visible && commandPaletteOpenRef.current) {
             closeModal();
           } else if (!visible) {
+            previousFocusRef.current = document.activeElement;
             openCommandPalette();
             commandPaletteOpenRef.current = true;
           }


### PR DESCRIPTION
## Summary
- When the new command palette closes, focus now returns to the element that was focused before it opened
- The GlobalModal's focus-trap doesn't reliably handle this because the palette input's `autoFocus` moves focus into the portal before the trap's `activate()` runs, causing it to store the wrong "previous" element
- Saves `document.activeElement` explicitly when opening the palette and restores it when the modal closes (via any method: Escape, backdrop click, Cmd+K toggle, route change)

Depends on #111441

## Test plan
- [ ] Focus on search query builder → Cmd+K → close palette → focus returns to search input
- [ ] Focus on a button → Cmd+K → Escape → focus returns to button
- [ ] Focus on an input → Cmd+K → click backdrop → focus returns to input
- [ ] Open palette with no specific focus → close → no error thrown