### PR TITLE
ref(scm): Move `should_increment_contributor_seat` to provider-agnostic location

### DIFF
--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -8,15 +8,7 @@ from urllib.parse import urlparse
 
 from rest_framework.response import Response
 
-from sentry import features, options, quotas
-from sentry.constants import DataCategory, ObjectStatus
-from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.models.options.project_option import ProjectOption
-from sentry.models.organization import Organization
-from sentry.models.organizationcontributors import OrganizationContributors
-from sentry.models.repository import Repository
-from sentry.models.repositorysettings import RepositorySettings
-from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry import options
 from sentry.utils import jwt
 
 logger = logging.getLogger(__name__)
@@ -86,74 +78,6 @@ def parse_github_blob_url(repo_url: str, source_url: str) -> tuple[str, str]:
 
     branch, _, remainder = after_blob.partition("/")
     return branch, remainder.lstrip("/")
-
-
-def _is_code_review_enabled_for_repo(repository_id: int) -> bool:
-    """Check if code review is explicitly enabled for this repository."""
-    return RepositorySettings.objects.filter(
-        repository_id=repository_id,
-        enabled_code_review=True,
-    ).exists()
-
-
-def _is_autofix_enabled_for_repo(organization_id: int, repository_id: int) -> bool:
-    """
-    Check if autofix automation is enabled (not "off") for any project
-    associated with this repository via code mappings.
-    """
-    repo_configs = RepositoryProjectPathConfig.objects.filter(
-        repository_id=repository_id,
-        organization_id=organization_id,
-    ).values_list("project_id", flat=True)
-
-    if not repo_configs:
-        return False
-
-    return (
-        ProjectOption.objects.filter(
-            project_id__in=repo_configs,
-            project__status=ObjectStatus.ACTIVE,
-            key="sentry:autofix_automation_tuning",
-        )
-        .exclude(value=AutofixAutomationTuningSettings.OFF.value)
-        .exclude(value__isnull=True)
-        .exists()
-    )
-
-
-def _has_code_review_or_autofix_enabled(organization_id: int, repository_id: int) -> bool:
-    """
-    Check if either code review is enabled for the repo OR autofix automation
-    is enabled for any linked project.
-    """
-    return _is_code_review_enabled_for_repo(repository_id) or _is_autofix_enabled_for_repo(
-        organization_id, repository_id
-    )
-
-
-def should_increment_contributor_seat(
-    organization: Organization, repo: Repository, contributor: OrganizationContributors
-) -> bool:
-    """
-    Determines if we should increment an OrganizationContributor record
-    and potentially assign a new seat.
-
-    Require repo integration, code review OR autofix enabled for the repo,
-    seat-based Seer enabled for the organization, and contributor is not a bot.
-    """
-    if (
-        repo.integration_id is None
-        or not _has_code_review_or_autofix_enabled(organization.id, repo.id)
-        or contributor.is_bot
-        or not features.has("organizations:seat-based-seer-enabled", organization)
-    ):
-        return False
-
-    return quotas.backend.check_seer_quota(
-        org_id=organization.id,
-        data_category=DataCategory.SEER_USER,
-        seat_object=contributor,
-    )
 
 
 def is_github_rate_limit_sensitive(organization_slug: str) -> bool:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -47,10 +47,6 @@ from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange, post_bulk_create
 from sentry.models.organization import Organization
-from sentry.models.organizationcontributors import (
-    ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD,
-    OrganizationContributors,
-)
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.serial import serialize_rpc_organization
@@ -61,13 +57,12 @@ from sentry.plugins.providers.integration_repository import (
 from sentry.preprod.vcs.webhooks import handle_preprod_check_run_event
 from sentry.scm.private.stream_producer import produce_event_to_scm_stream
 from sentry.seer.autofix.webhooks import handle_github_pr_webhook_for_autofix
-from sentry.seer.code_review.contributor_seats import should_increment_contributor_seat
+from sentry.seer.code_review.contributor_seats import track_contributor_seat
 from sentry.seer.code_review.webhooks.handlers import (
     handle_webhook_event as code_review_handle_webhook_event,
 )
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
-from sentry.tasks.organization_contributors import assign_seat_to_organization_contributor
 from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 
@@ -900,49 +895,14 @@ class PullRequestEventWebhook(GitHubWebhook):
                     },
                 )
 
