### PR TITLE
fix(releases): Prevent false positive regressions when `follows_semver` flips after resolution

### DIFF
--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -132,7 +132,19 @@ class GroupResolution(Model):
                     release_raw = parse_release(release.version, json_loads=orjson.loads).get(
                         "version_raw"
                     )
-                    return compare_version_relay(current_release_raw, release_raw) >= 0
+                    if compare_version_relay(current_release_raw, release_raw) >= 0:
+                        return True
+
+                    # If current_release_version was set under different
+                    # follows_semver conditions (e.g. date ordering when
+                    # follows_semver was False), it may be stale. Fall back to
+                    # comparing the event release against the resolved-in
+                    # release: if the event is on an older version than the fix,
+                    # the resolution still holds.
+                    res_release_raw = parse_release(
+                        res_release_version, json_loads=orjson.loads
+                    ).get("version_raw")
+                    return compare_version_relay(res_release_raw, release_raw) == 1
                 except RelayError:
                     ...
             else:

--- a/tests/sentry/models/test_groupresolution.py
+++ b/tests/sentry/models/test_groupresolution.py
@@ -214,3 +214,62 @@ class GroupResolutionTest(TestCase):
             )
 
             resolution.delete()
+
+    def test_stale_current_release_version_with_semver_flip(self) -> None:
+        now = timezone.now()
+        current_at_resolution = self.create_release(
+            version="hotfix_pkg@1.3.0",
+            date_added=now - timedelta(minutes=45),
+        )
+        resolved_in_release = self.create_release(
+            version="hotfix_pkg@1.5.0",
+            date_added=now - timedelta(minutes=30),
+        )
+        # Out-of-order: older semver but created later
+        event_release = self.create_release(
+            version="hotfix_pkg@1.4.0",
+            date_added=now - timedelta(minutes=15),
+        )
+        # Non-semver release makes follows_semver False at resolution time;
+        # by event time it's no longer in the recent 3 so follows_semver flips to True
+        self.create_release(
+            version="hotfix_pkg@nightly-100",
+            date_added=now - timedelta(minutes=60),
+        )
+
+        GroupResolution.objects.create(
+            release=resolved_in_release,
+            current_release_version=current_at_resolution.version,
+            group=self.group,
+            type=GroupResolution.Type.in_next_release,
+            status=GroupResolution.Status.pending,
+        )
+
+        # Fix is in 1.5.0; event on 1.4.0 (< 1.5.0 in semver) should NOT regress
+        assert GroupResolution.has_resolution(self.group, event_release)
+
+    def test_genuine_regression_detected_with_stale_current_release_version(self) -> None:
+        now = timezone.now()
+        current_at_resolution = self.create_release(
+            version="regtest_pkg@1.3.0",
+            date_added=now - timedelta(minutes=45),
+        )
+        resolved_in_release = self.create_release(
+            version="regtest_pkg@1.5.0",
+            date_added=now - timedelta(minutes=30),
+        )
+        event_release = self.create_release(
+            version="regtest_pkg@1.7.0",
+            date_added=now - timedelta(minutes=15),
+        )
+
+        GroupResolution.objects.create(
+            release=resolved_in_release,
+            current_release_version=current_at_resolution.version,
+            group=self.group,
+            type=GroupResolution.Type.in_next_release,
+            status=GroupResolution.Status.pending,
+        )
+
+        # Event on 1.7.0 > resolved-in 1.5.0, so this IS a regression
+        assert not GroupResolution.has_resolution(self.group, event_release)


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/111393.

When `has_resolution()` determines that `current_release_version` is older than the event's release (semver), also check whether the event's release is older than the resolved-in release before declaring regression.

Fixes false positive regressions when `follows_semver` flips from False to True between resolution time & event arrival time.