### PR TITLE
fix(settings): widen teams table actions column

### DIFF
--- a/static/app/views/settings/organizationTeams/otherTeamsTable.tsx
+++ b/static/app/views/settings/organizationTeams/otherTeamsTable.tsx
@@ -234,7 +234,7 @@ function TeamAction({
 }
 
 const StyledSimpleTable = styled(SimpleTable)`
-  grid-template-columns: 1fr 125px 150px 130px;
+  grid-template-columns: 1fr 125px 150px auto;
   margin-bottom: ${p => p.theme.space.xl};
 
   [data-column-name='actions'] {
@@ -242,7 +242,7 @@ const StyledSimpleTable = styled(SimpleTable)`
   }
 
   @media (max-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: 1fr 125px 130px;
+    grid-template-columns: 1fr 125px auto;
 
     [data-column-name='projects'] {
       display: none;

--- a/static/app/views/settings/organizationTeams/yourTeamsTable.tsx
+++ b/static/app/views/settings/organizationTeams/yourTeamsTable.tsx
@@ -208,7 +208,7 @@ function YourTeamRow({
 }
 
 const StyledSimpleTable = styled(SimpleTable)`
-  grid-template-columns: 1fr 125px 150px 130px;
+  grid-template-columns: 1fr 125px 150px auto;
   margin-bottom: ${p => p.theme.space.xl};
 
   [data-column-name='actions'] {
@@ -216,7 +216,7 @@ const StyledSimpleTable = styled(SimpleTable)`
   }
 
   @media (max-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: 1fr 125px 130px;
+    grid-template-columns: 1fr 125px auto;
 
     [data-column-name='projects'] {
       display: none;


### PR DESCRIPTION
In /settings/teams, if the button for a team was 'request access', the button would be cut off
Before:
<img width="190" height="239" alt="Screenshot 2026-03-26 at 2 10 04 PM" src="https://github.com/user-attachments/assets/30d3df82-1ec5-4409-a4fa-db5d7171c75e" />

After:
<img width="182" height="231" alt="Screenshot 2026-03-26 at 2 10 11 PM" src="https://github.com/user-attachments/assets/e473f56a-763a-4d6c-bf9f-5c3161aaf69f" />

checked that this works as the screen width decreases as well