### PR TITLE
feat(preprod): Add auto-expansion of a section on arrow key navigation

### DIFF
--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -27,6 +27,14 @@ interface SectionConfig {
   type: DiffStatus;
 }
 
+export const SECTION_TYPE_ORDER: DiffStatus[] = [
+  DiffStatus.CHANGED,
+  DiffStatus.ADDED,
+  DiffStatus.REMOVED,
+  DiffStatus.RENAMED,
+  DiffStatus.UNCHANGED,
+];
+
 const SECTION_ORDER: SectionConfig[] = [
   {
     type: DiffStatus.CHANGED,

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -127,6 +127,20 @@ export function SnapshotSidebarContent({
   }, [items, isDiffMode]);
 
   useEffect(() => {
+    if (!currentItemKey || !groupedItems) {
+      return;
+    }
+    for (const [sectionType, sectionItems] of groupedItems.entries()) {
+      if (sectionItems.some(item => item.key === currentItemKey)) {
+        setExpandedSections(prev =>
+          prev[sectionType] ? prev : {...prev, [sectionType]: true}
+        );
+        break;
+      }
+    }
+  }, [currentItemKey, groupedItems]);
+
+  useEffect(() => {
     if (!listRef.current || !currentItemKey) {
       return;
     }

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -27,15 +27,15 @@ interface SectionConfig {
   type: DiffStatus;
 }
 
-export const SECTION_TYPE_ORDER: DiffStatus[] = [
-  DiffStatus.CHANGED,
-  DiffStatus.ADDED,
-  DiffStatus.REMOVED,
-  DiffStatus.RENAMED,
-  DiffStatus.UNCHANGED,
-];
+// export const SECTION_TYPE_ORDER: DiffStatus[] = [
+//   DiffStatus.CHANGED,
+//   DiffStatus.ADDED,
+//   DiffStatus.REMOVED,
+//   DiffStatus.RENAMED,
+//   DiffStatus.UNCHANGED,
+// ];
 
-const SECTION_ORDER: SectionConfig[] = [
+export const SECTION_ORDER: SectionConfig[] = [
   {
     type: DiffStatus.CHANGED,
     label: t('Modified'),

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -27,14 +27,6 @@ interface SectionConfig {
   type: DiffStatus;
 }
 
-// export const SECTION_TYPE_ORDER: DiffStatus[] = [
-//   DiffStatus.CHANGED,
-//   DiffStatus.ADDED,
-//   DiffStatus.REMOVED,
-//   DiffStatus.RENAMED,
-//   DiffStatus.UNCHANGED,
-// ];
-
 export const SECTION_ORDER: SectionConfig[] = [
   {
     type: DiffStatus.CHANGED,
@@ -113,7 +105,10 @@ export function SnapshotSidebarContent({
 
   useEffect(() => {
     if (sectionParam && sectionRef.current) {
-      sectionRef.current.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+      sectionRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
       setSectionParam(null);
     }
   }, [sectionParam, setSectionParam]);

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -18,11 +18,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import {BuildProcessing} from 'sentry/views/preprod/components/buildProcessing';
-import {
-  ComparisonState,
-  DiffStatus,
-  getImageGroup,
-} from 'sentry/views/preprod/types/snapshotTypes';
+import {ComparisonState, getImageGroup} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDetailsApiResponse,
@@ -35,17 +31,14 @@ import {SnapshotDevTools} from './header/snapshotDevTools';
 import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
 import type {DiffMode} from './main/imageDisplay/diffImageDisplay';
 import {SnapshotMainContent} from './main/snapshotMainContent';
-import {SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
+import {
+  SECTION_TYPE_ORDER,
+  SnapshotSidebarContent,
+} from './sidebar/snapshotSidebarContent';
 
-// Must match SECTION_ORDER in snapshotSidebarContent so keyboard
-// navigation follows the visual section order.
-const DIFF_TYPE_ORDER: Record<string, number> = {
-  [DiffStatus.CHANGED]: 0,
-  [DiffStatus.ADDED]: 1,
-  [DiffStatus.REMOVED]: 2,
-  [DiffStatus.RENAMED]: 3,
-  [DiffStatus.UNCHANGED]: 4,
-};
+const DIFF_TYPE_ORDER: Record<string, number> = Object.fromEntries(
+  SECTION_TYPE_ORDER.map((type, i) => [type, i])
+);
 
 export default function SnapshotsPage() {
   const organization = useOrganization();

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -18,7 +18,11 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import {BuildProcessing} from 'sentry/views/preprod/components/buildProcessing';
-import {ComparisonState, getImageGroup} from 'sentry/views/preprod/types/snapshotTypes';
+import {
+  ComparisonState,
+  DiffStatus,
+  getImageGroup,
+} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDetailsApiResponse,
@@ -32,6 +36,16 @@ import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
 import type {DiffMode} from './main/imageDisplay/diffImageDisplay';
 import {SnapshotMainContent} from './main/snapshotMainContent';
 import {SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
+
+// Must match SECTION_ORDER in snapshotSidebarContent so keyboard
+// navigation follows the visual section order.
+const DIFF_TYPE_ORDER: Record<string, number> = {
+  [DiffStatus.CHANGED]: 0,
+  [DiffStatus.ADDED]: 1,
+  [DiffStatus.REMOVED]: 2,
+  [DiffStatus.RENAMED]: 3,
+  [DiffStatus.UNCHANGED]: 4,
+};
 
 export default function SnapshotsPage() {
   const organization = useOrganization();
@@ -112,47 +126,30 @@ export default function SnapshotsPage() {
     if (comparisonType === 'diff') {
       const items: SidebarItem[] = [];
 
-      const changedGroups = new Map<string, SnapshotDiffPair[]>();
-      for (const pair of data.changed) {
-        const group = getImageGroup(pair.head_image);
-        const existing = changedGroups.get(group);
-        if (existing) {
-          existing.push(pair);
-        } else {
-          changedGroups.set(group, [pair]);
+      const groupDiffPairs = (pairs: SnapshotDiffPair[], type: 'changed' | 'renamed') => {
+        const groups = new Map<string, SnapshotDiffPair[]>();
+        for (const pair of pairs) {
+          const group = getImageGroup(pair.head_image);
+          const existing = groups.get(group);
+          if (existing) {
+            existing.push(pair);
+          } else {
+            groups.set(group, [pair]);
+          }
         }
-      }
-      for (const [groupKey, pairs] of changedGroups) {
-        const label = pairs[0]!.head_image.group ?? pairs[0]!.head_image.image_file_name;
-        items.push({
-          type: 'changed',
-          key: `changed:${groupKey}`,
-          name: label,
-          badge: null,
-          pairs,
-        });
-      }
-
-      const renamedGroups = new Map<string, SnapshotDiffPair[]>();
-      for (const pair of data.renamed ?? []) {
-        const group = getImageGroup(pair.head_image);
-        const existing = renamedGroups.get(group);
-        if (existing) {
-          existing.push(pair);
-        } else {
-          renamedGroups.set(group, [pair]);
+        for (const [groupKey, groupedPairs] of groups) {
+          const label =
+            groupedPairs[0]!.head_image.group ??
+            groupedPairs[0]!.head_image.image_file_name;
+          items.push({
+            type,
+            key: `${type}:${groupKey}`,
+            name: label,
+            badge: null,
+            pairs: groupedPairs,
+          });
         }
-      }
-      for (const [groupKey, pairs] of renamedGroups) {
-        const label = pairs[0]!.head_image.group ?? pairs[0]!.head_image.image_file_name;
-        items.push({
-          type: 'renamed',
-          key: `renamed:${groupKey}`,
-          name: label,
-          badge: null,
-          pairs,
-        });
-      }
+      };
 
       const groupImages = (
         imgs: SnapshotImage[],
@@ -180,9 +177,15 @@ export default function SnapshotsPage() {
         }
       };
 
+      groupDiffPairs(data.changed, 'changed');
+      groupDiffPairs(data.renamed ?? [], 'renamed');
       groupImages(data.added, 'added');
       groupImages(data.removed, 'removed');
       groupImages(data.unchanged, 'unchanged');
+
+      items.sort(
+        (a, b) => (DIFF_TYPE_ORDER[a.type] ?? 99) - (DIFF_TYPE_ORDER[b.type] ?? 99)
+      );
 
       computeSidebarBadges(items);
       return items;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -31,13 +31,10 @@ import {SnapshotDevTools} from './header/snapshotDevTools';
 import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
 import type {DiffMode} from './main/imageDisplay/diffImageDisplay';
 import {SnapshotMainContent} from './main/snapshotMainContent';
-import {
-  SECTION_TYPE_ORDER,
-  SnapshotSidebarContent,
-} from './sidebar/snapshotSidebarContent';
+import {SECTION_ORDER, SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
 
 const DIFF_TYPE_ORDER: Record<string, number> = Object.fromEntries(
-  SECTION_TYPE_ORDER.map((type, i) => [type, i])
+  SECTION_ORDER.map((section, i) => [section.type, i])
 );
 
 export default function SnapshotsPage() {
@@ -245,7 +242,12 @@ export default function SnapshotsPage() {
     safeVariantIndex,
     variantCount,
   });
-  stateRef.current = {filteredItems, currentItemKey, safeVariantIndex, variantCount};
+  stateRef.current = {
+    filteredItems,
+    currentItemKey,
+    safeVariantIndex,
+    variantCount,
+  };
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
If navigating with arrow keys into a section that's not expanded, you couldn't see which item was focused. This now updates teh sidebar to expand the section the focus is in if an item is selected within it.

Resolves EME-978

![arrow_nav](https://github.com/user-attachments/assets/c9a13059-27d4-4099-8745-e246dcc82b84)

