### PR TITLE
fix(preprod): Use content_hash as canonical image key for deduplication

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -14,14 +14,19 @@ from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
+from sentry.api.bases.organization import (
+    OrganizationEndpoint,
+    OrganizationReleasePermission,
+)
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.objectstore import get_preprod_session
 from sentry.preprod.analytics import PreprodArtifactApiGetSnapshotDetailsEvent
-from sentry.preprod.api.models.project_preprod_build_details_models import BuildDetailsVcsInfo
+from sentry.preprod.api.models.project_preprod_build_details_models import (
+    BuildDetailsVcsInfo,
+)
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
     SnapshotComparisonRunInfo,
     SnapshotDetailsApiResponse,
@@ -33,8 +38,15 @@ from sentry.preprod.snapshots.comparison_categorizer import (
     CategorizedComparison,
     categorize_comparison_images,
 )
-from sentry.preprod.snapshots.manifest import ComparisonManifest, ImageMetadata, SnapshotManifest
-from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.snapshots.manifest import (
+    ComparisonManifest,
+    ImageMetadata,
+    SnapshotManifest,
+)
+from sentry.preprod.snapshots.models import (
+    PreprodSnapshotComparison,
+    PreprodSnapshotMetrics,
+)
 from sentry.preprod.snapshots.tasks import compare_snapshots
 from sentry.preprod.snapshots.utils import find_base_snapshot_artifact
 from sentry.preprod.url_utils import get_preprod_artifact_url
@@ -69,7 +81,9 @@ SNAPSHOT_POST_REQUEST_ERROR_MESSAGES: dict[str, str] = {
 }
 
 
-def validate_preprod_snapshot_post_schema(request_body: bytes) -> tuple[dict[str, Any], str | None]:
+def validate_preprod_snapshot_post_schema(
+    request_body: bytes,
+) -> tuple[dict[str, Any], str | None]:
     try:
         data = orjson.loads(request_body)
         jsonschema.validate(data, SNAPSHOT_POST_REQUEST_SCHEMA)
@@ -191,7 +205,9 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             PreprodArtifactApiGetSnapshotDetailsEvent(
                 organization_id=organization.id,
                 project_id=artifact.project_id,
-                user_id=request.user.id if request.user and request.user.is_authenticated else None,
+                user_id=(
+                    request.user.id if request.user and request.user.is_authenticated else None
+                ),
                 artifact_id=str(artifact.id),
             )
         )
