### PR TITLE
fix(snapshots): Disable CSS animations for snapshot testing

### DIFF
--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -55,7 +55,7 @@ function renderToHTML(element: ReactElement): string {
   <style>${getFontFaceCSS()}</style>
   ${styleTags}
   <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; animation: none !important; transition: none !important; }
     body { font-family: 'Rubik', sans-serif; background: transparent; }
     #root { display: inline-block; }
   </style>


### PR DESCRIPTION
A recent flake in `radio.tsx` was caused by an animation on the checked state. After some investigation, this caused flakes in our snapshot suite as small timing differences resulted in some minor diffs in the checked state, indicating the animation wasn't completing.

This will disable CSS animations in our snapshot tests to ensure stability.