### PR TITLE
feat(preprod): Register preprod_artifact webhook resource and event types

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -151,3 +151,7 @@ class SentryAppEventType(StrEnum):
     SEER_IMPACT_ASSESSMENT_STARTED = "seer.impact_assessment_started"
     SEER_IMPACT_ASSESSMENT_COMPLETED = "seer.impact_assessment_completed"
     SEER_PR_CREATED = "seer.pr_created"
+
+    # preprod artifact webhooks
+    PREPROD_ARTIFACT_SIZE_ANALYSIS_COMPLETED = "preprod_artifact.size_analysis_completed"
+    PREPROD_ARTIFACT_BUILD_DISTRIBUTION_COMPLETED = "preprod_artifact.build_distribution_completed"

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -44,6 +44,7 @@ REQUIRED_EVENT_PERMISSIONS = {
     "organization": "org:read",
     "team": "team:read",
     "comment": "event:read",
+    "preprod_artifact": "project:read",
 }
 
 # The only events valid for Sentry Apps are the ones listed in the values of

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -54,6 +54,11 @@ class SeerActionType(SentryAppActionType):
     PR_CREATED = "pr_created"
 
 
+class PreprodArtifactActionType(SentryAppActionType):
+    SIZE_ANALYSIS_COMPLETED = "size_analysis_completed"
+    BUILD_DISTRIBUTION_COMPLETED = "build_distribution_completed"
+
+
 class SentryAppResourceType(StrEnum):
     @staticmethod
     def map_sentry_app_webhook_events(
@@ -71,6 +76,7 @@ class SentryAppResourceType(StrEnum):
     INSTALLATION = "installation"
     METRIC_ALERT = "metric_alert"
     SEER = "seer"
+    PREPROD_ARTIFACT = "preprod_artifact"
 
     # Represents an issue alert resource
     EVENT_ALERT = "event_alert"
@@ -91,6 +97,9 @@ EVENT_EXPANSION: Final[dict[SentryAppResourceType, list[str]]] = {
     ),
     SentryAppResourceType.SEER: SentryAppResourceType.map_sentry_app_webhook_events(
         SentryAppResourceType.SEER.value, SeerActionType
+    ),
+    SentryAppResourceType.PREPROD_ARTIFACT: SentryAppResourceType.map_sentry_app_webhook_events(
+        SentryAppResourceType.PREPROD_ARTIFACT.value, PreprodArtifactActionType
     ),
 }
 # We present Webhook Subscriptions per-resource (Issue, Project, etc.), not


### PR DESCRIPTION
## Summary

Register `preprod_artifact` as a new webhook resource for Sentry Apps with two action types: `size_analysis_completed` and `build_distribution_completed`.

- Add `preprod_artifact` to `REQUIRED_EVENT_PERMISSIONS` with `project:read` permission
- Add `PreprodArtifactActionType` enum with the two action types
- Register `PREPROD_ARTIFACT` in `SentryAppResourceType` and `EVENT_EXPANSION`
- Add corresponding metric event types in `SentryAppEventType`

This is the foundation for the preprod artifact webhook stack — no functional behavior yet, just event type registration.

## Stack

1. **#111472 (this PR)** — Webhook infrastructure
2. #111473 — Size analysis webhook
3. #111474 — Build distribution webhook
4. #111475 — Frontend webhook settings UI

Linear: [EME-907](https://linear.app/getsentry/issue/EME-907/create-webhook-resource-and-events-for-size-analysis)