-                contributor, _ = OrganizationContributors.objects.get_or_create(
-                    organization_id=organization.id,
+                track_contributor_seat(
+                    organization=organization,
+                    repo=repo,
                     integration_id=integration.id,
-                    external_identifier=user["id"],
-                    defaults={
-                        "alias": user["login"],
-                    },
+                    user_id=user["id"],
+                    user_username=user["login"],
+                    provider="github",
                 )
-
-                if should_increment_contributor_seat(organization, repo, contributor):
-                    metrics.incr(
-                        "github.webhook.organization_contributor.should_create",
-                        sample_rate=1.0,
-                    )
-
-                    locked_contributor = None
-                    with transaction.atomic(router.db_for_write(OrganizationContributors)):
-                        try:
-                            locked_contributor = (
-                                OrganizationContributors.objects.select_for_update().get(
-                                    organization_id=organization.id,
-                                    integration_id=integration.id,
-                                    external_identifier=user["id"],
-                                )
-                            )
-                            locked_contributor.num_actions += 1
-                            locked_contributor.save(update_fields=["num_actions", "date_updated"])
-                        except OrganizationContributors.DoesNotExist:
-                            logger.warning(
-                                "github.webhook.organization_contributor.not_found",
-                                extra={
-                                    "organization_id": organization.id,
-                                    "integration_id": integration.id,
-                                    "external_identifier": user["id"],
-                                },
-                            )
-
-                    if (
-                        locked_contributor
-                        and locked_contributor.num_actions
-                        >= ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD
-                    ):
-                        assign_seat_to_organization_contributor.delay(locked_contributor.id)
 
         except IntegrityError:
             pass

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -27,7 +27,6 @@ from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.identity.services.identity.service import identity_service
 from sentry.integrations.base import IntegrationDomain
-from sentry.integrations.github.utils import should_increment_contributor_seat
 from sentry.integrations.github.webhook_types import (
     GITHUB_WEBHOOK_TYPE_HEADER_KEY,
     GithubWebhookType,
@@ -62,6 +61,7 @@ from sentry.plugins.providers.integration_repository import (
 from sentry.preprod.vcs.webhooks import handle_preprod_check_run_event
 from sentry.scm.private.stream_producer import produce_event_to_scm_stream
 from sentry.seer.autofix.webhooks import handle_github_pr_webhook_for_autofix
+from sentry.seer.code_review.contributor_seats import should_increment_contributor_seat
 from sentry.seer.code_review.webhooks.handlers import (
     handle_webhook_event as code_review_handle_webhook_event,
 )

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -1,0 +1,86 @@
+"""
+Shared contributor-seat helpers used by provider webhooks (GitHub, GitLab, etc.).
+
+This module is kept free of provider-specific imports so any SCM integration
+can reuse it without pulling in GitHub/GitLab internals.
+"""
+
+from __future__ import annotations
+
+from sentry import features, quotas
+from sentry.constants import DataCategory, ObjectStatus
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.models.options.project_option import ProjectOption
+from sentry.models.organization import Organization
+from sentry.models.organizationcontributors import OrganizationContributors
+from sentry.models.repository import Repository
+from sentry.models.repositorysettings import RepositorySettings
+from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+
+
+def _is_code_review_enabled_for_repo(repository_id: int) -> bool:
+    """Check if code review is explicitly enabled for this repository."""
+    return RepositorySettings.objects.filter(
+        repository_id=repository_id,
+        enabled_code_review=True,
+    ).exists()
+
+
+def _is_autofix_enabled_for_repo(organization_id: int, repository_id: int) -> bool:
+    """
+    Check if autofix automation is enabled (not "off") for any project
+    associated with this repository via code mappings.
+    """
+    repo_configs = RepositoryProjectPathConfig.objects.filter(
+        repository_id=repository_id,
+        organization_id=organization_id,
+    ).values_list("project_id", flat=True)
+
+    if not repo_configs:
+        return False
+
+    return (
+        ProjectOption.objects.filter(
+            project_id__in=repo_configs,
+            project__status=ObjectStatus.ACTIVE,
+            key="sentry:autofix_automation_tuning",
+        )
+        .exclude(value=AutofixAutomationTuningSettings.OFF.value)
+        .exclude(value__isnull=True)
+        .exists()
+    )
+
+
+def _has_code_review_or_autofix_enabled(organization_id: int, repository_id: int) -> bool:
+    """
+    Check if either code review is enabled for the repo OR autofix automation
+    is enabled for any linked project.
+    """
+    return _is_code_review_enabled_for_repo(repository_id) or _is_autofix_enabled_for_repo(
+        organization_id, repository_id
+    )
+
+
+def should_increment_contributor_seat(
+    organization: Organization, repo: Repository, contributor: OrganizationContributors
+) -> bool:
+    """
+    Determines if we should increment an OrganizationContributor record
+    and potentially assign a new seat.
+
+    Require repo integration, code review OR autofix enabled for the repo,
+    seat-based Seer enabled for the organization, and contributor is not a bot.
+    """
+    if (
+        repo.integration_id is None
+        or not _has_code_review_or_autofix_enabled(organization.id, repo.id)
+        or contributor.is_bot
+        or not features.has("organizations:seat-based-seer-enabled", organization)
+    ):
+        return False
+
+    return quotas.backend.check_seer_quota(
+        org_id=organization.id,
+        data_category=DataCategory.SEER_USER,
+        seat_object=contributor,
+    )

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -7,15 +7,26 @@ can reuse it without pulling in GitHub/GitLab internals.
 
 from __future__ import annotations
 
+import logging
+
+from django.db import router, transaction
+
 from sentry import features, quotas
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
-from sentry.models.organizationcontributors import OrganizationContributors
+from sentry.models.organizationcontributors import (
+    ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD,
+    OrganizationContributors,
+)
 from sentry.models.repository import Repository
 from sentry.models.repositorysettings import RepositorySettings
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.tasks.organization_contributors import assign_seat_to_organization_contributor
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
 
 
 def _is_code_review_enabled_for_repo(repository_id: int) -> bool:
@@ -84,3 +95,59 @@ def should_increment_contributor_seat(
         data_category=DataCategory.SEER_USER,
         seat_object=contributor,
     )
+
+
+def track_contributor_seat(
+    *,
+    organization: Organization,
+    repo: Repository,
+    integration_id: int,
+    user_id: str | int,
+    user_username: str,
+    provider: str,
+) -> None:
+    """
+    Track a contributor for seat billing. Creates or retrieves the contributor
+    record, checks eligibility, atomically increments the action count, and
+    queues seat assignment when the activation threshold is reached.
+    """
+    contributor, _ = OrganizationContributors.objects.get_or_create(
+        organization_id=organization.id,
+        integration_id=integration_id,
+        external_identifier=str(user_id),
+        defaults={"alias": user_username},
+    )
+
+    if not should_increment_contributor_seat(organization, repo, contributor):
+        return
+
+    metrics.incr(
+        "scm.webhook.organization_contributor.should_create",
+        sample_rate=1.0,
+        tags={"provider": provider},
+    )
+
+    locked_contributor = None
+    with transaction.atomic(router.db_for_write(OrganizationContributors)):
+        try:
+            locked_contributor = OrganizationContributors.objects.select_for_update().get(
+                id=contributor.id,
+            )
+            locked_contributor.num_actions += 1
+            locked_contributor.save(update_fields=["num_actions", "date_updated"])
+        except OrganizationContributors.DoesNotExist:
+            logger.warning(
+                "scm.webhook.organization_contributor.not_found",
+                extra={
+                    "provider": provider,
+                    "organization_id": organization.id,
+                    "integration_id": integration_id,
+                    "external_identifier": str(user_id),
+                },
+            )
+
+    if (
+        locked_contributor
+        and locked_contributor.num_actions >= ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD
+    ):
+        assign_seat_to_organization_contributor.delay(locked_contributor.id)

--- a/tests/sentry/integrations/github/test_utils.py
+++ b/tests/sentry/integrations/github/test_utils.py
@@ -1,107 +1,10 @@
-from unittest.mock import patch
-
 import pytest
 
 from sentry.integrations.github.utils import (
     is_github_rate_limit_sensitive,
     parse_github_blob_url,
-    should_increment_contributor_seat,
 )
-from sentry.models.organizationcontributors import OrganizationContributors
 from sentry.testutils.cases import TestCase
-
-
-class ShouldIncrementContributorSeatTest(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.integration = self.create_integration(
-            organization=self.organization,
-            provider="github",
-            external_id="github:1",
-        )
-        self.repo = self.create_repo(
-            project=self.project,
-            provider="integrations:github",
-            integration_id=self.integration.id,
-        )
-        self.contributor = OrganizationContributors.objects.create(
-            organization=self.organization,
-            integration_id=self.integration.id,
-            external_identifier="12345",
-            alias="testuser",
-        )
-
-    def test_returns_false_when_seat_based_seer_disabled(self):
-        self.create_repository_settings(repository=self.repo, enabled_code_review=True)
-
-        result = should_increment_contributor_seat(self.organization, self.repo, self.contributor)
-        assert result is False
-
-    def test_returns_false_when_no_code_review_or_autofix_enabled(self):
-        with self.feature("organizations:seat-based-seer-enabled"):
-            result = should_increment_contributor_seat(
-                self.organization, self.repo, self.contributor
-            )
-            assert result is False
-
-    def test_returns_false_when_repo_has_no_integration_id(self):
-        repo_no_integration = self.create_repo(
-            project=self.project,
-            provider="integrations:github",
-            integration_id=None,
-        )
-        self.create_repository_settings(repository=repo_no_integration, enabled_code_review=True)
-
-        with self.feature("organizations:seat-based-seer-enabled"):
-            result = should_increment_contributor_seat(
-                self.organization, repo_no_integration, self.contributor
-            )
-            assert result is False
-
-    @patch("sentry.integrations.github.utils.quotas.backend.check_seer_quota", return_value=True)
-    def test_returns_false_when_contributor_is_bot(self, mock_quota):
-        self.create_repository_settings(repository=self.repo, enabled_code_review=True)
-        self.contributor.alias = "testuser[bot]"
-        self.contributor.save()
-
-        with self.feature("organizations:seat-based-seer-enabled"):
-            result = should_increment_contributor_seat(
-                self.organization, self.repo, self.contributor
-            )
-            assert result is False
-
-    @patch("sentry.integrations.github.utils.quotas.backend.check_seer_quota", return_value=True)
-    def test_returns_true_when_code_review_enabled_and_quota_available(self, mock_quota):
-        self.create_repository_settings(repository=self.repo, enabled_code_review=True)
-
-        with self.feature("organizations:seat-based-seer-enabled"):
-            result = should_increment_contributor_seat(
-                self.organization, self.repo, self.contributor
-            )
-            assert result is True
-            mock_quota.assert_called_once()
-
-    @patch("sentry.integrations.github.utils.quotas.backend.check_seer_quota", return_value=True)
-    def test_returns_true_when_autofix_enabled_and_quota_available(self, mock_quota):
-        self.create_code_mapping(project=self.project, repo=self.repo)
-        self.project.update_option("sentry:autofix_automation_tuning", "medium")
-
-        with self.feature("organizations:seat-based-seer-enabled"):
-            result = should_increment_contributor_seat(
-                self.organization, self.repo, self.contributor
-            )
-            assert result is True
-            mock_quota.assert_called_once()
-
-    @patch("sentry.integrations.github.utils.quotas.backend.check_seer_quota", return_value=False)
-    def test_returns_false_when_quota_not_available(self, mock_quota):
-        self.create_repository_settings(repository=self.repo, enabled_code_review=True)
-
-        with self.feature("organizations:seat-based-seer-enabled"):
-            result = should_increment_contributor_seat(
-                self.organization, self.repo, self.contributor
-            )
-            assert result is False
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -1099,7 +1099,7 @@ class PullRequestEventWebhookTest(APITestCase):
         self,
         mock_track_contributor_seat: MagicMock,
     ) -> None:
-        Repository.objects.create(
+        repo = Repository.objects.create(
             organization_id=self.project.organization.id,
             external_id="35129377",
             provider="integrations:github",
@@ -1114,6 +1114,8 @@ class PullRequestEventWebhookTest(APITestCase):
         assert str(call_kwargs["user_id"]) == "6752317"
         assert call_kwargs["user_username"] == "baxterthehacker"
         assert call_kwargs["provider"] == "github"
+        assert call_kwargs["organization"] == self.project.organization
+        assert call_kwargs["repo"] == repo
 
 
 class IssuesEventWebhookTest(APITestCase):

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -28,7 +28,6 @@ from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.grouplink import GroupLink
-from sentry.models.organizationcontributors import OrganizationContributors
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
@@ -1095,15 +1094,10 @@ class PullRequestEventWebhookTest(APITestCase):
         assert link.linked_id == pr.id
         assert link.linked_type == GroupLink.LinkedType.pull_request
 
-    @patch("sentry.integrations.github.webhook.assign_seat_to_organization_contributor")
-    @patch(
-        "sentry.integrations.github.webhook.should_increment_contributor_seat",
-        return_value=False,
-    )
-    def test_no_contributor_tracking_when_feature_disabled(
+    @patch("sentry.integrations.github.webhook.track_contributor_seat")
+    def test_pull_request_calls_track_contributor_seat(
         self,
-        mock_should_increment_contributor_seat: MagicMock,
-        mock_assign_seat: MagicMock,
+        mock_track_contributor_seat: MagicMock,
     ) -> None:
         Repository.objects.create(
             organization_id=self.project.organization.id,
@@ -1114,89 +1108,12 @@ class PullRequestEventWebhookTest(APITestCase):
 
         integration = self._create_integration_and_send_pull_request_opened_event()
 
-        contributor = OrganizationContributors.objects.get(
-            organization_id=self.organization.id,
-            integration_id=integration.id,
-            external_identifier="6752317",
-        )
-        assert contributor.num_actions == 0
-        mock_assign_seat.delay.assert_not_called()
-
-    @patch("sentry.integrations.github.webhook.assign_seat_to_organization_contributor")
-    @patch(
-        "sentry.integrations.github.webhook.should_increment_contributor_seat",
-        return_value=True,
-    )
-    def test_seat_assignment_not_triggered_when_contributor_becomes_inactive(
-        self,
-        mock_should_increment_contributor_seat: MagicMock,
-        mock_assign_seat: MagicMock,
-    ) -> None:
-        Repository.objects.create(
-            organization_id=self.project.organization.id,
-            external_id="35129377",
-            provider="integrations:github",
-            name="baxterthehacker/public-repo",
-        )
-
-        integration = self._create_integration_and_send_pull_request_opened_event()
-
-        contributor = OrganizationContributors.objects.get(
-            organization_id=self.organization.id,
-            integration_id=integration.id,
-            external_identifier="6752317",
-        )
-
-        assert contributor.num_actions == 1
-        mock_assign_seat.delay.assert_not_called()
-
-    @patch("sentry.integrations.github.webhook.assign_seat_to_organization_contributor")
-    @patch(
-        "sentry.integrations.github.webhook.should_increment_contributor_seat",
-        return_value=True,
-    )
-    def test_seat_assignment_triggered_when_contributor_becomes_active(
-        self,
-        mock_should_increment_contributor_seat: MagicMock,
-        mock_assign_seat: MagicMock,
-    ) -> None:
-        Repository.objects.create(
-            organization_id=self.project.organization.id,
-            external_id="35129377",
-            provider="integrations:github",
-            name="baxterthehacker/public-repo",
-        )
-
-        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = self.create_integration(
-                organization=self.organization,
-                external_id="12345",
-                provider="github",
-                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
-            )
-            integration.add_organization(self.project.organization.id, self.user)
-
-        contributor = OrganizationContributors.objects.create(
-            organization_id=self.organization.id,
-            integration_id=integration.id,
-            external_identifier="6752317",
-            num_actions=1,
-        )
-
-        self.client.post(
-            path=self.url,
-            data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="pull_request",
-            HTTP_X_HUB_SIGNATURE="sha1=6ab37f1f7c8b4f0c223d1c346855fc2ac47ee749",
-            HTTP_X_HUB_SIGNATURE_256="sha256=a9f96076ede4be8eaf808e78c891287617af9d2292b7359c3dc3d063c3e356b8",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-
-        contributor.refresh_from_db()
-        assert contributor.num_actions == 2
-        mock_assign_seat.delay.assert_called_once_with(contributor.id)
+        mock_track_contributor_seat.assert_called_once()
+        call_kwargs = mock_track_contributor_seat.call_args[1]
+        assert call_kwargs["integration_id"] == integration.id
+        assert str(call_kwargs["user_id"]) == "6752317"
+        assert call_kwargs["user_username"] == "baxterthehacker"
+        assert call_kwargs["provider"] == "github"
 
 
 class IssuesEventWebhookTest(APITestCase):

--- a/tests/sentry/seer/code_review/test_contributor_seats.py
+++ b/tests/sentry/seer/code_review/test_contributor_seats.py
@@ -1,7 +1,13 @@
 from unittest.mock import patch
 
-from sentry.models.organizationcontributors import OrganizationContributors
-from sentry.seer.code_review.contributor_seats import should_increment_contributor_seat
+from sentry.models.organizationcontributors import (
+    ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD,
+    OrganizationContributors,
+)
+from sentry.seer.code_review.contributor_seats import (
+    should_increment_contributor_seat,
+    track_contributor_seat,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -108,3 +114,123 @@ class ShouldIncrementContributorSeatTest(TestCase):
                 self.organization, self.repo, self.contributor
             )
             assert result is False
+
+
+class TrackContributorSeatTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="github:1",
+        )
+        self.repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            integration_id=self.integration.id,
+        )
+
+    def _call(self, user_id="12345", user_username="testuser"):
+        track_contributor_seat(
+            organization=self.organization,
+            repo=self.repo,
+            integration_id=self.integration.id,
+            user_id=user_id,
+            user_username=user_username,
+            provider="github",
+        )
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.should_increment_contributor_seat",
+        return_value=False,
+    )
+    def test_creates_contributor_record(self, mock_should_increment):
+        self._call(user_id="999", user_username="newuser")
+
+        contributor = OrganizationContributors.objects.get(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            external_identifier="999",
+        )
+        assert contributor.alias == "newuser"
+        assert contributor.num_actions == 0
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.should_increment_contributor_seat",
+        return_value=False,
+    )
+    def test_does_not_increment_when_should_increment_returns_false(self, mock_should_increment):
+        OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="12345",
+            alias="testuser",
+            num_actions=0,
+        )
+
+        self._call()
+
+        contributor = OrganizationContributors.objects.get(
+            organization_id=self.organization.id,
+            external_identifier="12345",
+        )
+        assert contributor.num_actions == 0
+
+    @patch("sentry.seer.code_review.contributor_seats.assign_seat_to_organization_contributor")
+    @patch(
+        "sentry.seer.code_review.contributor_seats.should_increment_contributor_seat",
+        return_value=True,
+    )
+    def test_increments_and_does_not_assign_below_threshold(
+        self, mock_should_increment, mock_assign_seat
+    ):
+        self._call()
+
+        contributor = OrganizationContributors.objects.get(
+            organization_id=self.organization.id,
+            external_identifier="12345",
+        )
+        assert contributor.num_actions == 1
+        mock_assign_seat.delay.assert_not_called()
+
+    @patch("sentry.seer.code_review.contributor_seats.assign_seat_to_organization_contributor")
+    @patch(
+        "sentry.seer.code_review.contributor_seats.should_increment_contributor_seat",
+        return_value=True,
+    )
+    def test_increments_and_assigns_at_threshold(self, mock_should_increment, mock_assign_seat):
+        OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="12345",
+            alias="testuser",
+            num_actions=ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD - 1,
+        )
+
+        self._call()
+
+        contributor = OrganizationContributors.objects.get(
+            organization_id=self.organization.id,
+            external_identifier="12345",
+        )
+        assert contributor.num_actions == ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD
+        mock_assign_seat.delay.assert_called_once_with(contributor.id)
+
+    @patch("sentry.seer.code_review.contributor_seats.assign_seat_to_organization_contributor")
+    @patch(
+        "sentry.seer.code_review.contributor_seats.should_increment_contributor_seat",
+        return_value=True,
+    )
+    def test_handles_deleted_contributor_gracefully(self, mock_should_increment, mock_assign_seat):
+        contributor = OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="12345",
+            alias="testuser",
+        )
+        # Delete after creation so the select_for_update will fail
+        OrganizationContributors.objects.filter(id=contributor.id).delete()
+
+        # Should not raise
+        self._call()
+        mock_assign_seat.delay.assert_not_called()

--- a/tests/sentry/seer/code_review/test_contributor_seats.py
+++ b/tests/sentry/seer/code_review/test_contributor_seats.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from sentry.models.organizationcontributors import (
     ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD,
@@ -12,7 +12,7 @@ from sentry.testutils.cases import TestCase
 
 
 class ShouldIncrementContributorSeatTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -31,20 +31,20 @@ class ShouldIncrementContributorSeatTest(TestCase):
             alias="testuser",
         )
 
-    def test_returns_false_when_seat_based_seer_disabled(self):
+    def test_returns_false_when_seat_based_seer_disabled(self) -> None:
         self.create_repository_settings(repository=self.repo, enabled_code_review=True)
 
         result = should_increment_contributor_seat(self.organization, self.repo, self.contributor)
         assert result is False
 
-    def test_returns_false_when_no_code_review_or_autofix_enabled(self):
+    def test_returns_false_when_no_code_review_or_autofix_enabled(self) -> None:
         with self.feature("organizations:seat-based-seer-enabled"):
             result = should_increment_contributor_seat(
                 self.organization, self.repo, self.contributor
             )
             assert result is False
 
-    def test_returns_false_when_repo_has_no_integration_id(self):
+    def test_returns_false_when_repo_has_no_integration_id(self) -> None:
         repo_no_integration = self.create_repo(
             project=self.project,
             provider="integrations:github",
@@ -62,7 +62,7 @@ class ShouldIncrementContributorSeatTest(TestCase):
         "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
         return_value=True,
     )
-    def test_returns_false_when_contributor_is_bot(self, mock_quota):
+    def test_returns_false_when_contributor_is_bot(self, mock_quota: MagicMock) -> None:
         self.create_repository_settings(repository=self.repo, enabled_code_review=True)
         self.contributor.alias = "testuser[bot]"
         self.contributor.save()
@@ -77,7 +77,9 @@ class ShouldIncrementContributorSeatTest(TestCase):
         "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
         return_value=True,
     )
