### PR TITLE
fix(dashboards): Allow number-typed tags in categorical bar X-axis

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/xAxisSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/xAxisSelector.tsx
@@ -39,12 +39,11 @@ export function WidgetBuilderXAxisSelector() {
     hiddenKeys = HIDDEN_PREPROD_ATTRIBUTES;
   }
 
-  // Only use string tags for categorical X-axis (numeric values don't make good
-  // categories). This has a major caveat that _some_ numerical tags like HTTP
-  // response status _are_ good for grouping, so we may want to allow that.
   const {traceItemType, ...traceItemOptions} = useWidgetBuilderTraceItemConfig();
-  const {attributes: stringSpanTags, isLoading: isLoadingSpanTags} =
+  const {attributes: stringSpanTags, isLoading: isLoadingStringTags} =
     useTraceItemDatasetAttributes(traceItemType, traceItemOptions, 'string', hiddenKeys);
+  const {attributes: numericSpanTags, isLoading: isLoadingNumericTags} =
+    useTraceItemDatasetAttributes(traceItemType, traceItemOptions, 'number', hiddenKeys);
 
   const datasetConfig = getDatasetConfig(state.dataset);
 
@@ -54,20 +53,21 @@ export function WidgetBuilderXAxisSelector() {
     state.dataset === WidgetType.LOGS ||
     state.dataset === WidgetType.TRACEMETRICS;
 
-  const isLoading = isEAPDataset && isLoadingSpanTags;
+  const isLoading = isEAPDataset && (isLoadingStringTags || isLoadingNumericTags);
 
   const fieldOptions = useMemo(() => {
-    // For EAP, use the EAP-style tags and format them directly, we've already
-    // narrowed down to just string tags
+    // For EAP, use EAP-style tags. Both string and number tags are valid
+    // categories (e.g. run_id, HTTP status codes).
     if (isEAPDataset) {
-      return Object.values(stringSpanTags).map(tag => ({
+      const allTags = {...stringSpanTags, ...numericSpanTags};
+      return Object.values(allTags).map(tag => ({
         label: prettifyTagKey(tag.name),
         value: tag.key,
         trailingItems: () => <TypeBadge valueKind={FieldValueKind.TAG} />,
       }));
     }
 
-    // For other datasets, use getGroupByFieldOptions and filter for string types only
+    // For other datasets, use getGroupByFieldOptions and filter to string/number types
     if (datasetConfig.getGroupByFieldOptions) {
       const options = datasetConfig.getGroupByFieldOptions(organization, tags);
       return Object.values(options)
@@ -80,7 +80,8 @@ export function WidgetBuilderXAxisSelector() {
             return false;
           }
 
-          return option.value.meta.dataType === 'string';
+          const dataType = option.value.meta.dataType;
+          return dataType === 'string' || dataType === 'number';
         })
         .map(option => ({
           label: option.value.meta.name,
@@ -90,7 +91,7 @@ export function WidgetBuilderXAxisSelector() {
     }
 
     return [];
-  }, [isEAPDataset, datasetConfig, organization, tags, stringSpanTags]);
+  }, [isEAPDataset, datasetConfig, organization, tags, stringSpanTags, numericSpanTags]);
 
   // Extract the current X-axis field from state.fields.
   // For categorical bars, state.fields contains both X-axis fields (FIELD kind)


### PR DESCRIPTION
The X-axis selector for categorical bar charts was filtering to only string-typed tags, excluding valid numeric tags like `run_id` and HTTP status codes. This made it impossible to group by these tags directly in the bar chart builder. I did this on purpose to prevent people from using high-cardinality values as groups but I changed my mind, there are a whole bunch of compelling reasons for people to do this (e.g., HTTP response codes) and it's not wise to just forbid it! We should probably allow boolean tags, too.

Users have to manually specify the limit of how many groups to plot, and it's <25, so the worst case scenario is they make a very silly chart with a high-cardinality X-axis like this:

<img width="582" height="421" alt="Screenshot 2026-03-24 at 5 34 38 PM" src="https://github.com/user-attachments/assets/c995e1b4-1c02-4107-88c0-992bbfdee742" />

On the flip side, you can make exciting charts like this, grouping by HTTP response code!

<img width="526" height="421" alt="Screenshot 2026-03-24 at 5 36 55 PM" src="https://github.com/user-attachments/assets/1f0ca598-89b5-49f4-b441-0b412aee0bba" />

There was also a related bug where users could get numeric tags as the X-axis by setting a groupBy in timeseries mode and then switching to categorical bar — but the tag was then unselectable in the X-axis dropdown.

Refs DAIN-1400