### PR TITLE
fix(cache): Ensure per-thread pymemcache clients in ReconnectingMemcache

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@
 /bin/mock*                                              @getsentry/app-backend
 /src/sentry/data/samples/                               @getsentry/app-backend
 /src/sentry/cache/                                      @getsentry/app-backend
+/tests/sentry/cache/                                    @getsentry/app-backend
 /src/sentry/conf/                                       @getsentry/app-backend
 /src/sentry/db/models/                                  @getsentry/app-backend
 /src/sentry/models/                                     @getsentry/app-backend

--- a/src/sentry/cache/backends/reconnectingmemcache.py
+++ b/src/sentry/cache/backends/reconnectingmemcache.py
@@ -1,11 +1,19 @@
+import contextvars
+import threading
 import time
 from collections.abc import Mapping
-from threading import Lock
+from typing import NamedTuple
 
 import pymemcache
 from django.core.cache.backends.memcached import PyMemcacheCache
 
 from sentry.utils import metrics
+
+
+class _BackendState(NamedTuple):
+    thread_id: int
+    created_at: float
+    client: pymemcache.Client
 
 
 class ReconnectingMemcache(PyMemcacheCache):
@@ -15,6 +23,15 @@ class ReconnectingMemcache(PyMemcacheCache):
 
     Periodically this adapter will close and reconnect the underlying
     cache adapter to help even out load on Twemproxy.
+
+    Each thread gets its own pymemcache client instance. This is
+    necessary because pymemcache's HashClient is not thread-safe for
+    concurrent access (e.g. the _retry_dead method races on a shared
+    dict). Cross-thread sharing can happen when contextvars are
+    copied via copy_context(), since Django's CacheHandler stores
+    connections in a contextvar. We detect this by checking the
+    thread ID and creating a fresh client when a copied context is
+    accessed from a different thread.
     """
 
     _class: pymemcache.Client
@@ -22,30 +39,39 @@ class ReconnectingMemcache(PyMemcacheCache):
 
     def __init__(self, server, params) -> None:
         self._reconnect_age: int = params.get("OPTIONS", {}).pop("reconnect_age", 300)
-        self._last_reconnect_at: float = time.time()
-        self._backend: pymemcache.Client | None = None
-        self._backend_lock = Lock()
+        self._backend_var: contextvars.ContextVar[_BackendState | None] = contextvars.ContextVar(
+            f"reconnecting_memcache_{id(self)}", default=None
+        )
 
         super().__init__(server, params)
 
     @property
-    def _cache(self) -> pymemcache.Client | None:
+    def _cache(self) -> pymemcache.Client:
         """
