### PR TITLE
fix(preprod): Align relative_diff extract_value with frontend percentage convention

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -193,7 +193,7 @@ class PreprodSizeAnalysisDetectorHandler(
                 return self._extract_head(data_packet) - self._extract_base(data_packet)
             case "relative_diff":
                 base = self._extract_base(data_packet)
-                return (self._extract_head(data_packet) - base) / base
+                return ((self._extract_head(data_packet) - base) / base) * 100
             case _:
                 raise ValueError(f"Unknown threshold_type: {threshold_type}")
 

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -281,11 +281,11 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
-        # Trigger when relative diff > 0.1 (10%)
+        # Trigger when relative diff > 10 (10%)
         self.create_data_condition(
             condition_group=condition_group,
             type=Condition.GREATER,
-            comparison=0.1,
+            comparison=10,
             condition_result=DetectorPriorityLevel.HIGH,
         )
         detector = self.create_detector(
@@ -296,7 +296,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
             workflow_condition_group=condition_group,
         )
 
-        # (5000000 - 4000000) / 4000000 = 0.25 > 0.1
+        # (5000000 - 4000000) / 4000000 = 25% > 10%
         data_packet: SizeAnalysisDataPacket = DataPacket(
             source_id="test",
             packet={
@@ -316,11 +316,11 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
-        # Trigger when relative diff > 0.1 (10%)
+        # Trigger when relative diff > 10 (10%)
         self.create_data_condition(
             condition_group=condition_group,
             type=Condition.GREATER,
-            comparison=0.1,
+            comparison=10,
             condition_result=DetectorPriorityLevel.HIGH,
         )
         detector = self.create_detector(
@@ -331,7 +331,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
             workflow_condition_group=condition_group,
         )
 
-        # (5000000 - 4900000) / 4900000 ≈ 0.02 < 0.1
+        # (5000000 - 4900000) / 4900000 ≈ 2.04% < 10%
         data_packet: SizeAnalysisDataPacket = DataPacket(
             source_id="test",
             packet={


### PR DESCRIPTION
`extract_value` for `relative_diff` monitors returned a ratio (e.g. `0.05` for a 5% increase), but the frontend stores percentage-scale values (e.g. `5.0`). The condition `operator.gt(0.05, 5.0)` was always false, so relative_diff monitors created through the UI never fired.

This multiplies by 100 in `extract_value` so both sides use percentage-scale values, consistent with how VCS status checks already compute diffs. Tests updated to match.

Feature is `released = False` so no production impact.

refs EME-985