### PR TITLE
fix(preprod): Allow org auth tokens to access build install-details

### DIFF
--- a/src/sentry/preprod/api/endpoints/public/organization_preprod_artifact_install_details.py
+++ b/src/sentry/preprod/api/endpoints/public/organization_preprod_artifact_install_details.py
@@ -8,7 +8,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -30,6 +30,7 @@ class OrganizationPreprodArtifactPublicInstallDetailsEndpoint(OrganizationEndpoi
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
+    permission_classes = (OrganizationReleasePermission,)
     rate_limits = RateLimitConfig(
         limit_overrides={
             "GET": {

--- a/tests/sentry/preprod/api/endpoints/public/test_organization_preprod_artifact_install_details.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_organization_preprod_artifact_install_details.py
@@ -1,7 +1,11 @@
 from django.urls import reverse
 
+from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.preprod.models import PreprodArtifact
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
 class OrganizationPreprodArtifactPublicInstallDetailsEndpointTest(APITestCase):
@@ -162,3 +166,19 @@ class OrganizationPreprodArtifactPublicInstallDetailsEndpointTest(APITestCase):
         assert data["isInstallable"] is False
         assert data["installUrl"] is None
         assert data["isCodeSignatureValid"] is False
+
+    def test_org_auth_token_with_org_ci_scope(self):
+        """Org auth tokens with org:ci scope can access install details (used by sentry-cli build download)."""
+        token_str = generate_token(self.organization.slug, "")
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            OrgAuthToken.objects.create(
+                organization_id=self.organization.id,
+                name="CI Token",
+                token_hashed=hash_token(token_str),
+                scope_list=["org:ci"],
+            )
+
+        response = self.client.get(self._get_url(), HTTP_AUTHORIZATION=f"Bearer {token_str}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["buildId"] == str(self.preprod_artifact.id)


### PR DESCRIPTION
The public install-details endpoint (`/organizations/{org}/preprodartifacts/{id}/install-details/`) inherited `OrganizationPermission` from `OrganizationEndpoint`, which only accepts `org:read`, `org:write`, and `org:admin` scopes. Org auth tokens used in CI typically have `org:ci` scope, so `sentry-cli build download` failed at the install-details step while `build upload` worked fine (since upload endpoints use `OrganizationReleasePermission` which accepts `org:ci`).

This switches the endpoint to use `OrganizationReleasePermission`, matching the permission class used by the upload/assemble endpoints.