### PR TITLE
feat(insights): Use prebuilt dashboard URLs for platformized insights

### DIFF
--- a/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
+++ b/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
@@ -29,6 +29,9 @@ import {t} from 'sentry/locale';
 import {useMutateUserOptions} from 'sentry/utils/useMutateUserOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {usePrebuiltDashboardUrlBuilder} from 'sentry/views/dashboards/utils/usePrebuiltDashboardUrl';
+import {useHasPlatformizedInsights} from 'sentry/views/insights/common/utils/useHasPlatformizedInsights';
 import {AGENTS_LANDING_SUB_PATH} from 'sentry/views/insights/pages/agents/settings';
 import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
@@ -48,6 +51,18 @@ function useNavigationActions(): CommandPaletteAction[] {
   const prefix = `/organizations/${slug}`;
   const {starredViews} = useStarredIssueViews();
   const {data: starredDashboards = []} = useGetStarredDashboards();
+  const isPlatformized = useHasPlatformizedInsights();
+  const buildPrebuiltDashboardUrl = usePrebuiltDashboardUrlBuilder();
+
+  const getInsightsUrl = (
+    prebuiltId: PrebuiltDashboardId,
+    fallbackPath: string
+  ): string => {
+    if (isPlatformized) {
+      return buildPrebuiltDashboardUrl(prebuiltId) ?? `${prefix}/dashboards/`;
+    }
+    return `${prefix}/insights/${fallbackPath}/`;
+  };
 
   const issuesChildren: CommandPaletteActionChild[] = [
     makeCommandPaletteLink({
@@ -158,19 +173,22 @@ function useNavigationActions(): CommandPaletteAction[] {
       display: {
         label: t('Frontend'),
       },
-      to: `${prefix}/insights/${FRONTEND_LANDING_SUB_PATH}/`,
+      to: getInsightsUrl(
+        PrebuiltDashboardId.FRONTEND_OVERVIEW,
+        FRONTEND_LANDING_SUB_PATH
+      ),
     }),
     makeCommandPaletteLink({
       display: {
         label: t('Backend'),
       },
-      to: `${prefix}/insights/${BACKEND_LANDING_SUB_PATH}/`,
+      to: getInsightsUrl(PrebuiltDashboardId.BACKEND_OVERVIEW, BACKEND_LANDING_SUB_PATH),
     }),
     makeCommandPaletteLink({
       display: {
         label: t('Mobile'),
       },
-      to: `${prefix}/insights/${MOBILE_LANDING_SUB_PATH}/`,
+      to: getInsightsUrl(PrebuiltDashboardId.MOBILE_VITALS, MOBILE_LANDING_SUB_PATH),
     }),
     makeCommandPaletteLink({
       display: {

--- a/static/app/views/dashboards/utils/usePrebuiltDashboardUrl.tsx
+++ b/static/app/views/dashboards/utils/usePrebuiltDashboardUrl.tsx
@@ -1,10 +1,18 @@
+import {useCallback, useMemo} from 'react';
 import * as qs from 'query-string';
 
 import {pageFiltersToQueryParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import type {DashboardFilters, GlobalFilter} from 'sentry/views/dashboards/types';
+import {
+  DashboardFilter,
+  type DashboardDetails,
+  type DashboardFilters,
+  type GlobalFilter,
+} from 'sentry/views/dashboards/types';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 import {hasPlatformizedInsights} from 'sentry/views/insights/common/utils/useHasPlatformizedInsights';
@@ -62,4 +70,86 @@ export function usePrebuiltDashboardUrl(
   }
 
   return undefined;
+}
+
+/**
+ * Hook that fetches all requested prebuilt dashboards in a single API call
+ * and returns a function to build URLs by prebuilt ID.
+ */
+export function usePrebuiltDashboardUrlBuilder(
+  prebuiltIds: PrebuiltDashboardId[] = [],
+  options: PrebuiltDashboardUrlOptions = {}
+) {
+  const {bare = false, filters} = options;
+  const organization = useOrganization({allowNull: true});
+  const {selection} = usePageFilters();
+  const isPlatformized = organization ? hasPlatformizedInsights(organization) : false;
+
+  const fetchAll = prebuiltIds.length === 0;
+
+  const sortedIds = useMemo(
+    () => (isPlatformized && !fetchAll ? [...prebuiltIds].sort((a, b) => a - b) : []),
+    [prebuiltIds, isPlatformized, fetchAll]
+  );
+
+  const apiQueryParams: Record<string, unknown> = {
+    filter: DashboardFilter.SHOW_HIDDEN,
+  };
+  if (!fetchAll) {
+    apiQueryParams.prebuiltId = sortedIds;
+  }
+
+  const {data} = useApiQuery<DashboardDetails[]>(
+    [
+      getApiUrl('/organizations/$organizationIdOrSlug/dashboards/', {
+        path: {organizationIdOrSlug: organization?.slug ?? ''},
+      }),
+      {query: apiQueryParams},
+    ],
+    {
+      enabled: isPlatformized && (fetchAll || sortedIds.length > 0),
+      staleTime: Infinity,
+      retry: false,
+    }
+  );
+
+  const idMap = useMemo(() => {
+    const map = new Map<PrebuiltDashboardId, string>();
+    if (data) {
+      for (const dashboard of data) {
+        if (dashboard.prebuiltId) {
+          map.set(dashboard.prebuiltId, dashboard.id);
+        }
+      }
+    }
+    return map;
+  }, [data]);
+
+  const buildUrl = useCallback(
+    (prebuiltId: PrebuiltDashboardId): string | undefined => {
+      if (!organization || !isPlatformized) {
+        return undefined;
+      }
+
+      const dashboardId = idMap.get(prebuiltId);
+      if (!dashboardId) {
+        return undefined;
+      }
+
+      const queryParams = pageFiltersToQueryParams(selection);
+      applyDashboardFilters(queryParams, filters);
+      const query = Object.keys(queryParams).length
+        ? `?${qs.stringify(queryParams)}`
+        : '';
+
+      return bare
+        ? `dashboard/${dashboardId}/${query}`
+        : normalizeUrl(
+            `/organizations/${organization.slug}/dashboard/${dashboardId}/${query}`
+          );
+    },
+    [organization, isPlatformized, idMap, selection, filters, bare]
+  );
+
+  return buildUrl;
 }

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -35,6 +35,9 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {usePrebuiltDashboardUrlBuilder} from 'sentry/views/dashboards/utils/usePrebuiltDashboardUrl';
+import {useHasPlatformizedInsights} from 'sentry/views/insights/common/utils/useHasPlatformizedInsights';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 import {ERRORS_BASIC_CHART_PERIODS} from './charts/projectErrorsBasicChart';
@@ -81,6 +84,8 @@ export function ProjectDetail() {
   }, [hasTransactions, hasSessions]);
 
   const {setPageInfo, pageAlert} = usePageAlert();
+  const isPlatformized = useHasPlatformizedInsights();
+  const buildPrebuiltDashboardUrl = usePrebuiltDashboardUrlBuilder();
   const {orgId, projectId: projectSlug} = params;
   const msg = useMemo(
     () =>
@@ -89,12 +94,29 @@ export function ProjectDetail() {
         {
           settingsLink: <Link to={`/settings/${orgId}/projects/${projectSlug}/`} />,
           sessionHealth: (
-            <Link to={`/organizations/${orgId}/insights/mobile/sessions/`} />
+            <Link
+              to={
+                isPlatformized
+                  ? (buildPrebuiltDashboardUrl(
+                      PrebuiltDashboardId.MOBILE_SESSION_HEALTH
+                    ) ?? `/organizations/${orgId}/dashboards/`)
+                  : `/organizations/${orgId}/insights/mobile/sessions/`
+              }
+            />
           ),
-          backendOverview: <Link to={`/organizations/${orgId}/insights/backend/`} />,
+          backendOverview: (
+            <Link
+              to={
+                isPlatformized
+                  ? (buildPrebuiltDashboardUrl(PrebuiltDashboardId.BACKEND_OVERVIEW) ??
+                    `/organizations/${orgId}/dashboards/`)
+                  : `/organizations/${orgId}/insights/backend/`
+              }
+            />
+          ),
         }
       ),
-    [orgId, projectSlug]
+    [orgId, projectSlug, isPlatformized, buildPrebuiltDashboardUrl]
   );
   useEffect(() => {
     if (pageAlert?.message !== msg) {


### PR DESCRIPTION
When platformized insights is enabled, insight overview links now point to
prebuilt dashboard URLs instead of the legacy insights module pages.

Adds `usePrebuiltDashboardUrlBuilder` — a hook that fetches prebuilt dashboards
in a single API call and returns a URL builder function. When called with no
arguments, it fetches all prebuilt dashboards; when given specific IDs, it fetches
only those.

Updates the command palette and project detail deprecation notice to use dashboard
URLs for Frontend, Backend, and Mobile overview pages when the
`insights-prebuilt-dashboards` feature flag is active.

Refs BROWSE-436