### PR TITLE
feat(github): Add issue types support for Sentry issues

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -967,7 +967,7 @@ class GitHubBaseClient(
             api_request_type=GitHubApiRequestType.GET_LABELS,
         )
 
-    def get_types(self, owner: str) -> list[Any]:
+    def get_org_issue_types(self, owner: str) -> list[Any]:
         """
         Fetches all issue types for an organization.
         https://docs.github.com/en/rest/orgs/issue-types#list-issue-types-for-an-organization

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -967,6 +967,13 @@ class GitHubBaseClient(
             api_request_type=GitHubApiRequestType.GET_LABELS,
         )
 
+    def get_types(self, owner: str) -> list[Any]:
+        """
+        Fetches all issue types for an organization.
+        https://docs.github.com/en/rest/orgs/issue-types#list-issue-types-for-an-organization
+        """
+        return self._get_with_pagination(f"/orgs/{owner}/issue-types")
+
     def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
         return self.head_cached(
             path=f"/repos/{repo.name}/contents/{path}",

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -1102,6 +1102,13 @@ class GitHubBaseClient(
             api_request_type=GitHubApiRequestType.GET_LABELS,
         )
 
+    def get_types(self, owner: str) -> list[Any]:
+        """
+        Fetches all issue types for an organization.
+        https://docs.github.com/en/rest/orgs/issue-types#list-issue-types-for-an-organization
+        """
+        return self._get_with_pagination(f"/orgs/{owner}/issue-types")
+
     def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
         return self.head_cached(
             path=f"/repos/{repo.name}/contents/{path}",

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -1102,7 +1102,7 @@ class GitHubBaseClient(
             api_request_type=GitHubApiRequestType.GET_LABELS,
         )
 
-    def get_types(self, owner: str) -> list[Any]:
+    def get_org_issue_types(self, owner: str) -> list[Any]:
         """
         Fetches all issue types for an organization.
         https://docs.github.com/en/rest/orgs/issue-types#list-issue-types-for-an-organization

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -405,7 +405,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         return types
 
-    def natural_sort_pair(self, response, pair: tuple[str, str]) -> list[str | int]:
+    def natural_sort_pair(self, pair: tuple[str, str]) -> list[str | int]:
             return [
                 int(text) if text.isdecimal() else text.lower()
                 for text in re.split("([0-9]+)", pair[0])

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -180,14 +180,14 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         assignees = self.get_allowed_assignees(default_repo) if default_repo else []
         labels: Sequence[tuple[str, str]] = []
-        types: Sequence[tuple[str, str]] = []
+        issue_types: Sequence[tuple[str, str]] = []
         if default_repo:
             owner, repo = default_repo.split("/")
             labels = self.get_repo_labels(owner, repo)
             try:
-                types = self.get_org_types(owner)
+                issue_types = self.get_org_issue_types(owner)
             except IntegrationResourceNotFoundError:
-                types = []
+                issue_types = []
 
         autocomplete_url = reverse(
             "sentry-integration-github-search", args=[org.slug, self.model.id]
@@ -229,7 +229,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
                 "type": "select",
                 "multiple": False,
                 "required": False,
-                "choices": types,
+                "choices": issue_types,
             },
         ]
 
@@ -398,10 +398,10 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         return labels
 
-    def get_org_types(self, owner: str) -> Sequence[tuple[str, str]]:
+    def get_org_issue_types(self, owner: str) -> Sequence[tuple[str, str]]:
         client = self.get_client()
         try:
-            response = client.get_types(owner)
+            response = client.get_org_issue_types(owner)
         except Exception as e:
             self.raise_error(e)
 

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -184,7 +184,10 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         if default_repo:
             owner, repo = default_repo.split("/")
             labels = self.get_repo_labels(owner, repo)
-            types = self.get_org_types(owner)
+            try:
+                types = self.get_org_types(owner)
+            except IntegrationResourceNotFoundError:
+                types = []
 
         autocomplete_url = reverse(
             "sentry-integration-github-search", args=[org.slug, self.model.id]

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -406,7 +406,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         return types
 
     def natural_sort_pair(self, pair: tuple[str, str]) -> list[str | int]:
-            return [
-                int(text) if text.isdecimal() else text.lower()
-                for text in re.split("([0-9]+)", pair[0])
-            ]
+        return [
+            int(text) if text.isdecimal() else text.lower()
+            for text in re.split("([0-9]+)", pair[0])
+        ]

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -180,9 +180,11 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         assignees = self.get_allowed_assignees(default_repo) if default_repo else []
         labels: Sequence[tuple[str, str]] = []
+        types: Sequence[tuple[str, str]] = []
         if default_repo:
             owner, repo = default_repo.split("/")
             labels = self.get_repo_labels(owner, repo)
+            types = self.get_repo_types(owner)
 
         autocomplete_url = reverse(
             "sentry-integration-github-search", args=[org.slug, self.model.id]
@@ -216,6 +218,15 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
                 "multiple": True,
                 "required": False,
                 "choices": labels,
+            },
+            {
+                "name": "type",
+                "label": "Type",
+                "default": [],
+                "type": "select",
+                "multiple": False,
+                "required": False,
+                "choices": types,
             },
         ]
 
