### PR TITLE
feat(preprod): Add size_analysis.completed webhook for Sentry Apps

### DIFF
--- a/src/sentry/preprod/api/models/public/size_analysis.py
+++ b/src/sentry/preprod/api/models/public/size_analysis.py
@@ -10,13 +10,15 @@ from sentry.models.files.file import File
 from sentry.preprod.api.models.public.shared import (
     AppInfoResponseDict,
     GitInfoResponseDict,
+    create_app_info_dict,
+    create_git_info_dict,
 )
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeComparison,
     PreprodArtifactSizeMetrics,
 )
-from sentry.preprod.size_analysis.models import ComparisonResults
+from sentry.preprod.size_analysis.models import ComparisonResults, SizeAnalysisResults
 from sentry.preprod.size_analysis.utils import match_and_fetch_comparisons
 from sentry.utils import json
 
@@ -60,19 +62,31 @@ class InsightDiffItemResponseDict(TypedDict):
     groupDiffs: list[DiffItemResponseDict]
 
 
-# Keep in sync with internal models in sentry.preprod.size_analysis.models
-class ComparisonResponseDict(TypedDict):
+class ComparisonSummaryResponseDict(TypedDict):
+    """Comparison data shared between the public API and the webhook."""
+
     metricsArtifactType: str
     identifier: str | None
     state: str
     errorCode: str | None
     errorMessage: str | None
-    diffItems: list[DiffItemResponseDict] | None
-    insightDiffItems: list[InsightDiffItemResponseDict] | None
     sizeMetricDiff: SizeMetricDiffResponseDict | None
 
 
-class SizeAnalysisResponseDict(TypedDict):
+# Keep in sync with internal models in sentry.preprod.size_analysis.models
+class ComparisonResponseDict(ComparisonSummaryResponseDict):
+    diffItems: list[DiffItemResponseDict] | None
+    insightDiffItems: list[InsightDiffItemResponseDict] | None
+
+
+class _SizeAnalysisBaseResponseDict(TypedDict):
+    """Fields shared by the webhook summary and the full API response.
+
+    Not used directly — subclassed by ``SizeAnalysisSummaryResponseDict`` and
+    ``SizeAnalysisResponseDict`` which each add their own ``comparisons``
+    field (different element types) plus any shape-specific extras.
+    """
+
     buildId: str
     state: str
     appInfo: AppInfoResponseDict
@@ -83,10 +97,27 @@ class SizeAnalysisResponseDict(TypedDict):
     installSize: int | None
     analysisDuration: float | None
     analysisVersion: str | None
-    insights: dict[str, Any] | None
-    appComponents: list[AppComponentResponseDict] | None
     baseBuildId: str | None
     baseAppInfo: AppInfoResponseDict | None
+
+
+class SizeAnalysisSummaryResponseDict(_SizeAnalysisBaseResponseDict):
+    """Webhook payload shape — the public API response minus heavy fields.
+
+    Includes ``organizationSlug``, ``projectSlug``, and ``platform`` as
+    webhook-specific convenience fields for routing — these are not present
+    in the public API response.
+    """
+
+    organizationSlug: str
+    projectSlug: str
+    platform: str | None
+    comparisons: list[ComparisonSummaryResponseDict] | None
+
+
+class SizeAnalysisResponseDict(_SizeAnalysisBaseResponseDict):
+    insights: dict[str, Any] | None
+    appComponents: list[AppComponentResponseDict] | None
     comparisons: list[ComparisonResponseDict] | None
 
 
