### PR TITLE
feat(preprod): Improve Slack alert messages for size analysis monitors

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, NotRequired, TypeAlias, TypedDict
 from uuid import uuid4
 
 from sentry.exceptions import InvalidSearchQuery
-from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.issues.grouptype import GroupCategory, GroupType, NotificationConfig
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.preprod.artifact_search import artifact_matches_query
 from sentry.types.group import PriorityLevel
@@ -59,6 +59,104 @@ def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
     tags["artifact_id"] = str(artifact.id)
 
     return tags
+
+
+_OPERATOR_SYMBOLS: dict[str, str] = {
+    "gte": "≥",
+    "gt": ">",
+    "lte": "≤",
+    "lt": "<",
+    "eq": "=",
+    "ne": "≠",
+}
+
+_THRESHOLD_TYPE_LABELS: dict[str, str] = {
+    "absolute_diff": "Absolute Diff",
+    "relative_diff": "Relative Diff",
+    "absolute": "Absolute Size",
+}
+
+
+def _get_measurement_label(measurement: str, platform: str) -> str:
+    """Get platform-aware display label for a measurement type.
+
+    On Android, install_size is called "Uncompressed Size".
+    On iOS/apple, install_size is called "Install Size".
+    """
+    if measurement == "install_size":
+        return "Uncompressed Size" if platform == "android" else "Install Size"
+    if measurement == "download_size":
+        return "Download Size"
+    return measurement.replace("_", " ").title()
+
+
+def _build_evidence_text(
+    detector_config: dict[str, Any],
+    evaluation_result: ProcessedDataConditionGroup,
+    data_packet: SizeAnalysisDataPacket,
+    platform: str,
+) -> str:
+    """Build a human-readable evidence string for Slack/Jira notifications.
+
+    Output format:
+        Measurement: Install Size
+        Threshold: Absolute Diff ≥ 1.0 MB
+        Size: 45.2 MB → 47.5 MB (+2.3 MB)
+    """
+    from sentry.preprod.utils import format_bytes_base10
+
+    measurement = detector_config["measurement"]
+    threshold_type = detector_config["threshold_type"]
+
+    # Line 1: Measurement
+    measurement_label = _get_measurement_label(measurement, platform)
+    lines = [f"Measurement: {measurement_label}"]
+
+    # Line 2: Threshold (metric type + operator + value)
+    if evaluation_result.condition_results:
+        condition = evaluation_result.condition_results[0].condition
+        operator_symbol = _OPERATOR_SYMBOLS.get(condition.type, condition.type)
+        threshold_label = _THRESHOLD_TYPE_LABELS.get(threshold_type, threshold_type)
+
+        if threshold_type == "relative_diff":
+            comparison_value = condition.comparison
+            if isinstance(comparison_value, float) and comparison_value < 1:
+                formatted_value = f"{comparison_value * 100:g}%"
+            else:
+                formatted_value = f"{comparison_value}%"
+        else:
+            formatted_value = format_bytes_base10(int(condition.comparison))
+
+        lines.append(f"Threshold: {threshold_label} {operator_symbol} {formatted_value}")
+
+    # Line 3: Size
+    match measurement:
+        case "install_size":
+            head_bytes = data_packet.packet["head_install_size_bytes"]
+            base_bytes = data_packet.packet.get("base_install_size_bytes")
+        case "download_size":
+            head_bytes = data_packet.packet["head_download_size_bytes"]
+            base_bytes = data_packet.packet.get("base_download_size_bytes")
+        case _:
+            head_bytes = 0
+            base_bytes = None
+
+    head_formatted = format_bytes_base10(head_bytes)
+
+    if threshold_type == "absolute" or base_bytes is None:
+        lines.append(f"Size: {head_formatted}")
+    else:
+        base_formatted = format_bytes_base10(base_bytes)
+        if threshold_type == "relative_diff":
+            pct = ((head_bytes - base_bytes) / base_bytes) * 100 if base_bytes else 0
+            lines.append(f"Size: {base_formatted} → {head_formatted} (+{pct:.1f}%)")
+        else:
+            delta = head_bytes - base_bytes
+            delta_formatted = format_bytes_base10(abs(delta))
+            sign = "+" if delta >= 0 else "-"
+            lines.append(f"Size: {base_formatted} → {head_formatted} ({sign}{delta_formatted})")
+
+    return "\n".join(lines)
 
 
 class SizeAnalysisMetadata(TypedDict):