@@ -385,3 +396,23 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         )
 
         return labels
+
+    def get_org_types(self, owner: str) -> Sequence[tuple[str, str]]:
+        client = self.get_client()
+        try:
+            response = client.get_types(owner)
+        except Exception as e:
+            self.raise_error(e)
+
+        def natural_sort_pair(pair: tuple[str, str]) -> list[str | int]:
+            return [
+                int(text) if text.isdecimal() else text.lower()
+                for text in re.split("([0-9]+)", pair[0])
+            ]
+
+        # sort alphabetically
+        types = tuple(
+            sorted([(type_obj["name"], type_obj["name"]) for type_obj in response], key=natural_sort_pair)
+        )
+
+        return types

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -391,7 +391,9 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         # sort alphabetically
         labels = tuple(
-            sorted([(label["name"], label["name"]) for label in response], key=self.natural_sort_pair)
+            sorted(
+                [(label["name"], label["name"]) for label in response], key=self.natural_sort_pair
+            )
         )
 
         return labels
@@ -405,7 +407,10 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         # sort alphabetically
         types = tuple(
-            sorted([(type_obj["name"], type_obj["name"]) for type_obj in response], key=self.natural_sort_pair)
+            sorted(
+                [(type_obj["name"], type_obj["name"]) for type_obj in response],
+                key=self.natural_sort_pair,
+            )
         )
 
         return types

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -186,7 +186,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             labels = self.get_repo_labels(owner, repo)
             try:
                 types = self.get_org_types(owner)
