### PR TITLE
ref(layout): use Layout.Page on standalone pages

### DIFF
--- a/static/app/views/acceptOrganizationInvite/index.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.tsx
@@ -7,6 +7,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import {logout} from 'sentry/actionCreators/account';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -261,62 +262,66 @@ function AcceptOrganizationInvite() {
 
   if (isError) {
     return (
-      <NarrowLayout>
-        <Alert.Container>
-          <Alert variant="warning" showIcon={false}>
-            {tct(
-              'This organization invite link is invalid. It may be expired, or you may need to [switchLink:sign in with a different account].',
-              {
-                switchLink: (
-                  <Link
-                    to=""
-                    data-test-id="existing-member-link"
-                    onClick={e => {
-                      e.preventDefault();
-                      logout(api, `/accept/${params.memberId}/${params.token}/`);
-                    }}
-                  />
-                ),
-              }
-            )}
-          </Alert>
-        </Alert.Container>
-      </NarrowLayout>
+      <Layout.Page withPadding>
+        <NarrowLayout>
+          <Alert.Container>
+            <Alert variant="warning" showIcon={false}>
+              {tct(
+                'This organization invite link is invalid. It may be expired, or you may need to [switchLink:sign in with a different account].',
+                {
+                  switchLink: (
+                    <Link
+                      to=""
+                      data-test-id="existing-member-link"
+                      onClick={e => {
+                        e.preventDefault();
+                        logout(api, `/accept/${params.memberId}/${params.token}/`);
+                      }}
+                    />
+                  ),
+                }
+              )}
+            </Alert>
+          </Alert.Container>
+        </NarrowLayout>
+      </Layout.Page>
     );
   }
 
   return (
-    <NarrowLayout>
-      <SentryDocumentTitle title={t('Accept Organization Invite')} />
-      <SettingsPageHeader title={t('Accept organization invite')} />
-      {isAcceptError && (
-        <Alert.Container>
-          <Alert variant="danger" showIcon={false}>
-            {t('Failed to join this organization. Please try again')}
-          </Alert>
-        </Alert.Container>
-      )}
-      <InviteDescription data-test-id="accept-invite">
-        {tct('[orgSlug] is using Sentry to track and debug errors.', {
-          orgSlug: <strong>{inviteDetails.orgSlug}</strong>,
-        })}
-      </InviteDescription>
-      {inviteDetails.needsAuthentication ? (
-        <AuthenticationActions inviteDetails={inviteDetails} />
-      ) : inviteDetails.existingMember ? (
-        <ExistingMemberAlert />
-      ) : inviteDetails.needs2fa ? (
-        <Warning2fa inviteDetails={inviteDetails} />
-      ) : inviteDetails.requireSso ? (
-        <AuthenticationActions inviteDetails={inviteDetails} />
-      ) : (
-        <AcceptActions
-          inviteDetails={inviteDetails}
-          isAccepting={isAccepting}
-          acceptInvite={acceptInvite}
-        />
-      )}
-    </NarrowLayout>
+    <Layout.Page withPadding>
+      <NarrowLayout>
+        <SentryDocumentTitle title={t('Accept Organization Invite')} />
+        <SettingsPageHeader title={t('Accept organization invite')} />
+        {isAcceptError && (
+          <Alert.Container>
+            <Alert variant="danger" showIcon={false}>
+              {t('Failed to join this organization. Please try again')}
+            </Alert>
+          </Alert.Container>
+        )}
+        <InviteDescription data-test-id="accept-invite">
+          {tct('[orgSlug] is using Sentry to track and debug errors.', {
+            orgSlug: <strong>{inviteDetails.orgSlug}</strong>,
+          })}
+        </InviteDescription>
+        {inviteDetails.needsAuthentication ? (
+          <AuthenticationActions inviteDetails={inviteDetails} />
+        ) : inviteDetails.existingMember ? (
+          <ExistingMemberAlert />
+        ) : inviteDetails.needs2fa ? (
+          <Warning2fa inviteDetails={inviteDetails} />
+        ) : inviteDetails.requireSso ? (
+          <AuthenticationActions inviteDetails={inviteDetails} />
+        ) : (
+          <AcceptActions
+            inviteDetails={inviteDetails}
+            isAccepting={isAccepting}
+            acceptInvite={acceptInvite}
+          />
+        )}
+      </NarrowLayout>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -2,6 +2,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {SelectField} from 'sentry/components/forms/fields/selectField';
 import {Form} from 'sentry/components/forms/form';
 import type {Data} from 'sentry/components/forms/types';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -105,40 +106,45 @@ function AcceptProjectTransfer() {
   const organization = options?.[0]?.value;
 
   return (
-    <NarrowLayout>
-      <SentryDocumentTitle title={t('Accept Project Transfer')} />
-      <SettingsPageHeader title={t('Approve Transfer Project Request')} />
-      <p>
-        {tct(
-          'Projects must be transferred to a specific [organization]. You can grant specific teams access to the project later under the [projectSettings]. (Note that granting access to at least one team is necessary for the project to appear in all parts of the UI.)',
-          {
-            organization: <strong>{t('Organization')}</strong>,
-            projectSettings: <strong>{t('Project Settings')}</strong>,
-          }
-        )}
-      </p>
-      {transferDetails && (
+    <Layout.Page withPadding>
+      <NarrowLayout>
+        <SentryDocumentTitle title={t('Accept Project Transfer')} />
+        <SettingsPageHeader title={t('Approve Transfer Project Request')} />
         <p>
-          {tct('Please select which [organization] you want for the project [project].', {
-            organization: <strong>{t('Organization')}</strong>,
-            project: transferDetails.project.slug,
-          })}
+          {tct(
+            'Projects must be transferred to a specific [organization]. You can grant specific teams access to the project later under the [projectSettings]. (Note that granting access to at least one team is necessary for the project to appear in all parts of the UI.)',
+            {
+              organization: <strong>{t('Organization')}</strong>,
+              projectSettings: <strong>{t('Project Settings')}</strong>,
+            }
+          )}
         </p>
-      )}
-      <Form
-        onSubmit={data => handleSubmitMutation.mutate(data)}
-        submitLabel={t('Transfer Project')}
-        submitPriority="danger"
-        initialData={organization ? {organization} : undefined}
-      >
-        <SelectField
-          options={options}
-          label={t('Organization')}
-          name="organization"
-          style={{borderBottom: 'none'}}
-        />
-      </Form>
-    </NarrowLayout>
+        {transferDetails && (
+          <p>
+            {tct(
+              'Please select which [organization] you want for the project [project].',
+              {
+                organization: <strong>{t('Organization')}</strong>,
+                project: transferDetails.project.slug,
+              }
+            )}
+          </p>
+        )}
+        <Form
+          onSubmit={data => handleSubmitMutation.mutate(data)}
+          submitLabel={t('Transfer Project')}
+          submitPriority="danger"
+          initialData={organization ? {organization} : undefined}
+        >
+          <SelectField
+            options={options}
+            label={t('Organization')}
+            name="organization"
+            style={{borderBottom: 'none'}}
+          />
+        </Form>
+      </NarrowLayout>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/auth/login.tsx
+++ b/static/app/views/auth/login.tsx
@@ -5,6 +5,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
@@ -76,60 +77,62 @@ function Login() {
   ];
 
   return (
-    <Fragment>
-      <Header>
-        <Heading>{t('Sign in to continue')}</Heading>
-        <TabsContainer>
-          <Tabs
-            value={activeTab}
-            onChange={tab => {
-              setActiveTab(tab);
-            }}
-          >
-            <TabList>
-              {tabs
-                .map(([key, label, disabled]) => {
-                  if (disabled) {
-                    return null;
-                  }
-                  return <TabList.Item key={key}>{label}</TabList.Item>;
-                })
-                .filter(n => !!n)}
-            </TabList>
-          </Tabs>
-        </TabsContainer>
-      </Header>
-      {isPending && <LoadingIndicator />}
+    <Layout.Page withPadding>
+      <Fragment>
+        <Header>
+          <Heading>{t('Sign in to continue')}</Heading>
+          <TabsContainer>
+            <Tabs
+              value={activeTab}
+              onChange={tab => {
+                setActiveTab(tab);
+              }}
+            >
+              <TabList>
+                {tabs
+                  .map(([key, label, disabled]) => {
+                    if (disabled) {
+                      return null;
+                    }
+                    return <TabList.Item key={key}>{label}</TabList.Item>;
+                  })
+                  .filter(n => !!n)}
+              </TabList>
+            </Tabs>
+          </TabsContainer>
+        </Header>
+        {isPending && <LoadingIndicator />}
 
-      {isError && (
-        <StyledLoadingError
-          message={t('Unable to load authentication configuration')}
-          onRetry={refetch}
-        />
-      )}
-      {!isPending && authConfig !== null && !isError && (
-        <FormWrapper hasAuthProviders={hasAuthProviders}>
-          {orgId !== undefined && (
-            <Alert.Container>
-              <Alert
-                variant="warning"
-                trailingItems={
-                  <LinkButton to="/" size="xs">
-                    Reload
-                  </LinkButton>
-                }
-              >
-                {tct(
-                  "Experimental SPA mode does not currently support SSO style login. To develop against the [org] you'll need to copy your production session cookie.",
-                  {org: orgId}
-                )}
-              </Alert>
-            </Alert.Container>
-          )}
-          <FormComponent {...{authConfig}} />
-        </FormWrapper>
-      )}
-    </Fragment>
+        {isError && (
+          <StyledLoadingError
+            message={t('Unable to load authentication configuration')}
+            onRetry={refetch}
+          />
+        )}
+        {!isPending && authConfig !== null && !isError && (
+          <FormWrapper hasAuthProviders={hasAuthProviders}>
+            {orgId !== undefined && (
+              <Alert.Container>
+                <Alert
+                  variant="warning"
+                  trailingItems={
+                    <LinkButton to="/" size="xs">
+                      Reload
+                    </LinkButton>
+                  }
+                >
+                  {tct(
+                    "Experimental SPA mode does not currently support SSO style login. To develop against the [org] you'll need to copy your production session cookie.",
+                    {org: orgId}
+                  )}
+                </Alert>
+              </Alert.Container>
+            )}
+            <FormComponent {...{authConfig}} />
+          </FormWrapper>
+        )}
+      </Fragment>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/dataExport/dataDownload.tsx
+++ b/static/app/views/dataExport/dataDownload.tsx
@@ -5,6 +5,7 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 
 import {ExportQueryType} from 'sentry/components/dataExport';
 import {DateTime} from 'sentry/components/dateTime';
+import * as LayoutThirds from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {IconDownload} from 'sentry/icons';
@@ -96,20 +97,22 @@ export default function DataDownload() {
   if (isError) {
     const errDetail = error?.responseJSON?.detail;
     return (
-      <Layout>
-        <main>
-          <Header>
-            <h3>
-              {error.status} - {error.statusText}
-            </h3>
-          </Header>
-          {errDetail && (
-            <Body>
-              <p>{errDetail as string}</p>
-            </Body>
-          )}
-        </main>
-      </Layout>
+      <LayoutThirds.Page>
+        <Layout>
+          <main>
+            <Header>
+              <h3>
+                {error.status} - {error.statusText}
+              </h3>
+            </Header>
+            {errDetail && (
+              <Body>
+                <p>{errDetail as string}</p>
+              </Body>
+            )}
+          </main>
+        </Layout>
+      </LayoutThirds.Page>
     );
   }
 
@@ -369,11 +372,13 @@ export default function DataDownload() {
   };
 
   return (
-    <SentryDocumentTitle title={t('Download Center')}>
-      <Layout>
-        <main>{renderContent()}</main>
-      </Layout>
-    </SentryDocumentTitle>
+    <LayoutThirds.Page>
+      <SentryDocumentTitle title={t('Download Center')}>
+        <Layout>
+          <main>{renderContent()}</main>
+        </Layout>
+      </SentryDocumentTitle>
+    </LayoutThirds.Page>
   );
 }
 

--- a/static/app/views/disabledMember/index.tsx
+++ b/static/app/views/disabledMember/index.tsx
@@ -1,10 +1,15 @@
 import {NotFound} from 'sentry/components/errors/notFound';
 import {HookOrDefault} from 'sentry/components/hookOrDefault';
+import * as Layout from 'sentry/components/layouts/thirds';
 
 // getsentry will add the view
 const DisabledMemberComponent = HookOrDefault({
   hookName: 'component:disabled-member',
-  defaultComponent: () => <NotFound />,
+  defaultComponent: () => (
+    <Layout.Page withPadding>
+      <NotFound />
+    </Layout.Page>
+  ),
 });
 
 export default DisabledMemberComponent;

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -10,6 +10,7 @@ import {Select} from '@sentry/scraps/select';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {FieldGroup} from 'sentry/components/forms/fieldGroup';
 import {IdBadge} from 'sentry/components/idBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -393,30 +394,32 @@ export default function IntegrationOrganizationLink() {
   }));
 
   return (
-    <NarrowLayout>
-      <SentryDocumentTitle title={t('Choose Installation Organization')} />
-      <h3>{t('Finish integration installation')}</h3>
-      {renderCallout()}
-      <p>
-        {tct(
-          `Please pick a specific [organization:organization] to link with
+    <Layout.Page withPadding>
+      <NarrowLayout>
+        <SentryDocumentTitle title={t('Choose Installation Organization')} />
+        <h3>{t('Finish integration installation')}</h3>
+        {renderCallout()}
+        <p>
+          {tct(
+            `Please pick a specific [organization:organization] to link with
           your integration installation of [integation].`,
-          {
-            organization: <strong />,
-            integation: <strong>{integrationSlug}</strong>,
-          }
-        )}
-      </p>
-      <FieldGroup label={t('Organization')} inline={false} stacked required>
-        <Select
-          onChange={(option: SelectOption<string>) => selectOrganization(option.value)}
-          value={selectedOrgSlug}
-          placeholder={t('Select an organization')}
-          options={options}
-        />
-      </FieldGroup>
-      {renderBottom}
-    </NarrowLayout>
+            {
+              organization: <strong />,
+              integation: <strong>{integrationSlug}</strong>,
+            }
+          )}
+        </p>
+        <FieldGroup label={t('Organization')} inline={false} stacked required>
+          <Select
+            onChange={(option: SelectOption<string>) => selectOrganization(option.value)}
+            value={selectedOrgSlug}
+            placeholder={t('Select an organization')}
+            options={options}
+          />
+        </FieldGroup>
+        {renderBottom}
+      </NarrowLayout>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -7,6 +7,7 @@ import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
 import Hook from 'sentry/components/hook';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LogoSentry} from 'sentry/components/logoSentry';
 import {
   OnboardingContextProvider,
@@ -307,84 +308,86 @@ export function OnboardingWithoutContext() {
   }
 
   return (
-    <Stack as="main" flexGrow={1} data-test-id="targeted-onboarding">
-      <SentryDocumentTitle title={stepObj.title} />
-      <Header>
-        <LogoSvg />
-        {stepIndex !== -1 && (
-          <StyledStepper
-            numSteps={onboardingSteps.length}
-            currentStepIndex={stepIndex}
-            onClick={i => {
-              if (i < stepIndex && shallProjectBeDeleted) {
-                handleGoBack(i);
-                return;
-              }
+    <Layout.Page>
+      <Stack as="main" flexGrow={1} data-test-id="targeted-onboarding">
+        <SentryDocumentTitle title={stepObj.title} />
+        <Header>
+          <LogoSvg />
+          {stepIndex !== -1 && (
+            <StyledStepper
+              numSteps={onboardingSteps.length}
+              currentStepIndex={stepIndex}
+              onClick={i => {
+                if (i < stepIndex && shallProjectBeDeleted) {
+                  handleGoBack(i);
+                  return;
+                }
 
-              goToStep(onboardingSteps[i]!);
-            }}
+                goToStep(onboardingSteps[i]!);
+              }}
+            />
+          )}
+          <UpsellWrapper>
+            <Hook
+              name="onboarding:targeted-onboarding-header"
+              source="targeted-onboarding"
+            />
+          </UpsellWrapper>
+        </Header>
+        <ContainerVariable
+          hasFooter={containerHasFooter}
+          id={stepObj.id}
+          hasNewWelcomeUI={hasNewWelcomeUI}
+        >
+          <AdaptivePageCorners
+            // Controls the current corner variant
+            animateVariant={stepIndex === 0 ? 'top-right' : 'top-left'}
           />
-        )}
-        <UpsellWrapper>
-          <Hook
-            name="onboarding:targeted-onboarding-header"
-            source="targeted-onboarding"
-          />
-        </UpsellWrapper>
-      </Header>
-      <ContainerVariable
-        hasFooter={containerHasFooter}
-        id={stepObj.id}
-        hasNewWelcomeUI={hasNewWelcomeUI}
-      >
-        <AdaptivePageCorners
-          // Controls the current corner variant
-          animateVariant={stepIndex === 0 ? 'top-right' : 'top-left'}
-        />
-        {stepIndex > 0 && (
-          <BackMotionDiv
-            initial="initial"
-            animate="visible"
-            transition={testableTransition()}
-            variants={{
-              initial: {opacity: 0, visibility: 'hidden'},
-              visible: {
-                opacity: 1,
-                transition: testableTransition({delay: 1}),
-                transitionEnd: {
-                  visibility: 'visible',
+          {stepIndex > 0 && (
+            <BackMotionDiv
+              initial="initial"
+              animate="visible"
+              transition={testableTransition()}
+              variants={{
+                initial: {opacity: 0, visibility: 'hidden'},
+                visible: {
+                  opacity: 1,
+                  transition: testableTransition({delay: 1}),
+                  transitionEnd: {
+                    visibility: 'visible',
+                  },
                 },
-              },
-            }}
-          >
-            <Button
-              onClick={() => handleGoBack()}
-              icon={<IconArrow direction="left" />}
-              priority="link"
+              }}
             >
-              {t('Back')}
-            </Button>
-          </BackMotionDiv>
-        )}
-        <AnimatePresence mode="wait" onExitComplete={updateAnimationState}>
-          <OnboardingStepVariable id={stepObj.id} hasNewWelcomeUI={hasNewWelcomeUI}>
-            {stepObj.Component && (
-              <stepObj.Component
-                data-test-id={`onboarding-step-${stepObj.id}`}
-                stepIndex={stepIndex}
-                onComplete={platform => {
-                  if (stepObj) {
-                    goNextStep(stepObj, platform);
-                  }
-                }}
-                recentCreatedProject={recentCreatedProject}
-                genSkipOnboardingLink={genSkipOnboardingLink}
-              />
-            )}
-          </OnboardingStepVariable>
-        </AnimatePresence>
-      </ContainerVariable>
-    </Stack>
+              <Button
+                onClick={() => handleGoBack()}
+                icon={<IconArrow direction="left" />}
+                priority="link"
+              >
+                {t('Back')}
+              </Button>
+            </BackMotionDiv>
+          )}
+          <AnimatePresence mode="wait" onExitComplete={updateAnimationState}>
+            <OnboardingStepVariable id={stepObj.id} hasNewWelcomeUI={hasNewWelcomeUI}>
+              {stepObj.Component && (
+                <stepObj.Component
+                  data-test-id={`onboarding-step-${stepObj.id}`}
+                  stepIndex={stepIndex}
+                  onComplete={platform => {
+                    if (stepObj) {
+                      goNextStep(stepObj, platform);
+                    }
+                  }}
+                  recentCreatedProject={recentCreatedProject}
+                  genSkipOnboardingLink={genSkipOnboardingLink}
+                />
+              )}
+            </OnboardingStepVariable>
+          </AnimatePresence>
+        </ContainerVariable>
+      </Stack>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -10,6 +10,7 @@ import {TextField} from 'sentry/components/forms/fields/textField';
 import {Form} from 'sentry/components/forms/form';
 import type {OnSubmitCallback} from 'sentry/components/forms/types';
 import {HookOrDefault} from 'sentry/components/hookOrDefault';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
@@ -73,95 +74,97 @@ function OrganizationCreate() {
   );
 
   return (
-    <SentryDocumentTitle title={t('Create Organization')}>
-      <NarrowLayout showLogout>
-        <h3>{t('Create a New Organization')}</h3>
-        <p>
-          {t(
-            "Organizations represent the top level in your hierarchy. You'll be able to bundle a collection of teams within an organization as well as give organization-wide permissions to users."
-          )}
-        </p>
+    <Layout.Page withPadding>
+      <SentryDocumentTitle title={t('Create Organization')}>
+        <NarrowLayout showLogout>
+          <h3>{t('Create a New Organization')}</h3>
+          <p>
+            {t(
+              "Organizations represent the top level in your hierarchy. You'll be able to bundle a collection of teams within an organization as well as give organization-wide permissions to users."
+            )}
+          </p>
 
-        <Form
-          initialData={{defaultTeam: true}}
-          submitLabel={t('Create Organization')}
-          apiEndpoint="/organizations/"
-          apiMethod="POST"
-          onSubmit={submitOrganizationCreate}
-          onSubmitSuccess={(createdOrg: OrganizationSummary) => {
-            const hasCustomerDomain =
-              ConfigStore.get('features').has('system:multi-region');
-            let nextUrl = normalizeUrl(
-              `/organizations/${createdOrg.slug}/projects/new/`,
-              {forceCustomerDomain: hasCustomerDomain}
-            );
-            if (hasCustomerDomain) {
-              nextUrl = `${createdOrg.links.organizationUrl}${nextUrl}`;
-            }
-            // redirect to project creation *(BYPASS REACT ROUTER AND FORCE PAGE REFRESH TO GRAB CSRF TOKEN)*
-            // browserHistory.pushState(null, `/organizations/${data.slug}/projects/new/`);
-            testableWindowLocation.assign(nextUrl);
-          }}
-          onSubmitError={error => {
-            addErrorMessage(
-              error.responseJSON?.detail ?? t('Unable to create organization.')
-            );
-          }}
-          requireChanges
-        >
-          <TextField
-            id="organization-name"
-            name="name"
-            label={t('Organization Name')}
-            autoComplete="organization"
-            placeholder={t('e.g. My Company')}
-            inline={false}
-            flexibleControlStateSize
-            stacked
-            required
-          />
-          {shouldDisplayRegions() && (
-            <SelectField
-              name="dataStorageLocation"
-              label={t('Data Storage Location')}
-              help={tct(
-                "Choose where to store your organization's data. Please note, you won't be able to change locations once your organization has been created. [learnMore:Learn More]",
-                {learnMore: <a href={DATA_STORAGE_DOCS_LINK} />}
-              )}
-              choices={regionChoices}
+          <Form
+            initialData={{defaultTeam: true}}
+            submitLabel={t('Create Organization')}
+            apiEndpoint="/organizations/"
+            apiMethod="POST"
+            onSubmit={submitOrganizationCreate}
+            onSubmitSuccess={(createdOrg: OrganizationSummary) => {
+              const hasCustomerDomain =
+                ConfigStore.get('features').has('system:multi-region');
+              let nextUrl = normalizeUrl(
+                `/organizations/${createdOrg.slug}/projects/new/`,
+                {forceCustomerDomain: hasCustomerDomain}
+              );
+              if (hasCustomerDomain) {
+                nextUrl = `${createdOrg.links.organizationUrl}${nextUrl}`;
+              }
+              // redirect to project creation *(BYPASS REACT ROUTER AND FORCE PAGE REFRESH TO GRAB CSRF TOKEN)*
+              // browserHistory.pushState(null, `/organizations/${data.slug}/projects/new/`);
+              testableWindowLocation.assign(nextUrl);
+            }}
+            onSubmitError={error => {
+              addErrorMessage(
+                error.responseJSON?.detail ?? t('Unable to create organization.')
+              );
+            }}
+            requireChanges
+          >
+            <TextField
+              id="organization-name"
+              name="name"
+              label={t('Organization Name')}
+              autoComplete="organization"
+              placeholder={t('e.g. My Company')}
               inline={false}
+              flexibleControlStateSize
               stacked
               required
             />
-          )}
-          {termsUrl && privacyUrl && (
-            <TermsWrapper hasDataConsent={hasDataConsent}>
-              <CheckboxField
-                name="agreeTerms"
-                label={tct(
-                  'I agree to the [termsLink:Terms of Service] and the [privacyLink:Privacy Policy]',
-                  {
-                    termsLink: <ExternalLink href={termsUrl} />,
-                    privacyLink: <ExternalLink href={privacyUrl} />,
-                  }
+            {shouldDisplayRegions() && (
+              <SelectField
+                name="dataStorageLocation"
+                label={t('Data Storage Location')}
+                help={tct(
+                  "Choose where to store your organization's data. Please note, you won't be able to change locations once your organization has been created. [learnMore:Learn More]",
+                  {learnMore: <a href={DATA_STORAGE_DOCS_LINK} />}
                 )}
+                choices={regionChoices}
                 inline={false}
                 stacked
                 required
               />
-            </TermsWrapper>
-          )}
-          <DataConsentCheck />
-          {!isSelfHosted && ConfigStore.get('features').has('relocation:enabled') && (
-            <div>
-              {tct('[relocationLink:Relocating from self-hosted?]', {
-                relocationLink: <a href={relocationUrl} />,
-              })}
-            </div>
-          )}
-        </Form>
-      </NarrowLayout>
-    </SentryDocumentTitle>
+            )}
+            {termsUrl && privacyUrl && (
+              <TermsWrapper hasDataConsent={hasDataConsent}>
+                <CheckboxField
+                  name="agreeTerms"
+                  label={tct(
+                    'I agree to the [termsLink:Terms of Service] and the [privacyLink:Privacy Policy]',
+                    {
+                      termsLink: <ExternalLink href={termsUrl} />,
+                      privacyLink: <ExternalLink href={privacyUrl} />,
+                    }
+                  )}
+                  inline={false}
+                  stacked
+                  required
+                />
+              </TermsWrapper>
+            )}
+            <DataConsentCheck />
+            {!isSelfHosted && ConfigStore.get('features').has('relocation:enabled') && (
+              <div>
+                {tct('[relocationLink:Relocating from self-hosted?]', {
+                  relocationLink: <a href={relocationUrl} />,
+                })}
+              </div>
+            )}
+          </Form>
+        </NarrowLayout>
+      </SentryDocumentTitle>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/organizationJoinRequest/index.tsx
+++ b/static/app/views/organizationJoinRequest/index.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {EmailField} from 'sentry/components/forms/fields/emailField';
 import {Form} from 'sentry/components/forms/form';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {IconMegaphone} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -41,45 +42,49 @@ export default function OrganizationJoinRequest() {
 
   if (submitSuccess) {
     return (
-      <NarrowLayout maxWidth="550px">
-        <SuccessModal>
-          <StyledIconMegaphone size="2xl" />
-          <StyledHeader>{t('Request Sent')}</StyledHeader>
-          <StyledText>{t('Your request to join has been sent.')}</StyledText>
-          <ReceiveEmailMessage>
-            {t('You will receive an email when your request is approved.')}
-          </ReceiveEmailMessage>
-        </SuccessModal>
-      </NarrowLayout>
+      <Layout.Page withPadding>
+        <NarrowLayout maxWidth="550px">
+          <SuccessModal>
+            <StyledIconMegaphone size="2xl" />
+            <StyledHeader>{t('Request Sent')}</StyledHeader>
+            <StyledText>{t('Your request to join has been sent.')}</StyledText>
+            <ReceiveEmailMessage>
+              {t('You will receive an email when your request is approved.')}
+            </ReceiveEmailMessage>
+          </SuccessModal>
+        </NarrowLayout>
+      </Layout.Page>
     );
   }
 
   return (
-    <NarrowLayout maxWidth="650px">
-      <StyledIconMegaphone size="2xl" />
-      <StyledHeader data-test-id="join-request">{t('Request to Join')}</StyledHeader>
-      <StyledText>
-        {tct('Ask the admins if you can join the [orgId] organization.', {
-          orgId,
-        })}
-      </StyledText>
-      <Form
-        requireChanges
-        apiEndpoint={`/organizations/${orgId}/join-request/`}
-        apiMethod="POST"
-        submitLabel={t('Request to Join')}
-        onSubmitSuccess={handleSubmitSuccess}
-        onSubmitError={handleSubmitError}
-        onCancel={handleCancel}
-      >
-        <StyledEmailField
-          name="email"
-          inline={false}
-          label={t('Email Address')}
-          placeholder="name@example.com"
-        />
-      </Form>
-    </NarrowLayout>
+    <Layout.Page withPadding>
+      <NarrowLayout maxWidth="650px">
+        <StyledIconMegaphone size="2xl" />
+        <StyledHeader data-test-id="join-request">{t('Request to Join')}</StyledHeader>
+        <StyledText>
+          {tct('Ask the admins if you can join the [orgId] organization.', {
+            orgId,
+          })}
+        </StyledText>
+        <Form
+          requireChanges
+          apiEndpoint={`/organizations/${orgId}/join-request/`}
+          apiMethod="POST"
+          submitLabel={t('Request to Join')}
+          onSubmitSuccess={handleSubmitSuccess}
+          onSubmitError={handleSubmitError}
+          onCancel={handleCancel}
+        >
+          <StyledEmailField
+            name="email"
+            inline={false}
+            label={t('Email Address')}
+            placeholder="name@example.com"
+          />
+        </Form>
+      </NarrowLayout>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/organizationRestore/index.tsx
+++ b/static/app/views/organizationRestore/index.tsx
@@ -8,6 +8,7 @@ import {Button} from '@sentry/scraps/button';
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {ApiForm} from 'sentry/components/forms/apiForm';
 import {HiddenField} from 'sentry/components/forms/fields/hiddenField';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -22,12 +23,14 @@ import {useParams} from 'sentry/utils/useParams';
 function OrganizationRestore() {
   const params = useParams<{orgId: string}>();
   return (
-    <SentryDocumentTitle title={t('Restore Organization')}>
-      <NarrowLayout>
-        <h3>{t('Deletion Scheduled')}</h3>
-        <OrganizationRestoreBody orgSlug={params.orgId} />
-      </NarrowLayout>
-    </SentryDocumentTitle>
+    <Layout.Page withPadding>
+      <SentryDocumentTitle title={t('Restore Organization')}>
+        <NarrowLayout>
+          <h3>{t('Deletion Scheduled')}</h3>
+          <OrganizationRestoreBody orgSlug={params.orgId} />
+        </NarrowLayout>
+      </SentryDocumentTitle>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/relocation/relocation.tsx
+++ b/static/app/views/relocation/relocation.tsx
@@ -5,6 +5,7 @@ import {AnimatePresence, motion} from 'framer-motion';
 import {Button} from '@sentry/scraps/button';
 import {Stack} from '@sentry/scraps/layout';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {LogoSentry} from 'sentry/components/logoSentry';
@@ -311,18 +312,20 @@ export function RelocationOnboarding() {
   ) : null;
 
   return (
-    <Stack as="main" flexGrow={1} data-test-id="relocation-onboarding">
-      <SentryDocumentTitle title={stepObj.title} />
-      {headerView}
-      <Container>
-        {backButtonView}
-        {contentView}
-        <AdaptivePageCorners
-          animateVariant={stepIndex === 0 ? 'top-right' : 'top-left'}
-        />
-        {errView}
-      </Container>
-    </Stack>
+    <Layout.Page>
+      <Stack as="main" flexGrow={1} data-test-id="relocation-onboarding">
+        <SentryDocumentTitle title={stepObj.title} />
+        {headerView}
+        <Container>
+          {backButtonView}
+          {contentView}
+          <AdaptivePageCorners
+            animateVariant={stepIndex === 0 ? 'top-right' : 'top-left'}
+          />
+          {errView}
+        </Container>
+      </Stack>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/sentryAppExternalInstallation/index.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.tsx
@@ -9,6 +9,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {fetchOrganizations} from 'sentry/actionCreators/organizations';
 import {installSentryApp} from 'sentry/actionCreators/sentryAppInstallations';
 import {FieldGroup} from 'sentry/components/forms/fieldGroup';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryAppDetailsModal} from 'sentry/components/modals/sentryAppDetailsModal';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
@@ -30,12 +31,14 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 // Page Layout
 export default function SentryAppExternalInstallation() {
   return (
-    <NarrowLayout>
-      <Content>
-        <h3>{t('Finish integration installation')}</h3>
-        <SentryAppExternalInstallationContent />
-      </Content>
-    </NarrowLayout>
+    <Layout.Page withPadding>
+      <NarrowLayout>
+        <Content>
+          <h3>{t('Finish integration installation')}</h3>
+          <SentryAppExternalInstallationContent />
+        </Content>
+      </NarrowLayout>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/sharedGroupDetails/index.tsx
+++ b/static/app/views/sharedGroupDetails/index.tsx
@@ -6,6 +6,7 @@ import {Link} from '@sentry/scraps/link';
 import {NotFound} from 'sentry/components/errors/notFound';
 import {BorderlessEventEntries} from 'sentry/components/events/eventEntries';
 import {Footer} from 'sentry/components/footer';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -72,43 +73,45 @@ function SharedGroupDetails() {
   const org = {...group.project.organization, features: []};
 
   return (
-    <SentryDocumentTitle noSuffix title={group?.title ?? 'Sentry'}>
-      <OrganizationContext value={org}>
-        <div className="app">
-          <div className="pattern-bg" />
-          <div className="container">
-            <div className="box box-modal">
-              <div className="box-header">
-                <Link className="logo" to="/">
-                  <span className="icon-sentry-logo-full" />
-                </Link>
-                {group.permalink && (
-                  <Link className="details" to={group.permalink}>
-                    {t('Details')}
+    <Layout.Page>
+      <SentryDocumentTitle noSuffix title={group?.title ?? 'Sentry'}>
+        <OrganizationContext value={org}>
+          <div className="app">
+            <div className="pattern-bg" />
+            <div className="container">
+              <div className="box box-modal">
+                <div className="box-header">
+                  <Link className="logo" to="/">
+                    <span className="icon-sentry-logo-full" />
                   </Link>
-                )}
-              </div>
-              <div className="box-content">
-                <SharedGroupHeader group={group} />
-                <Container
-                  padding="3xl"
-                  className="group-overview event-details-container"
-                >
-                  <BorderlessEventEntries
-                    organization={org}
-                    group={group}
-                    event={group.latestEvent}
-                    project={group.project}
-                    isShare
-                  />
-                </Container>
-                <Footer />
+                  {group.permalink && (
+                    <Link className="details" to={group.permalink}>
+                      {t('Details')}
+                    </Link>
+                  )}
+                </div>
+                <div className="box-content">
+                  <SharedGroupHeader group={group} />
+                  <Container
+                    padding="3xl"
+                    className="group-overview event-details-container"
+                  >
+                    <BorderlessEventEntries
+                      organization={org}
+                      group={group}
+                      event={group.latestEvent}
+                      project={group.project}
+                      isShare
+                    />
+                  </Container>
+                  <Footer />
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </OrganizationContext>
-    </SentryDocumentTitle>
+        </OrganizationContext>
+      </SentryDocumentTitle>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/unsubscribe/issue.tsx
+++ b/static/app/views/unsubscribe/issue.tsx
@@ -5,6 +5,7 @@ import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import {ApiForm} from 'sentry/components/forms/apiForm';
 import {HiddenField} from 'sentry/components/forms/fields/hiddenField';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -21,16 +22,18 @@ function UnsubscribeIssue() {
   const signature = decodeScalar(location.query._);
   const params = useParams();
   return (
-    <SentryDocumentTitle title={t('Issue Notification Unsubscribe')}>
-      <NarrowLayout>
-        <h3>{t('Issue Notification Unsubscribe')}</h3>
-        <UnsubscribeBody
-          signature={signature}
-          orgSlug={params.orgId!}
-          issueId={params.id!}
-        />
-      </NarrowLayout>
-    </SentryDocumentTitle>
+    <Layout.Page withPadding>
+      <SentryDocumentTitle title={t('Issue Notification Unsubscribe')}>
+        <NarrowLayout>
+          <h3>{t('Issue Notification Unsubscribe')}</h3>
+          <UnsubscribeBody
+            signature={signature}
+            orgSlug={params.orgId!}
+            issueId={params.id!}
+          />
+        </NarrowLayout>
+      </SentryDocumentTitle>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/unsubscribe/project.tsx
+++ b/static/app/views/unsubscribe/project.tsx
@@ -4,6 +4,7 @@ import {Alert} from '@sentry/scraps/alert';
 
 import {ApiForm} from 'sentry/components/forms/apiForm';
 import {HiddenField} from 'sentry/components/forms/fields/hiddenField';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -20,16 +21,18 @@ export default function UnsubscribeProject() {
   const signature = decodeScalar(location.query._);
   const params = useParams();
   return (
-    <SentryDocumentTitle title={t('Unsubscribe')}>
-      <NarrowLayout>
-        <h3>{t('Unsubscribe')}</h3>
-        <UnsubscribeBody
-          signature={signature}
-          orgSlug={params.orgId!}
-          issueId={params.id!}
-        />
-      </NarrowLayout>
-    </SentryDocumentTitle>
+    <Layout.Page withPadding>
+      <SentryDocumentTitle title={t('Unsubscribe')}>
+        <NarrowLayout>
+          <h3>{t('Unsubscribe')}</h3>
+          <UnsubscribeBody
+            signature={signature}
+            orgSlug={params.orgId!}
+            issueId={params.id!}
+          />
+        </NarrowLayout>
+      </SentryDocumentTitle>
+    </Layout.Page>
   );
 }
 


### PR DESCRIPTION
## Summary

- Wraps each standalone page route with `Layout.Page` as the outermost content container
- Ensures every route in the standalone-pages group renders a `<main>` element at the top of its render tree
- Leaf fixes only — each component was updated independently with no shared logic changes

## Changes

- `static/app/views/auth/login.tsx` — wrap return in `Layout.Page withPadding`
- `static/app/views/acceptOrganizationInvite/index.tsx` — wrap both error and main returns in `Layout.Page withPadding`
- `static/app/views/acceptProjectTransfer/index.tsx` — wrap return in `Layout.Page withPadding`
- `static/app/views/integrationOrganizationLink/index.tsx` — wrap return in `Layout.Page withPadding`
- `static/app/views/sentryAppExternalInstallation/index.tsx` — wrap return in `Layout.Page withPadding`
- `static/app/views/sharedGroupDetails/index.tsx` — wrap return in `Layout.Page`
- `static/app/views/unsubscribe/project.tsx` — wrap return in `Layout.Page withPadding`
- `static/app/views/unsubscribe/issue.tsx` — wrap return in `Layout.Page withPadding`
- `static/app/views/organizationCreate/index.tsx` — wrap return in `Layout.Page withPadding`
- `static/app/views/dataExport/dataDownload.tsx` — wrap both error and main returns in `LayoutThirds.Page`
- `static/app/views/disabledMember/index.tsx` — wrap default component render in `Layout.Page withPadding`
- `static/app/views/organizationRestore/index.tsx` — wrap return in `Layout.Page withPadding`
- `static/app/views/organizationJoinRequest/index.tsx` — wrap both success and main returns in `Layout.Page withPadding`
- `static/app/views/relocation/relocation.tsx` — wrap return in `Layout.Page`
- `static/app/views/onboarding/onboarding.tsx` — wrap return in `Layout.Page`

## Affected routes

| Path | Component | Strategy |
|------|-----------|----------|
| `/auth/login/` | `auth/login.tsx` | leaf fix |
| `/accept/:orgId/:memberId/:token/` and `/accept/:memberId/:token/` | `acceptOrganizationInvite/index.tsx` | leaf fix |
| `/accept-transfer/` | `acceptProjectTransfer/index.tsx` | leaf fix |
| `/extensions/external-install/:integrationSlug/:installationId` and `/extensions/:integrationSlug/link/` | `integrationOrganizationLink/index.tsx` | leaf fix |
| `/sentry-apps/:sentryAppSlug/external-install/` | `sentryAppExternalInstallation/index.tsx` | leaf fix |
| `/share/issue/:shareId/` and `/organizations/:orgId/share/issue/:shareId/` | `sharedGroupDetails/index.tsx` | leaf fix |
| `/unsubscribe/project/:id/` and `/unsubscribe/:orgId/project/:id/` | `unsubscribe/project.tsx` | leaf fix |
| `/unsubscribe/issue/:id/` and `/unsubscribe/:orgId/issue/:id/` | `unsubscribe/issue.tsx` | leaf fix |
| `/organizations/new/` | `organizationCreate/index.tsx` | leaf fix |
| `/organizations/:orgId/data-export/:dataExportId` | `dataExport/dataDownload.tsx` | leaf fix |
| `/organizations/:orgId/disabled-member/` | `disabledMember/index.tsx` | leaf fix |
| `/restore/` and `/organizations/:orgId/restore/` | `organizationRestore/index.tsx` | leaf fix |
| `/join-request/` and `/join-request/:orgId/` | `organizationJoinRequest/index.tsx` | leaf fix |
| `/relocation/:step/` | `relocation/relocation.tsx` | leaf fix |
| `/onboarding/:orgId/:step/` | `onboarding/onboarding.tsx` | leaf fix |

## Verification checklist

- [ ] Each route renders `Layout.Page` (a `<main>` element) as the outermost content container
- [ ] `withPadding` is used on simple content/form pages without inner `Layout.Body`/`Layout.Main` structure
- [ ] No logic, props, state, or styling was changed — structural wrapping only
- [ ] All pre-commit hooks pass (eslint, stylelint, format)