### PR TITLE
fix(context engine tasks): Fix stale task names after module move to sentry/tasks/seer/

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1148,12 +1148,12 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "schedule": crontab("0", "*/1", "*", "*", "*"),
     },
     "context-engine-index": {
-        "task": "seer:sentry.tasks.context_engine_index.schedule_context_engine_indexing_tasks",
+        "task": "seer:sentry.tasks.seer.context_engine_index.schedule_context_engine_indexing_tasks",
         # Offset by 30 minutes from seer-explorer-index to spread load
         "schedule": crontab("30", "*/1", "*", "*", "*"),
     },
     "index-sentry-knowledge": {
-        "task": "seer:sentry.tasks.context_engine_index.index_sentry_knowledge",
+        "task": "seer:sentry.tasks.seer.context_engine_index.index_sentry_knowledge",
         # Run once a month at midnight
         "schedule": crontab("0", "0", "*", "1", "*"),
     },

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 
 @instrumented_task(
-    name="sentry.tasks.context_engine_index.index_org_project_knowledge",
+    name="sentry.tasks.seer.context_engine_index.index_org_project_knowledge",
     namespace=seer_tasks,
     processing_deadline_duration=10 * 60,
 )
@@ -136,7 +136,7 @@ def index_org_project_knowledge(org_id: int) -> None:
 
 
 @instrumented_task(
-    name="sentry.tasks.context_engine_index.build_service_map",
+    name="sentry.tasks.seer.context_engine_index.build_service_map",
     namespace=seer_tasks,
     processing_deadline_duration=10 * 60,  # 10 minutes
     retry=Retry(times=3, on=(SnubaRPCRateLimitExceeded,), delay=60),
@@ -266,7 +266,7 @@ def get_allowed_org_ids_context_engine_indexing() -> list[int]:
 
 
 @instrumented_task(
-    name="sentry.tasks.context_engine_index.schedule_context_engine_indexing_tasks",
+    name="sentry.tasks.seer.context_engine_index.schedule_context_engine_indexing_tasks",
     namespace=seer_tasks,
     processing_deadline_duration=30 * 60,
     retry=Retry(times=3, on=(RpcRemoteException,), delay=60),
@@ -307,7 +307,7 @@ def schedule_context_engine_indexing_tasks() -> None:
 
 
 @instrumented_task(
-    name="sentry.tasks.context_engine_index.index_sentry_knowledge",
+    name="sentry.tasks.seer.context_engine_index.index_sentry_knowledge",
     namespace=seer_tasks,
     processing_deadline_duration=30,
 )

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -79,7 +79,7 @@ SAMPLED_TASKS = {
     "sentry.dynamic_sampling.tasks.recalibrate_orgs": 0.2 * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.dynamic_sampling.tasks.sliding_window_org": 0.2 * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.tasks.autofix.configure_seer_for_existing_org": 1.0,
-    "sentry.tasks.context_engine_index.schedule_context_engine_indexing_tasks": 1.0,
+    "sentry.tasks.seer.context_engine_index.schedule_context_engine_indexing_tasks": 1.0,
 }
 
 SAMPLED_ROUTES = {


### PR DESCRIPTION
+ The context engine indexing tasks were moved from sentry/tasks/context_engine_index.py to sentry/tasks/seer/context_engine_index.py in a recent refactor, but the name= strings in the @instrumented_task decorators were not updated. This caused the taskworker's activation.taskname to use the old dotted path, which no longer matched the SAMPLED_TASKS key in sdk.py or the scheduler config in server.py.
+ As a result, traces_sampler could not look up the correct sample rate for schedule_context_engine_indexing_tasks, falling through to the low default SENTRY_BACKEND_APM_SAMPLING rate instead of the intended 1.0.
+ Updates all four task name= strings, the SAMPLED_TASKS entry, and both cron schedule "task" references to use the correct sentry.tasks.seer.context_engine_index.* path.