### PR TITLE
ref(cmdk) update cmdk to use scraps input

### DIFF
--- a/static/app/components/commandPalette/ui/content.tsx
+++ b/static/app/components/commandPalette/ui/content.tsx
@@ -29,7 +29,7 @@ function actionToMenuItem(
     label: action.display.label,
     details: action.display.details,
     leadingItems: action.display.icon ? (
-      <Flex align="center" justify="center" width="100%" height="100%">
+      <Flex align="start" justify="center" width="100%" height="100%" paddingTop="2xs">
         <IconDefaultsProvider size="sm">{action.display.icon}</IconDefaultsProvider>
       </Flex>
     ) : undefined,

--- a/static/app/components/commandPalette/ui/content.tsx
+++ b/static/app/components/commandPalette/ui/content.tsx
@@ -1,5 +1,4 @@
-import {Fragment, useCallback, useLayoutEffect, useMemo, useRef} from 'react';
-import styled from '@emotion/styled';
+import {useCallback, useLayoutEffect, useMemo, useRef} from 'react';
 import {Item, Section} from '@react-stately/collections';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -11,7 +10,7 @@ import {COMMAND_PALETTE_GROUP_KEY_CONFIG} from 'sentry/components/commandPalette
 import {CommandPaletteList} from 'sentry/components/commandPalette/ui/list';
 import {useCommandPaletteState} from 'sentry/components/commandPalette/ui/useCommandPaletteState';
 import {useDsnLookupActions} from 'sentry/components/commandPalette/useDsnLookupActions';
-import {SvgIcon} from 'sentry/icons/svgIcon';
+import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 import {unreachable} from 'sentry/utils/unreachable';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -30,9 +29,9 @@ function actionToMenuItem(
     label: action.display.label,
     details: action.display.details,
     leadingItems: action.display.icon ? (
-      <IconWrap align="center" justify="center">
-        {action.display.icon}
-      </IconWrap>
+      <Flex align="center" justify="center" width="100%" height="100%">
+        <IconDefaultsProvider size="sm">{action.display.icon}</IconDefaultsProvider>
+      </Flex>
     ) : undefined,
     children: action.type === 'group' ? action.actions.map(actionToMenuItem) : [],
     hideCheck: true,
@@ -113,30 +112,23 @@ export function CommandPaletteContent() {
   }, [selectedAction, setQuery]);
 
   return (
-    <Fragment>
-      <CommandPaletteList
-        onActionKey={handleActionByKey}
-        inputRef={inputRef}
-        query={query}
-        setQuery={setQuery}
-        clearSelection={clearSelection}
-        selectedAction={selectedAction}
-      >
-        {groupedMenuItems.map(({key: sectionKey, label, children}) => (
-          <Section key={sectionKey} title={label}>
-            {children.map(({key: actionKey, ...action}) => (
-              <Item<CommandPaletteActionMenuItem> key={actionKey} {...action}>
-                {action.label}
-              </Item>
-            ))}
-          </Section>
-        ))}
-      </CommandPaletteList>
-    </Fragment>
+    <CommandPaletteList
+      onActionKey={handleActionByKey}
+      inputRef={inputRef}
+      query={query}
+      setQuery={setQuery}
+      clearSelection={clearSelection}
+      selectedAction={selectedAction}
+    >
+      {groupedMenuItems.map(({key: sectionKey, label, children}) => (
+        <Section key={sectionKey} title={label}>
+          {children.map(({key: actionKey, ...action}) => (
+            <Item<CommandPaletteActionMenuItem> key={actionKey} {...action}>
+              {action.label}
+            </Item>
+          ))}
+        </Section>
+      ))}
+    </CommandPaletteList>
   );
 }
-
-const IconWrap = styled(Flex)`
-  width: ${() => SvgIcon.ICON_SIZES.md};
-  height: ${() => SvgIcon.ICON_SIZES.md};
-`;

--- a/static/app/components/commandPalette/ui/list.tsx
+++ b/static/app/components/commandPalette/ui/list.tsx
@@ -5,17 +5,18 @@ import {mergeProps} from '@react-aria/utils';
 import type {TreeProps} from '@react-stately/tree';
 import {useTreeState} from '@react-stately/tree';
 
