### PR TITLE
feat(autofix): Track below_occurrence_threshold as a filtered skip reason

### DIFF
--- a/src/sentry/seer/autofix/trigger.py
+++ b/src/sentry/seer/autofix/trigger.py
@@ -29,6 +29,7 @@ SeerAutomationSkipReason = Union[
         "already_triggered",
         "already_triggered_explorer",
         "automation_already_dispatched",
+        "below_occurrence_threshold",
         "fixability_too_low",
         "issue_too_old",
         "lock_already_held",
@@ -141,7 +142,7 @@ def get_seat_based_seer_automation_skip_reason(
         if is_seer_scanner_rate_limited(group.project, group.organization):
             return "rate_limited"
 
-        return None
+        return "below_occurrence_threshold"
 
     # Event count >= threshold: run automation
     # Long-term check to avoid re-running

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -22,7 +22,6 @@ from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.killswitches import killswitch_matches_context
 from sentry.replays.lib.event_linking import transform_event_for_linking_payload
 from sentry.replays.lib.kafka import initialize_replays_publisher
-from sentry.seer.autofix.constants import AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD
 from sentry.signals import event_processed, issue_unignored
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -1555,29 +1554,28 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             metrics.incr(
                 "seer.automation.filtered", tags={"reason": skip_reason, "tier": "seat_based"}
             )
+            if skip_reason == "below_occurrence_threshold":
+                generate_issue_summary_only.delay(group.id)
             return
 
-        if group.times_seen_with_pending < AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD:
-            generate_issue_summary_only.delay(group.id)
+        # Check if summary exists in cache
+        cache_key = get_issue_summary_cache_key(group.id)
+        if cache.get(cache_key) is not None:
+            # Summary exists, run automation directly
+            run_automation_only_task.delay(group.id)
         else:
-            # Check if summary exists in cache
-            cache_key = get_issue_summary_cache_key(group.id)
-            if cache.get(cache_key) is not None:
-                # Summary exists, run automation directly
-                run_automation_only_task.delay(group.id)
-            else:
-                # Rate limit check before generating summary
-                if is_seer_scanner_rate_limited(group.project, group.organization):
-                    metrics.incr(
-                        "seer.automation.filtered",
-                        tags={"reason": "rate_limited", "tier": "seat_based"},
-                    )
-                    return
-
-                # No summary yet, generate summary + run automation in one go
-                generate_summary_and_run_automation.delay(
-                    group.id, trigger_path="seat_based_seer_automation"
+            # Rate limit check before generating summary
+            if is_seer_scanner_rate_limited(group.project, group.organization):
+                metrics.incr(
+                    "seer.automation.filtered",
+                    tags={"reason": "rate_limited", "tier": "seat_based"},
                 )
+                return
+
+            # No summary yet, generate summary + run automation in one go
+            generate_summary_and_run_automation.delay(
+                group.id, trigger_path="seat_based_seer_automation"
+            )
 
 
 GROUP_CATEGORY_POST_PROCESS_PIPELINE = {


### PR DESCRIPTION
Issues below `AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD` are now tracked with a `below_occurrence_threshold` skip reason in the `seer.automation.filtered` metric. Summary generation (`generate_issue_summary_only`) still fires for these issues — they're only filtered from full automation.

This gives visibility into how many issues are skipped because they don't have enough occurrences, which disproportionately affects smaller orgs.

The threshold check is moved into `get_seat_based_seer_automation_skip_reason()` and handled as a special case in the caller:

```python
if skip_reason == "below_occurrence_threshold":
    generate_issue_summary_only.delay(group.id)
```

Refs AIML-2686