### PR TITLE
feat(core-ui): Add ClearButton to CompositeSelect

### DIFF
--- a/static/app/components/core/compactSelect/composite.mdx
+++ b/static/app/components/core/compactSelect/composite.mdx
@@ -14,7 +14,7 @@ resources:
 
 import {useState} from 'react';
 
-import {CompositeSelect, type SelectKey} from '@sentry/scraps/compactSelect';
+import {CompositeSelect} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {IconSentry} from 'sentry/icons';
@@ -132,8 +132,6 @@ Use `<CompositeSelect.ClearButton>` in `menuHeaderTrailingItems` to add a "Clear
 Only render the button when there is an active selection to clear.
 
 export function ClearButtonDemo() {
-  const [month, setMonth] = useState<SelectKey | null>(null);
-  const [tags, setTags] = useState<string[]>([]);
   const monthOptions = [
     {value: 'jan', label: 'January'},
     {value: 'feb', label: 'February'},
@@ -144,7 +142,9 @@ export function ClearButtonDemo() {
     {value: 'funny', label: 'funny'},
     {value: 'awesome', label: 'awesome'},
   ];
-  const hasSelection = month !== null || tags.length > 0;
+  const [month, setMonth] = useState('');
+  const [tags, setTags] = useState(tagOptions.slice(0, 0).map(o => o.value));
+  const hasSelection = month !== '' || tags.length > 0;
   return (
     <CompositeSelect
       size="sm"
@@ -153,7 +153,7 @@ export function ClearButtonDemo() {
         hasSelection ? (
           <CompositeSelect.ClearButton
             onClick={() => {
-              setMonth(null);
+              setMonth('');
               setTags([]);
             }}
           />

--- a/static/app/components/core/compactSelect/composite.mdx
+++ b/static/app/components/core/compactSelect/composite.mdx
@@ -53,6 +53,7 @@ Use `<CompositeSelect>` when you need a dropdown with multiple independent selec
 
 - **`<CompositeSelect>`**: The wrapper component that manages the dropdown
 - **`<CompositeSelect.Region>`**: Individual selection sections within the dropdown
+- **`<CompositeSelect.ClearButton>`**: A "Clear" button for use in `menuHeaderTrailingItems` that calls your `onClick` to reset all regions
 
 Each region acts like an independent `<CompactSelect>`, requiring its own `value`, `onChange`, and `options`.
 
@@ -120,6 +121,102 @@ const [day, setDay] = useState('1');
     value={day}
     onChange={selection => setDay(selection.value)}
     options={dayOptions}
+  />
+</CompositeSelect>;
+```
+
+## Clear Button
+
+Use `<CompositeSelect.ClearButton>` in `menuHeaderTrailingItems` to add a "Clear" button to the menu header. When clicked, it calls your `onClick` handler where you reset each region's value. The menu stays open, matching the behavior of the built-in clear button in `<CompactSelect>`.
+
+Only render the button when there is an active selection to clear.
+
+export function ClearButtonDemo() {
+  const [month, setMonth] = useState(null);
+  const [tags, setTags] = useState([]);
+  const monthOptions = [
+    {value: 'jan', label: 'January'},
+    {value: 'feb', label: 'February'},
+    {value: 'mar', label: 'March'},
+  ];
+  const tagOptions = [
+    {value: 'cool', label: 'cool'},
+    {value: 'funny', label: 'funny'},
+    {value: 'awesome', label: 'awesome'},
+  ];
+  const hasSelection = month !== null || tags.length > 0;
+  return (
+    <CompositeSelect
+      size="sm"
+      menuTitle="Filters"
+      menuHeaderTrailingItems={
+        hasSelection ? (
+          <CompositeSelect.ClearButton
+            onClick={() => {
+              setMonth(null);
+              setTags([]);
+            }}
+          />
+        ) : null
+      }
+      trigger={props => (
+        <OverlayTrigger.Button icon={<IconSentry />} {...props}>
+          Filters
+        </OverlayTrigger.Button>
+      )}
+    >
+      <CompositeSelect.Region
+        label="Month"
+        value={month}
+        onChange={selection => setMonth(selection.value)}
+        options={monthOptions}
+      />
+      <CompositeSelect.Region
+        label="Tags"
+        multiple
+        value={tags}
+        onChange={selection => setTags(selection.map(s => s.value))}
+        options={tagOptions}
+      />
+    </CompositeSelect>
+  );
+}
+
+<Storybook.Demo minHeight="400px" align="start">
+  <ClearButtonDemo />
+</Storybook.Demo>
+
+```jsx
+const [month, setMonth] = useState(null);
+const [tags, setTags] = useState([]);
+const hasSelection = month !== null || tags.length > 0;
+
+<CompositeSelect
+  menuTitle="Filters"
+  menuHeaderTrailingItems={
+    hasSelection ? (
+      <CompositeSelect.ClearButton
+        onClick={() => {
+          setMonth(null);
+          setTags([]);
+        }}
+      />
+    ) : null
+  }
+  trigger={props => <OverlayTrigger.Button {...props}>Filters</OverlayTrigger.Button>}
+>
+  <CompositeSelect.Region
+    label="Month"
+    value={month}
+    onChange={selection => setMonth(selection.value)}
+    options={monthOptions}
+  />
+  <CompositeSelect.Region
+    label="Tags"
+    multiple
+    value={tags}
+    onChange={selection => setTags(selection.map(s => s.value))}
+    options={tagOptions}
   />
 </CompositeSelect>;
 ```

--- a/static/app/components/core/compactSelect/composite.mdx
+++ b/static/app/components/core/compactSelect/composite.mdx
@@ -53,7 +53,7 @@ Use `<CompositeSelect>` when you need a dropdown with multiple independent selec
 
 - **`<CompositeSelect>`**: The wrapper component that manages the dropdown
 - **`<CompositeSelect.Region>`**: Individual selection sections within the dropdown
-- **`<CompositeSelect.ClearButton>`**: A "Clear" button for use in `menuHeaderTrailingItems` that calls your `onClick` to reset all regions
+- **`<CompositeSelect.ClearButton>`**: A "Clear" button for use in `menuHeaderTrailingItems` that calls your `onClick` to reset all regions. Re-exported from `<CompactSelect>`'s internal clear button for visual consistency
 
 Each region acts like an independent `<CompactSelect>`, requiring its own `value`, `onChange`, and `options`.
 
@@ -127,7 +127,7 @@ const [day, setDay] = useState('1');
 
 ## Clear Button
 
-Use `<CompositeSelect.ClearButton>` in `menuHeaderTrailingItems` to add a "Clear" button to the menu header. When clicked, it calls your `onClick` handler where you reset each region's value. The menu stays open, matching the behavior of the built-in clear button in `<CompactSelect>`.
+Use `<CompositeSelect.ClearButton>` in `menuHeaderTrailingItems` to add a "Clear" button to the menu header. When clicked, it calls your `onClick` handler where you reset each region's value. The menu stays open, matching the behavior of the built-in clear button in `<CompactSelect>`. The component is the same styled button used internally by `<CompactSelect>`, ensuring visual consistency.
 
 Only render the button when there is an active selection to clear.
 

--- a/static/app/components/core/compactSelect/composite.mdx
+++ b/static/app/components/core/compactSelect/composite.mdx
@@ -14,7 +14,7 @@ resources:
 
 import {useState} from 'react';
 
-import {CompositeSelect} from '@sentry/scraps/compactSelect';
+import {CompositeSelect, type SelectKey} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {IconSentry} from 'sentry/icons';
@@ -132,8 +132,8 @@ Use `<CompositeSelect.ClearButton>` in `menuHeaderTrailingItems` to add a "Clear
 Only render the button when there is an active selection to clear.
 
 export function ClearButtonDemo() {
-  const [month, setMonth] = useState(null);
-  const [tags, setTags] = useState([]);
+  const [month, setMonth] = useState<SelectKey | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
   const monthOptions = [
     {value: 'jan', label: 'January'},
     {value: 'feb', label: 'February'},

--- a/static/app/components/core/compactSelect/composite.tsx
+++ b/static/app/components/core/compactSelect/composite.tsx
@@ -4,12 +4,12 @@ import {FocusScope} from '@react-aria/focus';
 import {Item} from '@react-stately/collections';
 import type {DistributedOmit} from 'type-fest';
 
-import {Button, type ButtonProps} from '@sentry/scraps/button';
+import {type ButtonProps} from '@sentry/scraps/button';
 
 import {t} from 'sentry/locale';
 
+import {ClearButton, Control} from './control';
 import type {ControlProps} from './control';
-import {Control} from './control';
 import type {MultipleListProps, SingleListProps} from './list';
 import {List} from './list';
 import {EmptyMessage} from './styles';
@@ -124,9 +124,9 @@ CompositeSelect.ClearButton = function CompositeSelectClearButton(
   props: DistributedOmit<ButtonProps, 'priority' | 'size' | 'children'>
 ) {
   return (
-    <StyledClearButton size="zero" priority="transparent" {...props}>
+    <ClearButton size="zero" priority="transparent" {...props}>
       {t('Clear')}
-    </StyledClearButton>
+    </ClearButton>
   );
 };
 
@@ -163,14 +163,6 @@ function Region<Value extends SelectKey>({
     </List>
   );
 }
-
-const StyledClearButton = styled(Button)`
-  font-size: inherit; /* Inherit font size from MenuHeader */
-  font-weight: ${p => p.theme.font.weight.sans.regular};
-  color: ${p => p.theme.tokens.content.secondary};
-  padding: 0 ${p => p.theme.space.xs};
-  margin: -${p => p.theme.space.sm} -${p => p.theme.space.xs};
-`;
 
 const RegionsWrap = styled('div')`
   min-height: 0;

--- a/static/app/components/core/compactSelect/composite.tsx
+++ b/static/app/components/core/compactSelect/composite.tsx
@@ -4,6 +4,8 @@ import {FocusScope} from '@react-aria/focus';
 import {Item} from '@react-stately/collections';
 import type {DistributedOmit} from 'type-fest';
 
+import {Button, type ButtonProps} from '@sentry/scraps/button';
+
 import {t} from 'sentry/locale';
 
 import type {ControlProps} from './control';
@@ -118,6 +120,16 @@ CompositeSelect.Region = function <Value extends SelectKey>(
   return null;
 };
 
+CompositeSelect.ClearButton = function CompositeSelectClearButton(
+  props: DistributedOmit<ButtonProps, 'priority' | 'size' | 'children'>
+) {
+  return (
+    <StyledClearButton size="zero" priority="transparent" {...props}>
+      {t('Clear')}
+    </StyledClearButton>
+  );
+};
+
 export {CompositeSelect};
 
 type RegionProps<Value extends SelectKey> = CompositeSelectRegion<Value> & {
@@ -151,6 +163,14 @@ function Region<Value extends SelectKey>({
     </List>
   );
 }
+
+const StyledClearButton = styled(Button)`
+  font-size: inherit; /* Inherit font size from MenuHeader */
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+  color: ${p => p.theme.tokens.content.secondary};
+  padding: 0 ${p => p.theme.space.xs};
+  margin: -${p => p.theme.space.sm} -${p => p.theme.space.xs};
+`;
 
 const RegionsWrap = styled('div')`
   min-height: 0;

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -643,7 +643,7 @@ const StyledLoadingIndicator = styled(LoadingIndicator)`
   }
 `;
 
-const ClearButton = styled(Button)`
+export const ClearButton = styled(Button)`
   font-size: inherit; /* Inherit font size from MenuHeader */
   font-weight: ${p => p.theme.font.weight.sans.regular};
   color: ${p => p.theme.tokens.content.secondary};

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -48,10 +48,18 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
   }
 
   const selectedList = [...selectedNames].filter(Boolean);
+  const defaultValue = DEFAULT_YAXIS_BY_TYPE[traceMetric.type];
+  const isDefaultSelection =
+    selectedList.length === 1 && selectedList[0] === defaultValue;
 
   return (
     <CompositeSelect
       disabled={groups.length === 0}
+      menuHeaderTrailingItems={
+        isDefaultSelection
+          ? undefined
+          : () => <CompositeSelect.ClearButton onClick={() => handleChange([])} />
+      }
       style={{width: '100%'}}
       trigger={triggerProps => (
         <OverlayTrigger.Button

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -96,11 +96,11 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
           return (
             <CompositeSelect.Region
               key={groupKey}
-              label={group.label as string}
+              label={group.label}
               multiple
               options={group.options}
               value={activeValues}
-              onChange={(opts: Array<SelectOption<string>>) => handleChange(opts)}
+              onChange={handleChange}
             />
           );
         }
@@ -108,10 +108,10 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
         return (
           <CompositeSelect.Region
             key={groupKey}
-            label={group.label as string}
+            label={group.label}
             options={group.options}
-            value={activeValues[0] as string}
-            onChange={(opt: SelectOption<string>) => handleChange([opt])}
+            value={activeValues[0]}
+            onChange={opt => handleChange([opt])}
           />
         );
       })}


### PR DESCRIPTION
The current `CompositeSelect` component doesn't seem to have an easy way to hook up clearing selections, which is understandable since there are multi-selection possibilities so to tackle this I'd like to add in a button that is styled to match that of the `CompactSelect`'s clear button.

Example:

<img width="276" height="505" alt="Screenshot 2026-03-27 at 09 27 39" src="https://github.com/user-attachments/assets/6feeb397-3f7c-4570-8528-fcebf526f88c" />