### PR TITLE
ci(snapshots): Bump sentry-cli from 3.3.3 to 3.3.4

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install sentry-cli
         if: ${{ !cancelled() }}
-        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.3.3 sh
+        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.3.4 sh
 
       - name: Upload snapshots
         id: upload


### PR DESCRIPTION
Bumps sentry-cli from 3.3.3 to 3.3.4 in the frontend snapshots workflow.