### PR TITLE
fix(_admin): Dedupe GroupSubscription conflicts during user merge

### DIFF
--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -685,6 +685,25 @@ def dedupe_and_reassign_groupseen_in_org(
     GroupSeen.objects.filter(scoped, user_id=from_user_id).update(user_id=to_user_id)
 
 
+def dedupe_and_reassign_groupsubscription_in_org(
+    organization_id: int, from_user_id: int, to_user_id: int
+) -> None:
+    """
+    Dedupe GroupSubscription rows inside an organization and reassign them to the new user.
+    """
+    from sentry.models.groupsubscription import GroupSubscription
+
+    scoped = Q(group__project__organization_id=organization_id)
+    GroupSubscription.objects.filter(
+        scoped,
+        user_id=from_user_id,
+        group_id__in=GroupSubscription.objects.filter(scoped, user_id=to_user_id).values(
+            "group_id"
+        ),
+    ).delete()
+    GroupSubscription.objects.filter(scoped, user_id=from_user_id).update(user_id=to_user_id)
+
+
 def merge_users_for_model_in_org(
     model: type[models.base.Model], *, organization_id: int, from_user_id: int, to_user_id: int
 ) -> None:
@@ -694,6 +713,7 @@ def merge_users_for_model_in_org(
     """
 
     from sentry.models.groupseen import GroupSeen
+    from sentry.models.groupsubscription import GroupSubscription
     from sentry.models.organization import Organization
     from sentry.users.models.user import User
 
@@ -701,6 +721,11 @@ def merge_users_for_model_in_org(
     # then update remaining rows.
     if model is GroupSeen:
         dedupe_and_reassign_groupseen_in_org(organization_id, from_user_id, to_user_id)
+        return
+
+    # Special-case: GroupSubscription has unique_together (group, user_id). Same pattern.
+    if model is GroupSubscription:
+        dedupe_and_reassign_groupsubscription_in_org(organization_id, from_user_id, to_user_id)
         return
 
     model_relations = dependencies()[get_model_name(model)]

--- a/tests/sentry/users/models/test_user.py
+++ b/tests/sentry/users/models/test_user.py
@@ -281,6 +281,32 @@ class UserMergeToTest(BackupTestCase, HybridCloudTestMixin):
             assert not GroupSeen.objects.filter(group=group, user_id=from_user.id).exists()
             assert GroupSeen.objects.filter(group=group, user_id=to_user.id).count() == 1
 
+    def test_merge_handles_groupsubscription_conflicts(self) -> None:
+        from_user = self.create_user("from-user@example.com")
+        to_user = self.create_user("to-user@example.com")
+        org = self.create_organization(name="subscription-conflict-org")
+
+        with outbox_runner():
+            with assume_test_silo_mode(SiloMode.CELL):
+                self.create_member(user=from_user, organization=org)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            project = self.create_project(organization=org)
+            group = self.create_group(project=project)
+            GroupSubscription.objects.create(
+                project=project, group=group, user_id=from_user.id, is_active=True
+            )
+            GroupSubscription.objects.create(
+                project=project, group=group, user_id=to_user.id, is_active=True
+            )
+
+        with outbox_runner():
+            from_user.merge_to(to_user)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert not GroupSubscription.objects.filter(group=group, user_id=from_user.id).exists()
+            assert GroupSubscription.objects.filter(group=group, user_id=to_user.id).count() == 1
+
     @expect_models(
         ORG_MEMBER_MERGE_TESTED,
         OrgAuthToken,


### PR DESCRIPTION
When merging two user accounts, if both users are subscribed to the
same issue group, the unique_together constraint on GroupSubscription
causes an IntegrityError. Add dedupe logic matching the existing
GroupSeen pattern: delete the secondary user's conflicting
subscriptions before reassigning the remaining ones.

Fixes SENTRY-4YFH
Fixes SENTRY-5HVP

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
