### PR TITLE
fix(onboarding): Reset downstream state when repository changes

### DIFF
--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -6,6 +6,7 @@ import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 type OnboardingContextProps = {
+  clearDerivedState: () => void;
   setCreatedProjectSlug: (slug?: string) => void;
   setSelectedFeatures: (features?: ProductSolution[]) => void;
   setSelectedIntegration: (integration?: Integration) => void;
@@ -40,6 +41,7 @@ const OnboardingContext = createContext<OnboardingContextProps>({
   setSelectedFeatures: () => {},
   createdProjectSlug: undefined,
   setCreatedProjectSlug: () => {},
+  clearDerivedState: () => {},
 });
 
 type ProviderProps = {
@@ -81,6 +83,17 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
       createdProjectSlug: onboarding?.createdProjectSlug,
       setCreatedProjectSlug: (createdProjectSlug?: string) => {
         setOnboarding(prev => ({...prev, createdProjectSlug}));
+      },
+      // Clear state derived from the selected repository (platform, features,
+      // created project) without wiping the entire session. Use this when the
+      // repo changes so downstream steps start fresh.
+      clearDerivedState: () => {
+        setOnboarding(prev => ({
+          ...prev,
+          selectedPlatform: undefined,
+          selectedFeatures: undefined,
+          createdProjectSlug: undefined,
+        }));
       },
     }),
     [onboarding, setOnboarding, removeOnboarding]

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -51,13 +51,7 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
 
   const {busy, handleSelect, handleRemove} = useScmRepoSelection({
     integration,
-    onSelect: repo => {
-      setSelectedRepository(repo);
-
-      // Changing repos invalidates downstream state (platform, features,
-      // created project) which are all derived from the selected repo.
-      clearDerivedState();
-    },
+    onSelect: setSelectedRepository,
     reposByIdentifier,
   });
 
