### PR TITLE
feat(tracemetrics): Display metric name in aggregates table when no group by selected

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
@@ -99,6 +99,9 @@ describe('AggregatesTab', () => {
 
     // Both aggregate columns should be present
     expect(screen.getByRole('columnheader', {name: /sum/i})).toBeInTheDocument();
+
+    // Metric name column should be prepended when no group bys are selected
+    expect(screen.getByRole('columnheader', {name: 'Metric'})).toBeInTheDocument();
   });
 
   it('renders table with groupBys and aggregate columns', async () => {
@@ -153,6 +156,9 @@ describe('AggregatesTab', () => {
     // Aggregate columns
     expect(screen.getByRole('columnheader', {name: /avg/i})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: /p95/i})).toBeInTheDocument();
+
+    // Metric name column should NOT appear when group bys are selected
+    expect(screen.queryByRole('columnheader', {name: 'Metric'})).not.toBeInTheDocument();
   });
 
   it('shows empty state when no data is returned', async () => {

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
@@ -101,7 +101,8 @@ describe('AggregatesTab', () => {
     expect(screen.getByRole('columnheader', {name: /sum/i})).toBeInTheDocument();
 
     // Metric name column should be prepended when no group bys are selected
-    expect(screen.getByRole('columnheader', {name: 'Metric'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Metric'}).tagName).toBe('DIV');
+    expect(screen.getByRole('columnheader', {name: /avg/i}).tagName).toBe('BUTTON');
   });
 
   it('renders table with groupBys and aggregate columns', async () => {

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -6,12 +6,13 @@ import throttle from 'lodash/throttle';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
 import {parseFunction} from 'sentry/utils/discover/fields';
-import {COL_WIDTH_UNDEFINED} from 'sentry/utils/discover/fields';
 import {prettifyTagKey} from 'sentry/utils/fields';
+import type {TableColumn} from 'sentry/views/discover/table/types';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
@@ -41,6 +42,18 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 const RESULT_LIMIT = 50;
+
+const METRIC_NAME_COLUMN: TableColumn<string> = {
+  key: TraceMetricKnownFieldKey.METRIC_NAME,
+  name: TraceMetricKnownFieldKey.METRIC_NAME,
+  type: 'string',
+  isSortable: false,
+  column: {
+    kind: 'field',
+    field: TraceMetricKnownFieldKey.METRIC_NAME,
+  },
+  width: COL_WIDTH_UNDEFINED,
+};
 
 interface AggregatesTabProps {
   traceMetric: TraceMetric;
@@ -98,18 +111,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
 
   const displayColumns = useMemo(() => {
     if (groupBys.length === 0) {
-      const metricNameColumn = {
-        key: TraceMetricKnownFieldKey.METRIC_NAME,
-        name: TraceMetricKnownFieldKey.METRIC_NAME,
-        type: 'string' as const,
-        isSortable: false,
-        column: Object.freeze({
-          kind: 'field' as const,
-          field: TraceMetricKnownFieldKey.METRIC_NAME,
-        }),
-        width: COL_WIDTH_UNDEFINED,
-      };
-      return [metricNameColumn, ...columns];
+      return [METRIC_NAME_COLUMN, ...columns];
     }
     return columns;
   }, [groupBys.length, columns]);

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -10,6 +10,7 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
 import {parseFunction} from 'sentry/utils/discover/fields';
+import {COL_WIDTH_UNDEFINED} from 'sentry/utils/discover/fields';
 import {prettifyTagKey} from 'sentry/utils/fields';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
@@ -25,6 +26,7 @@ import {
   TransparentLoadingMask,
 } from 'sentry/views/explore/metrics/metricInfoTabs/metricInfoTabStyles';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 import {
   createTraceMetricFilter,
   getMetricsUnit,
@@ -86,8 +88,35 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
 
   const meta = result.meta ?? {};
 
-  const groupByFieldCount = groupBys.length;
-  const aggregateFieldCount = fields.length - groupByFieldCount;
+  // When no group bys are selected, prepend the metric name as a virtual group-by column
+  const displayFields = useMemo(() => {
+    if (groupBys.length === 0) {
+      return [TraceMetricKnownFieldKey.METRIC_NAME, ...fields];
+    }
+    return fields;
+  }, [groupBys.length, fields]);
+
+  const displayColumns = useMemo(() => {
+    if (groupBys.length === 0) {
+      const metricNameColumn = {
+        key: TraceMetricKnownFieldKey.METRIC_NAME,
+        name: TraceMetricKnownFieldKey.METRIC_NAME,
+        type: 'string' as const,
+        isSortable: false,
+        column: Object.freeze({
+          kind: 'field' as const,
+          field: TraceMetricKnownFieldKey.METRIC_NAME,
+        }),
+        width: COL_WIDTH_UNDEFINED,
+      };
+      return [metricNameColumn, ...columns];
+    }
+    return columns;
+  }, [groupBys.length, columns]);
+
+  // Include the virtual metric name column in the group-by count so grid/divider logic works
+  const groupByFieldCount = groupBys.length === 0 ? 1 : groupBys.length;
+  const aggregateFieldCount = displayFields.length - groupByFieldCount;
 
   const tableStyle = useMemo(() => {
     // First aggregate column gets 1fr, pushing remaining aggregates to the right
@@ -98,23 +127,21 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
         aggregateFieldCount > 1 ? `1fr repeat(${aggregateFieldCount - 1}, auto)` : '1fr';
       return {gridTemplateColumns: `${groupByColumns} ${aggregateColumns}`};
     }
-    if (aggregateFieldCount > 1) {
-      // Only aggregates: 1fr auto ... auto
-      return {gridTemplateColumns: `1fr repeat(${aggregateFieldCount - 1}, auto)`};
-    }
     // Single column or only groupBys
     return {
       gridTemplateColumns:
-        fields.length > 1 ? `repeat(${fields.length - 1}, auto) 1fr` : '1fr',
+        displayFields.length > 1
+          ? `repeat(${displayFields.length - 1}, auto) 1fr`
+          : '1fr',
     };
-  }, [aggregateFieldCount, fields.length, groupByFieldCount]);
+  }, [aggregateFieldCount, displayFields.length, groupByFieldCount]);
 
   const firstColumnOffset = useMemo(() => {
     return groupBys.length > 0 ? '15px' : '8px';
   }, [groupBys]);
 
   const isLastColumn = (index: number) => {
-    return index === fields.length - 1;
+    return index === displayFields.length - 1;
   };
 
   // Dividers: between last groupBy and first aggregate, and between all aggregates
@@ -124,8 +151,8 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
       return true;
     }
 
-    // Between aggregate columns (not the last one), we use fields here because we need the total number of columns
-    if (index > groupByFieldCount && index < fields.length) {
+    // Between aggregate columns (not the last one)
+    if (index > groupByFieldCount && index < displayFields.length) {
       return true;
     }
 
@@ -193,12 +220,14 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
       {isPending && <TransparentLoadingMask />}
 
       <StickyCompatibleStyledHeader>
-        {fields.map((field, i) => {
+        {displayFields.map((field, i) => {
           let label = field;
           const tag =
             stringTags?.[field] ?? numberTags?.[field] ?? booleanTags?.[field] ?? null;
           const func = parseFunction(field);
-          if (func) {
+          if (field === TraceMetricKnownFieldKey.METRIC_NAME) {
+            label = t('Metric');
+          } else if (func) {
             label = `${func.name}(…)`;
           } else if (tag) {
             label = tag.name;
@@ -237,30 +266,36 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
             <IconWarning data-test-id="error-indicator" variant="muted" size="lg" />
           </SimpleTable.Empty>
         ) : result.data?.length ? (
-          result.data.map((row, i) => (
-            <SimpleTable.Row key={i} style={{minHeight: '33px'}}>
-              {topEvents && i < topEvents && (
-                <StyledTopResultsIndicator count={topEvents} index={i} />
-              )}
-              {fields.map((field, j) => (
-                <StickyCompatibleStyledRowCell
-                  key={j}
-                  data-sticky-column={isLastColumn(j) ? 'true' : 'false'}
-                  isAggregate={Boolean(parseFunction(field))}
-                  isSticky={isLastColumn(j)}
-                  offset={j === 0 ? firstColumnOffset : undefined}
-                >
-                  <FieldRenderer
-                    column={columns[j]}
-                    data={row}
-                    unit={getMetricsUnit(meta, field)}
-                    meta={meta}
-                    usePortalOnDropdown
-                  />
-                </StickyCompatibleStyledRowCell>
-              ))}
-            </SimpleTable.Row>
-          ))
+          result.data.map((row, i) => {
+            const displayRow =
+              groupBys.length === 0
+                ? {...row, [TraceMetricKnownFieldKey.METRIC_NAME]: traceMetric.name}
+                : row;
+            return (
+              <SimpleTable.Row key={i} style={{minHeight: '33px'}}>
+                {topEvents && i < topEvents && (
+                  <StyledTopResultsIndicator count={topEvents} index={i} />
+                )}
+                {displayFields.map((field, j) => (
+                  <StickyCompatibleStyledRowCell
+                    key={j}
+                    data-sticky-column={isLastColumn(j) ? 'true' : 'false'}
+                    isAggregate={Boolean(parseFunction(field))}
+                    isSticky={isLastColumn(j)}
+                    offset={j === 0 ? firstColumnOffset : undefined}
+                  >
+                    <FieldRenderer
+                      column={displayColumns[j]}
+                      data={displayRow}
+                      unit={getMetricsUnit(meta, field)}
+                      meta={meta}
+                      usePortalOnDropdown
+                    />
+                  </StickyCompatibleStyledRowCell>
+                ))}
+              </SimpleTable.Row>
+            );
+          })
         ) : isPending ? (
           <SimpleTable.Empty>
             <LoadingIndicator />

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -238,6 +238,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
           }
 
           const direction = sorts.find(s => s.field === field)?.kind;
+          const canSort = displayColumns[i]?.isSortable !== false;
 
           function updateSort() {
             const kind = direction === 'desc' ? 'asc' : 'desc';
@@ -252,7 +253,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
               isAggregate={Boolean(func)}
               isSticky={isLastColumn(i)}
               sort={direction}
-              handleSortClick={updateSort}
+              handleSortClick={canSort ? updateSort : undefined}
             >
               <Tooltip showOnlyOnOverflow title={label}>
                 {label}


### PR DESCRIPTION
Display the selected metric name as a left-aligned column in the aggregates table when no group bys are selected. 

Refs LOGS-630

Example:

<img width="852" height="368" alt="Screenshot 2026-03-25 at 08 32 51" src="https://github.com/user-attachments/assets/ad21bf54-8ecc-43e8-902f-e346f827e964" />