### PR TITLE
ref(cells): RpcOrganizationSlugReservation uses cell_name on the wire

### DIFF
--- a/src/sentry/hybridcloud/services/control_organization_provisioning/model.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/model.py
@@ -10,16 +10,16 @@ class RpcOrganizationSlugReservation(RpcModel):
     organization_id: int
     user_id: int | None
     slug: str
-    region_name: str
+    cell_name: str
     reservation_type: int
 
     @root_validator(pre=True)
     @classmethod
-    def _accept_cell_name(cls, values: dict[str, Any]) -> dict[str, Any]:
-        if "cell_name" in values and "region_name" not in values:
-            values["region_name"] = values.pop("cell_name")
+    def _accept_region_name(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if "region_name" in values and "cell_name" not in values:
+            values["cell_name"] = values.pop("region_name")
         return values
 
     @property
-    def cell_name(self) -> str:
-        return self.region_name
+    def region_name(self) -> str:
+        return self.cell_name

--- a/src/sentry/hybridcloud/services/control_organization_provisioning/serial.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/serial.py
@@ -11,7 +11,7 @@ def serialize_slug_reservation(
         id=slug_reservation.id,
         organization_id=slug_reservation.organization_id,
         slug=slug_reservation.slug,
-        region_name=slug_reservation.cell_name,
+        cell_name=slug_reservation.cell_name,
         user_id=slug_reservation.user_id,
         reservation_type=slug_reservation.reservation_type,
     )

--- a/tests/sentry/hybridcloud/services/test_cell_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/services/test_cell_organization_provisioning.py
@@ -254,7 +254,7 @@ class TestRegionOrganizationProvisioningUpdateOrganizationSlug(TestCase):
             slug=slug,
             organization_id=self.provisioned_org.id,
             user_id=self.provisioning_user.id,
-            region_name="us",
+            cell_name="us",
             reservation_type=OrganizationSlugReservationType.TEMPORARY_RENAME_ALIAS.value,
         )
 


### PR DESCRIPTION
flips the wire format from "region_name" to "cell_name". Alias is still present for deploy safety.
