### PR TITLE
fix(modal): avoid modal shift

### DIFF
--- a/static/app/components/core/useScrollLock.tsx
+++ b/static/app/components/core/useScrollLock.tsx
@@ -41,6 +41,10 @@ class Lock {
         document.body.style.left = '0';
         document.body.style.right = '0';
         document.body.style.width = '100%';
+        document.documentElement.style.setProperty(
+          '--scrollbar-size',
+          `${scrollbarWidth}px`
+        );
         document.body.style.paddingRight = `${existingPaddingRight + scrollbarWidth}px`;
       } else {
         this.initialOverflow = this.container.style.overflow;
@@ -61,6 +65,7 @@ class Lock {
         document.body.style.right = this.initialBodyStyles.right;
         document.body.style.width = this.initialBodyStyles.width;
         document.body.style.paddingRight = this.initialBodyStyles.paddingRight;
+        document.documentElement.style.removeProperty('--scrollbar-size');
         const {x, y} = this.scroll;
         requestAnimationFrame(() => {
           if (this.acquiredBy.size === 0) {

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -292,7 +292,7 @@ export function GlobalModal({onClose}: Props) {
 const fullPageCss = css`
   position: fixed;
   top: 0;
-  right: var(--scrollbar-size, 0);
+  right: 0;
   bottom: 0;
   left: 0;
 `;
@@ -309,6 +309,7 @@ const Backdrop = styled('div')`
 
 const Container = styled('div')`
   ${fullPageCss};
+  right: var(--scrollbar-size, 0);
   z-index: ${p => p.theme.zIndex.modal};
   display: flex;
   justify-content: center;

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -291,9 +291,10 @@ export function GlobalModal({onClose}: Props) {
 
 const fullPageCss = css`
   position: fixed;
-  top: 50vh;
-  left: 50vw;
-  transform: translate(-50vh, -50vw);
+  top: 0;
+  right: var(--scrollbar-size, 0);
+  bottom: 0;
+  left: 0;
 `;
 
 const Backdrop = styled('div')`

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -291,10 +291,9 @@ export function GlobalModal({onClose}: Props) {
 
 const fullPageCss = css`
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  top: 50vh;
+  left: 50vw;
+  transform: translate(-50vh, -50vw);
 `;
 
 const Backdrop = styled('div')`

--- a/static/app/components/indicators.tsx
+++ b/static/app/components/indicators.tsx
@@ -37,7 +37,7 @@ export default Indicators;
 
 const Toasts = styled('div')`
   position: fixed;
-  right: calc(30px + var(--scrollbar-size, 0));
+  right: calc(30px + var(--scrollbar-size, 0px));
   bottom: 30px;
   z-index: ${p => p.theme.zIndex.toast};
 `;

--- a/static/app/components/indicators.tsx
+++ b/static/app/components/indicators.tsx
@@ -37,7 +37,7 @@ export default Indicators;
 
 const Toasts = styled('div')`
   position: fixed;
-  right: 30px;
+  right: calc(30px + var(--scrollbar-size, 0));
   bottom: 30px;
   z-index: ${p => p.theme.zIndex.toast};
 `;


### PR DESCRIPTION
fixes global modal layout shift from `useScrollLock` by exposing a `--scrollbar-size` variable on the root