### PR TITLE
ref(ai-search): cleanup redundant ai flag checks

### DIFF
--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -295,12 +295,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
     ]
   );
 
-  const areAiFeaturesAllowed =
-    enableAISearch &&
-    !organization?.hideAiFeatures &&
-    organization.features.includes('gen-ai-features');
-
-  if (!areAiFeaturesAllowed) {
+  if (!enableAISearch) {
     return null;
   }
 

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
@@ -158,8 +158,12 @@ export function ResultsSearchQueryBuilder(props: Props) {
       includeTransactions,
     });
 
-  // AI search is only enabled for Errors dataset
+  // AI search is only enabled for Errors dataset if translate endpoint is enabled
   const isErrorsDataset = dataset === DiscoverDatasets.ERRORS;
+  const organization = useOrganization();
+  const hasTranslateEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
 
   const searchBarProps = {
     placeholderText,
@@ -180,7 +184,7 @@ export function ResultsSearchQueryBuilder(props: Props) {
     return (
       <SearchQueryBuilderProvider
         initialQuery={props.query ?? ''}
-        enableAISearch
+        enableAISearch={hasTranslateEndpoint}
         aiSearchBadgeType="alpha"
         disabled={disabled}
         fieldDefinitionGetter={undefined}

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
@@ -143,8 +143,6 @@ export function ResultsSearchQueryBuilder(props: Props) {
     includeTransactions = true,
   } = props;
 
-  const organization = useOrganization();
-
   const placeholderText = useMemo(() => {
     return placeholder ?? t('Search for events, users, tags, and more');
   }, [placeholder]);
@@ -162,11 +160,6 @@ export function ResultsSearchQueryBuilder(props: Props) {
 
   // AI search is only enabled for Errors dataset
   const isErrorsDataset = dataset === DiscoverDatasets.ERRORS;
-  const areAiFeaturesAllowed =
-    isErrorsDataset &&
-    !organization?.hideAiFeatures &&
-    organization.features.includes('gen-ai-features') &&
-    organization.features.includes('gen-ai-search-agent-translate');
 
   const searchBarProps = {
     placeholderText,
@@ -187,7 +180,7 @@ export function ResultsSearchQueryBuilder(props: Props) {
     return (
       <SearchQueryBuilderProvider
         initialQuery={props.query ?? ''}
-        enableAISearch={areAiFeaturesAllowed}
+        enableAISearch
         aiSearchBadgeType="alpha"
         disabled={disabled}
         fieldDefinitionGetter={undefined}

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -25,7 +25,6 @@ import type {AggregationKey} from 'sentry/utils/fields';
 import {HOUR} from 'sentry/utils/formatters';
 import {useQueryClient, type InfiniteData} from 'sentry/utils/queryClient';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
 import {SchemaHintsList} from 'sentry/views/explore/components/schemaHints/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
@@ -122,7 +121,6 @@ const LogsSearchSection = memo(function LogsSearchSection({
   datePageFilterProps,
   searchBarWidthOffset,
 }: LogsSearchSectionProps) {
-  const organization = useOrganization();
   const logsSearch = useQueryParamsSearch();
   const logsSearchQuery = logsSearch.formatString();
   const groupBys = useQueryParamsGroupBys();
@@ -130,12 +128,6 @@ const LogsSearchSection = memo(function LogsSearchSection({
   const [interval] = useChartInterval();
   const visualizes = useQueryParamsVisualizes();
   const aggregateSortBys = useQueryParamsAggregateSortBys();
-
-  // AI search is gated behind the gen-ai-search-agent-translate feature flag
-  const areAiFeaturesAllowed =
-    !organization?.hideAiFeatures &&
-    organization.features.includes('gen-ai-features') &&
-    organization.features.includes('gen-ai-search-agent-translate');
 
   const saveAsItems = useSaveAsItems({
     visualizes,
@@ -178,7 +170,7 @@ const LogsSearchSection = memo(function LogsSearchSection({
 
   return (
     <SearchQueryBuilderProvider
-      enableAISearch={areAiFeaturesAllowed}
+      enableAISearch
       aiSearchBadgeType="alpha"
       {...searchQueryBuilderProviderProps}
     >

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -25,6 +25,7 @@ import type {AggregationKey} from 'sentry/utils/fields';
 import {HOUR} from 'sentry/utils/formatters';
 import {useQueryClient, type InfiniteData} from 'sentry/utils/queryClient';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
 import {SchemaHintsList} from 'sentry/views/explore/components/schemaHints/schemaHintsList';
 import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
@@ -168,9 +169,14 @@ const LogsSearchSection = memo(function LogsSearchSection({
     return [];
   }, []);
 
+  const organization = useOrganization();
+  const hasTranslateEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
+
   return (
     <SearchQueryBuilderProvider
-      enableAISearch
+      enableAISearch={hasTranslateEndpoint}
       aiSearchBadgeType="alpha"
       {...searchQueryBuilderProviderProps}
     >

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -259,11 +259,6 @@ export function LogsTabSeerComboBox() {
     ]
   );
 
-  const areAiFeaturesAllowed =
-    enableAISearch &&
-    !organization?.hideAiFeatures &&
-    organization.features.includes('gen-ai-features');
-
   const usePollingEndpoint = organization.features.includes(
     'gen-ai-search-agent-translate'
   );
@@ -311,7 +306,7 @@ export function LogsTabSeerComboBox() {
     []
   );
 
-  if (!areAiFeaturesAllowed) {
+  if (!enableAISearch) {
     return null;
   }
 

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -366,8 +366,6 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
 
   const organization = useOrganization();
-  const areAiFeaturesAllowed =
-    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
   const hasRawSearchReplacement = organization.features.includes(
     'search-query-builder-raw-search-replacement'
   );
@@ -449,10 +447,7 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
 
   return (
     <Layout.Main width="full">
-      <SearchQueryBuilderProvider
-        enableAISearch={areAiFeaturesAllowed}
-        {...spanSearchQueryBuilderProviderProps}
-      >
+      <SearchQueryBuilderProvider enableAISearch {...spanSearchQueryBuilderProviderProps}>
         <TourElement<ExploreSpansTour>
           tourContext={ExploreSpansTourContext}
           id={ExploreSpansTour.SEARCH_BAR}

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -268,13 +268,8 @@ export function SpansTabSeerComboBox() {
     [askSeerSuggestedQueryRef, navigate, organization, pageFilters.selection]
   );
 
-  const areAiFeaturesAllowed =
-    enableAISearch &&
-    !organization?.hideAiFeatures &&
-    organization.features.includes('gen-ai-features');
-
   useTraceExploreAiQuerySetup({
-    enableAISearch: areAiFeaturesAllowed && !useTranslateEndpoint,
+    enableAISearch: enableAISearch && !useTranslateEndpoint,
   });
 
   // Get selected project IDs for the polling variant

--- a/static/app/views/issueList/issueSearch.tsx
+++ b/static/app/views/issueList/issueSearch.tsx
@@ -41,6 +41,11 @@ export function IssueSearch({query, onSearch, className}: IssueSearchProps) {
   const {getFilterKeys, getFilterKeySections, getTagValues} =
     useIssueListSearchBarDataProvider({pageFilters});
 
+  const organization = useOrganization();
+  const hasTranslateEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
+
   return (
     <SearchQueryBuilderProvider
       initialQuery={query || ''}
@@ -48,7 +53,7 @@ export function IssueSearch({query, onSearch, className}: IssueSearchProps) {
       filterKeySections={getFilterKeySections()}
       getTagValues={getTagValues}
       searchSource="main_search"
-      enableAISearch
+      enableAISearch={hasTranslateEndpoint}
       aiSearchBadgeType="alpha"
       onSearch={onSearch}
       recentSearches={SavedSearchType.ISSUE}

--- a/static/app/views/issueList/issueSearch.tsx
+++ b/static/app/views/issueList/issueSearch.tsx
@@ -37,16 +37,9 @@ function IssueSearchBar({query, onSearch, className}: IssueSearchProps) {
 }
 
 export function IssueSearch({query, onSearch, className}: IssueSearchProps) {
-  const organization = useOrganization();
   const {selection: pageFilters} = usePageFilters();
   const {getFilterKeys, getFilterKeySections, getTagValues} =
     useIssueListSearchBarDataProvider({pageFilters});
-
-  // Gate behind gen-ai-search-agent-translate (internal only) plus standard AI consent checks
-  const areAiFeaturesAllowed =
-    !organization?.hideAiFeatures &&
-    organization.features.includes('gen-ai-features') &&
-    organization.features.includes('gen-ai-search-agent-translate');
 
   return (
     <SearchQueryBuilderProvider
@@ -55,7 +48,7 @@ export function IssueSearch({query, onSearch, className}: IssueSearchProps) {
       filterKeySections={getFilterKeySections()}
       getTagValues={getTagValues}
       searchSource="main_search"
-      enableAISearch={areAiFeaturesAllowed}
+      enableAISearch
       aiSearchBadgeType="alpha"
       onSearch={onSearch}
       recentSearches={SavedSearchType.ISSUE}


### PR DESCRIPTION
gen-ai access is already checked in https://github.com/getsentry/sentry/blob/master/static/app/components/searchQueryBuilder/context.tsx#L142-L145
