### PR TITLE
perf(code-mappings): Use bulk queries for code mapping upserts

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -1,6 +1,7 @@
 import logging
 
-from django.db import IntegrityError, router, transaction
+from django.db import IntegrityError
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -236,9 +237,6 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
                     )
 
         mappings = data["mappings"]
-        results = []
-        has_errors = False
-        last_saved_config = None
 
         defaults = {
             "repository": repo,
@@ -249,61 +247,124 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
             "automatically_generated": False,
         }
 
+        # Deduplicate by stack_root, keeping the last occurrence.
+        mappings = list({m["stack_root"]: m for m in mappings}.values())
+
+        # Fetch all existing mappings for this project in one query.
+        input_stack_roots = [m["stack_root"] for m in mappings]
+        existing_by_root = {
+            config.stack_root: config
+            for config in RepositoryProjectPathConfig.objects.filter(
+                project=project,
+                stack_root__in=input_stack_roots,
+            )
+        }
+
+        # Split into creates and updates.
+        to_create = []
+        to_update = []
+        results = []
+        now = timezone.now()
+
         for mapping in mappings:
-            try:
-                with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
-                    try:
-                        config = RepositoryProjectPathConfig.objects.select_for_update().get(
-                            project=project,
-                            stack_root=mapping["stack_root"],
-                        )
-                        for key, value in {
-                            **defaults,
-                            "source_root": mapping["source_root"],
-                        }.items():
-                            setattr(config, key, value)
-                        created = False
-                    except RepositoryProjectPathConfig.DoesNotExist:
-                        config = RepositoryProjectPathConfig(
-                            project=project,
-                            stack_root=mapping["stack_root"],
-                            source_root=mapping["source_root"],
-                            **defaults,
-                        )
-                        created = True
-                    config._skip_post_save = True
-                    config.save()
-                last_saved_config = config
+            stack_root = mapping["stack_root"]
+            source_root = mapping["source_root"]
+            existing = existing_by_root.get(stack_root)
+
+            if existing is not None:
+                existing.source_root = source_root
+                existing.repository = repo
+                existing.organization_integration_id = org_integration.id
+                existing.organization_id = organization.id
+                existing.integration_id = repo.integration_id
+                existing.default_branch = default_branch
+                existing.automatically_generated = False
+                existing.date_updated = now
+                to_update.append(existing)
                 results.append(
                     {
-                        "stackRoot": mapping["stack_root"],
-                        "sourceRoot": mapping["source_root"],
-                        "status": "created" if created else "updated",
+                        "stackRoot": stack_root,
+                        "sourceRoot": source_root,
+                        "status": "updated",
                     }
                 )
-            except IntegrityError:
-                logger.exception(
-                    "bulk_code_mappings.mapping_error",
-                    extra={
-                        "organization_id": organization.id,
-                        "project_id": project.id,
-                        "stack_root": mapping["stack_root"],
-                    },
+            else:
+                to_create.append(
+                    RepositoryProjectPathConfig(
+                        project=project,
+                        stack_root=stack_root,
+                        source_root=source_root,
+                        date_added=now,
+                        date_updated=now,
+                        **defaults,
+                    )
                 )
-                has_errors = True
                 results.append(
                     {
-                        "stackRoot": mapping["stack_root"],
-                        "sourceRoot": mapping["source_root"],
-                        "status": "error",
-                        "detail": "Failed to save mapping.",
+                        "stackRoot": stack_root,
+                        "sourceRoot": source_root,
+                        "status": "created",
                     }
                 )
 
+        has_errors = False
+
+        if to_create:
+            try:
+                RepositoryProjectPathConfig.objects.bulk_create(to_create)
+            except IntegrityError:
+                logger.exception(
+                    "bulk_code_mappings.bulk_create_error",
+                    extra={
+                        "organization_id": organization.id,
+                        "project_id": project.id,
+                        "count": len(to_create),
+                    },
+                )
+                has_errors = True
+                for r in results:
+                    if r["status"] == "created":
+                        r["status"] = "error"
+                        r["detail"] = "Failed to save mapping."
+
+        if to_update:
+            try:
+                RepositoryProjectPathConfig.objects.bulk_update(
+                    to_update,
+                    fields=[
+                        "source_root",
+                        "repository",
+                        "organization_integration_id",
+                        "organization_id",
+                        "integration_id",
+                        "default_branch",
+                        "automatically_generated",
+                        "date_updated",
+                    ],
+                )
+            except IntegrityError:
+                logger.exception(
+                    "bulk_code_mappings.bulk_update_error",
+                    extra={
+                        "organization_id": organization.id,
+                        "project_id": project.id,
+                        "count": len(to_update),
+                    },
+                )
+                has_errors = True
+                for r in results:
+                    if r["status"] == "updated":
+                        r["status"] = "error"
+                        r["detail"] = "Failed to update mapping."
+
         # Fire side effects once for the entire batch.
-        if last_saved_config is not None:
-            last_saved_config._skip_post_save = False
-            process_resource_change(last_saved_config)
+        # bulk_create/bulk_update don't trigger post_save signals,
+        # so we call process_resource_change manually with any saved config.
+        any_config = existing_by_root.get(input_stack_roots[0]) or (
+            to_create[0] if to_create else None
+        )
+        if any_config is not None:
+            process_resource_change(any_config)
 
         created_count = sum(1 for r in results if r["status"] == "created")
         updated_count = sum(1 for r in results if r["status"] == "updated")

--- a/src/sentry/integrations/models/repository_project_path_config.py
+++ b/src/sentry/integrations/models/repository_project_path_config.py
@@ -30,10 +30,6 @@ class RepositoryProjectPathConfig(DefaultFieldsModelExisting):
     # Indicates if Sentry created this mapping
     automatically_generated = models.BooleanField(default=False, db_default=False)
 
-    # Transient flag: when True, the post_save signal skips side effects.
-    # Used by the bulk endpoint to fire side effects once per batch.
-    _skip_post_save: bool = False
-
     class Meta:
         app_label = "sentry"
         db_table = "sentry_repositoryprojectpathconfig"
@@ -49,9 +45,6 @@ class RepositoryProjectPathConfig(DefaultFieldsModelExisting):
 
 
 def process_resource_change(instance: RepositoryProjectPathConfig, **kwargs):
-    if instance._skip_post_save:
-        return
-
     from sentry.models.project import Project
     from sentry.tasks.codeowners import update_code_owners_schema
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -302,8 +302,6 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
             )
         assert response.status_code == 200, response.content
         assert mock_prc.call_count == 1
