### PR TITLE
feat(seer): Rename SCM seer settings tab to Repositories

### DIFF
--- a/static/gsApp/views/seerAutomation/components/settingsPageTabs.spec.tsx
+++ b/static/gsApp/views/seerAutomation/components/settingsPageTabs.spec.tsx
@@ -20,9 +20,17 @@ describe('SettingsPageTabs', () => {
     });
 
     expect(screen.getByRole('tab', {name: 'Overview'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Repositories'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/seer/scm/`
+    );
     expect(screen.getByRole('link', {name: 'Autofix'})).toHaveAttribute(
       'href',
       `/settings/${organization.slug}/seer/projects/`
+    );
+    expect(screen.getByRole('link', {name: 'Code Review'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/seer/repos/`
     );
   });
 
@@ -49,7 +57,7 @@ describe('SettingsPageTabs', () => {
       'href',
       `/settings/${organization.slug}/seer/repos/`
     );
-    expect(screen.getByRole('link', {name: 'Source Code Management'})).toHaveAttribute(
+    expect(screen.getByRole('link', {name: 'Repositories'})).toHaveAttribute(
       'href',
       `/settings/${organization.slug}/seer/scm/`
     );

--- a/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
+++ b/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
@@ -16,14 +16,14 @@ export function SettingsPageTabs() {
     showNewSeer(organization)
       ? [
           [t('Overview'), '/seer/'],
-          [t('Source Code Management'), '/seer/scm/'],
+          [t('Repositories'), '/seer/scm/'],
           [t('Autofix'), '/seer/projects/'],
           [t('Code Review'), '/seer/repos/'],
         ]
       : [
           [t('Autofix'), '/seer/'],
           [t('Code Review'), '/seer/repos/'],
-          [t('Source Code Management'), '/seer/scm/'],
+          [t('Repositories'), '/seer/scm/'],
         ]
   ) satisfies Array<[string, string]>;
 

--- a/static/gsApp/views/seerAutomation/scm.tsx
+++ b/static/gsApp/views/seerAutomation/scm.tsx
@@ -18,9 +18,9 @@ export default function SeerAutomationSCM() {
   return (
     <AnalyticsArea name="scm">
       <SeerSettingsPageWrapper>
-        <SentryDocumentTitle title={t('Source Code Management')} />
+        <SentryDocumentTitle title={t('Repositories')} />
         <SettingsPageHeader
-          title={t('Source Code Management')}
+          title={t('Repositories')}
           subtitle={tct(
             `Integrate with a Seer compatible [scm:Source Code Management] provider and then connect repositories with Sentry. Seer needs read access to your source code to perform code review, and analyze your issues. [read_the_docs:Read the docs] and our [privacy:AI Privacy Principles] to learn more.`,
             {

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -133,14 +133,16 @@ export function SeerAutomationSettings() {
                 label={t('Allow Autofix to create PRs by Default')}
                 hintText={
                   <Stack gap="sm">
-                    {tct(
-                      'For all new projects with connected repos, Seer will be able to make pull requests for [docs:highly actionable] issues.',
-                      {
-                        docs: (
-                          <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#how-issue-autofix-works" />
-                        ),
-                      }
-                    )}
+                    <span>
+                      {tct(
+                        'For all new projects with connected repos, Seer will be able to make pull requests for [docs:highly actionable] issues.',
+                        {
+                          docs: (
+                            <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#how-issue-autofix-works" />
+                          ),
+                        }
+                      )}
+                    </span>
                     {organization.enableSeerCoding === false && (
                       <Alert variant="warning">
                         {tct(


### PR DESCRIPTION
This renames the tab and it's heading. Source Code Management is what the providers do... what we're interested in is having repositories available. 

Also wrapped some text with a span to prevent the Stack from turning the parts into block-level elems.