### PR TITLE
bug(snapshots): Fix snapshot grouping

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -203,6 +203,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 key=key,
                 display_name=metadata.display_name,
                 image_file_name=metadata.image_file_name,
+                group=metadata.group,
                 width=metadata.width,
                 height=metadata.height,
             )


### PR DESCRIPTION
Missed this spot when adding first-class group field, so snapshots aren't being grouped in our FE. This should fix. Resolves EME-979