@@ -252,14 +350,18 @@ class PreprodSizeAnalysisDetectorHandler(
                 if commit_comparison.pr_number is not None:
                     tags["git.pr_number"] = str(commit_comparison.pr_number)
 
+        evidence_text = _build_evidence_text(
+            self.detector.config, evaluation_result, data_packet, platform
+        )
+
         occurrence = DetectorOccurrence(
             issue_title=issue_title,
             subtitle="A preprod static analysis issue was detected",
             evidence_data=evidence_data,
             evidence_display=[
                 IssueEvidence(
-                    name="Source",
-                    value=data_packet.source_id,
+                    name="Size Analysis",
+                    value=evidence_text,
                     important=True,
                 )
             ],
@@ -299,6 +401,10 @@ class PreprodSizeAnalysisGroupType(GroupType):
     released = False
     enable_auto_resolve = True
     enable_escalation_detection = False
+    notification_config = NotificationConfig(
+        context=[],
+        text_code_formatted=False,
+    )
     detector_settings = DetectorSettings(
         handler=PreprodSizeAnalysisDetectorHandler,
         validator=PreprodSizeAnalysisDetectorValidator,

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -105,11 +105,7 @@ def _build_evidence_text(
         threshold_label = _THRESHOLD_TYPE_LABELS.get(threshold_type, threshold_type)
 
         if threshold_type == "relative_diff":
-            comparison_value = condition.comparison
-            if isinstance(comparison_value, float) and comparison_value < 1:
-                formatted_threshold = f"{comparison_value * 100:g}%"
-            else:
-                formatted_threshold = f"{comparison_value}%"
+            formatted_threshold = f"{condition.comparison}%"
         else:
             formatted_threshold = format_bytes_base10(int(condition.comparison))
 

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -61,15 +61,6 @@ def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
     return tags
 
 
-_OPERATOR_SYMBOLS: dict[str, str] = {
-    "gte": "≥",
-    "gt": ">",
-    "lte": "≤",
-    "lt": "<",
-    "eq": "=",
-    "ne": "≠",
-}
-
 _THRESHOLD_TYPE_LABELS: dict[str, str] = {
     "absolute_diff": "Absolute Diff",
     "relative_diff": "Relative Diff",
@@ -96,40 +87,35 @@ def _build_evidence_text(
     data_packet: SizeAnalysisDataPacket,
     platform: str,
 ) -> str:
-    """Build a human-readable evidence string for Slack/Jira notifications.
+    """Build a single-line evidence string for Slack/Jira notifications.
 
-    Output format:
-        Measurement: Install Size
-        Threshold: Absolute Diff ≥ 1.0 MB
-        Size: 45.2 MB → 47.5 MB (+2.3 MB)
+    Format: {measurement}, {threshold_type} > {threshold_value} ({actual_value})
+    Example: Install Size, Absolute Diff > 1.0 MB (+1.0 MB)
     """
     from sentry.preprod.utils import format_bytes_base10
 
     measurement = detector_config["measurement"]
     threshold_type = detector_config["threshold_type"]
-
-    # Line 1: Measurement
     measurement_label = _get_measurement_label(measurement, platform)
-    lines = [f"Measurement: {measurement_label}"]
 
-    # Line 2: Threshold (metric type + operator + value)
+    # Threshold: type > value
+    threshold_part = ""
     if evaluation_result.condition_results:
         condition = evaluation_result.condition_results[0].condition
-        operator_symbol = _OPERATOR_SYMBOLS.get(condition.type, condition.type)
         threshold_label = _THRESHOLD_TYPE_LABELS.get(threshold_type, threshold_type)
 
         if threshold_type == "relative_diff":
             comparison_value = condition.comparison
             if isinstance(comparison_value, float) and comparison_value < 1:
-                formatted_value = f"{comparison_value * 100:g}%"
+                formatted_threshold = f"{comparison_value * 100:g}%"
             else:
-                formatted_value = f"{comparison_value}%"
+                formatted_threshold = f"{comparison_value}%"
         else:
-            formatted_value = format_bytes_base10(int(condition.comparison))
+            formatted_threshold = format_bytes_base10(int(condition.comparison))
 
-        lines.append(f"Threshold: {threshold_label} {operator_symbol} {formatted_value}")
+        threshold_part = f", {threshold_label} > {formatted_threshold}"
 
-    # Line 3: Size
+    # Actual value
     match measurement:
         case "install_size":
             head_bytes = data_packet.packet["head_install_size_bytes"]
@@ -141,22 +127,18 @@ def _build_evidence_text(
             head_bytes = 0
             base_bytes = None
 
-    head_formatted = format_bytes_base10(head_bytes)
-
     if threshold_type == "absolute" or base_bytes is None:
-        lines.append(f"Size: {head_formatted}")
+        actual_value = format_bytes_base10(head_bytes)
+    elif threshold_type == "relative_diff":
+        pct = ((head_bytes - base_bytes) / base_bytes) * 100 if base_bytes else 0
+        actual_value = f"+{pct:.1f}%"
     else:
-        base_formatted = format_bytes_base10(base_bytes)
-        if threshold_type == "relative_diff":
-            pct = ((head_bytes - base_bytes) / base_bytes) * 100 if base_bytes else 0
-            lines.append(f"Size: {base_formatted} → {head_formatted} (+{pct:.1f}%)")
-        else:
-            delta = head_bytes - base_bytes
-            delta_formatted = format_bytes_base10(abs(delta))
-            sign = "+" if delta >= 0 else "-"
-            lines.append(f"Size: {base_formatted} → {head_formatted} ({sign}{delta_formatted})")
+        delta = head_bytes - base_bytes
+        delta_formatted = format_bytes_base10(abs(delta))
+        sign = "+" if delta >= 0 else "-"
+        actual_value = f"{sign}{delta_formatted}"
 
-    return "\n".join(lines)
+    return f"{measurement_label}{threshold_part} ({actual_value})"
 
 
 class SizeAnalysisMetadata(TypedDict):

--- a/src/sentry/preprod/utils.py
+++ b/src/sentry/preprod/utils.py
@@ -33,3 +33,21 @@ def parse_release_version(release_version: str) -> ParsedReleaseVersion | None:
         return ParsedReleaseVersion(app_id=app_id, build_version=build_version)
 
     return None
+
+
+def format_bytes_base10(size_bytes: int) -> str:
+    """Format file size using decimal (base-10) units. Matches the frontend implementation of formatBytesBase10."""
+    units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+    threshold = 1000
+
+    if size_bytes < threshold:
+        return f"{size_bytes} {units[0]}"
+
+    u = 0
+    number = float(size_bytes)
+    max_unit = len(units) - 1
+    while number >= threshold and u < max_unit:
+        number /= threshold
+        u += 1
+
+    return f"{number:.1f} {units[u]}"

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -575,17 +575,6 @@ def _format_file_size(size_bytes: int | None) -> str:
 
 def _format_bytes_base10(size_bytes: int) -> str:
     """Format file size using decimal (base-10) units. Matches the frontend implementation of formatBytesBase10."""
-    units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
-    threshold = 1000
+    from sentry.preprod.utils import format_bytes_base10
 
-    if size_bytes < threshold:
-        return f"{size_bytes} {units[0]}"
-
-    u = 0
-    number = float(size_bytes)
-    max_unit = len(units) - 1
-    while number >= threshold and u < max_unit:
-        number /= threshold
-        u += 1
-
-    return f"{number:.1f} {units[u]}"
+    return format_bytes_base10(size_bytes)

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -568,13 +568,8 @@ def _calculate_size_change(head_size: int | None, base_size: int | None) -> str:
 
 def _format_file_size(size_bytes: int | None) -> str:
     """Format file size with null handling for display in templates."""
-    if size_bytes is None:
-        return "Unknown"
-    return _format_bytes_base10(size_bytes)
-
-
-def _format_bytes_base10(size_bytes: int) -> str:
-    """Format file size using decimal (base-10) units. Matches the frontend implementation of formatBytesBase10."""
     from sentry.preprod.utils import format_bytes_base10
 
+    if size_bytes is None:
+        return "Unknown"
     return format_bytes_base10(size_bytes)

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -800,3 +801,164 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert event_data["platform"] == "unknown"
         assert event_data["tags"] == {}
         assert occurrence.evidence_data == {"detector_id": detector.id}
+
+
+@cell_silo_test
+class PreprodSizeAnalysisEvidenceTextTest(TestCase):
+    """Tests for the evidence display text formatting in Slack/Jira notifications."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+
+    def _create_condition(self, condition_type, comparison):
+        self.create_data_condition(
+            condition_group=self.condition_group,
+            type=condition_type,
+            comparison=comparison,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+
+    def _evaluate(
+        self,
+        threshold_type,
+        measurement,
+        head_install,
+        head_download,
+        metadata=None,
+        base_install=None,
+        base_download=None,
+    ):
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": threshold_type, "measurement": measurement},
+            workflow_condition_group=self.condition_group,
+        )
+        packet_data: dict[str, Any] = {
+            "head_install_size_bytes": head_install,
+            "head_download_size_bytes": head_download,
+        }
+        if base_install is not None:
+            packet_data["base_install_size_bytes"] = base_install
+        if base_download is not None:
+            packet_data["base_download_size_bytes"] = base_download
+        if metadata is not None:
+            packet_data["metadata"] = metadata
+
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test-source",
+            packet=packet_data,
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        result = handler.evaluate(data_packet)
+        assert None in result
+        occurrence = result[None].result
+        assert isinstance(occurrence, IssueOccurrence)
+        return occurrence
+
+    def test_evidence_absolute_install_size(self):
+        self._create_condition(Condition.GREATER, 1000000)
+        occurrence = self._evaluate(
+            "absolute",
+            "install_size",
+            head_install=5000000,
+            head_download=3000000,
+        )
+        evidence = occurrence.evidence_display[0]
+        assert evidence.name == "Size Analysis"
+        assert evidence.important is True
+        lines = evidence.value.split("\n")
+        assert lines[0] == "Measurement: Install Size"
+        assert lines[1] == "Threshold: Absolute Size > 1.0 MB"
+        assert lines[2] == "Size: 5.0 MB"
+
+    def test_evidence_absolute_diff_install_size(self):
+        self._create_condition(Condition.GREATER_OR_EQUAL, 500000)
+        occurrence = self._evaluate(
+            "absolute_diff",
+            "install_size",
+            head_install=5000000,
+            head_download=3000000,
+            base_install=4000000,
+            base_download=2500000,
+        )
+        evidence = occurrence.evidence_display[0]
+        lines = evidence.value.split("\n")
+        assert lines[0] == "Measurement: Install Size"
+        assert lines[1] == "Threshold: Absolute Diff ≥ 500.0 KB"
+        assert lines[2] == "Size: 4.0 MB → 5.0 MB (+1.0 MB)"
+
+    def test_evidence_relative_diff_download_size(self):
+        self._create_condition(Condition.GREATER_OR_EQUAL, 0.05)
+        occurrence = self._evaluate(
+            "relative_diff",
+            "download_size",
+            head_install=5000000,
+            head_download=3000000,
+            base_install=4000000,
+            base_download=2500000,
+        )
+        evidence = occurrence.evidence_display[0]
+        lines = evidence.value.split("\n")
+        assert lines[0] == "Measurement: Download Size"
+        assert lines[1] == "Threshold: Relative Diff ≥ 5%"
+        assert lines[2] == "Size: 2.5 MB → 3.0 MB (+20.0%)"
+
+    def _make_metadata(self, platform: str, artifact_type: int) -> dict[str, Any]:
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            app_id="com.example.app",
+            artifact_type=artifact_type,
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            app_id="com.example.app",
+            artifact_type=artifact_type,
+        )
+        head_artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "commit_comparison"
+        ).get(id=head_artifact.id)
+        base_artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "commit_comparison"
+        ).get(id=base_artifact.id)
+        return {
+            "platform": platform,
+            "head_metric_id": 1,
+            "base_metric_id": 2,
+            "head_artifact_id": head_artifact.id,
+            "base_artifact_id": base_artifact.id,
+            "head_artifact": head_artifact,
+            "base_artifact": base_artifact,
+        }
+
+    def test_evidence_android_shows_uncompressed_size(self):
+        self._create_condition(Condition.GREATER, 1000000)
+        metadata = self._make_metadata("android", PreprodArtifact.ArtifactType.APK)
+        occurrence = self._evaluate(
+            "absolute",
+            "install_size",
+            head_install=5000000,
+            head_download=3000000,
+            metadata=metadata,
+        )
+        evidence = occurrence.evidence_display[0]
+        lines = evidence.value.split("\n")
+        assert lines[0] == "Measurement: Uncompressed Size"
+
+    def test_evidence_apple_shows_install_size(self):
+        self._create_condition(Condition.GREATER, 1000000)
+        metadata = self._make_metadata("apple", PreprodArtifact.ArtifactType.XCARCHIVE)
+        occurrence = self._evaluate(
+            "absolute",
+            "install_size",
+            head_install=5000000,
+            head_download=3000000,
+            metadata=metadata,
+        )
+        evidence = occurrence.evidence_display[0]
+        lines = evidence.value.split("\n")
+        assert lines[0] == "Measurement: Install Size"

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -871,10 +871,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
         evidence = occurrence.evidence_display[0]
         assert evidence.name == "Size Analysis"
         assert evidence.important is True
-        lines = evidence.value.split("\n")
-        assert lines[0] == "Measurement: Install Size"
-        assert lines[1] == "Threshold: Absolute Size > 1.0 MB"
-        assert lines[2] == "Size: 5.0 MB"
+        assert evidence.value == "Install Size, Absolute Size > 1.0 MB (5.0 MB)"
 
     def test_evidence_absolute_diff_install_size(self):
         self._create_condition(Condition.GREATER_OR_EQUAL, 500000)
@@ -887,10 +884,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
             base_download=2500000,
         )
         evidence = occurrence.evidence_display[0]
-        lines = evidence.value.split("\n")
-        assert lines[0] == "Measurement: Install Size"
-        assert lines[1] == "Threshold: Absolute Diff ≥ 500.0 KB"
-        assert lines[2] == "Size: 4.0 MB → 5.0 MB (+1.0 MB)"
+        assert evidence.value == "Install Size, Absolute Diff > 500.0 KB (+1.0 MB)"
 
     def test_evidence_relative_diff_download_size(self):
         self._create_condition(Condition.GREATER_OR_EQUAL, 0.05)
@@ -903,10 +897,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
             base_download=2500000,
         )
         evidence = occurrence.evidence_display[0]
