### PR TITLE
NodeStore: Install nodestore in docker image similar to as in getsentry/self-hosted

### DIFF
--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -84,6 +84,8 @@ RUN : \
 COPY ./self-hosted/sentry.conf.py ./self-hosted/config.yml $SENTRY_CONF/
 COPY ./self-hosted/docker-entrypoint.sh /
 
+RUN pip install https://github.com/getsentry/sentry-nodestore-s3/archive/main.zip
+
 # note: sentry help is needed here since the earlier invocation doesn't have pipefail
 RUN : double-check some built files are available \
     && test -f /usr/src/sentry/src/sentry/loader/_registry.json \


### PR DESCRIPTION


NodeStore: Install nodestore in docker image similar to as in getsentry/self-hosted https://github.com/getsentry/self-hosted/blob/c858558fbfc66e8b250db293fea13f839d780587/sentry/Dockerfile#L4

<!-- This prevents the need for installation of nodestore as a plugin on ones own. Without this, to use Sentry with the S3 nodestore, an additional pip install is required. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
