### PR TITLE
feat(nav): improve mobile navigation

### DIFF
--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -173,7 +173,7 @@ interface PrimaryNavigationLinkProps
 
 function PrimaryNavigationLink(props: PrimaryNavigationLinkProps) {
   const organization = useOrganization({allowNull: true});
-  const {layout} = usePrimaryNavigation();
+  const {layout, features} = usePrimaryNavigation();
   const hasPageFrame = useHasPageFrameFeature();
   const isMobilePageFrame = hasPageFrame && layout === 'mobile';
   // Reload the page when the frontend is stale to ensure users get the latest version
@@ -189,6 +189,10 @@ function PrimaryNavigationLink(props: PrimaryNavigationLinkProps) {
     onMouseEnter: props.onMouseEnter,
     onMouseLeave: props.onMouseLeave,
     onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
+      // On touch devices with page frame, prevent navigation and let setActiveGroup handle the active state
+      if (isMobilePageFrame && !features.hover) {
+        e.preventDefault();
+      }
       trackAnalytics('navigation.primary_item_clicked', {
         item: props.analyticsKey,
         organization,

--- a/static/app/views/navigation/primaryNavigationContext.tsx
+++ b/static/app/views/navigation/primaryNavigationContext.tsx
@@ -21,8 +21,14 @@ const PRIMARY_NAVIGATION_GROUP_CONFIG = {
 
 type NavigationGroup = keyof typeof PRIMARY_NAVIGATION_GROUP_CONFIG;
 
+interface PrimaryNavigationFeatures {
+  /** Whether the device supports hover interactions (false on touch-only devices) */
+  hover: boolean;
+}
+
 interface PrimaryNavigationContext {
   activeGroup: NavigationGroup;
+  features: PrimaryNavigationFeatures;
   layout: 'mobile' | 'sidebar';
   setActiveGroup: (group: NavigationGroup | null) => void;
 }
@@ -30,6 +36,7 @@ interface PrimaryNavigationContext {
 const PrimaryNavigationContext = createContext<PrimaryNavigationContext>({
   layout: 'sidebar',
   activeGroup: 'issues',
+  features: {hover: true},
   setActiveGroup: () => {},
 });
 
@@ -48,15 +55,17 @@ export function PrimaryNavigationContextProvider(
 
   const theme = useTheme();
   const isMobile = useMedia(`(width < ${theme.breakpoints.md})`);
+  const hasHover = useMedia('(hover: hover)');
   const activeRouteGroup = useActiveNavigationGroup();
 
   const value = useMemo(
     () => ({
       layout: isMobile ? ('mobile' as const) : ('sidebar' as const),
+      features: {hover: hasHover},
       activeGroup: activeGroupOverride ?? activeRouteGroup,
       setActiveGroup,
     }),
-    [isMobile, activeGroupOverride, activeRouteGroup]
+    [isMobile, hasHover, activeGroupOverride, activeRouteGroup]
   );
 
   return (

--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -461,9 +461,11 @@ function SecondaryNavigationLink({
   const isActive =
     incomingIsActive ?? isPrimaryNavigationLinkActive(activeTo, location.pathname, {end});
 
-  const {layout} = usePrimaryNavigation();
+  const {layout, features} = usePrimaryNavigation();
   const {reset: closeCollapsedNavigationHovercard} = useHovercardContext();
   const hasPageFrame = useHasPageFrameFeature();
+  const {setView} = useSecondaryNavigation();
+  const isMobilePageFrame = hasPageFrame && layout === 'mobile';
 
   const sharedLinkProps = {
     ...linkProps,
@@ -481,6 +483,13 @@ function SecondaryNavigationLink({
       // When this is rendered inside a hovercard (when the nav is collapsed)
       // this will dismiss it when clicking on a link.
       closeCollapsedNavigationHovercard();
+
+      // On touch devices with page frame, close the nav panel when navigating to a secondary item.
+      // MobilePageFrameNavigation watches for view === 'collapsed' and calls setIsOpen(false).
+      if (isMobilePageFrame && !features.hover) {
+        setView('collapsed');
+      }
+
       onClick?.(e);
     },
   };
@@ -912,10 +921,12 @@ function SecondaryNavigationReorderableLink({
   const navigate = useNavigate();
   const isActive =
     incomingIsActive ?? isPrimaryNavigationLinkActive(activeTo, location.pathname, {end});
-  const {layout} = usePrimaryNavigation();
+  const {layout, features} = usePrimaryNavigation();
   const {reset: closeCollapsedNavigationHovercard} = useHovercardContext();
   const {isDragging} = useReorderableItemContext();
   const hasPageFrame = useHasPageFrameFeature();
+  const {setView} = useSecondaryNavigation();
+  const isMobilePageFrame = hasPageFrame && layout === 'mobile';
 
   function handleNavigate() {
     if (isDragging) {
@@ -928,6 +939,13 @@ function SecondaryNavigationReorderableLink({
       });
     }
     closeCollapsedNavigationHovercard();
+
+    // On touch devices with page frame, close the nav panel when navigating to a secondary item.
+    // MobilePageFrameNavigation watches for view === 'collapsed' and calls setIsOpen(false).
+    if (isMobilePageFrame && !features.hover) {
+      setView('collapsed');
+    }
+
     onNavigate?.();
     navigate(to, {state: {source: SIDEBAR_NAVIGATION_SOURCE}});
   }


### PR DESCRIPTION
Updates primary navigation to perform hover UA feature detection and bypass the current primary navigation mouseEnter logic to instead use onClick. As a consequence, this means that if users are on mobile and the UA does not support hover, clicking an item in the primary nav will no longer trigger a navigation. This unblocks users from being able to see other subsections of the navigation without having to actually navigate to them.

In a similar manner, secondary navigation interactions are now treated terminal destinations and will trigger the navigation close event, naturally landing the users on the page that they navigated to.