@@ -200,9 +216,10 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         image_list = [
             SnapshotImageResponse(
                 **{k: v for k, v in metadata.dict().items() if k not in first_class},
-                key=key,
+                key=metadata.content_hash
+                or key,  # TODO(EME-977): Remove backwards fallback for hash-keyed manifests once near EA/GA
                 display_name=metadata.display_name,
-                image_file_name=metadata.image_file_name,
+                image_file_name=key,
                 group=metadata.group,
                 width=metadata.width,
                 height=metadata.height,

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -39,11 +39,12 @@ def _build_base_images(
     first_class = SnapshotImageResponse.__fields__
     result: dict[str, SnapshotImageResponse] = {}
     for key, meta in base_images.items():
-        result[meta.image_file_name] = SnapshotImageResponse(
+        result[key] = SnapshotImageResponse(
             **{k: v for k, v in meta.dict().items() if k not in first_class},
-            key=key,
+            key=meta.content_hash
+            or key,  # TODO(EME-977): Remove backwards fallback for hash-keyed manifests once near EA/GA
             display_name=meta.display_name,
-            image_file_name=meta.image_file_name,
+            image_file_name=key,
             group=meta.group,
             width=meta.width,
             height=meta.height,

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -6,9 +6,9 @@ from pydantic import BaseModel, Field
 
 
 class ImageMetadata(BaseModel):
+    content_hash: str | None = None
     display_name: str | None = None
     group: str | None = None
-    image_file_name: str
     width: int = Field(ge=0)
     height: int = Field(ge=0)
 

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -53,8 +53,9 @@ class _ImageDiffResult(NamedTuple):
 def categorize_image_diff(
     head_manifest: SnapshotManifest, base_manifest: SnapshotManifest
 ) -> _ImageDiffResult:
-    head_by_name = {meta.image_file_name: h for h, meta in head_manifest.images.items()}
-    base_by_name = {meta.image_file_name: h for h, meta in base_manifest.images.items()}
+    # TODO(EME-977): Remove backwards fallback for hash-keyed manifests once near EA/GA
+    head_by_name = {key: (meta.content_hash or key) for key, meta in head_manifest.images.items()}
+    base_by_name = {key: (meta.content_hash or key) for key, meta in base_manifest.images.items()}
 
     matched = head_by_name.keys() & base_by_name.keys()
     added = head_by_name.keys() - base_by_name.keys()
@@ -257,6 +258,10 @@ def compare_snapshots(
         head_images = head_manifest.images
         base_images = base_manifest.images
 
+        # TODO(EME-977): Remove backwards fallback for hash-keyed manifests once near EA/GA
+        head_meta_by_hash = {(m.content_hash or k): m for k, m in head_images.items()}
+        base_meta_by_hash = {(m.content_hash or k): m for k, m in base_images.items()}
+
         categories = categorize_image_diff(head_manifest, base_manifest)
         renamed_pairs = categories.renamed_pairs
         added = categories.added
@@ -287,8 +292,8 @@ def compare_snapshots(
                 }
                 continue
 
-            head_meta = head_images[head_hash]
-            base_meta = base_images[base_hash]
+            head_meta = head_meta_by_hash[head_hash]
+            base_meta = base_meta_by_hash[base_hash]
             head_pixels = head_meta.width * head_meta.height
             base_pixels = base_meta.width * base_meta.height
             pixel_count = max(head_pixels, base_pixels)
@@ -450,7 +455,7 @@ def compare_snapshots(
 
         for name in sorted(removed):
             base_hash = base_by_name[name]
-            base_meta = base_images[base_hash]
+            base_meta = base_meta_by_hash[base_hash]
             image_results[name] = {
                 "status": "removed",
                 "base_hash": base_hash,

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -270,13 +270,11 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
             images = {
                 "img1": {
                     "display_name": "Screen1",
-                    "image_file_name": "Screen1",
                     "width": 375,
                     "height": 812,
                 },
                 "img2": {
                     "display_name": "Screen2",
-                    "image_file_name": "Screen2",
                     "width": 1080,
                     "height": 1920,
                 },
@@ -322,9 +320,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert len(response.data["images"]) == 2
         # Images should be sorted by key
         assert response.data["images"][0]["key"] == "img1"
-        assert (
-            response.data["images"][0]["image_file_name"] == "Screen1"
-        )  # response field is still "file_name"
+        assert response.data["images"][0]["image_file_name"] == "img1"
         assert response.data["images"][1]["key"] == "img2"
 
     @patch("sentry.preprod.api.endpoints.preprod_artifact_snapshot.get_preprod_session")

--- a/tests/sentry/preprod/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_tasks.py
@@ -2,14 +2,14 @@ from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
 from sentry.preprod.snapshots.tasks import categorize_image_diff
 
 
-def _meta(name: str) -> ImageMetadata:
-    return ImageMetadata(image_file_name=name, width=100, height=200)
+def _meta(content_hash: str) -> ImageMetadata:
+    return ImageMetadata(content_hash=content_hash, width=100, height=200)
 
 
 class TestCategorizeImageDiff:
     def test_basic_rename(self):
-        head = SnapshotManifest(images={"hash_a": _meta("new.png")})
-        base = SnapshotManifest(images={"hash_a": _meta("old.png")})
+        head = SnapshotManifest(images={"new.png": _meta("hash_a")})
+        base = SnapshotManifest(images={"old.png": _meta("hash_a")})
 
         result = categorize_image_diff(head, base)
 
@@ -18,8 +18,8 @@ class TestCategorizeImageDiff:
         assert result.removed == set()
 
     def test_no_rename_when_hashes_differ(self):
-        head = SnapshotManifest(images={"hash_1": _meta("a.png")})
-        base = SnapshotManifest(images={"hash_2": _meta("b.png")})
+        head = SnapshotManifest(images={"a.png": _meta("hash_1")})
+        base = SnapshotManifest(images={"b.png": _meta("hash_2")})
 
         result = categorize_image_diff(head, base)
 
@@ -28,8 +28,8 @@ class TestCategorizeImageDiff:
         assert result.removed == {"b.png"}
 
     def test_same_name_same_hash_is_matched_not_renamed(self):
-        head = SnapshotManifest(images={"hash_a": _meta("screen.png")})
-        base = SnapshotManifest(images={"hash_a": _meta("screen.png")})
+        head = SnapshotManifest(images={"screen.png": _meta("hash_a")})
+        base = SnapshotManifest(images={"screen.png": _meta("hash_a")})
 
         result = categorize_image_diff(head, base)
 
@@ -41,16 +41,16 @@ class TestCategorizeImageDiff:
     def test_mixed_renames_adds_removes(self):
         head = SnapshotManifest(
             images={
-                "hash_shared": _meta("renamed.png"),
-                "hash_new": _meta("brand_new.png"),
-                "hash_same": _meta("unchanged.png"),
+                "renamed.png": _meta("hash_shared"),
+                "brand_new.png": _meta("hash_new"),
+                "unchanged.png": _meta("hash_same"),
             }
         )
         base = SnapshotManifest(
             images={
-                "hash_shared": _meta("old_name.png"),
-                "hash_gone": _meta("deleted.png"),
-                "hash_same": _meta("unchanged.png"),
+                "old_name.png": _meta("hash_shared"),
+                "deleted.png": _meta("hash_gone"),
+                "unchanged.png": _meta("hash_same"),
             }
         )
 
@@ -61,8 +61,8 @@ class TestCategorizeImageDiff:
         assert result.removed == {"deleted.png"}
 
     def test_multiple_independent_renames(self):
-        head = SnapshotManifest(images={"hash_a": _meta("new_a.png"), "hash_b": _meta("new_b.png")})
-        base = SnapshotManifest(images={"hash_a": _meta("old_a.png"), "hash_b": _meta("old_b.png")})
+        head = SnapshotManifest(images={"new_a.png": _meta("hash_a"), "new_b.png": _meta("hash_b")})
+        base = SnapshotManifest(images={"old_a.png": _meta("hash_a"), "old_b.png": _meta("hash_b")})
 
         result = categorize_image_diff(head, base)
 


### PR DESCRIPTION
Switch the snapshot manifest to use the dict key as the image file name,
removing the redundant `image_file_name` field from `ImageMetadata`.
All consumers now derive the image name from the manifest key instead
of reading it from the value.

Changes:
- Remove `image_file_name` from `ImageMetadata` model
- `categorize_image_diff` uses dict key as the image name
- `_build_base_images` and API endpoint derive file name from key
- `content_hash` field used for objectstore lookups (falls back to key
  for old hash-keyed manifests)
- Tests rewritten to use filename-keyed manifests

Companion CLI PR: https://github.com/getsentry/sentry-cli/pull/3241