### PR TITLE
fix(dashboards): Hide prebuilt dashboards from All Dashboards list

### DIFF
--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -208,7 +208,9 @@ function ManageDashboards() {
           pin: 'favorites',
           per_page:
             dashboardsLayout === GRID ? rowCount * columnCount : DASHBOARD_TABLE_NUM_ROWS,
-          ...(isOnlyPrebuilt ? {filter: DashboardFilter.ONLY_PREBUILT} : {}),
+          ...(isOnlyPrebuilt
+            ? {filter: DashboardFilter.ONLY_PREBUILT}
+            : {filter: DashboardFilter.EXCLUDE_PREBUILT}),
         },
       },
     ],


### PR DESCRIPTION
Hide Sentry Built dashboards from the All Dashboards list by adding
the `excludePrebuilt` filter to the dashboard list API call. Previously
the All Dashboards view showed all dashboards including prebuilt ones,
which was surfaced as feedback from both internal and external users.

Prebuilt dashboards remain discoverable via the Sentry Built tab.

Refs LINEAR-DAIN-1415