### PR TITLE
ref(cells): jira frontend uses proper issue urls

### DIFF
--- a/static/app/plugins/components/issueActions.tsx
+++ b/static/app/plugins/components/issueActions.tsx
@@ -3,12 +3,12 @@ import {Fragment} from 'react';
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
 
-import Form from 'sentry/components/deprecatedforms/form';
-import FormState from 'sentry/components/forms/state';
+import {Form} from 'sentry/components/deprecatedforms/form';
+import {FormState} from 'sentry/components/forms/state';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import PluginComponentBase from 'sentry/plugins/pluginComponentBase';
+import {PluginComponentBase} from 'sentry/plugins/pluginComponentBase';
 import {GroupStore} from 'sentry/stores/groupStore';
 import type {Group} from 'sentry/types/group';
 import type {Plugin} from 'sentry/types/integrations';
@@ -60,7 +60,7 @@ type State = {
   unlinkFieldList?: Field[];
 } & PluginComponentBase['state'];
 
-class IssueActions extends PluginComponentBase<Props, State> {
+export class IssueActions extends PluginComponentBase<Props, State> {
   constructor(props: Props) {
     super(props);
 
@@ -401,8 +401,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
                 if (field.has_autocomplete) {
                   field = Object.assign(
                     {
-                      url:
-                        `/api/0/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/autocomplete`,
+                      url: `/api/0/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/autocomplete`,
                     },
                     field
                   );
@@ -429,8 +428,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
                 if (field.has_autocomplete) {
                   field = Object.assign(
                     {
-                      url:
-                        `/api/0/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/autocomplete`,
+                      url: `/api/0/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/autocomplete`,
                     },
                     field
                   );
@@ -558,5 +556,3 @@ class IssueActions extends PluginComponentBase<Props, State> {
     );
   }
 }
-
-export default IssueActions;

--- a/static/app/plugins/components/issueActions.tsx
+++ b/static/app/plugins/components/issueActions.tsx
@@ -138,21 +138,15 @@ class IssueActions extends PluginComponentBase<Props, State> {
   }
 
   getPluginCreateEndpoint() {
-    return (
-      '/issues/' + this.getGroup().id + '/plugins/' + this.props.plugin.slug + '/create/'
-    );
+    return `/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/create/`;
   }
 
   getPluginLinkEndpoint() {
-    return (
-      '/issues/' + this.getGroup().id + '/plugins/' + this.props.plugin.slug + '/link/'
-    );
+    return `/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/link/`;
   }
 
   getPluginUnlinkEndpoint() {
-    return (
-      '/issues/' + this.getGroup().id + '/plugins/' + this.props.plugin.slug + '/unlink/'
-    );
+    return `/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/unlink/`;
   }
 
   setDependentFieldState(fieldName: any, state: any) {
@@ -165,7 +159,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
 
     const groupId = this.getGroup().id;
     const pluginSlug = this.props.plugin.slug;
-    const url = `/issues/${groupId}/plugins/${pluginSlug}/options/`;
+    const url = `/organizations/${this.getOrganization().slug}/issues/${groupId}/plugins/${pluginSlug}/options/`;
 
     // find the fields that this field is dependent on
     const dependentFormValues = Object.fromEntries(
@@ -408,11 +402,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
                   field = Object.assign(
                     {
                       url:
-                        '/api/0/issues/' +
-                        this.getGroup().id +
-                        '/plugins/' +
-                        this.props.plugin.slug +
-                        '/autocomplete',
+                        `/api/0/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/autocomplete`,
                     },
                     field
                   );
@@ -440,11 +430,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
                   field = Object.assign(
                     {
                       url:
-                        '/api/0/issues/' +
-                        this.getGroup().id +
-                        '/plugins/' +
-                        this.props.plugin.slug +
-                        '/autocomplete',
+                        `/api/0/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/autocomplete`,
                     },
                     field
                   );

--- a/static/app/plugins/jira/components/issueActions.tsx
+++ b/static/app/plugins/jira/components/issueActions.tsx
@@ -73,12 +73,7 @@ class IssueActions extends DefaultIssueActions {
           if (field.has_autocomplete) {
             field = Object.assign(
               {
-                url:
-                  '/api/0/issues/' +
-                  this.getGroup().id +
-                  '/plugins/' +
-                  this.props.plugin.slug +
-                  '/autocomplete',
+                url: `/api/0/organizations/${this.getOrganization().slug}/issues/${this.getGroup().id}/plugins/${this.props.plugin.slug}/autocomplete`,
               },
               field
             );


### PR DESCRIPTION
Issues links need to use the proper organization-scoped path, in order to be cell safe. the /issues/<issueid> url used currently is deprecated and is marked for brownout starting may 15th
