### PR TITLE
perf(workflows): Avoid N+1 in WorkflowEngineDetectorSerializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -257,7 +257,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
                 for detector_trigger in detector_trigger_data_conditions
             ],
             condition_group__in=Subquery(workflow_dcg_ids),
-        )
+        ).select_related("condition_group")
 
         dcgas = DataConditionGroupAction.objects.filter(
             condition_group__in=[


### PR DESCRIPTION
Not a major cost, but cumulatively can mean 10s of milliseconds, and easy to fix.