-    def test_returns_true_when_code_review_enabled_and_quota_available(self, mock_quota):
+    def test_returns_true_when_code_review_enabled_and_quota_available(
+        self, mock_quota: MagicMock
+    ) -> None:
         self.create_repository_settings(repository=self.repo, enabled_code_review=True)
 
         with self.feature("organizations:seat-based-seer-enabled"):
@@ -91,7 +93,9 @@ class ShouldIncrementContributorSeatTest(TestCase):
         "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
         return_value=True,
     )
-    def test_returns_true_when_autofix_enabled_and_quota_available(self, mock_quota):
+    def test_returns_true_when_autofix_enabled_and_quota_available(
+        self, mock_quota: MagicMock
+    ) -> None:
         self.create_code_mapping(project=self.project, repo=self.repo)
         self.project.update_option("sentry:autofix_automation_tuning", "medium")
 
@@ -106,7 +110,7 @@ class ShouldIncrementContributorSeatTest(TestCase):
         "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
         return_value=False,
     )
-    def test_returns_false_when_quota_not_available(self, mock_quota):
+    def test_returns_false_when_quota_not_available(self, mock_quota: MagicMock) -> None:
         self.create_repository_settings(repository=self.repo, enabled_code_review=True)
 
         with self.feature("organizations:seat-based-seer-enabled"):
