### PR TITLE
feat(integrations): Add API mode support to IntegrationPipeline

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -27,7 +27,7 @@ from sentry.organizations.services.organization import (
     organization_service,
 )
 from sentry.pipeline.provider import PipelineProvider
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.shared_integrations.constants import (
     ERR_INTERNAL,
     ERR_UNAUTHORIZED,
@@ -311,6 +311,14 @@ class IntegrationProvider(PipelineProvider["IntegrationPipeline"], abc.ABC):
         >>>    return []
         """
         raise NotImplementedError
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        """
+        Return API step objects for this provider's pipeline, or None if API
+        mode is not supported. Override to enable the pipeline API for this
+        integration.
+        """
+        return None
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
         """

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -4,16 +4,20 @@ import logging
 from collections.abc import Callable, Sequence
 from typing import Any, Never, TypedDict
 
+import sentry_sdk
 from django.db import IntegrityError
+from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase, HttpResponseRedirect
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from sentry_sdk.tracing import TransactionSource
 
 from sentry import analytics, features
 from sentry.analytics.events.integration_pipeline_step import IntegrationPipelineStep
 from sentry.api.serializers import serialize
 from sentry.auth.superuser import superuser_has_permission
 from sentry.constants import ObjectStatus
+from sentry.features.exceptions import FeatureNotRegistered
 from sentry.integrations.base import IntegrationData, IntegrationDomain, IntegrationProvider
 from sentry.integrations.manager import default_manager
 from sentry.integrations.models.integration import Integration
@@ -22,13 +26,15 @@ from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
 )
+from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline.base import Pipeline
 from sentry.pipeline.store import PipelineSessionStore
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationProviderError
 from sentry.silo.base import SiloMode
 from sentry.users.models.identity import Identity, IdentityProvider, IdentityStatus
@@ -36,9 +42,58 @@ from sentry.utils import metrics
 from sentry.web.helpers import render_to_response
 from sentry.workflow_engine.service.action import action_service
 
-__all__ = ["IntegrationPipeline"]
+__all__ = ["IntegrationPipeline", "IntegrationPipelineError", "initialize_integration_pipeline"]
 
 logger = logging.getLogger(__name__)
+
+
+class IntegrationPipelineError(Exception):
+    """Raised when an integration pipeline cannot be initialized."""
+
+    def __init__(self, message: str, not_found: bool = False) -> None:
+        self.not_found = not_found
+        super().__init__(message)
+
+
+def initialize_integration_pipeline(
+    request: HttpRequest,
+    organization: Organization | RpcOrganization,
+    provider_id: str,
+) -> IntegrationPipeline:
+    """
+    Creates, validates, and initializes an IntegrationPipeline for the given
+    organization and provider. Raises IntegrationPipelineError if any pre-checks
+    fail (feature flags disabled or provider cannot be added).
+    """
+    scope = sentry_sdk.get_current_scope()
+    scope.set_transaction_name(f"integration.{provider_id}", source=TransactionSource.VIEW)
+
+    pipeline = IntegrationPipeline(
+        request=request, organization=organization, provider_key=provider_id
+    )
+
+    assert isinstance(pipeline.provider, IntegrationProvider)
+
+    is_feature_enabled: dict[str, bool] = {}
+    for feature in pipeline.provider.features:
+        feature_flag_name = "organizations:integrations-%s" % feature.value
+        try:
+            features.get(feature_flag_name, None)
+            is_feature_enabled[feature_flag_name] = features.has(feature_flag_name, organization)
+        except FeatureNotRegistered:
+            is_feature_enabled[feature_flag_name] = True
+
+    if not any(is_feature_enabled.values()):
+        raise IntegrationPipelineError(
+            "At least one feature from this list has to be enabled in order to setup the integration:\n%s"
+            % "\n".join(is_feature_enabled)
+        )
+
+    if not pipeline.provider.can_add:
+        raise IntegrationPipelineError("Integration cannot be added.", not_found=True)
+
+    pipeline.initialize()
+    return pipeline
 
 
 class _IntegrationDefaults(TypedDict):