@@ -230,3 +261,149 @@ def _build_success_comparison(
         return _build_failed_comparison(
             head_metric, "PARSE_ERROR", "Failed to parse comparison data"
         )
+
+
+class SizeAnalysisSummaryBuildError(Exception):
+    """Raised when the summary builder encounters an unrecoverable data error."""
+
+
+def build_comparison_summary_data(
+    base_artifact: PreprodArtifact,
+    head_size_metrics: list[PreprodArtifactSizeMetrics],
+) -> list[ComparisonSummaryResponseDict] | None:
+    """Build comparison summaries (API subset without diffItems/insightDiffItems)."""
+    full_comparisons = build_comparison_data(base_artifact, head_size_metrics)
+    if full_comparisons is None:
+        return None
+    return [
+        ComparisonSummaryResponseDict(
+            metricsArtifactType=c["metricsArtifactType"],
+            identifier=c["identifier"],
+            state=c["state"],
+            errorCode=c["errorCode"],
+            errorMessage=c["errorMessage"],
+            sizeMetricDiff=c["sizeMetricDiff"],
+        )
+        for c in full_comparisons
+    ]
+
+
+def build_size_analysis_summary(
+    head_artifact: PreprodArtifact,
+    *,
+    base_artifact: PreprodArtifact | None = None,
+    size_metrics: list[PreprodArtifactSizeMetrics] | None = None,
+) -> SizeAnalysisSummaryResponseDict | None:
+    """
+    Build a webhook-ready summary of size analysis results.
+
+    Returns the same shape as the public Size Analysis API response, minus:
+    - ``insights``
+    - ``appComponents``
+    - ``comparisons[].diffItems``
+    - ``comparisons[].insightDiffItems``
+
+    Returns ``None`` for non-terminal states (PENDING, PROCESSING, NOT_RAN)
+    or when no size metrics exist.
+
+    Raises :class:`SizeAnalysisSummaryBuildError` when analysis data cannot
+    be loaded for a COMPLETED state.
+    """
+    if size_metrics is None:
+        size_metrics = list(head_artifact.get_size_metrics())
+
+    if not size_metrics:
+        return None
+
+    main_metric = next(
+        (
+            m
+            for m in size_metrics
+            if m.metrics_artifact_type
+            == PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
+        ),
+        size_metrics[0],
+    )
+
+    try:
+        state_enum = PreprodArtifactSizeMetrics.SizeAnalysisState(main_metric.state)
+    except ValueError:
+        raise SizeAnalysisSummaryBuildError(f"Invalid size analysis state: {main_metric.state}")
+
+    # Non-terminal states: don't fire webhook
+    if state_enum in (
+        PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING,
+        PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+    ):
+        return None
+
+    platform = head_artifact.platform
+
+    response: SizeAnalysisSummaryResponseDict = {
+        "buildId": str(head_artifact.id),
+        "organizationSlug": head_artifact.project.organization.slug,
+        "projectSlug": head_artifact.project.slug,
+        "platform": platform.value.upper() if platform is not None else None,
+        "state": state_enum.name,
+        "appInfo": create_app_info_dict(head_artifact),
+        "gitInfo": create_git_info_dict(head_artifact),
+        "errorCode": None,
+        "errorMessage": None,
+        "downloadSize": None,
+        "installSize": None,
+        "analysisDuration": None,
+        "analysisVersion": None,
+        "baseBuildId": None,
+        "baseAppInfo": None,
+        "comparisons": None,
+    }
+
+    if state_enum == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED:
+        if main_metric.error_code is not None:
+            try:
+                response["errorCode"] = PreprodArtifactSizeMetrics.ErrorCode(
+                    main_metric.error_code
+                ).name
+            except ValueError:
+                raise SizeAnalysisSummaryBuildError(f"Invalid error code: {main_metric.error_code}")
+        response["errorMessage"] = main_metric.error_message
+        return response
+
+    # COMPLETED state — load analysis results from file
+    analysis_file_id = main_metric.analysis_file_id
+    if not analysis_file_id:
+        raise SizeAnalysisSummaryBuildError(
+            f"Missing analysis_file_id for completed metric {main_metric.id}"
+        )
+
+    try:
+        file_obj = File.objects.get(id=analysis_file_id)
+    except File.DoesNotExist:
+        raise SizeAnalysisSummaryBuildError(f"Analysis file {analysis_file_id} not found")
+
+    try:
+        with file_obj.getfile() as fp:
+            content = fp.read()
+        analysis_data = json.loads(content)
+        analysis_results = SizeAnalysisResults(**analysis_data)
+    except SizeAnalysisSummaryBuildError:
+        raise
+    except Exception as e:
+        raise SizeAnalysisSummaryBuildError(
+            f"Failed to parse analysis file {analysis_file_id}: {e}"
+        ) from e
+
+    response["downloadSize"] = analysis_results.download_size
+    response["installSize"] = analysis_results.install_size
+    response["analysisDuration"] = analysis_results.analysis_duration
+    response["analysisVersion"] = analysis_results.analysis_version
+
+    if base_artifact:
+        comparisons = build_comparison_summary_data(base_artifact, size_metrics)
+        if comparisons:
+            response["baseBuildId"] = str(base_artifact.id)
+            response["baseAppInfo"] = create_app_info_dict(base_artifact)
+            response["comparisons"] = comparisons
+
+    return response

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -23,6 +23,7 @@ from sentry.preprod.size_analysis.grouptype import (
 )
 from sentry.preprod.size_analysis.models import ComparisonResults, SizeAnalysisResults
 from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
+from sentry.preprod.size_analysis.webhooks import send_size_analysis_webhook
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -72,195 +73,201 @@ def compare_preprod_artifact_size_analysis(
         )
         return
 
-    if not artifact.commit_comparison:
-        logger.info(
-            "preprod.size_analysis.compare.artifact_no_commit_comparison",
-            extra={"artifact_id": artifact_id},
-        )
-        return
-
-    comparisons: list[dict[str, PreprodArtifactSizeMetrics]] = []
-    preprod_artifact_status_check_updates: set[int] = {artifact.id}
-
-    # Create all comparisons with artifact as head
-    base_artifact = artifact.get_base_artifact_for_commit().first()
-    if base_artifact:
-        if artifact.build_configuration != base_artifact.build_configuration:
+    try:
+        if not artifact.commit_comparison:
             logger.info(
-                "preprod.size_analysis.compare.artifact_different_build_configurations",
-                extra={"head_artifact_id": artifact_id, "base_artifact_id": base_artifact.id},
-            )
-            # Update the status check even though we can't compare to avoid leaving it in a loading state
-            create_preprod_status_check_task.apply_async(
-                kwargs={
-                    "preprod_artifact_id": artifact_id,
-                    "caller": "compare_build_config_mismatch",
-                }
+                "preprod.size_analysis.compare.artifact_no_commit_comparison",
+                extra={"artifact_id": artifact_id},
             )
             return
 
-        base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[base_artifact.id],
-            preprod_artifact__project__organization_id=org_id,
-            preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
-        base_size_metrics = list(base_size_metrics_qs)
+        comparisons: list[dict[str, PreprodArtifactSizeMetrics]] = []
+        preprod_artifact_status_check_updates: set[int] = {artifact.id}
 
-        head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[artifact_id],
-            preprod_artifact__project__organization_id=org_id,
-            preprod_artifact__project_id=project_id,
-        ).select_related(
-            "preprod_artifact",
-            "preprod_artifact__mobile_app_info",
-            "preprod_artifact__commit_comparison",
-        )
-        head_size_metrics = list(head_size_metrics_qs)
+        # Create all comparisons with artifact as head
+        base_artifact = artifact.get_base_artifact_for_commit().first()
+        if base_artifact:
+            if artifact.build_configuration != base_artifact.build_configuration:
+                logger.info(
+                    "preprod.size_analysis.compare.artifact_different_build_configurations",
+                    extra={"head_artifact_id": artifact_id, "base_artifact_id": base_artifact.id},
+                )
+                # Update the status check even though we can't compare to avoid leaving it in a loading state
+                create_preprod_status_check_task.apply_async(
+                    kwargs={
+                        "preprod_artifact_id": artifact_id,
+                        "caller": "compare_build_config_mismatch",
+                    }
+                )
+                return
 
-        validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)
-        if validation_result.can_compare:
-            base_metrics_map = build_size_metrics_map(base_size_metrics)
+            base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact_id=base_artifact.id,
+                preprod_artifact__project__organization_id=org_id,
+                preprod_artifact__project_id=project_id,
+            ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
+            base_size_metrics = list(base_size_metrics_qs)
+
+            head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact_id=artifact_id,
+                preprod_artifact__project__organization_id=org_id,
+                preprod_artifact__project_id=project_id,
+            ).select_related(
+                "preprod_artifact",
+                "preprod_artifact__mobile_app_info",
+                "preprod_artifact__commit_comparison",
+            )
+            head_size_metrics = list(head_size_metrics_qs)
+
+            validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)
+            if validation_result.can_compare:
+                base_metrics_map = build_size_metrics_map(base_size_metrics)
+                head_metrics_map = build_size_metrics_map(head_size_metrics)
+
+                for key, base_metric in base_metrics_map.items():
+                    matching_head_size_metric = head_metrics_map.get(key)
+                    if matching_head_size_metric:
+                        logger.info(
+                            "preprod.size_analysis.compare.create_comparison",
+                            extra={
+                                "head_artifact_id": artifact_id,
+                                "base_artifact_id": base_artifact.id,
+                            },
+                        )
+                        comparisons.append(
+                            {"head_metric": matching_head_size_metric, "base_metric": base_metric},
+                        )
+                    else:
+                        logger.info(
+                            "preprod.size_analysis.compare.no_matching_base_size_metric",
+                            extra={
+                                "head_artifact_id": artifact_id,
+                                "size_metric_id": base_metric.id,
+                            },
+                        )
+            else:
+                logger.info(
+                    "preprod.size_analysis.compare.cannot_compare_size_metrics",
+                    extra={
+                        "head_artifact_id": artifact_id,
+                        "base_artifact_id": base_artifact.id,
+                        "error_message": validation_result.error_message,
+                    },
+                )
+
+        # Also create comparisons with artifact as base
+        head_artifacts = artifact.get_head_artifacts_for_commit()
+        for head_artifact in head_artifacts:
+            if head_artifact.build_configuration != artifact.build_configuration:
+                logger.info(
+                    "preprod.size_analysis.compare.head_artifact_different_build_configurations",
+                    extra={"head_artifact_id": head_artifact.id, "base_artifact_id": artifact_id},
+                )
+                continue
+
+            head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact_id=head_artifact.id,
+                preprod_artifact__project__organization_id=org_id,
+                preprod_artifact__project_id=project_id,
+            ).select_related(
+                "preprod_artifact",
+                "preprod_artifact__mobile_app_info",
+                "preprod_artifact__commit_comparison",
+            )
+            head_size_metrics = list(head_size_metrics_qs)
+
+            base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact_id=artifact_id,
+                preprod_artifact__project__organization_id=org_id,
+                preprod_artifact__project_id=project_id,
+            ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
+            base_size_metrics = list(base_size_metrics_qs)
+
+            validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)
+            if not validation_result.can_compare:
+                logger.info(
+                    "preprod.size_analysis.compare.cannot_compare_size_metrics",
+                    extra={
+                        "head_artifact_id": head_artifact.id,
+                        "base_artifact_id": artifact_id,
+                        "error_message": validation_result.error_message,
+                    },
+                )
+                continue
+
             head_metrics_map = build_size_metrics_map(head_size_metrics)
