### PR TITLE
ref(layout): use Layout.Page on monitors

### DIFF
--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -226,44 +226,42 @@ function AutomationEditForm({automation}: {automation: Automation}) {
     >
       <AutomationFormProvider automation={automation}>
         <AutomationDocumentTitle />
-        <Layout.Page>
-          <StyledLayoutHeader>
-            <HeaderInner maxWidth={maxWidth}>
-              <Layout.HeaderContent>
-                <AutomationBreadcrumbs automationId={params.automationId} />
-                <Layout.Title>
-                  <EditableAutomationName />
-                </Layout.Title>
-              </Layout.HeaderContent>
-              <div>
-                <AutomationFeedbackButton />
-              </div>
-            </HeaderInner>
-          </StyledLayoutHeader>
-          <StyledBody maxWidth={maxWidth}>
-            <Layout.Main width="full">
-              <AutomationBuilderErrorContext.Provider
+        <StyledLayoutHeader>
+          <HeaderInner maxWidth={maxWidth}>
+            <Layout.HeaderContent>
+              <AutomationBreadcrumbs automationId={params.automationId} />
+              <Layout.Title>
+                <EditableAutomationName />
+              </Layout.Title>
+            </Layout.HeaderContent>
+            <div>
+              <AutomationFeedbackButton />
+            </div>
+          </HeaderInner>
+        </StyledLayoutHeader>
+        <StyledBody maxWidth={maxWidth}>
+          <Layout.Main width="full">
+            <AutomationBuilderErrorContext.Provider
+              value={{
+                errors: automationBuilderErrors,
+                setErrors: setAutomationBuilderErrors,
+                removeError,
+                mutationErrors: error?.responseJSON,
+              }}
+            >
+              <AutomationBuilderContext.Provider
                 value={{
-                  errors: automationBuilderErrors,
-                  setErrors: setAutomationBuilderErrors,
-                  removeError,
-                  mutationErrors: error?.responseJSON,
+                  state,
+                  actions,
+                  showTriggerLogicTypeSelector:
+                    state.triggers.logicType === DataConditionGroupLogicType.ALL,
                 }}
               >
-                <AutomationBuilderContext.Provider
-                  value={{
-                    state,
-                    actions,
-                    showTriggerLogicTypeSelector:
-                      state.triggers.logicType === DataConditionGroupLogicType.ALL,
-                  }}
-                >
-                  <AutomationForm model={model} />
-                </AutomationBuilderContext.Provider>
-              </AutomationBuilderErrorContext.Provider>
-            </Layout.Main>
-          </StyledBody>
-        </Layout.Page>
+                <AutomationForm model={model} />
+              </AutomationBuilderContext.Provider>
+            </AutomationBuilderErrorContext.Provider>
+          </Layout.Main>
+        </StyledBody>
         <StickyFooter>
           <Flex maxWidth={maxWidth} align="center" gap="md" justify="end">
             <EditAutomationActions automation={automation} form={model} />

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -193,43 +193,41 @@ export default function AutomationNewSettings() {
     >
       <AutomationFormProvider>
         <AutomationDocumentTitle />
-        <Layout.Page>
-          <StyledLayoutHeader>
-            <HeaderInner maxWidth={maxWidth}>
-              <Layout.HeaderContent>
-                <AutomationBreadcrumbs />
-                <Layout.Title>
-                  <EditableAutomationName />
-                </Layout.Title>
-              </Layout.HeaderContent>
-              <div>
-                <AutomationFeedbackButton />
-              </div>
-            </HeaderInner>
-          </StyledLayoutHeader>
-          <StyledBody maxWidth={maxWidth}>
-            <Layout.Main width="full">
-              <AutomationBuilderErrorContext.Provider
+        <StyledLayoutHeader>
+          <HeaderInner maxWidth={maxWidth}>
+            <Layout.HeaderContent>
+              <AutomationBreadcrumbs />
+              <Layout.Title>
+                <EditableAutomationName />
+              </Layout.Title>
+            </Layout.HeaderContent>
+            <div>
+              <AutomationFeedbackButton />
+            </div>
+          </HeaderInner>
+        </StyledLayoutHeader>
+        <StyledBody maxWidth={maxWidth}>
+          <Layout.Main width="full">
+            <AutomationBuilderErrorContext.Provider
+              value={{
+                errors: automationBuilderErrors,
+                setErrors: setAutomationBuilderErrors,
+                removeError,
+                mutationErrors: error?.responseJSON,
+              }}
+            >
+              <AutomationBuilderContext.Provider
                 value={{
-                  errors: automationBuilderErrors,
-                  setErrors: setAutomationBuilderErrors,
-                  removeError,
-                  mutationErrors: error?.responseJSON,
+                  state,
+                  actions,
+                  showTriggerLogicTypeSelector: false,
                 }}
               >
-                <AutomationBuilderContext.Provider
-                  value={{
-                    state,
-                    actions,
-                    showTriggerLogicTypeSelector: false,
-                  }}
-                >
-                  <AutomationForm model={model} />
-                </AutomationBuilderContext.Provider>
-              </AutomationBuilderErrorContext.Provider>
-            </Layout.Main>
-          </StyledBody>
-        </Layout.Page>
+                <AutomationForm model={model} />
+              </AutomationBuilderContext.Provider>
+            </AutomationBuilderErrorContext.Provider>
+          </Layout.Main>
+        </StyledBody>
         <StickyFooter>
           <Flex maxWidth={maxWidth} align="center" gap="md" justify="end">
             <Observer>

--- a/static/app/views/detectors/detectorViewContainer.tsx
+++ b/static/app/views/detectors/detectorViewContainer.tsx
@@ -1,5 +1,6 @@
 import {Outlet} from 'react-router-dom';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 
@@ -7,8 +8,10 @@ export default function DetectorViewContainer() {
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
-    <PageFiltersContainer>
-      <Outlet />
-    </PageFiltersContainer>
+    <Layout.Page>
+      <PageFiltersContainer>
+        <Outlet />
+      </PageFiltersContainer>
+    </Layout.Page>
   );
 }

--- a/static/app/views/detectors/new-settings.tsx
+++ b/static/app/views/detectors/new-settings.tsx
@@ -28,13 +28,11 @@ export default function DetectorNewSettings() {
 
   if (isFetchingProjects) {
     return (
-      <Layout.Page>
-        <Layout.Body>
-          <Layout.Main width="full">
-            <LoadingIndicator />
-          </Layout.Main>
-        </Layout.Body>
-      </Layout.Page>
+      <Layout.Body>
+        <Layout.Main width="full">
+          <LoadingIndicator />
+        </Layout.Main>
+      </Layout.Body>
     );
   }
 


### PR DESCRIPTION
Wraps non-compliant routes in the monitors area with Layout.Page.
Part of the Layout.Page audit remediation.

## Changes

- wrap `PageFiltersContainer` + `Outlet` in `Layout.Page` in `detectorViewContainer.tsx` (covers all 12 child routes at once)
- remove redundant `Layout.Page` from loading state in `detectors/new-settings.tsx` (would have double-wrapped)
- remove redundant `Layout.Page` from `automations/new.tsx` (would have double-wrapped)
- remove redundant `Layout.Page` from `automations/edit.tsx` (would have double-wrapped)

## Affected routes

| Path | Strategy |
| --- | --- |
| `/organizations/:orgId/monitors/` | wrapper fix |
| `/organizations/:orgId/monitors/monitors/new` | wrapper fix |
| `/organizations/:orgId/monitors/monitors/:detectorId/` | wrapper fix |
| `/organizations/:orgId/monitors/monitors/:detectorId/edit/` | wrapper fix |
| `/organizations/:orgId/monitors/my-monitors/` | wrapper fix |
| `/organizations/:orgId/monitors/errors/` | wrapper fix |
| `/organizations/:orgId/monitors/metrics/` | wrapper fix |
| `/organizations/:orgId/monitors/crons/` | wrapper fix |
| `/organizations/:orgId/monitors/uptime/` | wrapper fix |
| `/organizations/:orgId/monitors/mobile-builds/` | wrapper fix |
| `/organizations/:orgId/monitors/alerts/` | wrapper fix |
| `/organizations/:orgId/monitors/alerts/:automationId/` | wrapper fix |

## Verification

- [ ] Each route above loads in the browser and renders inside a `<main>` element