### PR TITLE
feat(pipeline): Detect API-driven pipelines in existing callback URL

### DIFF
--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -1,14 +1,18 @@
+from urllib.parse import parse_qs
+
 from django.contrib import messages
-from django.http import HttpRequest, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.http.response import HttpResponseBase
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+from sentry import features
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.utils.http import absolute_uri, create_redirect_url
+from sentry.utils.json import dumps_htmlsafe
 from sentry.web.frontend.base import BaseView, all_silo_view
 
 # The request doesn't contain the pipeline type (pipeline information is stored
@@ -16,10 +20,70 @@ from sentry.web.frontend.base import BaseView, all_silo_view
 # and use whichever one works.
 PIPELINE_CLASSES = (IntegrationPipeline, IdentityPipeline)
 
+TRAMPOLINE_HTML = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body
+    style="margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;
+    font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+    flex-direction:column;padding:2rem">
+<script type="module">
+  const data = {data_json};
+  if (window.opener) {{
+    window.opener.postMessage(data, {origin});
+    window.close();
+  }} else {{
+    document.getElementById("fallback").style.display = "flex";
+  }}
+</script>
+<div id="fallback" style="display:none;flex-direction:column;align-items:center;gap:1.5rem;max-width:600px">
+  <p style="font-size:1.1rem;margin:0">Unable to continue. Please restart the flow.</p>
+</div>
+</body>
+</html>"""
+
+
+def _render_trampoline(request: HttpRequest, pipeline: object) -> HttpResponse:
+    """Render a minimal page that posts callback params back to the opener."""
+    params: dict[str, str] = {"source": "sentry-pipeline"}
+    for key, values in parse_qs(request.META.get("QUERY_STRING", "")).items():
+        if values:
+            params[key] = values[0]
+
+    data_json = str(dumps_htmlsafe(params))
+
+    # In multi-region the opener may be on a different origin (e.g.
+    # org-slug.sentry.io) than the trampoline (sentry.io/extensions/...),
+    # so we need the org-specific URL. In single-region document.origin works.
+    if features.has("system:multi-region"):
+        org = getattr(pipeline, "organization", None)
+        origin = str(dumps_htmlsafe(generate_organization_url(org.slug if org else "")))
+    else:
+        origin = "document.origin"
+
+    return HttpResponse(
+        TRAMPOLINE_HTML.format(data_json=data_json, origin=origin),
+        content_type="text/html",
+    )
+
 
 @all_silo_view
 class PipelineAdvancerView(BaseView):
-    """Gets the current pipeline from the request and executes the current step."""
+    """
+    Gets the current pipeline from the request and executes the current step.
+
+    External services (e.g. GitHub OAuth) redirect back to this view after the
+    user completes an action. For legacy template-driven pipelines this view
+    processes the callback server-side via pipeline.current_step().
+
+    For API-driven pipelines (is_api_mode) this view does NOT process the
+    callback. Instead it renders a lightweight trampoline page that relays the
+    callback URL query params (code, state, installation_id, etc.) back to the
+    opener window via postMessage and closes itself. The frontend is
+    responsible for POSTing those params to the pipeline API endpoint to
+    advance the pipeline.
+    """
 
     auth_required = False
 
@@ -49,6 +113,12 @@ class PipelineAdvancerView(BaseView):
         if pipeline is None or not pipeline.is_valid():
             messages.add_message(request, messages.ERROR, _("Invalid request."))
             return self.redirect("/")
+
+        # If the pipeline was initiated via the API, render a trampoline page
+        # that relays the callback params back to the opener window via
+        # postMessage instead of processing the callback server-side.
+        if pipeline.is_api_mode:
+            return _render_trampoline(request, pipeline)
 
         subdomain = pipeline.fetch_state("subdomain")
         if subdomain is not None and request.subdomain != subdomain:


### PR DESCRIPTION
Integration providers register callback URLs with external services
(e.g. GitHub OAuth redirect). These URLs point to PipelineAdvancerView,
which traditionally drives the pipeline server-side by calling
pipeline.current_step() on each callback.

For the new API-driven pipeline mode, we cannot change the callback URLs
already registered with production integrations. Instead, this view now
detects when a pipeline was initiated in API mode (api_mode flag in
session state) and renders a lightweight trampoline page. The trampoline
relays the callback URL query parameters (code, state, installation_id,
etc.) back to the opener window via postMessage and closes itself. The
frontend pipeline system then continues driving the pipeline via API
endpoints.

Fixes [VDY-36](https://linear.app/getsentry/issue/VDY-36)