### PR TITLE
ci(snapshots): Update sentry-cli to 3.3.4-snapshot build

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install sentry-cli
         if: ${{ !cancelled() }}
-        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.3.3 sh
+        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.3.4-snapshot.20260325.06cbbda sh
 
       - name: Upload snapshots
         id: upload


### PR DESCRIPTION
Update the sentry-cli version used in the frontend snapshots workflow from 3.3.3 to 3.3.4-snapshot.20260325.06cbbda.