@@ -117,7 +121,7 @@ class ShouldIncrementContributorSeatTest(TestCase):
 
 
 class TrackContributorSeatTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -130,7 +134,7 @@ class TrackContributorSeatTest(TestCase):
             integration_id=self.integration.id,
         )
 
-    def _call(self, user_id="12345", user_username="testuser"):
+    def _call(self, user_id: str = "12345", user_username: str = "testuser") -> None:
         track_contributor_seat(
             organization=self.organization,
             repo=self.repo,
@@ -144,7 +148,7 @@ class TrackContributorSeatTest(TestCase):
         "sentry.seer.code_review.contributor_seats.should_increment_contributor_seat",
         return_value=False,
     )
-    def test_creates_contributor_record(self, mock_should_increment):
+    def test_creates_contributor_record(self, mock_should_increment: MagicMock) -> None:
         self._call(user_id="999", user_username="newuser")
 
         contributor = OrganizationContributors.objects.get(
@@ -159,7 +163,9 @@ class TrackContributorSeatTest(TestCase):
         "sentry.seer.code_review.contributor_seats.should_increment_contributor_seat",
         return_value=False,
     )
-    def test_does_not_increment_when_should_increment_returns_false(self, mock_should_increment):
+    def test_does_not_increment_when_should_increment_returns_false(
+        self, mock_should_increment: MagicMock
+    ) -> None:
         OrganizationContributors.objects.create(
             organization=self.organization,
             integration_id=self.integration.id,
@@ -182,8 +188,8 @@ class TrackContributorSeatTest(TestCase):
         return_value=True,
     )
     def test_increments_and_does_not_assign_below_threshold(
-        self, mock_should_increment, mock_assign_seat
-    ):
+        self, mock_should_increment: MagicMock, mock_assign_seat: MagicMock
+    ) -> None:
         self._call()
 
         contributor = OrganizationContributors.objects.get(
@@ -198,7 +204,9 @@ class TrackContributorSeatTest(TestCase):
         "sentry.seer.code_review.contributor_seats.should_increment_contributor_seat",
         return_value=True,
     )
