### PR TITLE
chore: Add machine-learning-ai as codeowner for SeerComboBox files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -330,6 +330,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/api/endpoints/test_organization_traces.py                             @getsentry/explore
 
 /static/app/views/explore/                                                @getsentry/explore
+/static/app/views/explore/logs/logsTabSeerComboBox.tsx                    @getsentry/explore @getsentry/machine-learning-ai
+/static/app/views/explore/spans/spansTabSeerComboBox.tsx                  @getsentry/explore @getsentry/machine-learning-ai
 /static/app/views/traces/                                                 @getsentry/explore
 /static/app/components/quickTrace/                                        @getsentry/explore
 /src/sentry/insights/                                                     @getsentry/data-browsing
@@ -339,6 +341,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/events/interfaces/spans/                           @getsentry/data-browsing
 /static/app/components/events/viewHierarchy/*                             @getsentry/data-browsing
 /static/app/components/searchQueryBuilder/                                @getsentry/data-browsing
+/static/app/components/searchQueryBuilder/askSeerCombobox/                @getsentry/data-browsing @getsentry/machine-learning-ai
 /static/app/components/arithmeticBuilder/                                 @getsentry/data-browsing
 
 /static/app/components/charts/                                            @getsentry/data-browsing
@@ -349,6 +352,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/modals/widgetViewerModal*                          @getsentry/dashboards
 
 /static/app/views/discover/                                               @getsentry/explore
+/static/app/views/discover/results/issueListSeerComboBox.tsx              @getsentry/explore @getsentry/machine-learning-ai
 /static/app/utils/discover/                                               @getsentry/explore
 /static/app/utils/timeSeries/                                             @getsentry/data-browsing
 ## Endof Visibility
@@ -663,6 +667,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/issues/                              @getsentry/issue-workflow
 /static/app/components/stackTrace/                          @getsentry/issue-workflow
 /static/app/views/issueList/                                @getsentry/issue-workflow
+/static/app/views/issueList/issueListSeerComboBox.tsx       @getsentry/issue-workflow @getsentry/machine-learning-ai
 /static/app/views/issueList/pages/supergroups.tsx           @getsentry/issue-detection-frontend
 /static/app/views/issueList/supergroups/                    @getsentry/issue-detection-frontend
 /static/app/views/issueDetails/                             @getsentry/issue-workflow


### PR DESCRIPTION
Add `@getsentry/machine-learning-ai` as co-owner for all `*SeerComboBox*` files. Each rule is placed after the longest matching parent directory rule and includes the existing parent owner:

- `searchQueryBuilder/askSeerCombobox/` — `@getsentry/data-browsing` + `@getsentry/machine-learning-ai`
- `explore/logs/logsTabSeerComboBox.tsx` — `@getsentry/explore` + `@getsentry/machine-learning-ai`
- `explore/spans/spansTabSeerComboBox.tsx` — `@getsentry/explore` + `@getsentry/machine-learning-ai`
- `discover/results/issueListSeerComboBox.tsx` — `@getsentry/explore` + `@getsentry/machine-learning-ai`
- `issueList/issueListSeerComboBox.tsx` — `@getsentry/issue-workflow` + `@getsentry/machine-learning-ai`