### PR TITLE
fix(dashboards): Disable edit button for pre-built dashboard widgets in fullscreen

### DIFF
--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -70,7 +70,11 @@ import type {
   DashboardPermissions,
   Widget,
 } from 'sentry/views/dashboards/types';
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DisplayType,
+  PREBUILT_DASHBOARD_LABEL,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import {
   dashboardFiltersToString,
   eventViewFromWidget,
@@ -843,9 +847,13 @@ function DataWidgetViewerModal(props: Props) {
                           }}
                           disabled={!hasEditAccess}
                           tooltipProps={{
-                            title:
-                              !hasEditAccess &&
-                              t('You do not have permission to edit this widget'),
+                            title: hasEditAccess
+                              ? undefined
+                              : isPrebuiltDashboard
+                                ? tct('[label] dashboards cannot be edited', {
+                                    label: PREBUILT_DASHBOARD_LABEL,
+                                  })
+                                : t('You do not have permission to edit this widget'),
                           }}
                         >
                           {t('Edit Widget')}

--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -129,6 +129,7 @@ export interface DataWidgetViewerModalOptions {
   dashboardCreator?: User;
   dashboardFilters?: DashboardFilters;
   dashboardPermissions?: DashboardPermissions;
+  isPrebuiltDashboard?: boolean;
   onEdit?: () => void;
   widgetInterval?: string;
 }
@@ -197,6 +198,7 @@ function DataWidgetViewerModal(props: Props) {
     widgetLegendState,
     dashboardPermissions,
     dashboardCreator,
+    isPrebuiltDashboard,
     widgetInterval,
   } = props;
   const theme = useTheme();
@@ -616,13 +618,14 @@ function DataWidgetViewerModal(props: Props) {
 
   const currentUser = useUser();
   const {teams: userTeams} = useUserTeams();
-  const hasEditAccess = checkUserHasEditAccess(
-    currentUser,
-    userTeams,
-    organization,
-    dashboardPermissions,
-    dashboardCreator
-  );
+  const hasEditAccess =
+    checkUserHasEditAccess(
+      currentUser,
+      userTeams,
+      organization,
+      dashboardPermissions,
+      dashboardCreator
+    ) && !isPrebuiltDashboard;
 
   const shouldRenderChartVisualization =
     widget.displayType !== DisplayType.TABLE &&

--- a/static/app/components/modals/textWidgetViewerModal.tsx
+++ b/static/app/components/modals/textWidgetViewerModal.tsx
@@ -6,7 +6,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
@@ -19,6 +19,7 @@ import type {
   DashboardPermissions,
   Widget,
 } from 'sentry/views/dashboards/types';
+import {PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 import {checkUserHasEditAccess} from 'sentry/views/dashboards/utils/checkUserHasEditAccess';
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import type {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
@@ -97,8 +98,13 @@ function TextWidgetViewerModal(props: Props) {
               }}
               disabled={!hasEditAccess}
               tooltipProps={{
-                title:
-                  !hasEditAccess && t('You do not have permission to edit this widget'),
+                title: hasEditAccess
+                  ? undefined
+                  : isPrebuiltDashboard
+                    ? tct('[label] dashboards cannot be edited', {
+                        label: PREBUILT_DASHBOARD_LABEL,
+                      })
+                    : t('You do not have permission to edit this widget'),
               }}
             >
               {t('Edit Widget')}

--- a/static/app/components/modals/textWidgetViewerModal.tsx
+++ b/static/app/components/modals/textWidgetViewerModal.tsx
@@ -30,6 +30,7 @@ interface TextWidgetViewerModalOptions {
   dashboardCreator?: User;
   dashboardFilters?: DashboardFilters;
   dashboardPermissions?: DashboardPermissions;
+  isPrebuiltDashboard?: boolean;
   onEdit?: () => void;
 }
 
@@ -53,16 +54,18 @@ function TextWidgetViewerModal(props: Props) {
     widgetLegendState,
     dashboardPermissions,
     dashboardCreator,
+    isPrebuiltDashboard,
   } = props;
   const currentUser = useUser();
   const {teams: userTeams} = useUserTeams();
-  const hasEditAccess = checkUserHasEditAccess(
-    currentUser,
-    userTeams,
-    organization,
-    dashboardPermissions,
-    dashboardCreator
-  );
+  const hasEditAccess =
+    checkUserHasEditAccess(
+      currentUser,
+      userTeams,
+      organization,
+      dashboardPermissions,
+      dashboardCreator
+    ) && !isPrebuiltDashboard;
 
   return (
     <Fragment>

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -297,6 +297,7 @@ class DashboardDetail extends Component<Props, State> {
           dashboardFilters: getDashboardFiltersFromURL(location) ?? dashboard.filters,
           dashboardPermissions: dashboard.permissions,
           dashboardCreator: dashboard.createdBy,
+          isPrebuiltDashboard: defined(dashboard.prebuiltId),
           widgetInterval: this.props.widgetInterval,
           onClose: () => {
             // Filter out Widget Viewer Modal query params when exiting the Modal


### PR DESCRIPTION
The widget viewer modal (fullscreen view) did not check whether the dashboard was pre-built, so the "Edit Widget" button was incorrectly enabled for pre-built dashboard widgets. This allowed users to open the edit flow for widgets that shouldn't be editable.

Passes `isPrebuiltDashboard` to both the data and text widget viewer modals and includes it in the edit access check, matching the existing behavior in the dashboard grid view (`sortableWidget.tsx`).

<img width="1150" height="424" alt="image" src="https://github.com/user-attachments/assets/0b894e6f-5f2e-4719-ace2-8e6af4faa1e1" />


Fixes DAIN-1411