### PR TITLE
fix(releases): Add gap between release detail header action groups

### DIFF
--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {archiveRelease, restoreRelease} from 'sentry/actionCreators/release';
@@ -184,7 +184,7 @@ export function ReleaseActions({projectSlug, release, releaseMeta, refetchData}:
   const hasNext = !!release.currentProjectMeta.nextReleaseVersion;
 
   return (
-    <ButtonBar>
+    <Flex gap="sm" align="center">
       {openFeedbackForm ? (
         <Container display={{'2xs': 'none', xs: 'block'}}>
           <Button
@@ -247,7 +247,7 @@ export function ReleaseActions({projectSlug, release, releaseMeta, refetchData}:
         }}
         position="bottom-end"
       />
-    </ButtonBar>
+    </Flex>
   );
 }
 


### PR DESCRIPTION
before

<img width="448" height="76" alt="image" src="https://github.com/user-attachments/assets/68b0d053-e32c-47f0-9e1c-d1b7b68af8b7" />

after

<img width="440" height="73" alt="image" src="https://github.com/user-attachments/assets/677547ef-186f-4b67-a26b-ff428b0a36fd" />