@@ -117,6 +172,9 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
     ]:
         return self.provider.get_pipeline_views()
 
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return self.provider.get_pipeline_api_steps()
+
     def get_analytics_event(self) -> analytics.Event | None:
         pipeline_type = "reauth" if self.fetch_state("integration_id") else "install"
         return IntegrationPipelineStep(
@@ -146,9 +204,8 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
                 id=self.organization.id, user_id=self.request.user.id
             )
 
-            if (
-                org_context
-                and (not org_context.member or "org:integrations" not in org_context.member.scopes)
+            if not org_context or (
+                (not org_context.member or "org:integrations" not in org_context.member.scopes)
                 and not superuser_has_permission(self.request, ["org:integrations"])
             ):
                 error_message = "You must be an organization owner, manager or admin to install this integration."
@@ -188,14 +245,17 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
                 )
                 return self.render_warning(str(e))
 
-            response = self._finish_pipeline(data)
+            try:
+                response = self._finish_pipeline(data)
+            except IntegrationError as e:
+                lifecycle.record_failure(e)
+                return self._dialog_response({"error": str(e)}, False)
 
             extra = data.get("post_install_data", {})
 
             self.provider.create_audit_log_entry(
                 self.integration, self.organization, self.request, "install", extra=extra
             )
-            # Enable all actions for the organization installing the integration
             self._enable_actions()
             self.provider.post_install(self.integration, self.organization, extra=extra)
             self.clear_session()
@@ -208,7 +268,13 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
 
         return response
 
-    def _finish_pipeline(self, data: IntegrationData) -> HttpResponseBase:
+    def _install_integration(self, data: IntegrationData) -> OrganizationIntegration:
+        """
+        Core model operations for finishing the pipeline: create/update
+        Integration, link identity, create OrganizationIntegration.
+
+        Raises IntegrationError on failure. Returns the created OrganizationIntegration.
+        """
         if "expect_exists" in data:
             self.integration = Integration.objects.get(
                 provider=self.provider.integration_key, external_id=data["external_id"]
@@ -229,7 +295,6 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
             idp_external_id = data.get("idp_external_id", data["external_id"])
             idp_config = data.get("idp_config", {})
 
-            # Create identity provider for this integration if necessary
             idp, created = IdentityProvider.objects.get_or_create(
                 external_id=idp_external_id, type=identity["type"], defaults={"config": idp_config}
             )
@@ -278,19 +343,15 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
                             "provider_key": self.provider.key,
                         },
                     )
-                    # if we don't need a default identity, we don't have to throw an error
+                    # If we don't need a default identity, we don't have to throw an error
                     if self.provider.needs_default_identity:
-                        # The external_id is linked to a different user.
                         proper_name = idp.get_provider().name
-                        return self._dialog_response(
-                            {
-                                "error": _(
-                                    "The provided %(proper_name)s account is linked to a different Sentry user. "
-                                    "To continue linking the current Sentry user, please use a different %(proper_name)s account."
-                                )
-                                % ({"proper_name": proper_name})
-                            },
-                            False,
+                        raise IntegrationError(
+                            _(
+                                "The provided %(proper_name)s account is linked to a different Sentry user. "
+                                "To continue linking the current Sentry user, please use a different %(proper_name)s account."
+                            )
+                            % ({"proper_name": proper_name})
                         )
 
         default_auth_id = None
@@ -309,7 +370,7 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
                     "integration_id": self.integration.id,
                 },
             )
-            return self.error(
+            raise IntegrationError(
                 "This integration has already been installed on another Sentry organization which resides in a different cell. Installation could not be completed."
             )
 
@@ -317,8 +378,15 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
             self.organization, self.request.user, default_auth_id=default_auth_id
         )
 
+        if org_integration is None:
+            raise IntegrationError("Could not create the integration for this organization.")
+
+        return org_integration
+
+    def _finish_pipeline(self, data: IntegrationData) -> HttpResponseBase:
+        org_integration = self._install_integration(data)
+
         extra = data.get("post_install_data", {})
-        # If a particular provider has a redirect for a successful install, use that instead of the generic success
         redirect_url_format = extra.get("redirect_url_format", None)
         if redirect_url_format is not None:
             return self._get_redirect_response(redirect_url_format=redirect_url_format)
