### PR TITLE
feat(metrics): Enable AI searchbar on metrics explorer filter

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -1,8 +1,12 @@
 import {useMemo} from 'react';
 
-import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {
+  SearchQueryBuilderProvider,
+  useSearchQueryBuilder,
+} from 'sentry/components/searchQueryBuilder/context';
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
@@ -16,6 +20,7 @@ import {
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {MetricsTabSeerComboBox} from 'sentry/views/explore/metrics/metricsTabSeerComboBox';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsQuery,
@@ -30,7 +35,22 @@ interface FilterProps {
   traceMetric: TraceMetric;
 }
 
+function MetricsSearchBar({
+  tracesItemSearchQueryBuilderProps,
+}: {
+  tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps;
+}) {
+  const {displayAskSeer} = useSearchQueryBuilder();
+
+  if (displayAskSeer) {
+    return <MetricsTabSeerComboBox />;
+  }
+
+  return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;
+}
+
 export function Filter({traceMetric}: FilterProps) {
+  const organization = useOrganization();
   const query = useQueryParamsQuery();
   const setQuery = useSetQueryParamsQuery();
 
@@ -137,14 +157,23 @@ export function Filter({traceMetric}: FilterProps) {
     tracesItemSearchQueryBuilderProps
   );
 
+  const areAiFeaturesAllowed =
+    !organization?.hideAiFeatures &&
+    organization.features.includes('gen-ai-features') &&
+    organization.features.includes('gen-ai-search-agent-translate');
+
   return (
     <SearchQueryBuilderProvider
       // Use the metric name as a key to force remount when it changes
       // This prevents race conditions when navigating between different metrics
       key={traceMetric.name}
       {...searchQueryBuilderProviderProps}
+      enableAISearch={areAiFeaturesAllowed}
+      aiSearchBadgeType="alpha"
     >
-      <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
+      <MetricsSearchBar
+        tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}
+      />
     </SearchQueryBuilderProvider>
   );
 }

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -1,0 +1,191 @@
+import {useCallback, useMemo} from 'react';
+
+import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
+import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
+import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+import {Token} from 'sentry/components/searchSyntax/parser';
+import {stringifyToken} from 'sentry/components/searchSyntax/utils';
+import ConfigStore from 'sentry/stores/configStore';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {getFieldDefinition} from 'sentry/utils/fields';
+import {fetchMutation, mutationOptions} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {
+  useQueryParamsQuery,
+  useSetQueryParamsQuery,
+} from 'sentry/views/explore/queryParams/context';
+
+interface AskSeerSearchQuery {
+  query: string;
+}
+
+interface MetricsAskSeerTranslateResponse {
+  responses: Array<{
+    query: string;
+  }>;
+  unsupported_reason: string | null;
+}
+
+export function MetricsTabSeerComboBox() {
+  const {projects} = useProjects();
+  const pageFilters = usePageFilters();
+  const organization = useOrganization();
+  const currentQuery = useQueryParamsQuery();
+  const setQuery = useSetQueryParamsQuery();
+  const {
+    currentInputValueRef,
+    query,
+    committedQuery,
+    askSeerSuggestedQueryRef,
+    enableAISearch,
+  } = useSearchQueryBuilder();
+
+  let initialSeerQuery = '';
+  const queryDetails = useMemo(() => {
+    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
+    const parsedQuery = parseQueryBuilderValue(queryToUse, getFieldDefinition);
+    return {parsedQuery, queryToUse};
+  }, [committedQuery, query]);
+
+  const inputValue = currentInputValueRef.current.trim();
+
+  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
+  const filteredCommittedQuery = queryDetails?.parsedQuery
+    ?.filter(
+      token =>
+        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
+    )
+    ?.map(token => stringifyToken(token))
+    ?.join(' ')
+    ?.trim();
+
+  // Use filteredCommittedQuery if it exists and has content, otherwise fall back to queryToUse
+  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
+    initialSeerQuery = filteredCommittedQuery;
+  } else if (queryDetails?.queryToUse) {
+    initialSeerQuery = queryDetails.queryToUse;
+  }
+
+  if (inputValue) {
+    initialSeerQuery =
+      initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
+  }
+
+  const metricsTabAskSeerMutationOptions = mutationOptions({
+    mutationFn: async (queryToSubmit: string) => {
+      const selectedProjects =
+        pageFilters.selection.projects?.length > 0 &&
+        pageFilters.selection.projects?.[0] !== -1
+          ? pageFilters.selection.projects
+          : projects.filter(p => p.isMember).map(p => p.id);
+
+      const user = ConfigStore.get('user');
+      const data = await fetchMutation<MetricsAskSeerTranslateResponse>({
+        url: `/organizations/${organization.slug}/search-agent/translate/`,
+        method: 'POST',
+        data: {
+          org_id: organization.id,
+          org_slug: organization.slug,
+          natural_language_query: queryToSubmit,
+          project_ids: selectedProjects,
+          strategy: 'Metrics',
+          user_email: user?.email,
+        },
+      });
+
+      return {
+        status: 'ok',
+        unsupported_reason: data.unsupported_reason,
+        queries: data.responses.map(r => ({
+          query: r?.query ?? '',
+        })),
+      };
+    },
+  });
+
+  const applySeerSearchQuery = useCallback(
+    (result: AskSeerSearchQuery) => {
+      if (!result) return;
+
+      // Apply the query to the current metric filter
+      setQuery(result.query);
+
+      askSeerSuggestedQueryRef.current = JSON.stringify({
+        query: result.query,
+      });
+
+      trackAnalytics('metrics.ai_query_applied', {
+        organization,
+        query: result.query,
+      });
+    },
+    [askSeerSuggestedQueryRef, organization, setQuery]
+  );
+
+  const areAiFeaturesAllowed =
+    enableAISearch &&
+    !organization?.hideAiFeatures &&
+    organization.features.includes('gen-ai-features');
+
+  const usePollingEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
+
+  // Get selected project IDs for the polling variant
+  const selectedProjectIds = useMemo(() => {
+    if (
+      pageFilters.selection.projects?.length > 0 &&
+      pageFilters.selection.projects?.[0] !== -1
+    ) {
+      return pageFilters.selection.projects;
+    }
+    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
+  }, [pageFilters.selection.projects, projects]);
+
+  // Transform the final_response from Seer to match the expected format
+  const transformResponse = useCallback(
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const seerResponse = response as unknown as {
+        responses?: Array<{
+          query: string;
+        }>;
+      };
+
+      if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
+        return seerResponse.responses.map(r => ({
+          query: r?.query ?? '',
+        }));
+      }
+
+      return [response];
+    },
+    []
+  );
+
+  if (!areAiFeaturesAllowed) {
+    return null;
+  }
+
+  if (usePollingEndpoint) {
+    return (
+      <AskSeerPollingComboBox<AskSeerSearchQuery>
+        initialQuery={initialSeerQuery}
+        onApplySearchQuery={applySeerSearchQuery}
+        strategy="Metrics"
+        projectIds={selectedProjectIds}
+        transformResponse={transformResponse}
+      />
+    );
+  }
+
+  return (
+    <AskSeerComboBox<AskSeerSearchQuery>
+      initialQuery={initialSeerQuery}
+      onApplySearchQuery={applySeerSearchQuery}
+      mutationOptions={metricsTabAskSeerMutationOptions}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add `MetricsTabSeerComboBox` component for AI-powered natural language query translation on the metrics filter bar
- Enable `enableAISearch` in the metrics `SearchQueryBuilderProvider`, gated behind `gen-ai-features` and `gen-ai-search-agent-translate` feature flags
- Follows the same pattern as Logs (`LogsTabSeerComboBox`) and Traces (`SpansTabSeerComboBox`)

## How it works
- The AI search is per-metric-query (each metric panel has its own filter bar)
- When the user types a natural language query, it sends `strategy: 'Metrics'` to Seer
- Seer translates the query and returns a filter string
- The filter is applied to the current metric panel via `useSetQueryParamsQuery()`

## Dependencies
- Requires Seer MetricsStrategy: https://github.com/getsentry/seer/pull/5451

## Test plan
- [ ] Verify AI search icon appears on metrics filter bar when feature flags are enabled
- [ ] Verify natural language queries are translated and applied to the filter
- [ ] Verify feature flag gating works (no AI search without flags)
- [ ] Verify it works per-metric-panel (each filter bar is independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)