### PR TITLE
feat(onboarding): SCM platform features step UI polish and analytics

### DIFF
--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -44,6 +44,17 @@ export type OnboardingEventParameters = {
     repo: string;
   };
   'onboarding.scm_connect_step_viewed': Record<string, unknown>;
+  'onboarding.scm_platform_change_platform_clicked': Record<string, unknown>;
+  'onboarding.scm_platform_feature_toggled': {
+    enabled: boolean;
+    feature: string;
+    platform: string;
+  };
+  'onboarding.scm_platform_features_step_viewed': Record<string, unknown>;
+  'onboarding.scm_platform_selected': {
+    platform: string;
+    source: 'detected' | 'manual';
+  };
   'onboarding.select_framework_modal_close_button_clicked': {
     platform: string;
   };
@@ -108,4 +119,10 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.next_step_clicked': 'Onboarding: Next Step Clicked',
   'onboarding.scm_connect_repo_selected': 'Onboarding: SCM Connect Repo Selected',
   'onboarding.scm_connect_step_viewed': 'Onboarding: SCM Connect Step Viewed',
+  'onboarding.scm_platform_change_platform_clicked':
+    'Onboarding: SCM Platform Change Platform Clicked',
+  'onboarding.scm_platform_feature_toggled': 'Onboarding: SCM Platform Feature Toggled',
+  'onboarding.scm_platform_features_step_viewed':
+    'Onboarding: SCM Platform Features Step Viewed',
+  'onboarding.scm_platform_selected': 'Onboarding: SCM Platform Selected',
 };

--- a/static/app/views/onboarding/components/scmCardButton.tsx
+++ b/static/app/views/onboarding/components/scmCardButton.tsx
@@ -12,7 +12,6 @@ export const ScmCardButton = styled('button')`
   padding: 0;
   text-align: left;
   cursor: pointer;
-  width: 100%;
 
   &:disabled {
     cursor: not-allowed;

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -29,18 +29,25 @@ export function ScmFeatureCard({
   onClick,
 }: ScmFeatureCardProps) {
   return (
-    <Tooltip title={disabledReason} disabled={!disabledReason} delay={500}>
+    <Tooltip
+      title={disabledReason}
+      disabled={!disabledReason}
+      delay={500}
+      style={{height: '100%'}}
+    >
       <ScmCardButton
         onClick={onClick}
         role="checkbox"
         aria-checked={isSelected}
         disabled={disabled}
+        style={{width: '100%', height: '100%'}}
       >
         <Container
           border={isSelected ? 'accent' : 'secondary'}
           padding="xl"
           radius="md"
-          style={isSelected ? undefined : {borderBottomWidth: 3}}
+          height="100%"
+          style={isSelected ? {marginBottom: 2} : {borderBottomWidth: 3}}
         >
           <Flex gap="lg" align="start">
             <Container padding="xs 0 0 0">

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -1,7 +1,7 @@
 import type {ComponentType, ReactNode} from 'react';
 
 import {Checkbox} from '@sentry/scraps/checkbox';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -49,25 +49,39 @@ export function ScmFeatureCard({
           height="100%"
           style={isSelected ? {marginBottom: 2} : {borderBottomWidth: 3}} // this prevents el height from changing when switching border variant
         >
-          <Flex gap="lg" align="start">
-            <Container padding="xs 0 0 0">
-              {containerProps => <Icon size="sm" {...containerProps} />}
-            </Container>
-            <Flex direction="column" gap="xs" flex="1">
-              <Flex justify="between" align="center">
+          <Flex>
+            <Grid
+              columns="min-content 1fr"
+              rows="min-content min-content"
+              gap="xs lg"
+              align="center"
+              areas={`
+                    "cell1 cell2"
+                    ". cell4"
+                  `}
+            >
+              <Flex area="cell1">
+                <Icon size="md" variant={isSelected ? 'accent' : undefined} />
+              </Flex>
+
+              <Flex area="cell2">
                 <Text bold size="lg">
                   {label}
                 </Text>
-                <Checkbox
-                  readOnly
-                  size="sm"
-                  tabIndex={-1}
-                  role="presentation"
-                  checked={isSelected}
-                  disabled={disabled}
-                />
               </Flex>
-              <Text variant="muted">{description}</Text>
+              <Flex area="cell4">
+                <Text variant="muted">{description}</Text>
+              </Flex>
+            </Grid>
+            <Flex align="start">
+              <Checkbox
+                readOnly
+                size="sm"
+                tabIndex={-1}
+                role="presentation"
+                checked={isSelected}
+                disabled={disabled}
+              />
             </Flex>
           </Flex>
         </Container>

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -60,18 +60,24 @@ export function ScmFeatureCard({
                     ". cell4"
                   `}
             >
-              <Flex area="cell1">
-                <Icon size="md" variant={isSelected ? 'accent' : undefined} />
-              </Flex>
+              <Container area="cell1">
+                {containerProps => (
+                  <Icon
+                    {...containerProps}
+                    size="md"
+                    variant={isSelected ? 'accent' : undefined}
+                  />
+                )}
+              </Container>
 
-              <Flex area="cell2">
+              <Container area="cell2">
                 <Text bold size="lg">
                   {label}
                 </Text>
-              </Flex>
-              <Flex area="cell4">
+              </Container>
+              <Container area="cell4">
                 <Text variant="muted">{description}</Text>
