### PR TITLE
ref: Migrate ThreadPoolExecutor to ContextPropagatingThreadPoolExecutor

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from typing import Any, NotRequired, TypedDict
 
 import sentry_sdk
@@ -54,6 +54,7 @@ from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.types import DatasetQuery
 from sentry.snuba.utils import RPC_DATASETS, dataset_split_decision_inferred_from_query, get_dataset
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.cursors import Cursor, EAPPageTokenCursor
 from sentry.utils.snuba import SnubaError
 
@@ -409,7 +410,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                     # Unable to infer based on selected fields and query string, so run both queries.
                     else:
                         map = {}
-                        with ThreadPoolExecutor(max_workers=3) as exe:
+                        with ContextPropagatingThreadPoolExecutor(max_workers=3) as exe:
                             futures = {
                                 exe.submit(
                                     _data_fn, dataset_query, offset, limit, scoped_query

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -4,7 +4,7 @@ import abc
 import logging
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from datetime import datetime, timedelta
 from typing import Any, Optional, TypedDict, TypeVar, cast
 
@@ -38,6 +38,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.numbers import base32_encode, format_grouped_length
 from sentry.utils.sdk import set_span_attribute
 from sentry.utils.snuba import bulk_snuba_queries
@@ -1286,7 +1287,7 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
     @staticmethod
     def nodestore_event_map(events: Sequence[SnubaTransaction]) -> dict[str, Event | GroupEvent]:
         event_map = {}
-        with ThreadPoolExecutor(max_workers=20) as executor:
+        with ContextPropagatingThreadPoolExecutor(max_workers=20) as executor:
             future_to_event = {
                 executor.submit(
                     eventstore.backend.get_event_by_id, event["project.id"], event["id"]

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -1,5 +1,4 @@
 import logging
-from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
 import sentry_sdk
@@ -24,6 +23,7 @@ from sentry.snuba.discover import create_result_key, zerofill
 from sentry.snuba.metrics_performance import query as metrics_query
 from sentry.snuba.referrer import Referrer
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.iterators import chunked
 from sentry.utils.snuba import SnubaTSResult
 
@@ -275,7 +275,9 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsEndpointBase):
             ]
 
             # send the data to microservice
-            with ThreadPoolExecutor(thread_name_prefix=__name__) as query_thread_pool:
+            with ContextPropagatingThreadPoolExecutor(
+                thread_name_prefix=__name__
+            ) as query_thread_pool:
                 results = list(
                     query_thread_pool.map(
                         partial(detect_breakpoints, viewer_context=viewer_context),

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Any, Literal, NotRequired, TypedDict
 
@@ -71,6 +70,7 @@ from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.tagstore.types import TagValue
 from sentry.utils import snuba_rpc
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.cursors import Cursor, CursorResult
 
 POSSIBLE_ATTRIBUTE_TYPES = ["string", "number", "boolean"]
@@ -321,7 +321,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
 
         def data_fn(offset: int, limit: int) -> list[TraceItemAttributeKey]:
             futures = []
-            with ThreadPoolExecutor(
+            with ContextPropagatingThreadPoolExecutor(
                 thread_name_prefix=__name__,
                 max_workers=len(POSSIBLE_ATTRIBUTE_TYPES),
             ) as pool:

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -1,6 +1,5 @@
 import logging
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, TypedDict, cast
 
 from rest_framework.request import Request
@@ -34,6 +33,7 @@ from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.utils import snuba_rpc
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.snuba_rpc import trace_item_stats_rpc
 
 logger = logging.getLogger(__name__)
@@ -326,7 +326,7 @@ def query_attribute_distributions(
                 referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_DATA.value,
             )
 
-    with ThreadPoolExecutor(
+    with ContextPropagatingThreadPoolExecutor(
         thread_name_prefix=__name__,
         max_workers=PARALLELIZATION_FACTOR * 2 + 2,  # 2 cohorts * threads + 2 totals queries
     ) as query_thread_pool:

--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -28,6 +28,7 @@ from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.cursors import Cursor, CursorResult
 
 logger = logging.getLogger(__name__)
@@ -210,7 +211,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                 )
 
             stats_results: dict[str, dict[str, dict]] = defaultdict(lambda: {"data": {}})
-            with ThreadPoolExecutor(
+            with ContextPropagatingThreadPoolExecutor(
                 thread_name_prefix=__name__,
                 max_workers=MAX_THREADS,
             ) as query_thread_pool:

--- a/src/sentry/api/endpoints/organization_trace_meta.py
+++ b/src/sentry/api/endpoints/organization_trace_meta.py
@@ -1,5 +1,4 @@
 import logging
-from concurrent.futures import ThreadPoolExecutor
 from typing import TypedDict
 
 import sentry_sdk
@@ -28,6 +27,7 @@ from sentry.snuba.referrer import Referrer
 from sentry.snuba.rpc_dataset_common import RPCBase, TableQuery
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace import _run_uptime_results_query, _uptime_results_query
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -208,7 +208,7 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsEndpointBase):
             # parallelizing the queries here, but ideally this parallelization happens by calling run_bulk_table_queries
             include_uptime = request.GET.get("include_uptime", "0") == "1"
             max_workers = 3 + (1 if include_uptime else 0)
-            with ThreadPoolExecutor(
+            with ContextPropagatingThreadPoolExecutor(
                 thread_name_prefix=__name__,
                 max_workers=max_workers,
             ) as query_thread_pool:

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -1,7 +1,6 @@
 import dataclasses
 from collections import defaultdict
 from collections.abc import Callable, Generator, Mapping, MutableMapping
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import Any, Literal, NotRequired, TypedDict
@@ -56,6 +55,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.occurrences_rpc import OccurrenceCategory
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.numbers import clip
 from sentry.utils.sdk import set_span_attribute
 from sentry.utils.snuba import bulk_snuba_queries_with_referrers
@@ -253,7 +253,7 @@ class TracesExecutor:
         # issue
         if len(self.snuba_params.projects) < len(all_projects) and self.offset == 0:
             selected_project_request = self.get_traces_rpc(list(self.snuba_params.projects))
-            with ThreadPoolExecutor(
+            with ContextPropagatingThreadPoolExecutor(
                 thread_name_prefix=__name__, max_workers=2
             ) as query_thread_pool:
                 all_project_future = query_thread_pool.submit(get_traces_rpc, all_project_request)

--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
 from botocore.exceptions import ClientError
@@ -31,6 +30,7 @@ from sentry.projects.services.project import project_service
 from sentry.silo.base import control_silo_function
 from sentry.users.models.user import User
 from sentry.users.services.user.serial import serialize_rpc_user
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.sdk import capture_exception
 
 from .client import ConfigurationError, gen_aws_client
@@ -421,7 +421,7 @@ class AwsLambdaSetupLayerPipelineView:
         failures = []
         success_count = 0
 
-        with ThreadPoolExecutor(
+        with ContextPropagatingThreadPoolExecutor(
             max_workers=options.get("aws-lambda.thread-count")
         ) as _lambda_setup_thread_pool:
             # use threading here to parallelize requests

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.conf import settings
@@ -33,6 +33,7 @@ from sentry.silo.base import SiloLimit, SiloMode
 from sentry.silo.client import CellSiloClient, SiloClientError
 from sentry.types.cell import Cell, find_cells_for_orgs, get_cell_by_name
 from sentry.utils import metrics
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.options import sample_modulo
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ class BaseRequestParser(ABC):
 
         cell_to_response_map = {}
 
-        with ThreadPoolExecutor(max_workers=len(cells)) as executor:
+        with ContextPropagatingThreadPoolExecutor(max_workers=len(cells)) as executor:
             future_to_cell = {
                 executor.submit(self.get_response_from_cell_silo, cell): cell for cell in cells
             }

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -10,6 +10,7 @@ from sentry.models.group import Group
 from sentry.seer.autofix.constants import SeerAutomationSource
 from sentry.seer.autofix.issue_summary import get_issue_summary
 from sentry.seer.autofix.utils import is_seer_scanner_rate_limited
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +48,7 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
 
     try:
         with sentry_sdk.start_span(op="ai_summary.fetch_issue_summary_for_alert"):
-            with concurrent.futures.ThreadPoolExecutor() as executor:
+            with ContextPropagatingThreadPoolExecutor() as executor:
                 future = executor.submit(
                     get_issue_summary, group, source=SeerAutomationSource.ALERT
                 )

--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -7,7 +7,6 @@ import mmap
 import os
 import tempfile
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha1
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
@@ -25,6 +24,7 @@ from sentry.models.files.abstractfileblob import AbstractFileBlob
 from sentry.models.files.abstractfileblobindex import AbstractFileBlobIndex
 from sentry.models.files.utils import DEFAULT_BLOB_SIZE, AssembleChecksumMismatch, nooplogger
 from sentry.utils import metrics
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ class ChunkedFileBlobIndexWrapper:
                     mem[offset : offset + len(chunk)] = chunk
                     offset += len(chunk)
 
-        with ThreadPoolExecutor(max_workers=4) as exe:
+        with ContextPropagatingThreadPoolExecutor(max_workers=4) as exe:
             for idx in self._indexes:
                 exe.submit(fetch_file, idx.offset, idx.blob.getfile)
 

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import concurrent.futures as cf
 import logging
 from typing import Any
 
@@ -27,6 +26,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import replays_tasks
 from sentry.utils import metrics
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.pubsub import KafkaPublisher
 
 logger = logging.getLogger()
@@ -86,7 +86,7 @@ def delete_replays_script_async(
     for segment in segments:
         rrweb_filenames.append(make_recording_filename(segment))
 
-    with cf.ThreadPoolExecutor(max_workers=100) as pool:
+    with ContextPropagatingThreadPoolExecutor(max_workers=100) as pool:
         pool.map(_delete_if_exists, rrweb_filenames)
 
     # Backwards compatibility. Should be deleted one day.
@@ -128,7 +128,7 @@ def delete_replay_recording(project_id: int, replay_id: str) -> None:
             direct_storage_segments.append(segment)
 
     # Issue concurrent delete requests when interacting with a remote service provider.
-    with cf.ThreadPoolExecutor(max_workers=100) as pool:
+    with ContextPropagatingThreadPoolExecutor(max_workers=100) as pool:
         if direct_storage_segments:
             pool.map(storage.delete, direct_storage_segments)
 

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import concurrent.futures as cf
 import functools
 import logging
 from datetime import datetime
@@ -36,6 +35,7 @@ from sentry.replays.usecases.events import archive_event
 from sentry.replays.usecases.query import execute_query, handle_search_filters
 from sentry.replays.usecases.query.configs.aggregate import search_config as agg_search_config
 from sentry.seer.signed_seer_api import SeerViewerContext
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.snuba import (
     QueryExecutionError,
@@ -76,7 +76,7 @@ def delete_replays(project_id: int, replay_ids: list[str]) -> None:
 
 
 def delete_replay_recordings(project_id: int, row: MatchedRow) -> None:
-    with cf.ThreadPoolExecutor(max_workers=100) as pool:
+    with ContextPropagatingThreadPoolExecutor(max_workers=100) as pool:
         pool.map(_delete_if_exists, _make_recording_filenames(project_id, row))
 
 

--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import uuid
 import zlib
 from collections.abc import Generator, Iterator
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -29,6 +28,7 @@ from sentry.models.files.fileblobindex import FileBlobIndex
 from sentry.replays.lib.storage import RecordingSegmentStorageMeta, filestore, storage
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.usecases.pack import unpack
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.snuba import raw_snql_query
 
 # METADATA QUERY BEHAVIOR.
@@ -265,7 +265,7 @@ def download_segments(segments: list[RecordingSegmentStorageMeta]) -> Iterator[b
 def iter_segment_data(
     segments: list[RecordingSegmentStorageMeta],
 ) -> Generator[tuple[int, memoryview]]:
-    with ThreadPoolExecutor(max_workers=10) as pool:
+    with ContextPropagatingThreadPoolExecutor(max_workers=10) as pool:
         segment_data = pool.map(_download_segment, segments)
 
     for i, result in enumerate(segment_data):

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -50,6 +50,7 @@ from sentry.snuba.referrer import Referrer
 from sentry.tasks.seer.autofix import check_autofix_status
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.event_frames import EventFrame
 
 logger = logging.getLogger(__name__)
@@ -341,7 +342,7 @@ def _get_trace_tree_for_event(
 
     try:
         with sentry_sdk.start_span(op="seer.autofix.get_trace_tree_for_event"):
-            with concurrent.futures.ThreadPoolExecutor() as executor:
+            with ContextPropagatingThreadPoolExecutor() as executor:
                 future = executor.submit(_fetch_trace)
                 return future.result(timeout=timeout)
     except concurrent.futures.TimeoutError:

--- a/src/sentry/seer/explorer/index_data.py
+++ b/src/sentry/seer/explorer/index_data.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -32,6 +32,7 @@ from sentry.services.eventstore import backend as eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -396,7 +397,9 @@ def get_profiles_for_trace(trace_id: str, project_id: int) -> TraceProfiles | No
         for p in profile_data
     ]
 
-    with ThreadPoolExecutor(max_workers=min(len(profiles_to_fetch), 5)) as executor:
+    with ContextPropagatingThreadPoolExecutor(
+        max_workers=min(len(profiles_to_fetch), 5)
+    ) as executor:
         future_to_profile = {
             executor.submit(
                 _fetch_and_process_profile,

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -1,7 +1,6 @@
 import logging
 import time
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import sentry_sdk
@@ -30,6 +29,7 @@ from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import rpc_dataset_common
 from sentry.utils import json, snuba_rpc
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger("sentry.snuba.spans_rpc")
 
@@ -200,7 +200,9 @@ class Spans(rpc_dataset_common.RPCBase):
                 break
             request.page_token.CopyFrom(response.page_token)
             # We want to process the spans while querying the next page
-            with ThreadPoolExecutor(thread_name_prefix=__name__, max_workers=2) as thread_pool:
+            with ContextPropagatingThreadPoolExecutor(
+                thread_name_prefix=__name__, max_workers=2
+            ) as thread_pool:
                 _ = thread_pool.submit(process_item_groups, response.item_groups)
                 response_future = thread_pool.submit(snuba_rpc.get_trace_rpc, request)
             response = response_future.result()

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -1,11 +1,11 @@
 import logging
 from collections import defaultdict
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any, Literal, NotRequired, TypedDict
 
 from sentry.uptime.subscriptions.regions import get_region_config
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -640,7 +640,9 @@ def query_trace_data(
 
     # 1 worker each for spans, errors, performance issues, and optionally uptime
     max_workers = 4 if include_uptime else 3
-    query_thread_pool = ThreadPoolExecutor(thread_name_prefix=__name__, max_workers=max_workers)
+    query_thread_pool = ContextPropagatingThreadPoolExecutor(
+        thread_name_prefix=__name__, max_workers=max_workers
+    )
     with query_thread_pool:
         spans_future = query_thread_pool.submit(
             Spans.run_trace_query,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -9,7 +9,6 @@ import re
 import time
 from collections import namedtuple
 from collections.abc import Callable, Collection, Mapping, MutableMapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
@@ -46,6 +45,7 @@ from sentry.snuba.events import Columns
 from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import validate_referrer
 from sentry.utils import json, metrics
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.dates import outside_retention_with_modified_start
 
 logger = logging.getLogger(__name__)
@@ -1237,7 +1237,7 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
         span.set_tag("snuba.num_queries", len(snuba_requests_list))
 
         if len(snuba_requests_list) > 1:
-            with ThreadPoolExecutor(
+            with ContextPropagatingThreadPoolExecutor(
                 thread_name_prefix=__name__,
                 max_workers=10,
             ) as query_thread_pool:

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import partial
 from typing import Protocol, TypeVar
@@ -48,6 +47,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 from urllib3.response import BaseHTTPResponse
 
 from sentry.utils import json, metrics
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.snuba import SnubaError, _snuba_pool
 
 logger = logging.getLogger(__name__)
@@ -159,7 +159,9 @@ def _make_rpc_requests(
         thread_isolation_scope=sentry_sdk.get_isolation_scope(),
         thread_current_scope=sentry_sdk.get_current_scope(),
     )
-    with ThreadPoolExecutor(thread_name_prefix=__name__, max_workers=10) as query_thread_pool:
+    with ContextPropagatingThreadPoolExecutor(
+        thread_name_prefix=__name__, max_workers=10
+    ) as query_thread_pool:
         response = [
             result
             for result in query_thread_pool.map(


### PR DESCRIPTION
Mechanical import swap of `concurrent.futures.ThreadPoolExecutor` to `sentry.utils.concurrent.ContextPropagatingThreadPoolExecutor` across 22 files. This ensures `contextvars.Context` (including Sentry SDK scopes and OpenTelemetry trace context) is automatically propagated to worker threads.

The wrapper (added in #111451) overrides `submit()` to call `contextvars.copy_context().run()`, which is the same pattern used in production in Seer's `ContextAwareThreadPoolExecutor`. No behavior change — the wrapper is a strict superset of the base class.

This covers all "zero risk" usages — scoped `with` blocks where the parent blocks on results. Remaining long-lived instance executors (Kafka consumers) will be migrated separately with additional review.

Depends on #111451


Agent transcript: https://claudescope.sentry.dev/share/QnsOk2l0-uRvsU_onK7WIQZOUCRhaVHKc_lj_o-l8yQ