### PR TITLE
ref(autofix): Use AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD constant

### DIFF
--- a/src/sentry/seer/autofix/constants.py
+++ b/src/sentry/seer/autofix/constants.py
@@ -1,5 +1,9 @@
 import enum
 
+# An issue group must have >= this number of occurrences in order to be
+# a target for 'workflow' autofix.
+AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD = 10
+
 
 class FixabilityScoreThresholds(enum.Enum):
     SUPER_HIGH = 0.76

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -21,6 +21,7 @@ from sentry.net.http import connection_from_url
 from sentry.seer.autofix.autofix import _get_trace_tree_for_event, trigger_autofix
 from sentry.seer.autofix.autofix_agent import AutofixStep, trigger_autofix_explorer
 from sentry.seer.autofix.constants import (
+    AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD,
     AutofixAutomationTuningSettings,
     AutofixReferrer,
     FixabilityScoreThresholds,
@@ -433,7 +434,7 @@ def run_automation(
                 if hasattr(group, "_times_seen_pending")
                 else group.times_seen
             )
-            if times_seen < 10:
+            if times_seen < AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD:
                 return
 
     user_id = user.id if user else None

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -22,7 +22,10 @@ from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.killswitches import killswitch_matches_context
 from sentry.replays.lib.event_linking import transform_event_for_linking_payload
 from sentry.replays.lib.kafka import initialize_replays_publisher
-from sentry.seer.autofix.constants import FixabilityScoreThresholds
+from sentry.seer.autofix.constants import (
+    AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD,
+    FixabilityScoreThresholds,
+)
 from sentry.signals import event_processed, issue_unignored
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -1559,8 +1562,8 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
         generate_summary_and_run_automation.delay(group.id, trigger_path="old_seer_automation")
     else:
         # Seat-based tier behaviour
-        # If event count < 10, only generate summary (no automation)
-        if group.times_seen_with_pending < 10:
+        # If event count < threshold, only generate summary (no automation)
+        if group.times_seen_with_pending < AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD:
             # Check if summary exists in cache
             cache_key = get_issue_summary_cache_key(group.id)
             if cache.get(cache_key) is not None:
@@ -1581,7 +1584,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
 
             generate_issue_summary_only.delay(group.id)
         else:
-            # Event count >= 10: run automation
+            # Event count >= threshold: run automation
             # Long-term check to avoid re-running
             if group.seer_autofix_last_triggered is not None:
                 return

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -107,7 +107,7 @@ def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
 def generate_issue_summary_only(group_id: int) -> None:
     """
     Generate issue summary WITHOUT triggering automation.
-    Used for triage signals flow when event count < 10 or when summary doesn't exist yet.
+    Used for triage signals flow when event count < AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD or when summary doesn't exist yet.
     """
     from sentry.seer.autofix.issue_summary import (
         get_and_update_group_fixability_score,
@@ -150,7 +150,7 @@ def generate_issue_summary_only(group_id: int) -> None:
 def run_automation_only_task(group_id: int) -> None:
     """
     Run automation directly for a group (assumes summary and fixability already exist).
-    Used for triage signals flow when event count >= 10 and summary exists.
+    Used for triage signals flow when event count >= AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD and summary exists.
     """
     from django.contrib.auth.models import AnonymousUser
 


### PR DESCRIPTION
Replace hardcoded occurrence threshold of `10` with the `AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD` constant from `seer/autofix/constants.py` across `post_process`, `issue_summary`, and autofix task files.

This makes the threshold easier to find and update in one place.


Agent transcript: https://claudescope.sentry.dev/share/Ds3urei5NiOArAv3zKTZQix_f66h60mux0NyITDbB5M