### PR TITLE
fix(seer): render explorer panel when page-frame feature is enabled

### DIFF
--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -783,18 +783,15 @@ export function ExplorerPanel() {
     return null;
   }
 
-  if (hasPageFrame) {
-    // When an organization has page frame enabled, Seer is a button inside the top bar.
-    return null;
-  }
-
   return createPortal(
     <Fragment>
       {panelContent}
-      <SeerFloatingActionButton
-        visible={!isVisible && !isSeerDrawerOpen}
-        onClick={openExplorerPanel}
-      />
+      {!hasPageFrame && (
+        <SeerFloatingActionButton
+          visible={!isVisible && !isSeerDrawerOpen}
+          onClick={openExplorerPanel}
+        />
+      )}
     </Fragment>,
     document.body
   );


### PR DESCRIPTION
The early return was preventing the panel from ever rendering - we should have only disabled the trigger (floating point when that is the case)