### PR TITLE
ref(metrics): Tidy up metrics UI for refresh layout

### DIFF
--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -1,7 +1,5 @@
 import {useState} from 'react';
 
-import {Stack} from '@sentry/scraps/layout';
-
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
@@ -15,7 +13,6 @@ import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetri
 import {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
 import {useTableOrientationControl} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
 import {MetricsGraph} from 'sentry/views/explore/metrics/metricGraph';
-import {MetricInfoTabs} from 'sentry/views/explore/metrics/metricInfoTabs';
 import {SideBySideOrientation} from 'sentry/views/explore/metrics/metricPanel/sideBySideOrientation';
 import {StackedOrientation} from 'sentry/views/explore/metrics/metricPanel/stackedOrientation';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
@@ -91,21 +88,12 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
     return (
       <Panel data-test-id="metric-panel">
         <PanelBody>
-          <Stack gap="sm">
-            <MetricsGraph
-              timeseriesResult={timeseriesResult}
-              orientation={orientation}
-              isMetricOptionsEmpty={isMetricOptionsEmpty}
-              queryIndex={queryIndex}
-            />
-            <MetricInfoTabs
-              traceMetric={traceMetric}
-              additionalActions={undefined}
-              contentsHidden={infoContentHidden}
-              orientation={orientation}
-              isMetricOptionsEmpty={isMetricOptionsEmpty}
-            />
-          </Stack>
+          <MetricsGraph
+            timeseriesResult={timeseriesResult}
+            orientation={orientation}
+            isMetricOptionsEmpty={isMetricOptionsEmpty}
+            queryIndex={queryIndex}
+          />
         </PanelBody>
       </Panel>
     );

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -1,5 +1,7 @@
 import {useState} from 'react';
 
+import {Stack} from '@sentry/scraps/layout';
+
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
@@ -13,10 +15,12 @@ import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetri
 import {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
 import {useTableOrientationControl} from 'sentry/views/explore/metrics/hooks/useOrientationControl';
 import {MetricsGraph} from 'sentry/views/explore/metrics/metricGraph';
+import {MetricInfoTabs} from 'sentry/views/explore/metrics/metricInfoTabs';
 import {SideBySideOrientation} from 'sentry/views/explore/metrics/metricPanel/sideBySideOrientation';
 import {StackedOrientation} from 'sentry/views/explore/metrics/metricPanel/stackedOrientation';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
+import {useMetricVisualize} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {getMetricTableColumnType} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsAggregateSortBys,
@@ -84,16 +88,29 @@ export function MetricPanel({traceMetric, queryIndex}: MetricPanelProps) {
     panelIndex: queryIndex,
   });
 
+  const visualize = useMetricVisualize();
+
   if (hasMetricsUIRefresh) {
     return (
       <Panel data-test-id="metric-panel">
         <PanelBody>
-          <MetricsGraph
-            timeseriesResult={timeseriesResult}
-            orientation={orientation}
-            isMetricOptionsEmpty={isMetricOptionsEmpty}
-            queryIndex={queryIndex}
-          />
+          <Stack gap="sm">
+            <MetricsGraph
+              timeseriesResult={timeseriesResult}
+              orientation={orientation}
+              isMetricOptionsEmpty={isMetricOptionsEmpty}
+              queryIndex={queryIndex}
+            />
+            {visualize.visible && (
+              <MetricInfoTabs
+                traceMetric={traceMetric}
+                additionalActions={undefined}
+                contentsHidden={infoContentHidden}
+                orientation={orientation}
+                isMetricOptionsEmpty={isMetricOptionsEmpty}
+              />
+            )}
+          </Stack>
         </PanelBody>
       </Panel>
     );

--- a/static/app/views/explore/metrics/metricToolbar/visualizeLabel.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/visualizeLabel.tsx
@@ -6,6 +6,8 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconShow} from 'sentry/icons';
 import {IconHide} from 'sentry/icons/iconHide';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
 import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
@@ -16,6 +18,24 @@ interface VisualizeLabelProps {
 }
 
 export function VisualizeLabel({index, onClick, visualize}: VisualizeLabelProps) {
+  const organization = useOrganization();
+
+  if (canUseMetricsUIRefresh(organization)) {
+    const label = visualize.visible ? (
+      <Text as="span" bold variant="accent">
+        {getVisualizeLabel(index)}
+      </Text>
+    ) : (
+      <IconHide />
+    );
+
+    return (
+      <RefreshLabel onClick={onClick} justify="center" align="center">
+        {label}
+      </RefreshLabel>
+    );
+  }
+
   const label = getVisualizeLabel(index);
   const icon = visualize.visible ? <IconShow /> : <IconHide />;
 
@@ -30,6 +50,15 @@ export function VisualizeLabel({index, onClick, visualize}: VisualizeLabelProps)
     </Flex>
   );
 }
+
+const RefreshLabel = styled(Flex)`
+  cursor: pointer;
+  background-color: ${p => p.theme.tokens.background.transparent.accent.muted};
+  color: ${p => p.theme.tokens.content.accent};
+  width: 24px;
+  height: 36px;
+  border-radius: ${p => p.theme.radius.md};
+`;
 
 const IconLabel = styled(Flex)`
   cursor: pointer;


### PR DESCRIPTION
Update the metrics explore tab when the UI refresh flag is enabled:

- Replace the eye icon toggle in the metric toolbar with a letter label that swaps to a closed eye icon when hidden, matching the pattern used in the spans tab
- Remove the Samples and Aggregates tabs from the metric panel when hidden

Examples:

<img width="337" height="401" alt="Screenshot 2026-03-25 at 12 46 14" src="https://github.com/user-attachments/assets/90f707b4-acf9-4259-ac04-141b5959cbb6" />

<img width="893" height="143" alt="Screenshot 2026-03-25 at 12 46 22" src="https://github.com/user-attachments/assets/933246bc-977e-4953-b59a-4d2b921c1c27" />