### PR TITLE
fix(preprod): Show total image count in snapshot sidebar sections

### DIFF
--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -233,7 +233,17 @@ export function SnapshotSidebarContent({
                       </Text>
                     </Flex>
                     <Flex align="center" gap="xs">
-                      <Text size="sm">{sectionItems.length}</Text>
+                      <Text size="sm">
+                        {/* changed/renamed store images as pairs; added/removed/unchanged use images */}
+                        {sectionItems.reduce(
+                          (sum, item) =>
+                            sum +
+                            (item.type === 'changed' || item.type === 'renamed'
+                              ? item.pairs.length
+                              : item.images.length),
+                          0
+                        )}
+                      </Text>
                       {section.icon}
                     </Flex>
                   </Flex>


### PR DESCRIPTION
Section headers in the snapshot diff sidebar (Modified, Added, Removed, etc.)
displayed the number of groups rather than the total number of images. For
example, "UNCHANGED" showed 14 (groups) instead of the actual image count
across all groups.

Sum `images.length` or `pairs.length` within each group to show the correct
total per section.