### PR TITLE
feat(workflow): Make OrganizationIncidentDetailsEndpoint.get support single-written workflows

### DIFF
--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -72,7 +72,9 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
-        if features.has("organizations:workflow-engine-rule-serializers", organization):
+        if request.method == "GET" and features.has(
+            "organizations:workflow-engine-rule-serializers", organization
+        ):
             gop: GroupOpenPeriod | None = None
 
             # Try the association table first (dual-written data).

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -1,16 +1,29 @@
+from typing import Any
+
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializer
+from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
+from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
+    WorkflowEngineDetailedIncidentSerializer,
+)
 from sentry.incidents.logic import update_incident_status
-from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
+from sentry.incidents.models.incident import Incident, IncidentStatus, IncidentStatusMethod
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
+from sentry.workflow_engine.models import IncidentGroupOpenPeriod
 from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 
@@ -37,16 +50,98 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
+    def convert_args(
+        self,
+        request: Request,
+        incident_identifier: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        int_id = to_valid_int_id("incident_identifier", incident_identifier, raise_404=True)
+
+        # We call OrganizationEndpoint.convert_args directly instead of super()
+        # (IncidentEndpoint.convert_args) because IncidentEndpoint unconditionally queries
+        # the legacy Incident model, which would 404 before we can check the feature flag
+        # and redirect to workflow engine data.  The legacy Incident lookup at the bottom
+        # of this method replicates IncidentEndpoint's behaviour for the flag-off path.
+        # TODO: once PUT is migrated to the workflow engine path, the flag-off branch can
+        # be removed and this override eliminated in favour of a WE-aware IncidentEndpoint.
+        args, kwargs = OrganizationEndpoint.convert_args(self, request, *args, **kwargs)
+        organization = kwargs["organization"]
+
+        if not features.has("organizations:incidents", organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        if features.has("organizations:workflow-engine-rule-serializers", organization):
+            gop: GroupOpenPeriod | None = None
+
+            # Try the association table first (dual-written data).
+            try:
+                igop = IncidentGroupOpenPeriod.objects.select_related(
+                    "group_open_period__project",
+                    "group_open_period__group",
+                ).get(
+                    incident_identifier=int_id,
+                    group_open_period__project__organization=organization,
+                )
+                gop = igop.group_open_period
+            except IncidentGroupOpenPeriod.DoesNotExist:
+                pass
+
+            # Fall back to manufactured ID (single-written data).
+            if gop is None:
+                gop_id = get_object_id_from_fake_id(int_id)
+                if gop_id > 0:
+                    try:
+                        gop = GroupOpenPeriod.objects.select_related("project", "group").get(
+                            id=gop_id, project__organization=organization
+                        )
+                    except GroupOpenPeriod.DoesNotExist:
+                        pass
+
+            if gop is None:
+                raise ResourceDoesNotExist
+
+            if not request.access.has_project_access(gop.project):
+                raise PermissionDenied
+
+            kwargs["incident"] = gop
+            return args, kwargs
+
+        # Legacy path (flag off): replicate IncidentEndpoint.convert_args lookup.
+        try:
+            incident = kwargs["incident"] = Incident.objects.get(
+                organization=organization, identifier=int_id
+            )
+        except Incident.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        if not any(p for p in incident.projects.all() if request.access.has_project_access(p)):
+            raise PermissionDenied
+
+        return args, kwargs
+
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-details")
-    def get(self, request: Request, organization, incident) -> Response:
+    def get(
+        self,
+        request: Request,
+        organization: Organization,
+        incident: Incident | GroupOpenPeriod,
+    ) -> Response:
         """
         Fetch an Incident.
         ``````````````````
         :auth: required
         """
-        data = serialize(incident, request.user, DetailedIncidentSerializer())
+        if isinstance(incident, GroupOpenPeriod):
+            expand = request.GET.getlist("expand", [])
+            return Response(
+                serialize(
+                    incident, request.user, WorkflowEngineDetailedIncidentSerializer(expand=expand)
+                )
+            )
 
-        return Response(data)
+        return Response(serialize(incident, request.user, DetailedIncidentSerializer()))
 
     @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-incident-details")
     def put(self, request: Request, organization: Organization, incident) -> Response:

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -155,8 +155,7 @@ class WorkflowEngineIncidentDetailsTest(APITestCase):
     def test_unmapped_real_identifier_returns_404(self) -> None:
         # Real identifier with no IncidentGroupOpenPeriod row and not a fake ID → 404.
         incident = self.create_incident()
-        resp = self.get_response(self.organization.slug, incident.identifier)
-        assert resp.status_code == 404
+        self.get_error_response(self.organization.slug, incident.identifier, status_code=404)
 
     def test_fake_id_cross_org_returns_404(self) -> None:
         other_org = self.create_organization(owner=self.user)

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -1,10 +1,21 @@
 from functools import cached_property
 
 from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
+from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.incident import Incident, IncidentStatus
+from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.serializer_parity import assert_serializer_parity
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
+from sentry.workflow_engine.models import IncidentGroupOpenPeriod
+from tests.sentry.incidents.serializers.test_workflow_engine_base import (
+    TestWorkflowEngineSerializer,
+)
 
 
 class BaseIncidentDetailsTest(APITestCase):
@@ -57,6 +68,12 @@ class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest):
         assert resp.data["dateCreated"] == expected["dateCreated"]
         assert resp.data["projects"] == expected["projects"]
 
+    def test_workflow_engine_flag_off_uses_legacy_path(self) -> None:
+        incident = self.create_incident()
+        with self.feature("organizations:incidents"):
+            resp = self.get_success_response(self.organization.slug, incident.identifier)
+        assert resp.data["id"] == str(incident.id)
+
 
 class OrganizationIncidentUpdateStatusTest(BaseIncidentDetailsTest):
     method = "put"
@@ -90,3 +107,107 @@ class OrganizationIncidentUpdateStatusTest(BaseIncidentDetailsTest):
             resp = self.get_response(incident.organization.slug, incident.identifier, status=5000)
             assert resp.status_code == 400
             assert resp.data["status"][0].startswith("Invalid value for status")
+
+
+@with_feature(["organizations:incidents", "organizations:workflow-engine-rule-serializers"])
+class WorkflowEngineIncidentDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-incident-details"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+        self.alert_rule = self.create_alert_rule()
+        _, _, _, self.detector, _, self.ard, _, _ = migrate_alert_rule(self.alert_rule)
+
+        self.group = self.create_group(type=MetricIssue.type_id)
+        self.group.update(priority=PriorityLevel.HIGH)
+        self.create_detector_group(detector=self.detector, group=self.group)
+        self.gop = GroupOpenPeriod.objects.get(group=self.group, project=self.project)
+
+    def test_dual_written_get(self) -> None:
+        incident = self.create_incident(alert_rule=self.alert_rule)
+        igop = IncidentGroupOpenPeriod.objects.create(
+            group_open_period=self.gop,
+            incident_id=incident.id,
+            incident_identifier=incident.identifier,
+        )
+
+        resp = self.get_success_response(self.organization.slug, incident.identifier)
+
+        assert resp.data["id"] == str(igop.incident_id)
+        assert resp.data["identifier"] == str(igop.incident_identifier)
+        assert resp.data["status"] == IncidentStatus.CRITICAL.value
+
+    def test_single_written_get(self) -> None:
+        # Single-written: no IncidentGroupOpenPeriod, no AlertRuleDetector mapping.
+        self.ard.delete()
+        fake_id = get_fake_id_from_object_id(self.gop.id)
+        fake_detector_id = get_fake_id_from_object_id(self.detector.id)
+
+        resp = self.get_success_response(self.organization.slug, fake_id)
+
+        assert resp.data["id"] == str(fake_id)
+        assert resp.data["identifier"] == str(fake_id)
+        assert resp.data["alertRule"]["id"] == str(fake_detector_id)
+        assert resp.data["status"] == IncidentStatus.CRITICAL.value
+
+    def test_unmapped_real_identifier_returns_404(self) -> None:
+        # Real identifier with no IncidentGroupOpenPeriod row and not a fake ID → 404.
+        incident = self.create_incident()
+        resp = self.get_response(self.organization.slug, incident.identifier)
+        assert resp.status_code == 404
+
+    def test_fake_id_cross_org_returns_404(self) -> None:
+        other_org = self.create_organization(owner=self.user)
+        fake_id = get_fake_id_from_object_id(self.gop.id)
+
+        resp = self.get_response(other_org.slug, fake_id)
+        assert resp.status_code == 404
+
+
+class IncidentDetailsDeltaTest(APITestCase, TestWorkflowEngineSerializer):
+    endpoint = "sentry-api-0-organization-incident-details"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.add_warning_trigger()
+        self.add_incident_data()
+        self.login_as(self.user)
+
+    @with_feature("organizations:incidents")
+    def test_serializer_parity(self) -> None:
+        old_resp = self.get_success_response(self.organization.slug, self.incident.identifier)
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            new_resp = self.get_success_response(self.organization.slug, self.incident.identifier)
+
+        old_data = dict(old_resp.data)
+        new_data = dict(new_resp.data)
+
+        # Sort triggers for order-independent comparison.
+        for data in (old_data, new_data):
+            if isinstance(data.get("alertRule"), dict):
+                data["alertRule"] = {
+                    **data["alertRule"],
+                    "triggers": sorted(
+                        data["alertRule"].get("triggers", []), key=lambda t: t.get("label", "")
+                    ),
+                }
+
+        assert_serializer_parity(
+            old=old_data,
+            new=new_data,
+            known_differences={
+                # migration always creates a resolve condition; the old serializer can
+                # return None when AlertRule.resolve_threshold is unset.
+                "alertRule.resolveThreshold",
+                "alertRule.triggers.resolveThreshold",
+                # WE derives status from group priority (HIGH→CRITICAL); legacy preserves
+                # the incident's own status field which starts as OPEN.
+                "status",
+                # WE uses the live group title; legacy preserves the incident title
+                # as it was at creation time.
+                "title",
+            },
+        )

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -25,6 +25,9 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
         super().setUp()
         self.add_warning_trigger()
         self.add_incident_data()
+        # Incident serializer uses DetailedWorkflowEngineDetectorSerializer, which always
+        # includes eventTypes and snooze to match DetailedAlertRuleSerializer behaviour.
+        self.expected.update({"eventTypes": ["error"], "snooze": False})
         self.incident_identifier = str(self.incident_group_open_period.incident_identifier)
         self.expected["eventTypes"] = sorted(
             SnubaQueryEventType.EventType(et.type).name.lower()

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -25,9 +25,6 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
         super().setUp()
         self.add_warning_trigger()
         self.add_incident_data()
-        # Incident serializer uses DetailedWorkflowEngineDetectorSerializer, which always
-        # includes eventTypes and snooze to match DetailedAlertRuleSerializer behaviour.
-        self.expected.update({"eventTypes": ["error"], "snooze": False})
         self.incident_identifier = str(self.incident_group_open_period.incident_identifier)
         self.expected["eventTypes"] = sorted(
             SnubaQueryEventType.EventType(et.type).name.lower()


### PR DESCRIPTION
Part of the project described in src/sentry/workflow_engine/docs/legacy_backport.md.

Fixes ISWF-2296.