@@ -358,6 +426,57 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
             organization_id=self.organization.id,
             integration_id=self.integration.id,
             status=ObjectStatus.ACTIVE,
+        )
+
+    def api_finish_pipeline(self) -> PipelineStepResult:
+        with IntegrationPipelineViewEvent(
+            interaction_type=IntegrationPipelineViewType.FINISH_PIPELINE,
+            domain=IntegrationDomain.GENERAL,
+            provider_key=self.provider.key,
+        ).capture() as lifecycle:
+            org_context = organization_service.get_organization_by_id(
+                id=self.organization.id, user_id=self.request.user.id
+            )
+
+            if not org_context or (
+                (not org_context.member or "org:integrations" not in org_context.member.scopes)
+                and not superuser_has_permission(self.request, ["org:integrations"])
+            ):
+                return PipelineStepResult.error(
+                    "You must be an organization owner, manager or admin to install this integration."
+                )
+
+            try:
+                data = self.provider.build_integration(self.state.data)
+            except IntegrationError as e:
+                lifecycle.record_failure(e)
+                return PipelineStepResult.error(str(e))
+            except IntegrationProviderError as e:
+                return PipelineStepResult.error(str(e))
+
+            try:
+                org_integration = self._install_integration(data)
+            except IntegrationError as e:
+                lifecycle.record_failure(e)
+                return PipelineStepResult.error(str(e))
+
+            extra = data.get("post_install_data", {})
+
+            self.provider.create_audit_log_entry(
+                self.integration, self.organization, self.request, "install", extra=extra
+            )
+            self._enable_actions()
+            self.provider.post_install(self.integration, self.organization, extra=extra)
+            self.clear_session()
+
+        metrics.incr(
+            "sentry.integrations.installation_finished",
+            tags={"integration_name": self.provider.key},
+            sample_rate=1.0,
+        )
+
+        return PipelineStepResult.complete(
+            data=serialize(org_integration, self.request.user),
         )
 
     def _get_redirect_response(self, redirect_url_format: str) -> HttpResponseRedirect:

--- a/src/sentry/integrations/web/organization_integration_setup.py
+++ b/src/sentry/integrations/web/organization_integration_setup.py
@@ -1,15 +1,11 @@
 import logging
 
-import sentry_sdk
 from django.http import Http404, HttpRequest
 from django.http.response import HttpResponseBase
-from sentry_sdk.tracing import TransactionSource
 
-from sentry import features
-from sentry.features.exceptions import FeatureNotRegistered
-from sentry.integrations.base import IntegrationProvider
-from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.pipeline import IntegrationPipelineError, initialize_integration_pipeline
 from sentry.web.frontend.base import ControlSiloOrganizationView, control_silo_view
+from sentry.web.helpers import render_to_response
 
 logger = logging.getLogger("sentry.integrations")
 
@@ -21,36 +17,13 @@ class OrganizationIntegrationSetupView(ControlSiloOrganizationView):
     csrf_protect = False
 
     def handle(self, request: HttpRequest, organization, provider_id) -> HttpResponseBase:
