### PR TITLE
fix(dashboards): Gate 'View span samples' cell action behind visibility-explore-view

### DIFF
--- a/static/app/components/modals/dataWidgetViewerModal.spec.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.spec.tsx
@@ -1340,6 +1340,14 @@ describe('Modals -> DataWidgetViewerModal', () => {
           location: {...defaultInitialRouterConfig.location},
         },
       };
+      initialDataWithFlag = {
+        organization: OrganizationFixture({features: ['visibility-explore-view']}),
+        projects,
+        initialRouterConfig: {
+          ...defaultInitialRouterConfig,
+          location: {...defaultInitialRouterConfig.location},
+        },
+      };
     });
 
     it('renders the Open in Explore button', async () => {
@@ -1422,7 +1430,7 @@ describe('Modals -> DataWidgetViewerModal', () => {
       });
 
       const {router} = await renderModal({
-        initialData,
+        initialData: initialDataWithFlag,
         widget: mockSpanWidget,
       });
 
@@ -1441,6 +1449,40 @@ describe('Modals -> DataWidgetViewerModal', () => {
           '/organizations/org-slug/explore/traces/'
         )
       );
+    });
+
+    it('does not show "View span samples" without visibility-explore-view', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events/',
+        body: {
+          data: [{transaction: 'test-transaction', 'count()': 10}],
+          meta: {
+            fields: {transaction: 'string', 'count()': 'integer'},
+          },
+        },
+      });
+      const mockSpanWidget = WidgetFixture({
+        widgetType: WidgetType.SPANS,
+        title: 'Span Transactions Widget',
+        displayType: DisplayType.TABLE,
+        queries: [
+          {
+            fields: ['transaction', 'count()'],
+            aggregates: ['count()'],
+            columns: ['transaction'],
+            name: '',
+            conditions: '',
+            orderby: '',
+          },
+        ],
+      });
+
+      await renderModal({initialData, widget: mockSpanWidget});
+
+      const transactionCell = await screen.findByText('test-transaction');
+      await userEvent.click(transactionCell);
+
+      expect(screen.queryByText('View span samples')).not.toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -1107,6 +1107,7 @@ function ViewerTableV2({
   }
 
   const cellActions =
+    organization.features.includes('visibility-explore-view') &&
     tableWidget.widgetType === WidgetType.SPANS
       ? [...ALLOWED_CELL_ACTIONS, Actions.OPEN_ROW_IN_EXPLORE]
       : ALLOWED_CELL_ACTIONS;

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -641,7 +641,10 @@ function TableComponent({
     let cellActions = ALLOWED_CELL_ACTIONS;
     if (disableTableActions) {
       cellActions = [];
-    } else if (widget.widgetType === WidgetType.SPANS) {
+    } else if (
+      organization.features.includes('visibility-explore-view') &&
+      widget.widgetType === WidgetType.SPANS
+    ) {
       cellActions = [...ALLOWED_CELL_ACTIONS, Actions.OPEN_ROW_IN_EXPLORE];
     }
 

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -311,7 +311,8 @@ function VisualizationWidgetContent({
           firstColumn &&
           typeof firstColumnGroupByValue === 'string' &&
           widget.queries.length === 1 &&
-          widget.widgetType === WidgetType.SPANS
+          widget.widgetType === WidgetType.SPANS &&
+          organization.features.includes('visibility-explore-view')
         ) {
           const exploreQuery = new MutableSearch(widget.queries[0]?.conditions ?? '');
           exploreQuery.addFilterValue(firstColumn, firstColumnGroupByValue);

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -311,8 +311,7 @@ function VisualizationWidgetContent({
           firstColumn &&
           typeof firstColumnGroupByValue === 'string' &&
           widget.queries.length === 1 &&
-          widget.widgetType === WidgetType.SPANS &&
-          organization.features.includes('visibility-explore-view')
+          widget.widgetType === WidgetType.SPANS
         ) {
           const exploreQuery = new MutableSearch(widget.queries[0]?.conditions ?? '');
           exploreQuery.addFilterValue(firstColumn, firstColumnGroupByValue);


### PR DESCRIPTION
Gate the `OPEN_ROW_IN_EXPLORE` cell action (rendered as "View span samples") behind the `visibility-explore-view` feature flag in the dashboard widget table view and the data widget viewer modal.

Previously, the "View span samples" context menu option appeared for all span widgets regardless of whether the user had access to the Explore view. Clicking it would navigate to `/explore/traces/`, which is only available to orgs with `visibility-explore-view`. This change hides the option entirely for orgs without the flag, so users are never sent to an unsupported page.

The fix is applied in two independent places:
* inline table on the dashboard card
*  expanded modal view

Refs DAIN-1368