-        lines = evidence.value.split("\n")
-        assert lines[0] == "Measurement: Download Size"
-        assert lines[1] == "Threshold: Relative Diff ≥ 5%"
-        assert lines[2] == "Size: 2.5 MB → 3.0 MB (+20.0%)"
+        assert evidence.value == "Download Size, Relative Diff > 5% (+20.0%)"
 
     def _make_metadata(self, platform: str, artifact_type: int) -> dict[str, Any]:
         head_artifact = self.create_preprod_artifact(
@@ -946,8 +937,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
             metadata=metadata,
         )
         evidence = occurrence.evidence_display[0]
-        lines = evidence.value.split("\n")
-        assert lines[0] == "Measurement: Uncompressed Size"
+        assert evidence.value == "Uncompressed Size, Absolute Size > 1.0 MB (5.0 MB)"
 
     def test_evidence_apple_shows_install_size(self):
         self._create_condition(Condition.GREATER, 1000000)
@@ -960,5 +950,4 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
             metadata=metadata,
         )
         evidence = occurrence.evidence_display[0]
-        lines = evidence.value.split("\n")
-        assert lines[0] == "Measurement: Install Size"
+        assert evidence.value == "Install Size, Absolute Size > 1.0 MB (5.0 MB)"

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -12,6 +12,7 @@ from sentry.preprod.size_analysis.grouptype import (
     PreprodSizeAnalysisDetectorValidator,
     PreprodSizeAnalysisGroupType,
     SizeAnalysisDataPacket,
+    SizeAnalysisValue,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
@@ -838,7 +839,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
             config={"threshold_type": threshold_type, "measurement": measurement},
             workflow_condition_group=self.condition_group,
         )
