### PR TITLE
feat(utils): Add ContextPropagatingThreadPoolExecutor and S016 lint rule

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,8 @@ sentry =
 # All other linting (E, W, F, B, LOG, I) is handled by ruff.
 # See [tool.ruff] in pyproject.toml for the main linting configuration.
 select = S
+# S016 is temporarily disabled until the ThreadPoolExecutor migration is complete.
+extend-ignore = S016
 per-file-ignores =
     # these scripts must have minimal dependencies so opt out of the usual sentry rules
     .github/*: S

--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import contextvars
 import functools
 import logging
 import threading
 from collections.abc import Callable
 from concurrent.futures import Future, InvalidStateError
+from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor  # noqa: S016
 from concurrent.futures._base import FINISHED, RUNNING
 from contextlib import contextmanager
 from queue import Full, PriorityQueue
@@ -257,6 +259,20 @@ class ThreadedExecutor(Executor):
             if future.set_running_or_notify_cancel():
                 future.set_exception(error)
         return future
+
+
+class ContextPropagatingThreadPoolExecutor(_ThreadPoolExecutor):
+    """A ThreadPoolExecutor that automatically copies the caller's
+    ``contextvars.Context`` into each worker invocation.
+
+    This ensures Sentry SDK scopes (isolation_scope, current_scope),
+    OpenTelemetry trace context, and any other context variables are
+    available in worker threads without manual propagation.
+    """
+
+    def submit(self, fn, /, *args, **kwargs):
+        ctx = contextvars.copy_context()
+        return super().submit(ctx.run, fn, *args, **kwargs)
 
 
 class FutureSet:

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,4 +1,5 @@
 import _thread
+import contextvars
 from concurrent.futures import CancelledError, Future
 from contextlib import contextmanager
 from queue import Full
@@ -6,9 +7,11 @@ from threading import Event
 from unittest import mock
 
 import pytest
+import sentry_sdk
 
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
 from sentry.utils.concurrent import (
+    ContextPropagatingThreadPoolExecutor,
     FutureSet,
     SynchronousExecutor,
     ThreadedExecutor,
@@ -281,3 +284,60 @@ def test_threaded_executor() -> None:
     low_priority_waiting.set()  # let the task finish
     assert low_priority_future.result(timeout=1) == 2
     assert low_priority_future.done()
+
+
+# --- ContextPropagatingThreadPoolExecutor tests ---
+
+_test_var: contextvars.ContextVar[str] = contextvars.ContextVar("test_var")
+
+
+def test_context_propagating_executor_submit() -> None:
+    _test_var.set("hello")
+
+    def get_var():
+        return _test_var.get()
+
+    with ContextPropagatingThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(get_var)
+        assert future.result(timeout=2) == "hello"
+
+
+def test_context_propagating_executor_map() -> None:
+    _test_var.set("from_parent")
+
+    def get_var_with_arg(x):
+        return (_test_var.get(), x)
+
+    with ContextPropagatingThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(get_var_with_arg, [1, 2, 3]))
+
+    assert results == [("from_parent", 1), ("from_parent", 2), ("from_parent", 3)]
+
+
+def test_context_propagating_executor_isolation() -> None:
+    """Mutations in worker threads don't leak to the parent or other tasks."""
+    _test_var.set("original")
+
+    def mutate_var(value):
+        _test_var.set(value)
+        return _test_var.get()
+
+    with ContextPropagatingThreadPoolExecutor(max_workers=1) as executor:
+        assert executor.submit(mutate_var, "changed_1").result(timeout=2) == "changed_1"
+        assert executor.submit(mutate_var, "changed_2").result(timeout=2) == "changed_2"
+
+    # Parent context is unaffected
+    assert _test_var.get() == "original"
+
+
+def test_context_propagating_executor_sentry_scope() -> None:
+    """Sentry SDK scopes are propagated via contextvars."""
+    sentry_sdk.get_current_scope().set_tag("test_key", "test_value")
+
+    def read_scope_tag():
+        return sentry_sdk.get_current_scope()._tags.get("test_key")
+
+    with ContextPropagatingThreadPoolExecutor(max_workers=1) as executor:
+        result = executor.submit(read_scope_tag).result(timeout=2)
+
+    assert result == "test_value"

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -243,6 +243,32 @@ def test(monkeypatch) -> None: pass
     assert _run(src) == expected
 
 
+def test_S016() -> None:
+    # Direct import of ThreadPoolExecutor should be flagged
+    src = "from concurrent.futures import ThreadPoolExecutor\n"
+    errors = _run(src)
+    assert errors == [
+        "t.py:1:0: S016 Use `from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor`"
+        " instead of `concurrent.futures.ThreadPoolExecutor` to ensure contextvars propagation.",
+    ]
+
+    # Importing ThreadPoolExecutor alongside other names should still be flagged
+    src = "from concurrent.futures import ThreadPoolExecutor, as_completed\n"
+    errors = _run(src)
+    assert errors == [
+        "t.py:1:0: S016 Use `from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor`"
+        " instead of `concurrent.futures.ThreadPoolExecutor` to ensure contextvars propagation.",
+    ]
+
+    # Importing other names from concurrent.futures is fine
+    src = "from concurrent.futures import as_completed, wait, Future\n"
+    assert _run(src) == []
+
+    # Importing from our wrapper is fine
+    src = "from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor\n"
+    assert _run(src) == []
+
+
 def test_S015_current_or_future_year() -> None:
     cy = datetime.now(timezone.utc).year
     msg = _s015_msg()

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -41,6 +41,8 @@ S013_msg = "S013 Use `django.contrib.postgres.fields.array.ArrayField` instead"
 
 S014_msg = "S014 Use `unittest.mock` instead"
 
+S016_msg = "S016 Use `from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor` instead of `concurrent.futures.ThreadPoolExecutor` to ensure contextvars propagation."
+
 
 # --- S015: do not hardcode current or future UTC year as test "now" ---
 # Flag year >= current UTC year at lint time. Module/class scope + freeze_time(datetime(...)).
@@ -113,6 +115,10 @@ class SentryVisitor(ast.NodeVisitor):
                 self.errors.append((node.lineno, node.col_offset, S012_msg))
             elif node.module == "sentry.db.models.fields.array":
                 self.errors.append((node.lineno, node.col_offset, S013_msg))
+            elif node.module == "concurrent.futures" and any(
+                x.name == "ThreadPoolExecutor" for x in node.names
+            ):
+                self.errors.append((node.lineno, node.col_offset, S016_msg))
 
         self.generic_visit(node)
 


### PR DESCRIPTION
Add a `ThreadPoolExecutor` subclass that automatically propagates `contextvars.Context` to worker threads via `copy_context()`/`ctx.run()`. This ensures Sentry SDK scopes, OpenTelemetry trace context, and any other context variables are available in worker threads without manual scope passing.

Python's `ThreadPoolExecutor` doesn't propagate `contextvars.Context` to worker threads. Since Sentry SDK v2 stores scopes in contextvars, threads silently lose tracing context. Currently only 2-3 files (snuba.py, snuba_rpc.py) manually propagate scopes — ~25 other `ThreadPoolExecutor` usages have no context propagation at all. This is the same pattern already proven in production in [Seer's `ContextAwareThreadPoolExecutor`](https://github.com/getsentry/seer/blob/main/src/seer/automation/codebase/scm_api_metrics.py).

Also adds flake8 rule **S016** to ban direct `from concurrent.futures import ThreadPoolExecutor` imports, directing developers to use the new wrapper instead. This prevents future regressions.

Follow-up PRs will:
1. Migrate all existing `ThreadPoolExecutor` usages to the wrapper
2. Remove the manual scope-passing boilerplate in snuba.py and snuba_rpc.py


Agent transcript: https://claudescope.sentry.dev/share/F2CIltqVwgfmTBY5XDunaFCE5-miOvy8NQSltE-F-ZI