### PR TITLE
fix(onboarding): Handle repo selection race with background link_all_repos

### DIFF
--- a/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
-import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import type {IntegrationRepository} from 'sentry/types/integrations';
 
@@ -116,7 +116,7 @@ describe('useScmRepoSelection', () => {
     );
   });
 
-  it('reverts onSelect when both GET and POST fail', async () => {
+  it('reverts onSelect on POST failure', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/`,
       body: [],
@@ -146,7 +146,30 @@ describe('useScmRepoSelection', () => {
     expect(onSelect).toHaveBeenCalledWith(undefined);
   });
 
-  it('handleRemove calls onSelect with undefined', async () => {
+  it('reverts onSelect on GET failure', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
+      {organization}
+    );
+
+    await act(async () => {
+      await result.current.handleSelect({value: 'getsentry/sentry'});
+    });
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({id: '', name: 'sentry'})
+    );
+    expect(onSelect).toHaveBeenCalledWith(undefined);
+  });
+
+  it('handleRemove calls onSelect with undefined', () => {
     const {result} = renderHookWithProviders(
       () =>
         useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
@@ -160,7 +183,7 @@ describe('useScmRepoSelection', () => {
     expect(onSelect).toHaveBeenCalledWith(undefined);
   });
 
-  it('sets busy during selection and clears after', async () => {
+  it('clears busy state after selection completes', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/`,
       body: [
@@ -181,14 +204,8 @@ describe('useScmRepoSelection', () => {
 
     expect(result.current.busy).toBe(false);
 
-    let selectPromise: Promise<void>;
-    act(() => {
-      selectPromise = result.current.handleSelect({value: 'getsentry/sentry'});
-    });
-
-    await waitFor(() => expect(result.current.busy).toBe(false));
     await act(async () => {
-      await selectPromise!;
+      await result.current.handleSelect({value: 'getsentry/sentry'});
     });
 
     expect(result.current.busy).toBe(false);

--- a/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
@@ -3,24 +3,9 @@ import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegr
 
 import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {
-  OnboardingContextProvider,
-  type OnboardingSessionState,
-} from 'sentry/components/onboarding/onboardingContext';
 import type {IntegrationRepository} from 'sentry/types/integrations';
-import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 import {useScmRepoSelection} from './useScmRepoSelection';
-
-function makeOnboardingWrapper(initialState?: OnboardingSessionState) {
-  return function OnboardingWrapper({children}: {children?: React.ReactNode}) {
-    return (
-      <OnboardingContextProvider initialValue={initialState}>
-        {children}
-      </OnboardingContextProvider>
-    );
-  };
-}
 
 describe('useScmRepoSelection', () => {
   const organization = OrganizationFixture();
@@ -49,69 +34,16 @@ describe('useScmRepoSelection', () => {
     isInstalled: false,
   };
 
-  const mockInstalledRepo: IntegrationRepository = {
-    identifier: 'getsentry/sentry',
-    name: 'sentry',
-    isInstalled: true,
-  };
-
   beforeEach(() => {
-    sessionStorageWrapper.clear();
     onSelect = jest.fn();
     reposByIdentifier = new Map([['getsentry/sentry', mockRepo]]);
-
-    // Default: no existing repos
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/repos/`,
-      body: [],
-    });
   });
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
   });
 
-  it('calls POST to add new repo and updates onSelect with server ID', async () => {
-    const addRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/repos/`,
-      method: 'POST',
-      body: {
-        id: '42',
-        name: 'getsentry/sentry',
-        externalSlug: 'getsentry/sentry',
-        status: 'active',
-      },
-    });
-
-    const {result} = renderHookWithProviders(
-      () =>
-        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({}),
-      }
-    );
-
-    await act(async () => {
-      await result.current.handleSelect({value: 'getsentry/sentry'});
-    });
-
-    expect(addRequest).toHaveBeenCalled();
-    // Optimistic call with empty id
-    expect(onSelect).toHaveBeenCalledWith(
-      expect.objectContaining({id: '', name: 'sentry'})
-    );
-    // Then real call with server response spread over optimistic
-    expect(onSelect).toHaveBeenCalledWith(
-      expect.objectContaining({id: '42', name: 'getsentry/sentry'})
-    );
-  });
-
-  it('does not POST for already-installed repos, uses existing repo ID', async () => {
-    reposByIdentifier = new Map([['getsentry/sentry', mockInstalledRepo]]);
-
-    // Override repos response with an existing repo
-    MockApiClient.clearMockResponses();
+  it('uses existing repo when GET finds it, skips POST', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/`,
       body: [
@@ -133,14 +65,8 @@ describe('useScmRepoSelection', () => {
     const {result} = renderHookWithProviders(
       () =>
         useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({}),
-      }
+      {organization}
     );
-
-    // Wait for existing repos query to resolve
-    await waitFor(() => expect(result.current.busy).toBe(false));
 
     await act(async () => {
       await result.current.handleSelect({value: 'getsentry/sentry'});
@@ -152,7 +78,50 @@ describe('useScmRepoSelection', () => {
     );
   });
 
-  it('reverts onSelect on addRepository failure', async () => {
+  it('creates repo via POST when GET finds nothing', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: [],
+    });
+
+    const addRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      method: 'POST',
+      body: {
+        id: '42',
+        name: 'getsentry/sentry',
+        externalSlug: 'getsentry/sentry',
+        status: 'active',
+      },
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
+      {organization}
+    );
+
+    await act(async () => {
+      await result.current.handleSelect({value: 'getsentry/sentry'});
+    });
+
+    expect(addRequest).toHaveBeenCalled();
+    // Optimistic call with empty id
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({id: '', name: 'sentry'})
+    );
+    // Then real call with server response
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({id: '42', name: 'getsentry/sentry'})
+    );
+  });
+
+  it('reverts onSelect when both GET and POST fail', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: [],
+    });
+
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/`,
       method: 'POST',
@@ -163,10 +132,7 @@ describe('useScmRepoSelection', () => {
     const {result} = renderHookWithProviders(
       () =>
         useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({}),
-      }
+      {organization}
     );
 
     await act(async () => {
@@ -180,92 +146,51 @@ describe('useScmRepoSelection', () => {
     expect(onSelect).toHaveBeenCalledWith(undefined);
   });
 
-  it('cleans up previously added repo when selecting a new one', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/repos/`,
-      method: 'POST',
-      body: {
-        id: '42',
-        name: 'getsentry/sentry',
-        externalSlug: 'getsentry/sentry',
-        status: 'active',
-      },
-    });
-
-    const hideRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/repos/42/`,
-      method: 'PUT',
-      body: {},
-    });
-
+  it('handleRemove calls onSelect with undefined', async () => {
     const {result} = renderHookWithProviders(
       () =>
         useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({}),
-      }
+      {organization}
     );
 
-    // First selection
-    await act(async () => {
-      await result.current.handleSelect({value: 'getsentry/sentry'});
-    });
-
-    // Add a second repo
-    const secondRepo: IntegrationRepository = {
-      identifier: 'getsentry/relay',
-      name: 'relay',
-      isInstalled: false,
-    };
-    reposByIdentifier.set('getsentry/relay', secondRepo);
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/repos/`,
-      method: 'POST',
-      body: {
-        id: '43',
-        name: 'getsentry/relay',
-        externalSlug: 'getsentry/relay',
-        status: 'active',
-      },
-    });
-
-    // Second selection should clean up the first
-    await act(async () => {
-      await result.current.handleSelect({value: 'getsentry/relay'});
-    });
-
-    expect(hideRequest).toHaveBeenCalled();
-  });
-
-  it('does not call hideRepository on remove if repo was pre-existing', async () => {
-    const hideRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/repos/99/`,
-      method: 'PUT',
-      body: {},
-    });
-
-    const {result} = renderHookWithProviders(
-      () =>
-        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
-      {
-        organization,
-        additionalWrapper: makeOnboardingWrapper({
-          selectedRepository: {
-            id: '99',
-            name: 'sentry',
-            externalSlug: 'getsentry/sentry',
-          } as any,
-        }),
-      }
-    );
-
-    await act(async () => {
-      await result.current.handleRemove();
+    act(() => {
+      result.current.handleRemove();
     });
 
     expect(onSelect).toHaveBeenCalledWith(undefined);
-    expect(hideRequest).not.toHaveBeenCalled();
+  });
+
+  it('sets busy during selection and clears after', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: [
+        {
+          id: '99',
+          name: 'getsentry/sentry',
+          externalSlug: 'getsentry/sentry',
+          status: 'active',
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
+      {organization}
+    );
+
+    expect(result.current.busy).toBe(false);
+
+    let selectPromise: Promise<void>;
+    act(() => {
+      selectPromise = result.current.handleSelect({value: 'getsentry/sentry'});
+    });
+
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    await act(async () => {
+      await selectPromise!;
+    });
+
+    expect(result.current.busy).toBe(false);
   });
 });

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -78,7 +78,11 @@ export function useScmRepoSelection({
         queryFn: fetchDataQuery<Repository[]>,
         staleTime: 0,
       });
-      const existing = matches?.find(r => r.externalSlug === repo.identifier);
+      // Match on name rather than externalSlug because externalSlug varies
+      // by provider (e.g. GitLab uses a numeric project ID) while name is
+      // consistently the full repo path (e.g. "getsentry/sentry") across
+      // all providers — matching repo.identifier from the search results.
+      const existing = matches?.find(r => r.name === repo.identifier);
 
       if (existing) {
         onSelect({...optimistic, ...existing});

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -74,12 +74,32 @@ export function useScmRepoSelection({
     const optimistic = buildOptimisticRepo(repo, integration);
     onSelect(optimistic);
 
-    // Always try POST first. If the background link_all_repos task already
-    // created this repo, the POST will fail and we fall back to fetching
-    // the existing record. This avoids relying on a potentially stale cache
-    // that may not have caught up with the background task yet.
+    // Check if the repo already exists in Sentry (e.g. created by the
+    // background link_all_repos task or a previous session). Use a targeted
+    // query filtered by name to avoid pagination issues with the full list.
     setBusy(true);
     try {
+      const api = new Client();
+      const matches = await api.requestPromise(
+        `/organizations/${organization.slug}/repos/`,
+        {
+          query: {
+            status: 'active',
+            integration_id: integration.id,
+            query: repo.identifier,
+          },
+        }
+      );
+      const existing = (matches as Repository[])?.find(
+        r => r.externalSlug === repo.identifier
+      );
+
+      if (existing) {
+        onSelect({...optimistic, ...existing});
+        return;
+      }
+
+      // Repo not found — create it.
       const created = await fetchMutation<Repository>({
         url: `/organizations/${organization.slug}/repos/`,
         method: 'POST',
@@ -92,32 +112,7 @@ export function useScmRepoSelection({
       onSelect({...optimistic, ...created});
       addedRepoIdRef.current = created.id;
     } catch {
-      // POST failed — likely because the repo already exists (created by
-      // link_all_repos or a previous session). Query for it by name to
-      // avoid pagination issues with the full repo list.
-      try {
-        const api = new Client();
-        const matches = await api.requestPromise(
-          `/organizations/${organization.slug}/repos/`,
-          {
-            query: {
-              status: 'active',
-              integration_id: integration.id,
-              query: repo.identifier,
-            },
-          }
-        );
-        const existing = (matches as Repository[])?.find(
-          r => r.externalSlug === repo.identifier
-        );
-        if (existing) {
-          onSelect({...optimistic, ...existing});
-        } else {
-          onSelect(undefined);
-        }
-      } catch {
-        onSelect(undefined);
-      }
+      onSelect(undefined);
     } finally {
       setBusy(false);
     }

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -7,7 +7,7 @@ import type {
   Repository,
 } from 'sentry/types/integrations';
 import {RepositoryStatus} from 'sentry/types/integrations';
-import {fetchMutation, QUERY_API_CLIENT} from 'sentry/utils/queryClient';
+import {fetchDataQuery, fetchMutation, useQueryClient} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface UseScmRepoSelectionOptions {
@@ -42,6 +42,7 @@ export function useScmRepoSelection({
   reposByIdentifier,
 }: UseScmRepoSelectionOptions) {
   const organization = useOrganization();
+  const queryClient = useQueryClient();
   const {selectedRepository} = useOnboardingContext();
   const [busy, setBusy] = useState(false);
 
@@ -78,16 +79,20 @@ export function useScmRepoSelection({
     // query filtered by name to avoid pagination issues with the full list.
     setBusy(true);
     try {
-      const matches: Repository[] = await QUERY_API_CLIENT.requestPromise(
-        `/organizations/${organization.slug}/repos/`,
-        {
-          query: {
-            status: 'active',
-            integration_id: integration.id,
-            query: repo.identifier,
+      const [matches] = await queryClient.fetchQuery({
+        queryKey: [
+          `/organizations/${organization.slug}/repos/`,
+          {
+            query: {
+              status: 'active',
+              integration_id: integration.id,
+              query: repo.identifier,
+            },
           },
-        }
-      );
+        ],
+        queryFn: fetchDataQuery<Repository[]>,
+        staleTime: 0,
+      });
       const existing = matches?.find(r => r.externalSlug === repo.identifier);
 
       if (existing) {

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -7,7 +7,7 @@ import type {
   Repository,
 } from 'sentry/types/integrations';
 import {RepositoryStatus} from 'sentry/types/integrations';
-import {fetchMutation} from 'sentry/utils/queryClient';
+import {fetchMutation, QUERY_API_CLIENT} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface UseScmRepoSelectionOptions {
@@ -78,17 +78,16 @@ export function useScmRepoSelection({
     // query filtered by name to avoid pagination issues with the full list.
     setBusy(true);
     try {
-      const matches = await fetchMutation<Repository[]>({
-        url: `/organizations/${organization.slug}/repos/`,
-        method: 'GET',
-        options: {
+      const matches: Repository[] = await QUERY_API_CLIENT.requestPromise(
+        `/organizations/${organization.slug}/repos/`,
+        {
           query: {
             status: 'active',
             integration_id: integration.id,
             query: repo.identifier,
           },
-        },
-      });
+        }
+      );
       const existing = matches?.find(r => r.externalSlug === repo.identifier);
 
       if (existing) {

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -1,6 +1,5 @@
 import {useRef, useState} from 'react';
 
-import {Client} from 'sentry/api';
 import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import type {
   Integration,
@@ -79,20 +78,18 @@ export function useScmRepoSelection({
     // query filtered by name to avoid pagination issues with the full list.
     setBusy(true);
     try {
-      const api = new Client();
-      const matches = await api.requestPromise(
-        `/organizations/${organization.slug}/repos/`,
-        {
+      const matches = await fetchMutation<Repository[]>({
+        url: `/organizations/${organization.slug}/repos/`,
+        method: 'GET',
+        options: {
           query: {
             status: 'active',
             integration_id: integration.id,
             query: repo.identifier,
           },
-        }
-      );
-      const existing = (matches as Repository[])?.find(
-        r => r.externalSlug === repo.identifier
-      );
+        },
+      });
+      const existing = matches?.find(r => r.externalSlug === repo.identifier);
 
       if (existing) {
         onSelect({...optimistic, ...existing});

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -1,6 +1,5 @@
-import {useRef, useState} from 'react';
+import {useState} from 'react';
 
-import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import type {
   Integration,
   IntegrationRepository,
@@ -45,25 +44,7 @@ export function useScmRepoSelection({
 }: UseScmRepoSelectionOptions) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
-  const {selectedRepository} = useOnboardingContext();
   const [busy, setBusy] = useState(false);
-
-  // Track the ID of a repo we added during this session so we can clean
-  // it up if the user switches to a different repo.
-  const addedRepoIdRef = useRef<string | null>(null);
-
-  // Best-effort cleanup: fire-and-forget the hide request. If it fails the
-  // repo stays registered in Sentry but is non-critical for the onboarding flow.
-  const cleanupPreviousAdd = () => {
-    if (addedRepoIdRef.current) {
-      fetchMutation({
-        url: `/organizations/${organization.slug}/repos/${addedRepoIdRef.current}/`,
-        method: 'PUT',
-        data: {status: 'hidden'},
-      }).catch(() => {});
-      addedRepoIdRef.current = null;
-    }
-  };
 
   const handleSelect = async (selection: {value: string}) => {
     const repo = reposByIdentifier.get(selection.value);
@@ -71,14 +52,13 @@ export function useScmRepoSelection({
       return;
     }
 
-    cleanupPreviousAdd();
-
     const optimistic = buildOptimisticRepo(repo, integration);
     onSelect(optimistic);
 
-    // Check if the repo already exists in Sentry (e.g. created by the
-    // background link_all_repos task or a previous session). Use a targeted
-    // query filtered by name to avoid pagination issues with the full list.
+    // Look up the repo in Sentry. The background link_all_repos task
+    // registers all repos after integration install, so most repos will
+    // already exist. Use a targeted query filtered by name to avoid
+    // pagination issues with the full list.
     setBusy(true);
     try {
       const queryKey: ApiQueryKey = [
@@ -105,7 +85,7 @@ export function useScmRepoSelection({
         return;
       }
 
-      // Repo not found — create it.
+      // Repo not yet registered (link_all_repos may still be running).
       const created = await fetchMutation<Repository>({
         url: `/organizations/${organization.slug}/repos/`,
         method: 'POST',
@@ -116,7 +96,6 @@ export function useScmRepoSelection({
         },
       });
       onSelect({...optimistic, ...created});
-      addedRepoIdRef.current = created.id;
     } catch {
       onSelect(undefined);
     } finally {
@@ -124,34 +103,11 @@ export function useScmRepoSelection({
     }
   };
 
-  const handleRemove = async () => {
-    if (!selectedRepository) {
-      return;
-    }
-
-    const previous = selectedRepository;
+  const handleRemove = () => {
     onSelect(undefined);
-
-    if (addedRepoIdRef.current && addedRepoIdRef.current === previous.id) {
-      setBusy(true);
-      try {
-        await fetchMutation({
-          url: `/organizations/${organization.slug}/repos/${previous.id}/`,
-          method: 'PUT',
-          data: {status: 'hidden'},
-        });
-        addedRepoIdRef.current = null;
-      } catch {
-        onSelect(previous);
-      } finally {
-        setBusy(false);
-      }
-    }
   };
 
   return {
-    // Busy while adding/removing a repo.
-    // The UI disables the Select and remove button when true.
     busy,
     handleSelect,
     handleRemove,

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -1,5 +1,7 @@
 import {useState} from 'react';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
 import type {
   Integration,
   IntegrationRepository,
@@ -102,6 +104,7 @@ export function useScmRepoSelection({
       });
       onSelect({...optimistic, ...created});
     } catch {
+      addErrorMessage(t('Failed to select repository'));
       onSelect(undefined);
     } finally {
       setBusy(false);

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -7,6 +7,8 @@ import type {
   Repository,
 } from 'sentry/types/integrations';
 import {RepositoryStatus} from 'sentry/types/integrations';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {fetchDataQuery, fetchMutation, useQueryClient} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -79,17 +81,20 @@ export function useScmRepoSelection({
     // query filtered by name to avoid pagination issues with the full list.
     setBusy(true);
     try {
-      const [matches] = await queryClient.fetchQuery({
-        queryKey: [
-          `/organizations/${organization.slug}/repos/`,
-          {
-            query: {
-              status: 'active',
-              integration_id: integration.id,
-              query: repo.identifier,
-            },
+      const queryKey: ApiQueryKey = [
+        getApiUrl('/organizations/$organizationIdOrSlug/repos/', {
+          path: {organizationIdOrSlug: organization.slug},
+        }),
+        {
+          query: {
+            status: 'active',
+            integration_id: integration.id,
+            query: repo.identifier,
           },
-        ],
+        },
+      ];
+      const [matches] = await queryClient.fetchQuery({
+        queryKey,
         queryFn: fetchDataQuery<Repository[]>,
         staleTime: 0,
       });

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -78,10 +78,11 @@ export function useScmRepoSelection({
         queryFn: fetchDataQuery<Repository[]>,
         staleTime: 0,
       });
-      // Match on name rather than externalSlug because externalSlug varies
-      // by provider (e.g. GitLab uses a numeric project ID) while name is
-      // consistently the full repo path (e.g. "getsentry/sentry") across
-      // all providers — matching repo.identifier from the search results.
+      // Match on Repository.name === IntegrationRepository.identifier.
+      // This is the same comparison the backend uses in the search endpoint
+      // (organization_integration_repos.py) to determine isInstalled.
+      // Can't use externalSlug because it varies by provider (e.g. GitLab
+      // returns a numeric project ID).
       const existing = matches?.find(r => r.name === repo.identifier);
 
       if (existing) {

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -80,11 +80,12 @@ export function useScmRepoSelection({
         queryFn: fetchDataQuery<Repository[]>,
         staleTime: 0,
       });
-      // Match on Repository.name === IntegrationRepository.identifier.
-      // This is the same comparison the backend uses in the search endpoint
-      // (organization_integration_repos.py) to determine isInstalled.
-      // Can't use externalSlug because it varies by provider (e.g. GitLab
-      // returns a numeric project ID).
+      // The query param above is an icontains filter to narrow results
+      // and avoid pagination. The exact match here uses Repository.name
+      // against IntegrationRepository.identifier — the same comparison the
+      // backend uses in organization_integration_repos.py:61,80 to determine
+      // isInstalled. Can't use externalSlug because it varies by provider
+      // (e.g. GitLab returns a numeric project ID).
       const existing = matches?.find(r => r.name === repo.identifier);
 
       if (existing) {

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
@@ -104,7 +105,8 @@ export function useScmRepoSelection({
         },
       });
       onSelect({...optimistic, ...created});
-    } catch {
+    } catch (error) {
+      Sentry.captureException(error);
       addErrorMessage(t('Failed to select repository'));
       onSelect(undefined);
     } finally {

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -1,5 +1,6 @@
-import {useMemo, useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 
+import {Client} from 'sentry/api';
 import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import type {
   Integration,
@@ -7,8 +8,7 @@ import type {
   Repository,
 } from 'sentry/types/integrations';
 import {RepositoryStatus} from 'sentry/types/integrations';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface UseScmRepoSelectionOptions {
@@ -46,25 +46,6 @@ export function useScmRepoSelection({
   const {selectedRepository} = useOnboardingContext();
   const [busy, setBusy] = useState(false);
 
-  // Fetch repos already registered in Sentry for this integration, so we
-  // can look up the real Repository (with Sentry ID) for "Already Added" repos.
-  const {data: existingRepos, isPending: existingReposPending} = useApiQuery<
-    Repository[]
-  >(
-    [
-      getApiUrl('/organizations/$organizationIdOrSlug/repos/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
-      {query: {status: 'active', integration_id: integration.id}},
-    ],
-    {staleTime: 0}
-  );
-
-  const existingReposBySlug = useMemo(
-    () => new Map((existingRepos ?? []).map(r => [r.externalSlug, r])),
-    [existingRepos]
-  );
-
   // Track the ID of a repo we added during this session so we can clean
   // it up if the user switches to a different repo.
   const addedRepoIdRef = useRef<string | null>(null);
@@ -93,15 +74,10 @@ export function useScmRepoSelection({
     const optimistic = buildOptimisticRepo(repo, integration);
     onSelect(optimistic);
 
-    if (repo.isInstalled) {
-      const existing = existingReposBySlug.get(repo.identifier);
-      if (existing) {
-        onSelect({...optimistic, ...existing});
-        return;
-      }
-      // Lookup missed (e.g., repo was hidden). Fall through to re-add it.
-    }
-
+    // Always try POST first. If the background link_all_repos task already
+    // created this repo, the POST will fail and we fall back to fetching
+    // the existing record. This avoids relying on a potentially stale cache
+    // that may not have caught up with the background task yet.
     setBusy(true);
     try {
       const created = await fetchMutation<Repository>({
@@ -116,7 +92,32 @@ export function useScmRepoSelection({
       onSelect({...optimistic, ...created});
       addedRepoIdRef.current = created.id;
     } catch {
-      onSelect(undefined);
+      // POST failed — likely because the repo already exists (created by
+      // link_all_repos or a previous session). Query for it by name to
+      // avoid pagination issues with the full repo list.
+      try {
+        const api = new Client();
+        const matches = await api.requestPromise(
+          `/organizations/${organization.slug}/repos/`,
+          {
+            query: {
+              status: 'active',
+              integration_id: integration.id,
+              query: repo.identifier,
+            },
+          }
+        );
+        const existing = (matches as Repository[])?.find(
+          r => r.externalSlug === repo.identifier
+        );
+        if (existing) {
+          onSelect({...optimistic, ...existing});
+        } else {
+          onSelect(undefined);
+        }
+      } catch {
+        onSelect(undefined);
+      }
     } finally {
       setBusy(false);
     }
@@ -148,9 +149,9 @@ export function useScmRepoSelection({
   };
 
   return {
-    // Busy while adding/removing a repo or while existing repos are still
-    // loading. The UI disables the Select and remove button when true.
-    busy: busy || existingReposPending,
+    // Busy while adding/removing a repo.
+    // The UI disables the Select and remove button when true.
+    busy,
     handleSelect,
     handleRemove,
   };


### PR DESCRIPTION
Fix repo selection in the SCM onboarding connect step to handle the race with the background `link_all_repos` task.

After a GitHub integration is installed, `link_all_repos` runs async and registers all repos. The old approach cached existing repos on mount and checked that cache before deciding to POST. This broke because the cache was often stale (task still running) and the repos endpoint is paginated (specific repo might not be on page 1).

New approach:
- GET first with a targeted query filtered by repo name (sidesteps pagination)
- POST only if the repo doesn't exist yet

The old code also hid (soft-deleted) repo records when the user deselected or switched repos. This made sense when repos were manually registered one at a time, but with `link_all_repos` auto-registering everything, hiding repos on deselect was counterproductive -- it removed records the background task created, causing them to disappear from the integration settings page. Repo selection is now just a context pointer with no side effects on the repo records themselves.

Also switches to `queryClient.fetchQuery` + `fetchDataQuery` for the imperative GET instead of deprecated `Client.requestPromise`.

Replaces #111699 (closed due to CODEOWNERS auto-review noise from base change).