### PR TITLE
build(deps): Add codeowners-coverage as dev dependency

### DIFF
--- a/.github/workflows/codeowners-coverage.yml
+++ b/.github/workflows/codeowners-coverage.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install codeowners-coverage
-        run: pip install codeowners-coverage==0.2.1
+        run: pip install codeowners-coverage==0.3.0
 
       - name: Run CODEOWNERS coverage check
         run: codeowners-coverage check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ default = true
 
 [dependency-groups]
 dev = [
-  "codeowners-coverage>=0.2.1",
+  "codeowners-coverage>=0.3.0",
   "covdefaults>=2.3.0",
   "devservices>=1.2.4",
   "docker>=7.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform == 'linux')",
@@ -2393,7 +2393,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "codeowners-coverage", specifier = ">=0.2.1" },
+    { name = "codeowners-coverage", specifier = ">=0.3.0" },
     { name = "covdefaults", specifier = ">=2.3.0" },
     { name = "devservices", specifier = ">=1.2.4" },
     { name = "django-stubs", specifier = ">=5.2.9" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform == 'linux')",


### PR DESCRIPTION
*Need to re-run `uv lock` after https://github.com/getsentry/pypi/pull/2009 merges and update this PR before merging* 


## Summary
- Add `codeowners-coverage>=0.3.0` to dev dependency group in `pyproject.toml`
- Bump CI workflow from `0.2.1` to `0.3.0`

v0.3.0 makes ollama an optional dependency (getsentry/codeowners-coverage#2), removing the pydantic conflict that previously blocked adding this as a dev dependency. This enables running `codeowners-coverage check` locally via `devenv sync`.

## Blockers
- getsentry/pypi#2009 must merge before `uv lock` can resolve — lockfile update will follow

## Test plan
- [ ] getsentry/pypi#2009 merges
- [ ] `uv lock` resolves successfully
- [ ] `devenv sync` installs the package
- [ ] `codeowners-coverage check` runs locally
- [ ] CI workflow passes with v0.3.0