### PR TITLE
fix(explore): Gate explore links behind visibility-explore-view

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -889,6 +889,67 @@ describe('Dashboards > WidgetCard', () => {
     expect(await screen.findByLabelText('Widget warnings')).toBeInTheDocument();
   });
 
+  describe('Open in Explore visibility', () => {
+    const spansWidget: Widget = {
+      title: 'Cache Miss Rate',
+      description: '',
+      interval: '5m',
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      queries: [
+        {
+          conditions: 'span.op:[cache.get,cache.get_item]',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+          name: '',
+          orderby: '',
+        },
+      ],
+    };
+
+    it('does not show Open in Explore for spans widget without visibility-explore-view', async () => {
+      renderWithProviders(
+        <WidgetCard
+          api={api}
+          widget={spansWidget}
+          selection={selection}
+          isEditingDashboard={false}
+          onDelete={() => undefined}
+          onEdit={() => undefined}
+          onDuplicate={() => undefined}
+          showContextMenu
+          widgetLimitReached={false}
+          widgetLegendState={widgetLegendState}
+        />
+      );
+
+      await userEvent.click(await screen.findByLabelText('Widget actions'));
+      expect(screen.queryByText('Open in Explore')).not.toBeInTheDocument();
+    });
+
+    it('shows Open in Explore for spans widget with visibility-explore-view', async () => {
+      renderWithProviders(
+        <WidgetCard
+          api={api}
+          widget={spansWidget}
+          selection={selection}
+          isEditingDashboard={false}
+          onDelete={() => undefined}
+          onEdit={() => undefined}
+          onDuplicate={() => undefined}
+          showContextMenu
+          widgetLimitReached={false}
+          widgetLegendState={widgetLegendState}
+        />,
+        ['visibility-explore-view']
+      );
+
+      await userEvent.click(await screen.findByLabelText('Widget actions'));
+      expect(screen.getByText('Open in Explore')).toBeInTheDocument();
+    });
+  });
+
   describe('conflicting filter warning', () => {
     const spanWidget: Widget = {
       title: 'Span Operations',

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.spec.tsx
@@ -1,0 +1,96 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {VisualizationWidget} from 'sentry/views/dashboards/widgetCard/visualizationWidget';
+import {WidgetCardDataLoader} from 'sentry/views/dashboards/widgetCard/widgetCardDataLoader';
+
+jest.mock('sentry/components/pageFilters/usePageFilters');
+jest.mock('sentry/views/dashboards/widgetCard/widgetCardDataLoader');
+jest.mock(
+  'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization',
+  () => ({
+    TimeSeriesWidgetVisualization: jest.fn(() => <div data-testid="chart" />),
+  })
+);
+
+const spansBreakdownWidget = {
+  title: 'Cache Miss Rate',
+  description: '',
+  interval: '5m',
+  displayType: DisplayType.LINE,
+  widgetType: WidgetType.SPANS,
+  legendType: 'breakdown' as const,
+  queries: [
+    {
+      name: '',
+      conditions: 'span.op:[cache.get,cache.get_item]',
+      fields: ['transaction', 'count()'],
+      aggregates: ['count()'],
+      columns: ['transaction'],
+      orderby: '',
+    },
+  ],
+};
+
+const selection = PageFilterStateFixture().selection;
+
+// Series name format for a grouped SPANS query: "<groupValue> : <aggregate>"
+const timeseriesResults = [
+  {
+    seriesName: 'my_transaction : count()',
+    data: [{name: 1_000_000, value: 10}],
+    color: '#000',
+  },
+];
+
+// tableResults must be non-empty to trigger showBreakdownData
+const tableResults = [
+  {
+    title: '',
+    data: [{transaction: 'my_transaction', 'count()': 10}],
+    meta: {fields: {transaction: 'string', 'count()': 'integer'}, units: {}},
+  },
+];
+
+beforeEach(() => {
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/releases/stats/',
+    body: [],
+  });
+  jest.mocked(WidgetCardDataLoader).mockImplementation(({children}: any) =>
+    children({
+      timeseriesResults,
+      tableResults,
+      loading: false,
+      errorMessage: undefined,
+      confidence: undefined,
+      dataScanned: undefined,
+      isSampled: undefined,
+      sampleCount: undefined,
+    })
+  );
+});
+
+describe('VisualizationWidget breakdown series labels', () => {
+  it('renders series labels as plain text without visibility-explore-view', () => {
+    render(<VisualizationWidget widget={spansBreakdownWidget} selection={selection} />, {
+      organization: OrganizationFixture({features: []}),
+    });
+
+    expect(screen.queryByRole('link', {name: 'my_transaction'})).not.toBeInTheDocument();
+    expect(screen.getByText('my_transaction')).toBeInTheDocument();
+  });
+
+  it('renders series labels as explore links with visibility-explore-view', () => {
+    render(<VisualizationWidget widget={spansBreakdownWidget} selection={selection} />, {
+      organization: OrganizationFixture({features: ['visibility-explore-view']}),
+    });
+
+    expect(screen.getByRole('link', {name: 'my_transaction'})).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -310,7 +310,8 @@ function VisualizationWidgetContent({
           firstColumn &&
           typeof firstColumnGroupByValue === 'string' &&
           widget.queries.length === 1 &&
-          widget.widgetType === WidgetType.SPANS
+          widget.widgetType === WidgetType.SPANS &&
+          organization.features.includes('visibility-explore-view')
         ) {
           const exploreQuery = new MutableSearch(widget.queries[0]?.conditions ?? '');
           exploreQuery.addFilterValue(firstColumn, firstColumnGroupByValue);

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -307,11 +307,11 @@ function VisualizationWidgetContent({
         // TODO: to simplify things, we only support one widget query for explore urls right now
         // Otherwise we have to map the correct widget query to the timeseries result
         if (
+          organization.features.includes('visibility-explore-view') &&
           firstColumn &&
           typeof firstColumnGroupByValue === 'string' &&
           widget.queries.length === 1 &&
-          widget.widgetType === WidgetType.SPANS &&
-          organization.features.includes('visibility-explore-view')
+          widget.widgetType === WidgetType.SPANS
         ) {
           const exploreQuery = new MutableSearch(widget.queries[0]?.conditions ?? '');
           exploreQuery.addFilterValue(firstColumn, firstColumnGroupByValue);

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -257,7 +257,10 @@ export function getMenuOptions(
     }
   }
 
-  if (widget.widgetType === WidgetType.SPANS || widget.widgetType === WidgetType.LOGS) {
+  if (
+    organization.features.includes('visibility-explore-view') &&
+    (widget.widgetType === WidgetType.SPANS || widget.widgetType === WidgetType.LOGS)
+  ) {
     menuOptions.push({
       key: 'open-in-explore',
       label: t('Open in Explore'),

--- a/static/app/views/insights/common/components/chartActionDropdown.spec.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.spec.tsx
@@ -1,0 +1,45 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {BaseChartActionDropdown} from 'sentry/views/insights/common/components/chartActionDropdown';
+
+jest.mock('sentry/components/pageFilters/usePageFilters');
+
+beforeEach(() => {
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
+});
+
+describe('BaseChartActionDropdown', () => {
+  it('does not show Open in Explore when visibility-explore-view is not enabled', async () => {
+    render(
+      <BaseChartActionDropdown
+        alertMenuOptions={[]}
+        exploreUrl="/explore"
+        referrer="test"
+      />,
+      {organization: OrganizationFixture({features: []})}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Widget actions'}));
+
+    expect(screen.queryByText('Open in Explore')).not.toBeInTheDocument();
+  });
+
+  it('shows Open in Explore when visibility-explore-view is enabled', async () => {
+    render(
+      <BaseChartActionDropdown
+        alertMenuOptions={[]}
+        exploreUrl="/explore"
+        referrer="test"
+      />,
+      {organization: OrganizationFixture({features: ['visibility-explore-view']})}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Widget actions'}));
+
+    expect(screen.getByText('Open in Explore')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -120,10 +120,13 @@ export function BaseChartActionDropdown({
 }: BaseProps) {
   const organization = useOrganization();
   const hasDashboardEdit = organization.features.includes('dashboards-edit');
+  const hasExploreView = organization.features.includes('visibility-explore-view');
   const {addToSpanDashboard} = useAddToSpanDashboard();
 
-  const menuOptions: MenuItemProps[] = [
-    {
+  const menuOptions: MenuItemProps[] = [];
+
+  if (hasExploreView) {
+    menuOptions.push({
       key: 'open-in-explore',
       label: t('Open in Explore'),
       to: exploreUrl,
@@ -133,8 +136,8 @@ export function BaseChartActionDropdown({
           referrer,
         });
       },
-    },
-  ];
+    });
+  }
 
   if (addToDashboardOptions) {
     const menuOption: MenuItemProps = {


### PR DESCRIPTION
Gate explore-view links in insights/dashboard widgets behind the `visibility-explore-view` feature flag.

AM1 users were being sent to `/explore/traces/` from three separate code paths in the cache miss rates widget:

1. **Insights widget dropdown** (`chartActionDropdown.tsx`) — `BaseChartActionDropdown` always added the "Open in Explore" menu item for any widget that passed `queryInfo`, regardless of the flag. Fixed by checking `visibility-explore-view` before adding the menu item.

2. **Dashboard widget context menu** (`widgetCardContextMenu.tsx`) — `getMenuOptions` unconditionally added "Open in Explore" for all `SPANS`/`LOGS` widgets. This path is hit via `PlatformizedCachesOverview → PrebuiltDashboardRenderer`. Fixed by gating on `visibility-explore-view`.

3. **Breakdown series label links** (`visualizationWidget.tsx`) — Chart series labels for SPANS widgets with group-by columns were rendered as `<Link>` elements pointing to `/explore/traces/`, with no flag check. Fixed by gating on `visibility-explore-view`; without the flag, labels render as plain text.

Each fix is covered by a test:
- `chartActionDropdown.spec.tsx` (new file)
- `widgetCard/index.spec.tsx` (new describe block)
- `visualizationWidget.spec.tsx` (new file)

Refs DAIN-1368