### PR TITLE
ref(tracemetrics): Remove unsortable telemetry columns behind feature flag

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
@@ -6,6 +6,7 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TraceSamplesTableColumns,
   TraceSamplesTableEmbeddedColumns,
@@ -20,6 +21,7 @@ import {
 import {MetricsSamplesTableHeader} from 'sentry/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader';
 import {SampleTableRow} from 'sentry/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   TraceMetricKnownFieldKey,
   type TraceMetricEventsResponseItem,
@@ -52,8 +54,16 @@ export function MetricsSamplesTable({
   isMetricOptionsEmpty,
   overrideTableData,
 }: MetricsSamplesTableProps) {
-  const columns = embedded ? TraceSamplesTableEmbeddedColumns : TraceSamplesTableColumns;
-  const fields = columns.filter(c => getMetricTableColumnType(c) !== 'stat');
+  const organization = useOrganization();
+  const hasMetricsUIRefresh = canUseMetricsUIRefresh(organization);
+
+  const allColumns = embedded
+    ? TraceSamplesTableEmbeddedColumns
+    : TraceSamplesTableColumns;
+  const columns = hasMetricsUIRefresh
+    ? allColumns.filter(c => getMetricTableColumnType(c) !== 'stat')
+    : allColumns;
+  const fields = allColumns.filter(c => getMetricTableColumnType(c) !== 'stat');
 
   const {
     result: {data},
@@ -69,14 +79,18 @@ export function MetricsSamplesTable({
   });
 
   const traceIds = useMemo(() => {
-    if (!data || embedded) {
+    if (!data || embedded || hasMetricsUIRefresh) {
       return [];
     }
     return data.map(row => row[TraceMetricKnownFieldKey.TRACE]).filter(Boolean);
-  }, [data, embedded]);
+  }, [data, embedded, hasMetricsUIRefresh]);
 
   const {data: telemetryData} = useTraceTelemetry({
-    enabled: Boolean(traceMetric?.name) && traceIds.length > 0 && !embedded,
+    enabled:
+      Boolean(traceMetric?.name) &&
+      traceIds.length > 0 &&
+      !embedded &&
+      !hasMetricsUIRefresh,
     traceIds,
   });
 
@@ -95,8 +109,12 @@ export function MetricsSamplesTable({
     };
   }, [meta, traceMetric?.unit]);
 
+  const TableWrapper = hasMetricsUIRefresh
+    ? SimpleTableGrid
+    : SimpleTableWithHiddenColumns;
+
   return (
-    <SimpleTableWithHiddenColumns numColumns={columns.length - 1} embedded={embedded}>
+    <TableWrapper numColumns={columns.length - 1} embedded={embedded}>
       {isFetching && <TransparentLoadingMask />}
       <MetricsSamplesTableHeader columns={columns} embedded={embedded} />
       <StyledSimpleTableBody>
@@ -125,9 +143,17 @@ export function MetricsSamplesTable({
           </SimpleTable.Empty>
         )}
       </StyledSimpleTableBody>
-    </SimpleTableWithHiddenColumns>
+    </TableWrapper>
   );
 }
+
+const SimpleTableGrid = styled(StyledSimpleTable)<{
+  embedded: boolean;
+  numColumns: number;
+}>`
+  grid-template-columns: repeat(${p => p.numColumns}, min-content) 1fr;
+  grid-column: 1 / -1;
+`;
 
 const SimpleTableWithHiddenColumns = styled(StyledSimpleTable)<{
   embedded: boolean;

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -228,6 +228,20 @@ describe('MetricPanel', () => {
       expect(await screen.findByText('A')).toBeInTheDocument();
     });
 
+    it('does not render telemetry column headers in the samples table', async () => {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+        organization,
+        additionalWrapper: createWrapper({queryParams, traceMetric}),
+      });
+
+      // Wait for the samples table to render
+      expect(await screen.findByText('Timestamp')).toBeInTheDocument();
+
+      expect(screen.queryByText('Logs')).not.toBeInTheDocument();
+      expect(screen.queryByText('Spans')).not.toBeInTheDocument();
+      expect(screen.queryByText('Errors')).not.toBeInTheDocument();
+    });
+
     it('does not render orientation controls', async () => {
       render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
         organization,

--- a/static/app/views/explore/metrics/metricPanel/sideBySideOrientation.tsx
+++ b/static/app/views/explore/metrics/metricPanel/sideBySideOrientation.tsx
@@ -4,6 +4,7 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {SplitPanel} from 'sentry/components/splitPanel';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import type {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
 import type {TableOrientation} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
 import {MetricsGraph} from 'sentry/views/explore/metrics/metricGraph';
@@ -15,6 +16,7 @@ import {
 import {HideContentButton} from 'sentry/views/explore/metrics/metricPanel/hideContentButton';
 import {PanelPositionSelector} from 'sentry/views/explore/metrics/metricPanel/panelPositionSelector';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 
 const MIN_LEFT_WIDTH = 400;
 
@@ -40,15 +42,20 @@ export function SideBySideOrientation({
   timeseriesResult: ReturnType<typeof useMetricTimeseries>['result'];
   traceMetric: TraceMetric;
 }) {
+  const organization = useOrganization();
+  const hasMetricsUIRefresh = canUseMetricsUIRefresh(organization);
   const measureRef = useRef<HTMLDivElement>(null);
   const {width} = useDimensions({elementRef: measureRef});
 
   const hasSize = width > 0;
   // Default split is 65% of the available width but not less than MIN_LEFT_WIDTH
   // while also accommodating the desired right panel width to show all of the telemetry icons.
+  const rightPanelDesiredWidth = hasMetricsUIRefresh
+    ? SAMPLES_PANEL_MIN_WIDTH
+    : WIDTH_WITH_TELEMETRY_ICONS_VISIBLE;
   const defaultSplit = Math.min(
     Math.max(width * 0.65, MIN_LEFT_WIDTH),
-    width - (WIDTH_WITH_TELEMETRY_ICONS_VISIBLE + PADDING_SIZE + DIVIDER_WIDTH)
+    width - (rightPanelDesiredWidth + PADDING_SIZE + DIVIDER_WIDTH)
   );
 
   const additionalActions = (


### PR DESCRIPTION
Hide the unsortable telemetry columns (Logs, Spans, Errors) from the trace metrics samples table when `canUseMetricsUIRefresh` is enabled. 

This is the first step in some changes to the samples table as part of the metrics UI refresh.

Refs LOGS-631

Example:

<img width="853" height="310" alt="Screenshot 2026-03-25 at 09 46 28" src="https://github.com/user-attachments/assets/b14ac63f-07bc-4899-9a64-388311279c88" />