### PR TITLE
feat(pipeline): Add shared OAuth login step and redirect popup hook

### DIFF
--- a/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
+++ b/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
@@ -1,0 +1,217 @@
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {OAuthLoginStep} from './oauthLoginStep';
+
+describe('OAuthLoginStep', () => {
+  const mockOnOAuthCallback = jest.fn();
+  let mockPopup: Window;
+
+  beforeEach(() => {
+    mockOnOAuthCallback.mockClear();
+    mockPopup = {
+      closed: false,
+      close: jest.fn(),
+      focus: jest.fn(),
+    } as unknown as Window;
+    jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function dispatchPipelineMessage({
+    data,
+    origin = document.location.origin,
+    source = mockPopup,
+  }: {
+    data: Record<string, string>;
+    origin?: string;
+    source?: Window | MessageEventSource | null;
+  }) {
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {data, origin, source: source as Window})
+      );
+    });
+  }
+
+  it('renders the authorize button with the service name', () => {
+    render(
+      <OAuthLoginStep
+        serviceName="GitLab"
+        oauthUrl="https://gitlab.com/oauth/authorize"
+        onOAuthCallback={mockOnOAuthCallback}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorize GitLab'})).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Authorize your GitLab account with Sentry to complete the integration setup.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('disables the authorize button when no oauthUrl is provided', () => {
+    render(<OAuthLoginStep serviceName="GitHub" onOAuthCallback={mockOnOAuthCallback} />);
+
+    expect(screen.getByRole('button', {name: 'Authorize GitHub'})).toBeDisabled();
+  });
+
+  it('opens a popup when the authorize button is clicked', async () => {
+    render(
+      <OAuthLoginStep
+        serviceName="GitLab"
+        oauthUrl="https://gitlab.com/oauth/authorize"
+        onOAuthCallback={mockOnOAuthCallback}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
+
+    expect(window.open).toHaveBeenCalledWith(
+      'https://gitlab.com/oauth/authorize',
+      'pipeline_popup',
+      expect.any(String)
+    );
+  });
+
+  it('shows waiting state after popup is opened', async () => {
+    render(
+      <OAuthLoginStep
+        serviceName="GitLab"
+        oauthUrl="https://gitlab.com/oauth/authorize"
+        onOAuthCallback={mockOnOAuthCallback}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
+
+    expect(
+      screen.getByText('A popup should have opened to authorize with GitLab.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Reopen authorization window'})
+    ).toBeInTheDocument();
+  });
+
+  it('calls onOAuthCallback when postMessage is received from the popup', async () => {
+    render(
+      <OAuthLoginStep
+        serviceName="GitLab"
+        oauthUrl="https://gitlab.com/oauth/authorize"
+        onOAuthCallback={mockOnOAuthCallback}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
+
+    dispatchPipelineMessage({
+      data: {
+        source: 'sentry-pipeline',
+        code: 'auth-code-123',
+        state: 'state-456',
+        installation_id: 'inst-789',
+      },
+    });
+
+    expect(mockOnOAuthCallback).toHaveBeenCalledWith({
+      code: 'auth-code-123',
+      state: 'state-456',
+      rest: {installation_id: 'inst-789'},
+    });
+  });
+
+  it('ignores postMessage from non-pipeline sources', async () => {
+    render(
+      <OAuthLoginStep
+        serviceName="GitLab"
+        oauthUrl="https://gitlab.com/oauth/authorize"
+        onOAuthCallback={mockOnOAuthCallback}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
+
+    dispatchPipelineMessage({
+      data: {source: 'some-extension', code: 'nope'},
+    });
+
+    expect(mockOnOAuthCallback).not.toHaveBeenCalled();
+  });
+
+  it('ignores postMessage from an untrusted origin', async () => {
+    render(
+      <OAuthLoginStep
+        serviceName="GitLab"
+        oauthUrl="https://gitlab.com/oauth/authorize"
+        onOAuthCallback={mockOnOAuthCallback}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
+
+    dispatchPipelineMessage({
+      data: {source: 'sentry-pipeline', code: 'auth-code-123', state: 'state-456'},
+      origin: 'https://evil.example.com',
+    });
+
+    expect(mockOnOAuthCallback).not.toHaveBeenCalled();
+  });
+
+  it('ignores postMessage not from the popup window', async () => {
+    render(
+      <OAuthLoginStep
+        serviceName="GitLab"
+        oauthUrl="https://gitlab.com/oauth/authorize"
+        onOAuthCallback={mockOnOAuthCallback}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
+
+    dispatchPipelineMessage({
+      data: {source: 'sentry-pipeline', code: 'auth-code-123', state: 'state-456'},
+      source: null,
+    });
+
+    expect(mockOnOAuthCallback).not.toHaveBeenCalled();
+  });
+
+  it('shows warning when popup is blocked by the browser', async () => {
+    jest.spyOn(window, 'open').mockReturnValue(null);
+
+    render(
+      <OAuthLoginStep
+        serviceName="GitLab"
+        oauthUrl="https://gitlab.com/oauth/authorize"
+        onOAuthCallback={mockOnOAuthCallback}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
+
+    expect(
+      screen.getByText(
+        'The authorization popup was blocked by your browser. Please ensure popups are allowed and try again.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('A popup should have opened to authorize with GitLab.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows loading state when isLoading is true', () => {
+    render(
+      <OAuthLoginStep
+        serviceName="GitLab"
+        oauthUrl="https://gitlab.com/oauth/authorize"
+        isLoading
+        onOAuthCallback={mockOnOAuthCallback}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
+  });
+});

--- a/static/app/components/pipeline/shared/oauthLoginStep.tsx
+++ b/static/app/components/pipeline/shared/oauthLoginStep.tsx
@@ -1,0 +1,85 @@
+import {useCallback} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t, tct} from 'sentry/locale';
+
+import {useRedirectPopupStep, type PopupOptions} from './useRedirectPopupStep';
+
+export interface OAuthCallbackData {
+  code: string;
+  rest: Record<string, string>;
+  state: string;
+}
+
+interface OAuthLoginStepProps {
+  onOAuthCallback: (data: OAuthCallbackData) => void;
+  serviceName: string;
+  isLoading?: boolean;
+  oauthUrl?: string;
+  popup?: PopupOptions;
+}
+
+export function OAuthLoginStep({
+  oauthUrl,
+  isLoading,
+  serviceName,
+  onOAuthCallback,
+  popup,
+}: OAuthLoginStepProps) {
+  const handleCallback = useCallback(
+    (raw: Record<string, string>) => {
+      const {code = '', state = '', ...rest} = raw;
+      onOAuthCallback({code, state, rest});
+    },
+    [onOAuthCallback]
+  );
+
+  const {openPopup, popupStatus} = useRedirectPopupStep({
+    redirectUrl: oauthUrl,
+    onCallback: handleCallback,
+    popup,
+  });
+
+  return (
+    <Stack gap="lg" align="start">
+      <Stack gap="sm">
+        <Text>
+          {tct(
+            'Authorize your [service] account with Sentry to complete the integration setup.',
+            {service: serviceName}
+          )}
+        </Text>
+        {popupStatus === 'popup-open' && (
+          <Text variant="muted" size="sm">
+            {tct('A popup should have opened to authorize with [service].', {
+              service: serviceName,
+            })}
+          </Text>
+        )}
+        {popupStatus === 'failed-to-open' && (
+          <Text variant="danger" size="sm">
+            {t(
+              'The authorization popup was blocked by your browser. Please ensure popups are allowed and try again.'
+            )}
+          </Text>
+        )}
+      </Stack>
+      {isLoading ? (
+        <Button size="sm" disabled>
+          {t('Authorizing...')}
+        </Button>
+      ) : popupStatus === 'popup-open' ? (
+        <Button size="sm" onClick={openPopup}>
+          {t('Reopen authorization window')}
+        </Button>
+      ) : (
+        <Button size="sm" priority="primary" onClick={openPopup} disabled={!oauthUrl}>
+          {tct('Authorize [service]', {service: serviceName})}
+        </Button>
+      )}
+    </Stack>
+  );
+}

--- a/static/app/components/pipeline/shared/useRedirectPopupStep.tsx
+++ b/static/app/components/pipeline/shared/useRedirectPopupStep.tsx
@@ -1,0 +1,150 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {ConfigStore} from 'sentry/stores/configStore';
+
+/**
+ * Configuration of the redirect popup
+ */
+export interface PopupOptions {
+  height?: number;
+  width?: number;
+}
+
+export type PopupStatus = 'not-open' | 'popup-open' | 'failed-to-open';
+
+interface UseRedirectPopupStepOptions {
+  /**
+   * Called with the postMessage data when the popup completes the redirect flow.
+   * Typically this calls `advance(callbackData)` to move the pipeline forward.
+   */
+  onCallback: (data: Record<string, string>) => void;
+  /**
+   * The URL to open in the popup.
+   */
+  redirectUrl: string | undefined;
+  /**
+   * Width and height of the popup window. Defaults to 1000x700.
+   */
+  popup?: PopupOptions;
+}
+
+interface UseRedirectPopupStepResult {
+  isWaitingForCallback: boolean;
+  /**
+   * Opens the redirect popup. MUST be called from a user gesture (e.g. a
+   * button click handler) — browsers block `window.open` outside of a
+   * user-initiated call stack.
+   */
+  openPopup: () => void;
+  popupStatus: PopupStatus;
+}
+
+/**
+ * Manages a popup window for pipeline steps that redirect to an external
+ * service (e.g. GitHub OAuth, GitHub App installation). Listens for a
+ * postMessage callback from the trampoline page, and calls onCallback
+ * with the received data.
+ *
+ * Usage in a step component:
+ * ```tsx
+ * function OAuthStep({stepData, advance}: PipelineStepProps<OAuthStepData>) {
+ *   const {openPopup, popupStatus} = useRedirectPopupStep({
+ *     redirectUrl: stepData.oauthUrl,
+ *     onCallback: data => advance({code: data.code, state: data.state}),
+ *   });
+ *   if (popupStatus === 'popup-open') {
+ *     return <p>Waiting... <button onClick={openPopup}>Reopen</button></p>;
+ *   }
+ *   return <button onClick={openPopup}>Authorize</button>;
+ * }
+ * ```
+ */
+export function useRedirectPopupStep({
+  redirectUrl,
+  onCallback,
+  popup,
+}: UseRedirectPopupStepOptions): UseRedirectPopupStepResult {
+  const popupRef = useRef<Window | null>(null);
+  const [popupStatus, setPopupStatus] = useState<PopupStatus>('not-open');
+
+  const width = popup?.width ?? 650;
+  const height = popup?.height ?? 750;
+
+  const openPopupWindow = useCallback(
+    (url: string) => {
+      if (popupRef.current && !popupRef.current.closed) {
+        popupRef.current.focus();
+        return;
+      }
+      const left = Math.round(window.screenX + (window.outerWidth - width) / 2);
+      const top = Math.round(window.screenY + (window.outerHeight - height) / 2);
+      const features = `popup,width=${width},height=${height},left=${left},top=${top}`;
+
+      const opened = window.open(url, 'pipeline_popup', features);
+      popupRef.current = opened;
+
+      setPopupStatus(opened ? 'popup-open' : 'failed-to-open');
+    },
+    [width, height]
+  );
+
+  // Listen for postMessage from the trampoline page in the popup.
+  // The trampoline includes a `source: "sentry-pipeline"` key so we can
+  // distinguish it from unrelated messages (browser extensions, devtools, etc.).
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      if (!event.data || typeof event.data !== 'object') {
+        return;
+      }
+      if (event.data.source !== 'sentry-pipeline') {
+        return;
+      }
+
+      const links = ConfigStore.get('links');
+      const validOrigins = [
+        links?.sentryUrl,
+        links?.organizationUrl,
+        document.location.origin,
+      ];
+      if (!validOrigins.includes(event.origin)) {
+        return;
+      }
+      if (event.source !== popupRef.current) {
+        return;
+      }
+
+      if (popupRef.current && !popupRef.current.closed) {
+        popupRef.current.close();
+      }
+      popupRef.current = null;
+
+      setPopupStatus('not-open');
+      const {source: _source, ...callbackData} = event.data as Record<string, string>;
+      onCallback(callbackData);
+    }
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [onCallback]);
+
+  // Close popup on unmount
+  useEffect(() => {
+    return () => {
+      if (popupRef.current && !popupRef.current.closed) {
+        popupRef.current.close();
+      }
+    };
+  }, []);
+
+  const openPopup = useCallback(() => {
+    if (redirectUrl) {
+      openPopupWindow(redirectUrl);
+    }
+  }, [redirectUrl, openPopupWindow]);
+
+  return {
+    openPopup,
+    popupStatus,
+    isWaitingForCallback: popupStatus === 'popup-open',
+  };
+}


### PR DESCRIPTION
Extract reusable frontend components for the OAuth popup flow so
integration pipelines can share the same authorization UX. The
OAuthLoginStep handles opening the popup, listening for postMessage
callbacks from the trampoline, and forwarding the code/state params.

Refs VDY-35