### PR TITLE
ref(workflows): Use WorkflowId directly instead of _ActionFilterCacheKey when caching action filters

### DIFF
--- a/src/sentry/workflow_engine/caches/action_filters.py
+++ b/src/sentry/workflow_engine/caches/action_filters.py
@@ -16,17 +16,13 @@ METRIC_PREFIX = f"workflow_engine.cache.processing_workflow.{ACTION_FILTER_CACHE
 ActionFiltersByWorkflow = dict[WorkflowId, list[DataConditionGroup]]
 
 
-class _ActionFilterCacheKey(NamedTuple):
-    workflow_id: WorkflowId
-
-
 class _CacheResults(NamedTuple):
     cached: ActionFiltersByWorkflow
     missed_ids: list[WorkflowId]
 
 
-_action_filters_cache = CacheMapping[_ActionFilterCacheKey, list[DataConditionGroup]](
-    lambda key: f"{key.workflow_id}",
+_action_filters_cache = CacheMapping[WorkflowId, list[DataConditionGroup]](
+    str,
     namespace=f"workflow:{ACTION_FILTER_CACHE_NAME}",
     ttl_seconds=CACHE_TTL,
 )
@@ -36,15 +32,15 @@ def _check_cache_by_workflows(workflows: Collection[Workflow]) -> _CacheResults:
     results: ActionFiltersByWorkflow = {}
     missed_ids: list[WorkflowId] = []
 
-    keys = [_ActionFilterCacheKey(w.id) for w in workflows]
+    keys = [w.id for w in workflows]
     cache_results = _action_filters_cache.get_many(inputs=keys)
 
     for key, cached in cache_results.items():
         if cached is not None:
-            results[key.workflow_id] = cached
+            results[key] = cached
             metrics_incr(f"{METRIC_PREFIX}.hit")
         else:
-            missed_ids.append(key.workflow_id)
+            missed_ids.append(key)
             metrics_incr(f"{METRIC_PREFIX}.miss")
 
     return _CacheResults(
@@ -69,12 +65,7 @@ def _query_action_filters_by_workflows(workflow_ids: list[WorkflowId]) -> Action
 
 
 def _populate_cache(action_filters_by_workflow: ActionFiltersByWorkflow) -> None:
-    cache_items: dict[_ActionFilterCacheKey, list[DataConditionGroup]] = {
-        _ActionFilterCacheKey(workflow_id): action_filters
-        for workflow_id, action_filters in action_filters_by_workflow.items()
-    }
-
-    _action_filters_cache.set_many(cache_items)
+    _action_filters_cache.set_many(action_filters_by_workflow)
 
 
 @scopedstats.timer()
@@ -124,6 +115,4 @@ def invalidate_action_filter_cache_by_workflow_ids(workflow_ids: list[WorkflowId
     - DataConditionGroup post_save - When an update to the logic type in the condition group
     """
     metrics_incr(f"{METRIC_PREFIX}.invalidated", value=len(workflow_ids))
-    cache_keys = [_ActionFilterCacheKey(wid) for wid in workflow_ids]
-
-    _action_filters_cache.delete_many(cache_keys)
+    _action_filters_cache.delete_many(workflow_ids)

--- a/tests/sentry/workflow_engine/caches/test_action_filters.py
+++ b/tests/sentry/workflow_engine/caches/test_action_filters.py
@@ -6,7 +6,6 @@ from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.caches.action_filters import (
     ActionFiltersByWorkflow,
     _action_filters_cache,
-    _ActionFilterCacheKey,
     _CacheResults,
     _populate_cache,
     get_action_filters_by_workflows,
@@ -68,21 +67,21 @@ class ActionFilterTestCase(TestCase):
     def populate_action_filter_cache(
         self,
         cache_data: ActionFiltersByWorkflow,
-    ) -> list[_ActionFilterCacheKey]:
+    ) -> list[WorkflowId]:
         _populate_cache(cache_data)
-        cache_keys = [_ActionFilterCacheKey(wid) for wid in cache_data.keys()]
+        cache_keys = list(cache_data.keys())
 
         for cache_key in cache_keys:
-            assert _action_filters_cache.get(cache_key) == cache_data[cache_key.workflow_id]
+            assert _action_filters_cache.get(cache_key) == cache_data[cache_key]
 
         return cache_keys
 
     def get_data_from_cache(
         self,
-        cache_keys: list[_ActionFilterCacheKey],
+        cache_keys: list[WorkflowId],
     ) -> dict[WorkflowId, list[DataConditionGroup] | None]:
         cache_results = _action_filters_cache.get_many(cache_keys)
-        return {key.workflow_id: values for key, values in cache_results.items()}
+        return {key: values for key, values in cache_results.items()}
 
     def assert_cache_result(
         self,


### PR DESCRIPTION
Should be functionally equivalent, but less wordy.