### PR TITLE
ref(scm) Homogenize handling of errors in SCM RPC

### DIFF
--- a/src/sentry/scm/endpoints/scm_rpc.py
+++ b/src/sentry/scm/endpoints/scm_rpc.py
@@ -19,12 +19,14 @@ from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentic
 from sentry.api.base import Endpoint, internal_cell_silo_endpoint
 from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException
 from sentry.scm.errors import (
+    SCMCodedError,
     SCMError,
     SCMProviderException,
     SCMProviderNotSupported,
     SCMRpcActionCallError,
     SCMRpcActionNotFound,
     SCMRpcCouldNotDeserializeRequest,
+    SCMUnhandledException,
 )
 from sentry.scm.private.rpc import dispatch
 from sentry.silo.base import SiloMode
@@ -72,9 +74,12 @@ class ScmRpcSignatureAuthentication(StandardAuthentication):
             raise AuthenticationFailed(
                 {
                     "errors": [
-                        {
-                            "detail": f"SCM RPC signature validation failed: {signature_validation_error}"
-                        }
+                        _make_error(
+                            exception_type="AuthenticationFailure",
+                            status_code=401,
+                            title="SCM RPC signature validation failed.",
+                            detail=signature_validation_error,
+                        )
                     ]
                 }
             )
@@ -151,82 +156,78 @@ class ScmRpcServiceEndpoint(Endpoint):
         try:
             result = dispatch(method_name, request.data)
         except SCMRpcActionNotFound as e:
-            return Response(
-                {
-                    "errors": [
-                        {
-                            "status": "404",
-                            "title": "Not found",
-                            "detail": f"Could not find action {e.action_name}",
-                        }
-                    ]
-                },
-                status=404,
+            sentry_sdk.capture_exception()
+            return _make_single_error_response(
+                exception_type="SCMRpcActionNotFound",
+                status_code=404,
+                title="Not found",
+                detail=f"Could not find action {e.action_name}",
+                action_name=e.action_name,
             )
         except SCMRpcCouldNotDeserializeRequest as e:
-            return Response(
-                {
-                    "errors": [
-                        {
-                            "status": "400",
-                            "title": "The request could not be deserialized.",
-                            "meta": error,
-                        }
-                        for error in e.args[0]
-                    ]
-                },
-                status=400,
+            sentry_sdk.capture_exception()
+            return _make_errors_response(
+                status_code=400,
+                errors=[
+                    _make_error(
+                        exception_type="SCMRpcCouldNotDeserializeRequest",
+                        status_code=400,
+                        title="The request could not be deserialized.",
+                        meta=error,
+                    )
+                    for error in e.args[0]
+                ],
             )
         except SCMRpcActionCallError as e:
-            return Response(
-                {
-                    "errors": [
-                        {
-                            "status": "500",
-                            "title": "An unexpected error occurred.",
-                            "detail": e.message,
-                        }
-                    ]
-                },
-                status=500,
+            sentry_sdk.capture_exception()
+            return _make_single_error_response(
+                exception_type="SCMRpcActionCallError",
+                status_code=500,
+                title="An unexpected error occurred.",
+                detail=e.message,
+                action_name=e.action_name,
+                message=e.message,
             )
         except SCMProviderNotSupported as e:
             sentry_sdk.capture_exception()
-            return Response(
-                data={
-                    "errors": [
-                        {"status": "400", "title": "Provider not supported.", "detail": e.message}
-                    ]
-                },
-                status=400,
+            return _make_single_error_response(
+                exception_type="SCMProviderNotSupported",
+                status_code=400,
+                title="Provider not supported.",
+                detail=e.message,
             )
         except SCMProviderException as e:
             sentry_sdk.capture_exception()
-            return Response(
-                data={
-                    "errors": [
-                        {
-                            "status": "503",
-                            "title": "The service provider raised an error.",
-                            "detail": self._make_details(e),
-                        }
-                    ]
-                },
-                status=503,
+            return _make_single_error_response(
+                exception_type="SCMProviderException",
+                status_code=503,
+                title="The service provider raised an error.",
+                detail=_make_detail(e),
+            )
+        except SCMCodedError as e:
+            sentry_sdk.capture_exception()
+            return _make_single_error_response(
+                exception_type="SCMCodedError",
+                code=e.code,
+                status_code=500,
+                title="An error occurred.",
+                detail=_make_detail(e),
+            )
+        except SCMUnhandledException as e:
+            sentry_sdk.capture_exception()
+            return _make_single_error_response(
+                exception_type="SCMUnhandledException",
+                status_code=500,
+                title="An unexpected error occurred.",
+                detail=_make_detail(e),
             )
         except SCMError as e:
             sentry_sdk.capture_exception()
-            return Response(
-                data={
-                    "errors": [
-                        {
-                            "status": "500",
-                            "title": "An unexpected error occurred.",
-                            "detail": self._make_details(e),
-                        }
-                    ]
-                },
-                status=500,
+            return _make_single_error_response(
+                exception_type="SCMError",
+                status_code=500,
+                title="An unexpected error occurred.",
+                detail=_make_detail(e),
             )
         except Exception:
             sentry_sdk.capture_exception()
@@ -234,9 +235,72 @@ class ScmRpcServiceEndpoint(Endpoint):
         else:
             return Response(data={"data": result})
 
-    def _make_details(self, e: BaseException) -> list[Any]:
-        details = list(e.args)
-        while e.__cause__:
-            e = e.__cause__
-            details.extend(e.args)
-        return details
+
+def _make_single_error_response(
+    *,
+    exception_type: str,
+    status_code: int,
+    title: str,
+    detail: str,
+    code: str | None = None,
+    message: str | None = None,
+    action_name: str | None = None,
+) -> Response:
+    return _make_errors_response(
+        status_code=status_code,
+        errors=[
+            _make_error(
+                status_code=status_code,
+                title=title,
+                detail=detail,
+                exception_type=exception_type,
+                code=code,
+                message=message,
+                action_name=action_name,
+            )
+        ],
+    )
+
+
+def _make_errors_response(*, status_code: int, errors: list[dict[str, Any]]) -> Response:
+    return Response(data={"errors": errors}, status=status_code)
+
+
+def _make_error(
+    *,
+    exception_type: str,
+    status_code: int,
+    title: str,
+    detail: str | None = None,
+    code: str | None = None,
+    message: str | None = None,
+    action_name: str | None = None,
+    meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    error: dict[str, Any] = {
+        "status": str(status_code),
+        "title": title,
+    }
+    if detail is not None:
+        error["detail"] = detail
+    if meta is None:
+        meta = {}
+    if exception_type is not None:
+        meta["exception_type"] = exception_type
+    if code is not None:
+        meta["code"] = code
+    if message is not None:
+        meta["message"] = message
+    if action_name is not None:
+        meta["action_name"] = action_name
+    if meta:
+        error["meta"] = meta
+    return error
+
+
+def _make_detail(e: BaseException) -> str:
+    details = list(e.args)
+    while e.__cause__:
+        e = e.__cause__
+        details.extend(e.args)
+    return ", ".join(str(detail) for detail in details)

--- a/tests/sentry/scm/endpoints/test_scm_rpc.py
+++ b/tests/sentry/scm/endpoints/test_scm_rpc.py
@@ -148,7 +148,14 @@ class TestScmRpc(APITestCase):
         response = self.client.post(path, data=data, HTTP_AUTHORIZATION="rpcsignature rpc42:foobar")
         assert response.status_code == 401
         assert response.json() == {
-            "errors": [{"detail": "SCM RPC signature validation failed: invalid signature prefix"}]
+            "errors": [
+                {
+                    "status": "401",
+                    "title": "SCM RPC signature validation failed.",
+                    "detail": "invalid signature prefix",
+                    "meta": {"exception_type": "AuthenticationFailure"},
+                }
+            ]
         }
 
     def test_wrong_signature_in_authorization_header(self) -> None:
@@ -165,7 +172,14 @@ class TestScmRpc(APITestCase):
         )
         assert response.status_code == 401
         assert response.json() == {
-            "errors": [{"detail": "SCM RPC signature validation failed: wrong secret"}]
+            "errors": [
+                {
+                    "status": "401",
+                    "title": "SCM RPC signature validation failed.",
+                    "detail": "wrong secret",
+                    "meta": {"exception_type": "AuthenticationFailure"},
+                }
+            ]
         }
 
     def test_signature_with_more_colons_in_authorization_header(self) -> None:
@@ -182,7 +196,14 @@ class TestScmRpc(APITestCase):
         )
         assert response.status_code == 401
         assert response.json() == {
-            "errors": [{"detail": "SCM RPC signature validation failed: wrong secret"}]
+            "errors": [
+                {
+                    "status": "401",
+                    "title": "SCM RPC signature validation failed.",
+                    "detail": "wrong secret",
+                    "meta": {"exception_type": "AuthenticationFailure"},
+                }
+            ]
         }
 
     def test_signature_without_prefix_in_authorization_header(self) -> None:
@@ -199,7 +220,14 @@ class TestScmRpc(APITestCase):
         )
         assert response.status_code == 401
         assert response.json() == {
-            "errors": [{"detail": "SCM RPC signature validation failed: invalid signature format"}]
+            "errors": [
+                {
+                    "status": "401",
+                    "title": "SCM RPC signature validation failed.",
+                    "detail": "invalid signature format",
+                    "meta": {"exception_type": "AuthenticationFailure"},
+                }
+            ]
         }
 
     def test_invalid_endpoint(self) -> None:
@@ -208,6 +236,10 @@ class TestScmRpc(APITestCase):
         assert response.json() == {
             "errors": [
                 {
+                    "meta": {
+                        "exception_type": "SCMRpcActionNotFound",
+                        "action_name": "not_a_method",
+                    },
                     "status": "404",
                     "title": "Not found",
                     "detail": "Could not find action not_a_method",
@@ -224,6 +256,7 @@ class TestScmRpc(APITestCase):
                     "status": "400",
                     "title": "The request could not be deserialized.",
                     "meta": {
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                         "loc": ["args", "organization_id"],
                         "msg": "field required",
                         "type": "value_error.missing",
@@ -247,6 +280,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "organization_id"],
                         "msg": "value is not a valid integer",
                         "type": "type_error.integer",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 }
             ]
@@ -264,6 +298,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "repository_id"],
                         "msg": "field required",
                         "type": "value_error.missing",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 }
             ]
@@ -284,6 +319,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "repository_id"],
                         "msg": "value is not a valid integer",
                         "type": "type_error.integer",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 },
                 {
@@ -293,6 +329,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "repository_id"],
                         "msg": "value is not a valid dict",
                         "type": "type_error.dict",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 },
             ]