+            base_metrics_map = build_size_metrics_map(base_size_metrics)
 
-            for key, base_metric in base_metrics_map.items():
-                matching_head_size_metric = head_metrics_map.get(key)
-                if matching_head_size_metric:
+            for key, head_metric in head_metrics_map.items():
+                matching_base_size_metric = base_metrics_map.get(key)
+                if matching_base_size_metric:
                     logger.info(
                         "preprod.size_analysis.compare.create_comparison",
                         extra={
-                            "head_artifact_id": artifact_id,
-                            "base_artifact_id": base_artifact.id,
+                            "head_artifact_id": head_artifact.id,
+                            "base_artifact_id": artifact.id,
                         },
                     )
                     comparisons.append(
-                        {"head_metric": matching_head_size_metric, "base_metric": base_metric},
+                        {"head_metric": head_metric, "base_metric": matching_base_size_metric},
                     )
+                    preprod_artifact_status_check_updates.add(head_artifact.id)
                 else:
                     logger.info(
                         "preprod.size_analysis.compare.no_matching_base_size_metric",
-                        extra={"head_artifact_id": artifact_id, "size_metric_id": base_metric.id},
+                        extra={
+                            "head_artifact_id": head_artifact.id,
+                            "size_metric_id": head_metric.id,
+                        },
                     )
-        else:
-            logger.info(
-                "preprod.size_analysis.compare.cannot_compare_size_metrics",
-                extra={
-                    "head_artifact_id": artifact_id,
-                    "base_artifact_id": base_artifact.id,
-                    "error_message": validation_result.error_message,
-                },
-            )
 
-    # Also create comparisons with artifact as base
-    head_artifacts = artifact.get_head_artifacts_for_commit()
-    for head_artifact in head_artifacts:
-        if head_artifact.build_configuration != artifact.build_configuration:
-            logger.info(
-                "preprod.size_analysis.compare.head_artifact_different_build_configurations",
-                extra={"head_artifact_id": head_artifact.id, "base_artifact_id": artifact_id},
-            )
-            continue
+        # Create PENDING comparison records in DB and run comparisons
+        with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
+            for comp in comparisons:
+                head_metric = comp["head_metric"]
+                base_metric = comp["base_metric"]
+                comparison, created = PreprodArtifactSizeComparison.objects.get_or_create(
+                    head_size_analysis=head_metric,
+                    base_size_analysis=base_metric,
+                    organization_id=org_id,
+                    defaults={"state": PreprodArtifactSizeComparison.State.PENDING},
+                )
 
-        head_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[head_artifact.id],
-            preprod_artifact__project__organization_id=org_id,
-            preprod_artifact__project_id=project_id,
-        ).select_related(
-            "preprod_artifact",
-            "preprod_artifact__mobile_app_info",
-            "preprod_artifact__commit_comparison",
-        )
-        head_size_metrics = list(head_size_metrics_qs)
-
-        base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=[artifact_id],
-            preprod_artifact__project__organization_id=org_id,
-            preprod_artifact__project_id=project_id,
-        ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
-        base_size_metrics = list(base_size_metrics_qs)
-
-        validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)
-        if not validation_result.can_compare:
-            logger.info(
-                "preprod.size_analysis.compare.cannot_compare_size_metrics",
-                extra={
-                    "head_artifact_id": head_artifact.id,
-                    "base_artifact_id": artifact_id,
-                    "error_message": validation_result.error_message,
-                },
-            )
-            continue
-
-        head_metrics_map = build_size_metrics_map(head_size_metrics)
-        base_metrics_map = build_size_metrics_map(base_size_metrics)
-
-        for key, head_metric in head_metrics_map.items():
-            matching_base_size_metric = base_metrics_map.get(key)
-            if matching_base_size_metric:
                 logger.info(
-                    "preprod.size_analysis.compare.create_comparison",
+                    "preprod.size_analysis.compare.running_comparison",
                     extra={
-                        "head_artifact_id": head_artifact.id,
-                        "base_artifact_id": artifact.id,
+                        "head_metric_id": head_metric.id,
+                        "base_metric_id": base_metric.id,
+                        "comparison_created": created,
                     },
                 )
