### PR TITLE
fix(aci): There was a bug that `Rule` was being used, but only imported as a type

### DIFF
--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, NamedTuple, TypedDict
+from typing import NamedTuple, TypedDict
 
 from django.db import connection
 from django.db.models import Count, Max, OuterRef, Subquery
@@ -11,14 +11,12 @@ from django.db.models.functions import TruncHour
 
 from sentry.api.paginator import GenericOffsetPaginator, OffsetPaginator
 from sentry.models.group import Group
+from sentry.models.rule import Rule
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.history.base import RuleGroupHistory, RuleHistoryBackend, TimeSeriesValue
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.workflow_engine.models import AlertRuleWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
-
-if TYPE_CHECKING:
-    from sentry.models.rule import Rule
 
 logger = logging.getLogger(__name__)
 
@@ -255,7 +253,10 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         return existing_data
 
     def fetch_rule_hourly_stats(
-        self, target: Rule | Workflow, start: datetime, end: datetime
+        self,
+        target: Rule | Workflow,
+        start: datetime,
+        end: datetime,
     ) -> Sequence[TimeSeriesValue]:
         start = start.replace(tzinfo=timezone.utc)
         end = end.replace(tzinfo=timezone.utc)


### PR DESCRIPTION
# Description
`fetch_rule_hourly_stats` is using `Rule` in code: `if not workflow_id and isinstance(target, Rule):` but was only imported as a type.

This caused: https://sentry.sentry.io/issues/7357647430/events/711a705060e04fe2beac98a8c5e76178/?project=1&referrer=issue-list&statsPeriod=24h

also, causes this bug in the ui:
<img width="1624" height="1061" alt="Screenshot 2026-03-26 at 10 06 02 AM" src="https://github.com/user-attachments/assets/19c80037-7e34-434b-823c-8e09ef05a894" />