### PR TITLE
ref: Migrate remaining ThreadPoolExecutor usages and enable S016

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,8 +88,6 @@ sentry =
 # All other linting (E, W, F, B, LOG, I) is handled by ruff.
 # See [tool.ruff] in pyproject.toml for the main linting configuration.
 select = S
-# S016 is temporarily disabled until the ThreadPoolExecutor migration is complete.
-extend-ignore = S016
 per-file-ignores =
     # these scripts must have minimal dependencies so opt out of the usual sentry rules
     .github/*: S

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import wait
 from typing import Any
 from uuid import UUID
 
@@ -33,6 +33,7 @@ from sentry.ratelimits.sliding_windows import Quota, RedisSlidingWindowRateLimit
 from sentry.services.eventstore.models import Event
 from sentry.types.actor import parse_and_validate_actor
 from sentry.utils import metrics
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -434,7 +435,7 @@ def _process_message(
 @sentry_sdk.tracing.trace
 @metrics.wraps("occurrence_consumer.process_batch")
 def process_occurrence_batch(
-    worker: ThreadPoolExecutor, message: Message[ValuesBatch[KafkaPayload]]
+    worker: ContextPropagatingThreadPoolExecutor, message: Message[ValuesBatch[KafkaPayload]]
 ) -> None:
     """
     Receives batches of occurrences. This function will take the batch

--- a/src/sentry/issues/run.py
+++ b/src/sentry/issues/run.py
@@ -1,7 +1,6 @@
 import functools
 import logging
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor
 from typing import Literal
 
 import orjson
@@ -16,6 +15,7 @@ from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Commit, Message, Partition
 
 from sentry.utils.arroyo import MultiprocessingPool, run_task_with_multiprocessing
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,9 @@ class OccurrenceStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         self.batched = mode == "batched-parallel"
         # either use multi-process pool or a thread pool
         if self.batched:
-            self.worker: ThreadPoolExecutor | None = ThreadPoolExecutor()
+            self.worker: ContextPropagatingThreadPoolExecutor | None = (
+                ContextPropagatingThreadPoolExecutor()
+            )
             self.pool: MultiprocessingPool | None = None
         else:
             # make sure num_processes is not None
@@ -102,7 +104,9 @@ def process_message(message: Message[KafkaPayload]) -> None:
         logger.exception("failed to process message payload")
 
 
-def process_batch(worker: ThreadPoolExecutor, messages: Message[ValuesBatch[KafkaPayload]]) -> None:
+def process_batch(
+    worker: ContextPropagatingThreadPoolExecutor, messages: Message[ValuesBatch[KafkaPayload]]
+) -> None:
     from sentry.issues.occurrence_consumer import process_occurrence_batch
 
     try:

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from collections import defaultdict
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import wait
 from copy import deepcopy
 from datetime import UTC, datetime
 from functools import partial
@@ -81,6 +81,7 @@ from sentry.monitors.utils import (
 from sentry.monitors.validators import ConfigValidator, MonitorCheckInValidator
 from sentry.types.actor import parse_and_validate_actor
 from sentry.utils import json, metrics
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.dates import to_datetime
 from sentry.utils.outcomes import Outcome, track_outcome
 
@@ -1046,7 +1047,7 @@ def process_checkin_group(items: list[CheckinItem]) -> None:
 
 
 def process_batch(
-    executor: ThreadPoolExecutor, message: Message[ValuesBatch[KafkaPayload]]
+    executor: ContextPropagatingThreadPoolExecutor, message: Message[ValuesBatch[KafkaPayload]]
 ) -> None:
     """
     Receives batches of check-in messages. This function will take the batch
@@ -1142,7 +1143,7 @@ def process_single(message: Message[KafkaPayload | FilteredPayload]) -> None:
 
 
 class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
-    parallel_executor: ThreadPoolExecutor | None = None
+    parallel_executor: ContextPropagatingThreadPoolExecutor | None = None
 
     batched_parallel = False
     """
@@ -1168,7 +1169,7 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
     ) -> None:
         if mode == "batched-parallel":
             self.batched_parallel = True
-            self.parallel_executor = ThreadPoolExecutor(max_workers=max_workers)
+            self.parallel_executor = ContextPropagatingThreadPoolExecutor(max_workers=max_workers)
 
         if max_batch_size is not None:
             self.max_batch_size = max_batch_size

--- a/src/sentry/remote_subscriptions/consumers/result_consumer.py
+++ b/src/sentry/remote_subscriptions/consumers/result_consumer.py
@@ -5,7 +5,7 @@ import logging
 import multiprocessing
 from collections import defaultdict
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import wait
 from functools import partial
 from typing import Generic, Literal, TypeVar
 
@@ -23,6 +23,7 @@ from sentry.locks import locks
 from sentry.remote_subscriptions.models import BaseRemoteSubscription
 from sentry.utils import metrics
 from sentry.utils.arroyo import MultiprocessingPool, run_task_with_multiprocessing
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.retries import TimedRetryPolicy
 
 logger = logging.getLogger(__name__)
@@ -94,7 +95,7 @@ class ResultProcessor(abc.ABC, Generic[T, U]):
 
 
 class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T, U]):
-    parallel_executor: ThreadPoolExecutor | None = None
+    parallel_executor: ContextPropagatingThreadPoolExecutor | None = None
 
     batched_parallel = False
     """
@@ -137,7 +138,7 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
         self.result_processor = self.result_processor_cls(use_subscription_lock=mode == "parallel")
         if mode == "batched-parallel":
             self.batched_parallel = True
-            self.parallel_executor = ThreadPoolExecutor(max_workers=max_workers)
+            self.parallel_executor = ContextPropagatingThreadPoolExecutor(max_workers=max_workers)
             if max_workers is None:
                 metric_tags["workers"] = "default"
             else:

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -10,7 +10,7 @@ import os
 import re
 import sys
 from collections.abc import Callable, Generator
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor  # noqa: S016 - test infra, no tracing needed
 from string import Template
 from typing import Any, ContextManager, Protocol, overload
 


### PR DESCRIPTION
Migrate the 3 remaining long-lived Kafka consumer `ThreadPoolExecutor` instances (monitors, remote subscriptions, issues/occurrence) to `ContextPropagatingThreadPoolExecutor` and re-enable the S016 lint rule.

These are the "low risk" instance-based executors that persist across messages. Each `submit()` still captures context at call time, so each message gets the correct context snapshot. Safe because the Arroyo processing model processes batches sequentially per partition.

Also adds `# noqa: S016` to `testutils/pytest/fixtures.py` (test infra, no tracing needed). `build/_integration_docs.py` is already excluded via `per-file-ignores`.

With S016 now enforced, any future `from concurrent.futures import ThreadPoolExecutor` will be caught by flake8.

Depends on #111460


Agent transcript: https://claudescope.sentry.dev/share/wtQJhBibCle0b-7YblhDE_X19smx3uQBwtkhzwir9Fo