-                comparisons.append(
-                    {"head_metric": head_metric, "base_metric": matching_base_size_metric},
+                _run_size_analysis_comparison(org_id, head_metric, base_metric)
+
+            for artifact_id in preprod_artifact_status_check_updates:
+                # Update all artifact's status check with the new comparison
+                create_preprod_status_check_task.apply_async(
+                    kwargs={
+                        "preprod_artifact_id": artifact_id,
+                        "caller": "compare_completion",
+                    }
                 )
-                preprod_artifact_status_check_updates.add(head_artifact.id)
-            else:
-                logger.info(
-                    "preprod.size_analysis.compare.no_matching_base_size_metric",
-                    extra={"head_artifact_id": head_artifact.id, "size_metric_id": head_metric.id},
-                )
 
-    # Create PENDING comparison records in DB and run comparisons
-    with transaction.atomic(router.db_for_write(PreprodArtifactSizeComparison)):
-        for comp in comparisons:
-            head_metric = comp["head_metric"]
-            base_metric = comp["base_metric"]
-            comparison, created = PreprodArtifactSizeComparison.objects.get_or_create(
-                head_size_analysis=head_metric,
-                base_size_analysis=base_metric,
-                organization_id=org_id,
-                defaults={"state": PreprodArtifactSizeComparison.State.PENDING},
-            )
-
-            logger.info(
-                "preprod.size_analysis.compare.running_comparison",
-                extra={
-                    "head_metric_id": head_metric.id,
-                    "base_metric_id": base_metric.id,
-                    "comparison_created": created,
-                },
-            )
-            _run_size_analysis_comparison(org_id, head_metric, base_metric)
-
-        for artifact_id in preprod_artifact_status_check_updates:
-            # Update all artifact's status check with the new comparison
-            create_preprod_status_check_task.apply_async(
-                kwargs={
-                    "preprod_artifact_id": artifact_id,
-                    "caller": "compare_completion",
-                }
-            )
-
-    artifact_type_name = "unknown"
-    if artifact.artifact_type is not None:
         try:
             artifact_type_name = PreprodArtifact.ArtifactType(artifact.artifact_type).name.lower()
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError, TypeError):
             artifact_type_name = "unknown"
 
-    time_now = timezone.now()
-    e2e_size_analysis_compare_duration = time_now - artifact.date_added
-    metrics.distribution(
-        "preprod.size_analysis.compare.results_e2e",
-        e2e_size_analysis_compare_duration.total_seconds(),
-        sample_rate=1.0,
-        tags={
-            "artifact_type": artifact_type_name,
-        },
-    )
+        e2e_size_analysis_compare_duration = timezone.now() - artifact.date_added
+        metrics.distribution(
+            "preprod.size_analysis.compare.results_e2e",
+            e2e_size_analysis_compare_duration.total_seconds(),
+            sample_rate=1.0,
+            tags={
+                "artifact_type": artifact_type_name,
+            },
+        )
+    finally:
+        send_size_analysis_webhook(artifact=artifact, organization_id=org_id)
 
 
 @instrumented_task(

--- a/src/sentry/preprod/size_analysis/webhooks.py
+++ b/src/sentry/preprod/size_analysis/webhooks.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+
+from sentry.preprod.api.models.public.size_analysis import (
+    SizeAnalysisSummaryBuildError,
+    SizeAnalysisSummaryResponseDict,
+    build_size_analysis_summary,
+)
+from sentry.preprod.models import PreprodArtifact
+from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
+from sentry.sentry_apps.utils.webhooks import PreprodArtifactActionType
+
+logger = logging.getLogger(__name__)
+
+
+def build_webhook_payload(
+    artifact: PreprodArtifact,
+) -> SizeAnalysisSummaryResponseDict | None:
+    """
+    Build the ``size_analysis.completed`` webhook payload for a given artifact.
+
+    The payload mirrors the public Size Analysis API response, excluding:
+
+    - ``insights``
+    - ``appComponents``
+    - ``comparisons[].diffItems``
+    - ``comparisons[].insightDiffItems``
+
+    Returns ``None`` if the webhook should not be fired (e.g. PENDING,
+    PROCESSING, NOT_RAN states, no size metrics, or unreadable analysis data).
+    """
+    # Ensure needed relations are loaded for create_app_info_dict / create_git_info_dict
+    try:
+        head_artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info",
+            "build_configuration",
+            "commit_comparison",
+            "project__organization",
+        ).get(id=artifact.id)
+    except PreprodArtifact.DoesNotExist:
+        logger.warning(
+            "preprod.size_analysis.webhook.artifact_not_found",
+            extra={"artifact_id": artifact.id},
+        )
+        return None
+
+    base_artifact = _resolve_base_artifact(head_artifact)
+
+    try:
+        return build_size_analysis_summary(
+            head_artifact,
+            base_artifact=base_artifact,
+        )
+    except SizeAnalysisSummaryBuildError:
+        logger.exception(
+            "preprod.size_analysis.webhook.build_error",
+            extra={"artifact_id": artifact.id},
+        )
+        return None
+
+
+def send_size_analysis_webhook(
+    artifact: PreprodArtifact,
+    organization_id: int,
+) -> None:
+    """
+    Send the ``size_analysis.completed`` webhook for a given artifact, if applicable.
+
+    Builds the payload and enqueues via the generic broadcaster.
+    Fully fire-and-forget: exceptions are logged but never propagated.
+    """
+    try:
+        payload = build_webhook_payload(artifact)
+        if payload is None:
+            logger.info(
+                "preprod.size_analysis.webhook.no_payload",
+                extra={"artifact_id": artifact.id},
+            )
+            return
+
+        broadcast_webhooks_for_organization.delay(
+            resource_name="preprod_artifact",
+            event_name=PreprodArtifactActionType.SIZE_ANALYSIS_COMPLETED.value,
+            organization_id=organization_id,
+            payload=dict(payload),
+        )
+    except Exception:
+        logger.exception(
+            "preprod.size_analysis.webhook.failed",
+            extra={
+                "artifact_id": artifact.id,
+                "organization_id": organization_id,
+            },
+        )
+
+
+def _resolve_base_artifact(head_artifact: PreprodArtifact) -> PreprodArtifact | None:
+    """Resolve the default base artifact for comparison, mirroring the public API default path."""
+    if not head_artifact.commit_comparison:
+        return None
+
+    return (
+        head_artifact.get_base_artifact_for_commit()
+        .select_related("mobile_app_info", "build_configuration", "commit_comparison")
+        .first()
+    )

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -33,6 +33,7 @@ from sentry.preprod.size_analysis.tasks import (
     compare_preprod_artifact_size_analysis,
     maybe_emit_issues_from_absolute_size_results,
 )
+from sentry.preprod.size_analysis.webhooks import send_size_analysis_webhook
 from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
@@ -609,6 +610,10 @@ def _assemble_preprod_artifact_size_analysis(
                             "organization_id": org_id,
                         },
                     )
+
+        # Fire webhook unconditionally — the comparison task won't run
+        # (re-raise below) so notify subscribers with whatever DB state exists.
+        send_size_analysis_webhook(artifact=preprod_artifact, organization_id=org_id)
 
         # Re-raise to trigger further error handling if needed
         raise

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -151,3 +151,7 @@ class SentryAppEventType(StrEnum):
     SEER_IMPACT_ASSESSMENT_STARTED = "seer.impact_assessment_started"
     SEER_IMPACT_ASSESSMENT_COMPLETED = "seer.impact_assessment_completed"
     SEER_PR_CREATED = "seer.pr_created"
