### PR TITLE
feat(preprod): Add preprod_artifact webhooks to frontend settings UI

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -223,6 +223,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod frontend routes
     manager.add("organizations:preprod-frontend-routes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable preprod_artifact webhook subscription UI in Sentry App settings
+    manager.add("organizations:preprod-artifact-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod issue reporting
     manager.add("organizations:preprod-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod PR comments for build distribution

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -571,7 +571,7 @@ export type AppOrProviderOrPlugin =
 /**
  * Webhooks and servicehooks
  */
-export type WebhookEvent = 'issue' | 'error' | 'comment' | 'seer';
+export type WebhookEvent = 'issue' | 'error' | 'comment' | 'seer' | 'preprod_artifact';
 
 export type ServiceHook = {
   dateCreated: string;

--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -1,8 +1,15 @@
-export const EVENT_CHOICES = ['issue', 'error', 'comment', 'seer'] as const;
+export const EVENT_CHOICES = [
+  'issue',
+  'error',
+  'comment',
+  'seer',
+  'preprod_artifact',
+] as const;
 
 export const PERMISSIONS_MAP = {
   issue: 'Event',
   error: 'Event',
   comment: 'Event',
   seer: 'Event',
+  preprod_artifact: 'Project',
 } as const;

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Form} from 'sentry/components/forms/form';
@@ -6,6 +8,35 @@ import {Subscriptions} from 'sentry/views/settings/organizationDeveloperSettings
 describe('Resource Subscriptions', () => {
   describe('initial no-access permissions', () => {
     it('renders disabled checkbox with no issue permission', () => {
+      const org = OrganizationFixture({features: ['preprod-artifact-webhooks']});
+      render(
+        <Form>
+          <Subscriptions
+            events={[]}
+            permissions={{
+              Event: 'no-access',
+              Team: 'no-access',
+              Project: 'write',
+              Release: 'admin',
+              Organization: 'admin',
+              Member: 'admin',
+            }}
+            onChange={jest.fn()}
+          />
+        </Form>,
+        {organization: org}
+      );
+
+      expect(screen.getAllByRole('checkbox')).toHaveLength(5);
+      expect(screen.getByRole('checkbox', {name: 'issue'})).toBeDisabled();
+      expect(screen.getByRole('checkbox', {name: 'error'})).toBeDisabled();
+      expect(screen.getByRole('checkbox', {name: 'comment'})).toBeDisabled();
+      expect(screen.getByRole('checkbox', {name: 'seer'})).toBeDisabled();
+      // preprod_artifact requires Project permission which is 'write' here, so it's enabled
+      expect(screen.getByRole('checkbox', {name: 'preprod_artifact'})).toBeEnabled();
+    });
+
+    it('hides preprod_artifact checkbox without preprod-artifact-webhooks flag', () => {
       render(
         <Form>
           <Subscriptions
@@ -23,13 +54,10 @@ describe('Resource Subscriptions', () => {
         </Form>
       );
 
-      expect(screen.getAllByRole('checkbox')).toHaveLength(5);
-      expect(screen.getByRole('checkbox', {name: 'issue'})).toBeDisabled();
-      expect(screen.getByRole('checkbox', {name: 'error'})).toBeDisabled();
-      expect(screen.getByRole('checkbox', {name: 'comment'})).toBeDisabled();
-      expect(screen.getByRole('checkbox', {name: 'seer'})).toBeDisabled();
-      // preprod_artifact requires Project permission which is 'write' here, so it's enabled
-      expect(screen.getByRole('checkbox', {name: 'preprod_artifact'})).toBeEnabled();
+      expect(screen.getAllByRole('checkbox')).toHaveLength(4);
+      expect(
+        screen.queryByRole('checkbox', {name: 'preprod_artifact'})
+      ).not.toBeInTheDocument();
     });
 
     it('updates events state when new permissions props is passed', () => {

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
@@ -23,11 +23,13 @@ describe('Resource Subscriptions', () => {
         </Form>
       );
 
-      expect(screen.getAllByRole('checkbox')).toHaveLength(4);
+      expect(screen.getAllByRole('checkbox')).toHaveLength(5);
       expect(screen.getByRole('checkbox', {name: 'issue'})).toBeDisabled();
       expect(screen.getByRole('checkbox', {name: 'error'})).toBeDisabled();
       expect(screen.getByRole('checkbox', {name: 'comment'})).toBeDisabled();
       expect(screen.getByRole('checkbox', {name: 'seer'})).toBeDisabled();
+      // preprod_artifact requires Project permission which is 'write' here, so it's enabled
+      expect(screen.getByRole('checkbox', {name: 'preprod_artifact'})).toBeEnabled();
     });
 
     it('updates events state when new permissions props is passed', () => {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -82,6 +82,12 @@ const getEventTypes = memoize((app: SentryApp) => {
         ]
       : []),
     ...issueLinkEvents,
+    ...(app.events.includes('preprod_artifact')
+      ? [
+          'preprod_artifact.size_analysis_completed',
+          'preprod_artifact.build_distribution_completed',
+        ]
+      : []),
   ];
 
   return events;

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -84,8 +84,15 @@ describe('SubscriptionBox', () => {
   });
 
   describe('preprod_artifact resource subscription', () => {
-    it('renders preprod_artifact checkbox enabled', () => {
+    it('hidden without preprod-artifact-webhooks flag', () => {
       renderComponent({resource: 'preprod_artifact'});
+
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    it('renders preprod_artifact checkbox enabled with preprod-artifact-webhooks flag', () => {
+      const orgWithFlag = OrganizationFixture({features: ['preprod-artifact-webhooks']});
+      renderComponent({resource: 'preprod_artifact', organization: orgWithFlag});
 
       expect(screen.getByRole('checkbox')).toBeEnabled();
     });

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -82,4 +82,12 @@ describe('SubscriptionBox', () => {
       )
     ).toBeInTheDocument();
   });
+
+  describe('preprod_artifact resource subscription', () => {
+    it('renders preprod_artifact checkbox enabled', () => {
+      renderComponent({resource: 'preprod_artifact'});
+
+      expect(screen.getByRole('checkbox')).toBeEnabled();
+    });
+  });
 });

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -56,6 +56,7 @@ function SubscriptionBox({
     error: 'created',
     comment: 'created, edited, deleted',
     seer: 'root_cause_started, root_cause_completed, solution_started, solution_completed, coding_started, coding_completed, pr_created',
+    preprod_artifact: 'size_analysis_completed, build_distribution_completed',
   };
 
   return (

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -34,6 +34,13 @@ function SubscriptionBox({
 }: Props) {
   const {features} = organization;
 
+  if (
+    resource === 'preprod_artifact' &&
+    !features.includes('preprod-artifact-webhooks')
+  ) {
+    return null;
+  }
+
   let disabled = disabledFromPermissions || webhookDisabled;
   let message = t(
     "Must have at least 'Read' permissions enabled for %s",


### PR DESCRIPTION
## Summary

Add `size_analysis` and `build_distribution` to the frontend Sentry App developer settings so users can subscribe to preprod artifact webhooks.

**Changes:**
- Add `preprod_artifact` to the `WebhookEvent` type
- Add event choices and permissions mapping for `size_analysis` and `build_distribution`
- Add subscription box entry for the new resource
- Add request log dashboard entry for `preprod_artifact` events
- Update tests for the new subscription options

## Docs

Docs PR is https://github.com/getsentry/sentry-docs/pull/17116

## Stack

1. #111472 — Webhook infrastructure
2. #111473 — Size analysis webhook
3. #111474 — Build distribution webhook
4. **#111475 (this PR)** — Frontend webhook settings UI
5. Docs: https://github.com/getsentry/sentry-docs/pull/17116

Linear: [EME-907](https://linear.app/getsentry/issue/EME-907/create-webhook-resource-and-events-for-size-analysis)