-        scope = sentry_sdk.get_current_scope()
-        scope.set_transaction_name(f"integration.{provider_id}", source=TransactionSource.VIEW)
-
-        pipeline = IntegrationPipeline(
-            request=request, organization=organization, provider_key=provider_id
-        )
-
-        is_feature_enabled = {}
-        assert isinstance(pipeline.provider, IntegrationProvider), (
-            "Pipeline must be an integration provider to get features"
-        )
-        for feature in pipeline.provider.features:
-            feature_flag_name = "organizations:integrations-%s" % feature.value
-            try:
-                features.get(feature_flag_name, None)
-                is_feature_enabled[feature_flag_name] = features.has(
-                    feature_flag_name, organization
-                )
-            except FeatureNotRegistered:
-                is_feature_enabled[feature_flag_name] = True
-
-        if not any(is_feature_enabled.values()):
-            return pipeline.render_warning(
-                "At least one feature from this list has to be enabled in order to setup the integration:\n%s"
-                % "\n".join(is_feature_enabled)
+        try:
+            pipeline = initialize_integration_pipeline(request, organization, provider_id)
+        except IntegrationPipelineError as e:
+            if e.not_found:
+                raise Http404
+            return render_to_response(
+                "sentry/pipeline-provider-error.html", {"error": str(e)}, request
             )
-
-        if not pipeline.provider.can_add:
-            raise Http404
-
-        pipeline.initialize()
 
         return pipeline.current_step()

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -20,6 +20,7 @@ from sentry.models.repository import Repository
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization.serial import serialize_rpc_organization
+from sentry.pipeline.types import PipelineStepAction
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.issue2 import IssuePlugin2
 from sentry.signals import receivers_raise_on_send
@@ -695,6 +696,238 @@ class FinishPipelineTestCase(IntegrationTestCase):
             assert action.status == ObjectStatus.ACTIVE
             # Ensure that the second action is still disabled
             assert action2.status == ObjectStatus.DISABLED
+
+
+@control_silo_test
+@patch(
+    "sentry.integrations.example.ExampleIntegrationProvider.build_integration",
+    side_effect=naive_build_integration,
+)
+class ApiFinishPipelineTestCase(IntegrationTestCase):
+    provider = ExampleIntegrationProvider
+    cells = (
+        Cell("na", 0, "North America", RegionCategory.MULTI_TENANT),
+        Cell("eu", 5, "Europe", RegionCategory.MULTI_TENANT),
+    )
+    external_id = "dummy_id-123"
+
+    @pytest.fixture(autouse=True)
+    def _register_example_plugin(self) -> Generator[None]:
+        plugins.register(ExamplePlugin)
+        yield
+        plugins.unregister(ExamplePlugin)
+
+    @pytest.fixture(autouse=True)
+    def _modify_provider(self):
+        with patch.multiple(
+            self.provider,
+            needs_default_identity=False,
+            is_cell_restricted=False,
+        ):
+            yield
+
+    def _setup_cell_restriction(self):
+        self.provider.is_cell_restricted = True
+        na_orgs = [
+            self.create_organization(name="na_org"),
+            self.create_organization(name="na_org_2"),
+        ]
+        integration = self.create_provider_integration(
+            name="test", external_id=self.external_id, provider=self.provider.key
+        )
+        with (
+            receivers_raise_on_send(),
+            outbox_runner(),
+            unguarded_write(using=router.db_for_write(OrganizationMapping)),
+        ):
+            for org in na_orgs:
+                integration.add_organization(org)
+                mapping = OrganizationMapping.objects.get(organization_id=org.id)
+                mapping.update(cell_name="na")
+
+    def test_api_finish_pipeline_success(self, *args) -> None:
+        data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+        }
+        self.pipeline.state.data = data
+        result = self.pipeline.api_finish_pipeline()
+
+        assert result.action == PipelineStepAction.COMPLETE
+        assert result.data["id"] is not None
+
+        integration = Integration.objects.get(
+            provider=self.provider.key, external_id=self.external_id
+        )
+        assert integration.name == data["name"]
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id, integration_id=integration.id
+        ).exists()
+
+    def test_api_finish_pipeline_disallow_with_no_permission(self, *args) -> None:
+        member_user = self.create_user()
+        self.create_member(user=member_user, organization=self.organization, role="member")
+        self.login_as(member_user)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            rpc_organization = serialize_rpc_organization(self.organization)
+
+        self.request = self.make_request(member_user)
+
+        self.pipeline = IntegrationPipeline(
+            request=self.request,
+            organization=rpc_organization,
+            provider_key=self.provider.key,
+        )
+        self.pipeline.initialize()
+        self.save_session()
+
+        data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+        }
+        self.pipeline.state.data = data
+
+        result = self.pipeline.api_finish_pipeline()
+        assert result.action == PipelineStepAction.ERROR
+        assert (
+            result.data["detail"]
+            == "You must be an organization owner, manager or admin to install this integration."
+        )
+
+    def test_api_finish_pipeline_disallow_with_removed_membership(self, *args) -> None:
+        member_user = self.create_user()
+        om = self.create_member(user=member_user, organization=self.organization, role="manager")
+        self.login_as(member_user)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            rpc_organization = serialize_rpc_organization(self.organization)
+
+        self.request = self.make_request(member_user)
+
+        self.pipeline = IntegrationPipeline(
+            request=self.request,
+            organization=rpc_organization,
+            provider_key=self.provider.key,
+        )
+        self.pipeline.initialize()
+        self.save_session()
+
+        data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+        }
+        self.pipeline.state.data = data
+        with outbox_runner(), assume_test_silo_mode_of(OrganizationMember):
+            om.delete()
+
+        result = self.pipeline.api_finish_pipeline()
+        assert result.action == PipelineStepAction.ERROR
+        assert (
+            result.data["detail"]
+            == "You must be an organization owner, manager or admin to install this integration."
+        )
+
+    def test_api_finish_pipeline_disallow_with_no_org_context(self, *args) -> None:
+        data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+        }
+        self.pipeline.state.data = data
+
+        with patch(
+            "sentry.integrations.pipeline.organization_service.get_organization_by_id",
+            return_value=None,
+        ):
+            result = self.pipeline.api_finish_pipeline()
+
+        assert result.action == PipelineStepAction.ERROR
+        assert (
+            result.data["detail"]
+            == "You must be an organization owner, manager or admin to install this integration."
+        )
+
+    @patch("sentry.signals.integration_added.send_robust")
+    def test_api_finish_pipeline_cell_restriction_failure(self, *args) -> None:
+        self._setup_cell_restriction()
+
+        mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        with unguarded_write(using=router.db_for_write(OrganizationMapping)):
+            mapping.update(cell_name="eu")
+
+        self.pipeline.state.data = {"external_id": self.external_id}
+        with override_cells(self.cells):
+            result = self.pipeline.api_finish_pipeline()
+            assert result.action == PipelineStepAction.ERROR
+            assert (
+                result.data["detail"]
+                == "This integration has already been installed on another Sentry organization which resides in a different cell. Installation could not be completed."
+            )
+
+    @patch("sentry.signals.integration_added.send_robust")
+    def test_api_finish_pipeline_cell_restriction_success(self, *args) -> None:
+        self._setup_cell_restriction()
+
+        mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        with unguarded_write(using=router.db_for_write(OrganizationMapping)):
+            mapping.update(cell_name="na")
+
+        self.pipeline.state.data = {"external_id": self.external_id}
+        with override_cells(self.cells):
+            result = self.pipeline.api_finish_pipeline()
+            assert result.action == PipelineStepAction.COMPLETE
+
+    def test_api_finish_pipeline_identity_conflict(self, *args) -> None:
+        self.provider.needs_default_identity = True
+        new_user = self.create_user()
+        integration = self.create_provider_integration(
+            provider=self.provider.key,
+            external_id=self.external_id,
+            metadata={"url": "https://example.com"},
+        )
+        identity_provider = self.create_identity_provider(
+            external_id=self.external_id, type="slack"
+        )
+        Identity.objects.create(
+            idp_id=identity_provider.id, external_id="AccountId", user_id=new_user.id
+        )
+        self.pipeline.state.data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+            "user_identity": {
+                "type": "slack",
+                "external_id": "AccountId",
+                "scopes": [],
+                "data": {},
+            },
+        }
+
+        result = self.pipeline.api_finish_pipeline()
+        assert result.action == PipelineStepAction.ERROR
+        assert (
+            result.data["detail"]
+            == "The provided Slack account is linked to a different Sentry user. To continue linking the current Sentry user, please use a different Slack account."
+        )
+        assert not OrganizationIntegration.objects.filter(integration_id=integration.id).exists()
+
+    def test_api_finish_pipeline_add_organization_integrity_error(self, *args) -> None:
+        data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+        }
+        self.pipeline.state.data = data
+
+        with patch.object(Integration, "add_organization", return_value=None):
+            result = self.pipeline.api_finish_pipeline()
+
+        assert result.action == PipelineStepAction.ERROR
+        assert result.data["detail"] == "Could not create the integration for this organization."
 
 
 @control_silo_test


### PR DESCRIPTION
Extract initialize_integration_pipeline helper from the setup view and
add api_finish_pipeline to IntegrationPipeline. Refactor _finish_pipeline
into _execute_finish_pipeline so the core model operations (create
integration, link identity, create org integration) can be shared between
the legacy dialog response path and the new API result path.

Fixes [VDY-36](https://linear.app/getsentry/issue/VDY-36)