### PR TITLE
test: temporarily skip test_quick_start_not_rendered_because_all_tasks_completed_and_overdue

### DIFF
--- a/tests/acceptance/test_quick_start.py
+++ b/tests/acceptance/test_quick_start.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+import pytest
 from django.test import override_settings
 
 from sentry.models.organizationonboardingtask import (
@@ -38,6 +39,7 @@ class OrganizationQuickStartTest(AcceptanceTestCase):
 
         assert not self.browser.element_exists_by_test_id("quick-start-content")
 
+    @pytest.mark.skip(reason="Temporarily skipped")
     @with_feature("organizations:onboarding")
     def test_quick_start_not_rendered_because_all_tasks_completed_and_overdue(self) -> None:
         # Record tasks with all marked as COMPLETE, all overdue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR temporarily skips the test `test_quick_start_not_rendered_because_all_tasks_completed_and_overdue` in the acceptance test suite.

## Changes

- Added `@pytest.mark.skip(reason="Temporarily skipped")` decorator to the test method
- Imported `pytest` module to support the skip decorator

## Testing

- Verified pre-commit hooks pass
- Test will be skipped when running the test suite
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/D09259VQFAP/p1774526835160849?thread_ts=1774526835.160849&cid=D09259VQFAP)

<div><a href="https://cursor.com/agents/bc-7ca5447e-d6c0-5261-a9c3-c307fd73c3c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ca5447e-d6c0-5261-a9c3-c307fd73c3c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

