### PR TITLE
feat(onboarding): SCM project details step UI polish and analytics

### DIFF
--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -55,6 +55,21 @@ export type OnboardingEventParameters = {
     platform: string;
     source: 'detected' | 'manual';
   };
+  'onboarding.scm_project_details_alert_selected': {
+    option: string;
+  };
+  'onboarding.scm_project_details_create_clicked': Record<string, unknown>;
+  'onboarding.scm_project_details_create_failed': Record<string, unknown>;
+  'onboarding.scm_project_details_create_succeeded': {
+    project_slug: string;
+  };
+  'onboarding.scm_project_details_name_edited': {
+    custom: boolean;
+  };
+  'onboarding.scm_project_details_step_viewed': Record<string, unknown>;
+  'onboarding.scm_project_details_team_selected': {
+    team: string;
+  };
   'onboarding.select_framework_modal_close_button_clicked': {
     platform: string;
   };
@@ -125,4 +140,18 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.scm_platform_features_step_viewed':
     'Onboarding: SCM Platform Features Step Viewed',
   'onboarding.scm_platform_selected': 'Onboarding: SCM Platform Selected',
+  'onboarding.scm_project_details_alert_selected':
+    'Onboarding: SCM Project Details Alert Selected',
+  'onboarding.scm_project_details_create_clicked':
+    'Onboarding: SCM Project Details Create Clicked',
+  'onboarding.scm_project_details_create_failed':
+    'Onboarding: SCM Project Details Create Failed',
+  'onboarding.scm_project_details_create_succeeded':
+    'Onboarding: SCM Project Details Create Succeeded',
+  'onboarding.scm_project_details_name_edited':
+    'Onboarding: SCM Project Details Name Edited',
+  'onboarding.scm_project_details_step_viewed':
+    'Onboarding: SCM Project Details Step Viewed',
+  'onboarding.scm_project_details_team_selected':
+    'Onboarding: SCM Project Details Team Selected',
 };

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -1,0 +1,195 @@
+import {AnimatePresence, motion} from 'framer-motion';
+
+import {Input} from '@sentry/scraps/input';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Radio} from '@sentry/scraps/radio';
+import {Select} from '@sentry/scraps/select';
+import {Text} from '@sentry/scraps/text';
+
+import {IconClock, IconFix, IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {testableTransition} from 'sentry/utils/testableTransition';
+import {
+  type IssueAlertNotificationProps,
+  IssueAlertNotificationOptions,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {
+  type AlertRuleOptions,
+  INTERVAL_CHOICES,
+  METRIC_CHOICES,
+  RuleAction,
+} from 'sentry/views/projectInstall/issueAlertOptions';
+
+interface ScmAlertFrequencyProps extends Partial<AlertRuleOptions> {
+  onFieldChange: <K extends keyof AlertRuleOptions>(
+    key: K,
+    value: AlertRuleOptions[K]
+  ) => void;
+  notificationProps?: IssueAlertNotificationProps;
+}
+
+interface AlertOptionCardProps {
+  icon: React.ReactNode;
+  isSelected: boolean;
+  label: string;
+  onSelect: () => void;
+  children?: React.ReactNode;
+}
+
+function AlertOptionCard({
+  label,
+  icon,
+  isSelected,
+  onSelect,
+  children,
+}: AlertOptionCardProps) {
+  return (
+    <Stack gap="md">
+      <Container
+        border={isSelected ? 'accent' : 'secondary'}
+        padding="lg"
+        radius="md"
+        style={isSelected ? {marginBottom: 1} : {borderBottomWidth: 2}}
+        role="radio"
+        aria-checked={isSelected}
+        onClick={onSelect}
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
+            onSelect();
+          }
+        }}
+      >
+        {containerProps => (
+          <Flex gap="md" align="start" {...containerProps} style={{cursor: 'pointer'}}>
+            <Container padding="xs 0 0 0">
+              {() => <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />}
+            </Container>
+            <Text
+              bold={isSelected}
+              style={{flex: 1, lineHeight: '22px'}}
+              size="md"
+              density="comfortable"
+            >
+              {label}
+            </Text>
+            <Flex align="center" style={{paddingTop: 2}}>
+              {icon}
+            </Flex>
+          </Flex>
+        )}
+      </Container>
+      {children}
+    </Stack>
+  );
+}
+
+export function ScmAlertFrequency({
+  alertSetting = RuleAction.DEFAULT_ALERT,
+  interval = '1m',
+  metric = 0,
+  threshold = '10',
+  notificationProps,
+  onFieldChange,
+}: ScmAlertFrequencyProps) {
+  const isCustomSelected = alertSetting === RuleAction.CUSTOMIZED_ALERTS;
+
+  return (
+    <Stack gap="xl" role="radiogroup" aria-label={t('Alert frequency')}>
+      <Stack gap="lg">
+        <AlertOptionCard
+          label={t('High priority issues')}
+          icon={<IconWarning legacySize="16px" />}
+          isSelected={alertSetting === RuleAction.DEFAULT_ALERT}
+          onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
+        />
+
+        <AlertOptionCard
+          label={t('Custom')}
+          icon={<IconFix legacySize="16px" />}
+          isSelected={isCustomSelected}
+          onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
+        >
+          <AnimatePresence initial={false}>
+            {isCustomSelected && (
+              <motion.div
+                initial={{height: 0, opacity: 0}}
+                animate={{
+                  height: 'auto',
+                  opacity: 1,
+                  transition: testableTransition({duration: 0.2}),
+                }}
+                exit={{
+                  height: 0,
+                  opacity: 0,
+                  transition: testableTransition({duration: 0.15}),
+                }}
+                style={{overflow: 'hidden'}}
+              >
+                <Flex paddingLeft="3xl">
+                  <Stack
+                    gap="md"
+                    paddingLeft="3xl"
+                    width="100%"
+                    style={{
+                      borderLeft: `2px solid var(--border-accent, var(--accent400))`,
+                    }}
+                  >
+                    <Stack gap="xs" width="100%">
+                      <Text size="md" density="comfortable">
+                        {t('When there are more than')}
+                      </Text>
+                      <Flex gap="md" width="100%">
+                        <div style={{width: 91}}>
+                          <Input
+                            size="sm"
+                            type="number"
+                            min="0"
+                            placeholder="10"
+                            value={threshold}
+                            onChange={e => onFieldChange('threshold', e.target.value)}
+                          />
+                        </div>
+                        <div style={{flex: 1}}>
+                          <Select
+                            size="sm"
+                            value={metric}
+                            options={METRIC_CHOICES}
+                            onChange={option => onFieldChange('metric', option.value)}
+                          />
+                        </div>
+                      </Flex>
+                    </Stack>
+                    <Stack gap="xs" width="100%">
+                      <Text size="md" density="comfortable">
+                        {t('a unique error in')}
+                      </Text>
+                      <Select
+                        size="sm"
+                        value={interval}
+                        options={INTERVAL_CHOICES}
+                        onChange={option => onFieldChange('interval', option.value)}
+                      />
+                    </Stack>
+                  </Stack>
+                </Flex>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </AlertOptionCard>
+
+        <AlertOptionCard
+          label={t("I'll create my own alerts later")}
+          icon={<IconClock legacySize="16px" />}
+          isSelected={alertSetting === RuleAction.CREATE_ALERT_LATER}
+          onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
+        />
+      </Stack>
+
+      {notificationProps && alertSetting !== RuleAction.CREATE_ALERT_LATER && (
+        <IssueAlertNotificationOptions {...notificationProps} />
+      )}
+    </Stack>
+  );
+}

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -54,31 +54,29 @@ function AlertOptionCard({
         aria-checked={isSelected}
         onClick={onSelect}
         tabIndex={0}
-        onKeyDown={e => {
+        onKeyDown={(e: React.KeyboardEvent) => {
           if (e.key === ' ' || e.key === 'Enter') {
             e.preventDefault();
             onSelect();
           }
         }}
       >
-        {containerProps => (
-          <Flex gap="md" align="start" {...containerProps} style={{cursor: 'pointer'}}>
-            <Container padding="xs 0 0 0">
-              {() => <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />}
-            </Container>
-            <Text
-              bold={isSelected}
-              style={{flex: 1, lineHeight: '22px'}}
-              size="md"
-              density="comfortable"
-            >
-              {label}
-            </Text>
-            <Flex align="center" style={{paddingTop: 2}}>
-              {icon}
-            </Flex>
+        <Flex gap="md" align="start" style={{cursor: 'pointer'}}>
+          <Container padding="xs 0 0 0">
+            <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
+          </Container>
+          <Text
+            bold={isSelected}
+            style={{flex: 1, lineHeight: '22px'}}
+            size="md"
+            density="comfortable"
+          >
+            {label}
+          </Text>
+          <Flex align="center" style={{paddingTop: 2}}>
+            {icon}
           </Flex>
-        )}
+        </Flex>
       </Container>
       {children}
     </Stack>

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -1,5 +1,3 @@
-import {AnimatePresence, motion} from 'framer-motion';
-
 import {Input} from '@sentry/scraps/input';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
@@ -8,7 +6,6 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconClock, IconFix, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {testableTransition} from 'sentry/utils/testableTransition';
 import {
   type AlertRuleOptions,
   INTERVAL_CHOICES,
@@ -101,72 +98,53 @@ export function ScmAlertFrequency({
           isSelected={isCustomSelected}
           onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
         >
-          <AnimatePresence initial={false}>
-            {isCustomSelected && (
-              <motion.div
-                initial={{height: 0, opacity: 0}}
-                animate={{
-                  height: 'auto',
-                  opacity: 1,
-                  transition: testableTransition({duration: 0.2}),
-                }}
-                exit={{
-                  height: 0,
-                  opacity: 0,
-                  transition: testableTransition({duration: 0.15}),
-                }}
-                style={{overflow: 'hidden'}}
-              >
-                <Flex paddingLeft="3xl">
-                  <Stack
-                    gap="md"
-                    paddingLeft="3xl"
-                    width="100%"
-                    style={{
-                      borderLeft: `2px solid var(--border-accent, var(--accent400))`,
-                    }}
-                  >
-                    <Stack gap="xs" width="100%">
-                      <Text size="md" density="comfortable">
-                        {t('When there are more than')}
-                      </Text>
-                      <Flex gap="md" width="100%">
-                        <div style={{width: 91}}>
-                          <Input
-                            size="sm"
-                            type="number"
-                            min="0"
-                            placeholder="10"
-                            value={threshold}
-                            onChange={e => onFieldChange('threshold', e.target.value)}
-                          />
-                        </div>
-                        <div style={{flex: 1}}>
-                          <Select
-                            size="sm"
-                            value={metric}
-                            options={METRIC_CHOICES}
-                            onChange={option => onFieldChange('metric', option.value)}
-                          />
-                        </div>
-                      </Flex>
-                    </Stack>
-                    <Stack gap="xs" width="100%">
-                      <Text size="md" density="comfortable">
-                        {t('a unique error in')}
-                      </Text>
-                      <Select
-                        size="sm"
-                        value={interval}
-                        options={INTERVAL_CHOICES}
-                        onChange={option => onFieldChange('interval', option.value)}
-                      />
-                    </Stack>
-                  </Stack>
+          <Flex paddingLeft="3xl">
+            <Stack
+              gap="md"
+              paddingLeft="3xl"
+              width="100%"
+              style={{
+                borderLeft: `2px solid var(--border-accent, var(--accent400))`,
+              }}
+            >
+              <Stack gap="xs" width="100%">
+                <Text size="md" density="comfortable">
+                  {t('When there are more than')}
+                </Text>
+                <Flex gap="md" width="100%">
+                  <div style={{width: 91}}>
+                    <Input
+                      size="sm"
+                      type="number"
+                      min="0"
+                      placeholder="10"
+                      value={threshold}
+                      onChange={e => onFieldChange('threshold', e.target.value)}
+                    />
+                  </div>
+                  <div style={{flex: 1}}>
+                    <Select
+                      size="sm"
+                      value={metric}
+                      options={METRIC_CHOICES}
+                      onChange={option => onFieldChange('metric', option.value)}
+                    />
+                  </div>
                 </Flex>
-              </motion.div>
-            )}
-          </AnimatePresence>
+              </Stack>
+              <Stack gap="xs" width="100%">
+                <Text size="md" density="comfortable">
+                  {t('a unique error in')}
+                </Text>
+                <Select
+                  size="sm"
+                  value={interval}
+                  options={INTERVAL_CHOICES}
+                  onChange={option => onFieldChange('interval', option.value)}
+                />
+              </Stack>
+            </Stack>
+          </Flex>
         </AlertOptionCard>
 
         <AlertOptionCard

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -61,7 +61,7 @@ function AlertOptionCard({
           }
         }}
       >
-        <Flex gap="md" align="start" style={{cursor: 'pointer'}}>
+        <Flex gap="md" align="center">
           <Container padding="xs 0 0 0">
             <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
           </Container>
@@ -91,21 +91,25 @@ export function ScmAlertFrequency({
   notificationProps,
   onFieldChange,
 }: ScmAlertFrequencyProps) {
+  const isDefaultSelected = alertSetting === RuleAction.DEFAULT_ALERT;
   const isCustomSelected = alertSetting === RuleAction.CUSTOMIZED_ALERTS;
+  const isLaterSelected = alertSetting === RuleAction.CREATE_ALERT_LATER;
 
   return (
     <Stack gap="xl" role="radiogroup" aria-label={t('Alert frequency')}>
       <Stack gap="lg">
         <AlertOptionCard
           label={t('High priority issues')}
-          icon={<IconWarning legacySize="16px" />}
-          isSelected={alertSetting === RuleAction.DEFAULT_ALERT}
+          icon={
+            <IconWarning size="md" variant={isDefaultSelected ? 'accent' : 'secondary'} />
+          }
+          isSelected={isDefaultSelected}
           onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
         />
 
         <AlertOptionCard
           label={t('Custom')}
-          icon={<IconFix legacySize="16px" />}
+          icon={<IconFix size="md" variant={isCustomSelected ? 'accent' : 'secondary'} />}
           isSelected={isCustomSelected}
           onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
         >
@@ -179,8 +183,10 @@ export function ScmAlertFrequency({
 
         <AlertOptionCard
           label={t("I'll create my own alerts later")}
-          icon={<IconClock legacySize="16px" />}
-          isSelected={alertSetting === RuleAction.CREATE_ALERT_LATER}
+          icon={
+            <IconClock size="md" variant={isLaterSelected ? 'accent' : 'secondary'} />
+          }
+          isSelected={isLaterSelected}
           onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
         />
       </Stack>

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -46,8 +46,8 @@ function AlertOptionCard({
   children,
 }: AlertOptionCardProps) {
   return (
-    <Stack gap="md">
-      <ScmCardButton role="radio" aria-checked={isSelected} onClick={onSelect}>
+    <ScmCardButton aria-checked={isSelected} onClick={onSelect}>
+      <Stack gap="md">
         <Container
           border={isSelected ? 'accent' : 'secondary'}
           padding="lg"
@@ -71,9 +71,9 @@ function AlertOptionCard({
             </Flex>
           </Flex>
         </Container>
-      </ScmCardButton>
-      {children}
-    </Stack>
+        {children}
+      </Stack>
+    </ScmCardButton>
   );
 }
 

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -20,6 +20,8 @@ import {
   RuleAction,
 } from 'sentry/views/projectInstall/issueAlertOptions';
 
+import {ScmCardButton} from './scmCardButton';
+
 interface ScmAlertFrequencyProps extends Partial<AlertRuleOptions> {
   onFieldChange: <K extends keyof AlertRuleOptions>(
     key: K,
@@ -45,39 +47,31 @@ function AlertOptionCard({
 }: AlertOptionCardProps) {
   return (
     <Stack gap="md">
-      <Container
-        border={isSelected ? 'accent' : 'secondary'}
-        padding="lg"
-        radius="md"
-        style={isSelected ? {marginBottom: 1} : {borderBottomWidth: 2}}
-        role="radio"
-        aria-checked={isSelected}
-        onClick={onSelect}
-        tabIndex={0}
-        onKeyDown={(e: React.KeyboardEvent) => {
-          if (e.key === ' ' || e.key === 'Enter') {
-            e.preventDefault();
-            onSelect();
-          }
-        }}
-      >
-        <Flex gap="md" align="center">
-          <Container padding="xs 0 0 0">
-            <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
-          </Container>
-          <Text
-            bold={isSelected}
-            style={{flex: 1, lineHeight: '22px'}}
-            size="md"
-            density="comfortable"
-          >
-            {label}
-          </Text>
-          <Flex align="center" style={{paddingTop: 2}}>
-            {icon}
+      <ScmCardButton role="radio" aria-checked={isSelected} onClick={onSelect}>
+        <Container
+          border={isSelected ? 'accent' : 'secondary'}
+          padding="lg"
+          radius="md"
+          style={isSelected ? {marginBottom: 1} : {borderBottomWidth: 2}}
+        >
+          <Flex gap="md" align="center">
+            <Container padding="xs 0 0 0">
+              <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
+            </Container>
+            <Text
+              bold={isSelected}
+              style={{flex: 1, lineHeight: '22px'}}
+              size="md"
+              density="comfortable"
+            >
+              {label}
+            </Text>
+            <Flex align="center" style={{paddingTop: 2}}>
+              {icon}
+            </Flex>
           </Flex>
-        </Flex>
-      </Container>
+        </Container>
+      </ScmCardButton>
       {children}
     </Stack>
   );

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -10,10 +10,6 @@ import {IconClock, IconFix, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {testableTransition} from 'sentry/utils/testableTransition';
 import {
-  type IssueAlertNotificationProps,
-  IssueAlertNotificationOptions,
-} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
-import {
   type AlertRuleOptions,
   INTERVAL_CHOICES,
   METRIC_CHOICES,
@@ -27,7 +23,6 @@ interface ScmAlertFrequencyProps extends Partial<AlertRuleOptions> {
     key: K,
     value: AlertRuleOptions[K]
   ) => void;
-  notificationProps?: IssueAlertNotificationProps;
 }
 
 interface AlertOptionCardProps {
@@ -82,7 +77,6 @@ export function ScmAlertFrequency({
   interval = '1m',
   metric = 0,
   threshold = '10',
-  notificationProps,
   onFieldChange,
 }: ScmAlertFrequencyProps) {
   const isDefaultSelected = alertSetting === RuleAction.DEFAULT_ALERT;
@@ -184,10 +178,6 @@ export function ScmAlertFrequency({
           onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
         />
       </Stack>
-
-      {notificationProps && alertSetting !== RuleAction.CREATE_ALERT_LATER && (
-        <IssueAlertNotificationOptions {...notificationProps} />
-      )}
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -1,11 +1,11 @@
 import {Input} from '@sentry/scraps/input';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Radio} from '@sentry/scraps/radio';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
 import {IconClock, IconFix, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {ScmAlertOptionCard} from 'sentry/views/onboarding/components/scmAlertOptionCard';
 import {
   type AlertRuleOptions,
   INTERVAL_CHOICES,
@@ -13,60 +13,11 @@ import {
   RuleAction,
 } from 'sentry/views/projectInstall/issueAlertOptions';
 
-import {ScmCardButton} from './scmCardButton';
-
 interface ScmAlertFrequencyProps extends Partial<AlertRuleOptions> {
   onFieldChange: <K extends keyof AlertRuleOptions>(
     key: K,
     value: AlertRuleOptions[K]
   ) => void;
-}
-
-interface AlertOptionCardProps {
-  icon: React.ReactNode;
-  isSelected: boolean;
-  label: string;
-  onSelect: () => void;
-  children?: React.ReactNode;
-}
-
-function AlertOptionCard({
-  label,
-  icon,
-  isSelected,
-  onSelect,
-  children,
-}: AlertOptionCardProps) {
-  return (
-    <ScmCardButton aria-checked={isSelected} onClick={onSelect}>
-      <Stack gap="md">
-        <Container
-          border={isSelected ? 'accent' : 'secondary'}
-          padding="lg"
-          radius="md"
-          style={isSelected ? {marginBottom: 1} : {borderBottomWidth: 2}}
-        >
-          <Flex gap="md" align="center">
-            <Container padding="xs 0 0 0">
-              <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
-            </Container>
-            <Text
-              bold={isSelected}
-              style={{flex: 1, lineHeight: '22px'}}
-              size="md"
-              density="comfortable"
-            >
-              {label}
-            </Text>
-            <Flex align="center" style={{paddingTop: 2}}>
-              {icon}
-            </Flex>
-          </Flex>
-        </Container>
-        {children}
-      </Stack>
-    </ScmCardButton>
-  );
 }
 
 export function ScmAlertFrequency({
@@ -82,80 +33,74 @@ export function ScmAlertFrequency({
 
   return (
     <Stack gap="xl" role="radiogroup" aria-label={t('Alert frequency')}>
-      <Stack gap="lg">
-        <AlertOptionCard
-          label={t('High priority issues')}
-          icon={
-            <IconWarning size="md" variant={isDefaultSelected ? 'accent' : 'secondary'} />
-          }
-          isSelected={isDefaultSelected}
-          onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
-        />
+      <ScmAlertOptionCard
+        label={t('High priority issues')}
+        icon={
+          <IconWarning size="md" variant={isDefaultSelected ? 'accent' : 'secondary'} />
+        }
+        isSelected={isDefaultSelected}
+        onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
+      />
 
-        <AlertOptionCard
-          label={t('Custom')}
-          icon={<IconFix size="md" variant={isCustomSelected ? 'accent' : 'secondary'} />}
-          isSelected={isCustomSelected}
-          onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
-        >
-          <Flex paddingLeft="3xl">
-            <Stack
-              gap="md"
-              paddingLeft="3xl"
-              width="100%"
-              style={{
-                borderLeft: `2px solid var(--border-accent, var(--accent400))`,
-              }}
-            >
-              <Stack gap="xs" width="100%">
+      <ScmAlertOptionCard
+        label={t('Custom')}
+        icon={<IconFix size="md" variant={isCustomSelected ? 'accent' : 'secondary'} />}
+        isSelected={isCustomSelected}
+        onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
+      >
+        <Container paddingLeft="2xl">
+          <Stack
+            gap="lg"
+            padding="sm 0 0 2xl"
+            width="100%"
+            borderLeft={isCustomSelected ? 'accent' : 'secondary'}
+          >
+            <Stack gap="xs" width="100%">
+              <Container>
                 <Text size="md" density="comfortable">
                   {t('When there are more than')}
                 </Text>
-                <Flex gap="md" width="100%">
-                  <div style={{width: 91}}>
-                    <Input
-                      size="sm"
-                      type="number"
-                      min="0"
-                      placeholder="10"
-                      value={threshold}
-                      onChange={e => onFieldChange('threshold', e.target.value)}
-                    />
-                  </div>
-                  <div style={{flex: 1}}>
-                    <Select
-                      size="sm"
-                      value={metric}
-                      options={METRIC_CHOICES}
-                      onChange={option => onFieldChange('metric', option.value)}
-                    />
-                  </div>
-                </Flex>
-              </Stack>
-              <Stack gap="xs" width="100%">
+              </Container>
+              <Grid gap="md" width="100%" columns=".35fr .65fr">
+                <Input
+                  size="sm"
+                  type="number"
+                  min="0"
+                  placeholder="10"
+                  value={threshold}
+                  onChange={e => onFieldChange('threshold', e.target.value)}
+                />
+                <Select
+                  size="sm"
+                  value={metric}
+                  options={METRIC_CHOICES}
+                  onChange={option => onFieldChange('metric', option.value)}
+                />
+              </Grid>
+            </Stack>
+            <Stack gap="xs" width="100%">
+              <Container>
                 <Text size="md" density="comfortable">
                   {t('a unique error in')}
                 </Text>
-                <Select
-                  size="sm"
-                  value={interval}
-                  options={INTERVAL_CHOICES}
-                  onChange={option => onFieldChange('interval', option.value)}
-                />
-              </Stack>
+              </Container>
+              <Select
+                size="sm"
+                value={interval}
+                options={INTERVAL_CHOICES}
+                onChange={option => onFieldChange('interval', option.value)}
+              />
             </Stack>
-          </Flex>
-        </AlertOptionCard>
+          </Stack>
+        </Container>
+      </ScmAlertOptionCard>
 
-        <AlertOptionCard
-          label={t("I'll create my own alerts later")}
-          icon={
-            <IconClock size="md" variant={isLaterSelected ? 'accent' : 'secondary'} />
-          }
-          isSelected={isLaterSelected}
-          onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
-        />
-      </Stack>
+      <ScmAlertOptionCard
+        label={t("I'll create my own alerts later")}
+        icon={<IconClock size="md" variant={isLaterSelected ? 'accent' : 'secondary'} />}
+        isSelected={isLaterSelected}
+        onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
+      />
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -52,16 +52,15 @@ export function ScmAlertFrequency({
           <Stack
             gap="lg"
             padding="sm 0 0 2xl"
-            width="100%"
             borderLeft={isCustomSelected ? 'accent' : 'secondary'}
           >
-            <Stack gap="xs" width="100%">
+            <Stack gap="xs">
               <Container>
                 <Text size="md" density="comfortable">
                   {t('When there are more than')}
                 </Text>
               </Container>
-              <Grid gap="md" width="100%" columns=".35fr .65fr">
+              <Grid gap="md" columns=".35fr .65fr">
                 <Input
                   size="sm"
                   type="number"
@@ -80,7 +79,7 @@ export function ScmAlertFrequency({
                 />
               </Grid>
             </Stack>
-            <Stack gap="xs" width="100%">
+            <Stack gap="xs">
               <Container>
                 <Text size="md" density="comfortable">
                   {t('a unique error in')}

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -69,12 +69,14 @@ export function ScmAlertFrequency({
                   placeholder="10"
                   value={threshold}
                   onChange={e => onFieldChange('threshold', e.target.value)}
+                  disabled={!isCustomSelected}
                 />
                 <Select
                   size="sm"
                   value={metric}
                   options={METRIC_CHOICES}
                   onChange={option => onFieldChange('metric', option.value)}
+                  disabled={!isCustomSelected}
                 />
               </Grid>
             </Stack>
@@ -89,6 +91,7 @@ export function ScmAlertFrequency({
                 value={interval}
                 options={INTERVAL_CHOICES}
                 onChange={option => onFieldChange('interval', option.value)}
+                disabled={!isCustomSelected}
               />
             </Stack>
           </Stack>

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -21,7 +21,7 @@ export function ScmAlertOptionCard({
   children,
 }: ScmAlertOptionCardProps) {
   return (
-    <ScmCardButton aria-checked={isSelected} onClick={onSelect}>
+    <ScmCardButton role="radio" aria-checked={isSelected} onClick={onSelect}>
       <Stack gap="lg">
         <ScmSelectableContainer isSelected={isSelected} padding="lg">
           <Grid gap="md" align="center" columns="min-content 1fr min-content">

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,0 +1,43 @@
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Radio} from '@sentry/scraps/radio';
+import {Text} from '@sentry/scraps/text';
+
+import {ScmCardButton} from 'sentry/views/onboarding/components/scmCardButton';
+
+interface ScmAlertOptionCardProps {
+  icon: React.ReactNode;
+  isSelected: boolean;
+  label: string;
+  onSelect: () => void;
+  children?: React.ReactNode;
+}
+
+export function ScmAlertOptionCard({
+  label,
+  icon,
+  isSelected,
+  onSelect,
+  children,
+}: ScmAlertOptionCardProps) {
+  return (
+    <ScmCardButton aria-checked={isSelected} onClick={onSelect}>
+      <Stack gap="lg">
+        <Container
+          border={isSelected ? 'accent' : 'secondary'}
+          padding="lg"
+          radius="md"
+          style={isSelected ? {marginBottom: 1} : {borderBottomWidth: 2}}
+        >
+          <Grid gap="md" align="center" columns="min-content 1fr min-content">
+            <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
+            <Text bold={isSelected} size="md" density="comfortable">
+              {label}
+            </Text>
+            <Flex align="center">{icon}</Flex>
+          </Grid>
+        </Container>
+        {children}
+      </Stack>
+    </ScmCardButton>
+  );
+}

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,8 +1,9 @@
-import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
 
 import {ScmCardButton} from 'sentry/views/onboarding/components/scmCardButton';
+import {ScmSelectableContainer} from 'sentry/views/onboarding/components/scmSelectableContainer';
 
 interface ScmAlertOptionCardProps {
   icon: React.ReactNode;
@@ -22,12 +23,7 @@ export function ScmAlertOptionCard({
   return (
     <ScmCardButton aria-checked={isSelected} onClick={onSelect}>
       <Stack gap="lg">
-        <Container
-          border={isSelected ? 'accent' : 'secondary'}
-          padding="lg"
-          radius="md"
-          style={isSelected ? {marginBottom: 1} : {borderBottomWidth: 2}}
-        >
+        <ScmSelectableContainer isSelected={isSelected} padding="lg">
           <Grid gap="md" align="center" columns="min-content 1fr min-content">
             <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
             <Text bold={isSelected} size="md" density="comfortable">
@@ -35,7 +31,7 @@ export function ScmAlertOptionCard({
             </Text>
             <Flex align="center">{icon}</Flex>
           </Grid>
-        </Container>
+        </ScmSelectableContainer>
         {children}
       </Stack>
     </ScmCardButton>

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -21,8 +21,8 @@ export function ScmAlertOptionCard({
   children,
 }: ScmAlertOptionCardProps) {
   return (
-    <ScmCardButton role="radio" aria-checked={isSelected} onClick={onSelect}>
-      <Stack gap="lg">
+    <Stack gap="lg">
+      <ScmCardButton role="radio" aria-checked={isSelected} onClick={onSelect}>
         <ScmSelectableContainer isSelected={isSelected} padding="lg">
           <Grid gap="md" align="center" columns="min-content 1fr min-content">
             <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
@@ -32,8 +32,8 @@ export function ScmAlertOptionCard({
             <Flex align="center">{icon}</Flex>
           </Grid>
         </ScmSelectableContainer>
-        {children}
-      </Stack>
-    </ScmCardButton>
+      </ScmCardButton>
+      {children}
+    </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -8,6 +8,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 
 import {ScmCardButton} from './scmCardButton';
+import {ScmSelectableContainer} from './scmSelectableContainer';
 
 interface ScmFeatureCardProps {
   description: string;
@@ -42,12 +43,11 @@ export function ScmFeatureCard({
         disabled={disabled}
         style={{width: '100%', height: '100%'}}
       >
-        <Container
-          border={isSelected ? 'accent' : 'secondary'}
+        <ScmSelectableContainer
+          isSelected={isSelected}
           padding={{xs: 'md', md: 'xl'}}
-          radius="md"
           height="100%"
-          style={isSelected ? {marginBottom: 2} : {borderBottomWidth: 3}} // this prevents el height from changing when switching border variant
+          borderCompensation={3}
         >
           <Flex>
             <Grid
@@ -90,7 +90,7 @@ export function ScmFeatureCard({
               />
             </Flex>
           </Flex>
-        </Container>
+        </ScmSelectableContainer>
       </ScmCardButton>
     </Tooltip>
   );

--- a/static/app/views/onboarding/components/scmPlatformCard.tsx
+++ b/static/app/views/onboarding/components/scmPlatformCard.tsx
@@ -1,11 +1,12 @@
 import {PlatformIcon} from 'platformicons';
 
-import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import type {PlatformKey} from 'sentry/types/project';
 
 import {ScmCardButton} from './scmCardButton';
+import {ScmSelectableContainer} from './scmSelectableContainer';
 
 interface ScmPlatformCardProps {
   isSelected: boolean;
@@ -24,7 +25,7 @@ export function ScmPlatformCard({
 }: ScmPlatformCardProps) {
   return (
     <ScmCardButton onClick={onClick} role="radio" aria-checked={isSelected}>
-      <Container border={isSelected ? 'accent' : 'secondary'} padding="lg" radius="md">
+      <ScmSelectableContainer isSelected={isSelected} padding="lg">
         <Grid gap="md" align="center" columns="max-content min-content">
           <PlatformIcon platform={platform} size={28} />
           <Stack>
@@ -36,7 +37,7 @@ export function ScmPlatformCard({
             </Text>
           </Stack>
         </Grid>
-      </Container>
+      </ScmSelectableContainer>
     </ScmCardButton>
   );
 }

--- a/static/app/views/onboarding/components/scmSelectableContainer.tsx
+++ b/static/app/views/onboarding/components/scmSelectableContainer.tsx
@@ -1,0 +1,36 @@
+import type {ComponentProps} from 'react';
+
+import {Container} from '@sentry/scraps/layout';
+
+interface ScmSelectableContainerProps extends ComponentProps<typeof Container> {
+  isSelected: boolean;
+  /**
+   * Accent borders are thicker than secondary borders, causing a layout
+   * shift when toggling selection. This compensation value offsets the
+   * difference via marginBottom (selected) / borderBottomWidth (unselected).
+   * Will be unnecessary once the design system provides a stable-height
+   * selected border variant.
+   */
+  borderCompensation?: number;
+}
+
+export function ScmSelectableContainer({
+  isSelected,
+  borderCompensation = 2,
+  style,
+  ...props
+}: ScmSelectableContainerProps) {
+  return (
+    <Container
+      border={isSelected ? 'accent' : 'secondary'}
+      radius="md"
+      style={{
+        ...(isSelected
+          ? {marginBottom: borderCompensation - 1}
+          : {borderBottomWidth: borderCompensation}),
+        ...style,
+      }}
+      {...props}
+    />
+  );
+}

--- a/static/app/views/onboarding/components/scmSelectableContainer.tsx
+++ b/static/app/views/onboarding/components/scmSelectableContainer.tsx
@@ -1,8 +1,7 @@
-import type {ComponentProps} from 'react';
-
+import type {ContainerProps} from '@sentry/scraps/layout';
 import {Container} from '@sentry/scraps/layout';
 
-interface ScmSelectableContainerProps extends ComponentProps<typeof Container> {
+type ScmSelectableContainerProps = ContainerProps & {
   isSelected: boolean;
   /**
    * Accent borders are thicker than secondary borders, causing a layout
@@ -12,7 +11,7 @@ interface ScmSelectableContainerProps extends ComponentProps<typeof Container> {
    * selected border variant.
    */
   borderCompensation?: number;
-}
+};
 
 export function ScmSelectableContainer({
   isSelected,

--- a/static/app/views/onboarding/components/scmStepHeader.tsx
+++ b/static/app/views/onboarding/components/scmStepHeader.tsx
@@ -31,7 +31,14 @@ export function ScmStepHeader({
         <Heading as="h2" size="3xl">
           {heading}
         </Heading>
-        <Text variant="muted" size="lg" bold density="comfortable" align="center">
+        <Text
+          variant="muted"
+          size="lg"
+          wrap="pre-line"
+          align="center"
+          bold
+          density="comfortable"
+        >
           {subtitle}
         </Text>
       </Stack>

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -430,7 +430,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
           >
             <Heading as="h3">{t('Select a platform')}</Heading>
             <Select<(typeof platformOptions)[number]>
-              placeholder={t('Search 100+ SDKs by name, package, or description...')}
+              placeholder={t('Search SDKs...')}
               options={manualPickerOptions}
               value={currentPlatformKey ?? null}
               onChange={option => {

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -11,6 +11,7 @@ import {
 } from 'sentry/components/onboarding/onboardingContext';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import * as analytics from 'sentry/utils/analytics';
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 import {ScmProjectDetails} from './scmProjectDetails';
@@ -43,10 +44,62 @@ describe('ScmProjectDetails', () => {
   beforeEach(() => {
     sessionStorageWrapper.clear();
     TeamStore.loadInitialData([teamWithAccess]);
+
+    // useCreateNotificationAction queries messaging integrations on mount
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [],
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    });
+    // SetupMessagingIntegrationButton queries integration config
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/`,
+      body: {providers: []},
+    });
   });
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
+  });
+
+  it('renders step header with step counter and heading', async () => {
+    render(
+      <ScmProjectDetails
+        onComplete={jest.fn()}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    expect(await screen.findByText('Step 3 of 3')).toBeInTheDocument();
+    expect(screen.getByText('Project details')).toBeInTheDocument();
+  });
+
+  it('renders section headers with icons', async () => {
+    render(
+      <ScmProjectDetails
+        onComplete={jest.fn()}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    expect(await screen.findByText('Give your project a name')).toBeInTheDocument();
+    expect(screen.getByText('Assign a team')).toBeInTheDocument();
+    expect(screen.getByText('Alert frequency')).toBeInTheDocument();
+    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
   });
 
   it('renders project name defaulted from platform key', async () => {
@@ -88,7 +141,7 @@ describe('ScmProjectDetails', () => {
     expect(input).toHaveValue('javascript-nextjs');
   });
 
-  it('renders alert frequency options', async () => {
+  it('renders card-style alert frequency options', async () => {
     render(
       <ScmProjectDetails
         onComplete={jest.fn()}
@@ -103,9 +156,8 @@ describe('ScmProjectDetails', () => {
       }
     );
 
-    expect(
-      await screen.findByText('Alert me on high priority issues')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('High priority issues')).toBeInTheDocument();
+    expect(screen.getByText('Custom')).toBeInTheDocument();
     expect(screen.getByText("I'll create my own alerts later")).toBeInTheDocument();
   });
 
@@ -277,5 +329,78 @@ describe('ScmProjectDetails', () => {
     await waitFor(() => {
       expect(onComplete).not.toHaveBeenCalled();
     });
+  });
+
+  it('fires step viewed analytics on mount', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+
+    render(
+      <ScmProjectDetails
+        onComplete={jest.fn()}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    await screen.findByText('Project details');
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.scm_project_details_step_viewed',
+      expect.objectContaining({organization})
+    );
+  });
+
+  it('fires create analytics on successful project creation', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: ProjectFixture({slug: 'javascript-nextjs', name: 'javascript-nextjs'}),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [teamWithAccess],
+    });
+
+    const onComplete = jest.fn();
+
+    render(
+      <ScmProjectDetails
+        onComplete={onComplete}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+        }),
+      }
+    );
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    const eventKeys = trackAnalyticsSpy.mock.calls.map(call => call[0]);
+    expect(eventKeys).toContain('onboarding.scm_project_details_create_clicked');
+    expect(eventKeys).toContain('onboarding.scm_project_details_create_succeeded');
   });
 });

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -60,6 +60,7 @@ describe('ScmProjectDetails', () => {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
+    jest.restoreAllMocks();
   });
 
   it('renders step header with step counter and heading', async () => {

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Button} from '@sentry/scraps/button';
@@ -40,10 +40,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     trackAnalytics('onboarding.scm_project_details_step_viewed', {organization});
   }, [organization]);
 
-  const firstAdminTeam = useMemo(
-    () => teams.find((team: Team) => team.access.includes('team:admin')),
-    [teams]
-  );
+  const firstAdminTeam = teams.find((team: Team) => team.access.includes('team:admin'));
   const defaultName = slugify(selectedPlatform?.key ?? '');
 
   // State tracks user edits; derived values fall back to defaults from context/teams
@@ -57,23 +54,40 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     DEFAULT_ISSUE_ALERT_OPTIONS_VALUES
   );
 
-  const handleAlertChange = useCallback(
-    <K extends keyof AlertRuleOptions>(key: K, value: AlertRuleOptions[K]) => {
-      setAlertRuleConfig(prev => ({...prev, [key]: value}));
-      if (key === 'alertSetting') {
-        const optionMap: Record<number, string> = {
-          0: 'high_priority',
-          1: 'custom',
-          2: 'create_later',
-        };
-        trackAnalytics('onboarding.scm_project_details_alert_selected', {
-          organization,
-          option: optionMap[value as number] ?? String(value),
-        });
-      }
-    },
-    [organization]
-  );
+  function handleAlertChange<K extends keyof AlertRuleOptions>(
+    key: K,
+    value: AlertRuleOptions[K]
+  ) {
+    setAlertRuleConfig(prev => ({...prev, [key]: value}));
+    if (key === 'alertSetting') {
+      const optionMap: Record<number, string> = {
+        0: 'high_priority',
+        1: 'custom',
+        2: 'create_later',
+      };
+      trackAnalytics('onboarding.scm_project_details_alert_selected', {
+        organization,
+        option: optionMap[value as number] ?? String(value),
+      });
+    }
+  }
+
+  function handleProjectNameBlur() {
+    if (projectName !== null) {
+      trackAnalytics('onboarding.scm_project_details_name_edited', {
+        organization,
+        custom: projectName !== defaultName,
+      });
+    }
+  }
+
+  function handleTeamChange({value}: {value: string}) {
+    setTeamSlug(value);
+    trackAnalytics('onboarding.scm_project_details_team_selected', {
+      organization,
+      team: value,
+    });
+  }
 
   const canSubmit =
     projectNameResolved.length > 0 &&
@@ -81,7 +95,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     !!selectedPlatform &&
     !createProjectAndRules.isPending;
 
-  const handleCreateProject = useCallback(async () => {
+  async function handleCreateProject() {
     if (!selectedPlatform || !canSubmit) {
       return;
     }
@@ -113,18 +127,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
       addErrorMessage(t('Failed to create project'));
       Sentry.captureException(error);
     }
-  }, [
-    selectedPlatform,
-    canSubmit,
-    organization,
-    createProjectAndRules,
-    projectNameResolved,
-    teamSlugResolved,
-    alertRuleConfig,
-    selectedFeatures,
-    setCreatedProjectSlug,
-    onComplete,
-  ]);
+  }
 
   return (
     <Flex direction="column" align="center" gap="2xl" flexGrow={1}>
@@ -149,14 +152,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
             placeholder={t('project-name')}
             value={projectNameResolved}
             onChange={e => setProjectName(slugify(e.target.value))}
-            onBlur={() => {
-              if (projectName !== null) {
-                trackAnalytics('onboarding.scm_project_details_name_edited', {
-                  organization,
-                  custom: projectName !== defaultName,
-                });
-              }
-            }}
+            onBlur={handleProjectNameBlur}
           />
         </Stack>
 
@@ -175,13 +171,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
             placeholder={t('Select a Team')}
             teamFilter={(tm: Team) => tm.access.includes('team:admin')}
             value={teamSlugResolved}
-            onChange={({value}: {value: string}) => {
-              setTeamSlug(value);
-              trackAnalytics('onboarding.scm_project_details_team_selected', {
-                organization,
-                team: value,
-              });
-            }}
+            onChange={handleTeamChange}
           />
         </Stack>
 

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -135,12 +135,12 @@ export function ScmProjectDetails({onComplete}: StepProps) {
         stepNumber={3}
         heading={t('Project details')}
         subtitle={t(
-          'Set the project name, assign a team, and configure how you want to receive issue alerts'
+          'Set the project name, assign a team, and configure\nhow you want to receive issue alerts'
         )}
       />
 
-      <Stack gap="2xl" width="100%" maxWidth={PROJECT_DETAILS_WIDTH}>
-        <Stack gap="sm">
+      <Stack gap="3xl" width="100%" maxWidth={PROJECT_DETAILS_WIDTH}>
+        <Stack gap="md">
           <Flex gap="md" align="center" justify="center">
             <IconProject size="md" variant="secondary" />
             <Container>
@@ -158,7 +158,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
           />
         </Stack>
 
-        <Stack gap="sm">
+        <Stack gap="md">
           <Flex gap="md" align="center" justify="center">
             <IconGroup size="md" />
             <Container>
@@ -179,7 +179,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
           />
         </Stack>
 
-        <Stack gap="sm">
+        <Stack gap="md">
           <Flex gap="md" align="center" justify="center">
             <IconSiren size="md" />
             <Container>

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -143,9 +143,11 @@ export function ScmProjectDetails({onComplete}: StepProps) {
         <Stack gap="sm">
           <Flex gap="md" align="center" justify="center">
             <IconProject size="md" variant="secondary" />
-            <Text bold size="lg" density="comfortable">
-              {t('Give your project a name')}
-            </Text>
+            <Container>
+              <Text bold size="lg" density="comfortable">
+                {t('Give your project a name')}
+              </Text>
+            </Container>
           </Flex>
           <Input
             type="text"
@@ -159,9 +161,11 @@ export function ScmProjectDetails({onComplete}: StepProps) {
         <Stack gap="sm">
           <Flex gap="md" align="center" justify="center">
             <IconGroup size="md" />
-            <Text bold size="lg" density="comfortable">
-              {t('Assign a team')}
-            </Text>
+            <Container>
+              <Text bold size="lg" density="comfortable">
+                {t('Assign a team')}
+              </Text>
+            </Container>
           </Flex>
           <TeamSelector
             allowCreate
@@ -178,13 +182,17 @@ export function ScmProjectDetails({onComplete}: StepProps) {
         <Stack gap="sm">
           <Flex gap="md" align="center" justify="center">
             <IconSiren size="md" />
-            <Text bold size="lg" density="comfortable">
-              {t('Alert frequency')}
-            </Text>
+            <Container>
+              <Text bold size="lg" density="comfortable">
+                {t('Alert frequency')}
+              </Text>
+            </Container>
           </Flex>
-          <Text variant="muted" size="lg" density="comfortable" align="center">
-            {t('Get notified when things go wrong')}
-          </Text>
+          <Container>
+            <Text variant="muted" size="lg" density="comfortable" align="center">
+              {t('Get notified when things go wrong')}
+            </Text>
+          </Container>
           <ScmAlertFrequency {...alertRuleConfig} onFieldChange={handleAlertChange} />
         </Stack>
       </Stack>

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
-import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
@@ -27,8 +26,9 @@ import {
 import {ScmAlertFrequency} from './components/scmAlertFrequency';
 import {ScmStepFooter} from './components/scmStepFooter';
 import {ScmStepHeader} from './components/scmStepHeader';
-import {SCM_STEP_CONTENT_WIDTH} from './consts';
 import type {StepProps} from './types';
+
+const PROJECT_DETAILS_WIDTH = '285px';
 
 export function ScmProjectDetails({onComplete}: StepProps) {
   const organization = useOrganization();
@@ -136,91 +136,80 @@ export function ScmProjectDetails({onComplete}: StepProps) {
         )}
       />
 
-      <LayoutGroup>
-        <MotionStack
-          gap="2xl"
-          width="100%"
-          maxWidth={SCM_STEP_CONTENT_WIDTH}
-          layout="position"
-        >
-          <Stack gap="sm">
-            <Flex gap="md" align="center" justify="center">
-              <IconProject size="md" variant="secondary" />
-              <Text bold size="lg" density="comfortable">
-                {t('Give your project a name')}
-              </Text>
-            </Flex>
-            <Input
-              type="text"
-              placeholder={t('project-name')}
-              value={projectNameResolved}
-              onChange={e => setProjectName(slugify(e.target.value))}
-              onBlur={() => {
-                if (projectName !== null) {
-                  trackAnalytics('onboarding.scm_project_details_name_edited', {
-                    organization,
-                    custom: projectName !== defaultName,
-                  });
-                }
-              }}
-            />
-          </Stack>
-
-          <Stack gap="sm">
-            <Flex gap="md" align="center" justify="center">
-              <IconGroup size="md" />
-              <Text bold size="lg" density="comfortable">
-                {t('Assign a team')}
-              </Text>
-            </Flex>
-            <TeamSelector
-              allowCreate
-              name="team"
-              aria-label={t('Select a Team')}
-              clearable={false}
-              placeholder={t('Select a Team')}
-              teamFilter={(tm: Team) => tm.access.includes('team:admin')}
-              value={teamSlugResolved}
-              onChange={({value}: {value: string}) => {
-                setTeamSlug(value);
-                trackAnalytics('onboarding.scm_project_details_team_selected', {
-                  organization,
-                  team: value,
-                });
-              }}
-            />
-          </Stack>
-
-          <Stack gap="sm">
-            <Flex gap="md" align="center" justify="center">
-              <IconSiren size="md" />
-              <Text bold size="lg" density="comfortable">
-                {t('Alert frequency')}
-              </Text>
-            </Flex>
-            <Text variant="muted" size="lg" density="comfortable" align="center">
-              {t('Get notified when things go wrong')}
+      <Stack gap="2xl" width="100%" maxWidth={PROJECT_DETAILS_WIDTH}>
+        <Stack gap="sm">
+          <Flex gap="md" align="center" justify="center">
+            <IconProject size="md" variant="secondary" />
+            <Text bold size="lg" density="comfortable">
+              {t('Give your project a name')}
             </Text>
-            <ScmAlertFrequency {...alertRuleConfig} onFieldChange={handleAlertChange} />
-          </Stack>
-        </MotionStack>
+          </Flex>
+          <Input
+            type="text"
+            placeholder={t('project-name')}
+            value={projectNameResolved}
+            onChange={e => setProjectName(slugify(e.target.value))}
+            onBlur={() => {
+              if (projectName !== null) {
+                trackAnalytics('onboarding.scm_project_details_name_edited', {
+                  organization,
+                  custom: projectName !== defaultName,
+                });
+              }
+            }}
+          />
+        </Stack>
 
-        <MotionStack layout="position" width="100%" align="center">
-          <ScmStepFooter>
-            <Button
-              priority="primary"
-              onClick={handleCreateProject}
-              disabled={!canSubmit}
-              busy={createProjectAndRules.isPending}
-              icon={<IconProject />}
-            >
-              {t('Create project')}
-            </Button>
-          </ScmStepFooter>
-        </MotionStack>
-      </LayoutGroup>
+        <Stack gap="sm">
+          <Flex gap="md" align="center" justify="center">
+            <IconGroup size="md" />
+            <Text bold size="lg" density="comfortable">
+              {t('Assign a team')}
+            </Text>
+          </Flex>
+          <TeamSelector
+            allowCreate
+            name="team"
+            aria-label={t('Select a Team')}
+            clearable={false}
+            placeholder={t('Select a Team')}
+            teamFilter={(tm: Team) => tm.access.includes('team:admin')}
+            value={teamSlugResolved}
+            onChange={({value}: {value: string}) => {
+              setTeamSlug(value);
+              trackAnalytics('onboarding.scm_project_details_team_selected', {
+                organization,
+                team: value,
+              });
+            }}
+          />
+        </Stack>
+
+        <Stack gap="sm">
+          <Flex gap="md" align="center" justify="center">
+            <IconSiren size="md" />
+            <Text bold size="lg" density="comfortable">
+              {t('Alert frequency')}
+            </Text>
+          </Flex>
+          <Text variant="muted" size="lg" density="comfortable" align="center">
+            {t('Get notified when things go wrong')}
+          </Text>
+          <ScmAlertFrequency {...alertRuleConfig} onFieldChange={handleAlertChange} />
+        </Stack>
+      </Stack>
+
+      <ScmStepFooter>
+        <Button
+          priority="primary"
+          onClick={handleCreateProject}
+          disabled={!canSubmit}
+          busy={createProjectAndRules.isPending}
+          icon={<IconProject />}
+        >
+          {t('Create project')}
+        </Button>
+      </ScmStepFooter>
     </Flex>
   );
 }
-
-const MotionStack = motion.create(Stack);

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -64,7 +64,11 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     <K extends keyof AlertRuleOptions>(key: K, value: AlertRuleOptions[K]) => {
       setAlertRuleConfig(prev => ({...prev, [key]: value}));
       if (key === 'alertSetting') {
-        const optionMap = {0: 'high_priority', 1: 'custom', 2: 'create_later'};
+        const optionMap: Record<number, string> = {
+          0: 'high_priority',
+          1: 'custom',
+          2: 'create_later',
+        };
         trackAnalytics('onboarding.scm_project_details_alert_selected', {
           organization,
           option: optionMap[value as number] ?? String(value),

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,47 +1,52 @@
-import {useCallback, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
+import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
 import {TeamSelector} from 'sentry/components/teamSelector';
-import {IconProject} from 'sentry/icons';
+import {IconGroup, IconProject, IconSiren} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Team} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {slugify} from 'sentry/utils/slugify';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTeams} from 'sentry/utils/useTeams';
-import type {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
   getRequestDataFragment,
-  IssueAlertOptions,
   type AlertRuleOptions,
 } from 'sentry/views/projectInstall/issueAlertOptions';
 
+import {ScmAlertFrequency} from './components/scmAlertFrequency';
+import {ScmStepFooter} from './components/scmStepFooter';
+import {ScmStepHeader} from './components/scmStepHeader';
+import {SCM_STEP_CONTENT_WIDTH} from './consts';
 import type {StepProps} from './types';
 
 export function ScmProjectDetails({onComplete}: StepProps) {
+  const organization = useOrganization();
   const {selectedPlatform, selectedFeatures, setCreatedProjectSlug} =
     useOnboardingContext();
   const {teams} = useTeams();
   const createProjectAndRules = useCreateProjectAndRules();
+  const {createNotificationAction, notificationProps} = useCreateNotificationAction();
 
-  // Notification actions (Connect to messaging) deferred to VDY-28 UI polish pass.
-  // No-op avoids the API call that useCreateNotificationAction makes on mount.
-  const createNotificationAction = useCallback(
-    () =>
-      undefined as ReturnType<
-        ReturnType<typeof useCreateNotificationAction>['createNotificationAction']
-      >,
-    []
+  useEffect(() => {
+    trackAnalytics('onboarding.scm_project_details_step_viewed', {organization});
+  }, [organization]);
+
+  const firstAdminTeam = useMemo(
+    () => teams.find((team: Team) => team.access.includes('team:admin')),
+    [teams]
   );
-
-  const firstAdminTeam = teams.find((team: Team) => team.access.includes('team:admin'));
   const defaultName = slugify(selectedPlatform?.key ?? '');
 
   // State tracks user edits; derived values fall back to defaults from context/teams
@@ -58,8 +63,15 @@ export function ScmProjectDetails({onComplete}: StepProps) {
   const handleAlertChange = useCallback(
     <K extends keyof AlertRuleOptions>(key: K, value: AlertRuleOptions[K]) => {
       setAlertRuleConfig(prev => ({...prev, [key]: value}));
+      if (key === 'alertSetting') {
+        const optionMap = {0: 'high_priority', 1: 'custom', 2: 'create_later'};
+        trackAnalytics('onboarding.scm_project_details_alert_selected', {
+          organization,
+          option: optionMap[value as number] ?? String(value),
+        });
+      }
     },
-    []
+    [organization]
   );
 
   const canSubmit =
@@ -72,6 +84,8 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     if (!selectedPlatform || !canSubmit) {
       return;
     }
+
+    trackAnalytics('onboarding.scm_project_details_create_clicked', {organization});
 
     try {
       const {project} = await createProjectAndRules.mutateAsync({
@@ -87,14 +101,21 @@ export function ScmProjectDetails({onComplete}: StepProps) {
       // selectedPlatform.key (which the platform features step needs).
       setCreatedProjectSlug(project.slug);
 
+      trackAnalytics('onboarding.scm_project_details_create_succeeded', {
+        organization,
+        project_slug: project.slug,
+      });
+
       onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);
     } catch (error) {
+      trackAnalytics('onboarding.scm_project_details_create_failed', {organization});
       addErrorMessage(t('Failed to create project'));
       Sentry.captureException(error);
     }
   }, [
     selectedPlatform,
     canSubmit,
+    organization,
     createProjectAndRules,
     projectNameResolved,
     teamSlugResolved,
@@ -106,67 +127,104 @@ export function ScmProjectDetails({onComplete}: StepProps) {
   ]);
 
   return (
-    <Flex direction="column" align="center" gap="xl" flexGrow={1}>
-      <Stack align="center" gap="md">
-        <Heading as="h2">{t('Project details')}</Heading>
-        <Text variant="muted">
-          {t(
-            'Set the project name, assign a team, and configure how you want to receive issue alerts'
-          )}
-        </Text>
-      </Stack>
+    <Flex direction="column" align="center" gap="2xl" flexGrow={1}>
+      <ScmStepHeader
+        stepNumber={3}
+        heading={t('Project details')}
+        subtitle={t(
+          'Set the project name, assign a team, and configure how you want to receive issue alerts'
+        )}
+      />
 
-      <Stack gap="lg" width="100%" maxWidth="600px">
-        <Stack gap="sm">
-          <Flex gap="xs" align="center">
-            <IconProject size="sm" />
-            <Text bold>{t('Give your project a name')}</Text>
-          </Flex>
-          <Input
-            type="text"
-            placeholder={t('project-name')}
-            value={projectNameResolved}
-            onChange={e => setProjectName(slugify(e.target.value))}
-          />
-        </Stack>
-
-        <Stack gap="sm">
-          <Flex gap="xs" align="center">
-            <Text bold>{t('Assign a team')}</Text>
-          </Flex>
-          <TeamSelector
-            allowCreate
-            name="team"
-            aria-label={t('Select a Team')}
-            clearable={false}
-            placeholder={t('Select a Team')}
-            teamFilter={(tm: Team) => tm.access.includes('team:admin')}
-            value={teamSlugResolved}
-            onChange={({value}: {value: string}) => setTeamSlug(value)}
-          />
-        </Stack>
-
-        <Stack gap="sm">
-          <Flex gap="xs" align="center">
-            <Text bold>{t('Alert frequency')}</Text>
-          </Flex>
-          <Text variant="muted" size="sm">
-            {t('Get notified when things go wrong')}
-          </Text>
-          <IssueAlertOptions {...alertRuleConfig} onFieldChange={handleAlertChange} />
-        </Stack>
-      </Stack>
-
-      <Flex gap="md" align="center">
-        <Button
-          priority="primary"
-          onClick={handleCreateProject}
-          disabled={!canSubmit}
-          icon={<IconProject />}
+      <LayoutGroup>
+        <MotionStack
+          gap="2xl"
+          width="100%"
+          maxWidth={SCM_STEP_CONTENT_WIDTH}
+          layout="position"
         >
-          {t('Create project')}
-        </Button>
-      </Flex>
+          <Stack gap="sm">
+            <Flex gap="md" align="center">
+              <IconProject legacySize="16px" />
+              <Text bold size="lg" density="comfortable">
+                {t('Give your project a name')}
+              </Text>
+            </Flex>
+            <Input
+              type="text"
+              placeholder={t('project-name')}
+              value={projectNameResolved}
+              onChange={e => setProjectName(slugify(e.target.value))}
+              onBlur={() => {
+                if (projectName !== null) {
+                  trackAnalytics('onboarding.scm_project_details_name_edited', {
+                    organization,
+                    custom: projectName !== defaultName,
+                  });
+                }
+              }}
+            />
+          </Stack>
+
+          <Stack gap="sm">
+            <Flex gap="md" align="center">
+              <IconGroup legacySize="16px" />
+              <Text bold size="lg" density="comfortable">
+                {t('Assign a team')}
+              </Text>
+            </Flex>
+            <TeamSelector
+              allowCreate
+              name="team"
+              aria-label={t('Select a Team')}
+              clearable={false}
+              placeholder={t('Select a Team')}
+              teamFilter={(tm: Team) => tm.access.includes('team:admin')}
+              value={teamSlugResolved}
+              onChange={({value}: {value: string}) => {
+                setTeamSlug(value);
+                trackAnalytics('onboarding.scm_project_details_team_selected', {
+                  organization,
+                  team: value,
+                });
+              }}
+            />
+          </Stack>
+
+          <Stack gap="sm">
+            <Flex gap="md" align="center">
+              <IconSiren legacySize="16px" />
+              <Text bold size="lg" density="comfortable">
+                {t('Alert frequency')}
+              </Text>
+            </Flex>
+            <Text variant="muted" size="lg" density="comfortable">
+              {t('Get notified when things go wrong')}
+            </Text>
+            <ScmAlertFrequency
+              {...alertRuleConfig}
+              onFieldChange={handleAlertChange}
+              notificationProps={notificationProps}
+            />
+          </Stack>
+        </MotionStack>
+
+        <MotionStack layout="position" width="100%" align="center">
+          <ScmStepFooter>
+            <Button
+              priority="primary"
+              onClick={handleCreateProject}
+              disabled={!canSubmit}
+              busy={createProjectAndRules.isPending}
+              icon={<IconProject />}
+            >
+              {t('Create project')}
+            </Button>
+          </ScmStepFooter>
+        </MotionStack>
+      </LayoutGroup>
     </Flex>
   );
 }
+
+const MotionStack = motion.create(Stack);

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -21,6 +21,7 @@ import {
   DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
   getRequestDataFragment,
   type AlertRuleOptions,
+  RuleAction,
 } from 'sentry/views/projectInstall/issueAlertOptions';
 
 import {ScmAlertFrequency} from './components/scmAlertFrequency';
@@ -61,9 +62,9 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     setAlertRuleConfig(prev => ({...prev, [key]: value}));
     if (key === 'alertSetting') {
       const optionMap: Record<number, string> = {
-        0: 'high_priority',
-        1: 'custom',
-        2: 'create_later',
+        [RuleAction.DEFAULT_ALERT]: 'high_priority',
+        [RuleAction.CUSTOMIZED_ALERTS]: 'custom',
+        [RuleAction.CREATE_ALERT_LATER]: 'create_later',
       };
       trackAnalytics('onboarding.scm_project_details_alert_selected', {
         organization,

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -148,8 +148,8 @@ export function ScmProjectDetails({onComplete}: StepProps) {
           layout="position"
         >
           <Stack gap="sm">
-            <Flex gap="md" align="center">
-              <IconProject legacySize="16px" />
+            <Flex gap="md" align="center" justify="center">
+              <IconProject size="md" variant="secondary" />
               <Text bold size="lg" density="comfortable">
                 {t('Give your project a name')}
               </Text>
@@ -171,8 +171,8 @@ export function ScmProjectDetails({onComplete}: StepProps) {
           </Stack>
 
           <Stack gap="sm">
-            <Flex gap="md" align="center">
-              <IconGroup legacySize="16px" />
+            <Flex gap="md" align="center" justify="center">
+              <IconGroup size="md" />
               <Text bold size="lg" density="comfortable">
                 {t('Assign a team')}
               </Text>
@@ -196,13 +196,13 @@ export function ScmProjectDetails({onComplete}: StepProps) {
           </Stack>
 
           <Stack gap="sm">
-            <Flex gap="md" align="center">
-              <IconSiren legacySize="16px" />
+            <Flex gap="md" align="center" justify="center">
+              <IconSiren size="md" />
               <Text bold size="lg" density="comfortable">
                 {t('Alert frequency')}
               </Text>
             </Flex>
-            <Text variant="muted" size="lg" density="comfortable">
+            <Text variant="muted" size="lg" density="comfortable" align="center">
               {t('Get notified when things go wrong')}
             </Text>
             <ScmAlertFrequency

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -18,7 +18,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {slugify} from 'sentry/utils/slugify';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTeams} from 'sentry/utils/useTeams';
-import {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
   getRequestDataFragment,
@@ -37,8 +36,6 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     useOnboardingContext();
   const {teams} = useTeams();
   const createProjectAndRules = useCreateProjectAndRules();
-  const {createNotificationAction, notificationProps} = useCreateNotificationAction();
-
   useEffect(() => {
     trackAnalytics('onboarding.scm_project_details_step_viewed', {organization});
   }, [organization]);
@@ -97,7 +94,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
         platform: selectedPlatform,
         team: teamSlugResolved,
         alertRuleConfig: getRequestDataFragment(alertRuleConfig),
-        createNotificationAction,
+        createNotificationAction: () => undefined,
       });
 
       // Store the project slug separately so onboarding.tsx can find
@@ -124,7 +121,6 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     projectNameResolved,
     teamSlugResolved,
     alertRuleConfig,
-    createNotificationAction,
     selectedFeatures,
     setCreatedProjectSlug,
     onComplete,
@@ -205,11 +201,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
             <Text variant="muted" size="lg" density="comfortable" align="center">
               {t('Get notified when things go wrong')}
             </Text>
-            <ScmAlertFrequency
-              {...alertRuleConfig}
-              onFieldChange={handleAlertChange}
-              notificationProps={notificationProps}
-            />
+            <ScmAlertFrequency {...alertRuleConfig} onFieldChange={handleAlertChange} />
           </Stack>
         </MotionStack>
 

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -47,12 +47,12 @@ function metricValueToConditionType(metricValue: MetricValues): IssueAlertCondit
   }
 }
 
-const METRIC_CHOICES = [
+export const METRIC_CHOICES = [
   {value: MetricValues.ERRORS, label: t('occurrences of')},
   {value: MetricValues.USERS, label: t('users affected by')},
 ];
 
-const INTERVAL_CHOICES = [
+export const INTERVAL_CHOICES = [
   {value: '1m', label: t('one minute')},
   {value: '5m', label: t('5 minutes')},
   {value: '15m', label: t('15 minutes')},


### PR DESCRIPTION
UI polish and analytics pass for the `SCM_PROJECT_DETAILS` onboarding step, matching the Figma designs and adding comprehensive event tracking.

**UI changes:**
- Use `ScmStepHeader` with step counter ("Step 3 of 3"), proper heading size (3xl), and subtitle
- Fix content width from 600px to 506px (`SCM_STEP_CONTENT_WIDTH`)
- Add section icons: `IconProject`, `IconGroup`, `IconSiren`
- Use proper Figma typography tokens (`size="lg"`, `density="comfortable"`)
- Replace `RadioGroup`-based `IssueAlertOptions` with new card-style `ScmAlertFrequency` component (bordered cards with selection state, icons, animated Custom expand)
- Wire up real `useCreateNotificationAction` hook for "Connect to messaging" (replaces no-op)
- Add `ScmStepFooter` and `LayoutGroup` animations
- Add `busy` prop on Create button during project creation

**Analytics (7 new events):**
- `scm_project_details_step_viewed` — on mount
- `scm_project_details_name_edited` — on blur, with `custom` flag
- `scm_project_details_team_selected` — on change, with team slug
- `scm_project_details_alert_selected` — on option change
- `scm_project_details_create_clicked` — before API call
- `scm_project_details_create_succeeded` — with project slug
- `scm_project_details_create_failed` — on error

**New component:** `ScmAlertFrequency` renders card-style radio options rather than modifying the shared `IssueAlertOptions` component, avoiding cross-cutting risk to the legacy project-creation page. Uses `Container border="accent"/"secondary"` pattern from `ScmFeatureCard`.

Refs VDY-28