### PR TITLE
feat(preprod): Show detector section in sidebar for size analysis issues

### DIFF
--- a/static/app/utils/issueTypeConfig/preprodConfig.tsx
+++ b/static/app/utils/issueTypeConfig/preprodConfig.tsx
@@ -4,6 +4,11 @@ import {Tab} from 'sentry/views/issueDetails/types';
 
 export const preprodConfig: IssueCategoryConfigMapping = {
   _categoryDefaults: {
+    detector: {
+      enabled: true,
+      title: t('Mobile Build Monitor'),
+      ctaText: t('View monitor details'),
+    },
     actions: {
       archiveUntilOccurrence: {enabled: true},
       delete: {

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.spec.tsx
@@ -120,6 +120,41 @@ describe('DetectorSection', () => {
     ).toBeInTheDocument();
   });
 
+  it('displays the detector details for a mobile build monitor', () => {
+    const event = EventFixture({
+      occurrence: {
+        evidenceData: {
+          detectorId,
+        },
+        type: 11003,
+      },
+    });
+    const group = GroupFixture({
+      issueCategory: IssueCategory.PREPROD,
+      issueType: IssueType.PREPROD_SIZE_ANALYSIS,
+    });
+    const detectorDetails = getDetectorDetails({event, organization, project});
+
+    render(
+      <IssueDetailsContext value={{...issueDetailsContext, detectorDetails}}>
+        <DetectorSection group={group} project={project} />
+      </IssueDetailsContext>,
+      {organization}
+    );
+
+    expect(screen.getByText('Mobile Build Monitor')).toBeInTheDocument();
+    const link = screen.getByRole('button', {name: 'View monitor details'});
+    expect(link).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/monitors/${detectorId}/`
+    );
+    expect(
+      screen.getByText(
+        'This issue was created by a mobile build monitor. View the monitor details to learn more.'
+      )
+    ).toBeInTheDocument();
+  });
+
   it('displays the detector details for an uptime monitor', () => {
     const event = EventFixture({
       occurrence: {

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -23,7 +23,11 @@ export interface DetectorDetails {
   detectorId?: string;
   detectorPath?: string;
   detectorSlug?: string;
-  detectorType?: 'metric_alert' | 'cron_monitor' | 'uptime_monitor';
+  detectorType?:
+    | 'metric_alert'
+    | 'cron_monitor'
+    | 'uptime_monitor'
+    | 'mobile_build_monitor';
 }
 
 export function getDetectorDetails({
@@ -69,6 +73,24 @@ export function getDetectorDetails({
         'This issue was created by a cron monitor. View the monitor details to learn more.'
       ),
     };
+  }
+
+  const isPreprodSizeAnalysis = event?.occurrence?.type === 11003;
+  if (isPreprodSizeAnalysis) {
+    const preprodDetectorId = event.occurrence?.evidenceData.detectorId;
+    if (preprodDetectorId) {
+      return {
+        detectorType: 'mobile_build_monitor',
+        detectorId: String(preprodDetectorId),
+        detectorPath: makeMonitorDetailsPathname(
+          organization.slug,
+          String(preprodDetectorId)
+        ),
+        description: t(
+          'This issue was created by a mobile build monitor. View the monitor details to learn more.'
+        ),
+      };
+    }
   }
 
   const detectorId: number | undefined = event.occurrence?.evidenceData.detectorId;


### PR DESCRIPTION
Show the "Mobile Build Monitor" detector section in the issue detail sidebar for preprod size analysis issues, matching what metric, cron, and uptime monitors already have. Links to the monitor details page.

The backend already writes `detector_id` to occurrence evidence data, so this is frontend-only. A new detection branch for occurrence type `11003` is added before the existing uptime fallback to avoid misclassifying preprod issues as uptime monitors (both have `evidenceData.detectorId`).

<img width="2976" height="1492" alt="CleanShot 2026-03-25 at 15 34 20@2x" src="https://github.com/user-attachments/assets/3a81ced8-b353-48ad-b50e-c181c41801f3" />

Refs EME-982