### PR TITLE
fix(logs): Prevent cell action menu clicks from toggling row visibility

### DIFF
--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -489,6 +489,55 @@ describe('logsTableRow', () => {
     expect(parsedData).not.toHaveProperty('sentry.item_id');
   });
 
+  it('does not toggle row when clicking cell action menu items', async () => {
+    const mockWriteText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+    });
+
+    render(
+      <ProviderWrapper>
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={
+            {
+              current: null,
+            } as React.MutableRefObject<NodeJS.Timeout | null>
+          }
+        />
+      </ProviderWrapper>,
+      {organization, initialRouterConfig}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.click(logTableRow);
+
+    await waitFor(() => {
+      expect(rowDetailsMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Row is expanded - verify details are visible
+    expect(await screen.findByRole('button', {name: 'Copy as JSON'})).toBeInTheDocument();
+
+    // Open the ellipsis context menu on a cell
+    const actionsButton = screen.getAllByRole('button', {name: 'Actions'})[0]!;
+    await userEvent.click(actionsButton);
+
+    // Click "Copy to clipboard" in the dropdown menu
+    const copyItem = await screen.findByRole('menuitemradio', {
+      name: 'Copy to clipboard',
+    });
+    await userEvent.click(copyItem);
+
+    // Row should still be expanded - the cell action should not toggle visibility
+    expect(screen.getByRole('button', {name: 'Copy as JSON'})).toBeInTheDocument();
+  });
+
   it('renders fields with data scrubbing meta information', async () => {
     const traceItemMock = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/trace-items/${rowDataWithScrubbedFields[OurLogKnownFieldKey.ID]}/`,

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -213,17 +213,15 @@ describe('logsTableRow', () => {
     jest.useFakeTimers();
     expect(rowDetailsMock).toHaveBeenCalledTimes(0);
     render(
-      <ProviderWrapper>
-        <LogRowContent
-          dataRow={rowData}
-          highlightTerms={[]}
-          meta={LogFixtureMeta(rowData)}
-          sharedHoverTimeoutRef={
-            {current: null} as React.MutableRefObject<NodeJS.Timeout | null>
-          }
-        />
-      </ProviderWrapper>,
-      {organization, initialRouterConfig}
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={
+          {current: null} as React.MutableRefObject<NodeJS.Timeout | null>
+        }
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
     );
 
     expect(screen.queryByLabelText('Toggle trace details')).not.toBeInTheDocument(); // Fake button
@@ -247,19 +245,17 @@ describe('logsTableRow', () => {
 
   it('renders row details', async () => {
     render(
-      <ProviderWrapper>
-        <LogRowContent
-          dataRow={rowData}
-          highlightTerms={[]}
-          meta={LogFixtureMeta(rowData)}
-          sharedHoverTimeoutRef={
-            {
-              current: null,
-            } as React.MutableRefObject<NodeJS.Timeout | null>
-          }
-        />
-      </ProviderWrapper>,
-      {organization, initialRouterConfig}
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={
+          {
+            current: null,
+          } as React.MutableRefObject<NodeJS.Timeout | null>
+        }
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
     );
 
     // Check that the log body and timestamp are rendered
@@ -349,19 +345,21 @@ describe('logsTableRow', () => {
 
   it('shows a link when hovering over code file path in the table', async () => {
     render(
-      <ProviderWrapper>
-        <LogRowContent
-          dataRow={rowDataWithCodeFilePath}
-          highlightTerms={[]}
-          meta={LogFixtureMeta(rowDataWithCodeFilePath)}
-          sharedHoverTimeoutRef={
-            {
-              current: null,
-            } as React.MutableRefObject<NodeJS.Timeout | null>
-          }
-        />
-      </ProviderWrapper>,
-      {organization, initialRouterConfig: initialRouterConfigWithCodeFilePath}
+      <LogRowContent
+        dataRow={rowDataWithCodeFilePath}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithCodeFilePath)}
+        sharedHoverTimeoutRef={
+          {
+            current: null,
+          } as React.MutableRefObject<NodeJS.Timeout | null>
+        }
+      />,
+      {
+        organization,
+        initialRouterConfig: initialRouterConfigWithCodeFilePath,
+        additionalWrapper: ProviderWrapper,
+      }
     );
 
     // Expand the row to show the attributes
@@ -430,19 +428,17 @@ describe('logsTableRow', () => {
     });
 
     render(
-      <ProviderWrapper>
-        <LogRowContent
-          dataRow={rowData}
-          highlightTerms={[]}
-          meta={LogFixtureMeta(rowData)}
-          sharedHoverTimeoutRef={
-            {
-              current: null,
-            } as React.MutableRefObject<NodeJS.Timeout | null>
-          }
-        />
-      </ProviderWrapper>,
-      {organization, initialRouterConfig}
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={
+          {
+            current: null,
+          } as React.MutableRefObject<NodeJS.Timeout | null>
+        }
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
     );
 
     // Expand the row to show the action buttons
@@ -499,19 +495,17 @@ describe('logsTableRow', () => {
     });
 
     render(
-      <ProviderWrapper>
-        <LogRowContent
-          dataRow={rowData}
-          highlightTerms={[]}
-          meta={LogFixtureMeta(rowData)}
-          sharedHoverTimeoutRef={
-            {
-              current: null,
-            } as React.MutableRefObject<NodeJS.Timeout | null>
-          }
-        />
-      </ProviderWrapper>,
-      {organization, initialRouterConfig}
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={
+          {
+            current: null,
+          } as React.MutableRefObject<NodeJS.Timeout | null>
+        }
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
     );
 
     const logTableRow = await screen.findByTestId('log-table-row');
@@ -580,19 +574,21 @@ describe('logsTableRow', () => {
     });
 
     render(
-      <ProviderWrapper>
-        <LogRowContent
-          dataRow={rowDataWithScrubbedFields}
-          highlightTerms={[]}
-          meta={LogFixtureMeta(rowDataWithScrubbedFields)}
-          sharedHoverTimeoutRef={
-            {
-              current: null,
-            } as React.MutableRefObject<NodeJS.Timeout | null>
-          }
-        />
-      </ProviderWrapper>,
-      {organization, initialRouterConfig: initialRouterConfigWithScrubbedFields}
+      <LogRowContent
+        dataRow={rowDataWithScrubbedFields}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithScrubbedFields)}
+        sharedHoverTimeoutRef={
+          {
+            current: null,
+          } as React.MutableRefObject<NodeJS.Timeout | null>
+        }
+      />,
+      {
+        organization,
+        initialRouterConfig: initialRouterConfigWithScrubbedFields,
+        additionalWrapper: ProviderWrapper,
+      }
     );
 
     const logTableRow = await screen.findByTestId('log-table-row');

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -184,10 +184,22 @@ export const LogRowContent = memo(function LogRowContent({
   }
 
   function onPointerUp(event: SyntheticEvent) {
-    if (event.target instanceof Element && isInsideButton(event.target)) {
-      // do not expand the context menu if you clicked a button
-      return;
+    // do not expand the context menu if...
+    if (event.target instanceof Element) {
+      // ... you clicked a button
+      if (isInsideButton(event.target)) {
+        return;
+      }
+
+      // ... you clicked outside the row (e.g. a portal button)
+      if (
+        !(event.currentTarget instanceof Node) ||
+        !event.currentTarget.contains(event.target)
+      ) {
+        return;
+      }
     }
+
     if (window.getSelection()?.toString() === '') {
       toggleExpanded();
     }


### PR DESCRIPTION
The dropdown menu renders in a React portal, so its DOM lives outside the row. This adds a DOM containment check: before toggling, verify `event.currentTarget.contains(event.target)`. Portal-originating events fail this check since their DOM subtree is separate from the row's.

Fixes LOGS-638

Made with [Cursor](https://cursor.com)