### PR TITLE
feat(dashboard): Adds warning messages on generated dashboard errors when caught in the frontend

### DIFF
--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -19,7 +19,7 @@ import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/hooks/useSeer
 import {makeSeerExplorerQueryKey} from 'sentry/views/seerExplorer/utils';
 
 import {WidgetErrorProvider} from './contexts/widgetErrorContext';
-import {DashboardChatPanel} from './dashboardChatPanel';
+import {DashboardChatPanel, type WidgetError} from './dashboardChatPanel';
 import {EMPTY_DASHBOARD} from './data';
 import {DashboardDetailWithInjectedProps as DashboardDetail} from './detail';
 import {assignDefaultLayout, assignTempId, getInitialColumnDepths} from './layoutUtils';
@@ -211,6 +211,7 @@ export default function CreateFromSeer() {
           widgets: dashboardData.widgets,
         };
         setDashboard(newDashboard);
+        reportedWidgetErrors.current.clear();
       }
     }
   }, [organization, seerRunId, isUpdating, sessionStatus, session, sessionUpdatedAt]);
@@ -219,6 +220,8 @@ export default function CreateFromSeer() {
 
   // Prevent repeat errors on the same widget
   const reportedWidgetErrors = useRef(new Set<string>());
+  // Maps widget tempId to error message
+  const widgetErrorsMap = useRef(new Map<string, WidgetError>());
 
   const handleWidgetError = useCallback(
     (widget: Widget, errorMessage: string) => {
@@ -227,6 +230,12 @@ export default function CreateFromSeer() {
         return;
       }
       reportedWidgetErrors.current.add(errorKey);
+      if (widget.tempId !== undefined) {
+        widgetErrorsMap.current.set(widget.tempId, {
+          widgetTitle: widget.title,
+          errorMessage,
+        });
+      }
 
       Sentry.withScope(scope => {
         scope.setFingerprint(['generated-dashboard-widget-query-error']);
@@ -257,6 +266,7 @@ export default function CreateFromSeer() {
       setisUpdating(true);
       completedAtRef.current = null;
       hasValidatedRef.current = false;
+      reportedWidgetErrors.current.clear();
       try {
         const queryKey = makeSeerExplorerQueryKey(organization.slug, seerRunId);
         const {url} = parseQueryKey(queryKey);
@@ -294,6 +304,14 @@ export default function CreateFromSeer() {
     return <CreateFromSeerLoading blocks={session?.blocks ?? []} seerRunId={seerRunId} />;
   }
 
+  const widgetErrors: WidgetError[] = dashboard.widgets.flatMap(widget => {
+    if (widget.tempId === undefined) {
+      return [];
+    }
+    const error = widgetErrorsMap.current.get(widget.tempId);
+    return error ? [error] : [];
+  });
+
   return (
     <ErrorBoundary>
       <WidgetErrorProvider value={handleWidgetError}>
@@ -307,6 +325,8 @@ export default function CreateFromSeer() {
           pendingUserInput={session?.pending_user_input}
           onSend={sendMessage}
           isUpdating={isUpdating}
+          isError={sessionStatus === 'error'}
+          widgetErrors={widgetErrors}
         />
       </WidgetErrorProvider>
     </ErrorBoundary>

--- a/static/app/views/dashboards/createFromSeerLoading.tsx
+++ b/static/app/views/dashboards/createFromSeerLoading.tsx
@@ -22,7 +22,11 @@ export function CreateFromSeerLoading({blocks, seerRunId}: CreateFromSeerLoading
             {t('Stay on this page while we get this made for you')}
           </Text>
           <Container overflow="hidden" maxHeight="500px" paddingTop="lg">
-            <Stack border="primary" radius="md" background="primary">
+            <Stack
+              border={blocks.length > 0 ? 'primary' : undefined}
+              radius="md"
+              background="primary"
+            >
               {blocksToRender.map((block, index) => (
                 <BlockComponent
                   key={block.id}

--- a/static/app/views/dashboards/dashboardChatPanel.tsx
+++ b/static/app/views/dashboards/dashboardChatPanel.tsx
@@ -2,6 +2,7 @@ import {memo, useCallback, useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
@@ -16,11 +17,18 @@ import type {Block} from 'sentry/views/seerExplorer/types';
 
 const MAX_CHAT_HISTORY_HEIGHT = 500;
 
+export type WidgetError = {
+  errorMessage: string;
+  widgetTitle: string;
+};
+
 interface DashboardChatPanelProps {
   blocks: Block[];
   isUpdating: boolean;
   onSend: (message: string) => void;
+  isError?: boolean;
   pendingUserInput?: PendingUserInput | null;
+  widgetErrors?: WidgetError[];
 }
 
 export function DashboardChatPanel({
@@ -28,6 +36,8 @@ export function DashboardChatPanel({
   pendingUserInput,
   onSend,
   isUpdating,
+  isError,
+  widgetErrors,
 }: DashboardChatPanelProps) {
   const theme = useTheme();
   const location = useLocation();
@@ -51,7 +61,7 @@ export function DashboardChatPanel({
     if (chatContainerRef.current) {
       chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
     }
-  }, [blocks.length, pendingUserInput]);
+  }, [blocks.length, pendingUserInput, widgetErrors?.length]);
 
   const handleSubmit = useCallback(() => {
     const trimmed = inputValue.trim();
@@ -120,6 +130,8 @@ export function DashboardChatPanel({
           blocks={blocks}
           pendingUserInput={pendingUserInput}
           seerRunId={seerRunId}
+          isError={isError}
+          widgetErrors={widgetErrors}
         />
       )}
       <InputGroup>
@@ -150,11 +162,15 @@ const ChatHistory = memo(function ChatHistoryInner({
   blocks,
   pendingUserInput,
   seerRunId,
+  isError,
+  widgetErrors,
 }: {
   blocks: Block[];
   ref: React.Ref<HTMLDivElement>;
+  isError?: boolean;
   pendingUserInput?: PendingUserInput | null;
   seerRunId?: number;
+  widgetErrors?: WidgetError[];
 }) {
   return (
     <Container
@@ -174,9 +190,36 @@ const ChatHistory = memo(function ChatHistoryInner({
           />
         ))}
         {pendingUserInput && pendingUserInput.data.questions?.length > 0 && (
-          <Container padding="xl" style={{paddingLeft: '40px'}}>
+          <ChatMessageContainer padding="xl">
             <MarkedText text={pendingUserInput.data.questions[0].question} inline />
-          </Container>
+          </ChatMessageContainer>
+        )}
+        {isError && (
+          <ChatMessageContainer padding="xl">
+            <Alert.Container>
+              <Alert variant="warning" showIcon>
+                {t(
+                  'An error was encountered while generating the dashboard. Please resubmit your prompt to try again.'
+                )}
+              </Alert>
+            </Alert.Container>
+          </ChatMessageContainer>
+        )}
+        {widgetErrors && widgetErrors.length > 0 && (
+          <ChatMessageContainer padding="xl">
+            <Alert.Container>
+              <Alert variant="warning" showIcon>
+                {t('Some widgets encountered errors. You can ask Seer to fix them.')}
+                <ul>
+                  {widgetErrors.map(({widgetTitle, errorMessage}) => (
+                    <li key={`${widgetTitle}:${errorMessage}`}>
+                      <strong>{widgetTitle}</strong>: {errorMessage}
+                    </li>
+                  ))}
+                </ul>
+              </Alert>
+            </Alert.Container>
+          </ChatMessageContainer>
         )}
       </Stack>
     </Container>
@@ -188,4 +231,9 @@ const ChatHistoryToggle = styled(Button)`
     color: ${p => p.theme.tokens.content.primary};
     background-color: ${p => p.theme.tokens.background.primary};
   }
+`;
+
+const ChatMessageContainer = styled(Container)`
+  padding: ${p => p.theme.space.xl};
+  padding-left: 40px;
 `;


### PR DESCRIPTION
Displays a warning message to the user when a widget error is caught in the frontend for generated dashboards.
Widget errors are captured in a `widgetErrorsMap` ref by `tempId`  and then passed down the the dashboard chat component. Session errors are check by just checking the status of the seer run response.

<img width="838" height="292" alt="image" src="https://github.com/user-attachments/assets/c20e9e72-9251-4a33-8502-788417ae6a01" />