-            except except (IntegrationResourceNotFoundError, IntegrationConfigurationError, IntegrationError):
+            except IntegrationResourceNotFoundError:
                 types = []
 
         autocomplete_url = reverse(

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -186,7 +186,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             labels = self.get_repo_labels(owner, repo)
             try:
                 types = self.get_org_types(owner)
-            except IntegrationResourceNotFoundError:
+            except except (IntegrationResourceNotFoundError, IntegrationConfigurationError, IntegrationError):
                 types = []
 
         autocomplete_url = reverse(

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -264,6 +264,8 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             issue_data["assignee"] = data["assignee"]
         if data.get("labels"):
             issue_data["labels"] = data["labels"]
+        if data.get("type"):
+            issue_data["type"] = data["type"]
 
         try:
             issue = client.create_issue(repo=repo, data=issue_data)

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -184,7 +184,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         if default_repo:
             owner, repo = default_repo.split("/")
             labels = self.get_repo_labels(owner, repo)
-            types = self.get_repo_types(owner)
+            types = self.get_org_types(owner)
 
         autocomplete_url = reverse(
             "sentry-integration-github-search", args=[org.slug, self.model.id]
@@ -222,7 +222,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             {
                 "name": "type",
                 "label": "Type",
-                "default": [],
+                "default": "",
                 "type": "select",
                 "multiple": False,
                 "required": False,
@@ -384,15 +384,9 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         except Exception as e:
             self.raise_error(e)
 
-        def natural_sort_pair(pair: tuple[str, str]) -> list[str | int]:
-            return [
-                int(text) if text.isdecimal() else text.lower()
-                for text in re.split("([0-9]+)", pair[0])
-            ]
-
         # sort alphabetically
         labels = tuple(
-            sorted([(label["name"], label["name"]) for label in response], key=natural_sort_pair)
+            sorted([(label["name"], label["name"]) for label in response], key=self.natural_sort_pair)
         )
 
         return labels
@@ -404,15 +398,15 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         except Exception as e:
             self.raise_error(e)
 
-        def natural_sort_pair(pair: tuple[str, str]) -> list[str | int]:
+        # sort alphabetically
+        types = tuple(
+            sorted([(type_obj["name"], type_obj["name"]) for type_obj in response], key=self.natural_sort_pair)
+        )
+
+        return types
+
+    def natural_sort_pair(self, response, pair: tuple[str, str]) -> list[str | int]:
             return [
                 int(text) if text.isdecimal() else text.lower()
                 for text in re.split("([0-9]+)", pair[0])
             ]
-
-        # sort alphabetically
-        types = tuple(
-            sorted([(type_obj["name"], type_obj["name"]) for type_obj in response], key=natural_sort_pair)
-        )
-
-        return types

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -184,10 +184,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         if default_repo:
             owner, repo = default_repo.split("/")
             labels = self.get_repo_labels(owner, repo)
-            try:
-                issue_types = self.get_org_issue_types(owner)
-            except IntegrationResourceNotFoundError:
-                issue_types = []
+            issue_types = self.get_org_issue_types(owner)
 
         autocomplete_url = reverse(
             "sentry-integration-github-search", args=[org.slug, self.model.id]

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -641,11 +641,11 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "https://api.github.com/repos/getsentry/sentry/labels",
             json=[{"name": "bug"}, {"name": "enhancement"}],
         )
-        # responses.add(
-        #     responses.GET,
-        #     "https://api.github.com/orgs/getsentry/issue-types",
-        #     json=[{"name": "bug"}, {"name": "task"}],
-        # )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/orgs/getsentry/issue-types",
+            json=[{"name": "bug"}, {"name": "task"}],
+        )
 
         responses.add(
             responses.GET,

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -95,7 +95,7 @@ class GitHubIssueBasicAllSiloTest(TestCase):
 
         install = self.install
         config = install.get_create_issue_config(None, self.user, params={})
-        [repo_field, assignee_field, label_field] = config
+        repo_field, assignee_field, label_field = config[:3]
         assert repo_field["name"] == "repo"
         assert repo_field["type"] == "select"
         assert repo_field["label"] == "GitHub Repository"

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -641,11 +641,11 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "https://api.github.com/repos/getsentry/sentry/labels",
             json=[{"name": "bug"}, {"name": "enhancement"}],
         )
-        responses.add(
-            responses.GET,
-            "https://api.github.com/orgs/getsentry/issue-types",
-            json=[{"name": "bug"}, {"name": "task"}],
-        )
+        # responses.add(
+        #     responses.GET,
+        #     "https://api.github.com/orgs/getsentry/issue-types",
+        #     json=[{"name": "bug"}, {"name": "task"}],
+        # )
 
         responses.add(
             responses.GET,

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -635,7 +635,6 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "https://api.github.com/repos/getsentry/sentry/labels",
             json=[{"name": "bug"}, {"name": "enhancement"}],
         )
-        # Mock organization issue types endpoint used by get_types()/get_org_types()
         responses.add(
             responses.GET,
             "https://api.github.com/orgs/getsentry/issue-types",
@@ -792,6 +791,11 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             responses.GET,
             "https://api.github.com/repos/getsentry/sentry/labels",
             json=[{"name": "bug"}, {"name": "enhancement"}],
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/orgs/getsentry/issue-types",
+            json=[{"name": "bug"}, {"name": "task"}],
         )
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -635,6 +635,12 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "https://api.github.com/repos/getsentry/sentry/labels",
             json=[{"name": "bug"}, {"name": "enhancement"}],
         )
+        # Mock organization issue types endpoint used by get_types()/get_org_types()
+        responses.add(
+            responses.GET,
+            "https://api.github.com/orgs/getsentry/issue-types",
+            json=[{"name": "bug"}, {"name": "task"}],
+        )
 
         responses.add(
             responses.GET,

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -87,6 +87,12 @@ class GitHubIssueBasicAllSiloTest(TestCase):
             ],
         )
 
+        responses.add(
+            responses.GET,
+            "https://api.github.com/orgs/getsentry/issue-types",
+            json=[{"name": "bug"}, {"name": "task"}],
+        )
+
         install = self.install
         config = install.get_create_issue_config(None, self.user, params={})
         [repo_field, assignee_field, label_field] = config

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -95,7 +95,7 @@ class GitHubIssueBasicAllSiloTest(TestCase):
 
         install = self.install
         config = install.get_create_issue_config(None, self.user, params={})
-        repo_field, assignee_field, label_field = config[:3]
+        repo_field, assignee_field, label_field, type_field = config[:4]
         assert repo_field["name"] == "repo"
         assert repo_field["type"] == "select"
         assert repo_field["label"] == "GitHub Repository"
@@ -105,6 +105,13 @@ class GitHubIssueBasicAllSiloTest(TestCase):
         assert label_field["name"] == "labels"
         assert label_field["type"] == "select"
         assert label_field["label"] == "Labels"
+        assert type_field["name"] == "type"
+        assert type_field["type"] == "select"
+        assert type_field["label"] == "Type"
+        assert type_field["default"] == ""
+        assert type_field["multiple"] is False
+        assert type_field["required"] is False
+        assert type_field["choices"] == (("bug", "bug"), ("task", "task"))
 
 
 class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTestCase):


### PR DESCRIPTION
<!-- Describe your PR here. -->

This PR introduces the addition of types to the modal that opens when you try to link a GitHub issue to an external code tracking software.
An example of issue types:
<img width="359" height="442" alt="image" src="https://github.com/user-attachments/assets/e57c1711-0e4b-42a0-9e61-75e7d9450893" />

Closes #111404.
@cvxluo 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.