-              </Flex>
+              </Container>
             </Grid>
             <Flex align="start">
               <Checkbox

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -36,14 +36,21 @@ export function ScmFeatureCard({
         aria-checked={isSelected}
         disabled={disabled}
       >
-        <Container border={isSelected ? 'accent' : 'secondary'} padding="lg" radius="md">
-          <Flex gap="md" align="start">
+        <Container
+          border={isSelected ? 'accent' : 'secondary'}
+          padding="xl"
+          radius="md"
+          style={isSelected ? undefined : {borderBottomWidth: 3}}
+        >
+          <Flex gap="lg" align="start">
             <Container padding="xs 0 0 0">
               {containerProps => <Icon size="sm" {...containerProps} />}
             </Container>
             <Flex direction="column" gap="xs" flex="1">
               <Flex justify="between" align="center">
-                <Text bold>{label}</Text>
+                <Text bold size="lg">
+                  {label}
+                </Text>
                 <Checkbox
                   readOnly
                   size="xs"
@@ -53,9 +60,7 @@ export function ScmFeatureCard({
                   disabled={disabled}
                 />
               </Flex>
-              <Text variant="muted" size="sm">
-                {description}
-              </Text>
+              <Text variant="muted">{description}</Text>
             </Flex>
           </Flex>
         </Container>

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -53,7 +53,7 @@ export function ScmFeatureCard({
                 </Text>
                 <Checkbox
                   readOnly
-                  size="xs"
+                  size="sm"
                   tabIndex={-1}
                   role="presentation"
                   checked={isSelected}

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -47,7 +47,7 @@ export function ScmFeatureCard({
           padding="xl"
           radius="md"
           height="100%"
-          style={isSelected ? {marginBottom: 2} : {borderBottomWidth: 3}}
+          style={isSelected ? {marginBottom: 2} : {borderBottomWidth: 3}} // this prevents el height from changing when switching border variant
         >
           <Flex gap="lg" align="start">
             <Container padding="xs 0 0 0">

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -56,11 +56,11 @@ export function ScmFeatureCard({
               gap="xs lg"
               align="center"
               areas={`
-                    "cell1 cell2"
-                    ". cell4"
+                    "icon label"
+                    ". description"
                   `}
             >
-              <Container area="cell1">
+              <Container area="icon">
                 {containerProps => (
                   <Icon
                     {...containerProps}
@@ -70,12 +70,12 @@ export function ScmFeatureCard({
                 )}
               </Container>
 
-              <Container area="cell2">
+              <Container area="label">
                 <Text bold size="lg">
                   {label}
                 </Text>
               </Container>
-              <Container area="cell4">
+              <Container area="description">
                 <Text variant="muted">{description}</Text>
               </Container>
             </Grid>

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -44,7 +44,7 @@ export function ScmFeatureCard({
       >
         <Container
           border={isSelected ? 'accent' : 'secondary'}
-          padding="xl"
+          padding={{xs: 'md', md: 'xl'}}
           radius="md"
           height="100%"
           style={isSelected ? {marginBottom: 2} : {borderBottomWidth: 3}} // this prevents el height from changing when switching border variant
@@ -53,7 +53,7 @@ export function ScmFeatureCard({
             <Grid
               columns="min-content 1fr"
               rows="min-content min-content"
-              gap="xs lg"
+              gap={{xs: 'xs md', md: 'xs lg'}}
               align="center"
               areas={`
                     "icon label"

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -84,7 +84,7 @@ export function ScmFeatureSelectionCards({
   const totalCount = availableFeatures.length;
 
   return (
-    <Flex direction="column" gap="md" width="100%">
+    <Flex direction="column" gap="md" width="100%" justify="center">
       <Grid columns="1fr auto 1fr" align="center" areas='"spacer heading counter"'>
         <Flex area="heading">
           <Heading as="h3">{t('What do you want to set up?')}</Heading>
@@ -94,11 +94,10 @@ export function ScmFeatureSelectionCards({
         </Flex>
       </Grid>
       <Grid
-        columns={availableFeatures.length === 1 ? '1fr' : 'repeat(2, 1fr)'}
         gap="lg"
-        style={
-          availableFeatures.length === 1 ? {maxWidth: '50%', margin: '0 auto'} : undefined
-        }
+        columns={availableFeatures.length === 1 ? '1fr' : 'repeat(2, 1fr)'}
+        maxWidth={availableFeatures.length === 1 ? '50%' : undefined}
+        margin={availableFeatures.length === 1 ? '0 auto' : undefined}
       >
         {availableFeatures.map(feature => {
           const meta = FEATURE_META[feature];

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -85,11 +85,21 @@ export function ScmFeatureSelectionCards({
 
   return (
     <Flex direction="column" gap="md" width="100%">
-      <Flex justify="between" align="center">
-        <Heading as="h3">{t('What do you want to set up?')}</Heading>
-        <Text variant="muted">{t('%s of %s selected', selectedCount, totalCount)}</Text>
-      </Flex>
-      <Grid columns={2} gap="lg">
+      <Grid columns="1fr auto 1fr" align="center" areas='"spacer heading counter"'>
+        <Flex area="heading">
+          <Heading as="h3">{t('What do you want to set up?')}</Heading>
+        </Flex>
+        <Flex area="counter" justify="end">
+          <Text variant="muted">{t('%s of %s selected', selectedCount, totalCount)}</Text>
+        </Flex>
+      </Grid>
+      <Grid
+        columns={availableFeatures.length === 1 ? '1fr' : 'repeat(2, 1fr)'}
+        gap="lg"
+        style={
+          availableFeatures.length === 1 ? {maxWidth: '50%', margin: '0 auto'} : undefined
+        }
+      >
         {availableFeatures.map(feature => {
           const meta = FEATURE_META[feature];
           const disabledProduct = disabledProducts[feature];

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -89,7 +89,7 @@ export function ScmFeatureSelectionCards({
         <Heading as="h3">{t('What do you want to set up?')}</Heading>
         <Text variant="muted">{t('%s of %s selected', selectedCount, totalCount)}</Text>
       </Flex>
-      <Grid columns={2} gap="md">
+      <Grid columns={2} gap="lg">
         {availableFeatures.map(feature => {
           const meta = FEATURE_META[feature];
           const disabledProduct = disabledProducts[feature];

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -103,7 +103,7 @@ export function ScmFeatureSelectionCards({
         columns={
           availableFeatures.length === 1 ? '1fr' : {xs: '1fr', md: 'repeat(2, 1fr)'}
         }
-        maxWidth={availableFeatures.length === 1 ? '50%' : undefined}
+        maxWidth={availableFeatures.length === 1 ? {xs: '100%', md: '50%'} : undefined}
         margin={availableFeatures.length === 1 ? '0 auto' : undefined}
       >
         {availableFeatures.map(feature => {

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -92,7 +92,9 @@ export function ScmFeatureSelectionCards({
         areas={{xs: '"heading" "counter"', md: '"spacer heading counter"'}}
       >
         <Flex area="heading" justify={{xs: 'center', md: 'start'}}>
-          <Heading as="h3">{t('What do you want to set up?')}</Heading>
+          <Heading as="h3" size="xl">
+            {t('What do you want to set up?')}
+          </Heading>
         </Flex>
         <Flex area="counter" justify={{xs: 'center', md: 'end'}}>
           <Text variant="muted">{t('%s of %s selected', selectedCount, totalCount)}</Text>

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -85,17 +85,24 @@ export function ScmFeatureSelectionCards({
 
   return (
     <Flex direction="column" gap="md" width="100%" justify="center">
-      <Grid columns="1fr auto 1fr" align="center" areas='"spacer heading counter"'>
-        <Flex area="heading">
+      <Grid
+        columns={{xs: '1fr', md: '1fr auto 1fr'}}
+        align="center"
+        justify="center"
+        areas={{xs: '"heading" "counter"', md: '"spacer heading counter"'}}
+      >
+        <Flex area="heading" justify={{xs: 'center', md: 'start'}}>
           <Heading as="h3">{t('What do you want to set up?')}</Heading>
         </Flex>
-        <Flex area="counter" justify="end">
+        <Flex area="counter" justify={{xs: 'center', md: 'end'}}>
           <Text variant="muted">{t('%s of %s selected', selectedCount, totalCount)}</Text>
         </Flex>
       </Grid>
       <Grid
         gap="lg"
-        columns={availableFeatures.length === 1 ? '1fr' : 'repeat(2, 1fr)'}
+        columns={
+          availableFeatures.length === 1 ? '1fr' : {xs: '1fr', md: 'repeat(2, 1fr)'}
+        }
         maxWidth={availableFeatures.length === 1 ? '50%' : undefined}
         margin={availableFeatures.length === 1 ? '0 auto' : undefined}
       >

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -84,7 +84,7 @@ export function ScmFeatureSelectionCards({
   const totalCount = availableFeatures.length;
 
   return (
-    <Flex direction="column" gap="md" width="100%" justify="center">
+    <Flex direction="column" gap="2xl" width="100%" justify="center">
       <Grid
         columns={{xs: '1fr', md: '1fr auto 1fr'}}
         align="center"
@@ -99,7 +99,7 @@ export function ScmFeatureSelectionCards({
         </Flex>
       </Grid>
       <Grid
-        gap="lg"
+        gap="xl"
         columns={
           availableFeatures.length === 1 ? '1fr' : {xs: '1fr', md: 'repeat(2, 1fr)'}
         }

--- a/static/app/views/onboarding/components/scmPlatformCard.tsx
+++ b/static/app/views/onboarding/components/scmPlatformCard.tsx
@@ -24,7 +24,7 @@ export function ScmPlatformCard({
 }: ScmPlatformCardProps) {
   return (
     <ScmCardButton onClick={onClick} role="radio" aria-checked={isSelected}>
-      <Container border={isSelected ? 'accent' : 'secondary'} padding="md lg" radius="md">
+      <Container border={isSelected ? 'accent' : 'secondary'} padding="lg" radius="md">
         <Grid gap="md" align="center" columns="max-content min-content">
           <PlatformIcon platform={platform} size={28} />
           <Stack gap="0">

--- a/static/app/views/onboarding/components/scmPlatformCard.tsx
+++ b/static/app/views/onboarding/components/scmPlatformCard.tsx
@@ -24,9 +24,9 @@ export function ScmPlatformCard({
 }: ScmPlatformCardProps) {
   return (
     <ScmCardButton onClick={onClick} role="radio" aria-checked={isSelected}>
-      <Container border={isSelected ? 'accent' : 'secondary'} padding="md" radius="md">
-        <Flex gap="sm" align="center">
-          <PlatformIcon platform={platform} size={20} />
+      <Container border={isSelected ? 'accent' : 'secondary'} padding="md lg" radius="md">
+        <Flex gap="md" align="center">
+          <PlatformIcon platform={platform} size={28} />
           <Stack gap="0">
             <Text bold>{name}</Text>
             <Text variant="muted" size="sm">

--- a/static/app/views/onboarding/components/scmPlatformCard.tsx
+++ b/static/app/views/onboarding/components/scmPlatformCard.tsx
@@ -1,6 +1,6 @@
 import {PlatformIcon} from 'platformicons';
 
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import type {PlatformKey} from 'sentry/types/project';
@@ -25,15 +25,17 @@ export function ScmPlatformCard({
   return (
     <ScmCardButton onClick={onClick} role="radio" aria-checked={isSelected}>
       <Container border={isSelected ? 'accent' : 'secondary'} padding="md lg" radius="md">
-        <Flex gap="md" align="center">
+        <Grid gap="md" align="center" columns="max-content min-content">
           <PlatformIcon platform={platform} size={28} />
           <Stack gap="0">
-            <Text bold>{name}</Text>
-            <Text variant="muted" size="sm">
+            <Text bold textWrap="nowrap">
+              {name}
+            </Text>
+            <Text variant="muted" size="sm" textWrap="nowrap">
               {type}
             </Text>
           </Stack>
-        </Flex>
+        </Grid>
       </Container>
     </ScmCardButton>
   );

--- a/static/app/views/onboarding/components/scmPlatformCard.tsx
+++ b/static/app/views/onboarding/components/scmPlatformCard.tsx
@@ -27,7 +27,7 @@ export function ScmPlatformCard({
       <Container border={isSelected ? 'accent' : 'secondary'} padding="lg" radius="md">
         <Grid gap="md" align="center" columns="max-content min-content">
           <PlatformIcon platform={platform} size={28} />
-          <Stack gap="0">
+          <Stack>
             <Text bold textWrap="nowrap">
               {name}
             </Text>

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -2,35 +2,15 @@ import {useMemo} from 'react';
 
 import {Select} from '@sentry/scraps/select';
 
-import {components as selectComponents} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
-import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Integration} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import {ScmSearchControl} from './scmSearchControl';
 import {useScmRepoSearch} from './useScmRepoSearch';
 import {useScmRepoSelection} from './useScmRepoSelection';
-
-/**
- * Custom Control that prepends a search icon inside the select input.
- * Control is the outermost flex container around ValueContainer + Indicators,
- * so adding a child here doesn't break react-select's internal layout.
- *
- * Props are typed as `any` because react-select's generic types don't
- * match the specific option shape our Select wrapper uses, and there's
- * no clean way to type custom components without casting. This matches
- * the pattern used elsewhere (e.g. ruleConditionsForm, typeSelector).
- */
-function SearchControl({children, ...props}: any) {
-  return (
-    <selectComponents.Control {...props}>
-      <IconSearch size="sm" variant="muted" style={{marginLeft: 12, flexShrink: 0}} />
-      {children}
-    </selectComponents.Control>
-  );
-}
 
 interface ScmRepoSelectorProps {
   integration: Integration;
@@ -121,7 +101,7 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
       isDisabled={busy}
       clearable
       searchable
-      components={{Control: SearchControl}}
+      components={{Control: ScmSearchControl}}
     />
   );
 }

--- a/static/app/views/onboarding/components/scmSearchControl.tsx
+++ b/static/app/views/onboarding/components/scmSearchControl.tsx
@@ -1,0 +1,21 @@
+import {components as selectComponents} from 'sentry/components/forms/controls/reactSelectWrapper';
+import {IconSearch} from 'sentry/icons';
+
+/**
+ * Custom Control that prepends a search icon inside a Select input.
+ * Control is the outermost flex container around ValueContainer + Indicators,
+ * so adding a child here doesn't break react-select's internal layout.
+ *
+ * Props are typed as `any` because react-select's generic types don't
+ * match the specific option shape our Select wrapper uses, and there's
+ * no clean way to type custom components without casting. This matches
+ * the pattern used elsewhere (e.g. ruleConditionsForm, typeSelector).
+ */
+export function ScmSearchControl({children, ...props}: any) {
+  return (
+    <selectComponents.Control {...props}>
+      <IconSearch size="sm" variant="muted" style={{marginLeft: 12, flexShrink: 0}} />
+      {children}
+    </selectComponents.Control>
+  );
+}

--- a/static/app/views/onboarding/components/scmSearchControl.tsx
+++ b/static/app/views/onboarding/components/scmSearchControl.tsx
@@ -1,3 +1,5 @@
+import {Container} from '@sentry/scraps/layout';
+
 import {components as selectComponents} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {IconSearch} from 'sentry/icons';
 
@@ -14,7 +16,9 @@ import {IconSearch} from 'sentry/icons';
 export function ScmSearchControl({children, ...props}: any) {
   return (
     <selectComponents.Control {...props}>
-      <IconSearch size="sm" variant="muted" style={{marginLeft: 12, flexShrink: 0}} />
+      <Container paddingLeft="lg" flexShrink={0}>
+        <IconSearch size="sm" variant="muted" />
+      </Container>
       {children}
     </selectComponents.Control>
   );

--- a/static/app/views/onboarding/components/scmStepFooter.tsx
+++ b/static/app/views/onboarding/components/scmStepFooter.tsx
@@ -4,16 +4,20 @@ import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
 interface ScmStepFooterProps {
   children: React.ReactNode;
+  maxWidth?: string;
 }
 
-export function ScmStepFooter({children}: ScmStepFooterProps) {
+export function ScmStepFooter({
+  children,
+  maxWidth = SCM_STEP_CONTENT_WIDTH,
+}: ScmStepFooterProps) {
   return (
     <Flex
       gap="lg"
       align="center"
       justify="end"
       width="100%"
-      maxWidth={SCM_STEP_CONTENT_WIDTH}
+      maxWidth={maxWidth}
       paddingTop="3xl"
     >
       {children}

--- a/static/app/views/onboarding/components/scmStepHeader.tsx
+++ b/static/app/views/onboarding/components/scmStepHeader.tsx
@@ -31,7 +31,7 @@ export function ScmStepHeader({
         <Heading as="h2" size="3xl">
           {heading}
         </Heading>
-        <Text variant="muted" size="lg" bold density="comfortable">
+        <Text variant="muted" size="lg" bold density="comfortable" align="center">
           {subtitle}
         </Text>
       </Stack>

--- a/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
+++ b/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
@@ -10,33 +10,36 @@
  * Usage: <Select components={{MenuList: ScmVirtualizedMenuList}} />
  */
 
-import {useRef} from 'react';
+import {useRef, type PropsWithChildren} from 'react';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 const OPTION_HEIGHT = 36;
 const MAX_MENU_HEIGHT = 300;
-export function ScmVirtualizedMenuList(props: {
-  children: React.ReactNode;
-  maxHeight: number;
-}) {
-  const {children, maxHeight} = props;
+
+interface ScmVirtualizedMenuListProps {
+  maxHeight?: number;
+  optionHeight?: number;
+}
+
+export function ScmVirtualizedMenuList({
+  children,
+  maxHeight = MAX_MENU_HEIGHT,
+  optionHeight = OPTION_HEIGHT,
+}: PropsWithChildren<ScmVirtualizedMenuListProps>) {
   const items = Array.isArray(children) ? children : [];
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const virtualizer = useVirtualizer({
     count: items.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => OPTION_HEIGHT,
+    estimateSize: () => optionHeight,
     overscan: 5,
   });
 
   const virtualItems = virtualizer.getVirtualItems();
 
   return (
-    <div
-      ref={scrollRef}
-      style={{maxHeight: maxHeight || MAX_MENU_HEIGHT, overflowY: 'auto'}}
-    >
+    <div ref={scrollRef} style={{maxHeight, overflowY: 'auto'}}>
       {virtualItems.length > 0 ? (
         <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>
           {virtualItems.map(virtualRow => (

--- a/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
+++ b/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
@@ -10,13 +10,17 @@
  * Usage: <Select components={{MenuList: ScmVirtualizedMenuList}} />
  */
 
-import {useRef, type PropsWithChildren} from 'react';
+import {type Ref, useRef} from 'react';
+import {mergeRefs} from '@react-aria/utils';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 const OPTION_HEIGHT = 36;
 const MAX_MENU_HEIGHT = 300;
 
 interface ScmVirtualizedMenuListProps {
+  children: React.ReactNode;
+  innerProps?: React.HTMLAttributes<HTMLDivElement>;
+  innerRef?: Ref<HTMLDivElement>;
   maxHeight?: number;
   optionHeight?: number;
 }
@@ -25,9 +29,12 @@ export function ScmVirtualizedMenuList({
   children,
   maxHeight = MAX_MENU_HEIGHT,
   optionHeight = OPTION_HEIGHT,
-}: PropsWithChildren<ScmVirtualizedMenuListProps>) {
+  innerRef,
+  innerProps,
+}: ScmVirtualizedMenuListProps) {
   const items = Array.isArray(children) ? children : [];
   const scrollRef = useRef<HTMLDivElement>(null);
+  const combinedRef = mergeRefs(scrollRef, innerRef ?? null);
 
   const virtualizer = useVirtualizer({
     count: items.length,
@@ -41,11 +48,15 @@ export function ScmVirtualizedMenuList({
   // When no options match, react-select passes a single NoOptionsMessage
   // element (not an array). Render it directly without virtualization.
   if (!Array.isArray(children)) {
-    return <div style={{maxHeight, overflowY: 'auto'}}>{children}</div>;
+    return (
+      <div ref={innerRef} {...innerProps} style={{maxHeight, overflowY: 'auto'}}>
+        {children}
+      </div>
+    );
   }
 
   return (
-    <div ref={scrollRef} style={{maxHeight, overflowY: 'auto'}}>
+    <div ref={combinedRef} {...innerProps} style={{maxHeight, overflowY: 'auto'}}>
       <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>
         {virtualItems.map(virtualRow => (
           <div

--- a/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
+++ b/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
@@ -40,27 +40,22 @@ export function ScmVirtualizedMenuList({
 
   return (
     <div ref={scrollRef} style={{maxHeight, overflowY: 'auto'}}>
-      {virtualItems.length > 0 ? (
-        <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>
-          {virtualItems.map(virtualRow => (
-            <div
-              key={virtualRow.key}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                transform: `translateY(${virtualRow.start}px)`,
-              }}
-            >
-              {items[virtualRow.index]}
-            </div>
-          ))}
-        </div>
-      ) : (
-        // Fallback: render all items when virtualizer can't measure (JSDOM)
-        items
-      )}
+      <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>
+        {virtualItems.map(virtualRow => (
+          <div
+            key={virtualRow.key}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              transform: `translateY(${virtualRow.start}px)`,
+            }}
+          >
+            {items[virtualRow.index]}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
+++ b/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
@@ -1,0 +1,63 @@
+/**
+ * Virtualized MenuList for the Select (react-select) component.
+ * react-select re-renders every Option on hover/focus changes, which
+ * causes ~1s lag with 130+ platform options containing PlatformIcon SVGs.
+ * Virtualizing limits mounted components to the visible set.
+ *
+ * Stopgap until a Combobox scraps component replaces this
+ * (see #discuss-design-engineering).
+ *
+ * Usage: <Select components={{MenuList: ScmVirtualizedMenuList}} />
+ */
+
+import {useRef} from 'react';
+import {useVirtualizer} from '@tanstack/react-virtual';
+
+const OPTION_HEIGHT = 36;
+const MAX_MENU_HEIGHT = 300;
+export function ScmVirtualizedMenuList(props: {
+  children: React.ReactNode;
+  maxHeight: number;
+}) {
+  const {children, maxHeight} = props;
+  const items = Array.isArray(children) ? children : [];
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => OPTION_HEIGHT,
+    overscan: 5,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  return (
+    <div
+      ref={scrollRef}
+      style={{maxHeight: maxHeight || MAX_MENU_HEIGHT, overflowY: 'auto'}}
+    >
+      {virtualItems.length > 0 ? (
+        <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>
+          {virtualItems.map(virtualRow => (
+            <div
+              key={virtualRow.key}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              {items[virtualRow.index]}
+            </div>
+          ))}
+        </div>
+      ) : (
+        // Fallback: render all items when virtualizer can't measure (JSDOM)
+        items
+      )}
+    </div>
+  );
+}

--- a/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
+++ b/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
@@ -38,6 +38,12 @@ export function ScmVirtualizedMenuList({
 
   const virtualItems = virtualizer.getVirtualItems();
 
+  // When no options match, react-select passes a single NoOptionsMessage
+  // element (not an array). Render it directly without virtualization.
+  if (!Array.isArray(children)) {
+    return <div style={{maxHeight, overflowY: 'auto'}}>{children}</div>;
+  }
+
   return (
     <div ref={scrollRef} style={{maxHeight, overflowY: 'auto'}}>
       <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -10,6 +10,7 @@ import {
   OnboardingContextProvider,
   type OnboardingSessionState,
 } from 'sentry/components/onboarding/onboardingContext';
+import * as analytics from 'sentry/utils/analytics';
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 import {ScmPlatformFeatures} from './scmPlatformFeatures';
@@ -374,5 +375,144 @@ describe('ScmPlatformFeatures', () => {
 
     expect(screen.getByRole('checkbox', {name: /Tracing/})).not.toBeChecked();
     expect(screen.getByRole('checkbox', {name: /Profiling/})).not.toBeChecked();
+  });
+
+  describe('analytics', () => {
+    let trackAnalyticsSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    });
+
+    it('fires step viewed event on mount', async () => {
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper(),
+        }
+      );
+
+      await screen.findByRole('heading', {name: 'Select a platform'});
+
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'onboarding.scm_platform_features_step_viewed',
+        expect.objectContaining({organization})
+      );
+    });
+
+    it('fires platform selected event when clicking a detected platform', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {
+          platforms: [
+            DetectedPlatformFixture(),
+            DetectedPlatformFixture({
+              platform: 'python-django',
+              language: 'Python',
+              priority: 2,
+            }),
+          ],
+        },
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+          }),
+        }
+      );
+
+      // Wait for detected platforms, then click the second one
+      const djangoCard = await screen.findByRole('radio', {name: /Django/});
+      await userEvent.click(djangoCard);
+
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'onboarding.scm_platform_selected',
+        expect.objectContaining({
+          platform: 'python-django',
+          source: 'detected',
+        })
+      );
+    });
+
+    it('fires feature toggled event when toggling a feature', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {
+          platforms: [DetectedPlatformFixture({platform: 'python', language: 'Python'})],
+        },
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          }),
+        }
+      );
+
+      await screen.findByText('What do you want to set up?');
+
+      await userEvent.click(screen.getByRole('checkbox', {name: /Tracing/}));
+
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'onboarding.scm_platform_feature_toggled',
+        expect.objectContaining({
+          feature: ProductSolution.PERFORMANCE_MONITORING,
+          enabled: true,
+          platform: 'python',
+        })
+      );
+    });
+
+    it('fires change platform event when clicking the link', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {platforms: [DetectedPlatformFixture()]},
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+          }),
+        }
+      );
+
+      const changeButton = await screen.findByRole('button', {
+        name: "Doesn't look right? Change platform",
+      });
+      await userEvent.click(changeButton);
+
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'onboarding.scm_platform_change_platform_clicked',
+        expect.objectContaining({organization})
+      );
+    });
   });
 });

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -162,6 +162,33 @@ describe('ScmPlatformFeatures', () => {
     expect(screen.getByRole('heading', {name: 'Select a platform'})).toBeInTheDocument();
   });
 
+  it('falls back to manual picker when platform detection fails', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/42/platforms/`,
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    render(
+      <ScmPlatformFeatures
+        onComplete={jest.fn()}
+        stepIndex={2}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedRepository: mockRepository,
+        }),
+      }
+    );
+
+    expect(
+      await screen.findByRole('heading', {name: 'Select a platform'})
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Recommended SDK')).not.toBeInTheDocument();
+  });
+
   it('renders manual picker when no repository in context', async () => {
     render(
       <ScmPlatformFeatures

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -17,8 +17,23 @@ import {ScmPlatformFeatures} from './scmPlatformFeatures';
 
 jest.mock('sentry/actionCreators/modal');
 
+// Mock the virtualizer so all items render in JSDOM (no layout engine).
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: jest.fn(({count}) => ({
+    getVirtualItems: () =>
+      Array.from({length: count}, (_, i) => ({
+        key: i,
+        index: i,
+        start: i * 36,
+        size: 36,
+      })),
+    getTotalSize: () => count * 36,
+    measureElement: jest.fn(),
+  })),
+}));
+
 // Provide a small platform list so the Select dropdown renders
-// all options without virtualization in JSDOM.
+// a manageable number of options in JSDOM.
 jest.mock('sentry/data/platforms', () => {
   const actual = jest.requireActual('sentry/data/platforms');
   return {

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -17,8 +17,8 @@ import {ScmPlatformFeatures} from './scmPlatformFeatures';
 
 jest.mock('sentry/actionCreators/modal');
 
-// Provide a small platform list so CompactSelect stays below the
-// virtualizeThreshold (50) and renders all options in JSDOM.
+// Provide a small platform list so the Select dropdown renders
+// all options without virtualization in JSDOM.
 jest.mock('sentry/data/platforms', () => {
   const actual = jest.requireActual('sentry/data/platforms');
   return {
@@ -285,11 +285,9 @@ describe('ScmPlatformFeatures', () => {
 
     await screen.findByRole('heading', {name: 'Select a platform'});
 
-    // Open the CompactSelect and select a base language
-    await userEvent.click(screen.getByRole('button', {name: 'None'}));
-    await userEvent.click(
-      await screen.findByRole('option', {name: 'Browser JavaScript'})
-    );
+    // Type into the Select to search and pick a base language
+    await userEvent.type(screen.getByRole('textbox'), 'JavaScript');
+    await userEvent.click(await screen.findByText('Browser JavaScript'));
 
     await waitFor(() => {
       expect(mockOpenModal).toHaveBeenCalled();
@@ -316,9 +314,9 @@ describe('ScmPlatformFeatures', () => {
 
     await screen.findByRole('heading', {name: 'Select a platform'});
 
-    // Open the CompactSelect and select a console platform
-    await userEvent.click(screen.getByRole('button', {name: 'None'}));
-    await userEvent.click(await screen.findByRole('option', {name: 'Nintendo Switch'}));
+    // Type into the Select to search and pick a console platform
+    await userEvent.type(screen.getByRole('textbox'), 'Nintendo');
+    await userEvent.click(await screen.findByText('Nintendo Switch'));
 
     await waitFor(() => {
       expect(mockOpenConsoleModal).toHaveBeenCalled();

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -3,11 +3,12 @@ import {motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
-import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
 import {closeModal, openConsoleModal, openModal} from 'sentry/actionCreators/modal';
+import {components as selectComponents} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -17,6 +18,7 @@ import {
   platformProductAvailability,
 } from 'sentry/components/onboarding/productSelection';
 import {platforms} from 'sentry/data/platforms';
+import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
@@ -47,8 +49,23 @@ const platformOptions = platforms.map(platform => ({
   value: platform.id,
   label: platform.name,
   textValue: `${platform.name} ${platform.id}`,
-  leadingItems: () => <PlatformIcon platform={platform.id} size={16} />,
+  leadingItems: <PlatformIcon platform={platform.id} size={16} />,
 }));
+
+/**
+ * Custom Control that prepends a search icon inside the Select input.
+ * Props are typed as `any` because react-select's generic types don't
+ * match the specific option shape our Select wrapper uses. This matches
+ * the pattern used in scmRepoSelector and elsewhere in the codebase.
+ */
+function SearchControl({children, ...props}: any) {
+  return (
+    <selectComponents.Control {...props}>
+      <IconSearch size="sm" variant="muted" style={{marginLeft: 12, flexShrink: 0}} />
+      {children}
+    </selectComponents.Control>
+  );
+}
 
 function toSelectedSdk(info: PlatformIntegration): OnboardingSelectedSDK {
   return {
@@ -354,14 +371,17 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
           <motion.div {...SCM_STEP_FADE_IN}>
             <Stack gap="md" align="center">
               <Heading as="h3">{t('Select a platform')}</Heading>
-              <CompactSelect
-                search={{
-                  placeholder: t('Search 100+ SDKs by name, package, or description...'),
-                }}
+              <Select
+                placeholder={t('Search 100+ SDKs by name, package, or description...')}
                 options={platformOptions}
-                value={currentPlatformKey ?? ''}
-                onChange={handleManualPlatformSelect}
-                virtualizeThreshold={50}
+                value={currentPlatformKey ?? null}
+                onChange={option => {
+                  if (option) {
+                    handleManualPlatformSelect(option);
+                  }
+                }}
+                searchable
+                components={{Control: SearchControl}}
               />
               {hasScmConnected && (
                 <Button

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState, type ReactNode} from 'react';
 import {motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
@@ -48,8 +48,10 @@ const platformOptions = platforms.map(platform => ({
   value: platform.id,
   label: platform.name,
   textValue: `${platform.name} ${platform.id}`,
-  leadingItems: <PlatformIcon platform={platform.id} size={16} />,
+  leadingItems: (<PlatformIcon platform={platform.id} size={16} />) as ReactNode,
 }));
+
+type PlatformOption = (typeof platformOptions)[number];
 
 function toSelectedSdk(info: PlatformIntegration): OnboardingSelectedSDK {
   return {
@@ -294,6 +296,31 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     [selectedPlatform?.key, setPlatform, setSelectedFeatures, organization]
   );
 
+  // Ensure the selected platform is always present in the dropdown options.
+  // When the framework suggestion modal picks a specific framework (e.g.
+  // javascript-nextjs from a "javascript" base language selection), the key
+  // is already in the static list. But if a platform was set externally and
+  // isn't in the list, prepend it so the Select can resolve and display it.
+  const manualPickerOptions = useMemo(() => {
+    const key = currentPlatformKey;
+    if (!key || platformOptions.some(o => o.value === key)) {
+      return platformOptions;
+    }
+    const info = getPlatformInfo(key);
+    if (!info) {
+      return platformOptions;
+    }
+    return [
+      {
+        value: info.id,
+        label: info.name,
+        textValue: `${info.name} ${info.id}`,
+        leadingItems: (<PlatformIcon platform={info.id} size={16} />) as ReactNode,
+      },
+      ...platformOptions,
+    ];
+  }, [currentPlatformKey]);
+
   // If the user previously selected a platform manually (not in the detected
   // list), show the manual picker so their selection is visible.
   const currentPlatformIsDetected = resolvedPlatforms.some(
@@ -366,9 +393,9 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
           <motion.div {...SCM_STEP_FADE_IN}>
             <Stack gap="md" align="center">
               <Heading as="h3">{t('Select a platform')}</Heading>
-              <Select
+              <Select<PlatformOption>
                 placeholder={t('Search 100+ SDKs by name, package, or description...')}
-                options={platformOptions}
+                options={manualPickerOptions}
                 value={currentPlatformKey ?? null}
                 onChange={option => {
                   if (option) {
@@ -377,6 +404,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                 }}
                 searchable
                 components={{Control: ScmSearchControl}}
+                styles={{container: base => ({...base, width: '100%'})}}
               />
               {hasScmConnected && (
                 <Button

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,10 +1,11 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import {motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Heading} from '@sentry/scraps/text';
 
 import {closeModal, openConsoleModal, openModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -19,15 +20,19 @@ import {platforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
 import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
 
+import {ScmStepFooter} from './components/scmStepFooter';
+import {ScmStepHeader} from './components/scmStepHeader';
 import {
   useScmPlatformDetection,
   type DetectedPlatform,
 } from './components/useScmPlatformDetection';
+import {SCM_STEP_FADE_IN, scmStepFadeIn} from './consts';
 import type {StepProps} from './types';
 
 interface ResolvedPlatform extends DetectedPlatform {
@@ -66,6 +71,10 @@ function shouldSuggestFramework(platformKey: PlatformKey): boolean {
   );
 }
 
+// Width for the platform/feature content area (matches Figma spec).
+// Wider than SCM_STEP_CONTENT_WIDTH (506px) used by the footer.
+const PLATFORM_CONTENT_WIDTH = '564px';
+
 export function ScmPlatformFeatures({onComplete}: StepProps) {
   const organization = useOrganization();
   const {
@@ -77,6 +86,10 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
   } = useOnboardingContext();
 
   const [showManualPicker, setShowManualPicker] = useState(false);
+
+  useEffect(() => {
+    trackAnalytics('onboarding.scm_platform_features_step_viewed', {organization});
+  }, [organization]);
 
   const setPlatform = useCallback(
     (platformKey: PlatformKey) => {
@@ -140,8 +153,9 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
         return;
       }
 
+      const wasEnabled = currentFeatures.includes(feature);
       const newFeatures = new Set(
-        currentFeatures.includes(feature)
+        wasEnabled
           ? currentFeatures.filter(f => f !== feature)
           : [...currentFeatures, feature]
       );
@@ -162,8 +176,22 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
       }
 
       setSelectedFeatures(Array.from(newFeatures));
+
+      trackAnalytics('onboarding.scm_platform_feature_toggled', {
+        organization,
+        feature,
+        enabled: !wasEnabled,
+        platform: currentPlatformKey ?? '',
+      });
     },
-    [currentFeatures, setSelectedFeatures, disabledProducts, availableFeatures]
+    [
+      currentFeatures,
+      setSelectedFeatures,
+      disabledProducts,
+      availableFeatures,
+      organization,
+      currentPlatformKey,
+    ]
   );
 
   const applyPlatformSelection = useCallback(
@@ -230,6 +258,12 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
 
       setPlatform(platformKey);
       setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
+
+      trackAnalytics('onboarding.scm_platform_selected', {
+        organization,
+        platform: platformKey,
+        source: 'manual',
+      });
     },
     [
       selectedPlatform?.key,
@@ -247,8 +281,14 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
       }
       setPlatform(platformKey);
       setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
+
+      trackAnalytics('onboarding.scm_platform_selected', {
+        organization,
+        platform: platformKey,
+        source: 'detected',
+      });
     },
-    [selectedPlatform?.key, setPlatform, setSelectedFeatures]
+    [selectedPlatform?.key, setPlatform, setSelectedFeatures, organization]
   );
 
   // If the user previously selected a platform manually (not in the detected
@@ -264,102 +304,121 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     (!currentPlatformKey || currentPlatformIsDetected);
 
   return (
-    <Flex direction="column" align="center" gap="xl" flexGrow={1}>
-      <Stack align="center" gap="md">
-        <Heading as="h2">{t('Platform & features')}</Heading>
-        <Text variant="muted">
-          {t('Select your SDK first, then choose the features to enable.')}
-        </Text>
-      </Stack>
+    <Flex direction="column" align="center" gap="2xl" flexGrow={1}>
+      <ScmStepHeader
+        stepNumber={2}
+        heading={t('Platform & features')}
+        subtitle={t('Select your SDK first, then choose the features to enable.')}
+      />
 
-      <Stack gap="lg" width="100%" maxWidth="600px">
+      <Stack gap="lg" width="100%" maxWidth={PLATFORM_CONTENT_WIDTH}>
         {showDetectedPlatforms ? (
-          <Stack gap="md">
-            <Heading as="h3">{t('Recommended SDK')}</Heading>
-            {isDetecting ? (
-              <Flex justify="center" padding="xl">
-                <LoadingIndicator mini />
-              </Flex>
-            ) : (
-              <Stack gap="sm">
-                <Flex gap="md" wrap="wrap" role="radiogroup">
-                  {resolvedPlatforms.map(({platform, info}) => (
-                    <ScmPlatformCard
-                      key={platform}
-                      platform={platform}
-                      name={info.name}
-                      type={info.type}
-                      isSelected={currentPlatformKey === platform}
-                      onClick={() => handleSelectDetectedPlatform(platform)}
-                    />
-                  ))}
+          <motion.div {...SCM_STEP_FADE_IN}>
+            <Stack gap="md">
+              <Heading as="h3">{t('Recommended SDK')}</Heading>
+              {isDetecting ? (
+                <Flex justify="center" padding="xl">
+                  <LoadingIndicator mini />
                 </Flex>
-                <Button
-                  size="zero"
-                  priority="transparent"
-                  onClick={() => setShowManualPicker(true)}
-                >
-                  {t("Doesn't look right? Change platform")}
-                </Button>
-              </Stack>
-            )}
-          </Stack>
+              ) : (
+                <Stack gap="sm">
+                  <Flex gap="md" wrap="wrap" role="radiogroup">
+                    {resolvedPlatforms.map(({platform, info}) => (
+                      <ScmPlatformCard
+                        key={platform}
+                        platform={platform}
+                        name={info.name}
+                        type={info.type}
+                        isSelected={currentPlatformKey === platform}
+                        onClick={() => handleSelectDetectedPlatform(platform)}
+                      />
+                    ))}
+                  </Flex>
+                  <Button
+                    size="xs"
+                    priority="link"
+                    onClick={() => {
+                      setShowManualPicker(true);
+                      trackAnalytics('onboarding.scm_platform_change_platform_clicked', {
+                        organization,
+                      });
+                    }}
+                  >
+                    {t("Doesn't look right? Change platform")}
+                  </Button>
+                </Stack>
+              )}
+            </Stack>
+          </motion.div>
         ) : (
-          <Stack gap="md">
-            <Heading as="h3">{t('Select a platform')}</Heading>
-            <CompactSelect
-              search={{
-                placeholder: t('Search SDKs by name...'),
-              }}
-              options={platformOptions}
-              value={currentPlatformKey ?? ''}
-              onChange={handleManualPlatformSelect}
-              virtualizeThreshold={50}
-            />
-            {hasScmConnected && (
-              <Button
-                size="zero"
-                priority="transparent"
-                onClick={() => {
-                  setShowManualPicker(false);
-                  if (detectedPlatformKey) {
-                    setPlatform(detectedPlatformKey);
-                    setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
-                  }
+          <motion.div {...SCM_STEP_FADE_IN}>
+            <Stack gap="md" align="center">
+              <Heading as="h3">{t('Select a platform')}</Heading>
+              <CompactSelect
+                search={{
+                  placeholder: t('Search 100+ SDKs by name, package, or description...'),
                 }}
-              >
-                {t('Back to recommended platforms')}
-              </Button>
-            )}
-          </Stack>
+                options={platformOptions}
+                value={currentPlatformKey ?? ''}
+                onChange={handleManualPlatformSelect}
+                virtualizeThreshold={50}
+              />
+              {hasScmConnected && (
+                <Button
+                  size="xs"
+                  priority="link"
+                  onClick={() => {
+                    setShowManualPicker(false);
+                    if (detectedPlatformKey) {
+                      setPlatform(detectedPlatformKey);
+                      setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
+                    }
+                  }}
+                >
+                  {t('Back to recommended platforms')}
+                </Button>
+              )}
+            </Stack>
+          </motion.div>
         )}
 
         {availableFeatures.length > 0 && (
-          <ScmFeatureSelectionCards
-            availableFeatures={availableFeatures}
-            selectedFeatures={currentFeatures}
-            disabledProducts={disabledProducts}
-            onToggleFeature={handleToggleFeature}
-          />
+          <motion.div {...scmStepFadeIn(0.1)}>
+            <ScmFeatureSelectionCards
+              availableFeatures={availableFeatures}
+              selectedFeatures={currentFeatures}
+              disabledProducts={disabledProducts}
+              onToggleFeature={handleToggleFeature}
+            />
+          </motion.div>
         )}
       </Stack>
 
-      <Button
-        priority="primary"
-        onClick={() => {
-          // Persist derived defaults to context if user accepted them
-          if (currentPlatformKey && !selectedPlatform?.key) {
-            setPlatform(currentPlatformKey);
-          }
-          if (!selectedFeatures) {
-            setSelectedFeatures(currentFeatures);
-          }
-          onComplete();
-        }}
-        disabled={!currentPlatformKey}
-      >
-        {t('Continue')}
-      </Button>
+      <ScmStepFooter>
+        <Button
+          priority="primary"
+          analyticsEventKey="onboarding.scm_platform_features_continue_clicked"
+          analyticsEventName="Onboarding: SCM Platform Features Continue Clicked"
+          analyticsParams={{
+            platform: currentPlatformKey ?? '',
+            source: showDetectedPlatforms ? 'detected' : 'manual',
+            features: currentFeatures,
+          }}
+          onClick={() => {
+            // Persist derived defaults to context if user accepted them
+            if (currentPlatformKey && !selectedPlatform?.key) {
+              setPlatform(currentPlatformKey);
+            }
+            if (!selectedFeatures) {
+              setSelectedFeatures(currentFeatures);
+            }
+            onComplete();
+          }}
+          disabled={!currentPlatformKey}
+        >
+          {t('Continue')}
+        </Button>
+      </ScmStepFooter>
     </Flex>
   );
 }

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -8,7 +8,6 @@ import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
 import {closeModal, openConsoleModal, openModal} from 'sentry/actionCreators/modal';
-import {components as selectComponents} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -18,7 +17,6 @@ import {
   platformProductAvailability,
 } from 'sentry/components/onboarding/productSelection';
 import {platforms} from 'sentry/data/platforms';
-import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
@@ -28,6 +26,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
 import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
 
+import {ScmSearchControl} from './components/scmSearchControl';
 import {ScmStepFooter} from './components/scmStepFooter';
 import {ScmStepHeader} from './components/scmStepHeader';
 import {
@@ -51,21 +50,6 @@ const platformOptions = platforms.map(platform => ({
   textValue: `${platform.name} ${platform.id}`,
   leadingItems: <PlatformIcon platform={platform.id} size={16} />,
 }));
-
-/**
- * Custom Control that prepends a search icon inside the Select input.
- * Props are typed as `any` because react-select's generic types don't
- * match the specific option shape our Select wrapper uses. This matches
- * the pattern used in scmRepoSelector and elsewhere in the codebase.
- */
-function SearchControl({children, ...props}: any) {
-  return (
-    <selectComponents.Control {...props}>
-      <IconSearch size="sm" variant="muted" style={{marginLeft: 12, flexShrink: 0}} />
-      {children}
-    </selectComponents.Control>
-  );
-}
 
 function toSelectedSdk(info: PlatformIntegration): OnboardingSelectedSDK {
   return {
@@ -338,9 +322,16 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
             <Stack gap="md">
               <Heading as="h3">{t('Recommended SDK')}</Heading>
               {isDetecting ? (
-                <Flex justify="center" padding="xl">
+                <Stack gap="md" align="center" padding="xl">
                   <LoadingIndicator mini />
-                </Flex>
+                  <Button
+                    size="xs"
+                    priority="link"
+                    onClick={() => setShowManualPicker(true)}
+                  >
+                    {t('Skip detection and select manually')}
+                  </Button>
+                </Stack>
               ) : (
                 <Stack gap="sm">
                   <Flex gap="md" wrap="wrap" role="radiogroup">
@@ -385,7 +376,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                   }
                 }}
                 searchable
-                components={{Control: SearchControl}}
+                components={{Control: ScmSearchControl}}
               />
               {hasScmConnected && (
                 <Button

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -29,6 +29,7 @@ import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCar
 import {ScmSearchControl} from './components/scmSearchControl';
 import {ScmStepFooter} from './components/scmStepFooter';
 import {ScmStepHeader} from './components/scmStepHeader';
+import {ScmVirtualizedMenuList} from './components/scmVirtualizedMenuList';
 import {
   useScmPlatformDetection,
   type DetectedPlatform,
@@ -296,11 +297,9 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     [selectedPlatform?.key, setPlatform, setSelectedFeatures, organization]
   );
 
-  // Ensure the selected platform is always present in the dropdown options.
-  // When the framework suggestion modal picks a specific framework (e.g.
-  // javascript-nextjs from a "javascript" base language selection), the key
-  // is already in the static list. But if a platform was set externally and
-  // isn't in the list, prepend it so the Select can resolve and display it.
+  // Ensure the selected platform is always present in the dropdown options
+  // so the Select can resolve and display it. When the framework suggestion
+  // modal picks a key not in the static list, prepend it.
   const manualPickerOptions = useMemo(() => {
     const key = currentPlatformKey;
     if (!key || platformOptions.some(o => o.value === key)) {
@@ -403,7 +402,10 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                   }
                 }}
                 searchable
-                components={{Control: ScmSearchControl}}
+                components={{
+                  Control: ScmSearchControl,
+                  MenuList: ScmVirtualizedMenuList,
+                }}
                 styles={{container: base => ({...base, width: '100%'})}}
               />
               {hasScmConnected && (

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -446,7 +446,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
               }}
               styles={{container: base => ({...base, width: '100%'})}}
             />
-            {hasScmConnected && (
+            {hasScmConnected && !isDetectionError && (
               <Button size="xs" priority="link" onClick={handleBackToRecommended}>
                 {t('Back to recommended platforms')}
               </Button>

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -294,6 +294,34 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     [selectedPlatform?.key, setPlatform, setSelectedFeatures, organization]
   );
 
+  function handleChangePlatformClick() {
+    setShowManualPicker(true);
+    if (!isDetecting) {
+      trackAnalytics('onboarding.scm_platform_change_platform_clicked', {
+        organization,
+      });
+    }
+  }
+
+  function handleBackToRecommended() {
+    setShowManualPicker(false);
+    if (detectedPlatformKey) {
+      setPlatform(detectedPlatformKey);
+      setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
+    }
+  }
+
+  function handleContinue() {
+    // Persist derived defaults to context if user accepted them
+    if (currentPlatformKey && !selectedPlatform?.key) {
+      setPlatform(currentPlatformKey);
+    }
+    if (!selectedFeatures) {
+      setSelectedFeatures(currentFeatures);
+    }
+    onComplete();
+  }
+
   // Ensure the selected platform is always present in the dropdown options
   // so the Select can resolve and display it. When the framework suggestion
   // modal picks a key not in the static list, prepend it.
@@ -375,18 +403,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                 </Grid>
               )}
 
-              <Button
-                size="xs"
-                priority="link"
-                onClick={() => {
-                  setShowManualPicker(true);
-                  if (!isDetecting) {
-                    trackAnalytics('onboarding.scm_platform_change_platform_clicked', {
-                      organization,
-                    });
-                  }
-                }}
-              >
+              <Button size="xs" priority="link" onClick={handleChangePlatformClick}>
                 {isDetecting
                   ? t('Skip detection and select manually')
                   : t("Doesn't look right? Change platform")}
@@ -422,17 +439,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
               styles={{container: base => ({...base, width: '100%'})}}
             />
             {hasScmConnected && (
-              <Button
-                size="xs"
-                priority="link"
-                onClick={() => {
-                  setShowManualPicker(false);
-                  if (detectedPlatformKey) {
-                    setPlatform(detectedPlatformKey);
-                    setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
-                  }
-                }}
-              >
+              <Button size="xs" priority="link" onClick={handleBackToRecommended}>
                 {t('Back to recommended platforms')}
               </Button>
             )}
@@ -460,16 +467,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                 source: showDetectedPlatforms ? 'detected' : 'manual',
                 features: currentFeatures,
               }}
-              onClick={() => {
-                // Persist derived defaults to context if user accepted them
-                if (currentPlatformKey && !selectedPlatform?.key) {
-                  setPlatform(currentPlatformKey);
-                }
-                if (!selectedFeatures) {
-                  setSelectedFeatures(currentFeatures);
-                }
-                onComplete();
-              }}
+              onClick={handleContinue}
               disabled={!currentPlatformKey}
             >
               {t('Continue')}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -351,19 +351,10 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
             width="100%"
           >
             <Heading as="h3">{t('Recommended SDK')}</Heading>
-            {isDetecting ? (
-              <Stack gap="md" align="center" padding="xl">
+            <Stack gap="sm" align="center" width="100%">
+              {isDetecting ? (
                 <LoadingIndicator mini />
-                <Button
-                  size="xs"
-                  priority="link"
-                  onClick={() => setShowManualPicker(true)}
-                >
-                  {t('Skip detection and select manually')}
-                </Button>
-              </Stack>
-            ) : (
-              <Stack gap="sm" align="center" width="100%">
+              ) : (
                 <Grid
                   autoColumns="1fr"
                   flow="column"
@@ -382,20 +373,25 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                     />
                   ))}
                 </Grid>
-                <Button
-                  size="xs"
-                  priority="link"
-                  onClick={() => {
-                    setShowManualPicker(true);
+              )}
+
+              <Button
+                size="xs"
+                priority="link"
+                onClick={() => {
+                  setShowManualPicker(true);
+                  if (!isDetecting) {
                     trackAnalytics('onboarding.scm_platform_change_platform_clicked', {
                       organization,
                     });
-                  }}
-                >
-                  {t("Doesn't look right? Change platform")}
-                </Button>
-              </Stack>
-            )}
+                  }
+                }}
+              >
+                {isDetecting
+                  ? t('Skip detection and select manually')
+                  : t("Doesn't look right? Change platform")}
+              </Button>
+            </Stack>
           </MotionStack>
         ) : (
           <MotionStack

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,9 +1,9 @@
 import {useCallback, useEffect, useMemo, useState, type ReactNode} from 'react';
-import {motion} from 'framer-motion';
+import {LayoutGroup, motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
@@ -34,7 +34,6 @@ import {
   useScmPlatformDetection,
   type DetectedPlatform,
 } from './components/useScmPlatformDetection';
-import {SCM_STEP_FADE_IN, scmStepFadeIn} from './consts';
 import type {StepProps} from './types';
 
 interface ResolvedPlatform extends DetectedPlatform {
@@ -342,130 +341,144 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
         subtitle={t('Select your SDK first, then choose the features to enable.')}
       />
 
-      {showDetectedPlatforms && (
-        <MotionStack {...SCM_STEP_FADE_IN} gap="md" align="center">
-          <Heading as="h3">{t('Recommended SDK')}</Heading>
-          {isDetecting ? (
-            <Stack gap="md" align="center" padding="xl">
-              <LoadingIndicator mini />
-              <Button size="xs" priority="link" onClick={() => setShowManualPicker(true)}>
-                {t('Skip detection and select manually')}
-              </Button>
-            </Stack>
-          ) : (
-            <Stack gap="sm" align="center">
-              <Grid autoColumns="1fr" flow="column" gap="md" role="radiogroup">
-                {resolvedPlatforms.map(({platform, info}) => (
-                  <ScmPlatformCard
-                    key={platform}
-                    platform={platform}
-                    name={info.name}
-                    type={info.type}
-                    isSelected={currentPlatformKey === platform}
-                    onClick={() => handleSelectDetectedPlatform(platform)}
-                  />
-                ))}
-              </Grid>
+      <LayoutGroup>
+        {showDetectedPlatforms ? (
+          <MotionStack
+            key="detected"
+            exit={{opacity: 0}}
+            gap="md"
+            align="center"
+            width="100%"
+          >
+            <Heading as="h3">{t('Recommended SDK')}</Heading>
+            {isDetecting ? (
+              <Stack gap="md" align="center" padding="xl">
+                <LoadingIndicator mini />
+                <Button
+                  size="xs"
+                  priority="link"
+                  onClick={() => setShowManualPicker(true)}
+                >
+                  {t('Skip detection and select manually')}
+                </Button>
+              </Stack>
+            ) : (
+              <Stack gap="sm" align="center" width="100%">
+                <Grid
+                  autoColumns="1fr"
+                  flow="column"
+                  justify="center"
+                  gap="md"
+                  role="radiogroup"
+                >
+                  {resolvedPlatforms.map(({platform, info}) => (
+                    <ScmPlatformCard
+                      key={platform}
+                      platform={platform}
+                      name={info.name}
+                      type={info.type}
+                      isSelected={currentPlatformKey === platform}
+                      onClick={() => handleSelectDetectedPlatform(platform)}
+                    />
+                  ))}
+                </Grid>
+                <Button
+                  size="xs"
+                  priority="link"
+                  onClick={() => {
+                    setShowManualPicker(true);
+                    trackAnalytics('onboarding.scm_platform_change_platform_clicked', {
+                      organization,
+                    });
+                  }}
+                >
+                  {t("Doesn't look right? Change platform")}
+                </Button>
+              </Stack>
+            )}
+          </MotionStack>
+        ) : (
+          <MotionStack
+            key="manual"
+            gap="md"
+            align="center"
+            width="100%"
+            maxWidth={PLATFORM_CONTENT_WIDTH}
+            exit={{opacity: 0}}
+          >
+            <Heading as="h3">{t('Select a platform')}</Heading>
+            <Select<PlatformOption>
+              placeholder={t('Search 100+ SDKs by name, package, or description...')}
+              options={manualPickerOptions}
+              value={currentPlatformKey ?? null}
+              onChange={option => {
+                if (option) {
+                  handleManualPlatformSelect(option);
+                }
+              }}
+              searchable
+              components={{
+                Control: ScmSearchControl,
+                MenuList: ScmVirtualizedMenuList,
+              }}
+              styles={{container: base => ({...base, width: '100%'})}}
+            />
+            {hasScmConnected && (
               <Button
                 size="xs"
                 priority="link"
                 onClick={() => {
-                  setShowManualPicker(true);
-                  trackAnalytics('onboarding.scm_platform_change_platform_clicked', {
-                    organization,
-                  });
+                  setShowManualPicker(false);
+                  if (detectedPlatformKey) {
+                    setPlatform(detectedPlatformKey);
+                    setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
+                  }
                 }}
               >
-                {t("Doesn't look right? Change platform")}
+                {t('Back to recommended platforms')}
               </Button>
-            </Stack>
-          )}
-        </MotionStack>
-      )}
+            )}
+          </MotionStack>
+        )}
 
-      {!showDetectedPlatforms && (
-        <MotionStack
-          gap="md"
-          align="center"
-          width="100%"
-          maxWidth={PLATFORM_CONTENT_WIDTH}
-          {...SCM_STEP_FADE_IN}
-        >
-          <Heading as="h3">{t('Select a platform')}</Heading>
-          <Select<PlatformOption>
-            placeholder={t('Search 100+ SDKs by name, package, or description...')}
-            options={manualPickerOptions}
-            value={currentPlatformKey ?? null}
-            onChange={option => {
-              if (option) {
-                handleManualPlatformSelect(option);
-              }
-            }}
-            searchable
-            components={{
-              Control: ScmSearchControl,
-              MenuList: ScmVirtualizedMenuList,
-            }}
-            styles={{container: base => ({...base, width: '100%'})}}
-          />
-          {hasScmConnected && (
+        <MotionStack layout="position" width="100%" align="center">
+          {availableFeatures.length > 0 && (
+            <Container width="100%" maxWidth={PLATFORM_CONTENT_WIDTH}>
+              <ScmFeatureSelectionCards
+                availableFeatures={availableFeatures}
+                selectedFeatures={currentFeatures}
+                disabledProducts={disabledProducts}
+                onToggleFeature={handleToggleFeature}
+              />
+            </Container>
+          )}
+          <ScmStepFooter maxWidth={PLATFORM_CONTENT_WIDTH}>
             <Button
-              size="xs"
-              priority="link"
-              onClick={() => {
-                setShowManualPicker(false);
-                if (detectedPlatformKey) {
-                  setPlatform(detectedPlatformKey);
-                  setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
-                }
+              priority="primary"
+              analyticsEventKey="onboarding.scm_platform_features_continue_clicked"
+              analyticsEventName="Onboarding: SCM Platform Features Continue Clicked"
+              analyticsParams={{
+                platform: currentPlatformKey ?? '',
+                source: showDetectedPlatforms ? 'detected' : 'manual',
+                features: currentFeatures,
               }}
+              onClick={() => {
+                // Persist derived defaults to context if user accepted them
+                if (currentPlatformKey && !selectedPlatform?.key) {
+                  setPlatform(currentPlatformKey);
+                }
+                if (!selectedFeatures) {
+                  setSelectedFeatures(currentFeatures);
+                }
+                onComplete();
+              }}
+              disabled={!currentPlatformKey}
             >
-              {t('Back to recommended platforms')}
+              {t('Continue')}
             </Button>
-          )}
+          </ScmStepFooter>
         </MotionStack>
-      )}
-
-      {availableFeatures.length > 0 && (
-        <MotionStack
-          {...scmStepFadeIn(0.1)}
-          width="100%"
-          maxWidth={PLATFORM_CONTENT_WIDTH}
-        >
-          <ScmFeatureSelectionCards
-            availableFeatures={availableFeatures}
-            selectedFeatures={currentFeatures}
-            disabledProducts={disabledProducts}
-            onToggleFeature={handleToggleFeature}
-          />
-        </MotionStack>
-      )}
-
-      <ScmStepFooter>
-        <Button
-          priority="primary"
-          analyticsEventKey="onboarding.scm_platform_features_continue_clicked"
-          analyticsEventName="Onboarding: SCM Platform Features Continue Clicked"
-          analyticsParams={{
-            platform: currentPlatformKey ?? '',
-            source: showDetectedPlatforms ? 'detected' : 'manual',
-            features: currentFeatures,
-          }}
-          onClick={() => {
-            // Persist derived defaults to context if user accepted them
-            if (currentPlatformKey && !selectedPlatform?.key) {
-              setPlatform(currentPlatformKey);
-            }
-            if (!selectedFeatures) {
-              setSelectedFeatures(currentFeatures);
-            }
-            onComplete();
-          }}
-          disabled={!currentPlatformKey}
-        >
-          {t('Continue')}
-        </Button>
-      </ScmStepFooter>
+      </LayoutGroup>
     </Flex>
   );
 }

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -245,10 +245,20 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
               selectedPlatform={baseSdk}
               onConfigure={selectedFramework => {
                 applyPlatformSelection(selectedFramework);
+                trackAnalytics('onboarding.scm_platform_selected', {
+                  organization,
+                  platform: selectedFramework.key,
+                  source: 'manual',
+                });
                 closeModal();
               }}
               onSkip={() => {
                 applyPlatformSelection(baseSdk);
+                trackAnalytics('onboarding.scm_platform_selected', {
+                  organization,
+                  platform: platformKey,
+                  source: 'manual',
+                });
                 closeModal();
               }}
               newOrg

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -120,9 +120,11 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
 
   const hasScmConnected = !!selectedRepository;
 
-  const {detectedPlatforms, isPending: isDetecting} = useScmPlatformDetection(
-    hasScmConnected ? selectedRepository.id : undefined
-  );
+  const {
+    detectedPlatforms,
+    isPending: isDetecting,
+    isError: isDetectionError,
+  } = useScmPlatformDetection(hasScmConnected ? selectedRepository.id : undefined);
 
   const currentFeatures = useMemo(
     () => selectedFeatures ?? [ProductSolution.ERROR_MONITORING],
@@ -314,9 +316,11 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     p => p.platform === currentPlatformKey
   );
   const hasDetectedPlatforms = resolvedPlatforms.length > 0 || isDetecting;
+  // Fall through to manual picker on detection error
   const showDetectedPlatforms =
     hasScmConnected &&
     !showManualPicker &&
+    !isDetectionError &&
     hasDetectedPlatforms &&
     (!currentPlatformKey || currentPlatformIsDetected);
 

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -381,7 +381,6 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
         {showDetectedPlatforms ? (
           <MotionStack
             key="detected"
-            exit={{opacity: 0}}
             initial={{opacity: 0}}
             animate={{opacity: 1}}
             gap="md"
@@ -427,7 +426,6 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
             align="center"
             width="100%"
             maxWidth={PLATFORM_CONTENT_WIDTH}
-            exit={{opacity: 0}}
             initial={{opacity: 0}}
             animate={{opacity: 1}}
           >

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState, type ReactNode} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import {LayoutGroup, motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
@@ -48,10 +48,8 @@ const platformOptions = platforms.map(platform => ({
   value: platform.id,
   label: platform.name,
   textValue: `${platform.name} ${platform.id}`,
-  leadingItems: (<PlatformIcon platform={platform.id} size={16} />) as ReactNode,
+  leadingItems: <PlatformIcon platform={platform.id} size={16} />,
 }));
-
-type PlatformOption = (typeof platformOptions)[number];
 
 function toSelectedSdk(info: PlatformIntegration): OnboardingSelectedSDK {
   return {
@@ -313,7 +311,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
         value: info.id,
         label: info.name,
         textValue: `${info.name} ${info.id}`,
-        leadingItems: (<PlatformIcon platform={info.id} size={16} />) as ReactNode,
+        leadingItems: <PlatformIcon platform={info.id} size={16} />,
       },
       ...platformOptions,
     ];
@@ -346,6 +344,8 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
           <MotionStack
             key="detected"
             exit={{opacity: 0}}
+            initial={{opacity: 0}}
+            animate={{opacity: 1}}
             gap="md"
             align="center"
             width="100%"
@@ -405,9 +405,11 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
             width="100%"
             maxWidth={PLATFORM_CONTENT_WIDTH}
             exit={{opacity: 0}}
+            initial={{opacity: 0}}
+            animate={{opacity: 1}}
           >
             <Heading as="h3">{t('Select a platform')}</Heading>
-            <Select<PlatformOption>
+            <Select<(typeof platformOptions)[number]>
               placeholder={t('Search 100+ SDKs by name, package, or description...')}
               options={manualPickerOptions}
               value={currentPlatformKey ?? null}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -3,7 +3,7 @@ import {motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
@@ -342,102 +342,104 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
         subtitle={t('Select your SDK first, then choose the features to enable.')}
       />
 
-      <Stack gap="lg" width="100%" maxWidth={PLATFORM_CONTENT_WIDTH}>
-        {showDetectedPlatforms ? (
-          <motion.div {...SCM_STEP_FADE_IN}>
-            <Stack gap="md">
-              <Heading as="h3">{t('Recommended SDK')}</Heading>
-              {isDetecting ? (
-                <Stack gap="md" align="center" padding="xl">
-                  <LoadingIndicator mini />
-                  <Button
-                    size="xs"
-                    priority="link"
-                    onClick={() => setShowManualPicker(true)}
-                  >
-                    {t('Skip detection and select manually')}
-                  </Button>
-                </Stack>
-              ) : (
-                <Stack gap="sm">
-                  <Flex gap="md" wrap="wrap" role="radiogroup">
-                    {resolvedPlatforms.map(({platform, info}) => (
-                      <ScmPlatformCard
-                        key={platform}
-                        platform={platform}
-                        name={info.name}
-                        type={info.type}
-                        isSelected={currentPlatformKey === platform}
-                        onClick={() => handleSelectDetectedPlatform(platform)}
-                      />
-                    ))}
-                  </Flex>
-                  <Button
-                    size="xs"
-                    priority="link"
-                    onClick={() => {
-                      setShowManualPicker(true);
-                      trackAnalytics('onboarding.scm_platform_change_platform_clicked', {
-                        organization,
-                      });
-                    }}
-                  >
-                    {t("Doesn't look right? Change platform")}
-                  </Button>
-                </Stack>
-              )}
+      {showDetectedPlatforms && (
+        <MotionStack {...SCM_STEP_FADE_IN} gap="md" align="center">
+          <Heading as="h3">{t('Recommended SDK')}</Heading>
+          {isDetecting ? (
+            <Stack gap="md" align="center" padding="xl">
+              <LoadingIndicator mini />
+              <Button size="xs" priority="link" onClick={() => setShowManualPicker(true)}>
+                {t('Skip detection and select manually')}
+              </Button>
             </Stack>
-          </motion.div>
-        ) : (
-          <motion.div {...SCM_STEP_FADE_IN}>
-            <Stack gap="md" align="center">
-              <Heading as="h3">{t('Select a platform')}</Heading>
-              <Select<PlatformOption>
-                placeholder={t('Search 100+ SDKs by name, package, or description...')}
-                options={manualPickerOptions}
-                value={currentPlatformKey ?? null}
-                onChange={option => {
-                  if (option) {
-                    handleManualPlatformSelect(option);
-                  }
+          ) : (
+            <Stack gap="sm" align="center">
+              <Grid autoColumns="1fr" flow="column" gap="md" role="radiogroup">
+                {resolvedPlatforms.map(({platform, info}) => (
+                  <ScmPlatformCard
+                    key={platform}
+                    platform={platform}
+                    name={info.name}
+                    type={info.type}
+                    isSelected={currentPlatformKey === platform}
+                    onClick={() => handleSelectDetectedPlatform(platform)}
+                  />
+                ))}
+              </Grid>
+              <Button
+                size="xs"
+                priority="link"
+                onClick={() => {
+                  setShowManualPicker(true);
+                  trackAnalytics('onboarding.scm_platform_change_platform_clicked', {
+                    organization,
+                  });
                 }}
-                searchable
-                components={{
-                  Control: ScmSearchControl,
-                  MenuList: ScmVirtualizedMenuList,
-                }}
-                styles={{container: base => ({...base, width: '100%'})}}
-              />
-              {hasScmConnected && (
-                <Button
-                  size="xs"
-                  priority="link"
-                  onClick={() => {
-                    setShowManualPicker(false);
-                    if (detectedPlatformKey) {
-                      setPlatform(detectedPlatformKey);
-                      setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
-                    }
-                  }}
-                >
-                  {t('Back to recommended platforms')}
-                </Button>
-              )}
+              >
+                {t("Doesn't look right? Change platform")}
+              </Button>
             </Stack>
-          </motion.div>
-        )}
+          )}
+        </MotionStack>
+      )}
 
-        {availableFeatures.length > 0 && (
-          <motion.div {...scmStepFadeIn(0.1)}>
-            <ScmFeatureSelectionCards
-              availableFeatures={availableFeatures}
-              selectedFeatures={currentFeatures}
-              disabledProducts={disabledProducts}
-              onToggleFeature={handleToggleFeature}
-            />
-          </motion.div>
-        )}
-      </Stack>
+      {!showDetectedPlatforms && (
+        <MotionStack
+          gap="md"
+          align="center"
+          width="100%"
+          maxWidth={PLATFORM_CONTENT_WIDTH}
+          {...SCM_STEP_FADE_IN}
+        >
+          <Heading as="h3">{t('Select a platform')}</Heading>
+          <Select<PlatformOption>
+            placeholder={t('Search 100+ SDKs by name, package, or description...')}
+            options={manualPickerOptions}
+            value={currentPlatformKey ?? null}
+            onChange={option => {
+              if (option) {
+                handleManualPlatformSelect(option);
+              }
+            }}
+            searchable
+            components={{
+              Control: ScmSearchControl,
+              MenuList: ScmVirtualizedMenuList,
+            }}
+            styles={{container: base => ({...base, width: '100%'})}}
+          />
+          {hasScmConnected && (
+            <Button
+              size="xs"
+              priority="link"
+              onClick={() => {
+                setShowManualPicker(false);
+                if (detectedPlatformKey) {
+                  setPlatform(detectedPlatformKey);
+                  setSelectedFeatures([ProductSolution.ERROR_MONITORING]);
+                }
+              }}
+            >
+              {t('Back to recommended platforms')}
+            </Button>
+          )}
+        </MotionStack>
+      )}
+
+      {availableFeatures.length > 0 && (
+        <MotionStack
+          {...scmStepFadeIn(0.1)}
+          width="100%"
+          maxWidth={PLATFORM_CONTENT_WIDTH}
+        >
+          <ScmFeatureSelectionCards
+            availableFeatures={availableFeatures}
+            selectedFeatures={currentFeatures}
+            disabledProducts={disabledProducts}
+            onToggleFeature={handleToggleFeature}
+          />
+        </MotionStack>
+      )}
 
       <ScmStepFooter>
         <Button
@@ -467,3 +469,5 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     </Flex>
   );
 }
+
+const MotionStack = motion.create(Stack);

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -393,8 +393,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                 <LoadingIndicator mini />
               ) : (
                 <Grid
-                  autoColumns="1fr"
-                  flow="column"
+                  columns={{xs: '1fr', md: `repeat(${resolvedPlatforms.length}, 1fr)`}}
                   justify="center"
                   gap="md"
                   role="radiogroup"

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -370,7 +370,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     (!currentPlatformKey || currentPlatformIsDetected);
 
   return (
-    <Flex direction="column" align="center" gap="4xl" flexGrow={1}>
+    <Flex direction="column" align="center" flexGrow={1} style={{gap: 48}}>
       <ScmStepHeader
         stepNumber={2}
         heading={t('Platform & features')}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -370,7 +370,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     (!currentPlatformKey || currentPlatformIsDetected);
 
   return (
-    <Flex direction="column" align="center" gap="2xl" flexGrow={1}>
+    <Flex direction="column" align="center" gap="4xl" flexGrow={1}>
       <ScmStepHeader
         stepNumber={2}
         heading={t('Platform & features')}
@@ -388,7 +388,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
             width="100%"
           >
             <Heading as="h3">{t('Recommended SDK')}</Heading>
-            <Stack gap="sm" align="center" width="100%">
+            <Stack gap="lg" align="center" width="100%">
               {isDetecting ? (
                 <LoadingIndicator mini />
               ) : (

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -370,7 +370,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     (!currentPlatformKey || currentPlatformIsDetected);
 
   return (
-    <Flex direction="column" align="center" flexGrow={1} style={{gap: 48}}>
+    <Flex direction="column" align="center" gap="3xl" flexGrow={1}>
       <ScmStepHeader
         stepNumber={2}
         heading={t('Platform & features')}


### PR DESCRIPTION
## Summary

Visual polish and analytics for the SCM platform features step (step 2 of 3), aligning with Figma and following patterns from VDY-22.

**Layout**: Use ScmStepHeader/ScmStepFooter, LayoutGroup for smooth transitions between detected and manual picker sections.

**Platform cards**: Larger icons (28px), equal-width grid, skeleton loading state, "skip detection" bail-out during slow detection, error fallback to manual picker.

**Feature cards**: Match Figma sizing (padding, gaps, font sizes), 3px bottom border on unselected cards, equal-height rows, centered heading with grid areas.

**Manual picker**: Replace CompactSelect with Select + virtualized MenuList (react-select re-renders all options on hover, causing lag with 130+ platform icons).

**Analytics**: Step viewed, platform selected (detected vs manual), feature toggled, change platform clicked, continue with platform/features params.

**Shared components**: Extract ScmSearchControl (was duplicated) and ScmVirtualizedMenuList (stopgap until a Combobox scraps component exists).

Closes VDY-24

## Figma

- [Recommendations state](https://www.figma.com/design/bPNQPnm9R5Og1mTbAbdauL/Value-Discovery-%F0%9F%94%AD?node-id=265-4756&m=dev&focus-id=480-2309)
- [Manual state](https://www.figma.com/design/bPNQPnm9R5Og1mTbAbdauL/Value-Discovery-%F0%9F%94%AD?node-id=265-4756&m=dev&focus-id=503-4206)

## Test plan

- [ ] 15 unit tests passing (4 new analytics, 1 error fallback)
- [ ] Visual: both Figma variants match (recommendations + manual)
- [ ] Analytics events fire correctly in browser console
- [ ] Detection error falls back to manual picker
- [ ] Slow detection shows loading indicator with skip link