### PR TITLE
feat(nav): add cmd/ctrl+b nav toggle hotkey

### DIFF
--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -618,7 +618,7 @@ describe('desktop navigation', () => {
         ).not.toBeInTheDocument();
       });
 
-      it('can collapse the sidebar via Ctrl+B keyboard shortcut', async () => {
+      it('can collapse the sidebar via Ctrl+B keyboard shortcut', () => {
         render(
           <PrimaryNavigationContextProvider>
             <Navigation />
@@ -631,7 +631,7 @@ describe('desktop navigation', () => {
         expect(screen.getByTestId('collapsed-secondary-sidebar')).toBeInTheDocument();
       });
 
-      it('can expand a collapsed sidebar via Ctrl+B keyboard shortcut', async () => {
+      it('can expand a collapsed sidebar via Ctrl+B keyboard shortcut', () => {
         render(
           <PrimaryNavigationContextProvider>
             <Navigation />

--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -5,6 +5,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
+  fireEvent,
   render,
   screen,
   userEvent,
@@ -14,6 +15,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {ConfigStore} from 'sentry/stores/configStore';
+import {getKeyCode} from 'sentry/utils/getKeyCode';
 import {Navigation} from 'sentry/views/navigation';
 import {NAVIGATION_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY} from 'sentry/views/navigation/constants';
 import {PrimaryNavigationContextProvider} from 'sentry/views/navigation/primaryNavigationContext';
@@ -611,6 +613,36 @@ describe('desktop navigation', () => {
         await userEvent.click(screen.getByRole('button', {name: 'Collapse'}));
         await userEvent.click(screen.getByRole('button', {name: 'Expand'}));
 
+        expect(
+          screen.queryByTestId('collapsed-secondary-sidebar')
+        ).not.toBeInTheDocument();
+      });
+
+      it('can collapse the sidebar via Ctrl+B keyboard shortcut', async () => {
+        render(
+          <PrimaryNavigationContextProvider>
+            <Navigation />
+          </PrimaryNavigationContextProvider>,
+          navigationContext()
+        );
+
+        fireEvent.keyDown(document, {keyCode: getKeyCode('b'), ctrlKey: true});
+
+        expect(screen.getByTestId('collapsed-secondary-sidebar')).toBeInTheDocument();
+      });
+
+      it('can expand a collapsed sidebar via Ctrl+B keyboard shortcut', async () => {
+        render(
+          <PrimaryNavigationContextProvider>
+            <Navigation />
+          </PrimaryNavigationContextProvider>,
+          navigationContext()
+        );
+
+        fireEvent.keyDown(document, {keyCode: getKeyCode('b'), ctrlKey: true});
+        expect(screen.getByTestId('collapsed-secondary-sidebar')).toBeInTheDocument();
+
+        fireEvent.keyDown(document, {keyCode: getKeyCode('b'), ctrlKey: true});
         expect(
           screen.queryByTestId('collapsed-secondary-sidebar')
         ).not.toBeInTheDocument();

--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -25,7 +25,10 @@ import {
 import {PrimaryNavigation} from 'sentry/views/navigation/primary/components';
 import {UserDropdown} from 'sentry/views/navigation/primary/userDropdown';
 import {usePrimaryNavigation} from 'sentry/views/navigation/primaryNavigationContext';
-import {MobileSecondaryNavigationContextProvider} from 'sentry/views/navigation/secondaryNavigationContext';
+import {
+  MobileSecondaryNavigationContextProvider,
+  useSecondaryNavigation,
+} from 'sentry/views/navigation/secondaryNavigationContext';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {useResetActiveNavigationGroup} from 'sentry/views/navigation/useResetActiveNavigationGroup';
 
@@ -34,6 +37,7 @@ function UserAndOrganizationNavigation() {
   const {layout} = usePrimaryNavigation();
   const {visible} = useGlobalModal();
   const hasPageFrame = useHasPageFrameFeature();
+  const {view, setView} = useSecondaryNavigation();
 
   useGlobalCommandPaletteActions();
 
@@ -50,6 +54,10 @@ function UserAndOrganizationNavigation() {
                 openCommandPaletteDeprecated();
               }
             },
+          },
+          {
+            match: ['command+b', 'ctrl+b'],
+            callback: () => setView(view === 'collapsed' ? 'expanded' : 'collapsed'),
           },
         ]
   );

--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -57,7 +57,7 @@ function UserAndOrganizationNavigation() {
           },
           {
             match: ['command+b', 'ctrl+b'],
-            callback: () => setView(view === 'collapsed' ? 'expanded' : 'collapsed'),
+            callback: () => setView(view === 'expanded' ? 'collapsed' : 'expanded'),
           },
         ]
   );


### PR DESCRIPTION
Add a keyboard shortcut (Cmd+B on macOS, Ctrl+B on Windows/Linux) to toggle the secondary sidebar between expanded and collapsed states.
