### PR TITLE
perf(workflows): Avoid ~0.6s regression in backported OrganizationCombinedRuleIndexEndpoint.get

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from copy import deepcopy
 from datetime import UTC, datetime
 
+from django.db import connections, router, transaction
 from django.db.models import (
     Case,
     DateTimeField,
@@ -515,33 +516,45 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
                 ),
             )
 
-        # Build intermediaries for pagination
-        intermediaries: list[CombinedQuerysetIntermediary] = []
-
         def has_type(rule_type: str) -> bool:
             return not type_filter or rule_type in type_filter
 
-        if has_type("alert_rule"):
-            intermediaries.append(CombinedQuerysetIntermediary(metric_detectors, sort_key))
-        if has_type("rule"):
-            intermediaries.append(CombinedQuerysetIntermediary(issue_workflows, sort_key))
-        if has_type("uptime"):
-            intermediaries.append(CombinedQuerysetIntermediary(uptime_rules, sort_key))
-        if has_type("monitor"):
-            intermediaries.append(CombinedQuerysetIntermediary(crons_rules, sort_key))
+        # Disable JIT for the combined paginator queries.
+        # The planner thinks our metric detector query is going to be very slow because DetectorGroup
+        # in general has many Groups per Detector, even though for metrics detectors (our case here) it's effectively
+        # one-to-one.
+        # It decides to spend ~400ms JITing the query, thinking it is justified due to the bulk of the data, but it is
+        # wrong. What's worse, we send this query twice, and pay for the JIT twice.
+        # Disabling it makes this endpoint considerably faster.
+        # The risk of other regression here should be low; our API endpoint isn't generally doing the sort of bulk
+        # work that benefits from JIT.
+        db = router.db_for_write(Detector)
+        with transaction.atomic(using=db):
+            with connections[db].cursor() as cursor:
+                cursor.execute("SET LOCAL jit = off")
 
-        response = self.paginate(
-            request,
-            paginator_cls=CombinedQuerysetPaginator,
-            on_results=lambda x: serialize(
-                x, request.user, WorkflowEngineCombinedRuleSerializer(expand=expand)
-            ),
-            default_per_page=25,
-            intermediaries=intermediaries,
-            desc=not is_asc,
-            cursor_cls=StringCursor if case_insensitive else Cursor,
-            case_insensitive=case_insensitive,
-        )
+            intermediaries: list[CombinedQuerysetIntermediary] = []
+            if has_type("alert_rule"):
+                intermediaries.append(CombinedQuerysetIntermediary(metric_detectors, sort_key))
+            if has_type("rule"):
+                intermediaries.append(CombinedQuerysetIntermediary(issue_workflows, sort_key))
+            if has_type("uptime"):
+                intermediaries.append(CombinedQuerysetIntermediary(uptime_rules, sort_key))
+            if has_type("monitor"):
+                intermediaries.append(CombinedQuerysetIntermediary(crons_rules, sort_key))
+
+            response = self.paginate(
+                request,
+                paginator_cls=CombinedQuerysetPaginator,
+                on_results=lambda x: serialize(
+                    x, request.user, WorkflowEngineCombinedRuleSerializer(expand=expand)
+                ),
+                default_per_page=25,
+                intermediaries=intermediaries,
+                desc=not is_asc,
+                cursor_cls=StringCursor if case_insensitive else Cursor,
+                case_insensitive=case_insensitive,
+            )
         response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = get_max_metric_alert_subscriptions(organization)
         return response
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -1,9 +1,10 @@
 import logging
 from collections.abc import Sequence
+from contextlib import contextmanager
 from copy import deepcopy
 from datetime import UTC, datetime
 
