### PR TITLE
fix(dashboards): Persist global filters when adding widget to dashboard

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -386,6 +386,15 @@ export function getMenuOptions(
               id: undefined,
               dashboardId: undefined,
               layout: undefined,
+              queries: widget.queries.map(query => ({
+                ...query,
+                conditions:
+                  applyDashboardFilters(
+                    query.conditions,
+                    dashboardFilters,
+                    widget.widgetType
+                  ) ?? '',
+              })),
             },
           ],
           actions: ['add-and-stay-on-current-page', 'open-in-widget-builder'],


### PR DESCRIPTION
Apply dashboard global filters to widget query conditions before passing
them to the Add to Dashboard modal. Previously, global filters like
`span.system`, `span.domain`, or `sentry.normalized_description` were
lost when using "Add to Dashboard" or "Open in Widget Builder" from the
widget context menu.

The other context menu actions (Open in Discover, Open in Explore, etc.)
already called `applyDashboardFilters` to bake the filters into widget
queries, but the "Add to Dashboard" action was passing the raw widget
without them.

Fixes BROWSE-472