### PR TITLE
fix(issues): Add stack trace column gap between coverage border and source code

### DIFF
--- a/static/app/components/stackTrace/frame/frameContent.tsx
+++ b/static/app/components/stackTrace/frame/frameContent.tsx
@@ -167,6 +167,7 @@ const FrameSourceRow = styled(Grid)<{isActive: boolean; lineNumberDigits: number
     calc(${p => Math.max(p.lineNumberDigits, 3) + 1}ch)
     1fr;
   align-items: start;
+  column-gap: ${p => p.theme.space.sm};
   min-width: 0;
   background: ${p => (p.isActive ? p.theme.tokens.background.secondary : 'transparent')};
 `;

--- a/static/app/components/stackTrace/stackTrace.stories.tsx
+++ b/static/app/components/stackTrace/stackTrace.stories.tsx
@@ -1021,20 +1021,20 @@ export default Storybook.story('StackTrace', story => {
   story('StackTraceFrames - Single Frame Source Coverage', () => {
     const {event, stacktrace} = makeStackTraceData();
 
-    const frameWithContext = stacktrace.frames.find(
-      frame => frame.inApp && (frame.context?.length ?? 0) > 0
-    );
-    if (!frameWithContext) {
-      return null;
-    }
-
-    const sourceLineCoverage = getSampleSourceLineCoverage(
-      frameWithContext.context?.length ?? 0
-    );
+    const context: Frame['context'] = [
+      [1, 'import os'],
+      [2, ''],
+      [3, 'def process(data):'],
+      [4, '    result = validate(data)'],
+      [5, '    if result is None:'],
+      [6, '        raise ValueError("bad data")'],
+      [7, '    return result'],
+    ];
+    const sourceLineCoverage = getSampleSourceLineCoverage(context.length);
 
     const singleFrameStacktrace = {
       ...stacktrace,
-      frames: [frameWithContext],
+      frames: [makeFrame({context, lineNo: 6, inApp: true})],
     };
 
     function CoveredFrameContext() {
@@ -1057,30 +1057,23 @@ export default Storybook.story('StackTrace', story => {
   story('StackTraceFrames - Long Line Numbers', () => {
     const {event, stacktrace} = makeStackTraceData();
 
-    const frameWithContext = stacktrace.frames.find(
-      frame => frame.inApp && (frame.context?.length ?? 0) > 0
-    );
-    if (!frameWithContext) {
-      return null;
-    }
-
-    const context = frameWithContext.context ?? [];
-    const lineNumberOffset = 12000;
-    const longLineNumberFrame = {
-      ...frameWithContext,
-      context: context.map<[number, string | null]>(([lineNumber, lineValue]) => [
-        lineNumber + lineNumberOffset,
-        lineValue,
-      ]),
-      lineNo:
-        typeof frameWithContext.lineNo === 'number'
-          ? frameWithContext.lineNo + lineNumberOffset
-          : frameWithContext.lineNo,
-    };
-
     const singleFrameStacktrace = {
       ...stacktrace,
-      frames: [longLineNumberFrame],
+      frames: [
+        makeFrame({
+          inApp: true,
+          lineNo: 100000,
+          context: [
+            [99997, 'def handle_request(request):'],
+            [99998, '    data = parse(request.body)'],
+            [99999, '    result = validate(data)'],
+            [100000, '    if result is None:'],
+            [100001, '        raise ValueError("bad data")'],
+            [100002, '    return result'],
+            [100003, ''],
+          ],
+        }),
+      ],
     };
 
     return (


### PR DESCRIPTION
The coverage indicator border on the line number column was flush against the source code. Add column-gap to the grid row to create spacing between the two columns.

Also simplify the coverage and long line number stories to use makeFrame directly with explicit context lines.

before

<img width="384" height="104" alt="image" src="https://github.com/user-attachments/assets/110c5ae1-ab94-4759-8a76-d64041ea3c45" />

after

<img width="373" height="106" alt="image" src="https://github.com/user-attachments/assets/096ed6f8-f10c-4353-9360-f3a4cf72200a" />
