### PR TITLE
fix(code-mappings): Remove dead commit context cache clearing

### DIFF
--- a/src/sentry/integrations/models/repository_project_path_config.py
+++ b/src/sentry/integrations/models/repository_project_path_config.py
@@ -52,10 +52,8 @@ def process_resource_change(instance: RepositoryProjectPathConfig, **kwargs):
     if instance._skip_post_save:
         return
 
-    from sentry.models.group import Group
     from sentry.models.project import Project
     from sentry.tasks.codeowners import update_code_owners_schema
-    from sentry.utils.cache import cache
 
     def _spawn_update_schema_task():
         """
@@ -71,22 +69,7 @@ def process_resource_change(instance: RepositoryProjectPathConfig, **kwargs):
         except Project.DoesNotExist:
             pass
 
-    def _clear_commit_context_cache():
-        """
-        Once we have a new code mapping for a project, we want to give all groups in the project
-        a new chance to generate missing suspect commits. We debounce the process_commit_context task
-        if we cannot find the Suspect Committer from the given code mappings. Thus, need to clear the
-        cache to reprocess with the new code mapping
-        """
-
-        group_ids = Group.objects.filter(project_id=instance.project_id).values_list(
-            "id", flat=True
-        )
-        cache_keys = [f"process-commit-context-{group_id}" for group_id in group_ids]
-        cache.delete_many(cache_keys)
-
     transaction.on_commit(_spawn_update_schema_task, router.db_for_write(type(instance)))
-    transaction.on_commit(_clear_commit_context_cache, router.db_for_write(type(instance)))
 
 
 post_save.connect(


### PR DESCRIPTION
## Summary

- Remove `_clear_commit_context_cache` from `RepositoryProjectPathConfig` post-save handler
- This function was querying all group IDs for a project and calling `cache.delete_many` on keys with pattern `process-commit-context-{group_id}`
- These cache keys were **never being set** — the debounce key was removed in #65043 when suspect-commits-all-frames was GA'd, making this function a no-op
- Despite being a no-op, the query + `cache.delete_many` call was taking **~27 seconds** on projects with many groups (observed on the bulk code-mappings upload endpoint)

## Evidence

- The cache key `process-commit-context-{group_id}` (with dash) was set via `DEBOUNCE_CACHE_KEY` in `commit_context.py`, removed in #65043
- The lock key in `commit_context.py` uses `process-commit-context:{group_id}` (with colon) — a different key entirely
- No code in the codebase currently sets the dash-variant cache key
- Trace showing 26.5s "No Instrumentation" block corresponding to this function: the group IDs query takes ~183ms, the rest is `cache.delete_many` on nonexistent keys

## Test plan

- [x] Verified no tests reference `_clear_commit_context_cache` or the `process-commit-context-` cache key pattern
- [x] Verified `_spawn_update_schema_task` (the other post-save callback) is unaffected
- [ ] Deploy and verify code-mappings upload endpoint responds in <5s instead of ~90s

🤖 Generated with [Claude Code](https://claude.com/claude-code)