### PR TITLE
feat(seer agent): add integration button to handoff dropdown

### DIFF
--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -240,6 +240,33 @@ describe('SeerDrawerNextStep', () => {
         await screen.findByRole('button', {name: 'More code fix options'})
       ).toBeInTheDocument();
     });
+
+    it('shows Add Integration link in dropdown footer', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/coding-agents/',
+        body: {
+          integrations: [
+            {id: '1', name: 'Copilot', provider: 'github', requires_identity: false},
+          ],
+        },
+      });
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('root_cause')]}
+          autofix={autofix}
+        />
+      );
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'More code fix options'})
+      );
+      const addIntegrationLink = screen.getByRole('button', {name: 'Add Integration'});
+      expect(addIntegrationLink).toHaveAttribute(
+        'href',
+        '/settings/org-slug/integrations/?category=coding%20agent'
+      );
+    });
   });
 
   describe('SolutionNextStep', () => {

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -1,11 +1,13 @@
 import {useCallback, useMemo, useState, type ReactNode} from 'react';
 
 import {Button, ButtonBar} from '@sentry/scraps/button';
+import {MenuComponents} from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {
   organizationIntegrationsCodingAgents,
   type CodingAgentIntegration,
@@ -18,6 +20,7 @@ import {
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
@@ -287,6 +290,8 @@ function NextStepTemplate({
   codingAgentIntegrations,
   onCodingAgentHandoff,
 }: NextStepTemplateProps) {
+  const organization = useOrganization();
+
   const codingAgentOptions = useMemo(() => {
     return (codingAgentIntegrations ?? []).map(integration => {
       const actionLabel =
@@ -361,6 +366,16 @@ function NextStepTemplate({
                 />
               )}
               position="bottom-end"
+              menuFooter={
+                <DropdownMenuFooter>
+                  <MenuComponents.CTALinkButton
+                    icon={<IconAdd />}
+                    to={`/settings/${organization.slug}/integrations/?category=coding%20agent`}
+                  >
+                    {t('Add Integration')}
+                  </MenuComponents.CTALinkButton>
+                </DropdownMenuFooter>
+              }
             />
           ) : null}
         </ButtonBar>


### PR DESCRIPTION
Adds button labeled "Add Integration" to the bottom of the dropdown for coding agent handoff. This is only in explorer v3 as this will be EA and then GA very soon.  The button links to the integrations page and filters to "Coding Agents". 

Pictures provided below of the dropdown with and without agents configured + the page it links to. A test has also been written for the frontend.

<img width="394" height="197" alt="Screenshot 2026-03-24 at 4 52 05 PM" src="https://github.com/user-attachments/assets/c0b374da-9d29-4900-b651-ee05028b2ad4" />
<img width="501" height="217" alt="Screenshot 2026-03-24 at 4 46 10 PM" src="https://github.com/user-attachments/assets/efe347c5-e286-4d34-934f-193d72e97604" />
<img width="638" height="400" alt="Screenshot 2026-03-24 at 4 46 23 PM" src="https://github.com/user-attachments/assets/59c38982-5b10-42e9-a48a-aea89482d757" />

