### PR TITLE
fix(explore): Always show selected metric first in metric selector

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -323,6 +323,18 @@ describe('MetricSelector', () => {
   });
 
   describe('metric-specific behavior', () => {
+    it('places the selected metric first in the list', async () => {
+      // 'foo' is not first alphabetically, but it should appear first when selected
+      const traceMetric = {name: 'foo', type: 'distribution'};
+      render(<MetricSelector traceMetric={traceMetric} onChange={jest.fn()} />, {
+        organization,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'foo'}));
+      const options = await screen.findAllByRole('option');
+      expect(options[0]).toHaveTextContent('foo');
+    });
+
     it('renders list of metrics from API', async () => {
       render(<MetricSelector traceMetric={DEFAULT_TRACE_METRIC} onChange={jest.fn()} />, {
         organization,

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -206,7 +206,11 @@ export function MetricSelector({
   // avoid duplication.
   const metricOptions = useMemo((): MetricSelectOption[] => {
     const selectedMetricValue = traceMetric.name
-      ? makeMetricSelectValue(traceMetric)
+      ? makeMetricSelectValue(
+          hasMetricUnitsUI
+            ? traceMetric
+            : {name: traceMetric.name, type: traceMetric.type}
+        )
       : null;
 
     const apiOptions =

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -201,26 +201,16 @@ export function MetricSelector({
     ]
   );
 
-  // Merge API results with the currently selected metric. If the selected
-  // metric isn't present in the API response (e.g. filtered by search),
-  // prepend it so the user always sees their current selection.
+  // Always show the selected metric at the top of the list so it's easy to
+  // find when the dropdown is reopened. Filter it out of the API results to
+  // avoid duplication.
   const metricOptions = useMemo((): MetricSelectOption[] => {
-    const shouldIncludeOptionFromTraceMetric =
-      traceMetric.name &&
-      !metricOptionsData?.data?.some(
-        option =>
-          makeMetricSelectValue({
-            name: option[TraceMetricKnownFieldKey.METRIC_NAME],
-            type: option[TraceMetricKnownFieldKey.METRIC_TYPE],
-            unit: hasMetricUnitsUI
-              ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
-              : undefined,
-          }) === makeMetricSelectValue(traceMetric)
-      );
+    const selectedMetricValue = traceMetric.name
+      ? makeMetricSelectValue(traceMetric)
+      : null;
 
-    return [
-      ...(shouldIncludeOptionFromTraceMetric ? [optionFromTraceMetric] : []),
-      ...(metricOptionsData?.data?.map(option => ({
+    const apiOptions =
+      metricOptionsData?.data?.map(option => ({
         label: option[TraceMetricKnownFieldKey.METRIC_NAME],
         value: makeMetricSelectValue({
           name: option[TraceMetricKnownFieldKey.METRIC_NAME],
@@ -247,7 +237,18 @@ export function MetricSelector({
             metricUnit={option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT}
           />
         ),
-      })) ?? []),
+      })) ?? [];
+
+    // Prefer the API version of the selected metric (it has count/lastSeen),
+    // falling back to the bare optionFromTraceMetric when the API hasn't
+    // returned it (e.g. filtered by search or still loading).
+    const selectedOption = selectedMetricValue
+      ? (apiOptions.find(o => o.value === selectedMetricValue) ?? optionFromTraceMetric)
+      : null;
+
+    return [
+      ...(selectedOption ? [selectedOption] : []),
+      ...apiOptions.filter(o => o.value !== selectedMetricValue),
     ];
   }, [metricOptionsData, optionFromTraceMetric, traceMetric, hasMetricUnitsUI]);
 


### PR DESCRIPTION
Update the metrics selector so that the selected option is always at the top of the list. With the refactor to the new dropdown with this was not happening as expected.

Refs LOGS-634