### PR TITLE
fix(pipeline): Handle deleted provider model in unpack_state

### DIFF
--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -81,7 +81,10 @@ class Pipeline[M: Model, S: PipelineSessionStore](abc.ABC):
         provider_model = None
         if state.provider_model_id:
             assert cls.provider_model_cls is not None
-            provider_model = cls.provider_model_cls.objects.get(id=state.provider_model_id)
+            try:
+                provider_model = cls.provider_model_cls.objects.get(id=state.provider_model_id)
+            except cls.provider_model_cls.DoesNotExist:
+                return None
 
         organization: RpcOrganization | None = None
         if state.org_id:

--- a/tests/sentry/pipeline/test_pipeline.py
+++ b/tests/sentry/pipeline/test_pipeline.py
@@ -18,6 +18,7 @@ from sentry.pipeline.views.base import ApiPipelineEndpoint, ApiPipelineSteps, Pi
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.users.models.identity import IdentityProvider
 
 
 class PipelineStep:
@@ -312,6 +313,24 @@ class PipelineTestCase(TestCase):
         resp = intercepted_pipeline.next_step()
         assert isinstance(resp, HttpResponse)  # TODO(cathy): fix typing on
         assert ERR_MISMATCHED_USER.encode() in resp.content
+
+    @patch("sentry.pipeline.base.bind_organization_context")
+    def test_unpack_state_returns_none_when_provider_model_deleted(
+        self, mock_bind_org_context: MagicMock
+    ) -> None:
+        """If the provider model is deleted after the pipeline session was created,
+        get_for_request should return None instead of raising DoesNotExist."""
+        idp = IdentityProvider.objects.create(type="dummy", external_id="test123")
+
+        with patch.object(DummyPipeline, "provider_model_cls", IdentityProvider):
+            pipeline = DummyPipeline(self.request, "dummy", self.org, provider_model=idp)
+            pipeline.initialize()
+
+            assert DummyPipeline.get_for_request(self.request) is not None
+
+            idp.delete()
+
+            assert DummyPipeline.get_for_request(self.request) is None
 
 
 @control_silo_test


### PR DESCRIPTION
When a provider model (e.g. IdentityProvider) is deleted after a
pipeline session is created, unpack_state now returns None instead of
raising DoesNotExist. Callers already handle None gracefully.