### PR TITLE
fix(footer): use `StatusIndicator` component

### DIFF
--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 
 import {useFrontendVersion} from 'sentry/components/frontendVersionContext';
 import Hook from 'sentry/components/hook';
@@ -12,7 +13,6 @@ import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import {pulsingIndicatorStyles} from 'sentry/styles/pulsingIndicator';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SecondaryNavigationContext} from 'sentry/views/navigation/secondaryNavigationContext';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
@@ -90,7 +90,7 @@ function BaseFooter({className}: Props) {
             }}
             aria-label={t('Reload frontend')}
           >
-            <WaitingIndicator />
+            <StatusIndicator variant="promotion" />
           </Button>
         )}
         {!isSelfHosted && (
@@ -109,12 +109,6 @@ function BaseFooter({className}: Props) {
     </Container>
   );
 }
-
-const WaitingIndicator = styled('div')`
-  --pulsingIndicatorRing: ${p => p.theme.tokens.border.transparent.neutral.muted};
-  ${pulsingIndicatorStyles};
-  contain: layout;
-`;
 
 const LeftLinks = styled('div')`
   display: grid;


### PR DESCRIPTION
Replaces custom `pulsatingIndicatorStyles` with new `StatusIndicator` component

**Before**

https://github.com/user-attachments/assets/b781e751-1eb3-4cb3-8c87-675760581499

**After**

https://github.com/user-attachments/assets/b5cc5d21-4ced-4e95-9ce3-48981ddc37d6