### PR TITLE
ref(pipleine): Move `None` out of ApiPipelineSteps type

### DIFF
--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -257,7 +257,7 @@ class Pipeline[M: Model, S: PipelineSessionStore](abc.ABC):
             return nested_pipeline.fetch_state(key)
         return self._fetch_state(key)
 
-    def get_pipeline_api_steps(self) -> ApiPipelineSteps[Self]:
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[Self] | None:
         """
         Return API step objects for this pipeline, or None if API mode is not
         supported. Steps may be callables for late binding (resolved when the

--- a/src/sentry/pipeline/views/base.py
+++ b/src/sentry/pipeline/views/base.py
@@ -58,7 +58,7 @@ class ApiPipelineEndpoint[P, D = Any, V = Any](Protocol):
 
 
 type ApiPipelineStep[P] = ApiPipelineEndpoint[P] | Callable[[], ApiPipelineEndpoint[P]]
-type ApiPipelineSteps[P] = Sequence[ApiPipelineStep[P]] | None
+type ApiPipelineSteps[P] = Sequence[ApiPipelineStep[P]]
 
 
 def render_react_view(


### PR DESCRIPTION
Refs [VDY-32: Migrate integration setup pipelines to API-driven flows](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows)