### PR TITLE
test(insights): Replace useLocation/usePageFilters mocks with initialRouterConfig

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -1,14 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import ResourcesLandingPage from 'sentry/views/insights/browser/resources/views/resourcesLandingPage';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
@@ -25,8 +23,6 @@ const {
 } = SpanFields;
 const {EPM} = SpanFunction;
 
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 jest.mock('sentry/utils/useReleaseStats');
 
 const requestMocks: Record<string, jest.Mock> = {};
@@ -35,6 +31,14 @@ describe('ResourcesLandingPage', () => {
   const organization = OrganizationFixture({
     features: ['insight-modules'],
   });
+
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/insights/frontend/assets/`,
+      query: {statsPeriod: '10d'},
+    },
+    route: `/organizations/:orgId/insights/frontend/assets/`,
+  };
 
   beforeEach(() => {
     setupMocks();
@@ -46,7 +50,7 @@ describe('ResourcesLandingPage', () => {
   });
 
   it('renders a list of resources', async () => {
-    render(<ResourcesLandingPage />, {organization});
+    render(<ResourcesLandingPage />, {organization, initialRouterConfig});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(
@@ -59,7 +63,7 @@ describe('ResourcesLandingPage', () => {
   });
 
   it('fetches domain data', async () => {
-    render(<ResourcesLandingPage />, {organization});
+    render(<ResourcesLandingPage />, {organization, initialRouterConfig});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(requestMocks.domainSelector!.mock.calls).toMatchInlineSnapshot(`
@@ -77,7 +81,9 @@ describe('ResourcesLandingPage', () => {
           "count()",
         ],
         "per_page": 100,
-        "project": [],
+        "project": [
+          "2",
+        ],
         "query": "has:sentry.normalized_description span.category:resource !sentry.normalized_description:"browser-extension://*" span.op:[resource.script,resource.css,resource.font,resource.img]",
         "referrer": "api.insights.get-span-domains",
         "sampling": "NORMAL",
@@ -93,7 +99,7 @@ describe('ResourcesLandingPage', () => {
   });
 
   it('contains correct query in charts', async () => {
-    render(<ResourcesLandingPage />, {organization});
+    render(<ResourcesLandingPage />, {organization, initialRouterConfig});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(requestMocks.mainTable!.mock.calls).toMatchInlineSnapshot(`
@@ -118,7 +124,9 @@ describe('ResourcesLandingPage', () => {
           "sum(span.self_time)",
         ],
         "per_page": 100,
-        "project": [],
+        "project": [
+          "2",
+        ],
         "query": "has:sentry.normalized_description !sentry.normalized_description:"browser-extension://*" ( span.op:resource.script OR file_extension:css OR file_extension:[woff,woff2,ttf,otf,eot] OR file_extension:[jpg,jpeg,png,gif,svg,webp,apng,avif] OR span.op:resource.img ) ",
         "referrer": "api.insights.browser.resources.main-table",
         "sampling": "NORMAL",
@@ -135,34 +143,20 @@ describe('ResourcesLandingPage', () => {
 });
 
 const setupMocks = () => {
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
-      },
-    })
-  );
-
-  jest.mocked(useLocation).mockReturnValue({
-    pathname: '',
-    search: '',
-    query: {statsPeriod: '10d'},
-    hash: '',
-    state: undefined,
-    action: 'PUSH',
-    key: '',
-  });
-
   ProjectsStore.loadInitialData([
     ProjectFixture({hasInsightsAssets: true, firstTransactionEvent: true}),
   ]);
+
+  PageFiltersStore.onInitializeUrlState({
+    projects: [],
+    environments: [],
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
+    },
+  });
   jest.mocked(useReleaseStats).mockReturnValue({
     isLoading: false,
     isPending: false,

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.spec.tsx
@@ -1,40 +1,33 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import {useLocation} from 'sentry/utils/useLocation';
 import {PageOverviewWebVitalsDetailPanel} from 'sentry/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 describe('PageOverviewWebVitalsDetailPanel', () => {
   const organization = OrganizationFixture({
     features: ['performance-web-vitals-seer-suggestions'],
   });
   const project = ProjectFixture();
-  const location = LocationFixture({
-    query: {
-      project: project.id,
-      transaction: 'test-transaction',
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/insights/frontend/pageloads/overview/`,
+      query: {},
     },
-  });
+    route: `/organizations/:orgId/insights/frontend/pageloads/overview/`,
+  };
 
   beforeEach(() => {
-    jest.mocked(useLocation).mockReturnValue(location);
-    jest.mocked(usePageFilters).mockReturnValue({
-      ...PageFilterStateFixture(),
-      selection: {
-        ...PageFilterStateFixture().selection,
-        projects: [2],
-      },
-    });
     ProjectsStore.loadInitialData([project]);
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({
+        projects: [2],
+      })
+    );
 
     // Mock API responses
     MockApiClient.addMockResponse({
@@ -74,6 +67,16 @@ describe('PageOverviewWebVitalsDetailPanel', () => {
   it('renders correctly with web vital', async () => {
     render(<PageOverviewWebVitalsDetailPanel webVital="lcp" />, {
       organization,
+      initialRouterConfig: {
+        ...initialRouterConfig,
+        location: {
+          ...initialRouterConfig.location,
+          query: {
+            project: project.id,
+            transaction: 'test-transaction',
+          },
+        },
+      },
     });
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
@@ -1,7 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -10,25 +8,23 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import {useLocation} from 'sentry/utils/useLocation';
 import {PagePerformanceTable} from 'sentry/views/insights/browser/webVitals/components/tables/pagePerformanceTable';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 describe('PagePerformanceTable', () => {
   const organization = OrganizationFixture();
-  const router = RouterFixture();
+
+  const baseRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/insights/frontend/pageloads/overview/`,
+      query: {},
+    },
+    route: `/organizations/:orgId/insights/frontend/pageloads/overview/`,
+  };
 
   let eventsMock: jest.Mock;
 
   beforeEach(() => {
-    jest.mocked(useLocation).mockReturnValue(router.location);
-
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
-
     ProjectsStore.loadInitialData([
       ProjectFixture({
         id: '11276',
@@ -83,12 +79,15 @@ describe('PagePerformanceTable', () => {
   });
 
   it('escapes user input search filter', async () => {
-    jest.mocked(useLocation).mockReturnValue({
-      ...router.location,
-      query: {query: '/issues/*'},
-    });
     render(<PagePerformanceTable />, {
       organization,
+      initialRouterConfig: {
+        ...baseRouterConfig,
+        location: {
+          ...baseRouterConfig.location,
+          query: {query: '/issues/*'},
+        },
+      },
     });
     await waitFor(() => {
       expect(eventsMock).toHaveBeenCalledTimes(1);

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -1,20 +1,13 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useParams} from 'sentry/utils/useParams';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {DatabaseSpanSummaryPage} from 'sentry/views/insights/database/views/databaseSpanSummaryPage';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useParams');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 jest.mock('sentry/utils/useReleaseStats');
 
@@ -25,34 +18,13 @@ describe('DatabaseSpanSummaryPage', () => {
   const group = GroupFixture();
   const groupId = '1756baf8fd19c116';
 
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
-      },
-    })
-  );
-
-  jest.mocked(useParams).mockReturnValue({
-    groupId,
-  });
-
-  jest.mocked(useLocation).mockReturnValue({
-    pathname: '',
-    search: '',
-    query: {statsPeriod: '10d', transactionsCursor: '0:25:0'},
-    hash: '',
-    state: undefined,
-    action: 'PUSH',
-    key: '',
-  });
+  const initialRouterConfig = {
+    route: `/organizations/:orgId/insights/backend/database/spans/span/:groupId/`,
+    location: {
+      pathname: `/organizations/${organization.slug}/insights/backend/database/spans/span/${groupId}/`,
+      query: {statsPeriod: '10d', transactionsCursor: '0:25:0'},
+    },
+  };
 
   jest.mocked(useReleaseStats).mockReturnValue({
     isLoading: false,
@@ -64,6 +36,17 @@ describe('DatabaseSpanSummaryPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    });
   });
 
   afterAll(() => {
@@ -175,12 +158,7 @@ describe('DatabaseSpanSummaryPage', () => {
 
     render(<DatabaseSpanSummaryPage />, {
       organization,
-      initialRouterConfig: {
-        route: `/organizations/:orgId/insights/backend/database/spans/span/:groupId/`,
-        location: {
-          pathname: `/organizations/${organization.slug}/insights/backend/database/spans/span/${groupId}/`,
-        },
-      },
+      initialRouterConfig,
     });
 
     // Metrics ribbon

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {
@@ -9,54 +8,33 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {DurationUnit} from 'sentry/utils/discover/fields';
-import {useLocation} from 'sentry/utils/useLocation';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {HTTPSamplesPanel} from 'sentry/views/insights/http/components/httpSamplesPanel';
 import {SpanFields} from 'sentry/views/insights/types';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 describe('HTTPSamplesPanel', () => {
   const organization = OrganizationFixture();
 
   let eventsRequestMock: jest.Mock;
 
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
-      },
-    })
-  );
-
-  jest.mocked(useLocation).mockReturnValue({
-    pathname: '',
-    search: '',
-    query: {
-      domain: '*.sentry.dev',
-      statsPeriod: '10d',
-      transaction: '/api/0/users',
-      transactionMethod: 'GET',
-      panel: 'status',
-    },
-    hash: '',
-    state: undefined,
-    action: 'PUSH',
-    key: '',
-  });
+  const basePath = `/organizations/${organization.slug}/insights/backend/http/domains/`;
+  const baseRoute = `/organizations/:orgId/insights/backend/http/domains/`;
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    });
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-items/attributes/',
@@ -116,10 +94,9 @@ describe('HTTPSamplesPanel', () => {
     let eventsStatsRequestMock: jest.Mock;
     let samplesRequestMock: jest.Mock;
 
-    beforeEach(() => {
-      jest.mocked(useLocation).mockReturnValue({
-        pathname: '',
-        search: '',
+    const statusRouterConfig = {
+      location: {
+        pathname: basePath,
         query: {
           statsPeriod: '10d',
           transaction: '/api/0/users',
@@ -127,12 +104,11 @@ describe('HTTPSamplesPanel', () => {
           panel: 'status',
           responseCodeClass: '3',
         },
-        hash: '',
-        state: undefined,
-        action: 'PUSH',
-        key: '',
-      });
+      },
+      route: baseRoute,
+    };
 
+    beforeEach(() => {
       eventsStatsRequestMock = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/events-timeseries/`,
         method: 'GET',
@@ -191,7 +167,7 @@ describe('HTTPSamplesPanel', () => {
     });
 
     it('fetches panel data', async () => {
-      render(<HTTPSamplesPanel />);
+      render(<HTTPSamplesPanel />, {initialRouterConfig: statusRouterConfig});
 
       expect(eventsRequestMock).toHaveBeenNthCalledWith(
         1,
@@ -276,7 +252,7 @@ describe('HTTPSamplesPanel', () => {
     });
 
     it('shows basic transaction info', async () => {
-      render(<HTTPSamplesPanel />);
+      render(<HTTPSamplesPanel />, {initialRouterConfig: statusRouterConfig});
 
       // Panel heading
       expect(screen.getByRole('heading', {name: 'GET /api/0/users'})).toBeInTheDocument();
@@ -306,10 +282,9 @@ describe('HTTPSamplesPanel', () => {
     let chartRequestMock: jest.Mock;
     let samplesRequestMock: jest.Mock;
 
-    beforeEach(() => {
-      jest.mocked(useLocation).mockReturnValue({
-        pathname: '',
-        search: '',
+    const durationRouterConfig = {
+      location: {
+        pathname: basePath,
         query: {
           domain: '*.sentry.dev',
           statsPeriod: '10d',
@@ -317,12 +292,11 @@ describe('HTTPSamplesPanel', () => {
           transactionMethod: 'GET',
           panel: 'duration',
         },
-        hash: '',
-        state: undefined,
-        action: 'PUSH',
-        key: '',
-      });
+      },
+      route: baseRoute,
+    };
 
+    beforeEach(() => {
       chartRequestMock = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/events-timeseries/`,
         method: 'GET',
@@ -372,7 +346,7 @@ describe('HTTPSamplesPanel', () => {
     });
 
     it('fetches panel data', async () => {
-      render(<HTTPSamplesPanel />);
+      render(<HTTPSamplesPanel />, {initialRouterConfig: durationRouterConfig});
 
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
@@ -430,7 +404,7 @@ describe('HTTPSamplesPanel', () => {
     });
 
     it('show basic transaction info', async () => {
-      render(<HTTPSamplesPanel />);
+      render(<HTTPSamplesPanel />, {initialRouterConfig: durationRouterConfig});
 
       // Panel heading
       expect(screen.getByRole('heading', {name: 'GET /api/0/users'})).toBeInTheDocument();
@@ -465,14 +439,14 @@ describe('HTTPSamplesPanel', () => {
 
       expect(screen.getByRole('link', {name: 'b1bf1acde131623a'})).toHaveAttribute(
         'href',
-        '/organizations/org-slug/explore/traces/trace/2b60b2eb415c4bfba3efeaf65c21c605/?domain=%2A.sentry.dev&eventId=11c910c9c10b3ec4ecf8f209b8c6ce48&node=span-b1bf1acde131623a&node=txn-11c910c9c10b3ec4ecf8f209b8c6ce48&panel=duration&source=requests_module&statsPeriod=10d&timestamp=1711398696&transaction=%2Fapi%2F0%2Fusers&transactionMethod=GET'
+        '/organizations/org-slug/insights/backend/trace/2b60b2eb415c4bfba3efeaf65c21c605/?domain=%2A.sentry.dev&eventId=11c910c9c10b3ec4ecf8f209b8c6ce48&node=span-b1bf1acde131623a&node=txn-11c910c9c10b3ec4ecf8f209b8c6ce48&panel=duration&source=requests_module&statsPeriod=10d&timestamp=1711398696&transaction=%2Fapi%2F0%2Fusers&transactionMethod=GET'
       );
 
       expect(screen.getByRole('cell', {name: '200'})).toBeInTheDocument();
     });
 
     it('re-fetches samples', async () => {
-      render(<HTTPSamplesPanel />);
+      render(<HTTPSamplesPanel />, {initialRouterConfig: durationRouterConfig});
 
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {
@@ -9,14 +8,10 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {useLocation} from 'sentry/utils/useLocation';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {HTTPDomainSummaryPage} from 'sentry/views/insights/http/views/httpDomainSummaryPage';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 jest.mock('sentry/utils/useReleaseStats');
 
@@ -31,30 +26,13 @@ describe('HTTPDomainSummaryPage', () => {
   let domainMetricsRibbonRequestMock: jest.Mock;
   let regionFilterRequestMock: jest.Mock;
 
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
-      },
-    })
-  );
-
-  jest.mocked(useLocation).mockReturnValue({
-    pathname: '',
-    search: '',
-    query: {domain: '*.sentry.dev', statsPeriod: '10d', transactionsCursor: '0:20:0'},
-    hash: '',
-    state: undefined,
-    action: 'PUSH',
-    key: '',
-  });
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/insights/backend/http/domains/`,
+      query: {domain: '*.sentry.dev', statsPeriod: '10d', transactionsCursor: '0:20:0'},
+    },
+    route: `/organizations/:orgId/insights/backend/http/domains/`,
+  };
 
   jest.mocked(useReleaseStats).mockReturnValue({
     isLoading: false,
@@ -66,6 +44,17 @@ describe('HTTPDomainSummaryPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    });
 
     regionFilterRequestMock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/events/`,
@@ -186,7 +175,7 @@ describe('HTTPDomainSummaryPage', () => {
   });
 
   it('fetches module data', async () => {
-    render(<HTTPDomainSummaryPage />, {organization});
+    render(<HTTPDomainSummaryPage />, {organization, initialRouterConfig});
 
     await waitFor(() => {
       expect(throughputRequestMock).toHaveBeenNthCalledWith(
@@ -379,7 +368,7 @@ describe('HTTPDomainSummaryPage', () => {
       },
     });
 
-    render(<HTTPDomainSummaryPage />, {organization});
+    render(<HTTPDomainSummaryPage />, {organization, initialRouterConfig});
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -1,20 +1,16 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {HTTPLandingPage} from 'sentry/views/insights/http/views/httpLandingPage';
 
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 jest.mock('sentry/utils/useReleaseStats');
 
 describe('HTTPLandingPage', () => {
@@ -28,22 +24,14 @@ describe('HTTPLandingPage', () => {
 
   let spanListRequestMock!: jest.Mock;
   let regionFilterRequestMock!: jest.Mock;
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
-      },
-    })
-  );
 
-  const useLocationMock = jest.mocked(useLocation);
+  const baseRouterConfig = {
+    location: {
+      pathname: '/insights/backend/http/',
+      query: {statsPeriod: '10d', 'span.domain': 'git', project: '1'},
+    },
+    route: '/insights/backend/http/',
+  };
 
   jest.mocked(useReleaseStats).mockReturnValue({
     isLoading: false,
@@ -56,14 +44,15 @@ describe('HTTPLandingPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    useLocationMock.mockReturnValue({
-      pathname: '/insights/backend/http/',
-      search: '',
-      query: {statsPeriod: '10d', 'span.domain': 'git', project: '1'},
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
     });
 
     ProjectsStore.loadInitialData([
@@ -239,7 +228,7 @@ describe('HTTPLandingPage', () => {
   });
 
   it('fetches module data', async () => {
-    render(<HTTPLandingPage />, {organization});
+    render(<HTTPLandingPage />, {organization, initialRouterConfig: baseRouterConfig});
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
@@ -366,7 +355,7 @@ describe('HTTPLandingPage', () => {
   });
 
   it('renders a list of domains', async () => {
-    render(<HTTPLandingPage />, {organization});
+    render(<HTTPLandingPage />, {organization, initialRouterConfig: baseRouterConfig});
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
@@ -406,22 +395,21 @@ describe('HTTPLandingPage', () => {
   });
 
   it('sorts with query params', async () => {
-    useLocationMock.mockReturnValue({
-      pathname: '/insights/backend/http/',
-      search: '',
-      query: {
-        statsPeriod: '10d',
-        'span.domain': 'git',
-        project: '1',
-        [QueryParameterNames.DOMAINS_SORT]: '-avg(span.self_time)',
+    render(<HTTPLandingPage />, {
+      organization,
+      initialRouterConfig: {
+        ...baseRouterConfig,
+        location: {
+          ...baseRouterConfig.location,
+          query: {
+            statsPeriod: '10d',
+            'span.domain': 'git',
+            project: '1',
+            [QueryParameterNames.DOMAINS_SORT]: '-avg(span.self_time)',
+          },
+        },
       },
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
     });
-
-    render(<HTTPLandingPage />, {organization});
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 

--- a/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
@@ -1,18 +1,13 @@
-import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {useLocation} from 'sentry/utils/useLocation';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {useCrossPlatformProject} from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {ScreensOverview} from 'sentry/views/insights/mobile/screens/components/screensOverview';
 
 jest.mock('sentry/views/insights/mobile/common/queries/useCrossPlatformProject');
-jest.mock('sentry/components/pageFilters/usePageFilters');
-jest.mock('sentry/utils/useLocation');
 
 describe('ScreensOverview', () => {
   const organization = OrganizationFixture({
@@ -20,32 +15,28 @@ describe('ScreensOverview', () => {
   });
   const project = ProjectFixture();
 
-  jest.mocked(useLocation).mockReturnValue({
-    action: 'PUSH',
-    hash: '',
-    key: '',
-    pathname: '/organizations/org-slug/performance/mobile/mobile-vitals',
-    query: {
-      project: project.id,
-    },
-    search: '',
-    state: undefined,
-  } as Location);
-
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [parseInt(project.id, 10)],
+  const initialRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/performance/mobile/mobile-vitals',
+      query: {
+        project: project.id,
       },
-    })
-  );
+    },
+    route: '/organizations/:orgId/performance/mobile/mobile-vitals',
+  };
+
+  beforeEach(() => {
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    });
+  });
 
   jest.mocked(useCrossPlatformProject).mockReturnValue({
     project,
@@ -61,7 +52,7 @@ describe('ScreensOverview', () => {
       url: `/organizations/${organization.slug}/releases/`,
       body: [],
     });
-    render(<ScreensOverview />, {organization});
+    render(<ScreensOverview />, {organization, initialRouterConfig});
 
     expect(await screen.findByPlaceholderText('Search for Screen')).toBeInTheDocument();
     expect(await screen.findByRole('table')).toBeInTheDocument();
@@ -141,7 +132,7 @@ describe('ScreensOverview', () => {
       body: [],
     });
 
-    render(<ScreensOverview />, {organization});
+    render(<ScreensOverview />, {organization, initialRouterConfig});
 
     await waitFor(() => {
       expect(metricsMock).toHaveBeenCalled();

--- a/static/app/views/insights/mobile/screens/components/screensOverviewTable.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverviewTable.spec.tsx
@@ -1,21 +1,16 @@
-import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {EventView} from 'sentry/utils/discover/eventView';
-import {useLocation} from 'sentry/utils/useLocation';
 import {
   ScreensOverviewTable,
   type Row,
 } from 'sentry/views/insights/mobile/screens/components/screensOverviewTable';
 
-jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/views/insights/common/utils/useModuleURL');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 describe('ScreensOverviewTable', () => {
   const organization = OrganizationFixture({
@@ -23,35 +18,33 @@ describe('ScreensOverviewTable', () => {
   });
   const project = ProjectFixture();
 
-  const location = {
-    action: 'PUSH',
-    hash: '',
-    key: '',
-    pathname: '/organizations/org-slug/performance/mobile/mobile-vitals',
-    query: {
-      project: project.id,
-    },
-    search: '',
-    state: undefined,
-  } as Location;
-
-  jest.mocked(useLocation).mockReturnValue(location);
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [parseInt(project.id, 10)],
+  const initialRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/performance/mobile/mobile-vitals',
+      query: {
+        project: project.id,
       },
-    })
-  );
+    },
+    route: '/organizations/:orgId/performance/mobile/mobile-vitals',
+  };
 
-  const mockEventView = EventView.fromLocation(location);
+  beforeEach(() => {
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    });
+  });
+
+  const mockEventView = EventView.fromLocation({
+    pathname: '/organizations/org-slug/performance/mobile/mobile-vitals',
+    query: {project: project.id},
+  } as any);
 
   const mockData = {
     data: [
@@ -83,6 +76,7 @@ describe('ScreensOverviewTable', () => {
       />,
       {
         organization,
+        initialRouterConfig,
       }
     );
 

--- a/static/app/views/insights/pages/backend/backendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.spec.tsx
@@ -1,18 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFiltersFixture, PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import {useLocation} from 'sentry/utils/useLocation';
 import BackendOverviewPage from 'sentry/views/insights/pages/backend/backendOverviewPage';
-
-jest.mock('sentry/components/pageFilters/usePageFilters');
-jest.mock('sentry/utils/useLocation');
-
-let useLocationMock: jest.Mock;
 
 const organization = OrganizationFixture({features: ['performance-view']});
 const pageFilterSelection = PageFiltersFixture({
@@ -39,21 +33,20 @@ describe('BackendOverviewPage', () => {
 
   describe('data fetching', () => {
     it('contains correct query with search', async () => {
-      useLocationMock.mockClear();
-      useLocationMock.mockReturnValue({
-        pathname: '/insights/backend/http/',
-        search: '',
-        query: {
-          statsPeriod: '10d',
-          project: '1',
-          query: 'transaction:transaction-name',
+      render(<BackendOverviewPage />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/insights/backend/http/',
+            query: {
+              statsPeriod: '10d',
+              project: '1',
+              query: 'transaction:transaction-name',
+            },
+          },
+          route: '/insights/backend/http/',
         },
-        hash: '',
-        state: undefined,
-        action: 'PUSH',
-        key: '',
       });
-      render(<BackendOverviewPage />, {organization});
 
       await waitFor(() =>
         expect(mainTableApiCall).toHaveBeenCalledWith(
@@ -165,19 +158,6 @@ const setupMocks = () => {
     body: [],
   });
 
-  useLocationMock = jest.mocked(useLocation);
-  useLocationMock.mockReturnValue({
-    pathname: '/insights/backend/http/',
-    search: '',
-    query: {statsPeriod: '10d', 'span.domain': 'git', project: '1'},
-    hash: '',
-    state: undefined,
-    action: 'PUSH',
-    key: '',
-  });
-
-  jest
-    .mocked(usePageFilters)
-    .mockReturnValue(PageFilterStateFixture({selection: pageFilterSelection}));
+  PageFiltersStore.onInitializeUrlState(pageFilterSelection);
   ProjectsStore.loadInitialData(projects);
 };

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
@@ -1,16 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFiltersFixture, PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import {useLocation} from 'sentry/utils/useLocation';
 import FrontendOverviewPage from 'sentry/views/insights/pages/frontend/frontendOverviewPage';
-
-jest.mock('sentry/components/pageFilters/usePageFilters');
-jest.mock('sentry/utils/useLocation');
 
 const organization = OrganizationFixture({features: ['performance-view']});
 const pageFilterSelection = PageFiltersFixture({
@@ -37,7 +33,16 @@ describe('FrontendOverviewPage', () => {
 
   describe('data fetching', () => {
     it('fetches correct data with unknown + frontend platform', async () => {
-      render(<FrontendOverviewPage />, {organization});
+      render(<FrontendOverviewPage />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/insights/frontend/',
+            query: {statsPeriod: '10d', project: '1'},
+          },
+          route: '/insights/frontend/',
+        },
+      });
 
       await waitFor(() =>
         expect(mainTableApiCall).toHaveBeenCalledWith(
@@ -53,16 +58,22 @@ describe('FrontendOverviewPage', () => {
     });
 
     it('fetches correct data with unknown platform', async () => {
-      jest.mocked(usePageFilters).mockReturnValue(
-        PageFilterStateFixture({
-          selection: {
-            datetime: pageFilterSelection.datetime,
-            environments: [],
-            projects: [2],
-          },
+      PageFiltersStore.onInitializeUrlState(
+        PageFiltersFixture({
+          ...pageFilterSelection,
+          projects: [2],
         })
       );
-      render(<FrontendOverviewPage />, {organization});
+      render(<FrontendOverviewPage />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/insights/frontend/',
+            query: {statsPeriod: '10d', project: '2'},
+          },
+          route: '/insights/frontend/',
+        },
+      });
 
       await waitFor(() =>
         expect(mainTableApiCall).toHaveBeenCalledWith(
@@ -174,18 +185,6 @@ const setupMocks = () => {
     body: [],
   });
 
-  jest.mocked(useLocation).mockReturnValue({
-    pathname: '/insights/backend/http/',
-    search: '',
-    query: {statsPeriod: '10d', 'span.domain': 'git', project: '1'},
-    hash: '',
-    state: undefined,
-    action: 'PUSH',
-    key: '',
-  });
-
-  jest
-    .mocked(usePageFilters)
-    .mockReturnValue(PageFilterStateFixture({selection: pageFilterSelection}));
+  PageFiltersStore.onInitializeUrlState(pageFilterSelection);
   ProjectsStore.loadInitialData(projects);
 };

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
@@ -1,16 +1,11 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {DurationUnit} from 'sentry/utils/discover/fields';
-import {useLocation} from 'sentry/utils/useLocation';
 import {MessageSpanSamplesPanel} from 'sentry/views/insights/queues/components/messageSpanSamplesPanel';
-
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
 
 describe('messageSpanSamplesPanel', () => {
   const organization = OrganizationFixture();
@@ -20,32 +15,29 @@ describe('messageSpanSamplesPanel', () => {
   let samplesRequestMock: jest.Mock;
   let traceItemAttributesMock: jest.Mock;
 
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
-      },
-    })
-  );
+  const basePath = `/organizations/${organization.slug}/insights/queues/`;
+  const baseRoute = `/organizations/:orgId/insights/queues/`;
 
-  jest.mocked(useLocation).mockReturnValue({
-    pathname: '',
-    search: '',
-    query: {transaction: 'sentry.tasks.store.save_event', destination: 'event-queue'},
-    hash: '',
-    state: undefined,
-    action: 'PUSH',
-    key: '',
-  });
+  const baseRouterConfig = {
+    location: {
+      pathname: basePath,
+      query: {transaction: 'sentry.tasks.store.save_event', destination: 'event-queue'},
+    },
+    route: baseRoute,
+  };
 
   beforeEach(() => {
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: [],
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    });
+
     eventsTimeseriesRequestMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
@@ -164,20 +156,20 @@ describe('messageSpanSamplesPanel', () => {
   });
 
   it('renders consumer panel', async () => {
-    jest.mocked(useLocation).mockReturnValue({
-      pathname: '',
-      search: '',
-      query: {
-        transaction: 'sentry.tasks.store.save_event',
-        destination: 'event-queue',
-        'span.op': 'queue.process',
+    render(<MessageSpanSamplesPanel />, {
+      organization,
+      initialRouterConfig: {
+        ...baseRouterConfig,
+        location: {
+          ...baseRouterConfig.location,
+          query: {
+            transaction: 'sentry.tasks.store.save_event',
+            destination: 'event-queue',
+            'span.op': 'queue.process',
+          },
+        },
       },
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
     });
-    render(<MessageSpanSamplesPanel />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
     expect(eventsTimeseriesRequestMock).toHaveBeenCalled();
     expect(eventsRequestMock).toHaveBeenCalledWith(
@@ -272,20 +264,20 @@ describe('messageSpanSamplesPanel', () => {
   });
 
   it('renders producer panel', async () => {
-    jest.mocked(useLocation).mockReturnValue({
-      pathname: '',
-      search: '',
-      query: {
-        transaction: 'sentry.tasks.store.save_event',
-        destination: 'event-queue',
-        'span.op': 'queue.publish',
+    render(<MessageSpanSamplesPanel />, {
+      organization,
+      initialRouterConfig: {
+        ...baseRouterConfig,
+        location: {
+          ...baseRouterConfig.location,
+          query: {
+            transaction: 'sentry.tasks.store.save_event',
+            destination: 'event-queue',
+            'span.op': 'queue.publish',
+          },
+        },
       },
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
     });
-    render(<MessageSpanSamplesPanel />, {organization});
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
     expect(eventsTimeseriesRequestMock).toHaveBeenCalled();
     expect(eventsRequestMock).toHaveBeenCalledWith(

--- a/static/app/views/insights/queues/components/tables/transactionsTable.spec.tsx
+++ b/static/app/views/insights/queues/components/tables/transactionsTable.spec.tsx
@@ -2,11 +2,8 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {useLocation} from 'sentry/utils/useLocation';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {TransactionsTable} from 'sentry/views/insights/queues/components/tables/transactionsTable';
-
-jest.mock('sentry/utils/useLocation');
 
 describe('transactionsTable', () => {
   const organization = OrganizationFixture();
@@ -17,17 +14,15 @@ describe('transactionsTable', () => {
     '<https://sentry.io/fake/previous>; rel="previous"; results="false"; cursor="0:0:1", ' +
     '<https://sentry.io/fake/next>; rel="next"; results="true"; cursor="0:20:0"';
 
-  beforeEach(() => {
-    jest.mocked(useLocation).mockReturnValue({
-      pathname: '',
-      search: '',
+  const baseRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/insights/queues/`,
       query: {statsPeriod: '10d', project: '1'},
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
-    });
+    },
+    route: `/organizations/:orgId/insights/queues/`,
+  };
 
+  beforeEach(() => {
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       headers: {Link: pageLinks},
@@ -65,7 +60,7 @@ describe('transactionsTable', () => {
     });
   });
   it('renders', async () => {
-    render(<TransactionsTable />, {organization});
+    render(<TransactionsTable />, {organization, initialRouterConfig: baseRouterConfig});
     expect(screen.getByRole('table', {name: 'Transactions'})).toBeInTheDocument();
 
     expect(screen.getByRole('columnheader', {name: 'Transactions'})).toBeInTheDocument();
@@ -112,22 +107,21 @@ describe('transactionsTable', () => {
   });
 
   it('sorts by processing time', async () => {
-    jest.mocked(useLocation).mockReturnValue({
-      pathname: '',
-      search: '',
-      query: {
-        statsPeriod: '10d',
-        project: '1',
-        [QueryParameterNames.DESTINATIONS_SORT]:
-          '-avg_if(span.duration,span.op,equals,queue.process)',
+    render(<TransactionsTable />, {
+      organization,
+      initialRouterConfig: {
+        ...baseRouterConfig,
+        location: {
+          ...baseRouterConfig.location,
+          query: {
+            statsPeriod: '10d',
+            project: '1',
+            [QueryParameterNames.DESTINATIONS_SORT]:
+              '-avg_if(span.duration,span.op,equals,queue.process)',
+          },
+        },
       },
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
     });
-
-    render(<TransactionsTable />, {organization});
 
     expect(eventsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',

--- a/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
@@ -1,20 +1,22 @@
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {useLocation} from 'sentry/utils/useLocation';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 
 import {QuotaExceededAlert} from './quotaExceededAlert';
 
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/components/pageFilters/usePageFilters');
-
 describe('Renders QuotaExceededAlert correctly for spans', () => {
-  const {organization} = initializeOrg();
+  const organization = OrganizationFixture();
+  const initialRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/performance/quota-exceeded-alert',
+      query: {statsPeriod: '7d'},
+    },
+    route: '/organizations/:orgId/performance/quota-exceeded-alert',
+  };
   const getSubscription = ({
     spansUsageExceeded,
     logsUsageExceeded,
@@ -41,29 +43,15 @@ describe('Renders QuotaExceededAlert correctly for spans', () => {
   };
   beforeEach(() => {
     setMockDate(new Date('2024-12-14').getTime());
-    jest.mocked(usePageFilters).mockReturnValue(
-      PageFilterStateFixture({
-        selection: {
-          datetime: {
-            period: '7d',
-            start: null,
-            end: null,
-            utc: false,
-          },
-          environments: [],
-          projects: [2],
-        },
-      })
-    );
-
-    jest.mocked(useLocation).mockReturnValue({
-      pathname: '',
-      search: '',
-      query: {statsPeriod: '7d'},
-      hash: '',
-      state: undefined,
-      action: 'PUSH',
-      key: '',
+    PageFiltersStore.onInitializeUrlState({
+      projects: [2],
+      environments: [],
+      datetime: {
+        period: '7d',
+        start: null,
+        end: null,
+        utc: false,
+      },
     });
   });
 
@@ -102,6 +90,7 @@ describe('Renders QuotaExceededAlert correctly for spans', () => {
       />,
       {
         organization,
+        initialRouterConfig,
       }
     );
 
@@ -154,6 +143,7 @@ describe('Renders QuotaExceededAlert correctly for spans', () => {
       />,
       {
         organization,
+        initialRouterConfig,
       }
     );
 

--- a/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
@@ -3,15 +3,12 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {useDismissAlert} from 'sentry/utils/useDismissAlert';
-import {useLocation} from 'sentry/utils/useLocation';
 
 import {SeerAutomationAlert} from 'getsentry/views/subscriptionPage/seerAutomationAlert';
 
 jest.mock('sentry/utils/useDismissAlert');
-jest.mock('sentry/utils/useLocation');
 
 const mockUseDismissAlert = jest.mocked(useDismissAlert);
-const mockUseLocation = jest.mocked(useLocation);
 
 describe('SeerAutomationAlert', () => {
   const defaultOrganization = OrganizationFixture({
@@ -19,21 +16,19 @@ describe('SeerAutomationAlert', () => {
     slug: 'test-org',
   });
 
+  const baseRouterConfig = {
+    location: {
+      pathname: '/settings/test-org/billing/overview/',
+      query: {showSeerAutomationAlert: 'true'},
+    },
+    route: '/settings/:orgId/billing/overview/',
+  };
+
   beforeEach(() => {
     // Default mocks
     mockUseDismissAlert.mockImplementation(() => ({
       dismiss: jest.fn(),
       isDismissed: false,
-    }));
-
-    mockUseLocation.mockImplementation(() => ({
-      query: {showSeerAutomationAlert: 'true'},
-      pathname: '/settings/test-org/billing/overview/',
-      search: '?showSeerAutomationAlert=true',
-      hash: '',
-      state: null,
-      key: 'test',
-      action: 'PUSH',
     }));
   });
 
@@ -42,7 +37,9 @@ describe('SeerAutomationAlert', () => {
   });
 
   it('renders when all conditions are met', () => {
-    render(<SeerAutomationAlert organization={defaultOrganization} />);
+    render(<SeerAutomationAlert organization={defaultOrganization} />, {
+      initialRouterConfig: baseRouterConfig,
+    });
 
     expect(
       screen.getByText(
@@ -58,7 +55,9 @@ describe('SeerAutomationAlert', () => {
   });
 
   it('has correct link to seer automation settings', () => {
-    render(<SeerAutomationAlert organization={defaultOrganization} />);
+    render(<SeerAutomationAlert organization={defaultOrganization} />, {
+      initialRouterConfig: baseRouterConfig,
+    });
 
     const link = screen.getByText('Manage Seer Automation Settings');
     expect(link.closest('a')).toHaveAttribute('href', '/settings/test-org/seer/');
@@ -71,7 +70,9 @@ describe('SeerAutomationAlert', () => {
       isDismissed: false,
     }));
 
-    render(<SeerAutomationAlert organization={defaultOrganization} />);
+    render(<SeerAutomationAlert organization={defaultOrganization} />, {
+      initialRouterConfig: baseRouterConfig,
+    });
 
     const dismissButton = screen.getByLabelText('Dismiss banner');
     await userEvent.click(dismissButton);
@@ -86,7 +87,8 @@ describe('SeerAutomationAlert', () => {
     }));
 
     const {container} = render(
-      <SeerAutomationAlert organization={defaultOrganization} />
+      <SeerAutomationAlert organization={defaultOrganization} />,
+      {initialRouterConfig: baseRouterConfig}
     );
     expect(container).toBeEmptyDOMElement();
   });
@@ -98,40 +100,32 @@ describe('SeerAutomationAlert', () => {
     });
 
     const {container} = render(
-      <SeerAutomationAlert organization={organizationWithoutSeer} />
+      <SeerAutomationAlert organization={organizationWithoutSeer} />,
+      {initialRouterConfig: baseRouterConfig}
     );
     expect(container).toBeEmptyDOMElement();
   });
 
   it('does not render when there is no showSeerAutomationAlert query parameter', () => {
-    mockUseLocation.mockImplementation(() => ({
-      query: {}, // No showSeerAutomationAlert
-      pathname: '/settings/test-org/billing/overview/',
-      search: '',
-      hash: '',
-      state: null,
-      key: 'test',
-      action: 'PUSH',
-    }));
-
     const {container} = render(
-      <SeerAutomationAlert organization={defaultOrganization} />
+      <SeerAutomationAlert organization={defaultOrganization} />,
+      {
+        initialRouterConfig: {
+          ...baseRouterConfig,
+          location: {
+            ...baseRouterConfig.location,
+            query: {},
+          },
+        },
+      }
     );
     expect(container).toBeEmptyDOMElement();
   });
 
   it('renders when there is a showSeerAutomationAlert query parameter', () => {
-    mockUseLocation.mockImplementation(() => ({
-      query: {showSeerAutomationAlert: 'true'},
-      pathname: '/settings/test-org/billing/overview/',
-      search: '?showSeerAutomationAlert=true',
-      hash: '',
-      state: null,
-      key: 'test',
-      action: 'PUSH',
-    }));
-
-    render(<SeerAutomationAlert organization={defaultOrganization} />);
+    render(<SeerAutomationAlert organization={defaultOrganization} />, {
+      initialRouterConfig: baseRouterConfig,
+    });
 
     expect(
       screen.getByText(
@@ -141,7 +135,9 @@ describe('SeerAutomationAlert', () => {
   });
 
   it('uses correct dismiss key with organization id', () => {
-    render(<SeerAutomationAlert organization={defaultOrganization} />);
+    render(<SeerAutomationAlert organization={defaultOrganization} />, {
+      initialRouterConfig: baseRouterConfig,
+    });
 
     expect(mockUseDismissAlert).toHaveBeenCalledWith({
       key: `${defaultOrganization.id}:seer-automation-billing-alert`,


### PR DESCRIPTION
Migrate tests from mocking useLocation and usePageFilters hooks to using initialRouterConfig on render() and PageFiltersStore.onInitializeUrlState(). This uses the real hook implementations for more realistic test coverage.
