### PR TITLE
ref(stacktrace): Clean up filename in new stack trace

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
@@ -5,7 +5,7 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-interface SourceMapDebugBlueThunderResponseFrame {
+export interface SourceMapDebugBlueThunderResponseFrame {
   debug_id_process: {
     debug_id: string | null;
     uploaded_source_file_with_correct_debug_id: boolean;
@@ -33,7 +33,7 @@ interface SourceMapDebugBlueThunderResponseFrame {
   };
 }
 
-interface SourceMapDebugBlueThunderResponse {
+export interface SourceMapDebugBlueThunderResponse {
   dist: string | null;
   exceptions: Array<{
     frames: SourceMapDebugBlueThunderResponseFrame[];

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
@@ -5,7 +5,7 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-export interface SourceMapDebugBlueThunderResponseFrame {
+interface SourceMapDebugBlueThunderResponseFrame {
   debug_id_process: {
     debug_id: string | null;
     uploaded_source_file_with_correct_debug_id: boolean;
@@ -33,7 +33,7 @@ export interface SourceMapDebugBlueThunderResponseFrame {
   };
 }
 
-export interface SourceMapDebugBlueThunderResponse {
+interface SourceMapDebugBlueThunderResponse {
   dist: string | null;
   exceptions: Array<{
     frames: SourceMapDebugBlueThunderResponseFrame[];

--- a/static/app/components/stackTrace/frame/actions/default.tsx
+++ b/static/app/components/stackTrace/frame/actions/default.tsx
@@ -32,7 +32,11 @@ export function DefaultFrameActions() {
           <Tag
             icon={<IconRefresh size="xs" />}
             variant="muted"
-            data-test-id="core-stacktrace-repeats-tag"
+            aria-label={tn(
+              'Frame repeated %s time',
+              'Frame repeated %s times',
+              timesRepeated
+            )}
           >
             {timesRepeated}
           </Tag>

--- a/static/app/components/stackTrace/frame/frameHeader.tsx
+++ b/static/app/components/stackTrace/frame/frameHeader.tsx
@@ -189,11 +189,13 @@ function FrameLocationTooltip({
   frame: Frame;
   frameDisplayPath: string;
 }) {
+  const externalUrl = frame.absPath && isUrl(frame.absPath) ? frame.absPath : undefined;
   const absPath =
-    frame.absPath && frame.absPath !== frameDisplayPath ? frame.absPath : undefined;
+    frame.absPath && frame.absPath !== frameDisplayPath && !externalUrl
+      ? frame.absPath
+      : undefined;
   const sourceMap = frame.mapUrl ?? frame.map;
   const showSourceMap = !!frame.origAbsPath && !!sourceMap;
-  const externalUrl = frame.absPath && isUrl(frame.absPath) ? frame.absPath : undefined;
 
   const hasContent = !!absPath || showSourceMap || !!externalUrl;
 
@@ -217,8 +219,9 @@ function FrameLocationTooltip({
             <Fragment>
               <strong>{t('URL')}</strong>
               <a
-                role="link"
+                href={externalUrl}
                 onClick={e => {
+                  e.preventDefault();
                   e.stopPropagation();
                   openNavigateToExternalLinkModal({linkText: externalUrl});
                 }}

--- a/static/app/components/stackTrace/frame/frameHeader.tsx
+++ b/static/app/components/stackTrace/frame/frameHeader.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
 import {
   getLeadHint,
   getPlatform,
@@ -178,8 +179,8 @@ function FrameLocationTooltip({
   children: React.ReactNode;
   frame: Frame;
 }) {
-  const sourceMapInfoText = frame.mapUrl ?? frame.map;
-  const showSourceMap = !!frame.origAbsPath && !!sourceMapInfoText;
+  const sourceMap = frame.mapUrl ?? frame.map;
+  const showSourceMap = !!frame.origAbsPath && !!sourceMap;
   const externalUrl = frame.absPath && isUrl(frame.absPath) ? frame.absPath : undefined;
 
   const hasContent = !!frame.absPath || showSourceMap || !!externalUrl;
@@ -190,24 +191,25 @@ function FrameLocationTooltip({
         <TooltipContent>
           {frame.absPath ? (
             <Fragment>
-              <strong>{t('File')}</strong>
+              <strong>{t('Absolute Path')}</strong>
               <span>{frame.absPath}</span>
             </Fragment>
           ) : null}
           {showSourceMap ? (
             <Fragment>
               <strong>{t('Source Map')}</strong>
-              <span>{sourceMapInfoText}</span>
+              <span>{sourceMap}</span>
             </Fragment>
           ) : null}
           {externalUrl ? (
             <Fragment>
               <strong>{t('URL')}</strong>
               <a
-                href={externalUrl}
-                target="_blank"
-                rel="noreferrer"
-                onClick={e => e.stopPropagation()}
+                role="link"
+                onClick={e => {
+                  e.stopPropagation();
+                  openNavigateToExternalLinkModal({linkText: externalUrl});
+                }}
               >
                 {externalUrl}
               </a>
@@ -216,7 +218,7 @@ function FrameLocationTooltip({
         </TooltipContent>
       }
       disabled={!hasContent}
-      maxWidth={450}
+      maxWidth={475}
       skipWrapper
       delay={1000}
       isHoverable

--- a/static/app/components/stackTrace/frame/frameHeader.tsx
+++ b/static/app/components/stackTrace/frame/frameHeader.tsx
@@ -127,8 +127,8 @@ function FrameLocation({
           {': '}
         </LeadHint>
       ) : null}
-      <FrameLocationTooltip frame={frame} frameDisplayPath={frameDisplayPath}>
-        <Path data-test-id="core-stacktrace-frame-location">
+      <FrameLocationTooltip frame={frame}>
+        <Path>
           <span>
             <span>{frameDisplayPath}</span>
             {frameLocationSuffix ? <span>{frameLocationSuffix}</span> : null}
@@ -173,32 +173,25 @@ function FrameContext({frame, platform}: {frame: Frame; platform: PlatformKey}) 
 
 function FrameLocationTooltip({
   frame,
-  frameDisplayPath,
   children,
 }: {
   children: React.ReactNode;
   frame: Frame;
-  frameDisplayPath: string;
 }) {
-  const absPath =
-    frame.absPath && frame.absPath !== frameDisplayPath
-      ? formatFrameLocation(frame.absPath, frame.lineNo, frame.colNo)
-      : undefined;
-
   const sourceMapInfoText = frame.mapUrl ?? frame.map;
   const showSourceMap = !!frame.origAbsPath && !!sourceMapInfoText;
   const externalUrl = frame.absPath && isUrl(frame.absPath) ? frame.absPath : undefined;
 
-  const hasContent = !!absPath || showSourceMap || !!externalUrl;
+  const hasContent = !!frame.absPath || showSourceMap || !!externalUrl;
 
   return (
     <Tooltip
       title={
         <TooltipContent>
-          {absPath ? (
+          {frame.absPath ? (
             <Fragment>
               <strong>{t('File')}</strong>
-              <span>{absPath}</span>
+              <span>{frame.absPath}</span>
             </Fragment>
           ) : null}
           {showSourceMap ? (

--- a/static/app/components/stackTrace/frame/frameHeader.tsx
+++ b/static/app/components/stackTrace/frame/frameHeader.tsx
@@ -9,19 +9,27 @@ import {
   getLeadHint,
   getPlatform,
   isDotnet,
+  isPotentiallyThirdPartyFrame,
 } from 'sentry/components/events/interfaces/frame/utils';
 import {useStackTraceFrameContext} from 'sentry/components/stackTrace/stackTraceContext';
 import {t} from 'sentry/locale';
-import type {Frame} from 'sentry/types/event';
+import type {Event, Frame} from 'sentry/types/event';
 import type {PlatformKey} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {isUrl} from 'sentry/utils/string/isUrl';
 
-function getFrameDisplayPath(frame: Frame, platform: PlatformKey) {
+function getFrameDisplayPath(frame: Frame, platform: PlatformKey, event: Event) {
   const framePlatform = getPlatform(frame.platform, platform);
 
+  // Prioritize module name for Java as filename is often only basename
   if (framePlatform === 'java') {
     return frame.module ?? frame.filename ?? '';
+  }
+
+  // For third-party JS frames, show the full absPath URL so the
+  // user can see which external domain the code came from.
+  if (isPotentiallyThirdPartyFrame(frame, event) && frame.absPath) {
+    return frame.absPath;
   }
 
   return frame.filename ?? frame.module ?? '';
@@ -32,11 +40,11 @@ function formatFrameLocation(
   lineNo: number | null | undefined,
   colNo: number | null | undefined
 ): string {
-  if (!defined(lineNo) || lineNo < 0) {
+  if (!defined(lineNo) || lineNo <= 0) {
     return path;
   }
 
-  if (!defined(colNo) || colNo < 0) {
+  if (!defined(colNo) || colNo <= 0) {
     return `${path}:${lineNo}`;
   }
 
@@ -117,7 +125,7 @@ function FrameLocation({
   platform: PlatformKey;
 }) {
   const {event} = useStackTraceFrameContext();
-  const frameDisplayPath = getFrameDisplayPath(frame, platform);
+  const frameDisplayPath = getFrameDisplayPath(frame, platform, event);
   const frameLocationSuffix = formatFrameLocation('', frame.lineNo, frame.colNo);
 
   return (
@@ -128,7 +136,7 @@ function FrameLocation({
           {': '}
         </LeadHint>
       ) : null}
-      <FrameLocationTooltip frame={frame}>
+      <FrameLocationTooltip frame={frame} frameDisplayPath={frameDisplayPath}>
         <Path>
           <span>
             <span>{frameDisplayPath}</span>
@@ -174,25 +182,29 @@ function FrameContext({frame, platform}: {frame: Frame; platform: PlatformKey}) 
 
 function FrameLocationTooltip({
   frame,
+  frameDisplayPath,
   children,
 }: {
   children: React.ReactNode;
   frame: Frame;
+  frameDisplayPath: string;
 }) {
+  const absPath =
+    frame.absPath && frame.absPath !== frameDisplayPath ? frame.absPath : undefined;
   const sourceMap = frame.mapUrl ?? frame.map;
   const showSourceMap = !!frame.origAbsPath && !!sourceMap;
   const externalUrl = frame.absPath && isUrl(frame.absPath) ? frame.absPath : undefined;
 
-  const hasContent = !!frame.absPath || showSourceMap || !!externalUrl;
+  const hasContent = !!absPath || showSourceMap || !!externalUrl;
 
   return (
     <Tooltip
       title={
         <TooltipContent>
-          {frame.absPath ? (
+          {absPath ? (
             <Fragment>
               <strong>{t('Absolute Path')}</strong>
-              <span>{frame.absPath}</span>
+              <span>{absPath}</span>
             </Fragment>
           ) : null}
           {showSourceMap ? (

--- a/static/app/components/stackTrace/issueStackTrace/issueFrameActions.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/issueFrameActions.tsx
@@ -36,7 +36,11 @@ export function IssueFrameActions({isHovering}: IssueFrameActionsProps) {
           <Tag
             icon={<IconRefresh size="xs" />}
             variant="muted"
-            data-test-id="core-stacktrace-repeats-tag"
+            aria-label={tn(
+              'Frame repeated %s time',
+              'Frame repeated %s times',
+              timesRepeated
+            )}
           >
             {timesRepeated}
           </Tag>

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -9,7 +9,6 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import type {SourceMapDebugBlueThunderResponse} from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData';
 import {DisplayOptions} from 'sentry/components/stackTrace/displayOptions';
 import {FrameContent} from 'sentry/components/stackTrace/frame/frameContent';
 import {IssueFrameActions} from 'sentry/components/stackTrace/issueStackTrace/issueFrameActions';
@@ -497,7 +496,7 @@ describe('Core StackTrace', () => {
         release_has_some_artifact: false,
         sdk_debug_id_support: 'not-supported',
         sdk_version: '10.0.0',
-      } satisfies SourceMapDebugBlueThunderResponse,
+      },
     });
 
     render(

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -9,6 +9,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
+import type {SourceMapDebugBlueThunderResponse} from 'sentry/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData';
 import {DisplayOptions} from 'sentry/components/stackTrace/displayOptions';
 import {FrameContent} from 'sentry/components/stackTrace/frame/frameContent';
 import {IssueFrameActions} from 'sentry/components/stackTrace/issueStackTrace/issueFrameActions';
@@ -494,9 +495,9 @@ describe('Core StackTrace', () => {
         project_has_some_artifact_bundle: false,
         release: null,
         release_has_some_artifact: false,
-        sdk_debug_id_support: 'not-supported' as const,
+        sdk_debug_id_support: 'not-supported',
         sdk_version: '10.0.0',
-      },
+      } satisfies SourceMapDebugBlueThunderResponse,
     });
 
     render(
@@ -655,12 +656,8 @@ describe('Core StackTrace', () => {
 
   it('renders a repeat tag with tooltip in frame actions', async () => {
     const {event, stacktrace} = makeStackTraceData();
-    const recursiveFrame = {
+    const recursiveFrame: StacktraceWithFrames['frames'][number] = {
       ...stacktrace.frames[stacktrace.frames.length - 1]!,
-      filename: 'raven/scripts/runner.py',
-      module: 'raven.scripts.runner',
-      function: 'main',
-      lineNo: 112,
       inApp: true,
       package: 'raven',
       instructionAddr: '0x00000001',
@@ -671,7 +668,7 @@ describe('Core StackTrace', () => {
         event={event}
         stacktrace={{
           ...stacktrace,
-          frames: [{...recursiveFrame}, {...recursiveFrame}, {...recursiveFrame}],
+          frames: [recursiveFrame, recursiveFrame, recursiveFrame],
         }}
       >
         <DisplayOptions />
@@ -680,11 +677,68 @@ describe('Core StackTrace', () => {
     );
 
     expect(await screen.findAllByTestId('core-stacktrace-frame-row')).toHaveLength(1);
-    const repeatsTag = screen.getByTestId('core-stacktrace-repeats-tag');
-    expect(repeatsTag).toHaveTextContent('2');
+    expect(screen.getByLabelText('Frame repeated 2 times')).toBeInTheDocument();
+  });
 
-    await userEvent.hover(repeatsTag);
-    expect(await screen.findByText('Frame repeated 2 times')).toBeInTheDocument();
+  it('displays module name instead of filename for Java frames', async () => {
+    const {stacktrace} = makeStackTraceData();
+    const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
+    const event = EventFixture({
+      platform: 'java',
+      projectID: '1',
+    });
+
+    render(
+      <TestStackTraceProvider
+        event={event}
+        stacktrace={{
+          ...stacktrace,
+          frames: [
+            {
+              ...frame,
+              platform: 'java',
+              module: 'com.example.app.MainActivity',
+              filename: 'MainActivity.java',
+              inApp: true,
+            },
+          ],
+        }}
+      >
+        <StackTraceFrames frameContextComponent={FrameContent} />
+      </TestStackTraceProvider>
+    );
+
+    expect(await screen.findByText('com.example.app.MainActivity')).toBeInTheDocument();
+    expect(screen.queryByText('MainActivity.java')).not.toBeInTheDocument();
+  });
+
+  it('does not render line number when lineNo is zero', async () => {
+    const {event, stacktrace} = makeStackTraceData();
+    const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
+
+    render(
+      <TestStackTraceProvider
+        event={event}
+        stacktrace={{
+          ...stacktrace,
+          frames: [
+            {
+              ...frame,
+              filename: 'native_module.c',
+              lineNo: 0,
+              colNo: 0,
+              inApp: true,
+            },
+          ],
+        }}
+      >
+        <StackTraceFrames frameContextComponent={FrameContent} />
+      </TestStackTraceProvider>
+    );
+
+    expect(await screen.findByText('native_module.c')).toBeInTheDocument();
+    expect(screen.queryByText(':0')).not.toBeInTheDocument();
+    expect(screen.queryByText(':0:0')).not.toBeInTheDocument();
   });
 
   it('falls back to raw function and renders trimmed package in title metadata', async () => {
@@ -726,7 +780,7 @@ describe('Core StackTrace', () => {
         event={{
           ...event,
           platform: 'csharp',
-          contexts: {device: {type: 'device' as const, name: '', arch: 'x86_64'}},
+          contexts: {device: {type: 'device', name: '', arch: 'x86_64'}},
         }}
         stacktrace={{
           ...stacktrace,
@@ -786,6 +840,41 @@ describe('Core StackTrace', () => {
 
     expect(
       await screen.findByText('No additional details are available for this frame.')
+    ).toBeInTheDocument();
+  });
+
+  it('displays full absPath URL for third-party JS frames from a different domain', async () => {
+    const {stacktrace} = makeStackTraceData();
+    const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
+    const event = EventFixture({
+      platform: 'javascript',
+      projectID: '1',
+      tags: [{key: 'url', value: 'https://myapp.example.com/issues/123/'}],
+    });
+
+    render(
+      <TestStackTraceProvider
+        event={event}
+        stacktrace={{
+          ...stacktrace,
+          frames: [
+            {
+              ...frame,
+              absPath: 'https://cdn.thirdparty.net/js/tracker.js',
+              filename: '/js/tracker.js',
+              lineNo: 1,
+              colNo: 1114,
+              inApp: true,
+            },
+          ],
+        }}
+      >
+        <StackTraceFrames frameContextComponent={FrameContent} />
+      </TestStackTraceProvider>
+    );
+
+    expect(
+      await screen.findByText('https://cdn.thirdparty.net/js/tracker.js')
     ).toBeInTheDocument();
   });
 

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -818,7 +818,7 @@ describe('Core StackTrace', () => {
 
     expect(
       await screen.findByRole('link', {name: 'https://example.com/static/app.js'})
-    ).toHaveAttribute('href', 'https://example.com/static/app.js');
+    ).toBeInTheDocument();
     jest.useRealTimers();
   });
 });

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -6,7 +6,7 @@ import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {DisplayOptions} from 'sentry/components/stackTrace/displayOptions';
@@ -423,6 +423,7 @@ describe('Core StackTrace', () => {
   });
 
   it('renders source map info tooltip when frame map metadata exists', async () => {
+    jest.useFakeTimers();
     const {event, stacktrace} = makeStackTraceData();
     const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
 
@@ -446,16 +447,14 @@ describe('Core StackTrace', () => {
       </TestStackTraceProvider>
     );
 
-    await userEvent.hover(screen.getByTestId('core-stacktrace-frame-location'));
+    await userEvent.hover(screen.getByText('raven/scripts/runner.py'), {delay: null});
+    act(() => jest.advanceTimersByTime(2000));
 
+    expect(await screen.findByText('Source Map')).toBeInTheDocument();
     expect(
-      await screen.findByText('Source Map', undefined, {timeout: 2000})
+      await screen.findByText('https://cdn.example.com/runner.min.js.map')
     ).toBeInTheDocument();
-    expect(
-      await screen.findByText('https://cdn.example.com/runner.min.js.map', undefined, {
-        timeout: 2000,
-      })
-    ).toBeInTheDocument();
+    jest.useRealTimers();
   });
 
   it('renders unminify action when frame source map debugger data is unresolved', async () => {
@@ -571,6 +570,7 @@ describe('Core StackTrace', () => {
   });
 
   it('shows a tooltip with absPath when hovering filename', async () => {
+    jest.useFakeTimers();
     const {event, stacktrace} = makeStackTraceData();
     const frameWithAbsolutePath = {
       ...stacktrace.frames[stacktrace.frames.length - 1]!,
@@ -592,12 +592,12 @@ describe('Core StackTrace', () => {
       </TestStackTraceProvider>
     );
 
-    await userEvent.hover(screen.getByTestId('core-stacktrace-frame-location'));
+    await userEvent.hover(screen.getByText('raven/scripts/runner.py'), {delay: null});
+    act(() => jest.advanceTimersByTime(2000));
     expect(
-      await screen.findByText('/home/ubuntu/raven/scripts/runner.py:112', undefined, {
-        timeout: 2000,
-      })
+      await screen.findByText('/home/ubuntu/raven/scripts/runner.py')
     ).toBeInTheDocument();
+    jest.useRealTimers();
   });
 
   it('shows copy path and code mapping setup actions on hover for collapsed frames', async () => {
@@ -790,6 +790,7 @@ describe('Core StackTrace', () => {
   });
 
   it('shows URL link in tooltip when absPath is an http URL', async () => {
+    jest.useFakeTimers();
     const {event, stacktrace} = makeStackTraceData();
     const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
 
@@ -812,11 +813,12 @@ describe('Core StackTrace', () => {
       </TestStackTraceProvider>
     );
 
-    const location = await screen.findByTestId('core-stacktrace-frame-location');
-    await userEvent.hover(location);
+    await userEvent.hover(screen.getByText('app.js'), {delay: null});
+    act(() => jest.advanceTimersByTime(2000));
 
     expect(
       await screen.findByRole('link', {name: 'https://example.com/static/app.js'})
     ).toHaveAttribute('href', 'https://example.com/static/app.js');
+    jest.useRealTimers();
   });
 });

--- a/static/app/components/stackTrace/stackTrace.stories.tsx
+++ b/static/app/components/stackTrace/stackTrace.stories.tsx
@@ -767,7 +767,11 @@ function StoryFrameActions({isHovering}: {isHovering: boolean}) {
           <Tag
             icon={<IconRefresh size="xs" />}
             variant="muted"
-            data-test-id="core-stacktrace-repeats-tag"
+            aria-label={tn(
+              'Frame repeated %s time',
+              'Frame repeated %s times',
+              timesRepeated
+            )}
           >
             {timesRepeated}
           </Tag>


### PR DESCRIPTION
Fixes to the new stack trace component's frame header and tooltip behavior to match the old component.

- Show full absPath URL for third-party JS frames from different domains instead of just the relative filename
- Suppress `:0` line/column numbers that native platforms use to indicate missing source info
- Open the "leaving Sentry" confirmation modal when clicking external URLs in the tooltip instead of navigating directly
- Improved tests: replaced test-id selectors with `getByText`/`getByLabelText`/aria-labels, added fake timers for tooltip tests, added typed mock responses, and added coverage for Java module priority and third-party frame display

displays the full url instead of path for some minified cases again

<img width="864" height="137" alt="image" src="https://github.com/user-attachments/assets/8df81300-1e08-4660-b2c3-0fbeb9527eed" />

rename "File" to "Absolute Path"

<img width="856" height="185" alt="image" src="https://github.com/user-attachments/assets/678eb655-a2f6-40e1-9bf0-b6d9f07f5b35" />
