### PR TITLE
feat(dashboards): Blocks http_error_count function from dashboard generation

### DIFF
--- a/src/sentry/dashboards/models/generate_dashboard_artifact.py
+++ b/src/sentry/dashboards/models/generate_dashboard_artifact.py
@@ -31,7 +31,7 @@ WidgetType = Literal[
 Intervals = Literal["5m", "15m", "30m", "1h", "4h", "12h", "24h"]
 
 # Blocklist for frequently hallucinated functions or functions we want to avoid using
-FUNCTION_BLOCKLIST: set[str] = {"spm", "apdex"}
+FUNCTION_BLOCKLIST: set[str] = {"spm", "apdex", "http_error_count"}
 
 
 class GeneratedWidgetQuery(BaseModel):


### PR DESCRIPTION
Seer was frequently hallucinating `http_error_count` metrics function on the spans dataset.