### PR TITLE
ref(layout): use Layout.Page on performance summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionReplays/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.tsx
@@ -1,7 +1,6 @@
 import {Alert} from '@sentry/scraps/alert';
 
 import Feature from 'sentry/components/acl/feature';
-import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -9,13 +8,11 @@ import {TransactionReplays} from './transactionReplays';
 
 function renderNoAccess() {
   return (
-    <Layout.Page withPadding>
-      <Alert.Container>
-        <Alert variant="warning" showIcon={false}>
-          {t("You don't have access to this feature")}
-        </Alert>
-      </Alert.Container>
-    </Layout.Page>
+    <Alert.Container>
+      <Alert variant="warning" showIcon={false}>
+        {t("You don't have access to this feature")}
+      </Alert>
+    </Alert.Container>
   );
 }
 


### PR DESCRIPTION
Wraps non-compliant routes in the performance/summary area with Layout.Page.
Part of the Layout.Page audit remediation.

## Changes

- `pageLayout.tsx` already renders `Layout.Page` wrapping the `<Outlet />` — all 4 transaction summary routes are already compliant. Audit entry was stale; no wrapper change was needed.
- Removed double-wrapped `Layout.Page` from the `renderNoAccess` fallback in `transactionReplays/index.tsx`. The fallback renders inside the existing `Layout.Page` from `pageLayout.tsx`, so the extra wrapper was redundant.

## Affected routes

| Path | Strategy |
| --- | --- |
| `/organizations/:orgId/performance/summary/` | wrapper fix (already compliant via `pageLayout.tsx`) |
| `/organizations/:orgId/performance/summary/tags/` | wrapper fix (already compliant via `pageLayout.tsx`) |
| `/organizations/:orgId/performance/summary/events/` | wrapper fix (already compliant via `pageLayout.tsx`) |
| `/organizations/:orgId/performance/summary/profiles/` | wrapper fix (already compliant via `pageLayout.tsx`) |

## Verification

- [ ] Each route above loads in the browser and renders inside a `<main>` element
- [ ] The "no access" state for the Replays tab renders correctly without double-nesting