### PR TITLE
feat(workflows): Make thresholds in prune_old_fire_history options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3675,6 +3675,22 @@ register(
     default=10000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Tuning knobs for the periodic fire-history cleanup task.
+# time_limit is a wall-clock budget checked *between* batches, so a single
+# batch that exceeds it will still run to completion. Setting it to 0 allows
+# exactly one batch (elapsed time is always >= 0).
+register(
+    "workflow_engine.fire_history_cleanup.time_limit_seconds",
+    type=Float,
+    default=5.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "workflow_engine.fire_history_cleanup.batch_size",
+    type=Int,
+    default=10000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3677,8 +3677,8 @@ register(
 )
 # Tuning knobs for the periodic fire-history cleanup task.
 # time_limit is a wall-clock budget checked *between* batches, so a single
-# batch that exceeds it will still run to completion. Setting it to 0 allows
-# exactly one batch (elapsed time is always >= 0).
+# batch that exceeds it will still run to completion. Setting it to 0
+# prevents any batches from running.
 register(
     "workflow_engine.fire_history_cleanup.time_limit_seconds",
     type=Float,

--- a/src/sentry/workflow_engine/tasks/cleanup.py
+++ b/src/sentry/workflow_engine/tasks/cleanup.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry import options
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import workflow_engine_tasks
@@ -15,8 +16,6 @@ from sentry.utils.query import bulk_delete_objects
 logger = logging.getLogger(__name__)
 
 FIRE_HISTORY_RETENTION_DAYS = 90
-FIRE_HISTORY_BATCH_SIZE = 10000
-FIRE_HISTORY_TIME_LIMIT_SECONDS = 5
 
 
 @instrumented_task(
@@ -28,14 +27,17 @@ FIRE_HISTORY_TIME_LIMIT_SECONDS = 5
 def prune_old_fire_history() -> None:
     from sentry.workflow_engine.models import WorkflowFireHistory
 
+    time_limit: float = options.get("workflow_engine.fire_history_cleanup.time_limit_seconds")
+    batch_size: int = options.get("workflow_engine.fire_history_cleanup.batch_size")
+
     cutoff = timezone.now() - timedelta(days=FIRE_HISTORY_RETENTION_DAYS)
     start = time.time()
     batches_deleted = 0
 
-    while (time.time() - start) < FIRE_HISTORY_TIME_LIMIT_SECONDS:
+    while (time.time() - start) < time_limit:
         has_more = bulk_delete_objects(
             WorkflowFireHistory,
-            limit=FIRE_HISTORY_BATCH_SIZE,
+            limit=batch_size,
             logger=logger,
             date_added__lte=cutoff,
         )

--- a/tests/sentry/workflow_engine/tasks/test_cleanup.py
+++ b/tests/sentry/workflow_engine/tasks/test_cleanup.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.utils.query import bulk_delete_objects
 from sentry.workflow_engine.models import WorkflowFireHistory
 from sentry.workflow_engine.tasks.cleanup import (
     FIRE_HISTORY_RETENTION_DAYS,
@@ -53,7 +55,7 @@ class TestPruneOldFireHistory(TestCase):
         for row in rows:
             assert WorkflowFireHistory.objects.filter(id=row.id).exists()
 
-    @patch("sentry.workflow_engine.tasks.cleanup.FIRE_HISTORY_BATCH_SIZE", 10)
+    @override_options({"workflow_engine.fire_history_cleanup.batch_size": 10})
     def test_multiple_batches(self) -> None:
         old_ids = []
         for _ in range(25):
@@ -67,7 +69,12 @@ class TestPruneOldFireHistory(TestCase):
         mock_metrics.incr.assert_called_once()
         assert mock_metrics.incr.call_args.kwargs["amount"] >= 2
 
-    @patch("sentry.workflow_engine.tasks.cleanup.FIRE_HISTORY_BATCH_SIZE", 10)
+    @override_options(
+        {
+            "workflow_engine.fire_history_cleanup.batch_size": 10,
+            "workflow_engine.fire_history_cleanup.time_limit_seconds": 5.0,
+        }
+    )
     @patch("sentry.workflow_engine.tasks.cleanup.time")
     def test_time_bounded_leaves_remaining_rows(self, mock_time: MagicMock) -> None:
         # start=0, first check=0 (run batch), second check=6 (exit)
@@ -83,6 +90,24 @@ class TestPruneOldFireHistory(TestCase):
 
         remaining = WorkflowFireHistory.objects.filter(id__in=old_ids).count()
         assert remaining == 15  # only one batch of 10 was deleted
+
+    @override_options({"workflow_engine.fire_history_cleanup.batch_size": 5})
+    def test_options_honored(self) -> None:
+        old_ids = []
+        for _ in range(12):
+            obj = self._create_fire_history(days_ago=FIRE_HISTORY_RETENTION_DAYS + 1)
+            old_ids.append(obj.id)
+
+        with patch(
+            "sentry.workflow_engine.tasks.cleanup.bulk_delete_objects",
+            wraps=bulk_delete_objects,
+        ) as spy:
+            prune_old_fire_history()
+
+        for call in spy.call_args_list:
+            assert call.kwargs["limit"] == 5
+
+        assert WorkflowFireHistory.objects.filter(id__in=old_ids).count() == 0
 
     def test_metrics_emitted(self) -> None:
         self._create_fire_history(days_ago=FIRE_HISTORY_RETENTION_DAYS + 1)


### PR DESCRIPTION
We plan on tweaking these values as necessary, might as well make them possible to tweak very quickly.
