### PR TITLE
feat(eap): Add server.address and segment.name span attribute definitions

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -456,6 +456,8 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
         simple_sentry_field("os.name"),
         simple_sentry_field("app_start_type"),
         simple_sentry_field("ttid"),
+        simple_sentry_field("server.address"),
+        simple_sentry_field("segment.name"),
         simple_measurements_field("app_start_cold", "millisecond"),
         simple_measurements_field("app_start_warm", "millisecond"),
         simple_measurements_field("frames_frozen"),


### PR DESCRIPTION
Add `server.address` and `segment.name` to the EAP span attribute definitions.