### PR TITLE
ref(seer): Use signed API for grouping record project delete

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3184,13 +3184,6 @@ COGS_EVENT_STORE_LABEL = "bigtable_nodestore"
 SEER_SIMILARITY_MODEL_VERSION = "v0"
 SEER_SIMILAR_ISSUES_URL = f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues"
 SEER_MAX_GROUPING_DISTANCE = 0.01
-SEER_MAX_SIMILARITY_DISTANCE = 0.15  # Not yet in use - Seer doesn't obey this right now
-SEER_GROUPING_RECORDS_URL = (
-    f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues/grouping-record"
-)
-SEER_PROJECT_GROUPING_RECORDS_DELETE_URL = (
-    f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues/grouping-record/delete"
-)
 SEER_HASH_GROUPING_RECORDS_DELETE_URL = (
     f"/{SEER_SIMILARITY_MODEL_VERSION}/issues/similar-issues/grouping-record/delete-by-hash"
 )

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -41,6 +41,11 @@ seer_anomaly_detection_default_connection_pool = connection_from_url(
     timeout=settings.SEER_DEFAULT_TIMEOUT,
 )
 
+seer_grouping_default_connection_pool = connection_from_url(
+    settings.SEER_GROUPING_URL,
+    timeout=settings.SEER_DEFAULT_TIMEOUT,
+)
+
 
 @sentry_sdk.tracing.trace
 def make_signed_seer_api_request(
@@ -517,6 +522,24 @@ def make_compare_distributions_request(
     return make_signed_seer_api_request(
         seer_anomaly_detection_default_connection_pool,
         "/v1/workflows/compare/cohort",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        viewer_context=viewer_context,
+    )
+
+
+class DeleteGroupingRecordsByProjectRequest(TypedDict):
+    project_id: int
+
+
+def make_delete_grouping_records_by_project_request(
+    body: DeleteGroupingRecordsByProjectRequest,
+    timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_grouping_default_connection_pool,
+        "/v0/issues/similar-issues/grouping-record/delete",
         body=orjson.dumps(body),
         timeout=timeout,
         viewer_context=viewer_context,

--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -8,12 +8,13 @@ from django.conf import settings
 from urllib3.exceptions import MaxRetryError, ReadTimeoutError, TimeoutError
 
 from sentry import options
-from sentry.conf.server import (
-    SEER_HASH_GROUPING_RECORDS_DELETE_URL,
-    SEER_PROJECT_GROUPING_RECORDS_DELETE_URL,
-)
+from sentry.conf.server import SEER_HASH_GROUPING_RECORDS_DELETE_URL
 from sentry.net.http import connection_from_url
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import (
+    DeleteGroupingRecordsByProjectRequest,
+    make_delete_grouping_records_by_project_request,
+    make_signed_seer_api_request,
+)
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
@@ -39,11 +40,9 @@ def call_seer_to_delete_project_grouping_records(
     project_id: int,
 ) -> bool:
     try:
-        # TODO: Move this over to POST json_api implementation
-        response = seer_grouping_connection_pool.urlopen(
-            "GET",
-            f"{SEER_PROJECT_GROUPING_RECORDS_DELETE_URL}/{project_id}",
-            headers={"Content-Type": "application/json;charset=utf-8"},
+        body: DeleteGroupingRecordsByProjectRequest = {"project_id": project_id}
+        response = make_delete_grouping_records_by_project_request(
+            body,
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )
     except ReadTimeoutError:


### PR DESCRIPTION
Move the project grouping record delete endpoint (`/v0/issues/similar-issues/grouping-record/delete`) to use `make_signed_seer_api_request` instead of a raw unsigned `urlopen` call, consistent with all other Seer API methods.

- Add `make_delete_grouping_records_by_project_request` to `signed_seer_api.py` with a `DeleteGroupingRecordsByProjectRequest` typed dict
- Add `seer_grouping_default_connection_pool` using `settings.SEER_GROUPING_URL`
- Update `call_seer_to_delete_project_grouping_records` to use the new signed method (this also resolves the existing TODO comment about moving to POST)


Agent transcript: https://claudescope.sentry.dev/share/yp4ee9srss2V1UbfuaaD-PJyoIAqYGErBGG8WwuRn-I