### PR TITLE
fix(debug_files): Track count of renewed Artifact Bundles

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -284,7 +284,7 @@ def renew_artifact_bundle(artifact_bundle_id: int, threshold_date: datetime, now
 
     # If the transaction succeeded, and we did actually modify some rows, we want to track the metric.
     if updated_rows_count > 0:
-        metrics.incr("artifact_bundle_renewal.were_renewed")
+        metrics.incr("artifact_bundle_renewal.were_renewed", updated_rows_count)
 
 
 # ===== Querying of Artifact Bundles =====


### PR DESCRIPTION
The `artifact_bundle_renewal.were_renewed` metric was always incrementing by 1 regardless of how many rows were actually renewed.
I believe that this metric was intended to track the number of rows that were renewed instead, as its debug files counterpart does correctly: https://github.com/getsentry/sentry/blob/533c4a2dbdf91c41d28190be124540e1a9b1a280/src/sentry/debug_files/debug_files.py#L35
It's important for me to see how many artifact bundles are renewed each time to understand how TTI bumps should be implemented within the Objectstore migration for release files.