### PR TITLE
ref(ui): Remove overflow from guide steps

### DIFF
--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -371,7 +371,6 @@ const ChildrenWrapper = styled('div')<{isActive: boolean}>`
 `;
 
 const StepDetails = styled('div')`
-  overflow: hidden;
   grid-area: details;
 `;
 


### PR DESCRIPTION
When rendering forms inside of a guide step details it is cut-off.

Not sure if this was needed for something else?