### PR TITLE
ref(seer): Delete Seer settings ProjectOption rows instead of writing defaults

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -493,10 +493,11 @@ def resolve_repository_ids(
 
 
 def _write_preference_project_options(project: Project, preference: SeerProjectPreference) -> None:
-    project.update_option(
-        "sentry:seer_automated_run_stopping_point",
-        preference.automated_run_stopping_point or SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
-    )
+    stopping_point = preference.automated_run_stopping_point
+    if stopping_point and stopping_point != SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT:
+        project.update_option("sentry:seer_automated_run_stopping_point", stopping_point)
+    else:
+        project.delete_option("sentry:seer_automated_run_stopping_point")
 
     handoff = preference.automation_handoff
     if handoff is not None:
@@ -509,10 +510,10 @@ def _write_preference_project_options(project: Project, preference: SeerProjectP
             "sentry:seer_automation_handoff_auto_create_pr", handoff.auto_create_pr
         )
     else:
-        project.update_option("sentry:seer_automation_handoff_point", None)
-        project.update_option("sentry:seer_automation_handoff_target", None)
-        project.update_option("sentry:seer_automation_handoff_integration_id", None)
-        project.update_option("sentry:seer_automation_handoff_auto_create_pr", False)
+        project.delete_option("sentry:seer_automation_handoff_point")
+        project.delete_option("sentry:seer_automation_handoff_target")
+        project.delete_option("sentry:seer_automation_handoff_integration_id")
+        project.delete_option("sentry:seer_automation_handoff_auto_create_pr")
 
 
 def _write_preferences_to_sentry_db(

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -957,7 +957,7 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
         assert SeerProjectRepository.objects.filter(project=self.project).count() == 0
 
-    def test_writes_project_options_defaults(self):
+    def test_deletes_project_options_when_defaults(self):
         preference = SeerProjectPreference(
             organization_id=self.organization.id, project_id=self.project.id, repositories=[]
         )


### PR DESCRIPTION
When writing Seer project preferences, delete the ProjectOption row when the value matches the registered default. This lets us distinguish "never configured" from "configured with defaults" by checking for SeerProjectRepository and ProjectOption existence, which simplifies the upcoming dual-read from Sentry DB and allows us to return null preference for never-configured projects. Also, we don't needlessly store default project options. 