### PR TITLE
feat(aci): Align metric chart data points with open period markers

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -16,6 +16,7 @@ import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconInfo, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {Series} from 'sentry/types/echarts';
 import type {GroupOpenPeriod} from 'sentry/types/group';
 import type {MetricDetector, SnubaQuery} from 'sentry/types/workflowEngine/detectors';
 import {axisLabelFormatterUsingAggregateOutputType} from 'sentry/utils/discover/charts';
@@ -44,6 +45,27 @@ import {useMetricDetectorThresholdSeries} from 'sentry/views/detectors/hooks/use
 import {useMetricTimestamps} from 'sentry/views/detectors/hooks/useMetricTimestamps';
 import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {getDetectorChartFormatters} from 'sentry/views/detectors/utils/detectorChartFormatting';
+
+/**
+ * Shift data points from bucket-start to bucket-end timestamps.
+ * The API returns timestamps at the start of each bucket (e.g. 1pm for 1pm–2pm),
+ * but we want to display them at the end (2pm) since the value represents
+ * the data collected during the preceding interval.
+ *
+ * The reason we do this for metric charts is that it's important that the data points
+ * visually align with the open period markers. If an open period starts at 1pm, it should
+ * be vertically aligned with the data point for 12pm-1pm.
+ */
+function shiftSeriesToBucketEnd(seriesList: Series[], intervalSeconds: number): Series[] {
+  const offsetMs = intervalSeconds * 1000;
+  return seriesList.map(s => ({
+    ...s,
+    data: s.data.map(point => ({
+      ...point,
+      name: (point.name as number) + offsetMs,
+    })),
+  }));
+}
 
 interface IncidentTooltipContext {
   period: IncidentPeriod;
@@ -391,13 +413,31 @@ export function useMetricDetectorChart({
       showTimeInTooltip: true,
       height,
       stacked: false,
-      series,
+      series: shiftSeriesToBucketEnd(series, snubaQuery.timeWindow),
       additionalSeries,
       yAxes: yAxes.length > 1 ? yAxes : undefined,
       yAxis: yAxes.length === 1 ? yAxes[0] : undefined,
       grid,
       xAxis: openPeriodMarkerResult.incidentMarkerXAxis,
       tooltip: {
+        // Data points are shifted to bucket-end timestamps
+        // so we need to subtract the interval to get the bucket-start time.
+        formatAxisLabel: (
+          value,
+          isTimestamp,
+          utc,
+          showTimeInTooltip,
+          addSecondsToTimeFormat,
+          bucketSize
+        ) =>
+          defaultFormatAxisLabel(
+            value - snubaQuery.timeWindow * 1000,
+            isTimestamp,
+            utc,
+            showTimeInTooltip,
+            addSecondsToTimeFormat,
+            bucketSize
+          ).toString(),
         valueFormatter: getDetectorChartFormatters({
           detectionType,
           aggregate,
@@ -410,7 +450,7 @@ export function useMetricDetectorChart({
         chartZoomProps.onChartReady(chart);
         openPeriodMarkerResult.onChartReady(chart);
       },
-    };
+    } satisfies AreaChartProps;
   }, [
     additionalSeries,
     aggregate,
@@ -423,6 +463,7 @@ export function useMetricDetectorChart({
     openPeriodMarkerResult,
     series,
     serverOutputType,
+    snubaQuery.timeWindow,
     unit,
     yAxes,
   ]);


### PR DESCRIPTION
Closes ISWF-2263

This took me a while to wrap my head around so bear with me!

The way most of our charts work currently is that the data points are bucket-start aligned. That is, the data for `12pm-1pm` is shown on the `12pm` axis label.

This causes some visual confusion with the addition of our open period markers. If an open period is open between `12pm-12:30pm`, it will be rendered _after_ the data point for `12-1pm` which does not make sense visually. It would be better if it were shown in the preceding interval.

This PR shifts the data points so that they are aligned with the bucket end. This will more closely match the old UI (in terms of where the vertical line is placed) while still displaying the open period area accurately.

This also incidentally solves another issue where open periods were being cut off on the right side of the chart 🎉 

Before:

<img width="824" height="277" alt="CleanShot 2026-03-25 at 17 22 12" src="https://github.com/user-attachments/assets/b4289261-d277-4da5-875c-2169a667d1b9" />

After:

<img width="820" height="275" alt="CleanShot 2026-03-25 at 17 22 19" src="https://github.com/user-attachments/assets/7b263796-dbe2-456c-87b6-71fb1a147e1a" />
