### PR TITLE
test(insights): Remove useLocation/usePageFilters mocks from simple tests

### DIFF
--- a/static/app/views/insights/browser/resources/components/sampleImages.spec.tsx
+++ b/static/app/views/insights/browser/resources/components/sampleImages.spec.tsx
@@ -1,21 +1,15 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
-import {useLocation} from 'sentry/utils/useLocation';
 import {SampleImages} from 'sentry/views/insights/browser/resources/components/sampleImages';
 import {SpanFields} from 'sentry/views/insights/types';
 
 const {SPAN_GROUP, HTTP_RESPONSE_CONTENT_LENGTH, RAW_DOMAIN, SPAN_DESCRIPTION} =
   SpanFields;
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 describe('SampleImages', () => {
   const organization = OrganizationFixture({
@@ -62,18 +56,6 @@ describe('SampleImages', () => {
 const setupMocks = () => {
   const mockProjects = [ProjectFixture()];
   ProjectsStore.loadInitialData(mockProjects);
-
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
-
-  jest.mocked(useLocation).mockReturnValue({
-    pathname: '',
-    search: '',
-    query: {statsPeriod: '10d'},
-    hash: '',
-    state: undefined,
-    action: 'PUSH',
-    key: '',
-  });
 };
 
 const setupMockRequests = (

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
@@ -1,33 +1,16 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {useLocation} from 'sentry/utils/useLocation';
 import {formatTimeSeriesResultsToChartData} from 'sentry/views/insights/browser/webVitals/components/charts/formatTimeSeriesResultsToChartData';
 import PerformanceScoreBreakdownChartWidget from 'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 describe('PerformanceScoreBreakdownChartWidget', () => {
   const organization = OrganizationFixture();
   let eventsStatsMock: jest.Mock;
 
   beforeEach(() => {
-    jest.mocked(useLocation).mockReturnValue({
-      pathname: '',
-      search: '',
-      query: {},
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
-    });
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
-
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/stats/`,
       body: [],
@@ -55,15 +38,6 @@ describe('PerformanceScoreBreakdownChartWidget', () => {
   });
 
   it('renders', async () => {
-    jest.mocked(useLocation).mockReturnValue({
-      pathname: '',
-      search: '',
-      query: {},
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
-    });
     render(<PerformanceScoreBreakdownChartWidget />, {organization});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
@@ -1,14 +1,10 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {useLocation} from 'sentry/utils/useLocation';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {WebVitalsDetailPanel} from 'sentry/views/insights/browser/webVitals/components/webVitalsDetailPanel';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 describe('WebVitalsDetailPanel', () => {
   const organization = OrganizationFixture();
@@ -16,17 +12,7 @@ describe('WebVitalsDetailPanel', () => {
   let eventsStatsMock: jest.Mock;
 
   beforeEach(() => {
-    jest.mocked(useLocation).mockReturnValue({
-      pathname: '',
-      search: '',
-      query: {},
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
-    });
-
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture());
 
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,

--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.spec.tsx
@@ -1,17 +1,11 @@
-import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {useLocation} from 'sentry/utils/useLocation';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import ScreenDetailsPage from 'sentry/views/insights/mobile/screens/views/screenDetailsPage';
-
-jest.mock('sentry/components/pageFilters/usePageFilters');
-jest.mock('sentry/utils/useLocation');
 
 describe('ScreenDetailsPage', () => {
   const organization = OrganizationFixture({
@@ -19,33 +13,18 @@ describe('ScreenDetailsPage', () => {
   });
   const project = ProjectFixture();
 
-  jest.mocked(useLocation).mockReturnValue({
-    action: 'PUSH',
-    hash: '',
-    key: '',
-    pathname: '/organizations/org-slug/performance/mobile/mobile-vitals/details',
-    query: {
-      project: project.id,
-      transaction: 'HomeActivity',
-    },
-    search: '',
-    state: undefined,
-  } as Location);
-
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [parseInt(project.id, 10)],
+  beforeEach(() => {
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    })
-  );
+    });
+  });
 
   describe('Tabs', () => {
     beforeEach(() => {
@@ -75,18 +54,6 @@ describe('ScreenDetailsPage', () => {
     });
 
     it('renders the tabs correctly', async () => {
-      jest.mocked(useLocation).mockReturnValue({
-        action: 'PUSH',
-        hash: '',
-        key: '',
-        pathname: '/organizations/org-slug/performance/mobile/mobile-vitals/details',
-        query: {
-          project: project.id,
-        },
-        search: '',
-        state: undefined,
-      } as Location);
-
       render(<ScreenDetailsPage />, {organization});
 
       const tabs: string[] = ['App Start', 'Screen Load', 'Screen Rendering'];


### PR DESCRIPTION
Remove unnecessary jest.mock calls for useLocation and usePageFilters hooks in tests that don't rely on specific location or page filter state