+
+    # preprod artifact webhooks
+    PREPROD_ARTIFACT_SIZE_ANALYSIS_COMPLETED = "preprod_artifact.size_analysis_completed"
+    PREPROD_ARTIFACT_BUILD_DISTRIBUTION_COMPLETED = "preprod_artifact.build_distribution_completed"

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -44,6 +44,7 @@ REQUIRED_EVENT_PERMISSIONS = {
     "organization": "org:read",
     "team": "team:read",
     "comment": "event:read",
+    "preprod_artifact": "project:read",
 }
 
 # The only events valid for Sentry Apps are the ones listed in the values of

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -54,6 +54,11 @@ class SeerActionType(SentryAppActionType):
     PR_CREATED = "pr_created"
 
 
+class PreprodArtifactActionType(SentryAppActionType):
+    SIZE_ANALYSIS_COMPLETED = "size_analysis_completed"
+    BUILD_DISTRIBUTION_COMPLETED = "build_distribution_completed"
+
+
 class SentryAppResourceType(StrEnum):
     @staticmethod
     def map_sentry_app_webhook_events(
@@ -71,6 +76,7 @@ class SentryAppResourceType(StrEnum):
     INSTALLATION = "installation"
     METRIC_ALERT = "metric_alert"
     SEER = "seer"
+    PREPROD_ARTIFACT = "preprod_artifact"
 
     # Represents an issue alert resource
     EVENT_ALERT = "event_alert"
@@ -91,6 +97,9 @@ EVENT_EXPANSION: Final[dict[SentryAppResourceType, list[str]]] = {
     ),
     SentryAppResourceType.SEER: SentryAppResourceType.map_sentry_app_webhook_events(
         SentryAppResourceType.SEER.value, SeerActionType
+    ),
+    SentryAppResourceType.PREPROD_ARTIFACT: SentryAppResourceType.map_sentry_app_webhook_events(
+        SentryAppResourceType.PREPROD_ARTIFACT.value, PreprodArtifactActionType
     ),
 }
 # We present Webhook Subscriptions per-resource (Issue, Project, etc.), not