-        packet_data: dict[str, Any] = {
+        packet_data: SizeAnalysisValue = {
             "head_install_size_bytes": head_install,
             "head_download_size_bytes": head_download,
         }

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -888,7 +888,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
         assert evidence.value == "Install Size, Absolute Diff > 500.0 KB (+1.0 MB)"
 
     def test_evidence_relative_diff_download_size(self):
-        self._create_condition(Condition.GREATER_OR_EQUAL, 0.05)
+        self._create_condition(Condition.GREATER_OR_EQUAL, 5)
         occurrence = self._evaluate(
             "relative_diff",
             "download_size",


### PR DESCRIPTION
Replaces the raw source ID (`preprod-size-analysis:4510398352719872`) in Slack alert notifications from size analysis monitors with a structured, human-readable single-line evidence display.

**Before:**
```
preprod-size-analysis:4510398352719872
State: New   First Seen: Just now
```

**After:**
```
Install Size, Absolute Diff > 1.0 MB (+1.0 MB)
```

More examples:
```
Uncompressed Size, Relative Diff > 5% (+5.1%)    # Android
Download Size, Absolute Size > 50.0 MB (52.3 MB)  # absolute threshold
```

Changes:
- Build a single-line evidence string in `create_occurrence()` with format: `{measurement}, {threshold_type} > {threshold} ({actual_value})`
- Platform-aware labels: "Uncompressed Size" for Android, "Install Size" for iOS
- Set `notification_config` with `context=[]` and `text_code_formatted=False` to remove meaningless Events/Users/State/First Seen context and code formatting
- Extract `format_bytes_base10` to shared `preprod/utils.py` for reuse

refs eme-984