### PR TITLE
feat(agents): Fall back to gen_ai.function_id for agent name resolution

### DIFF
--- a/static/app/views/insights/common/components/agentSelector.tsx
+++ b/static/app/views/insights/common/components/agentSelector.tsx
@@ -13,8 +13,15 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {useWasSearchSpaceExhausted} from 'sentry/views/insights/common/utils/useWasSearchSpaceExhausted';
+import {
+  AGENT_NAME_FIELDS,
+  resolveAgentName,
+} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import {
+  getAgentNameSearchFilter,
+  getHasAgentNameFilter,
+} from 'sentry/views/insights/pages/agents/utils/query';
 import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
-import {SpanFields} from 'sentry/views/insights/types';
 
 const LIMIT = 100;
 const AGENT_URL_PARAM = 'agent';
@@ -83,9 +90,9 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
   );
 
   const query = useMemo(() => {
-    const parts = [`has:${SpanFields.GEN_AI_AGENT_NAME}`];
+    const parts = [getHasAgentNameFilter()];
     if (searchQuery) {
-      parts.push(`${SpanFields.GEN_AI_AGENT_NAME}:*${searchQuery}*`);
+      parts.push(getAgentNameSearchFilter(searchQuery));
     }
     return parts.join(' ');
   }, [searchQuery]);
@@ -99,7 +106,7 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
       limit: LIMIT,
       search: query,
       sorts: [{field: 'count()', kind: 'desc'}],
-      fields: [SpanFields.GEN_AI_AGENT_NAME, 'count()'],
+      fields: [...AGENT_NAME_FIELDS, 'count()'],
     },
     referrer
   );