-import error from 'sentry-images/spot/computer-missing.svg';
+import errorIllustration from 'sentry-images/spot/computer-missing.svg';
 
 import {Button} from '@sentry/scraps/button';
 import {ListBox} from '@sentry/scraps/compactSelect';
 import {Image} from '@sentry/scraps/image';
+import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {InnerWrap} from '@sentry/scraps/menuListItem';
 import {Text} from '@sentry/scraps/text';
 
 import type {CommandPaletteActionWithKey} from 'sentry/components/commandPalette/types';
-import {IconArrow} from 'sentry/icons';
+import {IconArrow, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 type CommandPaletteSection = {
@@ -102,40 +103,42 @@ export function CommandPaletteList({
     if (selectedAction) {
       return selectedAction.display.label;
     }
-    return t('Type for actions…');
+    return t('Search for commands…');
   }, [selectedAction]);
 
   return (
     <Fragment>
-      <Flex direction="column" align="start" gap="md" borderBottom="muted">
-        <Flex
-          position="relative"
-          direction="row"
-          align="center"
-          gap="xs"
-          padding="0 md"
-          width="100%"
-        >
-          {selectedAction && (
-            <Button
-              priority="transparent"
-              size="sm"
-              icon={<IconArrow direction="left" />}
-              onClick={() => {
-                clearSelection();
-                inputRef.current?.focus();
-              }}
-              aria-label={t('Return to all options')}
-            />
-          )}
-          <CommandInput
-            ref={inputRef}
-            value={query}
-            aria-label={t('Search commands')}
-            placeholder={placeholder}
-            autoFocus
-            {...inputProps}
-          />
+      <Flex direction="column" align="start" gap="md">
+        <Flex position="relative" direction="row" align="center" gap="xs" width="100%">
+          {p => {
+            return (
+              <InputGroup {...p}>
+                <InputGroup.LeadingItems>
+                  {selectedAction ? (
+                    <Button
+                      size="xs"
+                      priority="transparent"
+                      icon={<IconArrow direction="left" />}
+                      onClick={() => {
+                        clearSelection();
+                        inputRef.current?.focus();
+                      }}
+                      aria-label={t('Return to all options')}
+                    />
+                  ) : (
+                    <IconSearch size="sm" variant="muted" />
+                  )}
+                </InputGroup.LeadingItems>
+                <InputGroup.Input
+                  ref={inputRef}
+                  value={query}
+                  placeholder={placeholder}
+                  autoFocus
+                  {...inputProps}
+                />
+              </InputGroup>
+            );
+          }}
         </Flex>
       </Flex>
       {treeState.collection.size === 0 ? (
@@ -147,7 +150,7 @@ export function CommandPaletteList({
           padding="xl lg"
           height="400px"
         >
-          <Image src={error} alt="No results" width="400px" />
+          <Image src={errorIllustration} alt={t('No results')} width="400px" />
           <Stack align="center" gap="md">
             <Text size="md" align="center">
               {t("Whoops… we couldn't find any results matching your search.")}
@@ -165,12 +168,12 @@ export function CommandPaletteList({
         overflow="auto"
       >
         <ListBox
-          listState={treeState}
-          keyDownHandler={() => true}
           overlayIsOpen
+          listState={treeState}
           size="md"
-          aria-label="Search results"
           selectionMode="none"
+          keyDownHandler={() => true}
+          aria-label={t('Search results')}
           onAction={key => onActionKey?.(key)}
           shouldUseVirtualFocus
         />
@@ -179,24 +182,16 @@ export function CommandPaletteList({
   );
 }
 
-const CommandInput = styled('input')`
-  width: 100%;
-  background: transparent;
-  padding: ${p => p.theme.space.md};
-  border: none;
-  flex: 1;
-  font-size: ${p => p.theme.font.size.lg};
-  line-height: 2;
-
-  &:focus {
-    outline: none;
-  }
-`;
-
 const ResultsList = styled(Flex)`
   ul,
   li {
     scroll-margin: ${p => p.theme.space['3xl']} 0;
+  }
+
+  li ${InnerWrap} {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
   }
 
   li[data-focused] > ${InnerWrap} {

--- a/static/app/components/commandPalette/ui/list.tsx
+++ b/static/app/components/commandPalette/ui/list.tsx
@@ -134,7 +134,7 @@ export function CommandPaletteList({
                   ref={inputRef}
                   value={query}
                   placeholder={placeholder}
-                  aria-label={t('Search for commands…')}
+                  aria-label={t('Search commands')}
                   {...inputProps}
                 />
               </InputGroup>
@@ -144,10 +144,10 @@ export function CommandPaletteList({
       </Flex>
       {treeState.collection.size === 0 ? (
         <Flex
+          gap="lg"
           direction="column"
           align="center"
           justify="center"
-          gap="lg"
           padding="xl lg"
           height="400px"
         >
@@ -187,12 +187,6 @@ const ResultsList = styled(Flex)`
   ul,
   li {
     scroll-margin: ${p => p.theme.space['3xl']} 0;
-  }
-
-  li ${InnerWrap} {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
   }
 
   li[data-focused] > ${InnerWrap} {

--- a/static/app/components/commandPalette/ui/list.tsx
+++ b/static/app/components/commandPalette/ui/list.tsx
@@ -130,10 +130,11 @@ export function CommandPaletteList({
                   )}
                 </InputGroup.LeadingItems>
                 <InputGroup.Input
+                  autoFocus
                   ref={inputRef}
                   value={query}
                   placeholder={placeholder}
-                  autoFocus
+                  aria-label={t('Search for commands…')}
                   {...inputProps}
                 />
               </InputGroup>

--- a/static/app/components/commandPalette/ui/modal.tsx
+++ b/static/app/components/commandPalette/ui/modal.tsx
@@ -19,6 +19,7 @@ export const modalCss = (theme: Theme) => {
     [role='document'] {
       padding: 0;
 
+      background-color: ${theme.tokens.background.primary};
       border-top-left-radius: calc(${theme.radius.lg} + 1px);
       border-top-right-radius: calc(${theme.radius.lg} + 1px);
     }

--- a/static/app/components/commandPalette/ui/modal.tsx
+++ b/static/app/components/commandPalette/ui/modal.tsx
@@ -2,6 +2,7 @@ import {css} from '@emotion/react';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {CommandPaletteContent} from 'sentry/components/commandPalette/ui/content';
+import type {Theme} from 'sentry/utils/theme';
 
 function CommandPaletteModal({Body}: ModalRenderProps) {
   return (
@@ -13,8 +14,13 @@ function CommandPaletteModal({Body}: ModalRenderProps) {
 
 export default CommandPaletteModal;
 
-export const modalCss = css`
-  [role='document'] {
-    padding: 0;
-  }
-`;
+export const modalCss = (theme: Theme) => {
+  return css`
+    [role='document'] {
+      padding: 0;
+
+      border-top-left-radius: calc(${theme.radius.lg} + 1px);
+      border-top-right-radius: calc(${theme.radius.lg} + 1px);
+    }
+  `;
+};

--- a/static/app/components/commandPalette/ui/useCommandPaletteState.tsx
+++ b/static/app/components/commandPalette/ui/useCommandPaletteState.tsx
@@ -58,6 +58,7 @@ function flattenActions(
 export function useCommandPaletteState() {
   const [query, setQuery] = useState('');
   const actions = useCommandPaletteActions();
+
   const [selectedAction, setSelectedAction] =
     useState<CommandPaletteActionWithKey | null>(null);
 


### PR DESCRIPTION
Updates search input to use scraps input, adds leading search icon, updates the placeholder text to hint at searching, removes the icon wrap and centers the icon and text inside the content.

<img width="650" height="486" alt="CleanShot 2026-03-24 at 16 16 58" src="https://github.com/user-attachments/assets/48a0855f-7726-44ec-b2f7-a2b88d375802" />

<img width="673" height="482" alt="CleanShot 2026-03-24 at 16 16 49" src="https://github.com/user-attachments/assets/065c5747-c742-4177-9bd6-70cc4e9d7c57" />

Fixes DE-1029