-        instance = mock_prc.call_args[0][0]
-        assert instance._skip_post_save is False
 
     def test_provider_disambiguates_duplicate_repos(self) -> None:
         # Give repo1 a provider so we can filter on it
@@ -359,16 +357,6 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         repo = Repository.objects.get(name=new_repo_name, organization_id=self.organization.id)
         assert repo.provider == "integrations:github"
         assert repo.integration_id == self.integration.id
-
-    def test_skip_post_save_does_not_leak_to_fetched_instances(self) -> None:
-        """The endpoint sets _skip_post_save on in-memory instances to batch
-        side-effects. Verify that freshly fetched instances from the DB don't
-        carry the suppressed flag, so normal post_save signals fire for them."""
-        self.make_post()
-        config = RepositoryProjectPathConfig.objects.get(
-            project=self.project1, stack_root="com/example/maps"
-        )
-        assert config._skip_post_save is False
 
     def test_org_ci_scope_allows_post(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -456,8 +444,9 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
             }
         )
         assert response.status_code == 200, response.content
+        # Deduplication keeps only the last occurrence per stack_root.
         assert response.data["created"] == 1
-        assert response.data["updated"] == 1
+        assert response.data["updated"] == 0
 
         config = RepositoryProjectPathConfig.objects.get(
             project=self.project1, stack_root="com/example/maps"
@@ -476,21 +465,12 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         assert response.status_code == 409
         assert "Multiple repositories" in response.data["detail"]
 
-    def test_partial_failure_returns_207(self) -> None:
-        original_save = RepositoryProjectPathConfig.save
-        call_count = 0
-
-        def failing_save(self_inner, *args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 2:
-                raise IntegrityError("Simulated DB error")
-            return original_save(self_inner, *args, **kwargs)
-
+    def test_bulk_create_failure_returns_207(self) -> None:
+        """When bulk_create fails, all new mappings are marked as errors."""
         with mock.patch.object(
-            RepositoryProjectPathConfig,
-            "save",
-            failing_save,
+            RepositoryProjectPathConfig.objects,
+            "bulk_create",
+            side_effect=IntegrityError("Simulated DB error"),
         ):
             response = self.make_post(
                 {
@@ -503,17 +483,39 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
                             "stackRoot": "com/example/auth",
                             "sourceRoot": "modules/auth/src",
                         },
+                    ],
+                }
+            )
+
+        assert response.status_code == 207
+        assert response.data["created"] == 0
+        assert response.data["errors"] == 2
+        for m in response.data["mappings"]:
+            assert m["status"] == "error"
+            assert "Failed to save mapping" in m["detail"]
+
+    def test_bulk_update_failure_returns_207(self) -> None:
+        """When bulk_update fails, existing mappings are marked as errors."""
+        # First create a mapping.
+        self.make_post()
+
+        with mock.patch.object(
+            RepositoryProjectPathConfig.objects,
+            "bulk_update",
+            side_effect=IntegrityError("Simulated DB error"),
+        ):
+            response = self.make_post(
+                {
+                    "mappings": [
                         {
-                            "stackRoot": "com/example/core",
-                            "sourceRoot": "modules/core/src",
+                            "stackRoot": "com/example/maps",
+                            "sourceRoot": "updated/source/root",
                         },
                     ],
                 }
             )
 
         assert response.status_code == 207
-        assert response.data["created"] == 2
+        assert response.data["updated"] == 0
         assert response.data["errors"] == 1
-        error_mapping = next(m for m in response.data["mappings"] if m["status"] == "error")
-        assert error_mapping["stackRoot"] == "com/example/auth"
-        assert "Failed to save mapping" in error_mapping["detail"]
+        assert response.data["mappings"][0]["status"] == "error"


### PR DESCRIPTION
## Summary

- Replace per-mapping `SELECT FOR UPDATE` + `save()` loop with bulk operations:
  1. Single `SELECT` to fetch all existing mappings for the project
  2. `bulk_create` for new mappings
  3. `bulk_update` for changed mappings
- Remove `_skip_post_save` flag — no longer needed since `bulk_create`/`bulk_update` don't fire `post_save` signals
- Deduplicate input mappings by `stack_root` (last wins)

Depends on #111611

## Performance

Before: N mappings = N `SELECT ... FOR UPDATE` + N `INSERT/UPDATE` = 2N queries
After: 1 `SELECT` + 1 `INSERT` + 1 `UPDATE` = 3 queries

## Test plan

- [x] All 34 existing tests pass
- [x] Updated partial failure tests to reflect batch-level error semantics
- [ ] Deploy and verify with real bulk upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)