@@ -115,8 +122,8 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
     const list: Array<{label: string; value: string}> = [];
 
     agentData?.forEach(row => {
-      const agentName = row[SpanFields.GEN_AI_AGENT_NAME];
-      if (!agentName || typeof agentName !== 'string' || uniqueAgents.has(agentName)) {
+      const agentName = resolveAgentName(row);
+      if (!agentName || uniqueAgents.has(agentName)) {
         return;
       }
       uniqueAgents.add(agentName);

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -38,12 +38,14 @@ import type {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/compon
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
+import {resolveAgentName} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import {
   ErrorCell,
   NumberPlaceholder,
 } from 'sentry/views/insights/pages/agents/utils/cells';
 import {
   getAgentRunsFilter,
+  getHasAgentNameFilter,
   getHasAiSpansFilter,
 } from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
@@ -163,8 +165,8 @@ export function TracesTable({
 
   const agentsRequest = useSpans(
     {
-      search: `${getAgentRunsFilter()} has:gen_ai.agent.name trace:[${tracesRequest.data?.data.map(span => `"${span.trace}"`).join(',')}]`,
-      fields: ['trace', 'gen_ai.agent.name', 'timestamp'],
+      search: `${getAgentRunsFilter()} ${getHasAgentNameFilter()} trace:[${tracesRequest.data?.data.map(span => `"${span.trace}"`).join(',')}]`,
+      fields: ['trace', 'gen_ai.agent.name', 'gen_ai.function_id', 'timestamp'],
       sorts: [{field: 'timestamp', kind: 'asc'}],
       samplingMode: SAMPLING_MODE.HIGH_ACCURACY,
       enabled: Boolean(tracesRequest.data && tracesRequest.data.data.length > 0),
@@ -177,9 +179,12 @@ export function TracesTable({
       return new Map();
     }
     return agentsRequest.data.reduce((acc, span) => {
-      const agentsSet = acc.get(span.trace) ?? new Set();
-      agentsSet.add(span['gen_ai.agent.name']);
-      acc.set(span.trace, agentsSet);
+      const agentName = resolveAgentName(span);
+      if (agentName) {
+        const agentsSet = acc.get(span.trace) ?? new Set();
+        agentsSet.add(agentName);
+        acc.set(span.trace, agentsSet);
+      }
       return acc;
     }, new Map<string, Set<string>>());
   }, [agentsRequest.data]);

--- a/static/app/views/insights/pages/agents/hooks/useAgentFilter.tsx
+++ b/static/app/views/insights/pages/agents/hooks/useAgentFilter.tsx
@@ -1,7 +1,6 @@
 import {parseAsArrayOf, parseAsString, useQueryState} from 'nuqs';
 
-import {escapeDoubleQuotes} from 'sentry/utils';
-import {SpanFields} from 'sentry/views/insights/types';
+import {getAgentNamesFilter} from 'sentry/views/insights/pages/agents/utils/query';
 
 /**
  * Hook to read the agent filter from the URL and generate a query string.
@@ -12,12 +11,7 @@ export function useAgentFilter() {
     'agent',
     parseAsArrayOf(parseAsString).withDefault([])
   );
-  const agentQuery =
-    agentFilters.length > 0
-      ? `${SpanFields.GEN_AI_AGENT_NAME}:[${agentFilters
-          .map(v => `"${escapeDoubleQuotes(v)}"`)
-          .join(', ')}]`
-      : '';
+  const agentQuery = getAgentNamesFilter(agentFilters);
 
   return {agentQuery};
 }

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -96,6 +96,37 @@ export function getStringAttr(node: AITraceSpanNode, field: string): string | un
   return typeof val === 'string' ? val : undefined;
 }
 
+/**
+ * Agent name fallback resolution.
+ *
+ * The Vercel AI SDK sends `gen_ai.function_id` instead of the standard
+ * `gen_ai.agent.name` attribute. The constants and helpers below provide
+ * centralized fallback logic so agent identification works regardless of
+ * which attribute the SDK sets.
+ */
+
+/**
+ * Fields to check when resolving an agent name, in priority order.
+ */
+export const AGENT_NAME_FIELDS = [
+  SpanFields.GEN_AI_AGENT_NAME,
+  SpanFields.GEN_AI_FUNCTION_ID,
+] as const;
+
+/**
+ * Resolves the agent name from a keyed record (span row, attributes map, etc.)
+ * by trying each field in priority order.
+ */
+export function resolveAgentName(data: Record<string, unknown>): string | undefined {
+  for (const field of AGENT_NAME_FIELDS) {
+    const value = data[field];
+    if (value && typeof value === 'string') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 export function getNumberAttr(node: AITraceSpanNode, field: string): number | undefined {
   const val = getTraceNodeAttribute(field, node);
   if (typeof val === 'number') {

--- a/static/app/views/insights/pages/agents/utils/query.tsx
+++ b/static/app/views/insights/pages/agents/utils/query.tsx
@@ -1,3 +1,6 @@
+import {escapeDoubleQuotes} from 'sentry/utils';
+import {SpanFields} from 'sentry/views/insights/types';
+
 export function getIsAiAgentSpan(genAiOpType: string | undefined) {
   return genAiOpType === 'agent';
 }
@@ -29,6 +32,40 @@ export const getAgentAndAIClientFilter = () => {
 export const getAIGenerationsFilter = () => {
   return `gen_ai.operation.type:ai_client`;
 };
+
+/**
+ * Agent name fallback filters.
+ *
+ * The Vercel AI SDK sends `gen_ai.function_id` instead of the standard
+ * `gen_ai.agent.name` attribute. The filters below check both fields so
+ * agent identification works regardless of which attribute the SDK sets.
+ */
+
+/**
+ * Returns a search filter that matches spans having an agent name
+ * (either `gen_ai.agent.name` or `gen_ai.function_id`).
+ */
+export function getHasAgentNameFilter(): string {
+  return `(has:${SpanFields.GEN_AI_AGENT_NAME} OR has:${SpanFields.GEN_AI_FUNCTION_ID})`;
+}
+
+/**
+ * Returns a search filter matching specific agent names across both fields.
+ */
+export function getAgentNameSearchFilter(searchTerm: string): string {
+  return `(${SpanFields.GEN_AI_AGENT_NAME}:*${searchTerm}* OR ${SpanFields.GEN_AI_FUNCTION_ID}:*${searchTerm}*)`;
+}
+
+/**
+ * Returns a search filter for an exact set of agent names, checking both fields.
+ */
+export function getAgentNamesFilter(agents: string[]): string {
+  if (agents.length === 0) {
+    return '';
+  }
+  const values = agents.map(v => `"${escapeDoubleQuotes(v)}"`).join(', ');
+  return `(${SpanFields.GEN_AI_AGENT_NAME}:[${values}] OR ${SpanFields.GEN_AI_FUNCTION_ID}:[${values}])`;
+}
 
 export enum GenAiOperationType {
   AGENT = 'agent',

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -269,6 +269,7 @@ export type NonNullableStringFields =
   | SpanFields.KIND
   | SpanFields.STATUS_MESSAGE
   | SpanFields.GEN_AI_AGENT_NAME
+  | SpanFields.GEN_AI_FUNCTION_ID
   | SpanFields.GEN_AI_REQUEST_MODEL
   | SpanFields.GEN_AI_REQUEST_MESSAGES
   | SpanFields.GEN_AI_INPUT_MESSAGES

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -14,6 +14,7 @@ import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTra
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
+import {resolveAgentName} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import {
   getIsAiAgentSpan,
   getToolSpansFilter,
@@ -110,7 +111,7 @@ function getAISpanAttributes({
 
   const genAiOpType = attributes['gen_ai.operation.type'] as string | undefined;
 
-  const agentName = attributes['gen_ai.agent.name'] || attributes['gen_ai.function_id'];
+  const agentName = resolveAgentName(attributes);
   if (agentName) {
     highlightedAttributes.push({
       name: t('Agent Name'),


### PR DESCRIPTION
The Vercel AI SDK sends `gen_ai.function_id` instead of `gen_ai.agent.name`. Centralizes fallback logic in `query.tsx` and `aiTraceNodes.tsx` so the agent selector, filter, and traces table resolve names from either attribute.