### PR TITLE
feat(scm): Allow GitLab repos to be selected for Seer

### DIFF
--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -200,12 +200,10 @@ const BASE_SUPPORTED_PROVIDERS = [
 const FEATURE_GATED_PROVIDERS: Array<{
   flag: string;
   providerIds: string[];
-  requiresSeatBased: boolean;
 }> = [
   {
     flag: 'seer-gitlab-support',
     providerIds: ['gitlab', 'integrations:gitlab'],
-    requiresSeatBased: true,
   },
 ];
 
@@ -228,12 +226,8 @@ export function isSeerSupportedProvider(
 export function useSeerSupportedProviderIds(): string[] {
   const organization = useOrganization();
   return useMemo(() => {
-    const hasSeatBasedSeer = organization.features.includes('seat-based-seer-enabled');
     const ids = [...BASE_SUPPORTED_PROVIDERS];
-    for (const {flag, providerIds, requiresSeatBased} of FEATURE_GATED_PROVIDERS) {
-      if (requiresSeatBased && !hasSeatBasedSeer) {
-        continue;
-      }
+    for (const {flag, providerIds} of FEATURE_GATED_PROVIDERS) {
       if (organization.features.includes(flag)) {
         ids.push(...providerIds);
       }

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -208,6 +208,17 @@ const FEATURE_GATED_PROVIDERS: Array<{
 ];
 
 /**
+ * Pure function for non-hook contexts (e.g. buildIntegrationTreeNodes).
+ * Returns true if the provider is in the supported list.
+ */
+export function isSeerSupportedProvider(
+  provider: {id: string; name: string},
+  supportedProviderIds: string[]
+): boolean {
+  return supportedProviderIds.includes(provider.id);
+}
+
+/**
  * Returns the list of provider IDs supported for Seer based on the
  * organization's feature flags. To support a new provider, add an entry
  * to FEATURE_GATED_PROVIDERS above.
@@ -235,7 +246,8 @@ export function useIsSeerSupportedProvider(): (provider: {
 }) => boolean {
   const supportedProviderIds = useSeerSupportedProviderIds();
   return useCallback(
-    (provider: {id: string; name: string}) => supportedProviderIds.includes(provider.id),
+    (provider: {id: string; name: string}) =>
+      isSeerSupportedProvider(provider, supportedProviderIds),
     [supportedProviderIds]
   );
 }

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {formatRootCauseText} from 'sentry/components/events/autofix/autofixRootCause';
 import {formatSolutionText} from 'sentry/components/events/autofix/autofixSolution';
@@ -193,44 +193,68 @@ const BASE_SUPPORTED_PROVIDERS = [
   'integrations:github_enterprise',
 ];
 
-const GITLAB_PROVIDERS = ['gitlab', 'integrations:gitlab'];
-
-export const isSupportedAutofixProvider = (
-  provider: {id: string; name: string},
-  hasGitlabSupport?: boolean
-) => {
-  const providers = hasGitlabSupport
-    ? [...BASE_SUPPORTED_PROVIDERS, ...GITLAB_PROVIDERS]
-    : BASE_SUPPORTED_PROVIDERS;
-  return providers.includes(provider.id);
-};
+/**
+ * Feature-gated providers. Each entry maps a feature flag to the provider IDs
+ * it unlocks. Add new providers here as they become supported.
+ */
+const FEATURE_GATED_PROVIDERS: Array<{
+  flag: string;
+  providerIds: string[];
+  requiresSeatBased: boolean;
+}> = [
+  {
+    flag: 'seer-gitlab-support',
+    providerIds: ['gitlab', 'integrations:gitlab'],
+    requiresSeatBased: true,
+  },
+];
 
 /**
- * Hook that checks if the organization has GitLab support enabled for Seer.
- * GitLab is only supported for seat-based-billing features (code review, seer explorer).
- * Centralizes the feature flag checks so consumers don't need to know the flag names.
+ * Pure function for non-hook contexts (e.g. buildIntegrationTreeNodes).
+ * Returns true if the provider is in the supported list.
  */
-export function useHasGitlabSupport(): boolean {
-  const organization = useOrganization();
-  return (
-    organization.features.includes('seer-gitlab-support') &&
-    organization.features.includes('seat-based-seer-enabled')
-  );
+export function isSeerSupportedProvider(
+  provider: {id: string; name: string},
+  supportedProviderIds: string[]
+): boolean {
+  return supportedProviderIds.includes(provider.id);
 }
 
 /**
- * Hook that returns a provider-check callback with the GitLab feature flag baked in.
- * Use this in React components instead of calling isSupportedAutofixProvider directly.
+ * Returns the list of provider IDs supported for Seer based on the
+ * organization's feature flags. To support a new provider, add an entry
+ * to FEATURE_GATED_PROVIDERS above.
+ */
+export function useSeerSupportedProviderIds(): string[] {
+  const organization = useOrganization();
+  return useMemo(() => {
+    const hasSeatBasedSeer = organization.features.includes('seat-based-seer-enabled');
+    const ids = [...BASE_SUPPORTED_PROVIDERS];
+    for (const {flag, providerIds, requiresSeatBased} of FEATURE_GATED_PROVIDERS) {
+      if (requiresSeatBased && !hasSeatBasedSeer) {
+        continue;
+      }
+      if (organization.features.includes(flag)) {
+        ids.push(...providerIds);
+      }
+    }
+    return ids;
+  }, [organization.features]);
+}
+
+/**
+ * Convenience hook that returns a provider-check callback.
+ * Use this in React components that need to test individual providers.
  */
 export function useIsSeerSupportedProvider(): (provider: {
   id: string;
   name: string;
 }) => boolean {
-  const hasGitlabSupport = useHasGitlabSupport();
+  const supportedProviderIds = useSeerSupportedProviderIds();
   return useCallback(
     (provider: {id: string; name: string}) =>
-      isSupportedAutofixProvider(provider, hasGitlabSupport),
-    [hasGitlabSupport]
+      isSeerSupportedProvider(provider, supportedProviderIds),
+    [supportedProviderIds]
   );
 }
 

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -1,3 +1,5 @@
+import {useCallback} from 'react';
+
 import {formatRootCauseText} from 'sentry/components/events/autofix/autofixRootCause';
 import {formatSolutionText} from 'sentry/components/events/autofix/autofixSolution';
 import {
@@ -12,6 +14,7 @@ import {
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {formatEventToMarkdown} from 'sentry/views/issueDetails/streamline/hooks/useCopyIssueDetails';
 
 export function getRootCauseDescription(autofixData: AutofixData) {
@@ -184,14 +187,52 @@ export function hasPullRequest(autofixData: AutofixData | null | undefined): boo
   return Boolean(changesStep?.changes?.some(change => change.pull_request));
 }
 
-const supportedProviders = [
+const BASE_SUPPORTED_PROVIDERS = [
   'github',
   'integrations:github',
   'integrations:github_enterprise',
 ];
-export const isSupportedAutofixProvider = (provider: {id: string; name: string}) => {
-  return supportedProviders.includes(provider.id);
+
+const GITLAB_PROVIDERS = ['gitlab', 'integrations:gitlab'];
+
+export const isSupportedAutofixProvider = (
+  provider: {id: string; name: string},
+  hasGitlabSupport?: boolean
+) => {
+  const providers = hasGitlabSupport
+    ? [...BASE_SUPPORTED_PROVIDERS, ...GITLAB_PROVIDERS]
+    : BASE_SUPPORTED_PROVIDERS;
+  return providers.includes(provider.id);
 };
+
+/**
+ * Hook that checks if the organization has GitLab support enabled for Seer.
+ * GitLab is only supported for seat-based-billing features (code review, seer explorer).
+ * Centralizes the feature flag checks so consumers don't need to know the flag names.
+ */
+export function useHasGitlabSupport(): boolean {
+  const organization = useOrganization();
+  return (
+    organization.features.includes('seer-gitlab-support') &&
+    organization.features.includes('seat-based-seer-enabled')
+  );
+}
+
+/**
+ * Hook that returns a provider-check callback with the GitLab feature flag baked in.
+ * Use this in React components instead of calling isSupportedAutofixProvider directly.
+ */
+export function useIsSeerSupportedProvider(): (provider: {
+  id: string;
+  name: string;
+}) => boolean {
+  const hasGitlabSupport = useHasGitlabSupport();
+  return useCallback(
+    (provider: {id: string; name: string}) =>
+      isSupportedAutofixProvider(provider, hasGitlabSupport),
+    [hasGitlabSupport]
+  );
+}
 
 export interface AutofixProgressDetails {
   overallProgress: number;

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -208,17 +208,6 @@ const FEATURE_GATED_PROVIDERS: Array<{
 ];
 
 /**
- * Pure function for non-hook contexts (e.g. buildIntegrationTreeNodes).
- * Returns true if the provider is in the supported list.
- */
-export function isSeerSupportedProvider(
-  provider: {id: string; name: string},
-  supportedProviderIds: string[]
-): boolean {
-  return supportedProviderIds.includes(provider.id);
-}
-
-/**
  * Returns the list of provider IDs supported for Seer based on the
  * organization's feature flags. To support a new provider, add an entry
  * to FEATURE_GATED_PROVIDERS above.
@@ -246,8 +235,7 @@ export function useIsSeerSupportedProvider(): (provider: {
 }) => boolean {
   const supportedProviderIds = useSeerSupportedProviderIds();
   return useCallback(
-    (provider: {id: string; name: string}) =>
-      isSeerSupportedProvider(provider, supportedProviderIds),
+    (provider: {id: string; name: string}) => supportedProviderIds.includes(provider.id),
     [supportedProviderIds]
   );
 }

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
@@ -8,6 +8,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {addRepository, hideRepository} from 'sentry/actionCreators/integrations';
+import {useHasGitlabSupport} from 'sentry/components/events/autofix/utils';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
@@ -105,6 +106,8 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
     });
   }, []);
 
+  const hasGitlabSupport = useHasGitlabSupport();
+
   // Flatten the tree into a list based on current expansion state
   const flatNodes = useMemo<TreeNode[]>(
     () =>
@@ -121,6 +124,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
         search,
         repoFilter,
         providerFilter,
+        hasGitlabSupport,
       }),
     [
       scmProviders,
@@ -135,6 +139,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
       search,
       repoFilter,
       providerFilter,
+      hasGitlabSupport,
     ]
   );
 

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
@@ -8,7 +8,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {addRepository, hideRepository} from 'sentry/actionCreators/integrations';
-import {useHasGitlabSupport} from 'sentry/components/events/autofix/utils';
+import {useSeerSupportedProviderIds} from 'sentry/components/events/autofix/utils';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
@@ -106,7 +106,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
     });
   }, []);
 
-  const hasGitlabSupport = useHasGitlabSupport();
+  const supportedProviderIds = useSeerSupportedProviderIds();
 
   // Flatten the tree into a list based on current expansion state
   const flatNodes = useMemo<TreeNode[]>(
@@ -124,7 +124,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
         search,
         repoFilter,
         providerFilter,
-        hasGitlabSupport,
+        supportedProviderIds,
       }),
     [
       scmProviders,
@@ -139,7 +139,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
       search,
       repoFilter,
       providerFilter,
-      hasGitlabSupport,
+      supportedProviderIds,
     ]
   );
 

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
@@ -26,6 +26,7 @@ type Props = {
   scmProviders: IntegrationProvider[];
   search: string;
   togglingRepos: Set<string>;
+  hasGitlabSupport?: boolean;
 };
 
 export function buildIntegrationTreeNodes({
@@ -41,13 +42,16 @@ export function buildIntegrationTreeNodes({
   search,
   repoFilter,
   providerFilter,
+  hasGitlabSupport,
 }: Props): TreeNode[] {
   const nodes: TreeNode[] = [];
   const query = search.trim().toLowerCase();
 
   const visibleProviders =
     providerFilter === 'seer-supported'
-      ? scmProviders.filter(p => isSupportedAutofixProvider({id: p.key, name: p.name}))
+      ? scmProviders.filter(p =>
+          isSupportedAutofixProvider({id: p.key, name: p.name}, hasGitlabSupport)
+        )
       : scmProviders;
 
   for (const provider of visibleProviders) {

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
@@ -1,4 +1,3 @@
-import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
 import type {
   ProviderFilter,
   RepoFilter,
@@ -25,8 +24,8 @@ type Props = {
   scmIntegrations: OrganizationIntegration[];
   scmProviders: IntegrationProvider[];
   search: string;
+  supportedProviderIds: string[];
   togglingRepos: Set<string>;
-  hasGitlabSupport?: boolean;
 };
 
 export function buildIntegrationTreeNodes({
@@ -42,16 +41,14 @@ export function buildIntegrationTreeNodes({
   search,
   repoFilter,
   providerFilter,
-  hasGitlabSupport,
+  supportedProviderIds,
 }: Props): TreeNode[] {
   const nodes: TreeNode[] = [];
   const query = search.trim().toLowerCase();
 
   const visibleProviders =
     providerFilter === 'seer-supported'
-      ? scmProviders.filter(p =>
-          isSupportedAutofixProvider({id: p.key, name: p.name}, hasGitlabSupport)
-        )
+      ? scmProviders.filter(p => supportedProviderIds.includes(p.key))
       : scmProviders;
 
   for (const provider of visibleProviders) {

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -17,7 +17,7 @@ import type {
   ProjectSeerPreferences,
   RepoSettings,
 } from 'sentry/components/events/autofix/types';
-import {useHasGitlabSupport} from 'sentry/components/events/autofix/utils';
+import {useSeerSupportedProviderIds} from 'sentry/components/events/autofix/utils';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
@@ -39,7 +39,8 @@ interface ProjectSeerProps {
 export function AutofixRepositories({project}: ProjectSeerProps) {
   const theme = useTheme();
   const organization = useOrganization();
-  const hasGitlabSupport = useHasGitlabSupport();
+  const supportedProviderIds = useSeerSupportedProviderIds();
+  const hasNonGithubProviders = supportedProviderIds.some(id => !id.includes('github'));
   const {data: repositories, isFetching: isFetchingRepositories} =
     useOrganizationRepositories();
   const {
@@ -250,7 +251,7 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
           {t('Working Repositories')}
           <QuestionTooltip
             title={
-              hasGitlabSupport
+              hasNonGithubProviders
                 ? tct(
                     'Seer will only be able to see code from and make PRs to the repos that you select here. A supported [link:source code integration] is required for Seer to access these repos.',
                     {
@@ -297,7 +298,7 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
                 ),
                 to: `/settings/${organization.slug}/integrations/github_enterprise/`,
               },
-              ...(hasGitlabSupport
+              ...(hasNonGithubProviders
                 ? [
                     {
                       key: 'gitlab',

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -17,6 +17,7 @@ import type {
   ProjectSeerPreferences,
   RepoSettings,
 } from 'sentry/components/events/autofix/types';
+import {useHasGitlabSupport} from 'sentry/components/events/autofix/utils';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
@@ -38,6 +39,7 @@ interface ProjectSeerProps {
 export function AutofixRepositories({project}: ProjectSeerProps) {
   const theme = useTheme();
   const organization = useOrganization();
+  const hasGitlabSupport = useHasGitlabSupport();
   const {data: repositories, isFetching: isFetchingRepositories} =
     useOrganizationRepositories();
   const {
@@ -247,12 +249,25 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
         <Flex align="center" gap="xs">
           {t('Working Repositories')}
           <QuestionTooltip
-            title={tct(
-              'Seer will only be able to see code from and make PRs to the repos that you select here. The [link:GitHub integration] is required for Seer to access these repos.',
-              {
-                link: <Link to={`/settings/${organization.slug}/integrations/github/`} />,
-              }
-            )}
+            title={
+              hasGitlabSupport
+                ? tct(
+                    'Seer will only be able to see code from and make PRs to the repos that you select here. A supported [link:source code integration] is required for Seer to access these repos.',
+                    {
+                      link: <Link to={`/settings/${organization.slug}/integrations/`} />,
+                    }
+                  )
+                : tct(
+                    'Seer will only be able to see code from and make PRs to the repos that you select here. The [link:GitHub integration] is required for Seer to access these repos.',
+                    {
+                      link: (
+                        <Link
+                          to={`/settings/${organization.slug}/integrations/github/`}
+                        />
+                      ),
+                    }
+                  )
+            }
             size="sm"
             isHoverable
           />
@@ -282,6 +297,20 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
                 ),
                 to: `/settings/${organization.slug}/integrations/github_enterprise/`,
               },
+              ...(hasGitlabSupport
+                ? [
+                    {
+                      key: 'gitlab',
+                      label: (
+                        <Flex gap="sm" align="center">
+                          <PluginIcon pluginId="gitlab" size={16} />
+                          <div>{t('GitLab')}</div>
+                        </Flex>
+                      ),
+                      to: `/settings/${organization.slug}/integrations/gitlab/`,
+                    },
+                  ]
+                : []),
             ]}
           />
           <Tooltip

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -17,7 +17,6 @@ import type {
   ProjectSeerPreferences,
   RepoSettings,
 } from 'sentry/components/events/autofix/types';
-import {useSeerSupportedProviderIds} from 'sentry/components/events/autofix/utils';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
@@ -39,8 +38,6 @@ interface ProjectSeerProps {
 export function AutofixRepositories({project}: ProjectSeerProps) {
   const theme = useTheme();
   const organization = useOrganization();
-  const supportedProviderIds = useSeerSupportedProviderIds();
-  const hasNonGithubProviders = supportedProviderIds.some(id => !id.includes('github'));
   const {data: repositories, isFetching: isFetchingRepositories} =
     useOrganizationRepositories();
   const {
@@ -250,25 +247,12 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
         <Flex align="center" gap="xs">
           {t('Working Repositories')}
           <QuestionTooltip
-            title={
-              hasNonGithubProviders
-                ? tct(
-                    'Seer will only be able to see code from and make PRs to the repos that you select here. A supported [link:source code integration] is required for Seer to access these repos.',
-                    {
-                      link: <Link to={`/settings/${organization.slug}/integrations/`} />,
-                    }
-                  )
-                : tct(
-                    'Seer will only be able to see code from and make PRs to the repos that you select here. The [link:GitHub integration] is required for Seer to access these repos.',
-                    {
-                      link: (
-                        <Link
-                          to={`/settings/${organization.slug}/integrations/github/`}
-                        />
-                      ),
-                    }
-                  )
-            }
+            title={tct(
+              'Seer will only be able to see code from and make PRs to the repos that you select here. The [link:GitHub integration] is required for Seer to access these repos.',
+              {
+                link: <Link to={`/settings/${organization.slug}/integrations/github/`} />,
+              }
+            )}
             size="sm"
             isHoverable
           />
@@ -298,20 +282,6 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
                 ),
                 to: `/settings/${organization.slug}/integrations/github_enterprise/`,
               },
-              ...(hasNonGithubProviders
-                ? [
-                    {
-                      key: 'gitlab',
-                      label: (
-                        <Flex gap="sm" align="center">
-                          <PluginIcon pluginId="gitlab" size={16} />
-                          <div>{t('GitLab')}</div>
-                        </Flex>
-                      ),
-                      to: `/settings/${organization.slug}/integrations/gitlab/`,
-                    },
-                  ]
-                : []),
             ]}
           />
           <Tooltip

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -1251,7 +1251,7 @@ describe('ProjectSeer', () => {
 
     it('shows GitLab repos as selectable when seer-gitlab-support flag is on', async () => {
       const orgWithGitlabSupport = OrganizationFixture({
-        features: ['seer-gitlab-support', 'seat-based-seer-enabled'],
+        features: ['seer-gitlab-support'],
       });
 
       // Override the repos mock from beforeEach to include a GitLab repo

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -1230,4 +1230,88 @@ describe('ProjectSeer', () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe('GitLab support', () => {
+    const reposWithGitlab = [
+      RepositoryFixture({
+        id: '1',
+        name: 'getsentry/sentry',
+        externalId: '101',
+        provider: {id: 'integrations:github', name: 'GitHub'},
+        integrationId: '201',
+      }),
+      RepositoryFixture({
+        id: '3',
+        name: 'getsentry/gitlab-repo',
+        externalId: '103',
+        provider: {id: 'integrations:gitlab', name: 'GitLab'},
+        integrationId: '203',
+      }),
+    ];
+
+    it('shows GitLab repos as selectable when seer-gitlab-support flag is on', async () => {
+      const orgWithGitlabSupport = OrganizationFixture({
+        features: ['seer-gitlab-support', 'seat-based-seer-enabled'],
+      });
+
+      // Override the repos mock from beforeEach to include a GitLab repo
+      MockApiClient.addMockResponse({
+        url: `/organizations/${orgWithGitlabSupport.slug}/repos/`,
+        query: {status: 'active'},
+        method: 'GET',
+        body: reposWithGitlab,
+      });
+
+      render(<ProjectSeer />, {
+        organization: orgWithGitlabSupport,
+        outletContext: {project},
+      });
+      renderGlobalModal({organization: orgWithGitlabSupport});
+
+      // Wait for repos to load (sentry is pre-selected via code_mapping_repos in beforeEach)
+      expect(await screen.findByText('getsentry/sentry')).toBeInTheDocument();
+
+      // Open the add repo modal — it shows only unselected repos
+      await userEvent.click(screen.getByRole('button', {name: 'Add Repos'}));
+
+      const modal = await screen.findByRole('dialog');
+
+      // GitLab repo should appear in the modal and not be visually disabled
+      const gitlabRepoItem = await within(modal).findByText('getsentry/gitlab-repo');
+      expect(gitlabRepoItem).toBeInTheDocument();
+
+      // The checkbox for GitLab repo should not be disabled (since the flag is on)
+      const gitlabCheckbox = within(modal).getByRole('checkbox', {
+        checked: false,
+      });
+      expect(gitlabCheckbox).toBeEnabled();
+    });
+
+    it('shows GitLab repos as disabled when seer-gitlab-support flag is off', async () => {
+      // Override the repos mock from beforeEach to include a GitLab repo
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/`,
+        query: {status: 'active'},
+        method: 'GET',
+        body: reposWithGitlab,
+      });
+
+      render(<ProjectSeer />, {
+        organization,
+        outletContext: {project},
+      });
+      renderGlobalModal();
+
+      // Wait for repos to load (sentry is pre-selected via code_mapping_repos in beforeEach)
+      expect(await screen.findByText('getsentry/sentry')).toBeInTheDocument();
+
+      // Open the add repo modal — it shows only unselected repos
+      await userEvent.click(screen.getByRole('button', {name: 'Add Repos'}));
+
+      const modal = await screen.findByRole('dialog');
+
+      // GitLab repo should appear in the list but be disabled (not selectable without the flag)
+      expect(within(modal).getByText('getsentry/gitlab-repo')).toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/settings/projectSeer/selectableRepoItem.tsx
+++ b/static/app/views/settings/projectSeer/selectableRepoItem.tsx
@@ -5,7 +5,7 @@ import {Checkbox} from '@sentry/scraps/checkbox';
 import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
+import {useIsSeerSupportedProvider} from 'sentry/components/events/autofix/utils';
 import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 
@@ -16,7 +16,8 @@ interface Props {
 }
 
 export function SelectableRepoItem({repo, isSelected, onToggle}: Props) {
-  const isSupportedProvider = isSupportedAutofixProvider(repo.provider);
+  const isSeerSupportedProvider = useIsSeerSupportedProvider();
+  const isSupportedProvider = isSeerSupportedProvider(repo.provider);
 
   return (
     <RepoListItemContainer

--- a/static/app/views/settings/seer/overview/scmOverviewSection.tsx
+++ b/static/app/views/settings/seer/overview/scmOverviewSection.tsx
@@ -17,7 +17,10 @@ import {
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
-import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
+import {
+  isSeerSupportedProvider,
+  useSeerSupportedProviderIds,
+} from 'sentry/components/events/autofix/utils';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {getProviderConfigUrl} from 'sentry/components/repositories/scmIntegrationTree/providerConfigLink';
@@ -57,13 +60,17 @@ export function useSCMOverviewSection(): SCMOverviewSectionData {
     isPending,
     isError,
   } = useScmIntegrationTreeData();
+  const supportedProviderIds = useSeerSupportedProviderIds();
 
   const supportedScmIntegrations = useMemo(
     () =>
       scmIntegrations.filter(i =>
-        isSupportedAutofixProvider({id: i.provider.key, name: i.provider.name})
+        isSeerSupportedProvider(
+          {id: i.provider.key, name: i.provider.name},
+          supportedProviderIds
+        )
       ),
-    [scmIntegrations]
+    [scmIntegrations, supportedProviderIds]
   );
 
   const isReposPending = Object.values(reposPendingByIntegrationId).some(Boolean);

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -13,8 +13,8 @@ import {Text} from '@sentry/scraps/text';
 import {openModal} from 'sentry/actionCreators/modal';
 import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {
-  isSupportedAutofixProvider,
-  useHasGitlabSupport,
+  isSeerSupportedProvider,
+  useSeerSupportedProviderIds,
 } from 'sentry/components/events/autofix/utils';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -58,7 +58,7 @@ export function SeerRepoTable() {
     parseAsSort.withDefault({field: 'name', kind: 'asc'})
   );
 
-  const hasGitlabSupport = useHasGitlabSupport();
+  const supportedProviderIds = useSeerSupportedProviderIds();
 
   const queryOptions = organizationRepositoriesInfiniteOptions({
     organization,
@@ -74,7 +74,7 @@ export function SeerRepoTable() {
         .filter(
           repository =>
             repository.externalId &&
-            isSupportedAutofixProvider(repository.provider, hasGitlabSupport)
+            isSeerSupportedProvider(repository.provider, supportedProviderIds)
         )
         .sort((a, b) => {
           if (sort.field === 'name') {

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -12,7 +12,10 @@ import {Text} from '@sentry/scraps/text';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
-import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
+import {
+  isSupportedAutofixProvider,
+  useHasGitlabSupport,
+} from 'sentry/components/events/autofix/utils';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
@@ -55,6 +58,8 @@ export function SeerRepoTable() {
     parseAsSort.withDefault({field: 'name', kind: 'asc'})
   );
 
+  const hasGitlabSupport = useHasGitlabSupport();
+
   const queryOptions = organizationRepositoriesInfiniteOptions({
     organization,
     query: {per_page: 100, query: searchTerm, sort},
@@ -68,7 +73,8 @@ export function SeerRepoTable() {
       )
         .filter(
           repository =>
-            repository.externalId && isSupportedAutofixProvider(repository.provider)
+            repository.externalId &&
+            isSupportedAutofixProvider(repository.provider, hasGitlabSupport)
         )
         .sort((a, b) => {
           if (sort.field === 'name') {

--- a/static/gsApp/views/seerAutomation/repoDetails.tsx
+++ b/static/gsApp/views/seerAutomation/repoDetails.tsx
@@ -5,10 +5,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {NotFound} from 'sentry/components/errors/notFound';
-import {
-  isSupportedAutofixProvider,
-  useHasGitlabSupport,
-} from 'sentry/components/events/autofix/utils';
+import {useIsSeerSupportedProvider} from 'sentry/components/events/autofix/utils';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
@@ -25,7 +22,7 @@ import {useRepositoryWithSettings} from 'getsentry/views/seerAutomation/onboardi
 export default function SeerRepoDetails() {
   const {repoId} = useParams<{repoId: string}>();
   const organization = useOrganization();
-  const hasGitlabSupport = useHasGitlabSupport();
+  const isSupportedProvider = useIsSeerSupportedProvider();
 
   const hasSeer =
     organization.features.includes('seat-based-seer-enabled') ||
@@ -99,7 +96,7 @@ export default function SeerRepoDetails() {
             }
           )}
         />
-        {isSupportedAutofixProvider(repoWithSettings?.provider, hasGitlabSupport) ? (
+        {isSupportedProvider(repoWithSettings?.provider) ? (
           <RepoDetailsForm
             organization={organization}
             repoWithSettings={repoWithSettings}

--- a/static/gsApp/views/seerAutomation/repoDetails.tsx
+++ b/static/gsApp/views/seerAutomation/repoDetails.tsx
@@ -5,7 +5,10 @@ import {Text} from '@sentry/scraps/text';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {NotFound} from 'sentry/components/errors/notFound';
-import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
+import {
+  isSupportedAutofixProvider,
+  useHasGitlabSupport,
+} from 'sentry/components/events/autofix/utils';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
@@ -22,6 +25,7 @@ import {useRepositoryWithSettings} from 'getsentry/views/seerAutomation/onboardi
 export default function SeerRepoDetails() {
   const {repoId} = useParams<{repoId: string}>();
   const organization = useOrganization();
+  const hasGitlabSupport = useHasGitlabSupport();
 
   const hasSeer =
     organization.features.includes('seat-based-seer-enabled') ||
@@ -95,7 +99,7 @@ export default function SeerRepoDetails() {
             }
           )}
         />
-        {isSupportedAutofixProvider(repoWithSettings?.provider) ? (
+        {isSupportedAutofixProvider(repoWithSettings?.provider, hasGitlabSupport) ? (
           <RepoDetailsForm
             organization={organization}
             repoWithSettings={repoWithSettings}


### PR DESCRIPTION
If an org has seat-based billing enabled _and_ have the `seer-gitlab-support` feature flag enabled, then allow GitLab to be configurable for Seer. Note that only internal Sentry orgs have the gitlab feature flag enabled.
