### PR TITLE
fix(tasks): Add sentry.workflow_engine.tasks.cleanup to TASKWORKER_IMPORTS

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -976,6 +976,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.workflow_engine.tasks.delayed_workflows",
     "sentry.workflow_engine.tasks.workflows",
     "sentry.workflow_engine.tasks.actions",
+    "sentry.workflow_engine.tasks.cleanup",
     "sentry.tasks.seer.explorer_index",
     "sentry.tasks.seer.context_engine_index",
     # Used for tests


### PR DESCRIPTION
I thought CI wouldn't have allowed it if this were necessary, seems I was wrong.

