### PR TITLE
ref(layout): use Layout.Page on stats

### DIFF
--- a/static/app/views/organizationStats/organizationStatsWrapper.tsx
+++ b/static/app/views/organizationStats/organizationStatsWrapper.tsx
@@ -1,5 +1,6 @@
 import {Outlet} from 'react-router-dom';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import {Redirect} from 'sentry/components/redirect';
 import {useRedirectNavigationV2Routes} from 'sentry/views/navigation/useRedirectNavigationV2Routes';
 
@@ -15,5 +16,9 @@ export function OrganizationStatsWrapper() {
     return <Redirect to={redirectPath} />;
   }
 
-  return <Outlet />;
+  return (
+    <Layout.Page>
+      <Outlet />
+    </Layout.Page>
+  );
 }


### PR DESCRIPTION
Wraps non-compliant routes in the stats area with Layout.Page.
Part of the Layout.Page audit remediation.

## Changes

- Wrap Outlet in Layout.Page in organizationStatsWrapper.tsx

## Affected routes

| Path | Strategy |
| --- | --- |
| `/organizations/:orgId/stats/` | wrapper fix |
| `/organizations/:orgId/stats/` (teamInsights) | wrapper fix |
| `/organizations/:orgId/stats/issues/` | wrapper fix |
| `/organizations/:orgId/stats/health/` | wrapper fix |

## Verification

- [ ] Each route above loads in the browser and renders inside a `<main>` element