### PR TITLE
fix(dashboards): text widget unknown code block language

### DIFF
--- a/static/app/utils/marked/marked.spec.tsx
+++ b/static/app/utils/marked/marked.spec.tsx
@@ -235,4 +235,11 @@ describe('marked', () => {
       `<pre><code class="language-javascript"><span class="token keyword">const</span> x <span class="token operator">=</span> <span class="token number">1</span><span class="token punctuation">;</span>\n</code></pre>`
     );
   });
+
+  it('renders unknown language code blocks as plaintext via asyncSanitizedMarked', async () => {
+    const markdown = '```unknown\nconst x = 1;\n```';
+    expect(await asyncSanitizedMarked(markdown)).toBe(
+      `<pre><code class="language-unknown">const x = 1;\n</code></pre>`
+    );
+  });
 });

--- a/static/app/utils/prism.tsx
+++ b/static/app/utils/prism.tsx
@@ -121,7 +121,8 @@ export async function loadPrismLanguage(
           `No Prism grammar file for \`${lang}\` exists. Check the \`lang\` argument passed to \`loadPrismLanguage()\`.`
         );
       }
-
+      // to make sure the async call gets resolved and unformatted text shows up instead of hanging
+      onError?.(new Error(`No Prism grammar file for \`${lang}\` exists.`));
       return;
     }
 


### PR DESCRIPTION
Within dashboards we're adding a text widget which supports markdown via the `MarkedText` component. The only issue was that when the user put in a code block with an unrecognized language the text would not show up at all. This is unexpected; we'd expect the code to not be highlighted instead. This was because we didn't resolve the promise that, by calling onError we resolve that promise and it's also more intuitive! 