@@ -316,6 +353,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "repository_id"],
                         "msg": "value is not a valid integer",
                         "type": "type_error.integer",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 },
                 {
@@ -325,6 +363,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "repository_id", "provider"],
                         "msg": "field required",
                         "type": "value_error.missing",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 },
             ]
@@ -345,6 +384,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "repository_id"],
                         "msg": "value is not a valid integer",
                         "type": "type_error.integer",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 },
                 {
@@ -354,6 +394,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "repository_id", "external_id"],
                         "msg": "field required",
                         "type": "value_error.missing",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 },
             ]
@@ -384,6 +425,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "repository_id"],
                         "msg": "value is not a valid integer",
                         "type": "type_error.integer",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 },
                 {
@@ -393,6 +435,7 @@ class TestScmRpc(APITestCase):
                         "loc": ["args", "repository_id", "extra"],
                         "msg": "extra fields not permitted",
                         "type": "value_error.extra",
+                        "exception_type": "SCMRpcCouldNotDeserializeRequest",
                     },
                 },
             ]
@@ -437,6 +480,11 @@ class TestScmRpc(APITestCase):
                         "status": "500",
                         "title": "An unexpected error occurred.",
                         "detail": "Error calling method say_hello: add_say_hello.<locals>.say_hello() missing 1 required keyword-only argument: 'name'",
+                        "meta": {
+                            "exception_type": "SCMRpcActionCallError",
+                            "action_name": "say_hello",
+                            "message": "Error calling method say_hello: add_say_hello.<locals>.say_hello() missing 1 required keyword-only argument: 'name'",
+                        },
                     }
                 ]
             }
@@ -462,6 +510,11 @@ class TestScmRpc(APITestCase):
                         "status": "500",
                         "title": "An unexpected error occurred.",
                         "detail": "Error calling method say_hello: add_say_hello.<locals>.say_hello() got an unexpected keyword argument 'login'",
+                        "meta": {
+                            "exception_type": "SCMRpcActionCallError",
+                            "action_name": "say_hello",
+                            "message": "Error calling method say_hello: add_say_hello.<locals>.say_hello() got an unexpected keyword argument 'login'",
+                        },
                     }
                 ]
             }
@@ -486,6 +539,11 @@ class TestScmRpc(APITestCase):
                         "status": "500",
                         "title": "An unexpected error occurred.",
                         "detail": "Error calling method say_hello: add_say_hello.<locals>.say_hello() got an unexpected keyword argument 'fame'. Did you mean 'name'?",
