### PR TITLE
ref(db): Migrate create_or_update to update_or_create

### DIFF
--- a/src/sentry/audit_log/services/log/impl.py
+++ b/src/sentry/audit_log/services/log/impl.py
@@ -44,10 +44,10 @@ class DatabaseBackedLogService(LogService):
                 raise
 
     def record_user_ip(self, *, event: UserIpEvent) -> None:
-        UserIP.objects.create_or_update(
+        UserIP.objects.update_or_create(
             user_id=event.user_id,
             ip_address=event.ip_address,
-            values=dict(
+            defaults=dict(
                 last_seen=event.last_seen,
                 country_code=event.country_code,
                 region_code=event.region_code,

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -1333,10 +1333,10 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         if rebalanced_projects is not None:
             for rebalanced_item in rebalanced_projects:
                 if int(rebalanced_item.id) in project_ids:
-                    ProjectOption.objects.create_or_update(
+                    ProjectOption.objects.update_or_create(
                         project_id=rebalanced_item.id,
                         key="sentry:target_sample_rate",
-                        values={"value": round(rebalanced_item.new_sample_rate, 4)},
+                        defaults={"value": round(rebalanced_item.new_sample_rate, 4)},
                     )
 
     def handle_delete(self, request: Request, organization: Organization):

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -426,23 +426,21 @@ class ArtifactBundlePostAssembler:
 
             # If a release version is passed, we want to create the weak association between a bundle and a release.
             if self.release:
-                ReleaseArtifactBundle.objects.create_or_update(
+                ReleaseArtifactBundle.objects.update_or_create(
                     organization_id=self.organization.id,
                     release_name=self.release,
                     # In case no dist is provided, we will fall back to "" which is the NULL equivalent for our
                     # tables.
                     dist_name=self.dist or NULL_STRING,
                     artifact_bundle=artifact_bundle,
-                    values=new_date_added,
                     defaults=new_date_added,
                 )
 
             for project_id in self.project_ids:
-                ProjectArtifactBundle.objects.create_or_update(
+                ProjectArtifactBundle.objects.update_or_create(
                     organization_id=self.organization.id,
                     project_id=project_id,
                     artifact_bundle=artifact_bundle,
-                    values=new_date_added,
                     defaults=new_date_added,
                 )
 

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -426,21 +426,23 @@ class ArtifactBundlePostAssembler:
 
             # If a release version is passed, we want to create the weak association between a bundle and a release.
             if self.release:
-                ReleaseArtifactBundle.objects.update_or_create(
+                ReleaseArtifactBundle.objects.create_or_update(
                     organization_id=self.organization.id,
                     release_name=self.release,
                     # In case no dist is provided, we will fall back to "" which is the NULL equivalent for our
                     # tables.
                     dist_name=self.dist or NULL_STRING,
                     artifact_bundle=artifact_bundle,
+                    values=new_date_added,
                     defaults=new_date_added,
                 )
 
             for project_id in self.project_ids:
-                ProjectArtifactBundle.objects.update_or_create(
+                ProjectArtifactBundle.objects.create_or_update(
                     organization_id=self.organization.id,
                     project_id=project_id,
                     artifact_bundle=artifact_bundle,
+                    values=new_date_added,
                     defaults=new_date_added,
                 )
 

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -263,10 +263,10 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
                 ).values("deploy_id"),
                 date_finished__gt=date_finished,
             ).exists():
-                LatestRepoReleaseEnvironment.objects.create_or_update(
+                LatestRepoReleaseEnvironment.objects.update_or_create(
                     repository_id=repository_id,
                     environment_id=environment_id,
-                    values={
+                    defaults={
                         "release_id": release.id,
                         "deploy_id": deploy_id,
                         "commit_id": commit_id,

--- a/tests/sentry/test_no_create_or_update_usage.py
+++ b/tests/sentry/test_no_create_or_update_usage.py
@@ -21,11 +21,7 @@ ALLOWLIST_FILES: set[str] = {
     "src/sentry/models/release.py",
     "src/sentry/models/releases/set_commits.py",
     "src/sentry/models/options/organization_option.py",
-    "src/sentry/audit_log/services/log/impl.py",
     "src/sentry/utils/mockdata/core.py",
-    "src/sentry/core/endpoints/organization_details.py",
-    "src/sentry/tasks/assemble.py",
-    "src/sentry/tasks/commits.py",
     "src/sentry/services/nodestore/django/backend.py",
 }
 

--- a/tests/sentry/test_no_create_or_update_usage.py
+++ b/tests/sentry/test_no_create_or_update_usage.py
@@ -22,6 +22,7 @@ ALLOWLIST_FILES: set[str] = {
     "src/sentry/models/releases/set_commits.py",
     "src/sentry/models/options/organization_option.py",
     "src/sentry/utils/mockdata/core.py",
+    "src/sentry/tasks/assemble.py",
     "src/sentry/services/nodestore/django/backend.py",
 }
 


### PR DESCRIPTION
Continues the migration away from Sentry's legacy `create_or_update` helper toward Django's built-in `update_or_create`. 

All three files removed from the allowlist in `tests/sentry/test_no_create_or_update_usage.py`.

Return values were ignored at all sites, so no caller changes are needed.