### PR TITLE
ref(pipeline): Move `None` out of ApiPipelineSteps type

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -312,7 +312,7 @@ class IntegrationProvider(PipelineProvider["IntegrationPipeline"], abc.ABC):
         """
         raise NotImplementedError
 
-    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline] | None:
         """
         Return API step objects for this provider's pipeline, or None if API
         mode is not supported. Override to enable the pipeline API for this

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -172,7 +172,7 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
     ]:
         return self.provider.get_pipeline_views()
 
-    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline] | None:
         return self.provider.get_pipeline_api_steps()
 
     def get_analytics_event(self) -> analytics.Event | None:

--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -260,7 +260,7 @@ class Pipeline[M: Model, S: PipelineSessionStore](abc.ABC):
             return nested_pipeline.fetch_state(key)
         return self._fetch_state(key)
 
-    def get_pipeline_api_steps(self) -> ApiPipelineSteps[Self]:
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[Self] | None:
         """
         Return API step objects for this pipeline, or None if API mode is not
         supported. Steps may be callables for late binding (resolved when the

--- a/src/sentry/pipeline/provider.py
+++ b/src/sentry/pipeline/provider.py
@@ -36,7 +36,7 @@ class PipelineProvider[P](abc.ABC):
         >>> return [OAuthInitView(), OAuthCallbackView()]
         """
 
-    def get_pipeline_api_steps(self) -> ApiPipelineSteps[P]:
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[P] | None:
         """
         Return API step objects for this provider's pipeline, or None if API
         mode is not supported. Override to enable the pipeline API.

--- a/src/sentry/pipeline/views/base.py
+++ b/src/sentry/pipeline/views/base.py
@@ -58,7 +58,7 @@ class ApiPipelineEndpoint[P, D = Any, V = Any](Protocol):
 
 
 type ApiPipelineStep[P] = ApiPipelineEndpoint[P] | Callable[[], ApiPipelineEndpoint[P]]
-type ApiPipelineSteps[P] = Sequence[ApiPipelineStep[P]] | None
+type ApiPipelineSteps[P] = Sequence[ApiPipelineStep[P]]
 
 
 def render_react_view(


### PR DESCRIPTION
Refs [VDY-32: Migrate integration setup pipelines to API-driven flows](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows)