### PR TITLE
fix(issues): Move coverage legend above stack trace

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -126,6 +126,10 @@ const Details = styled(Name)`
 `;
 
 const StyledPills = styled(Pills)`
+  > li {
+    margin-bottom: 0;
+  }
+
   span:nth-of-type(2) {
     display: inline;
     white-space: nowrap;

--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -126,10 +126,6 @@ const Details = styled(Name)`
 `;
 
 const StyledPills = styled(Pills)`
-  > li {
-    margin-bottom: 0;
-  }
-
   span:nth-of-type(2) {
     display: inline;
     white-space: nowrap;

--- a/static/app/components/stackTrace/issueStackTrace/index.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 
@@ -88,11 +88,7 @@ function IssueStackTraceLineCoverageLegend() {
     return null;
   }
 
-  return (
-    <Container paddingTop="md">
-      <LineCoverageLegend />
-    </Container>
-  );
+  return <LineCoverageLegend />;
 }
 
 export function IssueStackTrace(props: IssueStackTraceProps) {
@@ -239,39 +235,41 @@ function IssueStackTraceContent({
 
     return (
       <InterimSection type={sectionKey} title="Stack Trace" actions={sectionActions}>
-        {hasExceptionInfo && (
-          <Flex direction="column" gap="sm">
-            <div>
-              <ExceptionHeader type={type} module={module} />
-            </div>
-            <ExceptionDescription
-              value={value}
-              mechanism={exc.mechanism}
-              meta={excMeta}
+        <Flex direction="column" gap="lg">
+          {hasExceptionInfo && (
+            <Flex direction="column" gap="sm">
+              <div>
+                <ExceptionHeader type={type} module={module} />
+              </div>
+              <ExceptionDescription
+                value={value}
+                mechanism={exc.mechanism}
+                meta={excMeta}
+              />
+            </Flex>
+          )}
+          <ErrorBoundary customComponent={null}>
+            <StacktraceBanners event={event} stacktrace={exc.stacktrace} />
+          </ErrorBoundary>
+          <IssueStackTraceLineCoverageLegend />
+          <StackTraceProvider
+            exceptionIndex={isStandalone ? undefined : exc.exceptionIndex}
+            event={event}
+            stacktrace={exc.stacktrace}
+            minifiedStacktrace={exc.rawStacktrace ?? undefined}
+            meta={isStandalone ? rawEntryMeta : excMeta?.stacktrace}
+          >
+            <StackTraceFrames
+              frameContextComponent={IssueStackTraceFrameContext}
+              frameActionsComponent={IssueFrameActions}
             />
-          </Flex>
-        )}
-        <ErrorBoundary customComponent={null}>
-          <StacktraceBanners event={event} stacktrace={exc.stacktrace} />
-        </ErrorBoundary>
-        <StackTraceProvider
-          exceptionIndex={isStandalone ? undefined : exc.exceptionIndex}
-          event={event}
-          stacktrace={exc.stacktrace}
-          minifiedStacktrace={exc.rawStacktrace ?? undefined}
-          meta={isStandalone ? rawEntryMeta : excMeta?.stacktrace}
-        >
-          <StackTraceFrames
-            frameContextComponent={IssueStackTraceFrameContext}
-            frameActionsComponent={IssueFrameActions}
+          </StackTraceProvider>
+          <IssueStackTraceSuspectCommits
+            event={event}
+            group={group}
+            projectSlug={projectSlug}
           />
-        </StackTraceProvider>
-        <IssueStackTraceLineCoverageLegend />
-        <IssueStackTraceSuspectCommits
-          event={event}
-          group={group}
-          projectSlug={projectSlug}
-        />
+        </Flex>
       </InterimSection>
     );
   }
@@ -287,6 +285,7 @@ function IssueStackTraceContent({
           )}
         </Text>
         <Separator orientation="horizontal" border="primary" />
+        <IssueStackTraceLineCoverageLegend />
         {exceptions.map((exc, idx) => {
           if (
             exc.mechanism?.parent_id !== undefined &&
@@ -356,7 +355,6 @@ function IssueStackTraceContent({
             </Disclosure>
           );
         })}
-        <IssueStackTraceLineCoverageLegend />
         <IssueStackTraceSuspectCommits
           event={event}
           group={group}

--- a/static/app/components/stackTrace/issueStackTrace/index.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.tsx
@@ -246,12 +246,12 @@ function IssueStackTraceContent({
                 mechanism={exc.mechanism}
                 meta={excMeta}
               />
+              <IssueStackTraceLineCoverageLegend />
             </Flex>
           )}
           <ErrorBoundary customComponent={null}>
             <StacktraceBanners event={event} stacktrace={exc.stacktrace} />
           </ErrorBoundary>
-          <IssueStackTraceLineCoverageLegend />
           <StackTraceProvider
             exceptionIndex={isStandalone ? undefined : exc.exceptionIndex}
             event={event}

--- a/static/app/components/stackTrace/issueStackTrace/index.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Flex} from '@sentry/scraps/layout';
@@ -236,19 +236,21 @@ function IssueStackTraceContent({
     return (
       <InterimSection type={sectionKey} title="Stack Trace" actions={sectionActions}>
         <Flex direction="column" gap="lg">
-          {hasExceptionInfo && (
-            <Flex direction="column" gap="sm">
-              <div>
-                <ExceptionHeader type={type} module={module} />
-              </div>
-              <ExceptionDescription
-                value={value}
-                mechanism={exc.mechanism}
-                meta={excMeta}
-              />
-              <IssueStackTraceLineCoverageLegend />
-            </Flex>
-          )}
+          <Flex direction="column" gap="sm">
+            {hasExceptionInfo && (
+              <Fragment>
+                <div>
+                  <ExceptionHeader type={type} module={module} />
+                </div>
+                <ExceptionDescription
+                  value={value}
+                  mechanism={exc.mechanism}
+                  meta={excMeta}
+                />
+              </Fragment>
+            )}
+            <IssueStackTraceLineCoverageLegend />
+          </Flex>
           <ErrorBoundary customComponent={null}>
             <StacktraceBanners event={event} stacktrace={exc.stacktrace} />
           </ErrorBoundary>


### PR DESCRIPTION
moves the coverage to the right place and fixes gap between things

before

<img width="869" height="448" alt="image" src="https://github.com/user-attachments/assets/d015b9c2-1ab8-48a8-820d-dc25f01f2c38" />


after

<img width="763" height="469" alt="image" src="https://github.com/user-attachments/assets/4fbce1e4-7493-457a-97bb-1a638c897399" />
