### PR TITLE
fix(preprod): Differentiate snapshot status check when base_sha is unset

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -21,6 +21,7 @@ from sentry.preprod.vcs.status_checks.size.tasks import (
 )
 from sentry.preprod.vcs.status_checks.snapshots.templates import (
     format_first_snapshot_status_check_messages,
+    format_generated_snapshot_status_check_messages,
     format_missing_base_snapshot_status_check_messages,
     format_snapshot_status_check_messages,
 )
@@ -168,10 +169,15 @@ def create_preprod_snapshot_status_check_task(
                 all_artifacts,
                 snapshot_metrics_map,
             )
-        else:
-            # TODO(EME-921) Add logic to fail if there's any base_sha set but no base artifact
-            status = StatusCheckStatus.SUCCESS
+        elif commit_comparison.base_sha:
+            status = StatusCheckStatus.FAILURE
             title, subtitle, summary = format_missing_base_snapshot_status_check_messages(
+                all_artifacts,
+                snapshot_metrics_map,
+            )
+        else:
+            status = StatusCheckStatus.SUCCESS
+            title, subtitle, summary = format_generated_snapshot_status_check_messages(
                 all_artifacts,
                 snapshot_metrics_map,
             )

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -140,6 +140,32 @@ def format_first_snapshot_status_check_messages(
     return str(title), str(subtitle), str(summary)
 
 
+def format_generated_snapshot_status_check_messages(
+    artifacts: list[PreprodArtifact],
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
+) -> tuple[str, str, str]:
+    if not artifacts:
+        raise ValueError("Cannot format messages for empty artifact list")
+
+    title = _SNAPSHOT_TITLE_BASE
+
+    total_images = 0
+    for artifact in artifacts:
+        metrics = snapshot_metrics_map.get(artifact.id)
+        if metrics:
+            total_images += metrics.image_count
+
+    subtitle = ngettext(
+        "Generated %(count)d snapshot",
+        "Generated %(count)d snapshots",
+        total_images,
+    ) % {"count": total_images}
+
+    summary = _format_solo_snapshot_summary(artifacts, snapshot_metrics_map)
+
+    return str(title), str(subtitle), str(summary)
+
+
 def format_missing_base_snapshot_status_check_messages(
     artifacts: list[PreprodArtifact],
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -8,6 +8,7 @@ from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.vcs.status_checks.snapshots.templates import (
     format_first_snapshot_status_check_messages,
+    format_generated_snapshot_status_check_messages,
     format_missing_base_snapshot_status_check_messages,
     format_snapshot_status_check_messages,
 )
@@ -748,6 +749,82 @@ class SnapshotFirstUploadFormattingTest(SnapshotStatusCheckTestBase):
             "| :--- | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app` | 15 | ✅ Uploaded |"
             "\n\nThis looks like your first snapshot upload. Snapshot diffs will appear when we have a base upload to compare against. Make sure to upload snapshots from your main branch."
+        )
+        assert summary == expected
+
+
+@cell_silo_test
+class SnapshotGeneratedFormattingTest(SnapshotStatusCheckTestBase):
+    def test_generated_single_artifact(self):
+        artifact, metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", app_name="My App", image_count=24
+        )
+        snapshot_metrics_map = {artifact.id: metrics}
+
+        title, subtitle, summary = format_generated_snapshot_status_check_messages(
+            [artifact], snapshot_metrics_map
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "Generated 24 snapshots"
+        assert "My App" in summary
+        assert "24" in summary
+        assert "✅ Uploaded" in summary
+
+    def test_generated_multiple_artifacts(self):
+        artifacts = []
+        snapshot_metrics_map: dict[int, PreprodSnapshotMetrics] = {}
+
+        for i in range(3):
+            artifact, metrics = self._create_artifact_with_metrics(
+                app_id=f"com.example.app{i}",
+                build_number=i + 1,
+                image_count=10,
+            )
+            artifacts.append(artifact)
+            snapshot_metrics_map[artifact.id] = metrics
+
+        title, subtitle, summary = format_generated_snapshot_status_check_messages(
+            artifacts, snapshot_metrics_map
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "Generated 30 snapshots"
+        for i in range(3):
+            assert f"com.example.app{i}" in summary
+
+    def test_generated_single_snapshot_singular(self):
+        artifact, metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", image_count=1
+        )
+        snapshot_metrics_map = {artifact.id: metrics}
+
+        _, subtitle, _ = format_generated_snapshot_status_check_messages(
+            [artifact], snapshot_metrics_map
+        )
+
+        assert subtitle == "Generated 1 snapshot"
+
+    def test_generated_empty_artifacts_raises(self):
+        with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
+            format_generated_snapshot_status_check_messages([], {})
+
+    def test_generated_summary_table_format(self):
+        artifact, metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", app_name="My App", image_count=15
+        )
+        snapshot_metrics_map = {artifact.id: metrics}
+
+        _, _, summary = format_generated_snapshot_status_check_messages(
+            [artifact], snapshot_metrics_map
+        )
+
+        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{artifact.id}"
+
+        expected = (
+            "| Name | Snapshots | Status |\n"
+            "| :--- | :---: | :---: |\n"
+            f"| [My App]({artifact_url})<br>`com.example.app` | 15 | ✅ Uploaded |"
         )
         assert summary == expected
 


### PR DESCRIPTION
When no base artifact is found and it's not the first upload, the snapshot
status check previously always showed "No base snapshots found" regardless
of whether a `base_sha` was actually specified. This was incorrect for main
branch pushes (no `base_sha`), which should show a happy-path message.

Now the code branches on `commit_comparison.base_sha`:
- **Set** (PR scenario, base expected but not found): `FAILURE` status with
  "No base snapshots found" message
- **Unset** (main branch push, no base expected): `SUCCESS` status with
  "Generated N snapshots" message

Adds `format_generated_snapshot_status_check_messages` template function
and corresponding tests.

Closes EME-921