### PR TITLE
chore(eco): Adds codeowner-coverage dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ default = true
 
 [dependency-groups]
 dev = [
+  "codeowners-coverage>=0.2.1",
   "covdefaults>=2.3.0",
   "devservices>=1.2.4",
   "docker>=7.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -190,6 +190,20 @@ wheels = [
 ]
 
 [[package]]
+name = "codeowners-coverage"
+version = "0.3.0"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pathspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/codeowners_coverage-0.3.0-py3-none-any.whl", hash = "sha256:d30abe67e36cdcee67b75f6364b04f61b382816e5040c84c3f85b0a1e96d2508" },
+]
+
+[[package]]
 name = "confluent-kafka"
 version = "2.8.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
@@ -1470,10 +1484,10 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "0.9.0"
+version = "1.0.4"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723" },
 ]
 
 [[package]]
@@ -2212,6 +2226,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "codeowners-coverage", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "covdefaults", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "devservices", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "django-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2378,6 +2393,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "codeowners-coverage", specifier = ">=0.2.1" },
     { name = "covdefaults", specifier = ">=2.3.0" },
     { name = "devservices", specifier = ">=1.2.4" },
     { name = "django-stubs", specifier = ">=5.2.9" },


### PR DESCRIPTION
This is currently needed to properly update coverage files when a codeowner changes.
