### PR TITLE
feat(monitors): Add info hint for diff-based issue detection

### DIFF
--- a/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
@@ -1,13 +1,15 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {InlineCode} from '@sentry/scraps/code';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {NumberField} from 'sentry/components/forms/fields/numberField';
 import {SegmentedRadioField} from 'sentry/components/forms/fields/segmentedRadioField';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
-import {t} from 'sentry/locale';
+import {IconInfo} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
 import {
   DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL,
   DetectorPriorityLevel,
@@ -79,6 +81,21 @@ export function MobileBuildDetectSection() {
               flexibleControlStateSize
               preserveOnUnmount
             />
+            {(thresholdType === 'absolute_diff' || thresholdType === 'relative_diff') && (
+              <Flex align="center" gap="sm">
+                <IconInfo size="xs" />
+                <Text variant="muted" size="sm">
+                  {tct(
+                    "Compares against the previous build matching this monitor's filters, [platform], [packageName], and [buildConfiguration].",
+                    {
+                      platform: <InlineCode>platform</InlineCode>,
+                      packageName: <InlineCode>package_name</InlineCode>,
+                      buildConfiguration: <InlineCode>build_configuration</InlineCode>,
+                    }
+                  )}
+                </Text>
+              </Flex>
+            )}
           </section>
 
           <ThresholdSection thresholdType={thresholdType} />


### PR DESCRIPTION
Shows an inline hint below the issue detection selector when Absolute Diff or Relative Diff is chosen, clarifying that comparisons use the previous build matching the monitor's filters, `platform`, `package_name`, and `build_configuration`.

Uses `IconInfo` + `Text` + `InlineCode` for a lightweight presentation that doesn't compete with the form controls.

<img width="2460" height="710" alt="CleanShot 2026-03-26 at 16 30 53@2x" src="https://github.com/user-attachments/assets/e0e7ce7a-1421-4d51-89b5-9d56168fa65d" />