-        Overload PyMemcacheCache._cache with periodic reconnections.
+        Return a per-thread pymemcache client, reconnecting periodically
+        to distribute load across Twemproxy instances.
         """
-        age = time.time() - self._last_reconnect_at
-        if not self._backend or age >= self._reconnect_age:
-            try:
-                if self._backend_lock.acquire(timeout=1.0):
-                    # Close the underlying cache connection if we haven't done that recently.
-                    if self._backend:
-                        self._backend.close()
-                        self._backend = None
-                        metrics.incr("cache.memcache.reconnect")
+        current_tid = threading.get_ident()
+        state = self._backend_var.get()
 
-                    self._backend = self._class(self.client_servers, **self._options)
-                    self._last_reconnect_at = time.time()
-            finally:
-                self._backend_lock.release()
+        if state is not None:
+            # Context was copied to a different thread (e.g. via
+            # ContextPropagatingThreadPoolExecutor). pymemcache's
+            # HashClient isn't thread-safe, so create a new client.
+            if state.thread_id != current_tid:
+                state = None
+            elif time.time() - state.created_at >= self._reconnect_age:
+                state.client.close()
+                metrics.incr("cache.memcache.reconnect")
+                state = None
 
-        return self._backend
+        if state is None:
+            client = self._class(self.client_servers, **self._options)
+            state = _BackendState(
+                thread_id=current_tid,
+                created_at=time.time(),
+                client=client,
+            )
+            self._backend_var.set(state)
+
+        return state.client

--- a/tests/sentry/cache/test_reconnectingmemcache.py
+++ b/tests/sentry/cache/test_reconnectingmemcache.py
@@ -18,7 +18,7 @@ def _make_cache(reconnect_age=300):
 
     cache._reconnect_age = reconnect_age
     cache._backend_var = contextvars.ContextVar(f"reconnecting_memcache_{id(cache)}", default=None)
-    cache._servers = [("localhost", 11211)]
+    cache._servers = [("localhost", 11211)]  # type: ignore[attr-defined]
     cache._options = {}
     cache._class = MagicMock(side_effect=lambda *a, **kw: MagicMock())
     return cache

--- a/tests/sentry/cache/test_reconnectingmemcache.py
+++ b/tests/sentry/cache/test_reconnectingmemcache.py
@@ -1,0 +1,115 @@
+import contextvars
+import time
+from concurrent.futures import ThreadPoolExecutor  # noqa: S016
+from unittest.mock import MagicMock, patch
+
+from sentry.cache.backends.reconnectingmemcache import ReconnectingMemcache
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
+
+
+def _make_cache(reconnect_age=300):
+    """Create a ReconnectingMemcache with a mocked pymemcache client class."""
+    with patch.object(
+        ReconnectingMemcache,
+        "__init__",
+        lambda self, *a, **kw: None,
+    ):
+        cache = ReconnectingMemcache.__new__(ReconnectingMemcache)
+
+    cache._reconnect_age = reconnect_age
+    cache._backend_var = contextvars.ContextVar(f"reconnecting_memcache_{id(cache)}", default=None)
+    cache._servers = [("localhost", 11211)]
+    cache._options = {}
+    cache._class = MagicMock(side_effect=lambda *a, **kw: MagicMock())
+    return cache
+
+
+def test_each_thread_gets_own_client():
+    """Plain ThreadPoolExecutor workers should each get their own client."""
+    cache = _make_cache()
+    parent_client = cache._cache
+
+    results = []
+
+    def check():
+        worker_client = cache._cache
+        results.append(worker_client is parent_client)
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        futures = [pool.submit(check) for _ in range(3)]
+        for f in futures:
+            f.result()
+
+    # No worker should share the parent's client
+    assert results == [False, False, False]
+
+
+def test_context_propagating_executor_isolates_clients():
+    """ContextPropagatingThreadPoolExecutor must not share the parent's
+    pymemcache client across threads, even though it copies contextvars."""
+    cache = _make_cache()
+    parent_client = cache._cache
+
+    results = []
+
+    def check():
+        worker_client = cache._cache
+        results.append(worker_client is parent_client)
+
+    with ContextPropagatingThreadPoolExecutor(max_workers=3) as pool:
+        futures = [pool.submit(check) for _ in range(3)]
+        for f in futures:
+            f.result()
+
+    # Workers must NOT share the parent's client
+    assert results == [False, False, False]
+
+
+def test_same_thread_reuses_client():
+    """Repeated accesses on the same thread should return the same client."""
+    cache = _make_cache()
+
+    client1 = cache._cache
+    client2 = cache._cache
+
+    assert client1 is client2
+    # Should only have created one client
+    assert cache._class.call_count == 1
+
+
+def test_reconnects_after_age():
+    """Client should be replaced after reconnect_age seconds."""
+    cache = _make_cache(reconnect_age=10)
+
+    client1 = cache._cache
+    assert cache._class.call_count == 1
+
+    # Simulate time passing beyond reconnect_age
+    state = cache._backend_var.get()
+    cache._backend_var.set(state._replace(created_at=time.time() - 11))
+
+    client2 = cache._cache
+    assert cache._class.call_count == 2
+    assert client1 is not client2
+    client1.close.assert_called_once()
+
+
+def test_workers_in_same_context_run_get_own_clients():
+    """Multiple workers spawned from the same context should each get
+    independent clients (not share one via the copied contextvar)."""
+    cache = _make_cache()
+    _ = cache._cache  # parent initializes
+
+    worker_clients = []
+
+    def collect():
+        worker_clients.append(id(cache._cache))
+
+    with ContextPropagatingThreadPoolExecutor(max_workers=3) as pool:
+        futures = [pool.submit(collect) for _ in range(6)]
+        for f in futures:
+            f.result()
+
+    # Each thread should have its own client (3 threads, up to 3 unique IDs)
+    unique_clients = set(worker_clients)
+    assert len(unique_clients) >= 2  # At least different from each other


### PR DESCRIPTION
Django's `CacheHandler` stores connections in a contextvar (`asgiref.local._CVar`). When `contextvars.copy_context()` copies these across threads — as `ContextPropagatingThreadPoolExecutor` does — multiple threads share a single `pymemcache.HashClient` instance. `HashClient` is not thread-safe: `_retry_dead()` races on a shared `_dead_clients` dict, causing `KeyError` crashes when a twemproxy node flaps.

This was surfaced by the `ThreadPoolExecutor` → `ContextPropagatingThreadPoolExecutor` migration in #111464 (reverted in 7e509b5), which caused consumer worker threads to inherit the parent's cache connection instead of creating their own. The same race also affects web workers (SENTRY-5MFX, SENTRY-5E8T) via granian's thread pool.

The fix stores the backend in a contextvar with a thread ID check. When a copied context is accessed from a different thread, a new client is created. This preserves contextvar semantics (async-safe) while restoring per-thread isolation for `HashClient`.

Fixes SENTRY-5H8T


Agent transcript: https://claudescope.sentry.dev/share/DUqlzydq70wt3Np4p2CKKgDFZAM251ooNsKQg4RIXiY