### PR TITLE
chore(conf): Remove context-engine-index from cron schedule

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1146,11 +1146,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "seer:sentry.tasks.seer_explorer_index.schedule_explorer_index",
         "schedule": crontab("0", "*/1", "*", "*", "*"),
     },
-    "context-engine-index": {
-        "task": "seer:sentry.tasks.context_engine_index.schedule_context_engine_indexing_tasks",
-        # Offset by 30 minutes from seer-explorer-index to spread load
-        "schedule": crontab("30", "*/1", "*", "*", "*"),
-    },
     "index-sentry-knowledge": {
         "task": "seer:sentry.tasks.context_engine_index.index_sentry_knowledge",
         # Run once a month at midnight


### PR DESCRIPTION
+ Remove the schedule_context_engine_indexing_tasks periodic task entry from the region task schedule. The task definition and related code remain intact will remove once the getsentry job is up and running - https://github.com/getsentry/getsentry/pull/19667
