### PR TITLE
ref(layout): use Layout.Page on insights

### DIFF
--- a/static/app/views/insights/agentModels/views/modelsLandingPage.tsx
+++ b/static/app/views/insights/agentModels/views/modelsLandingPage.tsx
@@ -59,62 +59,64 @@ function AgentModelsLandingPage({datePageFilterProps}: AgentModelsLandingPagePro
   }
 
   return (
-    <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>
-      <ModuleFeature moduleName={ModuleName.AGENT_MODELS}>
-        <Layout.Body>
-          <Layout.Main width="full">
-            <ModuleLayout.Layout>
-              <ModuleLayout.Full>
-                <ToolRibbon>
-                  <PageFilterBar condensed>
-                    <InsightsProjectSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <InsightsEnvironmentSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <DatePageFilter
-                      {...datePageFilterProps}
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                  </PageFilterBar>
-                  {!showOnboarding && (
-                    <Flex flex={2}>
-                      <TraceItemSearchQueryBuilder
-                        {...agentSpanSearchProps.queryBuilder}
+    <Layout.Page>
+      <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>
+        <ModuleFeature moduleName={ModuleName.AGENT_MODELS}>
+          <Layout.Body>
+            <Layout.Main width="full">
+              <ModuleLayout.Layout>
+                <ModuleLayout.Full>
+                  <ToolRibbon>
+                    <PageFilterBar condensed>
+                      <InsightsProjectSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
                       />
-                    </Flex>
-                  )}
-                </ToolRibbon>
-              </ModuleLayout.Full>
+                      <InsightsEnvironmentSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <DatePageFilter
+                        {...datePageFilterProps}
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                    </PageFilterBar>
+                    {!showOnboarding && (
+                      <Flex flex={2}>
+                        <TraceItemSearchQueryBuilder
+                          {...agentSpanSearchProps.queryBuilder}
+                        />
+                      </Flex>
+                    )}
+                  </ToolRibbon>
+                </ModuleLayout.Full>
 
-              <ModuleLayout.Full>
-                {showOnboarding ? (
-                  <Onboarding />
-                ) : (
-                  <Fragment>
-                    <WidgetGrid rowHeight={260}>
-                      <WidgetGrid.Position1>
-                        <TokenCostWidget />
-                      </WidgetGrid.Position1>
-                      <WidgetGrid.Position2>
-                        <TokenUsageWidget />
-                      </WidgetGrid.Position2>
-                      <WidgetGrid.Position3>
-                        <TokenTypesWidget />
-                      </WidgetGrid.Position3>
-                    </WidgetGrid>
-                    <ErrorBoundary mini>
-                      <ModelsTable />
-                    </ErrorBoundary>
-                  </Fragment>
-                )}
-              </ModuleLayout.Full>
-            </ModuleLayout.Layout>
-          </Layout.Main>
-        </Layout.Body>
-      </ModuleFeature>
-    </SearchQueryBuilderProvider>
+                <ModuleLayout.Full>
+                  {showOnboarding ? (
+                    <Onboarding />
+                  ) : (
+                    <Fragment>
+                      <WidgetGrid rowHeight={260}>
+                        <WidgetGrid.Position1>
+                          <TokenCostWidget />
+                        </WidgetGrid.Position1>
+                        <WidgetGrid.Position2>
+                          <TokenUsageWidget />
+                        </WidgetGrid.Position2>
+                        <WidgetGrid.Position3>
+                          <TokenTypesWidget />
+                        </WidgetGrid.Position3>
+                      </WidgetGrid>
+                      <ErrorBoundary mini>
+                        <ModelsTable />
+                      </ErrorBoundary>
+                    </Fragment>
+                  )}
+                </ModuleLayout.Full>
+              </ModuleLayout.Layout>
+            </Layout.Main>
+          </Layout.Body>
+        </ModuleFeature>
+      </SearchQueryBuilderProvider>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/agentTools/views/toolsLandingPage.tsx
+++ b/static/app/views/insights/agentTools/views/toolsLandingPage.tsx
@@ -57,57 +57,59 @@ function AgentToolsLandingPage({datePageFilterProps}: AgentToolsLandingPageProps
   }
 
   return (
-    <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>
-      <ModuleFeature moduleName={ModuleName.AGENT_TOOLS}>
-        <Layout.Body>
-          <Layout.Main width="full">
-            <ModuleLayout.Layout>
-              <ModuleLayout.Full>
-                <ToolRibbon>
-                  <PageFilterBar condensed>
-                    <InsightsProjectSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <InsightsEnvironmentSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <DatePageFilter
-                      {...datePageFilterProps}
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                  </PageFilterBar>
-                  {!showOnboarding && (
-                    <Flex flex={2}>
-                      <TraceItemSearchQueryBuilder
-                        {...agentSpanSearchProps.queryBuilder}
+    <Layout.Page>
+      <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>
+        <ModuleFeature moduleName={ModuleName.AGENT_TOOLS}>
+          <Layout.Body>
+            <Layout.Main width="full">
+              <ModuleLayout.Layout>
+                <ModuleLayout.Full>
+                  <ToolRibbon>
+                    <PageFilterBar condensed>
+                      <InsightsProjectSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
                       />
-                    </Flex>
-                  )}
-                </ToolRibbon>
-              </ModuleLayout.Full>
+                      <InsightsEnvironmentSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <DatePageFilter
+                        {...datePageFilterProps}
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                    </PageFilterBar>
+                    {!showOnboarding && (
+                      <Flex flex={2}>
+                        <TraceItemSearchQueryBuilder
+                          {...agentSpanSearchProps.queryBuilder}
+                        />
+                      </Flex>
+                    )}
+                  </ToolRibbon>
+                </ModuleLayout.Full>
 
-              <ModuleLayout.Full>
-                {showOnboarding ? (
-                  <Onboarding />
-                ) : (
-                  <Fragment>
-                    <TwoColumnWidgetGrid rowHeight={260}>
-                      <TwoColumnWidgetGrid.Position1>
-                        <ToolUsageWidget />
-                      </TwoColumnWidgetGrid.Position1>
-                      <TwoColumnWidgetGrid.Position2>
-                        <ToolErrorsWidget />
-                      </TwoColumnWidgetGrid.Position2>
-                    </TwoColumnWidgetGrid>
-                    <ToolsTable />
-                  </Fragment>
-                )}
-              </ModuleLayout.Full>
-            </ModuleLayout.Layout>
-          </Layout.Main>
-        </Layout.Body>
-      </ModuleFeature>
-    </SearchQueryBuilderProvider>
+                <ModuleLayout.Full>
+                  {showOnboarding ? (
+                    <Onboarding />
+                  ) : (
+                    <Fragment>
+                      <TwoColumnWidgetGrid rowHeight={260}>
+                        <TwoColumnWidgetGrid.Position1>
+                          <ToolUsageWidget />
+                        </TwoColumnWidgetGrid.Position1>
+                        <TwoColumnWidgetGrid.Position2>
+                          <ToolErrorsWidget />
+                        </TwoColumnWidgetGrid.Position2>
+                      </TwoColumnWidgetGrid>
+                      <ToolsTable />
+                    </Fragment>
+                  )}
+                </ModuleLayout.Full>
+              </ModuleLayout.Layout>
+            </Layout.Main>
+          </Layout.Body>
+        </ModuleFeature>
+      </SearchQueryBuilderProvider>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
@@ -102,7 +100,7 @@ function ResourceSummary() {
     (uniqueSpanOps.size === 1 && spanMetrics[SPAN_OP] === ResourceSpanOps.IMAGE);
 
   return (
-    <React.Fragment>
+    <Layout.Page>
       <FrontendHeader
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         headerTitle={spanMetrics[SpanFields.SPAN_DESCRIPTION]}
@@ -170,7 +168,7 @@ function ResourceSummary() {
           </Layout.Main>
         </Layout.Body>
       </ModuleFeature>
-    </React.Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -31,7 +31,7 @@ function ResourcesLandingPage() {
   const filters = useResourceModuleFilters();
 
   return (
-    <React.Fragment>
+    <Layout.Page>
       <PageAlertProvider>
         <ModuleFeature moduleName={ModuleName.RESOURCE}>
           <Layout.Body>
@@ -68,7 +68,7 @@ function ResourcesLandingPage() {
           </Layout.Body>
         </ModuleFeature>
       </PageAlertProvider>
-    </React.Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
@@ -128,7 +128,7 @@ function PageOverview() {
       : getWebVitalScoresFromTableDataRow(projectScores?.[0]);
 
   return (
-    <React.Fragment>
+    <Layout.Page>
       <FrontendHeader
         headerTitle={
           <Fragment>
@@ -210,7 +210,7 @@ function PageOverview() {
           </Layout.Side>
         </Layout.Body>
       </ModuleFeature>
-    </React.Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useEffect, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -72,7 +72,7 @@ function WebVitalsLandingPage() {
   });
 
   return (
-    <React.Fragment>
+    <Layout.Page>
       <ModuleFeature moduleName={ModuleName.VITAL}>
         <Layout.Body>
           <Layout.Main width="full">
@@ -137,7 +137,7 @@ function WebVitalsLandingPage() {
           </Layout.Main>
         </Layout.Body>
       </ModuleFeature>
-    </React.Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/cache/views/cacheLandingPage.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import keyBy from 'lodash/keyBy';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -102,7 +101,7 @@ export function CacheLandingPage() {
   addCustomMeta(meta);
 
   return (
-    <React.Fragment>
+    <Layout.Page>
       <ModuleFeature moduleName={ModuleName.CACHE}>
         <Layout.Body>
           <Layout.Main width="full">
@@ -134,7 +133,7 @@ export function CacheLandingPage() {
           </Layout.Main>
         </Layout.Body>
       </ModuleFeature>
-    </React.Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/crons/views/overview.tsx
+++ b/static/app/views/insights/crons/views/overview.tsx
@@ -82,7 +82,7 @@ function CronsOverview() {
   };
 
   const page = (
-    <Fragment>
+    <Layout.Page>
       <CronsListPageHeader organization={organization} />
       <Layout.Header unified>
         <Layout.HeaderContent>
@@ -179,7 +179,7 @@ function CronsOverview() {
           )}
         </Layout.Main>
       </Layout.Body>
-    </Fragment>
+    </Layout.Page>
   );
 
   return (

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type {AlertProps} from '@sentry/scraps/alert';
 import {Alert} from '@sentry/scraps/alert';
 
@@ -129,7 +127,7 @@ export function DatabaseLandingPage() {
       .some(({value}) => value && value > 0);
 
   return (
-    <React.Fragment>
+    <Layout.Page>
       <ModuleFeature moduleName={ModuleName.DB}>
         <Layout.Body>
           <Layout.Main width="full">
@@ -177,7 +175,7 @@ export function DatabaseLandingPage() {
           </Layout.Main>
         </Layout.Body>
       </ModuleFeature>
-    </React.Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -140,7 +139,7 @@ export function DatabaseSpanSummaryPage() {
   });
 
   return (
-    <Fragment>
+    <Layout.Page>
       <BackendHeader
         headerTitle={t('Query Summary')}
         breadcrumbs={[
@@ -242,7 +241,7 @@ export function DatabaseSpanSummaryPage() {
           </Layout.Main>
         </Layout.Body>
       </ModuleFeature>
-    </Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react';
+import {Fragment} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {ProjectAvatar} from '@sentry/scraps/avatar';
@@ -147,7 +147,7 @@ export function HTTPDomainSummaryPage() {
   };
 
   return (
-    <React.Fragment>
+    <Layout.Page>
       {view === FRONTEND_LANDING_SUB_PATH && <FrontendHeader {...headerProps} />}
       {view === BACKEND_LANDING_SUB_PATH && <BackendHeader {...headerProps} />}
       {view === MOBILE_LANDING_SUB_PATH && <MobileHeader {...headerProps} />}
@@ -254,7 +254,7 @@ export function HTTPDomainSummaryPage() {
           </Layout.Main>
         </Layout.Body>
       </ModuleFeature>
-    </React.Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import * as Layout from 'sentry/components/layouts/thirds';
 import {SearchBar} from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
@@ -96,7 +94,7 @@ export function HTTPLandingPage() {
   );
 
   return (
-    <React.Fragment>
+    <Layout.Page>
       <ModuleFeature moduleName={ModuleName.HTTP}>
         <Layout.Body>
           <Layout.Main width="full">
@@ -139,7 +137,7 @@ export function HTTPLandingPage() {
           </Layout.Main>
         </Layout.Body>
       </ModuleFeature>
-    </React.Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/mcp-prompts/views/mcpPromptsLandingPage.tsx
+++ b/static/app/views/insights/mcp-prompts/views/mcpPromptsLandingPage.tsx
@@ -52,55 +52,59 @@ function McpPromptsLandingPage({datePageFilterProps}: McpPromptsLandingPageProps
   }
 
   return (
-    <SearchQueryBuilderProvider {...mcpSpanSearchProps.provider}>
-      <ModuleFeature moduleName={ModuleName.MCP_PROMPTS}>
-        <Layout.Body>
-          <Layout.Main width="full">
-            <ModuleLayout.Layout>
-              <ModuleLayout.Full>
-                <ToolRibbon>
-                  <PageFilterBar condensed>
-                    <InsightsProjectSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <InsightsEnvironmentSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <DatePageFilter {...datePageFilterProps} />
-                  </PageFilterBar>
-                  {!showOnboarding && (
-                    <Flex flex={2}>
-                      <TraceItemSearchQueryBuilder {...mcpSpanSearchProps.queryBuilder} />
-                    </Flex>
-                  )}
-                </ToolRibbon>
-              </ModuleLayout.Full>
+    <Layout.Page>
+      <SearchQueryBuilderProvider {...mcpSpanSearchProps.provider}>
+        <ModuleFeature moduleName={ModuleName.MCP_PROMPTS}>
+          <Layout.Body>
+            <Layout.Main width="full">
+              <ModuleLayout.Layout>
+                <ModuleLayout.Full>
+                  <ToolRibbon>
+                    <PageFilterBar condensed>
+                      <InsightsProjectSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <InsightsEnvironmentSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <DatePageFilter {...datePageFilterProps} />
+                    </PageFilterBar>
+                    {!showOnboarding && (
+                      <Flex flex={2}>
+                        <TraceItemSearchQueryBuilder
+                          {...mcpSpanSearchProps.queryBuilder}
+                        />
+                      </Flex>
+                    )}
+                  </ToolRibbon>
+                </ModuleLayout.Full>
 
-              <ModuleLayout.Full>
-                {showOnboarding ? (
-                  <Onboarding />
-                ) : (
-                  <Fragment>
-                    <WidgetGrid>
-                      <WidgetGrid.Position1>
-                        <McpPromptTrafficWidget />
-                      </WidgetGrid.Position1>
-                      <WidgetGrid.Position2>
-                        <McpPromptDurationWidget />
-                      </WidgetGrid.Position2>
-                      <WidgetGrid.Position3>
-                        <McpPromptErrorRateWidget />
-                      </WidgetGrid.Position3>
-                    </WidgetGrid>
-                    <McpPromptsTable />
-                  </Fragment>
-                )}
-              </ModuleLayout.Full>
-            </ModuleLayout.Layout>
-          </Layout.Main>
-        </Layout.Body>
-      </ModuleFeature>
-    </SearchQueryBuilderProvider>
+                <ModuleLayout.Full>
+                  {showOnboarding ? (
+                    <Onboarding />
+                  ) : (
+                    <Fragment>
+                      <WidgetGrid>
+                        <WidgetGrid.Position1>
+                          <McpPromptTrafficWidget />
+                        </WidgetGrid.Position1>
+                        <WidgetGrid.Position2>
+                          <McpPromptDurationWidget />
+                        </WidgetGrid.Position2>
+                        <WidgetGrid.Position3>
+                          <McpPromptErrorRateWidget />
+                        </WidgetGrid.Position3>
+                      </WidgetGrid>
+                      <McpPromptsTable />
+                    </Fragment>
+                  )}
+                </ModuleLayout.Full>
+              </ModuleLayout.Layout>
+            </Layout.Main>
+          </Layout.Body>
+        </ModuleFeature>
+      </SearchQueryBuilderProvider>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/mcp-resources/views/mcpResourcesLandingPage.tsx
+++ b/static/app/views/insights/mcp-resources/views/mcpResourcesLandingPage.tsx
@@ -52,55 +52,59 @@ function McpResourcesLandingPage({datePageFilterProps}: McpResourcesLandingPageP
   }
 
   return (
-    <SearchQueryBuilderProvider {...mcpSpanSearchProps.provider}>
-      <ModuleFeature moduleName={ModuleName.MCP_RESOURCES}>
-        <Layout.Body>
-          <Layout.Main width="full">
-            <ModuleLayout.Layout>
-              <ModuleLayout.Full>
-                <ToolRibbon>
-                  <PageFilterBar condensed>
-                    <InsightsProjectSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <InsightsEnvironmentSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <DatePageFilter {...datePageFilterProps} />
-                  </PageFilterBar>
-                  {!showOnboarding && (
-                    <Flex flex={2}>
-                      <TraceItemSearchQueryBuilder {...mcpSpanSearchProps.queryBuilder} />
-                    </Flex>
-                  )}
-                </ToolRibbon>
-              </ModuleLayout.Full>
+    <Layout.Page>
+      <SearchQueryBuilderProvider {...mcpSpanSearchProps.provider}>
+        <ModuleFeature moduleName={ModuleName.MCP_RESOURCES}>
+          <Layout.Body>
+            <Layout.Main width="full">
+              <ModuleLayout.Layout>
+                <ModuleLayout.Full>
+                  <ToolRibbon>
+                    <PageFilterBar condensed>
+                      <InsightsProjectSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <InsightsEnvironmentSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <DatePageFilter {...datePageFilterProps} />
+                    </PageFilterBar>
+                    {!showOnboarding && (
+                      <Flex flex={2}>
+                        <TraceItemSearchQueryBuilder
+                          {...mcpSpanSearchProps.queryBuilder}
+                        />
+                      </Flex>
+                    )}
+                  </ToolRibbon>
+                </ModuleLayout.Full>
 
-              <ModuleLayout.Full>
-                {showOnboarding ? (
-                  <Onboarding />
-                ) : (
-                  <Fragment>
-                    <WidgetGrid>
-                      <WidgetGrid.Position1>
-                        <McpResourceTrafficWidget />
-                      </WidgetGrid.Position1>
-                      <WidgetGrid.Position2>
-                        <McpResourceDurationWidget />
-                      </WidgetGrid.Position2>
-                      <WidgetGrid.Position3>
-                        <McpResourceErrorRateWidget />
-                      </WidgetGrid.Position3>
-                    </WidgetGrid>
-                    <McpResourcesTable />
-                  </Fragment>
-                )}
-              </ModuleLayout.Full>
-            </ModuleLayout.Layout>
-          </Layout.Main>
-        </Layout.Body>
-      </ModuleFeature>
-    </SearchQueryBuilderProvider>
+                <ModuleLayout.Full>
+                  {showOnboarding ? (
+                    <Onboarding />
+                  ) : (
+                    <Fragment>
+                      <WidgetGrid>
+                        <WidgetGrid.Position1>
+                          <McpResourceTrafficWidget />
+                        </WidgetGrid.Position1>
+                        <WidgetGrid.Position2>
+                          <McpResourceDurationWidget />
+                        </WidgetGrid.Position2>
+                        <WidgetGrid.Position3>
+                          <McpResourceErrorRateWidget />
+                        </WidgetGrid.Position3>
+                      </WidgetGrid>
+                      <McpResourcesTable />
+                    </Fragment>
+                  )}
+                </ModuleLayout.Full>
+              </ModuleLayout.Layout>
+            </Layout.Main>
+          </Layout.Body>
+        </ModuleFeature>
+      </SearchQueryBuilderProvider>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/mcp-tools/views/mcpToolsLandingPage.tsx
+++ b/static/app/views/insights/mcp-tools/views/mcpToolsLandingPage.tsx
@@ -52,55 +52,59 @@ function McpToolsLandingPage({datePageFilterProps}: McpToolsLandingPageProps) {
   }
 
   return (
-    <SearchQueryBuilderProvider {...mcpSpanSearchProps.provider}>
-      <ModuleFeature moduleName={ModuleName.MCP_TOOLS}>
-        <Layout.Body>
-          <Layout.Main width="full">
-            <ModuleLayout.Layout>
-              <ModuleLayout.Full>
-                <ToolRibbon>
-                  <PageFilterBar condensed>
-                    <InsightsProjectSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <InsightsEnvironmentSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <DatePageFilter {...datePageFilterProps} />
-                  </PageFilterBar>
-                  {!showOnboarding && (
-                    <Flex flex={2}>
-                      <TraceItemSearchQueryBuilder {...mcpSpanSearchProps.queryBuilder} />
-                    </Flex>
-                  )}
-                </ToolRibbon>
-              </ModuleLayout.Full>
+    <Layout.Page>
+      <SearchQueryBuilderProvider {...mcpSpanSearchProps.provider}>
+        <ModuleFeature moduleName={ModuleName.MCP_TOOLS}>
+          <Layout.Body>
+            <Layout.Main width="full">
+              <ModuleLayout.Layout>
+                <ModuleLayout.Full>
+                  <ToolRibbon>
+                    <PageFilterBar condensed>
+                      <InsightsProjectSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <InsightsEnvironmentSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <DatePageFilter {...datePageFilterProps} />
+                    </PageFilterBar>
+                    {!showOnboarding && (
+                      <Flex flex={2}>
+                        <TraceItemSearchQueryBuilder
+                          {...mcpSpanSearchProps.queryBuilder}
+                        />
+                      </Flex>
+                    )}
+                  </ToolRibbon>
+                </ModuleLayout.Full>
 
-              <ModuleLayout.Full>
-                {showOnboarding ? (
-                  <Onboarding />
-                ) : (
-                  <Fragment>
-                    <WidgetGrid>
-                      <WidgetGrid.Position1>
-                        <McpToolTrafficWidget />
-                      </WidgetGrid.Position1>
-                      <WidgetGrid.Position2>
-                        <McpToolDurationWidget />
-                      </WidgetGrid.Position2>
-                      <WidgetGrid.Position3>
-                        <McpToolErrorRateWidget />
-                      </WidgetGrid.Position3>
-                    </WidgetGrid>
-                    <McpToolsTable />
-                  </Fragment>
-                )}
-              </ModuleLayout.Full>
-            </ModuleLayout.Layout>
-          </Layout.Main>
-        </Layout.Body>
-      </ModuleFeature>
-    </SearchQueryBuilderProvider>
+                <ModuleLayout.Full>
+                  {showOnboarding ? (
+                    <Onboarding />
+                  ) : (
+                    <Fragment>
+                      <WidgetGrid>
+                        <WidgetGrid.Position1>
+                          <McpToolTrafficWidget />
+                        </WidgetGrid.Position1>
+                        <WidgetGrid.Position2>
+                          <McpToolDurationWidget />
+                        </WidgetGrid.Position2>
+                        <WidgetGrid.Position3>
+                          <McpToolErrorRateWidget />
+                        </WidgetGrid.Position3>
+                      </WidgetGrid>
+                      <McpToolsTable />
+                    </Fragment>
+                  )}
+                </ModuleLayout.Full>
+              </ModuleLayout.Layout>
+            </Layout.Main>
+          </Layout.Body>
+        </ModuleFeature>
+      </SearchQueryBuilderProvider>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -104,109 +104,113 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
   useAgentMonitoringTrackPageView();
 
   return (
-    <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>
-      <Layout.Body>
-        <Layout.Main width="full">
-          <ModuleLayout.Layout>
-            <ModuleLayout.Full>
-              <ToolRibbon>
-                <PageFilterBar condensed>
-                  <InsightsProjectSelector
-                    resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    onChange={() => {
-                      trackAnalytics('agent-monitoring.page-filter-change', {
-                        organization,
-                        filter: 'project',
-                      });
-                    }}
-                  />
-                  <InsightsEnvironmentSelector
-                    resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    onChange={() => {
-                      trackAnalytics('agent-monitoring.page-filter-change', {
-                        organization,
-                        filter: 'environment',
-                      });
-                    }}
-                  />
-                  <DatePageFilter
-                    {...datePageFilterProps}
-                    resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    onChange={() => {
-                      trackAnalytics('agent-monitoring.page-filter-change', {
-                        organization,
-                        filter: 'date',
-                      });
-                    }}
-                  />
-                </PageFilterBar>
-                <AgentSelector
-                  storageKeyPrefix="agents:agent-filter"
-                  referrer={Referrer.AGENT_SELECTOR}
-                />
-                {!showOnboarding && (
-                  <Flex flex={2}>
-                    <TraceItemSearchQueryBuilder {...agentSpanSearchProps.queryBuilder} />
-                  </Flex>
-                )}
-              </ToolRibbon>
-            </ModuleLayout.Full>
-
-            {showSeerDataBanner && (
+    <Layout.Page>
+      <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>
+        <Layout.Body>
+          <Layout.Main width="full">
+            <ModuleLayout.Layout>
               <ModuleLayout.Full>
-                <Alert
-                  variant="warning"
-                  trailingItems={
-                    <Button
-                      aria-label="Dismiss"
-                      icon={<IconClose />}
-                      size="xs"
-                      onClick={dismiss}
+                <ToolRibbon>
+                  <PageFilterBar condensed>
+                    <InsightsProjectSelector
+                      resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      onChange={() => {
+                        trackAnalytics('agent-monitoring.page-filter-change', {
+                          organization,
+                          filter: 'project',
+                        });
+                      }}
                     />
-                  }
-                >
-                  SENTRY EMPLOYEES: Transaction size limits make seer instrumentation
-                  incomplete. Data shown here does not reflect actual state.
-                </Alert>
+                    <InsightsEnvironmentSelector
+                      resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      onChange={() => {
+                        trackAnalytics('agent-monitoring.page-filter-change', {
+                          organization,
+                          filter: 'environment',
+                        });
+                      }}
+                    />
+                    <DatePageFilter
+                      {...datePageFilterProps}
+                      resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      onChange={() => {
+                        trackAnalytics('agent-monitoring.page-filter-change', {
+                          organization,
+                          filter: 'date',
+                        });
+                      }}
+                    />
+                  </PageFilterBar>
+                  <AgentSelector
+                    storageKeyPrefix="agents:agent-filter"
+                    referrer={Referrer.AGENT_SELECTOR}
+                  />
+                  {!showOnboarding && (
+                    <Flex flex={2}>
+                      <TraceItemSearchQueryBuilder
+                        {...agentSpanSearchProps.queryBuilder}
+                      />
+                    </Flex>
+                  )}
+                </ToolRibbon>
               </ModuleLayout.Full>
-            )}
 
-            <ModuleLayout.Full>
-              {showOnboarding ? (
-                <Onboarding />
-              ) : (
-                <Stack gap="xl">
-                  <WidgetGrid rowHeight={210} paddingBottom={0}>
-                    <WidgetGrid.Position1>
-                      <OverviewAgentsRunsChartWidget />
-                    </WidgetGrid.Position1>
-                    <WidgetGrid.Position2>
-                      <OverviewLLMCallsChartWidget />
-                    </WidgetGrid.Position2>
-                    <WidgetGrid.Position3>
-                      <OverviewAgentsDurationChartWidget />
-                    </WidgetGrid.Position3>
-                  </WidgetGrid>
-                  <WidgetGrid rowHeight={260} paddingBottom={0}>
-                    <WidgetGrid.Position1>
-                      <LLMCallsByModelWidget />
-                    </WidgetGrid.Position1>
-                    <WidgetGrid.Position2>
-                      <TokenUsageWidget />
-                    </WidgetGrid.Position2>
-                    <WidgetGrid.Position3>
-                      <ToolUsageWidget />
-                    </WidgetGrid.Position3>
-                  </WidgetGrid>
-                  <IssuesWidget />
-                  <TracesTable openTraceViewDrawer={openTraceViewDrawer} />
-                </Stack>
+              {showSeerDataBanner && (
+                <ModuleLayout.Full>
+                  <Alert
+                    variant="warning"
+                    trailingItems={
+                      <Button
+                        aria-label="Dismiss"
+                        icon={<IconClose />}
+                        size="xs"
+                        onClick={dismiss}
+                      />
+                    }
+                  >
+                    SENTRY EMPLOYEES: Transaction size limits make seer instrumentation
+                    incomplete. Data shown here does not reflect actual state.
+                  </Alert>
+                </ModuleLayout.Full>
               )}
-            </ModuleLayout.Full>
-          </ModuleLayout.Layout>
-        </Layout.Main>
-      </Layout.Body>
-    </SearchQueryBuilderProvider>
+
+              <ModuleLayout.Full>
+                {showOnboarding ? (
+                  <Onboarding />
+                ) : (
+                  <Stack gap="xl">
+                    <WidgetGrid rowHeight={210} paddingBottom={0}>
+                      <WidgetGrid.Position1>
+                        <OverviewAgentsRunsChartWidget />
+                      </WidgetGrid.Position1>
+                      <WidgetGrid.Position2>
+                        <OverviewLLMCallsChartWidget />
+                      </WidgetGrid.Position2>
+                      <WidgetGrid.Position3>
+                        <OverviewAgentsDurationChartWidget />
+                      </WidgetGrid.Position3>
+                    </WidgetGrid>
+                    <WidgetGrid rowHeight={260} paddingBottom={0}>
+                      <WidgetGrid.Position1>
+                        <LLMCallsByModelWidget />
+                      </WidgetGrid.Position1>
+                      <WidgetGrid.Position2>
+                        <TokenUsageWidget />
+                      </WidgetGrid.Position2>
+                      <WidgetGrid.Position3>
+                        <ToolUsageWidget />
+                      </WidgetGrid.Position3>
+                    </WidgetGrid>
+                    <IssuesWidget />
+                    <TracesTable openTraceViewDrawer={openTraceViewDrawer} />
+                  </Stack>
+                )}
+              </ModuleLayout.Full>
+            </ModuleLayout.Layout>
+          </Layout.Main>
+        </Layout.Body>
+      </SearchQueryBuilderProvider>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -230,69 +230,74 @@ function EAPBackendOverviewPage({datePageFilterProps}: EAPBackendOverviewPagePro
   );
 
   return (
-    <Feature
-      features="performance-view"
-      organization={organization}
-      renderDisabled={NoAccess}
-    >
-      <Layout.Body>
-        <Layout.Main width="full">
-          <ModuleLayout.Layout>
-            <ModuleLayout.Full>
-              <ToolRibbon>
-                <PageFilterBar condensed>
-                  <InsightsProjectSelector />
-                  <InsightsEnvironmentSelector />
-                  <DatePageFilter {...datePageFilterProps} />
-                </PageFilterBar>
-                {!showOnboarding && (
-                  <StyledTransactionNameSearchBar
-                    organization={organization}
-                    projectIds={searchBarProjectsIds}
-                    onSearch={(query: string) => {
-                      handleSearch(query);
-                    }}
-                    query={getFreeTextFromQuery(searchBarQuery) ?? ''}
-                  />
-                )}
-              </ToolRibbon>
-            </ModuleLayout.Full>
-            <PageAlert />
-            {showOnboarding ? (
-              <LegacyOnboarding project={onboardingProject} organization={organization} />
-            ) : (
-              <Fragment>
-                <ModuleLayout.Third>
-                  <Stack gap="xl" height="100%" minHeight="502px">
-                    <OverviewRequestsChartWidget />
-                    <OverviewApiLatencyChartWidget />
-                  </Stack>
-                </ModuleLayout.Third>
-                <ModuleLayout.TwoThirds>
-                  <IssuesWidget />
-                </ModuleLayout.TwoThirds>
-                <ModuleLayout.Full>
-                  <TripleRowWidgetWrapper>
-                    <ModuleLayout.Third>
-                      <OverviewJobsChartWidget />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Third>
-                      <OverviewTimeConsumingQueriesWidget />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Third>
-                      <OverviewCacheMissChartWidget />
-                    </ModuleLayout.Third>
-                  </TripleRowWidgetWrapper>
-                </ModuleLayout.Full>
-                <ModuleLayout.Full>
-                  <BackendOverviewTable response={response} sort={sorts[1]} />
-                </ModuleLayout.Full>
-              </Fragment>
-            )}
-          </ModuleLayout.Layout>
-        </Layout.Main>
-      </Layout.Body>
-    </Feature>
+    <Layout.Page>
+      <Feature
+        features="performance-view"
+        organization={organization}
+        renderDisabled={NoAccess}
+      >
+        <Layout.Body>
+          <Layout.Main width="full">
+            <ModuleLayout.Layout>
+              <ModuleLayout.Full>
+                <ToolRibbon>
+                  <PageFilterBar condensed>
+                    <InsightsProjectSelector />
+                    <InsightsEnvironmentSelector />
+                    <DatePageFilter {...datePageFilterProps} />
+                  </PageFilterBar>
+                  {!showOnboarding && (
+                    <StyledTransactionNameSearchBar
+                      organization={organization}
+                      projectIds={searchBarProjectsIds}
+                      onSearch={(query: string) => {
+                        handleSearch(query);
+                      }}
+                      query={getFreeTextFromQuery(searchBarQuery) ?? ''}
+                    />
+                  )}
+                </ToolRibbon>
+              </ModuleLayout.Full>
+              <PageAlert />
+              {showOnboarding ? (
+                <LegacyOnboarding
+                  project={onboardingProject}
+                  organization={organization}
+                />
+              ) : (
+                <Fragment>
+                  <ModuleLayout.Third>
+                    <Stack gap="xl" height="100%" minHeight="502px">
+                      <OverviewRequestsChartWidget />
+                      <OverviewApiLatencyChartWidget />
+                    </Stack>
+                  </ModuleLayout.Third>
+                  <ModuleLayout.TwoThirds>
+                    <IssuesWidget />
+                  </ModuleLayout.TwoThirds>
+                  <ModuleLayout.Full>
+                    <TripleRowWidgetWrapper>
+                      <ModuleLayout.Third>
+                        <OverviewJobsChartWidget />
+                      </ModuleLayout.Third>
+                      <ModuleLayout.Third>
+                        <OverviewTimeConsumingQueriesWidget />
+                      </ModuleLayout.Third>
+                      <ModuleLayout.Third>
+                        <OverviewCacheMissChartWidget />
+                      </ModuleLayout.Third>
+                    </TripleRowWidgetWrapper>
+                  </ModuleLayout.Full>
+                  <ModuleLayout.Full>
+                    <BackendOverviewTable response={response} sort={sorts[1]} />
+                  </ModuleLayout.Full>
+                </Fragment>
+              )}
+            </ModuleLayout.Layout>
+          </Layout.Main>
+        </Layout.Body>
+      </Feature>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -147,97 +147,102 @@ function FrontendOverviewPage({datePageFilterProps}: FrontendOverviewPageProps) 
   ].map(project => project.id);
 
   return (
-    <Feature
-      features="performance-view"
-      organization={organization}
-      renderDisabled={NoAccess}
-    >
-      <Layout.Body>
-        <Layout.Main width="full">
-          <ModuleLayout.Layout>
-            <ModuleLayout.Full>
-              <ToolRibbon>
-                <PageFilterBar condensed>
-                  <InsightsProjectSelector />
-                  <InsightsEnvironmentSelector />
-                  <DatePageFilter {...datePageFilterProps} />
-                </PageFilterBar>
-                {!showOnboarding && (
-                  <Fragment>
-                    <CompactSelect
-                      value={spanOp}
-                      menuTitle={t('Filter by operation')}
-                      options={[
-                        {value: 'all', label: t('All Transactions')},
-                        {value: 'pageload', label: t('Pageload')},
-                        {value: 'navigation', label: t('Navigation')},
-                      ]}
-                      onChange={(selectedOption: SelectOption<PageSpanOps>) => {
-                        navigate({
-                          pathname: location.pathname,
-                          query: {
-                            ...location.query,
-                            [SPAN_OP_QUERY_PARAM]: selectedOption.value,
-                          },
-                        });
-                      }}
+    <Layout.Page>
+      <Feature
+        features="performance-view"
+        organization={organization}
+        renderDisabled={NoAccess}
+      >
+        <Layout.Body>
+          <Layout.Main width="full">
+            <ModuleLayout.Layout>
+              <ModuleLayout.Full>
+                <ToolRibbon>
+                  <PageFilterBar condensed>
+                    <InsightsProjectSelector />
+                    <InsightsEnvironmentSelector />
+                    <DatePageFilter {...datePageFilterProps} />
+                  </PageFilterBar>
+                  {!showOnboarding && (
+                    <Fragment>
+                      <CompactSelect
+                        value={spanOp}
+                        menuTitle={t('Filter by operation')}
+                        options={[
+                          {value: 'all', label: t('All Transactions')},
+                          {value: 'pageload', label: t('Pageload')},
+                          {value: 'navigation', label: t('Navigation')},
+                        ]}
+                        onChange={(selectedOption: SelectOption<PageSpanOps>) => {
+                          navigate({
+                            pathname: location.pathname,
+                            query: {
+                              ...location.query,
+                              [SPAN_OP_QUERY_PARAM]: selectedOption.value,
+                            },
+                          });
+                        }}
+                      />
+                      <StyledTransactionNameSearchBar
+                        organization={organization}
+                        projectIds={searchBarProjectsIds}
+                        onSearch={(query: string) => {
+                          handleSearch(query);
+                        }}
+                        query={getFreeTextFromQuery(searchBarQuery) ?? ''}
+                      />
+                    </Fragment>
+                  )}
+                </ToolRibbon>
+              </ModuleLayout.Full>
+              <PageAlert />
+              {showOnboarding ? (
+                <LegacyOnboarding
+                  project={onboardingProject}
+                  organization={organization}
+                />
+              ) : (
+                <Fragment>
+                  <ModuleLayout.Full>
+                    <TripleRowWidgetWrapper>
+                      <ModuleLayout.Third>
+                        <OverviewTransactionThroughputChartWidget />
+                      </ModuleLayout.Third>
+                      <ModuleLayout.Third>
+                        <OverviewTransactionDurationChartWidget />
+                      </ModuleLayout.Third>
+                      <ModuleLayout.Third>
+                        <OverviewIssuesWidget />
+                      </ModuleLayout.Third>
+                    </TripleRowWidgetWrapper>
+                  </ModuleLayout.Full>
+                  <ModuleLayout.Full>
+                    <TripleRowWidgetWrapper>
+                      <ModuleLayout.Third>
+                        <WebVitalsWidget />
+                      </ModuleLayout.Third>
+                      <ModuleLayout.Third>
+                        <OverviewAssetsByTimeSpentWidget />
+                      </ModuleLayout.Third>
+                      <ModuleLayout.Third>
+                        <OverviewTimeConsumingRequestsWidget />
+                      </ModuleLayout.Third>
+                    </TripleRowWidgetWrapper>
+                  </ModuleLayout.Full>
+                  <ModuleLayout.Full>
+                    <FrontendOverviewTable
+                      displayPerfScore={displayPerfScore}
+                      response={response}
+                      sort={sorts[1]}
                     />
-                    <StyledTransactionNameSearchBar
-                      organization={organization}
-                      projectIds={searchBarProjectsIds}
-                      onSearch={(query: string) => {
-                        handleSearch(query);
-                      }}
-                      query={getFreeTextFromQuery(searchBarQuery) ?? ''}
-                    />
-                  </Fragment>
-                )}
-              </ToolRibbon>
-            </ModuleLayout.Full>
-            <PageAlert />
-            {showOnboarding ? (
-              <LegacyOnboarding project={onboardingProject} organization={organization} />
-            ) : (
-              <Fragment>
-                <ModuleLayout.Full>
-                  <TripleRowWidgetWrapper>
-                    <ModuleLayout.Third>
-                      <OverviewTransactionThroughputChartWidget />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Third>
-                      <OverviewTransactionDurationChartWidget />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Third>
-                      <OverviewIssuesWidget />
-                    </ModuleLayout.Third>
-                  </TripleRowWidgetWrapper>
-                </ModuleLayout.Full>
-                <ModuleLayout.Full>
-                  <TripleRowWidgetWrapper>
-                    <ModuleLayout.Third>
-                      <WebVitalsWidget />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Third>
-                      <OverviewAssetsByTimeSpentWidget />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Third>
-                      <OverviewTimeConsumingRequestsWidget />
-                    </ModuleLayout.Third>
-                  </TripleRowWidgetWrapper>
-                </ModuleLayout.Full>
-                <ModuleLayout.Full>
-                  <FrontendOverviewTable
-                    displayPerfScore={displayPerfScore}
-                    response={response}
-                    sort={sorts[1]}
-                  />
-                </ModuleLayout.Full>
-              </Fragment>
-            )}
-          </ModuleLayout.Layout>
-        </Layout.Main>
-      </Layout.Body>
-    </Feature>
+                  </ModuleLayout.Full>
+                </Fragment>
+              )}
+            </ModuleLayout.Layout>
+          </Layout.Main>
+        </Layout.Body>
+      </Feature>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/pages/mcp/overview.tsx
+++ b/static/app/views/insights/pages/mcp/overview.tsx
@@ -69,70 +69,74 @@ function McpOverviewPage({datePageFilterProps}: McpOverviewPageProps) {
   }
 
   return (
-    <SearchQueryBuilderProvider {...mcpSpanSearchProps.provider}>
-      <Feature
-        features="performance-view"
-        organization={organization}
-        renderDisabled={NoAccess}
-      >
-        <Layout.Body>
-          <Layout.Main width="full">
-            <ModuleLayout.Layout>
-              <ModuleLayout.Full>
-                <ToolRibbon>
-                  <PageFilterBar condensed>
-                    <InsightsProjectSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <InsightsEnvironmentSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <DatePageFilter {...datePageFilterProps} />
-                  </PageFilterBar>
-                  {!showOnboarding && (
-                    <Flex flex={2}>
-                      <TraceItemSearchQueryBuilder {...mcpSpanSearchProps.queryBuilder} />
-                    </Flex>
-                  )}
-                </ToolRibbon>
-              </ModuleLayout.Full>
+    <Layout.Page>
+      <SearchQueryBuilderProvider {...mcpSpanSearchProps.provider}>
+        <Feature
+          features="performance-view"
+          organization={organization}
+          renderDisabled={NoAccess}
+        >
+          <Layout.Body>
+            <Layout.Main width="full">
+              <ModuleLayout.Layout>
+                <ModuleLayout.Full>
+                  <ToolRibbon>
+                    <PageFilterBar condensed>
+                      <InsightsProjectSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <InsightsEnvironmentSelector
+                        resetParamsOnChange={[TableUrlParams.CURSOR]}
+                      />
+                      <DatePageFilter {...datePageFilterProps} />
+                    </PageFilterBar>
+                    {!showOnboarding && (
+                      <Flex flex={2}>
+                        <TraceItemSearchQueryBuilder
+                          {...mcpSpanSearchProps.queryBuilder}
+                        />
+                      </Flex>
+                    )}
+                  </ToolRibbon>
+                </ModuleLayout.Full>
 
-              <ModuleLayout.Full>
-                {showOnboarding ? (
-                  <Onboarding />
-                ) : (
-                  <Fragment>
-                    <WidgetGrid>
-                      <WidgetGrid.Position1>
-                        <McpTrafficWidget />
-                      </WidgetGrid.Position1>
-                      <WidgetGrid.Position2>
-                        <McpTrafficByClientWidget />
-                      </WidgetGrid.Position2>
-                      <WidgetGrid.Position3>
-                        <McpTransportWidget />
-                      </WidgetGrid.Position3>
-                    </WidgetGrid>
-                    <WidgetGrid>
-                      <WidgetGrid.Position1>
-                        <McpToolTrafficWidget />
-                      </WidgetGrid.Position1>
-                      <WidgetGrid.Position2>
-                        <McpResourceTrafficWidget />
-                      </WidgetGrid.Position2>
-                      <WidgetGrid.Position3>
-                        <McpPromptTrafficWidget />
-                      </WidgetGrid.Position3>
-                    </WidgetGrid>
-                    <McpOverviewTable />
-                  </Fragment>
-                )}
-              </ModuleLayout.Full>
-            </ModuleLayout.Layout>
-          </Layout.Main>
-        </Layout.Body>
-      </Feature>
-    </SearchQueryBuilderProvider>
+                <ModuleLayout.Full>
+                  {showOnboarding ? (
+                    <Onboarding />
+                  ) : (
+                    <Fragment>
+                      <WidgetGrid>
+                        <WidgetGrid.Position1>
+                          <McpTrafficWidget />
+                        </WidgetGrid.Position1>
+                        <WidgetGrid.Position2>
+                          <McpTrafficByClientWidget />
+                        </WidgetGrid.Position2>
+                        <WidgetGrid.Position3>
+                          <McpTransportWidget />
+                        </WidgetGrid.Position3>
+                      </WidgetGrid>
+                      <WidgetGrid>
+                        <WidgetGrid.Position1>
+                          <McpToolTrafficWidget />
+                        </WidgetGrid.Position1>
+                        <WidgetGrid.Position2>
+                          <McpResourceTrafficWidget />
+                        </WidgetGrid.Position2>
+                        <WidgetGrid.Position3>
+                          <McpPromptTrafficWidget />
+                        </WidgetGrid.Position3>
+                      </WidgetGrid>
+                      <McpOverviewTable />
+                    </Fragment>
+                  )}
+                </ModuleLayout.Full>
+              </ModuleLayout.Layout>
+            </Layout.Main>
+          </Layout.Body>
+        </Feature>
+      </SearchQueryBuilderProvider>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -253,59 +253,64 @@ function EAPMobileOverviewPage({datePageFilterProps}: EAPMobileOverviewPageProps
   );
 
   return (
-    <Feature
-      features="performance-view"
-      organization={organization}
-      renderDisabled={NoAccess}
-    >
-      <Layout.Body>
-        <Layout.Main width="full">
-          <ModuleLayout.Layout>
-            <ModuleLayout.Full>
-              <ToolRibbon>
-                <PageFilterBar condensed>
-                  <InsightsProjectSelector />
-                  <InsightsEnvironmentSelector />
-                  <DatePageFilter {...datePageFilterProps} />
-                </PageFilterBar>
-                {!showOnboarding && (
-                  <StyledTransactionNameSearchBar
+    <Layout.Page>
+      <Feature
+        features="performance-view"
+        organization={organization}
+        renderDisabled={NoAccess}
+      >
+        <Layout.Body>
+          <Layout.Main width="full">
+            <ModuleLayout.Layout>
+              <ModuleLayout.Full>
+                <ToolRibbon>
+                  <PageFilterBar condensed>
+                    <InsightsProjectSelector />
+                    <InsightsEnvironmentSelector />
+                    <DatePageFilter {...datePageFilterProps} />
+                  </PageFilterBar>
+                  {!showOnboarding && (
+                    <StyledTransactionNameSearchBar
+                      organization={organization}
+                      projectIds={searchBarProjectsIds}
+                      onSearch={(query: string) => {
+                        handleSearch(query);
+                      }}
+                      query={getFreeTextFromQuery(searchBarQuery) ?? ''}
+                    />
+                  )}
+                </ToolRibbon>
+              </ModuleLayout.Full>
+              <PageAlert />
+              {hasPlatformizedInsights && <MobileVitalsBanner />}
+              <ModuleLayout.Full>
+                {showOnboarding ? (
+                  <LegacyOnboarding
+                    project={onboardingProject}
                     organization={organization}
-                    projectIds={searchBarProjectsIds}
-                    onSearch={(query: string) => {
-                      handleSearch(query);
-                    }}
-                    query={getFreeTextFromQuery(searchBarQuery) ?? ''}
                   />
+                ) : (
+                  <PerformanceDisplayProvider
+                    value={{performanceType: ProjectPerformanceType.MOBILE}}
+                  >
+                    <DoubleChartRow
+                      allowedCharts={doubleChartRowCharts}
+                      {...sharedProps}
+                      eventView={doubleChartRowEventView}
+                    />
+                    <TripleChartRow
+                      allowedCharts={tripleChartRowCharts}
+                      {...sharedProps}
+                    />
+                    <MobileOverviewTable response={response} sort={sorts[1]} />
+                  </PerformanceDisplayProvider>
                 )}
-              </ToolRibbon>
-            </ModuleLayout.Full>
-            <PageAlert />
-            {hasPlatformizedInsights && <MobileVitalsBanner />}
-            <ModuleLayout.Full>
-              {showOnboarding ? (
-                <LegacyOnboarding
-                  project={onboardingProject}
-                  organization={organization}
-                />
-              ) : (
-                <PerformanceDisplayProvider
-                  value={{performanceType: ProjectPerformanceType.MOBILE}}
-                >
-                  <DoubleChartRow
-                    allowedCharts={doubleChartRowCharts}
-                    {...sharedProps}
-                    eventView={doubleChartRowEventView}
-                  />
-                  <TripleChartRow allowedCharts={tripleChartRowCharts} {...sharedProps} />
-                  <MobileOverviewTable response={response} sort={sorts[1]} />
-                </PerformanceDisplayProvider>
-              )}
-            </ModuleLayout.Full>
-          </ModuleLayout.Layout>
-        </Layout.Main>
-      </Layout.Body>
-    </Feature>
+              </ModuleLayout.Full>
+            </ModuleLayout.Layout>
+          </Layout.Main>
+        </Layout.Body>
+      </Feature>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/queues/views/destinationSummaryPage.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.tsx
@@ -54,7 +54,7 @@ function DestinationSummaryPage() {
   });
 
   return (
-    <Fragment>
+    <Layout.Page>
       <BackendHeader
         headerTitle={destination}
         breadcrumbs={[
@@ -150,7 +150,7 @@ function DestinationSummaryPage() {
           </Layout.Main>
         </Layout.Body>
       </ModuleFeature>
-    </Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/queues/views/queuesLandingPage.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import {Stack} from '@sentry/scraps/layout';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -74,7 +72,7 @@ function QueuesLandingPage() {
     : undefined;
 
   return (
-    <Fragment>
+    <Layout.Page>
       <ModuleFeature moduleName={ModuleName.QUEUE}>
         <Layout.Body>
           <Layout.Main width="full">
@@ -104,7 +102,7 @@ function QueuesLandingPage() {
           </Layout.Main>
         </Layout.Body>
       </ModuleFeature>
-    </Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -35,7 +35,7 @@ function SessionsOverview() {
   const showOnboarding = !hasSessionData;
 
   return (
-    <Fragment>
+    <Layout.Page>
       <Layout.Body>
         <Layout.Main width="full">
           <ModuleLayout.Layout>
@@ -58,7 +58,7 @@ function SessionsOverview() {
           </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>
-    </Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/insights/uptime/views/overview.tsx
+++ b/static/app/views/insights/uptime/views/overview.tsx
@@ -69,7 +69,7 @@ export default function UptimeOverview() {
   );
 
   const page = (
-    <Fragment>
+    <Layout.Page>
       <Layout.Header unified>
         <Layout.HeaderContent>
           <Layout.Title>
@@ -166,7 +166,7 @@ export default function UptimeOverview() {
           )}
         </Layout.Main>
       </Layout.Body>
-    </Fragment>
+    </Layout.Page>
   );
 
   return (


### PR DESCRIPTION
Wraps non-compliant route components in the \`/organizations/:orgId/insights/\` area with \`Layout.Page\`. Part of the Layout.Page audit remediation.

## Changes

- \`insights/http/views/httpLandingPage\` — shared component (resolves \`frontend/http/\`, \`backend/http/\`, \`mobile/http/\`)
- \`insights/http/views/httpDomainSummaryPage\` — shared component (resolves \`frontend/http/domains/\`, \`backend/http/domains/\`, \`mobile/http/domains/\`)
- \`insights/sessions/views/overview\` — shared component (resolves \`frontend/sessions/\`, \`backend/sessions/\`, \`mobile/sessions/\`)
- \`insights/pages/frontend/frontendOverviewPage\`
- \`insights/browser/webVitals/views/webVitalsLandingPage\`
- \`insights/browser/webVitals/views/pageOverview\`
- \`insights/browser/resources/views/resourcesLandingPage\`
- \`insights/browser/resources/views/resourceSummaryPage\`
- \`insights/pages/backend/backendOverviewPage\`
- \`insights/database/views/databaseLandingPage\`
- \`insights/database/views/databaseSpanSummaryPage\`
- \`insights/cache/views/cacheLandingPage\`
- \`insights/queues/views/queuesLandingPage\`
- \`insights/queues/views/destinationSummaryPage\`
- \`insights/pages/mobile/mobileOverviewPage\`
- \`insights/pages/mcp/overview\`
- \`insights/mcp-tools/views/mcpToolsLandingPage\`
- \`insights/mcp-resources/views/mcpResourcesLandingPage\`
- \`insights/mcp-prompts/views/mcpPromptsLandingPage\`
- \`insights/pages/agents/overview\`
- \`insights/agentModels/views/modelsLandingPage\`
- \`insights/agentTools/views/toolsLandingPage\`
- \`insights/uptime/views/overview\`
- \`insights/crons/views/overview\`

## Affected routes (31 total)

| Path | Component |
|------|-----------|
| `/organizations/:orgId/insights/frontend/http/` | `httpLandingPage` |
| `/organizations/:orgId/insights/backend/http/` | `httpLandingPage` |
| `/organizations/:orgId/insights/mobile/http/` | `httpLandingPage` |
| `/organizations/:orgId/insights/frontend/http/domains/` | `httpDomainSummaryPage` |
| `/organizations/:orgId/insights/backend/http/domains/` | `httpDomainSummaryPage` |
| `/organizations/:orgId/insights/mobile/http/domains/` | `httpDomainSummaryPage` |
| `/organizations/:orgId/insights/frontend/sessions/` | `sessions/views/overview` |
| `/organizations/:orgId/insights/backend/sessions/` | `sessions/views/overview` |
| `/organizations/:orgId/insights/mobile/sessions/` | `sessions/views/overview` |
| `/organizations/:orgId/insights/frontend/` | `frontendOverviewPage` |
| `/organizations/:orgId/insights/frontend/pageloads/` | `webVitalsLandingPage` |
| `/organizations/:orgId/insights/frontend/pageloads/overview/` | `pageOverview` |
| `/organizations/:orgId/insights/frontend/assets/` | `resourcesLandingPage` |
| `/organizations/:orgId/insights/frontend/assets/spans/span/:groupId/` | `resourceSummaryPage` |
| `/organizations/:orgId/insights/backend/` | `backendOverviewPage` |
| `/organizations/:orgId/insights/backend/database/` | `databaseLandingPage` |
| `/organizations/:orgId/insights/backend/database/spans/span/:groupId/` | `databaseSpanSummaryPage` |
| `/organizations/:orgId/insights/backend/caches/` | `cacheLandingPage` |
| `/organizations/:orgId/insights/backend/queues/` | `queuesLandingPage` |
| `/organizations/:orgId/insights/backend/queues/destination/` | `destinationSummaryPage` |
| `/organizations/:orgId/insights/mobile/` | `mobileOverviewPage` |
| `/organizations/:orgId/insights/mcp/` | `pages/mcp/overview` |
| `/organizations/:orgId/insights/mcp/tools/` | `mcpToolsLandingPage` |
| `/organizations/:orgId/insights/mcp/resources/` | `mcpResourcesLandingPage` |
| `/organizations/:orgId/insights/mcp/prompts/` | `mcpPromptsLandingPage` |
| `/organizations/:orgId/insights/ai-agents/` | `pages/agents/overview` |
| `/organizations/:orgId/insights/ai-agents/models/` | `modelsLandingPage` |
| `/organizations/:orgId/insights/ai-agents/tools/` | `toolsLandingPage` |
| `/organizations/:orgId/insights/uptime/` | `uptime/views/overview` |
| `/organizations/:orgId/insights/crons/` | `crons/views/overview` |

Note: `/organizations/:orgId/insights/` maps to `InsightsIndex` which is a pure redirect component — no Layout.Page wrap needed.

## Verification

Each affected route now renders inside a `<main>` element (via `Layout.Page`) as the outermost content container.