### PR TITLE
ref(layout): use Layout.Page on issue detail tabs

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -10,6 +10,7 @@ import {TabPanels, Tabs} from '@sentry/scraps/tabs';
 
 import {FloatingFeedbackButton} from 'sentry/components/feedbackButton/floatingFeedbackButton';
 import {useDrawer} from 'sentry/components/globalDrawer';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
@@ -921,16 +922,18 @@ function GroupDetails() {
         <SampleEventAlert project={group.project} organization={organization} />
       )}
       <SentryDocumentTitle noSuffix title={getGroupDetailsTitle()}>
-        <PageFiltersContainer
-          skipLoadLastUsed
-          forceProject={group?.project}
-          shouldForceProject
-        >
-          {config?.showFeedbackWidget && <FloatingFeedbackButton />}
-          <GroupDetailsPageContent {...fetchGroupDetailsProps} group={group}>
-            <Outlet />
-          </GroupDetailsPageContent>
-        </PageFiltersContainer>
+        <Layout.Page>
+          <PageFiltersContainer
+            skipLoadLastUsed
+            forceProject={group?.project}
+            shouldForceProject
+          >
+            {config?.showFeedbackWidget && <FloatingFeedbackButton />}
+            <GroupDetailsPageContent {...fetchGroupDetailsProps} group={group}>
+              <Outlet />
+            </GroupDetailsPageContent>
+          </PageFiltersContainer>
+        </Layout.Page>
       </SentryDocumentTitle>
     </Fragment>
   );

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -5,7 +5,6 @@ import type {Location, Query} from 'history';
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 
-import * as Layout from 'sentry/components/layouts/thirds';
 import {Placeholder} from 'sentry/components/placeholder';
 import {
   SelectedReplayIndexProvider,
@@ -118,7 +117,7 @@ function GroupReplaysContent({group}: Props) {
   if (!eventView) {
     // Shown on load and no replay data available
     return (
-      <StyledLayoutPage withPadding>
+      <StyledLayoutPage>
         <Stack>
           <ReplayFilterMessage />
           <Flex align="center" gap="md">
@@ -145,7 +144,7 @@ function GroupReplaysContent({group}: Props) {
 
   return (
     <SelectedReplayIndexProvider>
-      <StyledLayoutPage withPadding>
+      <StyledLayoutPage>
         <Stack>
           <ReplayFilterMessage />
           <Flex align="center" gap="md">
@@ -325,7 +324,7 @@ function ReplayOverlay({
   );
 }
 
-const StyledLayoutPage = styled(Layout.Page)`
+const StyledLayoutPage = styled('div')`
   background-color: ${p => p.theme.tokens.background.primary};
   gap: ${p => p.theme.space.lg};
   border: 1px solid ${p => p.theme.tokens.border.primary};

--- a/static/app/views/issueDetails/groupReplays/index.tsx
+++ b/static/app/views/issueDetails/groupReplays/index.tsx
@@ -1,7 +1,6 @@
 import {Alert} from '@sentry/scraps/alert';
 
 import Feature from 'sentry/components/acl/feature';
-import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -13,13 +12,11 @@ import {GroupReplays} from './groupReplays';
 
 function renderNoAccess() {
   return (
-    <Layout.Page withPadding>
-      <Alert.Container>
-        <Alert variant="warning" showIcon={false}>
-          {t("You don't have access to this feature")}
-        </Alert>
-      </Alert.Container>
-    </Layout.Page>
+    <Alert.Container>
+      <Alert variant="warning" showIcon={false}>
+        {t("You don't have access to this feature")}
+      </Alert>
+    </Alert.Container>
   );
 }
 


### PR DESCRIPTION
Wraps non-compliant issue detail routes with `Layout.Page` via a single parent wrapper fix in `groupDetails.tsx`. Part of the Layout.Page audit remediation.

Every page route in Sentry should render `Layout.Page` as the outermost content container. The `GroupDetails` component renders `<Outlet />` for all 12 issue detail tab routes but had no `Layout.Page` wrapper. Adding it at the parent level makes all tab routes compliant in one change.

The `groupReplays` tab had its own `Layout.Page` in two places (`index.tsx` `renderNoAccess` and `groupReplays.tsx` `StyledLayoutPage`). Both are removed to avoid double-wrapping now that the parent provides the page shell. `StyledLayoutPage` is converted from `styled(Layout.Page)` to `styled("div")` preserving all existing visual styles.

## Changes

- `groupDetails.tsx` — wrap `PageFiltersContainer` + `Outlet` in `Layout.Page`
- `groupReplays/index.tsx` — remove `Layout.Page` from `renderNoAccess` to avoid double-wrap
- `groupReplays/groupReplays.tsx` — change `StyledLayoutPage` from `styled(Layout.Page)` to `styled("div")` to avoid double-wrap

## Affected routes

| Path | Strategy |
| --- | --- |
| `/organizations/:orgId/issues/:groupId/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/activity/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/events/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/open-periods/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/uptime-checks/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/check-ins/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/distributions/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/distributions/:tagKey/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/feedback/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/attachments/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/similar/` | wrapper fix |
| `/organizations/:orgId/issues/:groupId/merged/` | wrapper fix |