### PR TITLE
feat(integrations): Add lightweight RPC method to fetch org IDs by providers

### DIFF
--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -212,6 +212,21 @@ class DatabaseBackedIntegrationService(IntegrationService):
 
         return [serialize_organization_integration(oi) for oi in ois]
 
+    def get_organization_ids_with_providers(
+        self,
+        *,
+        providers: list[str],
+        status: int | None = None,
+    ) -> list[int]:
+        kwargs: dict[str, Any] = {"integration__provider__in": providers}
+        if status is not None:
+            kwargs["status"] = status
+        return list(
+            OrganizationIntegration.objects.filter(**kwargs)
+            .values_list("organization_id", flat=True)
+            .distinct()
+        )
+
     def organization_context(
         self,
         *,

--- a/src/sentry/integrations/services/integration/service.py
+++ b/src/sentry/integrations/services/integration/service.py
@@ -109,6 +109,19 @@ class IntegrationService(RpcService):
         """
 
     @rpc_method
+    @abstractmethod
+    def get_organization_ids_with_providers(
+        self,
+        *,
+        providers: list[str],
+        status: int | None = None,
+    ) -> list[int]:
+        """
+        Returns distinct organization IDs that have an integration with one of the given providers.
+        Lightweight alternative to get_organization_integrations when only org IDs are needed.
+        """
+
+    @rpc_method
     def get_organization_integration(
         self, *, integration_id: int, organization_id: int
     ) -> RpcOrganizationIntegration | None:

--- a/tests/sentry/integrations/services/test_integration.py
+++ b/tests/sentry/integrations/services/test_integration.py
@@ -242,6 +242,36 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
         result = integration_service.get_organization_integrations()
         assert len(result) == 0
 
+    def test_get_organization_ids_with_providers(self) -> None:
+        # integration2 is "github" with OI status=PENDING_DELETION
+        # integration1/3 are "example" with OI status=ACTIVE
+
+        # by provider, no status filter
+        result = integration_service.get_organization_ids_with_providers(providers=["github"])
+        assert set(result) == {self.organization.id}
+
+        # by provider with status filter — github OI is PENDING_DELETION, not ACTIVE
+        result = integration_service.get_organization_ids_with_providers(
+            providers=["github"], status=ObjectStatus.ACTIVE
+        )
+        assert result == []
+
+        # active example integrations
+        result = integration_service.get_organization_ids_with_providers(
+            providers=["example"], status=ObjectStatus.ACTIVE
+        )
+        assert set(result) == {self.organization.id}
+
+        # multiple providers
+        result = integration_service.get_organization_ids_with_providers(
+            providers=["github", "example"]
+        )
+        assert set(result) == {self.organization.id}
+
+        # no match
+        result = integration_service.get_organization_ids_with_providers(providers=["nonexistent"])
+        assert result == []
+
     def test_get_organization_integration(self) -> None:
         result = integration_service.get_organization_integration(
             integration_id=self.integration2.id,


### PR DESCRIPTION
## PR details
+ [get_allowed_org_ids_context_engine_indexing](https://github.com/getsentry/sentry/blob/e702861459fa0cfd50afb59b67ee32ba754b010a/src/sentry/tasks/seer/context_engine_index.py#L213) iterates **ALL** active orgs to decide which ones to index for the Seer context engine. We want to skip orgs that don't have a GitHub integration since that's a pre-requisite for Seer. 
+ The only existing way to check this across silos is get_organization_integrations, which returns full RpcOrganizationIntegration objects — ~100MB of serialized data for ~150K orgs with GitHub, when we only need the org IDs.
+ This PR adds get_organization_ids_with_providers to IntegrationService which returns just list[int] of distinct org IDs, reducing the payload to < 1MB. 
+ No existing callers of get_organization_integrations need this pattern — all current usage is scoped to a single org or integration. 