### PR TITLE
fix(dashboards): Fix global filter showing "All" instead of selected value

### DIFF
--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -154,6 +154,27 @@ describe('FilterSelector', () => {
     expect(screen.getByText('firefox')).toBeInTheDocument();
   });
 
+  it('shows selected value in trigger when tag values fail to load', async () => {
+    const emptySearchBarData: SearchBarData = {
+      getFilterKeySections: () => [],
+      getFilterKeys: () => ({}),
+      getTagValues: () => Promise.resolve([]),
+    };
+
+    render(
+      <FilterSelector
+        globalFilter={{...mockGlobalFilter, value: 'browser:firefox'}}
+        searchBarData={emptySearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
+    // Even with no fetched tag values, should show selected value, not "All"
+    expect(await screen.findByText('firefox')).toBeInTheDocument();
+    expect(screen.queryByText('All')).not.toBeInTheDocument();
+  });
+
   it('translates subregion codes to human-readable names for spans dataset', async () => {
     const subregionFilter: GlobalFilter = {
       dataset: WidgetType.SPANS,

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -471,7 +471,7 @@ export function FilterSelector({
       trigger={triggerProps => (
         <Container maxWidth={FILTER_SELECTOR_MAX_WIDTH}>
           <OverlayTrigger.Button {...triggerProps}>
-            {renderFilterSelectorTrigger(stagedFilterValues)}
+            {renderFilterSelectorTrigger(activeFilterValues)}
           </OverlayTrigger.Button>
         </Container>
       )}

--- a/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
@@ -30,12 +30,8 @@ export function FilterSelectorTrigger({
   const {isFetching} = queryResult;
   const {tag} = globalFilter;
 
-  const shouldShowBadge =
-    !isFetching &&
-    activeFilterValues.length > 1 &&
-    activeFilterValues.length !== options.length;
-  const isAllSelected =
-    activeFilterValues.length === 0 || activeFilterValues.length === options.length;
+  const shouldShowBadge = !isFetching && activeFilterValues.length > 1;
+  const isAllSelected = activeFilterValues.length === 0;
 
   const tagKey = prettifyTagKey(tag.key);
   const filterValue = activeFilterValues[0] ?? '';

--- a/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
@@ -31,6 +31,10 @@ export function FilterSelectorTrigger({
   const {tag} = globalFilter;
 
   const shouldShowBadge = !isFetching && activeFilterValues.length > 1;
+  // "All" means no filter is applied (empty selection). We intentionally avoid
+  // comparing against options.length because when tag values fail to load,
+  // options only contains the already-selected values — making a length
+  // comparison a tautology that incorrectly shows "All".
   const isAllSelected = activeFilterValues.length === 0;
 
   const tagKey = prettifyTagKey(tag.key);


### PR DESCRIPTION
Fix the global filter selector trigger displaying "All" when a specific value is saved but tag values fail to load.

**e.g.,**

<img width="267" height="195" alt="Screenshot 2026-03-24 at 11 03 59 PM" src="https://github.com/user-attachments/assets/5e15e065-9e6c-482d-86a5-75c439f74841" />

Two bugs combined to cause this:

1. The trigger rendered `stagedFilterValues` (in-flight dropdown state) instead of `activeFilterValues` (the committed filter). Before the dropdown was opened, staged values were empty → "All".

2. `isAllSelected` compared against `options.length`. When tag values failed to load, `options` only contained the already-selected values, making the comparison a tautology. Now it simply checks for an empty selection.

Refs DAIN-1407