### PR TITLE
fix(agents): Scope enrichment query to gen_ai spans only

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -365,7 +365,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     ) -> TableQuery:
         return TableQuery(
             name="enrichment",
-            query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}]",
+            query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}] has:gen_ai.operation.type",
             selected_columns=[
                 "gen_ai.conversation.id",
                 "gen_ai.operation.type",


### PR DESCRIPTION
The enrichment query was fetching all spans tagged with a conversation ID — including HTTP, DB, and other non-gen_ai spans that contribute nothing to enrichment data but consume the 10k row limit. When enough non-gen_ai spans exist, the limit gets exhausted before all conversations receive their enrichment data, causing user, trace, and flow fields to be inconsistently null.

Adds `has:gen_ai.operation.type` to the enrichment query filter so only gen_ai spans (ai_client, tool, invoke_agent) are returned — the only span types we actually extract data from.