--- a/tests/sentry/preprod/size_analysis/test_webhooks.py
+++ b/tests/sentry/preprod/size_analysis/test_webhooks.py
@@ -1,0 +1,673 @@
+from io import BytesIO
+from unittest.mock import patch
+
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeComparison,
+    PreprodArtifactSizeMetrics,
+)
+from sentry.preprod.size_analysis.webhooks import (
+    build_webhook_payload,
+    send_size_analysis_webhook,
+)
+from sentry.testutils.cases import TestCase
+from sentry.utils import json
+
+
+class BuildWebhookPayloadTest(TestCase):
+    """Tests for the build_webhook_payload function.
+
+    The webhook payload must be a strict subset of the public Size Analysis API
+    response, excluding ``insights``, ``appComponents``,
+    ``comparisons[].diffItems``, and ``comparisons[].insightDiffItems``.
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _create_analysis_file(self, data):
+        f = self.create_file(name="analysis.json", type="application/json")
+        f.putfile(BytesIO(json.dumps(data).encode()))
+        return f
+
+    def _make_analysis_data(self, **overrides):
+        defaults = {
+            "analysis_duration": 1.5,
+            "download_size": 28311552,
+            "install_size": 41943040,
+            "analysis_version": "1.0.0",
+            "treemap": None,
+            "insights": None,
+            "file_analysis": None,
+            "app_components": None,
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def _make_comparison_data(
+        self, head_sizes, base_sizes, metrics_artifact_type=0, identifier=None
+    ):
+        return {
+            "diff_items": [{"size_diff": 100, "path": "/test", "type": "added"}],
+            "insight_diff_items": [],
+            "size_metric_diff_item": {
+                "metrics_artifact_type": metrics_artifact_type,
+                "identifier": identifier,
+                "head_install_size": head_sizes[1],
+                "head_download_size": head_sizes[0],
+                "base_install_size": base_sizes[1],
+                "base_download_size": base_sizes[0],
+            },
+            "skipped_diff_item_comparison": False,
+        }
+
+    def _create_artifact_with_completed_analysis(
+        self,
+        commit_comparison=None,
+        artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        app_name="My App",
+        build_version="2.4.1",
+        build_number=347,
+        download_size=28311552,
+        install_size=41943040,
+        app_id="com.example.myapp",
+        analysis_data_overrides=None,
+    ):
+        """Create an artifact with a COMPLETED main metric backed by an analysis file."""
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            artifact_type=artifact_type,
+            commit_comparison=commit_comparison,
+            app_name=app_name,
+            build_version=build_version,
+            build_number=build_number,
+            app_id=app_id,
+        )
+        analysis_data = self._make_analysis_data(
+            download_size=download_size,
+            install_size=install_size,
+            **(analysis_data_overrides or {}),
+        )
+        analysis_file = self._create_analysis_file(analysis_data)
+        metric = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_download_size=download_size,
+            max_install_size=install_size,
+            analysis_file_id=analysis_file.id,
+        )
+        return artifact, metric
+
+    def _assert_no_api_heavy_fields(self, payload):
+        """Assert that API-only heavy fields are absent."""
+        for field in ("insights", "appComponents"):
+            assert field not in payload, f"API-only field '{field}' should not be present"
+
+    # ------------------------------------------------------------------
+    # Completed standalone builds
+    # ------------------------------------------------------------------
+
+    def test_standalone_build_success(self):
+        """Completed standalone build produces API-subset payload."""
+        artifact, _ = self._create_artifact_with_completed_analysis()
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["buildId"] == str(artifact.id)
+        assert payload["organizationSlug"] == self.organization.slug
+        assert payload["projectSlug"] == self.project.slug
+        assert payload["platform"] == "APPLE"
+        assert payload["state"] == "COMPLETED"
+        assert payload["errorCode"] is None
+        assert payload["errorMessage"] is None
+        assert payload["downloadSize"] == 28311552
+        assert payload["installSize"] == 41943040
+        assert payload["analysisDuration"] == 1.5
+        assert payload["analysisVersion"] == "1.0.0"
+
+        # appInfo matches canonical shape
+        assert payload["appInfo"]["name"] == "My App"
+        assert payload["appInfo"]["version"] == "2.4.1"
+        assert payload["appInfo"]["buildNumber"] == 347
+        assert payload["appInfo"]["artifactType"] == "XCARCHIVE"
+        assert payload["appInfo"]["appId"] == "com.example.myapp"
+        assert payload["appInfo"]["dateAdded"] is not None
+
+        # No comparison or base
+        assert payload["baseBuildId"] is None
+        assert payload["baseAppInfo"] is None
+        assert payload["comparisons"] is None
+        assert payload["gitInfo"] is None
+
+        self._assert_no_api_heavy_fields(payload)
+
+    def test_standalone_build_with_git_context(self):
+        """Standalone build on main branch has gitInfo but no comparison."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_sha="b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1",
+            head_ref="main",
+            base_ref="main",
+            head_repo_name="acme/my-android-app",
+            pr_number=None,
+        )
+        artifact, _ = self._create_artifact_with_completed_analysis(
+            commit_comparison=commit_comparison,
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["state"] == "COMPLETED"
+        assert payload["organizationSlug"] == self.organization.slug
+        assert payload["platform"] == "ANDROID"
+        assert payload["appInfo"]["artifactType"] == "AAB"
+        assert payload["comparisons"] is None
+        assert payload["gitInfo"] is not None
+        assert payload["gitInfo"]["headSha"] == "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1"
+        assert payload["gitInfo"]["headRef"] == "main"
+        assert payload["gitInfo"]["headRepoName"] == "acme/my-android-app"
+        assert payload["gitInfo"]["prNumber"] is None
+        assert payload["gitInfo"]["provider"] is not None
+
+        self._assert_no_api_heavy_fields(payload)
+
+    # ------------------------------------------------------------------
+    # PR builds with comparisons
+    # ------------------------------------------------------------------
+
+    def test_pr_build_comparison_succeeded(self):
+        """PR build with successful comparison includes per-artifact comparisons."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_sha="a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+            base_sha="f0e1d2c3b4a5f6e7d8c9b0a1f2e3d4c5b6a7f8e9",
+            head_ref="feature/new-onboarding",
+            base_ref="main",
+            head_repo_name="acme/my-ios-app",
+            pr_number=1042,
+        )
+        head_artifact, head_metric = self._create_artifact_with_completed_analysis(
+            commit_comparison=commit_comparison,
+            download_size=28311552,
+            install_size=41943040,
+        )
+
+        # Create base artifact reachable via commit comparison chain
+        base_commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_sha=commit_comparison.base_sha,
+            base_sha="0000000000000000000000000000000000000000",
+        )
+        base_artifact, base_metric = self._create_artifact_with_completed_analysis(
+            commit_comparison=base_commit_comparison,
+            download_size=28259072,
+            install_size=41864920,
+        )
+
+        comparison_data = self._make_comparison_data(
+            head_sizes=(28311552, 41943040),
+            base_sizes=(28259072, 41864920),
+        )
+        comparison_file = self._create_analysis_file(comparison_data)
+        self.create_preprod_artifact_size_comparison(
+            organization=self.organization,
+            head_size_analysis=head_metric,
+            base_size_analysis=base_metric,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+            file_id=comparison_file.id,
+        )
+
+        payload = build_webhook_payload(head_artifact)
+
+        assert payload is not None
+        assert payload["state"] == "COMPLETED"
+        assert payload["baseBuildId"] == str(base_artifact.id)
+        assert payload["baseAppInfo"] is not None
+        assert payload["baseAppInfo"]["name"] == "My App"
+        assert payload["comparisons"] is not None
+        assert len(payload["comparisons"]) == 1
+
+        comparison = payload["comparisons"][0]
+        assert comparison["metricsArtifactType"] == "MAIN_ARTIFACT"
+        assert comparison["state"] == "SUCCESS"
+        assert comparison["errorCode"] is None
+        assert comparison["errorMessage"] is None
+        assert comparison["sizeMetricDiff"] is not None
+        assert comparison["sizeMetricDiff"]["headDownloadSize"] == 28311552
+        assert comparison["sizeMetricDiff"]["baseDownloadSize"] == 28259072
+
+        # Webhook comparisons must NOT contain heavy diff fields
+        assert "diffItems" not in comparison
+        assert "insightDiffItems" not in comparison
+
+        assert payload["gitInfo"] is not None
+        assert payload["gitInfo"]["prNumber"] == 1042
+
+        self._assert_no_api_heavy_fields(payload)
+
+    def test_pr_build_comparison_failed(self):
+        """PR build with failed comparison: top-level state stays COMPLETED."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_ref="feature/new-onboarding",
+            base_ref="main",
+            head_repo_name="acme/my-ios-app",
+            pr_number=1042,
+        )
+        head_artifact, head_metric = self._create_artifact_with_completed_analysis(
+            commit_comparison=commit_comparison,
+        )
+
+        base_commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_sha=commit_comparison.base_sha,
+            base_sha="0000000000000000000000000000000000000000",
+        )
+        _base_artifact, base_metric = self._create_artifact_with_completed_analysis(
+            commit_comparison=base_commit_comparison,
+        )
+
+        self.create_preprod_artifact_size_comparison(
+            organization=self.organization,
+            head_size_analysis=head_metric,
+            base_size_analysis=base_metric,
+            state=PreprodArtifactSizeComparison.State.FAILED,
+        )
+
+        payload = build_webhook_payload(head_artifact)
+
+        assert payload is not None
+        # Top-level state is COMPLETED (analysis itself succeeded)
+        assert payload["state"] == "COMPLETED"
+        assert payload["errorCode"] is None
+        assert payload["errorMessage"] is None
+        assert payload["downloadSize"] == 28311552
+        assert payload["installSize"] == 41943040
+
+        # Comparison row shows the failure
+        assert payload["comparisons"] is not None
+        assert len(payload["comparisons"]) == 1
+        assert payload["comparisons"][0]["state"] == "FAILED"
+
+    def test_multi_metric_comparison(self):
+        """Multiple artifacts (main + watch) produce multiple comparison entries."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_sha="a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+            base_sha="f0e1d2c3b4a5f6e7d8c9b0a1f2e3d4c5b6a7f8e9",
+            head_ref="feature/watch-app",
+            base_ref="main",
+            head_repo_name="acme/my-ios-app",
+            pr_number=100,
+        )
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=commit_comparison,
+            app_name="My App",
+            build_version="1.0",
+            build_number=1,
+        )
+        analysis_file = self._create_analysis_file(self._make_analysis_data())
+        head_main_metric = self.create_preprod_artifact_size_metrics(
+            head_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_download_size=16000000,
+            max_install_size=18000000,
+            analysis_file_id=analysis_file.id,
+        )
+        head_watch_metric = self.create_preprod_artifact_size_metrics(
+            head_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_download_size=8000000,
+            max_install_size=9000000,
+        )
+
+        # Base artifact
+        base_commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_sha=commit_comparison.base_sha,
+            base_sha="0000000000000000000000000000000000000000",
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=base_commit_comparison,
+            app_name="My App",
+            build_version="0.9",
+            build_number=0,
+        )
+        base_main_metric = self.create_preprod_artifact_size_metrics(
+            base_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_download_size=15000000,
+            max_install_size=17000000,
+        )
+        base_watch_metric = self.create_preprod_artifact_size_metrics(
+            base_artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_download_size=7000000,
+            max_install_size=8000000,
+        )
+
+        # Main comparison
+        main_comp_data = self._make_comparison_data(
+            head_sizes=(16000000, 18000000),
+            base_sizes=(15000000, 17000000),
+        )
+        main_comp_file = self._create_analysis_file(main_comp_data)
+        self.create_preprod_artifact_size_comparison(
+            organization=self.organization,
+            head_size_analysis=head_main_metric,
+            base_size_analysis=base_main_metric,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+            file_id=main_comp_file.id,
+        )
+
+        # Watch comparison
+        watch_comp_data = self._make_comparison_data(
+            head_sizes=(8000000, 9000000),
+            base_sizes=(7000000, 8000000),
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.watch",
+        )
+        watch_comp_file = self._create_analysis_file(watch_comp_data)
+        self.create_preprod_artifact_size_comparison(
+            organization=self.organization,
+            head_size_analysis=head_watch_metric,
+            base_size_analysis=base_watch_metric,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+            file_id=watch_comp_file.id,
+        )
+
+        payload = build_webhook_payload(head_artifact)
+
+        assert payload is not None
+        assert payload["state"] == "COMPLETED"
+        assert payload["baseBuildId"] == str(base_artifact.id)
+        assert payload["comparisons"] is not None
+        assert len(payload["comparisons"]) == 2
+
+        comparisons_by_type = {c["metricsArtifactType"]: c for c in payload["comparisons"]}
+        assert "MAIN_ARTIFACT" in comparisons_by_type
+        assert "WATCH_ARTIFACT" in comparisons_by_type
+
+        main_comp = comparisons_by_type["MAIN_ARTIFACT"]
+        assert main_comp["state"] == "SUCCESS"
+        assert main_comp["sizeMetricDiff"] is not None
+        assert "diffItems" not in main_comp
+        assert "insightDiffItems" not in main_comp
+
+        watch_comp = comparisons_by_type["WATCH_ARTIFACT"]
+        assert watch_comp["state"] == "SUCCESS"
+        assert watch_comp["identifier"] == "com.example.watch"
+        assert watch_comp["sizeMetricDiff"] is not None
+        assert "diffItems" not in watch_comp
+        assert "insightDiffItems" not in watch_comp
+
+    # ------------------------------------------------------------------
+    # Analysis failures
+    # ------------------------------------------------------------------
+
+    def test_analysis_failed(self):
+        """Analysis failure produces FAILED payload with error details."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_ref="feature/broken-build",
+            base_ref="main",
+            head_repo_name="acme/my-ios-app",
+            pr_number=1050,
+        )
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=commit_comparison,
+        )
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.PROCESSING_ERROR,
+            error_message="Failed to extract size metrics from artifact",
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["state"] == "FAILED"
+        assert payload["errorCode"] == "PROCESSING_ERROR"
+        assert payload["errorMessage"] == "Failed to extract size metrics from artifact"
+        assert payload["downloadSize"] is None
+        assert payload["installSize"] is None
+        assert payload["comparisons"] is None
+
+        self._assert_no_api_heavy_fields(payload)
+
+    def test_analysis_timeout_error_code(self):
+        """Timeout error code is mapped correctly."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.TIMEOUT,
+            error_message="Size analysis timed out",
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["errorCode"] == "TIMEOUT"
+
+    def test_unsupported_artifact_error_code(self):
+        """Unsupported artifact error code is mapped correctly."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.UNSUPPORTED_ARTIFACT,
+            error_message="Unsupported artifact type",
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["errorCode"] == "UNSUPPORTED_ARTIFACT"
+
+    # ------------------------------------------------------------------
+    # Suppressed states
+    # ------------------------------------------------------------------
+
+    def test_not_ran_returns_none(self):
+        """NOT_RAN state should not produce a webhook payload."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.NO_QUOTA,
+            error_message="No quota available",
+        )
+
+        assert build_webhook_payload(artifact) is None
+
+    def test_pending_returns_none(self):
+        """PENDING state should not produce a webhook payload."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        )
+
+        assert build_webhook_payload(artifact) is None
+
+    def test_processing_returns_none(self):
+        """PROCESSING state should not produce a webhook payload."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING,
+        )
+
+        assert build_webhook_payload(artifact) is None
+
+    def test_no_metrics_returns_none(self):
+        """No size metrics at all should not produce a webhook payload."""
+        artifact = self.create_preprod_artifact(project=self.project)
+
+        assert build_webhook_payload(artifact) is None
+
+    # ------------------------------------------------------------------
+    # Edge cases
+    # ------------------------------------------------------------------
+
+    def test_no_mobile_app_info(self):
+        """Artifact without mobile app info has null appInfo fields."""
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            create_mobile_app_info=False,
+        )
+        analysis_file = self._create_analysis_file(self._make_analysis_data())
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            analysis_file_id=analysis_file.id,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["appInfo"]["name"] is None
+        assert payload["appInfo"]["version"] is None
+        assert payload["appInfo"]["buildNumber"] is None
+
+    def test_build_id_is_string(self):
+        """buildId should always be a string, not an integer."""
+        artifact, _ = self._create_artifact_with_completed_analysis()
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert isinstance(payload["buildId"], str)
+
+    def test_android_apk_artifact_type(self):
+        """Android APK artifact has correct appInfo.artifactType."""
+        artifact, _ = self._create_artifact_with_completed_analysis(
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["appInfo"]["artifactType"] == "APK"
+
+    def test_android_aab_artifact_type(self):
+        """Android AAB artifact has correct appInfo.artifactType."""
+        artifact, _ = self._create_artifact_with_completed_analysis(
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["appInfo"]["artifactType"] == "AAB"
+
+
+class SendSizeAnalysisWebhookTest(TestCase):
+    """Tests for the send_size_analysis_webhook function."""
+
+    def _create_analysis_file(self, data):
+        f = self.create_file(name="analysis.json", type="application/json")
+        f.putfile(BytesIO(json.dumps(data).encode()))
+        return f
+
+    def _create_artifact_with_completed_analysis(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_name="My App",
+            build_version="1.0.0",
+            build_number=1,
+        )
+        analysis_data = {
+            "analysis_duration": 1.5,
+            "download_size": 1048576,
+            "install_size": 2097152,
+            "analysis_version": "1.0.0",
+            "treemap": None,
+            "insights": None,
+            "file_analysis": None,
+            "app_components": None,
+        }
+        analysis_file = self._create_analysis_file(analysis_data)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            analysis_file_id=analysis_file.id,
+        )
+        return artifact
+
+    @patch("sentry.preprod.size_analysis.webhooks.broadcast_webhooks_for_organization")
+    def test_sends_webhook(self, mock_broadcast):
+        """Webhook is sent for a completed build with API-subset payload."""
+        artifact = self._create_artifact_with_completed_analysis()
+
+        send_size_analysis_webhook(artifact=artifact, organization_id=self.organization.id)
+
+        mock_broadcast.delay.assert_called_once()
+        call_kwargs = mock_broadcast.delay.call_args
+        assert call_kwargs.kwargs["resource_name"] == "preprod_artifact"
+        assert call_kwargs.kwargs["event_name"] == "size_analysis_completed"
+        assert call_kwargs.kwargs["organization_id"] == self.organization.id
+        assert call_kwargs.kwargs["payload"]["buildId"] == str(artifact.id)
+        assert call_kwargs.kwargs["payload"]["organizationSlug"] == self.organization.slug
+        assert call_kwargs.kwargs["payload"]["projectSlug"] == self.project.slug
+        assert call_kwargs.kwargs["payload"]["state"] == "COMPLETED"
+
+    @patch("sentry.preprod.size_analysis.webhooks.broadcast_webhooks_for_organization")
+    def test_does_not_send_for_not_ran(self, mock_broadcast):
+        """Webhook is NOT sent for NOT_RAN state."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.NO_QUOTA,
+            error_message="No quota available",
+        )
+
+        send_size_analysis_webhook(artifact=artifact, organization_id=self.organization.id)
+
+        mock_broadcast.delay.assert_not_called()
+
+    @patch("sentry.preprod.size_analysis.webhooks.broadcast_webhooks_for_organization")
+    def test_does_not_send_for_no_metrics(self, mock_broadcast):
+        """Webhook is NOT sent when no size metrics exist."""
+        artifact = self.create_preprod_artifact(project=self.project)
+
+        send_size_analysis_webhook(artifact=artifact, organization_id=self.organization.id)
+
+        mock_broadcast.delay.assert_not_called()
+
+    @patch("sentry.preprod.size_analysis.webhooks.broadcast_webhooks_for_organization")
+    def test_broadcast_exception_is_caught(self, mock_broadcast):
+        """Exceptions from broadcast are caught and logged, not re-raised."""
+        artifact = self._create_artifact_with_completed_analysis()
+        mock_broadcast.delay.side_effect = Exception("Celery task failed")
+
+        # Should not raise
+        send_size_analysis_webhook(artifact=artifact, organization_id=self.organization.id)
+
+        mock_broadcast.delay.assert_called_once()