-from django.db import connections, router, transaction
+from django.db import connections, router
 from django.db.models import (
     Case,
     DateTimeField,
@@ -112,6 +113,26 @@ from sentry.workflow_engine.utils.legacy_metric_tracking import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _postgres_jit_disabled(using: str):
+    """
+    Disable PostgreSQL JIT compilation on the given database connection for the duration of
+    the block.
+
+    Uses session-level SET/RESET rather than SET LOCAL (which requires a transaction) so that
+    callers don't need to open a transaction — important when the calling code may issue queries
+    against multiple databases.
+    """
+    with connections[using].cursor() as cursor:
+        cursor.execute("SET jit = off")
+    try:
+        yield
+    finally:
+        with connections[using].cursor() as cursor:
+            cursor.execute("RESET jit")
+
 
 # Sentinel values for incident_status annotation when sorting combined rules
 # Used to ensure proper sort order for rules without active incidents
@@ -519,7 +540,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         def has_type(rule_type: str) -> bool:
             return not type_filter or rule_type in type_filter
 
-        # Disable JIT for the combined paginator queries.
+        # Disable JIT on the Detector/DetectorGroup database for the combined paginator queries.
         # The planner thinks our metric detector query is going to be very slow because DetectorGroup
         # in general has many Groups per Detector, even though for metrics detectors (our case here) it's effectively
         # one-to-one.
@@ -528,11 +549,11 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         # Disabling it makes this endpoint considerably faster.
         # The risk of other regression here should be low; our API endpoint isn't generally doing the sort of bulk
         # work that benefits from JIT.
-        db = router.db_for_write(Detector)
-        with transaction.atomic(using=db):
-            with connections[db].cursor() as cursor:
-                cursor.execute("SET LOCAL jit = off")
-
+        #
+        # Note: Monitor lives on a different database, so we can't use a transaction here
+        # (SET LOCAL would require one). Session-level SET + RESET is fine for a request-scoped
+        # connection.
+        with _postgres_jit_disabled(using=router.db_for_write(Detector)):
             intermediaries: list[CombinedQuerysetIntermediary] = []
             if has_type("alert_rule"):
                 intermediaries.append(CombinedQuerysetIntermediary(metric_detectors, sort_key))

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -1,10 +1,9 @@
 import logging
 from collections.abc import Sequence
-from contextlib import contextmanager
 from copy import deepcopy
 from datetime import UTC, datetime
 
-from django.db import connections, router
+from django.db import connections, router, transaction
 from django.db.models import (
     Case,
     DateTimeField,
@@ -45,6 +44,7 @@ from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.db.models.manager.base_query_set import BaseQuerySet
+from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.exceptions import InvalidParams
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleBaseEndpoint
 from sentry.incidents.endpoints.serializers.alert_rule import (
@@ -113,25 +113,6 @@ from sentry.workflow_engine.utils.legacy_metric_tracking import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-@contextmanager
-def _postgres_jit_disabled(using: str):
-    """
-    Disable PostgreSQL JIT compilation on the given database connection for the duration of
-    the block.
-
-    Uses session-level SET/RESET rather than SET LOCAL (which requires a transaction) so that
-    callers don't need to open a transaction — important when the calling code may issue queries
-    against multiple databases.
-    """
-    with connections[using].cursor() as cursor:
-        cursor.execute("SET jit = off")
-    try:
-        yield
-    finally:
-        with connections[using].cursor() as cursor:
-            cursor.execute("RESET jit")
 
 
 # Sentinel values for incident_status annotation when sorting combined rules
@@ -549,11 +530,14 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         # Disabling it makes this endpoint considerably faster.
         # The risk of other regression here should be low; our API endpoint isn't generally doing the sort of bulk
         # work that benefits from JIT.
-        #
-        # Note: Monitor lives on a different database, so we can't use a transaction here
-        # (SET LOCAL would require one). Session-level SET + RESET is fine for a request-scoped
-        # connection.
-        with _postgres_jit_disabled(using=router.db_for_write(Detector)):
+        # in_test_hide_transaction_boundary is safe here: this transaction is only
+        # used to scope SET LOCAL, not to guard data mutations. No writes happen
+        # inside this block, so there's no cross-db atomicity concern to enforce.
+        db = router.db_for_write(Detector)
+        with in_test_hide_transaction_boundary(), transaction.atomic(using=db):
+            with connections[db].cursor() as cursor:
+                cursor.execute("SET LOCAL jit = off")
+
             intermediaries: list[CombinedQuerysetIntermediary] = []
             if has_type("alert_rule"):
                 intermediaries.append(CombinedQuerysetIntermediary(metric_detectors, sort_key))


### PR DESCRIPTION
The JIT is expensive and being used when we don't need it. We can try to work around it or restructure the query to avoid the jit threshold, but just scoped disabling gets us exactly what we want.

I've confirmed the JIT impact by analyzing sample queries and observing that the vast majority of the time is spent in JIT, but with JIT disabled the query is much faster.
Demo at https://redash.getsentry.net/queries/10853

I've also confirmed in traces that this query is consistently slow (280ms-450ms) and issued twice per request.

NB: The workflow engine variant of this endpoint isn't yet released, so the risk here should be quite low.