### PR TITLE
chore(ci): Add configurable timeout to setup-sentry composite action 

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Skip bringing up devservices'
     required: false
     default: 'false'
+  devservices-timeout-minutes:
+    description: 'Maximum minutes for devservices up'
+    required: false
+    default: '10'
 
 outputs:
   matrix-instance-number:
@@ -137,7 +141,7 @@ runs:
         # This is necessary to bring up devservices with appropriate sentry config
         cd "$WORKDIR"
 
-        devservices up --mode ${{ inputs.mode }}
+        timeout ${{ inputs.devservices-timeout-minutes }}m devservices up --mode ${{ inputs.mode }}
 
         # have tests listen on the docker gateway ip so loopback can occur
         echo "DJANGO_LIVE_TEST_SERVER_ADDRESS=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -135,13 +135,15 @@ runs:
       env:
         WORKDIR: ${{ inputs.workdir }}
         ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES: '1'
+        DEVSERVICES_TIMEOUT: ${{ inputs.devservices-timeout-minutes }}
+        DEVSERVICES_MODE: ${{ inputs.mode }}
       run: |
         sentry init
 
         # This is necessary to bring up devservices with appropriate sentry config
         cd "$WORKDIR"
 
-        timeout ${{ inputs.devservices-timeout-minutes }}m devservices up --mode ${{ inputs.mode }}
+        timeout "${DEVSERVICES_TIMEOUT}m" devservices up --mode "$DEVSERVICES_MODE"
 
         # have tests listen on the docker gateway ip so loopback can occur
         echo "DJANGO_LIVE_TEST_SERVER_ADDRESS=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')" >> "$GITHUB_ENV"


### PR DESCRIPTION
Sometimes github throws a tantrum and `setup-sentry` hangs, causing the calling action to timeout. Our median run time for this action is ~1.5minutes, so we really shouldn't be letting this action run loose.

This PR adds a configurable timeout (default 10 min) to the `devservices up` call so we can exit earlier. Uses the native linux `timeout` command.

### Other options explored

- `timeout-minutes` still [isn't supported](https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#timeout-minutes) in composite actions, a feature request has been open for years: https://github.com/actions/runner/issues/1979
- Putting a `timeout-minutes` on every single step that uses this action is possible but annoying, we already use this action in ~17 different places.
- Wrapping this in a reusable workflow will allow us to set a timeout, but reusable workflows run in their own runner and are aren't useful for setting up an environment for another workflow