### PR DESCRIPTION
## Summary

Add a `size_analysis.completed` webhook that fires when a mobile build's size analysis reaches a terminal state (COMPLETED or FAILED).

**Changes:**
- Refactor size analysis TypedDicts into a base/summary/full hierarchy so the webhook payload structurally excludes heavy fields (`insights`, `appComponents`, `diffItems`)
- Add `build_comparison_summary_data` builder that produces the webhook payload from the same models the public API uses
- Add `webhooks.py` module with `build_webhook_payload` / `send_size_analysis_webhook` orchestration
- Hook `send_size_analysis_webhook` into all terminal paths of the analysis task pipeline (standalone builds, config mismatches, successful comparisons, and assembly failures) using try/finally
- Webhook delivery is fire-and-forget via `broadcast_webhooks_for_organization` — failures are logged but never block the pipeline

The payload includes routing convenience fields (`organizationSlug`, `projectSlug`, `platform`) so consumers can route events without additional API calls.

### Example `size_analysis.completed` Webhook Payload

```json
{
  "action": "completed",
  "installation": {
    "uuid": "77081c59-d802-40b8-b635-2e6f792f74de"
  },
  "data": {
    "buildId": "72",
    "organizationSlug": "sentry",
    "projectSlug": "internal",
    "platform": "apple",
    "state": "COMPLETED",
    "appInfo": {
      "appId": "com.cameroncooke.test",
      "name": "test",
      "version": "1.0",
      "buildNumber": 2,
      "artifactType": "XCARCHIVE",
      "dateAdded": "2026-03-19T12:39:44.699049+00:00",
      "dateBuilt": "2026-03-19T12:39:26+00:00"
    },
    "gitInfo": {
      "headSha": "16bee14a5a68d4bb89c48735264b384223754fae",
      "baseSha": "88d7247b737f798e7ae4cfdea96e5c64b8718e8d",
      "provider": "github",
      "headRepoName": "cameroncooke/sentry_test_app",
      "baseRepoName": "cameroncooke/sentry_test_app",
      "headRef": "change_assets",
      "baseRef": "main",
      "prNumber": 3
    },
    "errorCode": null,
    "errorMessage": null,
    "downloadSize": 28864215,
    "installSize": 30806016,
    "analysisDuration": 21.640800952911377,
    "analysisVersion": "1.2.1",
    "baseBuildId": "57",
    "baseAppInfo": {
      "appId": "com.cameroncooke.test",
      "name": "test",
      "version": "1.0",
      "buildNumber": 2,
      "artifactType": "XCARCHIVE",
      "dateAdded": "2026-03-09T16:55:39.111991+00:00",
      "dateBuilt": "2026-03-09T16:55:26+00:00"
    },
    "comparisons": [
      {
        "metricsArtifactType": "WATCH_ARTIFACT",
        "identifier": "com.cameroncooke.test.watchkitapp",
        "state": "SUCCESS",
        "errorCode": null,
        "errorMessage": null,
        "sizeMetricDiff": {
          "metricsArtifactType": "WATCH_ARTIFACT",
          "identifier": "com.cameroncooke.test.watchkitapp",
          "headInstallSize": 9023488,
          "headDownloadSize": 8765015,
          "baseInstallSize": 290816,
          "baseDownloadSize": 51594
        }
      },
      {
        "metricsArtifactType": "APP_CLIP_ARTIFACT",
        "identifier": "com.cameroncooke.test.Clip",
        "state": "FAILED",
        "errorCode": "NO_BASE_METRIC",
        "errorMessage": "No matching base artifact size metric found.",
        "sizeMetricDiff": null
      },
      {
        "metricsArtifactType": "MAIN_ARTIFACT",
        "identifier": null,
        "state": "SUCCESS",
        "errorCode": null,
        "errorMessage": null,
        "sizeMetricDiff": {
          "metricsArtifactType": "MAIN_ARTIFACT",
          "identifier": null,
          "headInstallSize": 17833984,
          "headDownloadSize": 16255246,
          "baseInstallSize": 5394432,
          "baseDownloadSize": 3844031
        }
      }
    ]
  },
  "actor": {
    "type": "application",
    "id": "sentry",
    "name": "Sentry"
  }
}
```

## Tests

Comprehensive tests covering payload construction, suppressed states, error codes, multi-metric comparisons, and broadcast behavior.

## Stack

1. #111472 — Webhook infrastructure
2. **#111473 (this PR)** — Size analysis webhook
3. #111474 — Build distribution webhook
4. #111475 — Frontend webhook settings UI

Linear: [EME-907](https://linear.app/getsentry/issue/EME-907/create-webhook-resource-and-events-for-size-analysis)