### PR TITLE
fix(ui): Use design system Text components for organization role field

### DIFF
--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 
+import {Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
+import {Text} from '@sentry/scraps/text';
 
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
@@ -9,7 +11,6 @@ import {PanelItem} from 'sentry/components/panels/panelItem';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import type {OrgRole} from 'sentry/types/organization';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 const Label = styled('label')`
   display: flex;
@@ -55,15 +56,17 @@ export function OrganizationRoleSelect({
             <PanelItem
               key={id}
               onClick={() => !isDisabled && setSelected(id)}
-              css={isDisabled ? {color: 'grey', cursor: 'default'} : {}}
+              css={isDisabled ? {cursor: 'default'} : {}}
             >
               <Label>
                 <Radio id={id} value={name} checked={id === roleSelected} readOnly />
                 <div style={{flex: 1, padding: '0 16px'}}>
-                  {name}
-                  <TextBlock noMargin>
-                    <div className="help-block">{desc}</div>
-                  </TextBlock>
+                  <Stack gap="md">
+                    <Text variant="primary" bold>
+                      {name}
+                    </Text>
+                    <Text variant="muted">{desc}</Text>
+                  </Stack>
                 </div>
               </Label>
             </PanelItem>

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -17,6 +17,7 @@ const Label = styled('label')`
   flex: 1;
   align-items: center;
   margin-bottom: 0;
+  font-weight: ${p => p.theme.font.weight.sans.regular};
 `;
 
 type Props = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

User feedback reported that role descriptions in the organization settings member page appeared disabled and were hard to see. The component was using custom CSS styling (`color: 'grey'`) and legacy components (`TextBlock`, `.help-block` class) instead of the design system primitives.

## Solution

Replaced custom styling with proper design system components:
- Primary label now uses `<Text variant="primary" bold>`
- Description uses `<Text variant="muted">`
- Wrapped both in `<Stack gap="md">` for proper spacing
- Removed `TextBlock` component and custom CSS color styling
- Added `font-weight: regular` to Label component to override global label styles (600 weight)

This ensures consistent styling across the app and fixes the readability issue where descriptions appeared disabled.

## Changes

- Updated `static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx`:
  - Added imports for `Stack` and `Text` from `@sentry/scraps`
  - Replaced custom div/TextBlock structure with Stack + Text components
  - Removed custom `color: 'grey'` CSS that made disabled items hard to read
  - Added `font-weight: regular` to Label styled component to override global label styles

## Testing

- ✅ Pre-commit hooks passed (eslint, stylelint, format)
- Component follows design system guidelines from `static/AGENTS.md`
- Existing tests should continue to pass as the component's behavior is unchanged

Fixes issue reported in #all-user-feedback Slack channel.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C07525G48Q1/p1774534176223129?thread_ts=1774534176.223129&cid=C07525G48Q1)

<div><a href="https://cursor.com/agents/bc-b53c8e73-8623-57c1-9cbb-0eb4a53f65c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b53c8e73-8623-57c1-9cbb-0eb4a53f65c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<img width="1960" height="998" alt="CleanShot 2026-03-26 at 11 26 52@2x" src="https://github.com/user-attachments/assets/7d12415e-58a0-4e3a-a7f6-bdc0bab418e5" />

