### PR TITLE
feat(workflows): Add periodic WorkflowFireHistory backlog clean-up task

### DIFF
--- a/src/sentry/workflow_engine/tasks/__init__.py
+++ b/src/sentry/workflow_engine/tasks/__init__.py
@@ -2,7 +2,9 @@ __all__ = [
     "process_delayed_workflows",
     "process_workflow_activity",
     "process_workflows_event",
+    "prune_old_fire_history",
 ]
 
+from .cleanup import prune_old_fire_history
 from .delayed_workflows import process_delayed_workflows
 from .workflows import process_workflow_activity, process_workflows_event

--- a/src/sentry/workflow_engine/tasks/cleanup.py
+++ b/src/sentry/workflow_engine/tasks/cleanup.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+import time
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import workflow_engine_tasks
+from sentry.utils import metrics
+from sentry.utils.query import bulk_delete_objects
+
+logger = logging.getLogger(__name__)
+
+FIRE_HISTORY_RETENTION_DAYS = 90
+FIRE_HISTORY_BATCH_SIZE = 10000
+FIRE_HISTORY_TIME_LIMIT_SECONDS = 5
+
+
+@instrumented_task(
+    name="sentry.workflow_engine.tasks.cleanup.prune_old_fire_history",
+    namespace=workflow_engine_tasks,
+    processing_deadline_duration=15,
+    silo_mode=SiloMode.CELL,
+)
+def prune_old_fire_history() -> None:
+    from sentry.workflow_engine.models import WorkflowFireHistory
+
+    cutoff = timezone.now() - timedelta(days=FIRE_HISTORY_RETENTION_DAYS)
+    start = time.time()
+    batches_deleted = 0
+
+    while (time.time() - start) < FIRE_HISTORY_TIME_LIMIT_SECONDS:
+        has_more = bulk_delete_objects(
+            WorkflowFireHistory,
+            limit=FIRE_HISTORY_BATCH_SIZE,
+            logger=logger,
+            date_added__lte=cutoff,
+        )
+        if not has_more:
+            break
+        batches_deleted += 1
+
+    metrics.incr(
+        "workflow_engine.tasks.prune_old_fire_history.batches_deleted",
+        amount=batches_deleted,
+        sample_rate=1.0,
+    )

--- a/tests/sentry/workflow_engine/tasks/test_cleanup.py
+++ b/tests/sentry/workflow_engine/tasks/test_cleanup.py
@@ -1,0 +1,97 @@
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.models import WorkflowFireHistory
+from sentry.workflow_engine.tasks.cleanup import (
+    FIRE_HISTORY_RETENTION_DAYS,
+    prune_old_fire_history,
+)
+
+
+class TestPruneOldFireHistory(TestCase):
+    def _create_fire_history(self, days_ago: int) -> WorkflowFireHistory:
+        workflow = self.create_workflow(organization=self.organization)
+        group = self.create_group(project=self.project)
+        obj = WorkflowFireHistory.objects.create(workflow=workflow, group=group, event_id="abc123")
+        if days_ago > 0:
+            backdated = timezone.now() - timedelta(days=days_ago)
+            WorkflowFireHistory.objects.filter(id=obj.id).update(date_added=backdated)
+            obj.refresh_from_db()
+        return obj
+
+    def test_noop_when_nothing_to_delete(self) -> None:
+        with patch("sentry.workflow_engine.tasks.cleanup.metrics") as mock_metrics:
+            prune_old_fire_history()
+
+        mock_metrics.incr.assert_called_once_with(
+            "workflow_engine.tasks.prune_old_fire_history.batches_deleted",
+            amount=0,
+            sample_rate=1.0,
+        )
+
+    def test_deletes_rows_older_than_retention(self) -> None:
+        old = self._create_fire_history(days_ago=FIRE_HISTORY_RETENTION_DAYS + 1)
+        recent = self._create_fire_history(days_ago=FIRE_HISTORY_RETENTION_DAYS - 1)
+
+        prune_old_fire_history()
+
+        assert not WorkflowFireHistory.objects.filter(id=old.id).exists()
+        assert WorkflowFireHistory.objects.filter(id=recent.id).exists()
+
+    def test_preserves_recent_rows(self) -> None:
+        rows = [
+            self._create_fire_history(days_ago=1),
+            self._create_fire_history(days_ago=30),
+            self._create_fire_history(days_ago=FIRE_HISTORY_RETENTION_DAYS - 1),
+        ]
+
+        prune_old_fire_history()
+
+        for row in rows:
+            assert WorkflowFireHistory.objects.filter(id=row.id).exists()
+
+    @patch("sentry.workflow_engine.tasks.cleanup.FIRE_HISTORY_BATCH_SIZE", 10)
+    def test_multiple_batches(self) -> None:
+        old_ids = []
+        for _ in range(25):
+            obj = self._create_fire_history(days_ago=FIRE_HISTORY_RETENTION_DAYS + 1)
+            old_ids.append(obj.id)
+
+        with patch("sentry.workflow_engine.tasks.cleanup.metrics") as mock_metrics:
+            prune_old_fire_history()
+
+        assert WorkflowFireHistory.objects.filter(id__in=old_ids).count() == 0
+        mock_metrics.incr.assert_called_once()
+        assert mock_metrics.incr.call_args.kwargs["amount"] >= 2
+
+    @patch("sentry.workflow_engine.tasks.cleanup.FIRE_HISTORY_BATCH_SIZE", 10)
+    @patch("sentry.workflow_engine.tasks.cleanup.time")
+    def test_time_bounded_leaves_remaining_rows(self, mock_time: MagicMock) -> None:
+        # start=0, first check=0 (run batch), second check=6 (exit)
+        mock_time.time.side_effect = [0.0, 0.0, 6.0]
+
+        old_ids = []
+        for _ in range(25):
+            obj = self._create_fire_history(days_ago=FIRE_HISTORY_RETENTION_DAYS + 1)
+            old_ids.append(obj.id)
+
+        with patch("sentry.workflow_engine.tasks.cleanup.metrics"):
+            prune_old_fire_history()
+
+        remaining = WorkflowFireHistory.objects.filter(id__in=old_ids).count()
+        assert remaining == 15  # only one batch of 10 was deleted
+
+    def test_metrics_emitted(self) -> None:
+        self._create_fire_history(days_ago=FIRE_HISTORY_RETENTION_DAYS + 1)
+
+        with patch("sentry.workflow_engine.tasks.cleanup.metrics") as mock_metrics:
+            prune_old_fire_history()
+
+        mock_metrics.incr.assert_called_once_with(
+            "workflow_engine.tasks.prune_old_fire_history.batches_deleted",
+            amount=1,  # 1 row fits in a single batch
+            sample_rate=1.0,
+        )


### PR DESCRIPTION
Our trials of the deletion job have shown that conservative database impact likely will mean _many_ task runs.
So, here we pivot back to a task: the idea is to run this every 2min, doing a reasonable amount of cleanup in each run, for a sustainable and automatic clean-up. 
Once this is finished (should be 3-4 days based on current estimates), the standard incinerator should be able to take over.

Updates ISWF-2266.