@@ -79,6 +73,12 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
   }, [dropdownItems, selectedRepository]);
 
   function handleChange(option: {value: string} | null) {
+    // Changing or clearing the repo invalidates downstream state (platform,
+    // features, created project) which are all derived from the selected repo.
+    // Called here rather than inside onSelect so error-recovery paths in the
+    // hook (which restore the previous repo) don't wipe derived state.
+    clearDerivedState();
+
     if (option === null) {
       handleRemove();
     } else {

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -38,7 +38,8 @@ interface ScmRepoSelectorProps {
 
 export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
   const organization = useOrganization();
-  const {selectedRepository, setSelectedRepository} = useOnboardingContext();
+  const {selectedRepository, setSelectedRepository, clearDerivedState} =
+    useOnboardingContext();
   const {
     reposByIdentifier,
     dropdownItems,
@@ -50,7 +51,13 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
 
   const {busy, handleSelect, handleRemove} = useScmRepoSelection({
     integration,
-    onSelect: setSelectedRepository,
+    onSelect: repo => {
+      setSelectedRepository(repo);
+
+      // Changing repos invalidates downstream state (platform, features,
+      // created project) which are all derived from the selected repo.
+      clearDerivedState();
+    },
     reposByIdentifier,
   });
 

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -73,16 +73,14 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
   }, [dropdownItems, selectedRepository]);
 
   function handleChange(option: {value: string} | null) {
-    // Changing or clearing the repo invalidates downstream state (platform,
-    // features, created project) which are all derived from the selected repo.
-    // Called here rather than inside onSelect so error-recovery paths in the
-    // hook (which restore the previous repo) don't wipe derived state.
-    clearDerivedState();
-
     if (option === null) {
       setSearch('');
       handleRemove();
     } else {
+      // Selecting a new repo invalidates downstream state (platform, features,
+      // created project). Only cleared on selection, not on clear — clearing
+      // is async and error-recovery may restore the previous repo.
+      clearDerivedState();
       const repo = reposByIdentifier.get(option.value);
       if (repo) {
         trackAnalytics('onboarding.scm_connect_repo_selected', {

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -73,14 +73,14 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
   }, [dropdownItems, selectedRepository]);
 
   function handleChange(option: {value: string} | null) {
+    // Changing or clearing the repo invalidates downstream state (platform,
+    // features, created project) which are all derived from the selected repo.
+    clearDerivedState();
+
     if (option === null) {
       setSearch('');
       handleRemove();
     } else {
-      // Selecting a new repo invalidates downstream state (platform, features,
-      // created project). Only cleared on selection, not on clear — clearing
-      // is async and error-recovery may restore the previous repo.
-      clearDerivedState();
       const repo = reposByIdentifier.get(option.value);
       if (repo) {
         trackAnalytics('onboarding.scm_connect_repo_selected', {

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -80,6 +80,7 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
     clearDerivedState();
 
     if (option === null) {
+      setSearch('');
       handleRemove();
     } else {
       const repo = reposByIdentifier.get(option.value);

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -9,6 +9,7 @@ import {
   act,
   render,
   renderGlobalModal,
+  renderHookWithProviders,
   screen,
   userEvent,
   waitFor,
@@ -908,21 +909,17 @@ describe('Onboarding', () => {
 
       sessionStorage.setItem('onboarding', JSON.stringify(initialContext));
 
-      let contextValue: ReturnType<typeof useOnboardingContext>;
-      function ContextReader() {
-        contextValue = useOnboardingContext();
-        return null;
-      }
-
-      render(
-        <OnboardingContextProvider initialValue={initialContext}>
-          <ContextReader />
-        </OnboardingContextProvider>,
-        {organization: scmOrganization}
-      );
+      const {result} = renderHookWithProviders(() => useOnboardingContext(), {
+        organization: scmOrganization,
+        additionalWrapper: ({children}) => (
+          <OnboardingContextProvider initialValue={initialContext}>
+            {children}
+          </OnboardingContextProvider>
+        ),
+      });
 
       act(() => {
-        contextValue!.clearDerivedState();
+        result.current.clearDerivedState();
       });
 
       const stored = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -6,6 +6,7 @@ import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {
+  act,
   render,
   renderGlobalModal,
   screen,
@@ -14,7 +15,10 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
+import {
+  OnboardingContextProvider,
+  useOnboardingContext,
+} from 'sentry/components/onboarding/onboardingContext';
 import * as useRecentCreatedProjectHook from 'sentry/components/onboarding/useRecentCreatedProject';
 import {OnboardingDrawerStore} from 'sentry/stores/onboardingDrawerStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -869,6 +873,66 @@ describe('Onboarding', () => {
       expect(stored.selectedFeatures).toBeDefined();
       // createdProjectSlug should be cleared so the user can re-create
       expect(stored.createdProjectSlug).toBeUndefined();
+    });
+
+    it('clears derived state but preserves integration and repo on repo change', () => {
+      const initialContext = {
+        selectedIntegration: OrganizationIntegrationsFixture({
+          id: '1',
+          provider: {
+            key: 'github',
+            slug: 'github',
+            name: 'GitHub',
+            canAdd: true,
+            canDisable: false,
+            features: ['commits'],
+            aspects: {},
+          },
+        }),
+        selectedRepository: {
+          id: '42',
+          name: 'getsentry/sentry',
+          externalSlug: 'getsentry/sentry',
+        } as any,
+        selectedPlatform: {
+          key: 'javascript-nextjs' as PlatformKey,
+          type: 'framework' as const,
+          language: 'javascript' as const,
+          category: 'browser' as const,
+          name: 'Next.js',
+          link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+        },
+        selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        createdProjectSlug: 'javascript-nextjs',
+      };
+
+      sessionStorage.setItem('onboarding', JSON.stringify(initialContext));
+
+      let contextValue: ReturnType<typeof useOnboardingContext>;
+      function ContextReader() {
+        contextValue = useOnboardingContext();
+        return null;
+      }
+
+      render(
+        <OnboardingContextProvider initialValue={initialContext}>
+          <ContextReader />
+        </OnboardingContextProvider>,
+        {organization: scmOrganization}
+      );
+
+      act(() => {
+        contextValue!.clearDerivedState();
+      });
+
+      const stored = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');
+      // Derived state should be cleared
+      expect(stored.selectedPlatform).toBeUndefined();
+      expect(stored.selectedFeatures).toBeUndefined();
+      expect(stored.createdProjectSlug).toBeUndefined();
+      // Integration and repo should be preserved
+      expect(stored.selectedIntegration).toBeDefined();
+      expect(stored.selectedRepository).toBeDefined();
     });
 
     it('navigates back from scm-connect to welcome', async () => {

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
+import {RepositoryFixture} from 'sentry-fixture/repository';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {
@@ -636,6 +637,15 @@ describe('Onboarding', () => {
       features: ['commits'],
     });
 
+    const nextJsPlatform = {
+      key: 'javascript-nextjs' as PlatformKey,
+      type: 'framework' as const,
+      language: 'javascript' as const,
+      category: 'browser' as const,
+      name: 'Next.js',
+      link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+    };
+
     beforeEach(() => {
       MockApiClient.addMockResponse({
         url: `/organizations/${scmOrganization.slug}/config/integrations/`,
@@ -765,18 +775,7 @@ describe('Onboarding', () => {
 
     it('renders scm-project-details step with project details form', () => {
       render(
-        <OnboardingContextProvider
-          initialValue={{
-            selectedPlatform: {
-              key: 'javascript-nextjs' as PlatformKey,
-              type: 'framework',
-              language: 'javascript',
-              category: 'browser',
-              name: 'Next.js',
-              link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
-            },
-          }}
-        >
+        <OnboardingContextProvider initialValue={{selectedPlatform: nextJsPlatform}}>
           <OnboardingWithoutContext />
         </OnboardingContextProvider>,
         {
@@ -833,14 +832,7 @@ describe('Onboarding', () => {
       });
 
       const initialContext = {
-        selectedPlatform: {
-          key: nextJsProject.slug as PlatformKey,
-          type: 'framework',
-          language: 'javascript',
-          category: 'browser',
-          name: 'Next.js',
-          link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
-        },
+        selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
       };
 
@@ -890,19 +882,12 @@ describe('Onboarding', () => {
             aspects: {},
           },
         }),
-        selectedRepository: {
+        selectedRepository: RepositoryFixture({
           id: '42',
           name: 'getsentry/sentry',
           externalSlug: 'getsentry/sentry',
-        } as any,
-        selectedPlatform: {
-          key: 'javascript-nextjs' as PlatformKey,
-          type: 'framework' as const,
-          language: 'javascript' as const,
-          category: 'browser' as const,
-          name: 'Next.js',
-          link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
-        },
+        }),
+        selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
         createdProjectSlug: 'javascript-nextjs',
       };


### PR DESCRIPTION
When a user navigates back to repo selection and picks a different repo, the previously selected platform, features, and created project slug are stale.

Adds `clearDerivedState` to the onboarding context that clears these fields in a single session storage update without wiping the entire session -- which `setSelectedPlatform(undefined)` would do due to the `removeOnboarding()` call in its undefined branch.

The repo selector's `onSelect` callback now calls `clearDerivedState()` whenever the repository changes.

**Stacked on [PR #111478](https://github.com/getsentry/sentry/pull/111478)** (VDY-22: UI polish and analytics).

Refs VDY-22