### PR TITLE
feat(assisted-query): Add tracemetrics built-in fields to _get_built_in_fields

### DIFF
--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -48,12 +48,28 @@ _LOG_BUILT_IN_NUMBER_FIELDS = [
 ]
 
 
+_METRIC_BUILT_IN_STRING_FIELDS = [
+    "metric.name",
+    "metric.type",
+    "metric.unit",
+    "timestamp",
+    "project",
+    "environment",
+    "release",
+    "trace",
+]
+
+_METRIC_BUILT_IN_NUMBER_FIELDS = [
+    "value",
+]
+
+
 def _get_built_in_fields(item_type: str = "spans") -> list[dict[str, Any]]:
     """
     Get built-in fields for the specified item type.
 
     Args:
-        item_type: Type of trace item ("spans" or "logs")
+        item_type: Type of trace item ("spans", "logs", or "tracemetrics")
 
     Returns:
         List of built-in field definitions with key and type.
@@ -61,6 +77,9 @@ def _get_built_in_fields(item_type: str = "spans") -> list[dict[str, Any]]:
     if item_type == "logs":
         string_fields = _LOG_BUILT_IN_STRING_FIELDS
         number_fields = _LOG_BUILT_IN_NUMBER_FIELDS
+    elif item_type == "tracemetrics":
+        string_fields = _METRIC_BUILT_IN_STRING_FIELDS
+        number_fields = _METRIC_BUILT_IN_NUMBER_FIELDS
     else:
         string_fields = _SPAN_BUILT_IN_STRING_FIELDS
         number_fields = _SPAN_BUILT_IN_NUMBER_FIELDS


### PR DESCRIPTION
## Summary
- Add `_METRIC_BUILT_IN_STRING_FIELDS` and `_METRIC_BUILT_IN_NUMBER_FIELDS` defining the correct built-in fields for the metrics dataset
- Add `"tracemetrics"` branch to `_get_built_in_fields()` so the `get_attribute_names` RPC returns correct metrics built-in fields instead of falling through to span fields

## Why
When Seer calls `get_attribute_names` with `item_type="tracemetrics"`, the function currently falls through to the `else` branch and returns span built-in fields (`span.op`, `span.duration`, etc.). Seer has a workaround (`_reclassify_metrics_built_in_fields`) to fix this, but it's better to return the right fields at the source.

## Follow-up
After this is deployed, Seer's `_reclassify_metrics_built_in_fields` workaround and `METRICS_KNOWN_BUILT_IN_FIELDS` constant can be removed.

## Test plan
- [ ] Verify `_get_built_in_fields("tracemetrics")` returns metric fields (metric.name, metric.type, metric.unit, value, etc.)
- [ ] Verify `_get_built_in_fields("spans")` still returns span fields (unchanged)
- [ ] Verify `_get_built_in_fields("logs")` still returns log fields (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)