-    def test_increments_and_assigns_at_threshold(self, mock_should_increment, mock_assign_seat):
+    def test_increments_and_assigns_at_threshold(
+        self, mock_should_increment: MagicMock, mock_assign_seat: MagicMock
+    ) -> None:
         OrganizationContributors.objects.create(
             organization=self.organization,
             integration_id=self.integration.id,
@@ -221,7 +229,9 @@ class TrackContributorSeatTest(TestCase):
         "sentry.seer.code_review.contributor_seats.should_increment_contributor_seat",
         return_value=True,
     )
-    def test_handles_deleted_contributor_gracefully(self, mock_should_increment, mock_assign_seat):
+    def test_handles_deleted_contributor_gracefully(
+        self, mock_should_increment: MagicMock, mock_assign_seat: MagicMock
+    ) -> None:
         contributor = OrganizationContributors.objects.create(
             organization=self.organization,
             integration_id=self.integration.id,

--- a/tests/sentry/seer/code_review/test_contributor_seats.py
+++ b/tests/sentry/seer/code_review/test_contributor_seats.py
@@ -1,0 +1,110 @@
+from unittest.mock import patch
+
+from sentry.models.organizationcontributors import OrganizationContributors
+from sentry.seer.code_review.contributor_seats import should_increment_contributor_seat
+from sentry.testutils.cases import TestCase
+
+
+class ShouldIncrementContributorSeatTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="github:1",
+        )
+        self.repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            integration_id=self.integration.id,
+        )
+        self.contributor = OrganizationContributors.objects.create(
+            organization=self.organization,
+            integration_id=self.integration.id,
+            external_identifier="12345",
+            alias="testuser",
+        )
+
+    def test_returns_false_when_seat_based_seer_disabled(self):
+        self.create_repository_settings(repository=self.repo, enabled_code_review=True)
+
+        result = should_increment_contributor_seat(self.organization, self.repo, self.contributor)
+        assert result is False
+
+    def test_returns_false_when_no_code_review_or_autofix_enabled(self):
+        with self.feature("organizations:seat-based-seer-enabled"):
+            result = should_increment_contributor_seat(
+                self.organization, self.repo, self.contributor
+            )
+            assert result is False
+
+    def test_returns_false_when_repo_has_no_integration_id(self):
+        repo_no_integration = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            integration_id=None,
+        )
+        self.create_repository_settings(repository=repo_no_integration, enabled_code_review=True)
+
+        with self.feature("organizations:seat-based-seer-enabled"):
+            result = should_increment_contributor_seat(
+                self.organization, repo_no_integration, self.contributor
+            )
+            assert result is False
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
+        return_value=True,
+    )
+    def test_returns_false_when_contributor_is_bot(self, mock_quota):
+        self.create_repository_settings(repository=self.repo, enabled_code_review=True)
+        self.contributor.alias = "testuser[bot]"
+        self.contributor.save()
+
+        with self.feature("organizations:seat-based-seer-enabled"):
+            result = should_increment_contributor_seat(
+                self.organization, self.repo, self.contributor
+            )
+            assert result is False
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
+        return_value=True,
+    )
+    def test_returns_true_when_code_review_enabled_and_quota_available(self, mock_quota):
+        self.create_repository_settings(repository=self.repo, enabled_code_review=True)
+
+        with self.feature("organizations:seat-based-seer-enabled"):
+            result = should_increment_contributor_seat(
+                self.organization, self.repo, self.contributor
+            )
+            assert result is True
+            mock_quota.assert_called_once()
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
+        return_value=True,
+    )
+    def test_returns_true_when_autofix_enabled_and_quota_available(self, mock_quota):
+        self.create_code_mapping(project=self.project, repo=self.repo)
+        self.project.update_option("sentry:autofix_automation_tuning", "medium")
+
+        with self.feature("organizations:seat-based-seer-enabled"):
+            result = should_increment_contributor_seat(
+                self.organization, self.repo, self.contributor
+            )
+            assert result is True
+            mock_quota.assert_called_once()
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
+        return_value=False,
+    )
+    def test_returns_false_when_quota_not_available(self, mock_quota):
+        self.create_repository_settings(repository=self.repo, enabled_code_review=True)
+
+        with self.feature("organizations:seat-based-seer-enabled"):
+            result = should_increment_contributor_seat(
+                self.organization, self.repo, self.contributor
+            )
+            assert result is False


### PR DESCRIPTION
We will need to re-use this logic for other SCM providers (e.g. GitLab soon), so moving this out of GitHub utils + webhooks.