+                        "meta": {
+                            "exception_type": "SCMRpcActionCallError",
+                            "action_name": "say_hello",
+                            "message": "Error calling method say_hello: add_say_hello.<locals>.say_hello() got an unexpected keyword argument 'fame'. Did you mean 'name'?",
+                        },
                     }
                 ]
             }
@@ -500,6 +558,7 @@ class TestScmRpc(APITestCase):
                         "status": "400",
                         "title": "The request could not be deserialized.",
                         "meta": {
+                            "exception_type": "SCMRpcCouldNotDeserializeRequest",
                             "loc": ["args"],
                             "msg": "field required",
                             "type": "value_error.missing",
@@ -518,6 +577,7 @@ class TestScmRpc(APITestCase):
                         "status": "400",
                         "title": "The request could not be deserialized.",
                         "meta": {
+                            "exception_type": "SCMRpcCouldNotDeserializeRequest",
                             "loc": ["args"],
                             "msg": "field required",
                             "type": "value_error.missing",
@@ -536,6 +596,7 @@ class TestScmRpc(APITestCase):
                         "status": "400",
                         "title": "The request could not be deserialized.",
                         "meta": {
+                            "exception_type": "SCMRpcCouldNotDeserializeRequest",
                             "loc": ["args", "organization_id"],
                             "msg": "field required",
                             "type": "value_error.missing",
@@ -545,6 +606,7 @@ class TestScmRpc(APITestCase):
                         "status": "400",
                         "title": "The request could not be deserialized.",
                         "meta": {
+                            "exception_type": "SCMRpcCouldNotDeserializeRequest",
                             "loc": ["args", "repository_id"],
                             "msg": "field required",
                             "type": "value_error.missing",
@@ -553,7 +615,7 @@ class TestScmRpc(APITestCase):
                 ]
             }
 
-    def test_scm_error_in_provider_method(self) -> None:
+    def test_scm_unhandled_exception_in_provider_method(self) -> None:
         with add_raise_scm_error(SCMUnhandledException("Blah", 68)):
             response = self.call(
                 "raise_scm_error",
@@ -565,7 +627,8 @@ class TestScmRpc(APITestCase):
                     {
                         "status": "500",
                         "title": "An unexpected error occurred.",
-                        "detail": ["Blah", 68],
+                        "detail": "Blah, 68",
+                        "meta": {"exception_type": "SCMUnhandledException"},
                     }
                 ]
             }
@@ -581,13 +644,27 @@ class TestScmRpc(APITestCase):
                 "errors": [
                     {
                         "status": "500",
+                        "title": "An error occurred.",
+                        "detail": "repository_not_found, A repository could not be found., Blah, 68",
+                        "meta": {"exception_type": "SCMCodedError", "code": "repository_not_found"},
+                    }
+                ]
+            }
+
+    def test_scm_error_in_provider_method(self) -> None:
+        with add_raise_scm_error(SCMError("Blah", 42)):
+            response = self.call(
+                "raise_scm_error",
+                {"args": {"organization_id": self.organization.id, "repository_id": self.repo.id}},
+            )
+            assert response.status_code == 500
+            assert response.json() == {
+                "errors": [
+                    {
+                        "status": "500",
                         "title": "An unexpected error occurred.",
-                        "detail": [
-                            "repository_not_found",
-                            "A repository could not be found.",
-                            "Blah",
-                            68,
-                        ],
+                        "detail": "Blah, 42",
+                        "meta": {"exception_type": "SCMError"},
                     }
                 ]
             }
@@ -606,6 +683,7 @@ class TestScmRpc(APITestCase):
                     "status": "400",
                     "title": "Provider not supported.",
                     "detail": "call_missing_provider_method is not supported by service-provider GitHubProvider",
+                    "meta": {"exception_type": "SCMProviderNotSupported"},
                 }
             ]
         }
@@ -622,7 +700,8 @@ class TestScmRpc(APITestCase):
                     {
                         "status": "503",
                         "title": "The service provider raised an error.",
-                        "detail": ["Blah", 68],
+                        "detail": "Blah, 68",
+                        "meta": {"exception_type": "SCMProviderException"},
                     }
                 ]
             }


### PR DESCRIPTION
This returns the details of errors caught by the RPC in its response, allowing https://github.com/getsentry/seer/pull/5313 to reconstruct and raise appropriate exceptions.