### PR TITLE
ci: Optimize CI pipeline with caching, concurrency, and conditional steps

### DIFF
--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -7,6 +7,11 @@ on:
   schedule:
     - cron: '0,30 * * * *'
 
+# Prevent overlapping coverage runs from stacking up (e.g. schedule + workflow_call).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 env:
   SENTRY_SKIP_SELENIUM_PLUGIN: '1'
 
@@ -98,7 +103,15 @@ jobs:
         with:
           mode: backend-ci
 
+      - name: Cache odiff binary
+        id: odiff-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: /usr/local/bin/odiff
+          key: odiff-bin-4.3.2-linux-x64
+
       - name: Download odiff binary
+        if: steps.odiff-cache.outputs.cache-hit != 'true'
         run: |
           curl -sL https://registry.npmjs.org/odiff-bin/-/odiff-bin-4.3.2.tgz \
             | tar -xz --strip-components=2 package/raw_binaries/odiff-linux-x64

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -286,7 +286,15 @@ jobs:
         with:
           mode: backend-ci
 
+      - name: Cache odiff binary
+        id: odiff-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: /usr/local/bin/odiff
+          key: odiff-bin-4.3.2-linux-x64
+
       - name: Download odiff binary
+        if: steps.odiff-cache.outputs.cache-hit != 'true'
         run: |
           curl -sL https://registry.npmjs.org/odiff-bin/-/odiff-bin-4.3.2.tgz \
             | tar -xz --strip-components=2 package/raw_binaries/odiff-linux-x64

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -3,6 +3,12 @@ name: Enforce License Compliance
 on:
   pull_request:
 
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   enforce-license-compliance:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -42,11 +42,13 @@ jobs:
           path: sentry-api-schema
 
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
+        if: steps.changes.outputs.api_docs == 'true'
         id: setup-node
         with:
           node-version-file: '.node-version'
 
       - uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19 # v4
+        if: steps.changes.outputs.api_docs == 'true'
       - name: Build OpenAPI Derefed JSON
         if: steps.changes.outputs.api_docs == 'true'
         run: |

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -51,6 +51,7 @@ jobs:
           node-version-file: '.node-version'
 
       - uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19 # v4
+        if: steps.changes.outputs.api_docs == 'true'
       - name: Build OpenAPI Derefed JSON
         if: steps.changes.outputs.api_docs == 'true'
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reduce wasted CI compute across several workflows with three categories of optimization:

**Cache odiff binary across backend test shards** (`backend.yml`, `backend-with-coverage.yml`)

Every backend test shard (up to 22 on full runs) and every coverage shard independently downloads the same `odiff-bin-4.3.2` tarball from npm. This adds an `actions/cache` step keyed by version so only the first shard in a run actually downloads the binary — subsequent shards get a cache hit. This eliminates 21+ redundant network requests per CI run and removes a failure mode where npm registry issues could break unrelated test shards.

**Add missing concurrency groups** (`enforce-license-compliance.yml`, `backend-with-coverage.yml`)

- `enforce-license-compliance.yml` runs on every PR push but had no concurrency group, so rapid pushes (common during review iterations) created overlapping FOSSA runs that burned runner minutes for superseded commits. Added the same `workflow-headref` pattern used by all other PR workflows with `cancel-in-progress: true`.

- `backend-with-coverage.yml` runs on a 30-minute cron, `workflow_call`, and `workflow_dispatch` but had no concurrency group. If a scheduled run overlaps with a dispatch (or two cron triggers stack), multiple full test suites run for the same commit. Added a concurrency group keyed by SHA with `cancel-in-progress: false` to let the first run complete while preventing duplicates. The existing "skip if coverage exists" check already handles the data layer, but this prevents the wasted compute of spinning up shards only to discover coverage already exists partway through.

**Gate unconditional Node/pnpm setup behind path filter** (`openapi.yml`, `openapi-diff.yml`)

In `openapi.yml`, the `pnpm/action-setup` step ran unconditionally on every master push even when no `api_docs` files changed. In `openapi-diff.yml`, both `actions/setup-node` and `pnpm/action-setup` ran unconditionally on every PR. These steps download and configure Node.js and pnpm unnecessarily. Gated them behind the existing `api_docs` path filter check.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68fc2148-39c0-4800-add4-cd299bd80e6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68fc2148-39c0-4800-add4-cd299bd80e6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

