### PR TITLE
feat(github): Add API-driven GitHub integration setup

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -3,19 +3,21 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 from urllib.parse import parse_qsl
 
 from django.db.models import Count
-from django.http import HttpResponse
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
+from rest_framework.serializers import CharField
 
 from sentry import features, options
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.identity.github.provider import GitHubIdentityProvider
@@ -62,7 +64,12 @@ from sentry.organizations.services.organization.model import (
     RpcOrganization,
     RpcUserOrganizationContext,
 )
-from sentry.pipeline.views.base import PipelineView, render_react_view
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import (
+    ApiPipelineSteps,
+    PipelineView,
+    render_react_view,
+)
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError, IntegrationError
 from sentry.snuba.referrer import Referrer
@@ -177,6 +184,7 @@ class GithubInstallationInfo(TypedDict):
     installation_id: str
     github_account: str
     avatar_url: str
+    count: NotRequired[int]
 
 
 def build_repository_query(metadata: Mapping[str, Any], name: str, query: str) -> bytes:
@@ -789,6 +797,12 @@ class GitHubIntegrationProvider(IntegrationProvider):
     ]:
         return [OAuthLoginView(), GithubOrganizationSelection(), GitHubInstallation()]
 
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [
+            OAuthLoginApiStep(),
+            GithubOrganizationSelectionApiStep(),
+        ]
+
     def get_installation_info(self, installation_id: str) -> Mapping[str, Any]:
         resp: Mapping[str, Any] = self.client.get_installation_info(installation_id=installation_id)
         return resp
@@ -844,8 +858,16 @@ class GitHubInstallationError(StrEnum):
     USER_MISMATCH = "Authenticated user is not the same as who installed the app."
     MISSING_INTEGRATION = "Integration does not exist."
     INVALID_INSTALLATION = "User does not have access to given installation."
+    MISSING_OWNER_PRIVILEGES = (
+        "Your GitHub account does not have owner privileges for the chosen organization."
+    )
     FEATURE_NOT_AVAILABLE = "Your organization does not have access to this feature."
     MISSING_ORGANIZATION = "You must be logged into an organization to access this feature."
+
+
+def get_install_app_url() -> str:
+    name = options.get("github-app.name")
+    return f"https://github.com/apps/{slugify(name)}"
 
 
 def record_event(event: IntegrationPipelineViewType):
@@ -854,123 +876,473 @@ def record_event(event: IntegrationPipelineViewType):
     )
 
 
-class OAuthLoginView:
-    client: GithubSetupApiClient
+class GitHubPipelineError(Exception):
+    """Raised when a GitHub pipeline step fails validation."""
 
+    def __init__(self, message: GitHubInstallationError) -> None:
+        self.message = message
+        super().__init__(str(message))
+
+
+@dataclass
+class GitHubOAuthLoginResult:
+    authenticated_user: str
+    installation_info: list[GithubInstallationInfo]
+
+
+def _get_owner_github_organizations(client: GithubSetupApiClient) -> list[str]:
+    user_org_membership_details = client.get_organization_memberships_for_user()
+    return [
+        gh_org.get("organization", {}).get("login")
+        for gh_org in user_org_membership_details
+        if (
+            gh_org.get("role", "").lower() == "admin"
+            and gh_org.get("state", "").lower() == "active"
+        )
+    ]
+
+
+def _get_eligible_multi_org_installations(
+    client: GithubSetupApiClient, owner_orgs: list[str]
+) -> list[GithubInstallationInfo]:
+    installed_orgs = client.get_user_info_installations()
+    return [
+        {
+            "installation_id": str(installation.get("id")),
+            "github_account": installation.get("account").get("login"),
+            "avatar_url": installation.get("account").get("avatar_url"),
+        }
+        for installation in installed_orgs["installations"]
+        if (
+            installation.get("account").get("login") in owner_orgs
+            or installation.get("target_type") == "User"
+        )
+    ]
+
+
+def _build_github_oauth_url(pipeline: IntegrationPipeline) -> str:
+    ghip = GitHubIdentityProvider()
+    redirect_uri = absolute_uri(
+        reverse(
+            "sentry-extension-setup",
+            kwargs={"provider_id": IntegrationProviderSlug.GITHUB.value},
+        )
+    )
+    return (
+        f"{ghip.get_oauth_authorize_url()}"
+        f"?client_id={ghip.get_oauth_client_id()}"
+        f"&state={pipeline.signature}"
+        f"&redirect_uri={redirect_uri}"
+    )
+
+
+def exchange_github_oauth(
+    code: str,
+    fetch_installations: bool = True,
+) -> GitHubOAuthLoginResult:
+    """
+    Exchange an OAuth code for a GitHub access token, fetch the authenticated
+    user's info, and optionally determine eligible installations.
+
+    Raises GitHubPipelineError on failure.
+    """
+    ghip = GitHubIdentityProvider()
+    data = {
+        "code": code,
+        "client_id": ghip.get_oauth_client_id(),
+        "client_secret": ghip.get_oauth_client_secret(),
+    }
+
+    req = safe_urlopen(url=ghip.get_oauth_access_token_url(), data=data)
+    try:
+        body = safe_urlread(req).decode("utf-8")
+        payload = dict(parse_qsl(body))
+    except Exception:
+        payload = {}
+
+    if "access_token" not in payload:
+        raise GitHubPipelineError(GitHubInstallationError.MISSING_TOKEN)
+
+    client = GithubSetupApiClient(access_token=payload["access_token"])
+    authenticated_user_info = client.get_user_info()
+
+    installation_info: list[GithubInstallationInfo] = []
+    if fetch_installations:
+        owner_orgs = _get_owner_github_organizations(client)
+        installation_info = _get_eligible_multi_org_installations(client, owner_orgs)
+
+    if "login" not in authenticated_user_info:
+        raise GitHubPipelineError(GitHubInstallationError.MISSING_LOGIN)
+
+    return GitHubOAuthLoginResult(
+        authenticated_user=authenticated_user_info["login"],
+        installation_info=installation_info,
+    )
+
+
+def _build_installation_info_with_counts(
+    installation_info: list[GithubInstallationInfo],
+) -> list[GithubInstallationInfo]:
+    """
+    Enriches an installation info list with Sentry org install counts and appends
+    the 'install on new GitHub org' sentinel option.
+    """
+    installation_ids = [i["installation_id"] for i in installation_info]
+    counts_qs = (
+        OrganizationIntegration.objects.filter(
+            integration__provider=GitHubIntegrationProvider.key,
+            integration__external_id__in=installation_ids,
+        )
+        .values("integration__external_id")
+        .annotate(count=Count("id"))
+    )
+    counts_dict = {item["integration__external_id"]: item["count"] for item in counts_qs}
+
+    result: list[GithubInstallationInfo] = []
+    for installation in installation_info:
+        result.append(
+            {
+                **installation,
+                "count": counts_dict.get(installation["installation_id"], 0),
+            }
+        )
+    result.append(
+        {
+            "installation_id": "-1",
+            "github_account": "Integrate with a new GitHub organization",
+            "avatar_url": "",
+            "count": 0,
+        }
+    )
+    return result
+
+
+def validate_org_installation_choice(
+    chosen_installation_id: str,
+    pipeline: IntegrationPipeline,
+) -> None:
+    """
+    Validates a chosen GitHub installation can be linked to this Sentry org.
+    Checks multi-org feature flag, install count, org consistency, and that the
+    installation belongs to the user. Binds chosen_installation to pipeline state.
+
+    Raises GitHubPipelineError on validation failure.
+    """
+    installation_info: list[GithubInstallationInfo] = (
+        pipeline.fetch_state("existing_installation_info") or []
+    )
+
+    has_scm_multi_org = features.has(
+        "organizations:integrations-scm-multi-org",
+        organization=pipeline.organization,
+    )
+    install_count = OrganizationIntegration.objects.filter(
+        integration__provider=GitHubIntegrationProvider.key,
+        integration__external_id=chosen_installation_id,
+    ).count()
+    if not ((install_count == 0) or has_scm_multi_org):
+        raise GitHubPipelineError(GitHubInstallationError.FEATURE_NOT_AVAILABLE)
+
+    installing_org_slug = pipeline.fetch_state("installing_organization_slug")
+    if not (installing_org_slug is not None and installing_org_slug == pipeline.organization.slug):
+        raise GitHubPipelineError(GitHubInstallationError.FEATURE_NOT_AVAILABLE)
+
+    valid_ids = [i["installation_id"] for i in installation_info]
+    if chosen_installation_id not in valid_ids:
+        raise GitHubPipelineError(GitHubInstallationError.MISSING_OWNER_PRIVILEGES)
+
+    pipeline.bind_state("chosen_installation", chosen_installation_id)
+
+
+def validate_github_installation(
+    pipeline: IntegrationPipeline,
+) -> str | None:
+    """
+    Resolves the installation_id from pipeline state (handling chosen_installation),
+    checks for pending deletion and user mismatch against existing integrations.
+
+    Returns the resolved installation_id, or None if the user needs to install the
+    GitHub App first (caller should redirect).
+
+    Raises GitHubPipelineError on validation failure.
+    """
+    chosen_installation_id = pipeline.fetch_state("chosen_installation")
+    if chosen_installation_id is not None:
+        pipeline.bind_state("installation_id", chosen_installation_id)
+
+    installation_id = pipeline.fetch_state("installation_id")
+    if installation_id is None:
+        return None
+
+    pending_deletion = OrganizationIntegration.objects.filter(
+        integration__provider=GitHubIntegrationProvider.key,
+        organization_id=pipeline.organization.id,
+        status=ObjectStatus.PENDING_DELETION,
+    ).exists()
+    if pending_deletion:
+        raise GitHubPipelineError(GitHubInstallationError.PENDING_DELETION)
+
+    try:
+        integration = Integration.objects.get(
+            external_id=installation_id, status=ObjectStatus.ACTIVE
+        )
+    except Integration.DoesNotExist:
+        # The installation.created webhook from GitHub normally creates the
+        # Integration record (with sender metadata) before the user reaches
+        # this point. If it doesn't exist yet, the webhook likely hasn't
+        # been processed. We proceed without the sender validation that the
+        # existing-integration path provides below. In theory an attacker
+        # could race the webhook to link an installation they don't own,
+        # but the window is extremely narrow (they'd need to predict the
+        # installation_id before the webhook arrives).
+        return installation_id
+
+    if (
+        chosen_installation_id is None
+        and pipeline.fetch_state("github_authenticated_user")
+        != integration.metadata["sender"]["login"]
+    ):
+        raise GitHubPipelineError(GitHubInstallationError.USER_MISMATCH)
+
+    return installation_id
+
+
+class OAuthLoginStepData(TypedDict):
+    oauthUrl: str
+
+
+class OAuthLoginValidatedData(TypedDict):
+    code: str
+    state: str
+    installation_id: NotRequired[str]
+
+
+class OAuthLoginSerializer(CamelSnakeSerializer):
+    code = CharField(required=True)
+    state = CharField(required=True)
+    # GitHub includes installation_id in the OAuth callback URL when the user
+    # installs the app from GitHub's side rather than from Sentry.
+    installation_id = CharField(required=False)
+
+
+class OAuthLoginApiStep:
+    """
+    Initiates and completes the GitHub OAuth authorization flow.
+
+    On GET (via get_step_data): returns the GitHub OAuth authorize URL. The
+    frontend should open this in a popup/redirect so the user can authorize.
+
+    On POST (via handle_post): receives the OAuth callback params (code, state,
+    and optionally installation_id), exchanges the code for an access token,
+    verifies the authenticated GitHub user, and discovers existing GitHub App
+    installations the user has access to.
+
+    If installation_id is present in the callback, it is bound to pipeline
+    state early. This handles the case where the user started from GitHub's
+    side (installing the app directly on GitHub), which redirects back with
+    installation_id before OAuth has happened. The installation_id persists
+    in pipeline state across the OAuth redirect, so the later installation
+    validation step can find it without requiring user action.
+    """
+
+    step_name = "oauth_login"
+
+    def get_step_data(
+        self, pipeline: IntegrationPipeline, request: HttpRequest
+    ) -> OAuthLoginStepData:
+        return {"oauthUrl": _build_github_oauth_url(pipeline)}
+
+    def get_serializer_cls(self) -> type:
+        return OAuthLoginSerializer
+
+    def handle_post(
+        self,
+        validated_data: OAuthLoginValidatedData,
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        with record_event(IntegrationPipelineViewType.OAUTH_LOGIN).capture() as lifecycle:
+            lifecycle.add_extra("organization_id", pipeline.organization.id)
+
+            if installation_id := validated_data.get("installation_id"):
+                pipeline.bind_state("installation_id", installation_id)
+
+            if validated_data["state"] != pipeline.signature:
+                lifecycle.record_failure(GitHubInstallationError.INVALID_STATE)
+                return PipelineStepResult.error(GitHubInstallationError.INVALID_STATE)
+
+            try:
+                result = exchange_github_oauth(code=validated_data["code"])
+            except GitHubPipelineError as e:
+                lifecycle.record_failure(e.message)
+                return PipelineStepResult.error(e.message)
+
+            if result.installation_info:
+                pipeline.bind_state("existing_installation_info", result.installation_info)
+            pipeline.bind_state("github_authenticated_user", result.authenticated_user)
+            return PipelineStepResult.advance()
+
+
+class GithubInstallationApiInfo(TypedDict):
+    installationId: str
+    githubAccount: str
+    avatarUrl: str
+    count: NotRequired[int | None]
+
+
+class OrgSelectionStepData(TypedDict):
+    installAppUrl: str
+    installationInfo: list[GithubInstallationApiInfo]
+
+
+class OrgSelectionValidatedData(TypedDict):
+    chosen_installation_id: NotRequired[str]
+    installation_id: NotRequired[str]
+
+
+class OrgSelectionSerializer(CamelSnakeSerializer):
+    chosen_installation_id = CharField(required=False, allow_blank=True)
+    installation_id = CharField(required=False)
+
+
+class GithubOrganizationSelectionApiStep:
+    """
+    Connects a GitHub App installation to the user's Sentry org.
+
+    On GET: returns the list of GitHub orgs/accounts where the authenticated
+    user has the app installed, enriched with how many Sentry orgs already use
+    each installation.
+
+    On POST: handles three cases:
+      1. User selected an existing installation (chosen_installation_id) —
+         validates multi-org eligibility, org consistency, and ownership.
+      2. User completed the GitHub App install popup and the frontend posted
+         back the new installation_id.
+      3. The installation_id is already in pipeline state from the user
+         clicking "Install" on github.com and being redirected into this flow.
+
+    Cases 2 and 3 both go through validate_github_installation. If no
+    installation_id is available yet, returns a stay result prompting the
+    user to install the app.
+    """
+
+    step_name = "org_selection"
+
+    def get_step_data(
+        self, pipeline: IntegrationPipeline, request: HttpRequest
+    ) -> OrgSelectionStepData:
+        install_app_url = get_install_app_url()
+
+        installation_info: list[GithubInstallationInfo] = list(
+            pipeline.fetch_state("existing_installation_info") or []
+        )
+        if not installation_info:
+            return {"installationInfo": [], "installAppUrl": install_app_url}
+
+        # Bind the installing org slug so we can validate it hasn't changed when
+        # the user submits their choice (same logic as the template flow).
+        pipeline.bind_state("installing_organization_slug", pipeline.organization.slug)
+
+        enriched = _build_installation_info_with_counts(installation_info)
+        return {
+            "installAppUrl": install_app_url,
+            "installationInfo": [
+                {
+                    "installationId": info["installation_id"],
+                    "githubAccount": info["github_account"],
+                    "avatarUrl": info.get("avatar_url", ""),
+                    "count": info.get("count"),
+                }
+                for info in enriched
+            ],
+        }
+
+    def get_serializer_cls(self) -> type | None:
+        return OrgSelectionSerializer
+
+    def handle_post(
+        self,
+        validated_data: OrgSelectionValidatedData,
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        with record_event(
+            IntegrationPipelineViewType.ORGANIZATION_SELECTION
+        ).capture() as lifecycle:
+            lifecycle.add_extra("organization_id", pipeline.organization.id)
+
+            # If the user completed the GitHub App install popup, bind the
+            # installation_id and validate it
+            if post_installation_id := validated_data.get("installation_id"):
+                pipeline.bind_state("installation_id", post_installation_id)
+
+            # If the user selected a GitHub app installation from the list
+            # validate their choice and bind the installation_id.
+            chosen_installation_id = validated_data.get("chosen_installation_id")
+            if chosen_installation_id:
+                try:
+                    validate_org_installation_choice(chosen_installation_id, pipeline)
+                except GitHubPipelineError as e:
+                    lifecycle.record_failure(e.message)
+                    return PipelineStepResult.error(e.message)
+                pipeline.bind_state("installation_id", chosen_installation_id)
+
+            # Validate whatever installation_id is in pipeline state — handles
+            # pending deletion check and user mismatch against existing integrations.
+            try:
+                installation_id = validate_github_installation(pipeline)
+            except GitHubPipelineError as e:
+                lifecycle.record_failure(e.message)
+                return PipelineStepResult.error(e.message)
+
+            if installation_id is None:
+                return PipelineStepResult.stay(data={"installAppUrl": get_install_app_url()})
+
+            return PipelineStepResult.advance()
+
+
+class OAuthLoginView:
     def dispatch(self, request: HttpRequest, pipeline: IntegrationPipeline) -> HttpResponseBase:
         with record_event(IntegrationPipelineViewType.OAUTH_LOGIN).capture() as lifecycle:
-            self.active_user_organization = determine_active_organization(request)
+            active_user_organization = determine_active_organization(request)
             lifecycle.add_extra(
                 "organization_id",
-                (
-                    self.active_user_organization.organization.id
-                    if self.active_user_organization
-                    else None
-                ),
+                (active_user_organization.organization.id if active_user_organization else None),
             )
-
-            ghip = GitHubIdentityProvider()
-            github_client_id = ghip.get_oauth_client_id()
-            github_client_secret = ghip.get_oauth_client_secret()
 
             installation_id = request.GET.get("installation_id")
             if installation_id:
                 pipeline.bind_state("installation_id", installation_id)
 
             if not request.GET.get("state"):
-                state = pipeline.signature
+                return HttpResponseRedirect(_build_github_oauth_url(pipeline))
 
-                redirect_uri = absolute_uri(
-                    reverse(
-                        "sentry-extension-setup",
-                        kwargs={"provider_id": IntegrationProviderSlug.GITHUB.value},
-                    )
-                )
-                return HttpResponseRedirect(
-                    f"{ghip.get_oauth_authorize_url()}?client_id={github_client_id}&state={state}&redirect_uri={redirect_uri}"
-                )
-
-            # At this point, we are past the GitHub "authorize" step
             if request.GET.get("state") != pipeline.signature:
                 lifecycle.record_failure(GitHubInstallationError.INVALID_STATE)
                 return error(
                     request,
-                    self.active_user_organization,
+                    active_user_organization,
                     error_short=GitHubInstallationError.INVALID_STATE,
                 )
 
-            # similar to OAuth2CallbackView.get_token_params
-            data = {
-                "code": request.GET.get("code"),
-                "client_id": github_client_id,
-                "client_secret": github_client_secret,
-            }
-
-            # similar to OAuth2CallbackView.exchange_token
-            req = safe_urlopen(url=ghip.get_oauth_access_token_url(), data=data)
             try:
-                body = safe_urlread(req).decode("utf-8")
-                payload = dict(parse_qsl(body))
-            except Exception:
-                payload = {}
-
-            if "access_token" not in payload:
-                lifecycle.record_failure(GitHubInstallationError.MISSING_TOKEN)
+                result = exchange_github_oauth(
+                    code=request.GET.get("code", ""),
+                    fetch_installations=active_user_organization is not None,
+                )
+            except GitHubPipelineError as e:
+                lifecycle.record_failure(e.message)
                 return error(
                     request,
-                    self.active_user_organization,
-                    error_short=GitHubInstallationError.MISSING_TOKEN,
+                    active_user_organization,
+                    error_short=e.message,
+                    error_long=e.message,
                 )
-            self.client = GithubSetupApiClient(access_token=payload["access_token"])
-            authenticated_user_info = self.client.get_user_info()
 
-            if self.active_user_organization is not None:
-                owner_orgs = self._get_owner_github_organizations()
-
-                installation_info = self._get_eligible_multi_org_installations(
-                    owner_orgs=owner_orgs
-                )
-                pipeline.bind_state("existing_installation_info", installation_info)
-
-            if "login" not in authenticated_user_info:
-                lifecycle.record_failure(GitHubInstallationError.MISSING_LOGIN)
-                return error(
-                    request,
-                    self.active_user_organization,
-                    error_short=GitHubInstallationError.MISSING_LOGIN,
-                )
-            pipeline.bind_state("github_authenticated_user", authenticated_user_info["login"])
+            if result.installation_info:
+                pipeline.bind_state("existing_installation_info", result.installation_info)
+            pipeline.bind_state("github_authenticated_user", result.authenticated_user)
             return pipeline.next_step()
-
-    def _get_owner_github_organizations(self) -> list[str]:
-        user_org_membership_details = self.client.get_organization_memberships_for_user()
-
-        return [
-            gh_org.get("organization", {}).get("login")
-            for gh_org in user_org_membership_details
-            if (
-                gh_org.get("role", "").lower() == "admin"
-                and gh_org.get("state", "").lower() == "active"
-            )
-        ]
-
-    def _get_eligible_multi_org_installations(
-        self, owner_orgs: list[str]
-    ) -> list[GithubInstallationInfo]:
-        installed_orgs = self.client.get_user_info_installations()
-
-        return [
-            {
-                "installation_id": str(installation.get("id")),
-                "github_account": installation.get("account").get("login"),
-                "avatar_url": installation.get("account").get("avatar_url"),
-            }
-            for installation in installed_orgs["installations"]
-            if (
-                installation.get("account").get("login") in owner_orgs
-                or installation.get("target_type") == "User"
-            )
-        ]
 
 
 class GithubOrganizationSelection:
@@ -997,79 +1369,23 @@ class GithubOrganizationSelection:
             if len(installation_info) == 0:
                 return pipeline.next_step()
 
-            # add information about number of org integrations per installation
-            installation_ids = [
-                installation["installation_id"] for installation in installation_info
-            ]
-            integration_install_counts = (
-                OrganizationIntegration.objects.filter(
-                    integration__provider=GitHubIntegrationProvider.key,
-                    integration__external_id__in=installation_ids,
-                )
-                .values("integration__external_id")
-                .annotate(count=Count("id"))
-            )
-            integration_install_counts_dict = {
-                item["integration__external_id"]: item["count"]
-                for item in integration_install_counts
-            }
-            for installation in installation_info:
-                installation["count"] = integration_install_counts_dict.get(
-                    installation["installation_id"], 0
-                )
-
-            # add an option for users to install on a new GH organization
-            installation_info.append(
-                {
-                    "installation_id": "-1",
-                    "github_account": "Integrate with a new GitHub organization",
-                    "avatar_url": "",
-                    "count": 0,
-                }
-            )
+            installation_info = _build_installation_info_with_counts(installation_info)
 
             if chosen_installation_id := request.GET.get("chosen_installation_id"):
                 if chosen_installation_id == "-1":
                     return pipeline.next_step()
 
-                # NOTE: there may still be a race condition here where multiple orgs read the same count (0)
-                # the org integration creation logic is in finish_pipeline
-                can_install_chosen_installation = (
-                    integration_install_counts_dict.get(chosen_installation_id, 0) == 0
-                ) or has_scm_multi_org
-
-                # Validate the same org is installing and that they have the multi org feature
-                installing_organization_slug = pipeline.fetch_state("installing_organization_slug")
-                is_same_installing_org = (
-                    (installing_organization_slug is not None)
-                    and installing_organization_slug
-                    == self.active_user_organization.organization.slug
-                )
-
-                if not can_install_chosen_installation or not is_same_installing_org:
-                    lifecycle.record_failure(GitHubInstallationError.FEATURE_NOT_AVAILABLE)
+                try:
+                    validate_org_installation_choice(chosen_installation_id, pipeline)
+                except GitHubPipelineError as e:
+                    lifecycle.record_failure(e.message)
                     return error(
                         request,
                         self.active_user_organization,
-                        error_short=GitHubInstallationError.FEATURE_NOT_AVAILABLE,
+                        error_short=e.message,
+                        error_long=e.message,
                     )
 
-                # Verify that the given GH installation belongs to the person installing the pipeline
-                installation_ids = [
-                    installation["installation_id"] for installation in installation_info
-                ]
-                if chosen_installation_id not in installation_ids:
-                    lifecycle.record_failure(
-                        failure_reason=GitHubInstallationError.INVALID_INSTALLATION
-                    )
-                    return error(
-                        request,
-                        self.active_user_organization,
-                        error_short=GitHubInstallationError.INVALID_INSTALLATION,
-                        error_long=ERR_INTEGRATION_INVALID_INSTALLATION,
-                    )
-
-                pipeline.bind_state("chosen_installation", chosen_installation_id)
                 return pipeline.next_step()
             pipeline.bind_state(
                 "installing_organization_slug", self.active_user_organization.organization.slug
@@ -1093,85 +1409,39 @@ class GithubOrganizationSelection:
 
 
 class GitHubInstallation:
-    def get_app_url(self) -> str:
-        name = options.get("github-app.name")
-        return f"https://github.com/apps/{slugify(name)}"
-
     def dispatch(self, request: HttpRequest, pipeline: IntegrationPipeline) -> HttpResponseBase:
         with record_event(IntegrationPipelineViewType.GITHUB_INSTALLATION).capture() as lifecycle:
-            self.active_user_organization = determine_active_organization(request)
-
-            chosen_installation_id = pipeline.fetch_state("chosen_installation")
-            if chosen_installation_id is not None:
-                pipeline.bind_state("installation_id", chosen_installation_id)
-
-            installation_id = pipeline.fetch_state("installation_id") or request.GET.get(
-                "installation_id", None
-            )
-            if installation_id is None:
-                return HttpResponseRedirect(self.get_app_url())
-
-            pipeline.bind_state("installation_id", installation_id)
-
+            active_user_organization = determine_active_organization(request)
             lifecycle.add_extra(
                 "organization_id",
                 (
-                    self.active_user_organization.organization.id
-                    if self.active_user_organization is not None
+                    active_user_organization.organization.id
+                    if active_user_organization is not None
                     else None
                 ),
             )
 
-            error_page = self.check_pending_integration_deletion(request=request)
-            if error_page is not None:
-                lifecycle.record_failure(GitHubInstallationError.PENDING_DELETION)
-                return error_page
-
-            if self.active_user_organization is not None:
-                try:
-                    integration = Integration.objects.get(
-                        external_id=installation_id, status=ObjectStatus.ACTIVE
-                    )
-                except Integration.DoesNotExist:
-                    return pipeline.next_step()
-
-            # Check that the authenticated GitHub user is the same as who installed the app.
-            if (
-                chosen_installation_id is None
-                and pipeline.fetch_state("github_authenticated_user")
-                != integration.metadata["sender"]["login"]
-            ):
-                lifecycle.record_failure(GitHubInstallationError.USER_MISMATCH)
+            if active_user_organization is None:
                 return error(
                     request,
-                    self.active_user_organization,
-                    error_short=GitHubInstallationError.USER_MISMATCH,
+                    None,
+                    error_short=GitHubInstallationError.MISSING_ORGANIZATION,
+                    error_long=ERR_INTEGRATION_MISSING_ORGANIZATION,
                 )
 
+            # The template flow also picks up installation_id from query params
+            if installation_id := request.GET.get("installation_id"):
+                pipeline.bind_state("installation_id", installation_id)
+
+            try:
+                resolved_id = validate_github_installation(pipeline)
+            except GitHubPipelineError as e:
+                lifecycle.record_failure(e.message)
+                return error(
+                    request, active_user_organization, error_short=e.message, error_long=e.message
+                )
+
+            if resolved_id is None:
+                return HttpResponseRedirect(get_install_app_url())
+
             return pipeline.next_step()
-
-    def check_pending_integration_deletion(self, request: HttpRequest) -> HttpResponse | None:
-        if self.active_user_organization is None:
-            return error(
-                request,
-                None,
-                error_short=GitHubInstallationError.MISSING_ORGANIZATION,
-                error_long=ERR_INTEGRATION_MISSING_ORGANIZATION,
-            )
-
-        # We want to wait until the scheduled deletions finish or else the
-        # post install to migrate repos do not work.
-        integration_pending_deletion_exists = OrganizationIntegration.objects.filter(
-            integration__provider=GitHubIntegrationProvider.key,
-            organization_id=self.active_user_organization.organization.id,
-            status=ObjectStatus.PENDING_DELETION,
-        ).exists()
-
-        if integration_pending_deletion_exists:
-            return error(
-                request,
-                self.active_user_organization,
-                error_short=GitHubInstallationError.PENDING_DELETION,
-                error_long=ERR_INTEGRATION_PENDING_DELETION,
-            )
-        return None

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -28,10 +28,12 @@ from sentry.integrations.github.integration import (
     GitHubInstallationError,
     GitHubIntegration,
     GitHubIntegrationProvider,
-    OAuthLoginView,
+    _get_eligible_multi_org_installations,
+    _get_owner_github_organizations,
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
     FileBlameInfo,
@@ -52,7 +54,7 @@ from sentry.testutils.asserts import (
     assert_failure_metric,
     assert_success_metric,
 )
-from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.cases import APITestCase, IntegrationTestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.helpers.options import override_options
@@ -1468,11 +1470,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
         self.assertTemplateUsed(resp, "sentry/integrations/github-integration-failed.html")
         assert (
-            b'{"success":false,"data":{"error":"User does not have access to given installation."}'
-            in resp.content
-        )
-        assert (
-            b"Your GitHub account does not have owner privileges for the chosen organization."
+            b'{"success":false,"data":{"error":"Your GitHub account does not have owner privileges for the chosen organization."}'
             in resp.content
         )
         assert b'window.opener.postMessage({"success":false' in resp.content
@@ -1493,7 +1491,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             mock_record=mock_record, outcome=EventLifecycleOutcome.FAILURE, outcome_count=1
         )
 
-        assert_failure_metric(mock_record, GitHubInstallationError.INVALID_INSTALLATION)
+        assert_failure_metric(mock_record, GitHubInstallationError.MISSING_OWNER_PRIVILEGES)
 
     @with_feature({"organizations:integrations-scm-multi-org": False})
     @responses.activate
@@ -1658,10 +1656,9 @@ class GitHubIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_github_installation_gets_owner_orgs(self) -> None:
         self._setup_with_existing_installations()
-        pipeline_view = OAuthLoginView()
-        pipeline_view.client = GithubSetupApiClient(self.access_token)
+        client = GithubSetupApiClient(self.access_token)
 
-        owner_orgs = pipeline_view._get_owner_github_organizations()
+        owner_orgs = _get_owner_github_organizations(client)
 
         assert owner_orgs == ["santry"]
 
@@ -1669,15 +1666,12 @@ class GitHubIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_github_installation_filters_valid_installations(self) -> None:
         self._setup_with_existing_installations()
-        pipeline_view = OAuthLoginView()
-        pipeline_view.client = GithubSetupApiClient(self.access_token)
+        client = GithubSetupApiClient(self.access_token)
 
-        owner_orgs = pipeline_view._get_owner_github_organizations()
+        owner_orgs = _get_owner_github_organizations(client)
         assert owner_orgs == ["santry"]
 
-        installation_info = pipeline_view._get_eligible_multi_org_installations(
-            owner_orgs=owner_orgs
-        )
+        installation_info = _get_eligible_multi_org_installations(client, owner_orgs)
 
         assert installation_info == [
             {
@@ -2266,3 +2260,378 @@ class GitHubIntegrationTest(IntegrationTestCase):
             "domain_name": "github.com/Test-Organization",
             "permissions": None,
         }
+
+
+@control_silo_test
+class GitHubIntegrationApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    base_url = "https://api.github.com"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.installation_id = "install_1"
+        self.user_id = "user_1"
+        self.app_id = "app_1"
+        self.access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        self.expires_at = "3000-01-01T00:00:00Z"
+        self.login_as(self.user)
+        self._stub_github()
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    @pytest.fixture(autouse=True)
+    def stub_get_jwt(self):
+        with mock.patch.object(client, "get_jwt", return_value="jwt_token_1"):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def stub_get_jwt_function(self):
+        with mock.patch("sentry.integrations.github.utils.get_jwt", return_value="jwt_token_1"):
+            yield
+
+    def _stub_github(self) -> None:
+        """Stubs GitHub API responses needed for the integration pipeline."""
+        self.gh_org = "Test-Organization"
+
+        responses.add(
+            responses.POST,
+            "https://github.com/login/oauth/access_token",
+            body=f"access_token={self.access_token}",
+        )
+        responses.add(responses.GET, self.base_url + "/user", json={"login": "octocat"})
+        responses.add(
+            responses.POST,
+            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
+            json={
+                "token": self.access_token,
+                "expires_at": self.expires_at,
+                "permissions": {
+                    "administration": "read",
+                    "contents": "read",
+                    "issues": "write",
+                    "metadata": "read",
+                    "pull_requests": "read",
+                },
+                "repository_selection": "all",
+            },
+        )
+
+        repositories: dict[str, Any] = {
+            "xyz": {
+                "name": "xyz",
+                "full_name": "Test-Organization/xyz",
+                "default_branch": "master",
+            },
+            "foo": {
+                "id": 1296269,
+                "name": "foo",
+                "full_name": "Test-Organization/foo",
+                "default_branch": "master",
+            },
+        }
+
+        responses.add(
+            responses.GET,
+            url=self.base_url + "/installation/repositories",
+            json={
+                "total_count": len(repositories),
+                "repositories": list(repositories.values()),
+            },
+        )
+
+        responses.add(
+            responses.GET,
+            self.base_url + f"/app/installations/{self.installation_id}",
+            json={
+                "id": self.installation_id,
+                "app_id": self.app_id,
+                "account": {
+                    "id": 60591805,
+                    "login": "Test Organization",
+                    "avatar_url": "http://example.com/avatar.png",
+                    "html_url": "https://github.com/Test-Organization",
+                    "type": "Organization",
+                },
+            },
+        )
+
+        responses.add(responses.GET, self.base_url + "/repos/Test-Organization/foo/hooks", json=[])
+
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/user/memberships/orgs",
+            json=[
+                {
+                    "state": "active",
+                    "role": "admin",
+                    "organization": {
+                        "login": "santry",
+                        "id": 1,
+                        "avatar_url": "https://example.com/santry.png",
+                    },
+                },
+            ],
+        )
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        """POST action=initialize to start the pipeline, return the response."""
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "github"},
+            format="json",
+        )
+
+    def _get_step_info(self) -> Any:
+        """GET current step info."""
+        return self.client.get(self._get_pipeline_url())
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        """POST to advance the pipeline with step-specific data."""
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _get_pipeline_signature(self, init_resp: Any) -> str:
+        """Extract the pipeline signature (OAuth state) from an initialize response."""
+        return init_resp.data["data"]["oauthUrl"].split("state=")[1].split("&")[0]
+
+    def _stub_user_installations(self, installations: list[dict[str, Any]] | None = None) -> None:
+        """Stub the GitHub /user/installations endpoint."""
+        if installations is None:
+            installations = [
+                {
+                    "id": self.installation_id,
+                    "target_type": "Organization",
+                    "account": {
+                        "login": "santry",
+                        "avatar_url": "https://example.com/santry.png",
+                    },
+                }
+            ]
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/user/installations",
+            json={"installations": installations},
+        )
+
+    def _complete_oauth_step(self, pipeline_signature: str, **extra: Any) -> Any:
+        """Submit the OAuth callback data to advance past the OAuth step."""
+        return self._advance_step(
+            {
+                "code": "12345678901234567890",
+                "state": pipeline_signature,
+                **extra,
+            }
+        )
+
+    def _advance_to_org_selection(self) -> str:
+        """Initialize pipeline and complete OAuth, returning the pipeline signature."""
+        resp = self._initialize_pipeline()
+        pipeline_signature = self._get_pipeline_signature(resp)
+        self._stub_user_installations()
+
+        resp = self._complete_oauth_step(pipeline_signature)
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "org_selection"
+        return pipeline_signature
+
+    @responses.activate
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 2
+        assert resp.data["provider"] == "github"
+        assert "oauthUrl" in resp.data["data"]
+
+    @responses.activate
+    def test_get_oauth_step_info(self) -> None:
+        self._initialize_pipeline()
+        resp = self._get_step_info()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        assert "oauthUrl" in resp.data["data"]
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert "github.com/login/oauth/authorize" in oauth_url
+        assert "client_id=" in oauth_url
+
+    @responses.activate
+    def test_oauth_step_advance(self) -> None:
+        resp = self._initialize_pipeline()
+        pipeline_signature = self._get_pipeline_signature(resp)
+        self._stub_user_installations()
+
+        resp = self._complete_oauth_step(pipeline_signature)
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "org_selection"
+        assert resp.data["stepIndex"] == 1
+
+    @responses.activate
+    def test_oauth_step_invalid_state(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step(
+            {
+                "code": "12345678901234567890",
+                "state": "invalid_state_value",
+            }
+        )
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert GitHubInstallationError.INVALID_STATE in resp.data["data"]["detail"]
+
+    @responses.activate
+    def test_oauth_step_missing_fields(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({})
+        assert resp.status_code == 400
+
+    @responses.activate
+    def test_org_selection_get_with_installations(self) -> None:
+        self._advance_to_org_selection()
+        resp = self._get_step_info()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "org_selection"
+        data = resp.data["data"]
+        assert "installAppUrl" in data
+        assert "installationInfo" in data
+        assert len(data["installationInfo"]) > 0
+
+    @responses.activate
+    @with_feature("organizations:integrations-scm-multi-org")
+    def test_org_selection_choose_existing_installation(self) -> None:
+        self._advance_to_org_selection()
+
+        resp = self._advance_step(
+            {
+                "chosen_installation_id": self.installation_id,
+            }
+        )
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+    @responses.activate
+    @with_feature("organizations:integrations-scm-multi-org")
+    def test_org_selection_chosen_installation_blocked_by_pending_deletion(self) -> None:
+        """Choosing an existing installation should fail if there's a pending deletion."""
+        self._advance_to_org_selection()
+
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id=self.installation_id,
+            metadata={"sender": {"login": "octocat"}},
+        )
+        oi = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+        oi.status = ObjectStatus.PENDING_DELETION
+        oi.save()
+
+        resp = self._advance_step(
+            {
+                "chosen_installation_id": self.installation_id,
+            }
+        )
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert GitHubInstallationError.PENDING_DELETION in resp.data["data"]["detail"]
+
+    @responses.activate
+    def test_org_selection_new_installation_from_popup(self) -> None:
+        """When user installs the app via the GitHub popup, installation_id comes in the POST."""
+        self._advance_to_org_selection()
+
+        resp = self._advance_step(
+            {
+                "installation_id": self.installation_id,
+            }
+        )
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+    @responses.activate
+    def test_full_api_pipeline_flow_new_installation(self) -> None:
+        """End-to-end: initialize -> OAuth -> skip org selection -> complete."""
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        self._stub_user_installations(installations=[])
+
+        resp = self._complete_oauth_step(pipeline_signature, installation_id=self.installation_id)
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "org_selection"
+
+        resp = self._advance_step({"installation_id": self.installation_id})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+        assert "data" in resp.data
+
+        integration = Integration.objects.get(provider="github")
+        assert integration.external_id == self.installation_id
+        assert integration.name == "Test Organization"
+
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
+
+    @responses.activate
+    @with_feature("organizations:integrations-scm-multi-org")
+    def test_full_api_pipeline_flow_existing_installation(self) -> None:
+        """End-to-end: initialize -> OAuth -> choose existing installation -> complete."""
+        resp = self._initialize_pipeline()
+        pipeline_signature = self._get_pipeline_signature(resp)
+        self._stub_user_installations()
+
+        resp = self._complete_oauth_step(pipeline_signature)
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "org_selection"
+
+        resp = self._advance_step({"chosen_installation_id": self.installation_id})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="github")
+        assert integration.external_id == self.installation_id
+
+    @responses.activate
+    def test_oauth_exchange_failure(self) -> None:
+        """OAuth code exchange fails when GitHub returns no access_token."""
+        resp = self._initialize_pipeline()
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        responses.replace(
+            responses.POST,
+            "https://github.com/login/oauth/access_token",
+            body="error=bad_verification_code",
+        )
+
+        resp = self._complete_oauth_step(pipeline_signature)
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+
+    @responses.activate
+    def test_org_selection_invalid_installation(self) -> None:
+        """Choosing an installation not in the user's list fails validation."""
+        self._advance_to_org_selection()
+
+        resp = self._advance_step(
+            {
+                "chosen_installation_id": "99999",
+            }
+        )
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"


### PR DESCRIPTION
Adds backend support for completing the GitHub integration setup flow
via API endpoints instead of server-rendered Django views.

Extracts shared logic from the existing template-driven pipeline views
into reusable functions (exchange_github_oauth, validate_github_installation,
validate_org_installation_choice, _build_installation_info_with_counts) so
both the legacy views and new API steps can use them.

Adds OAuthLoginApiStep and GithubOrganizationSelectionApiStep which
implement the same flow as the existing views but return structured data
for the frontend to render. Adds api_finish_pipeline to IntegrationPipeline
for completing the pipeline without server-side redirects.

Refactors _finish_pipeline to separate model operations
(_execute_finish_pipeline) from HTTP response handling, and extracts
initialize_integration_pipeline from OrganizationIntegrationSetupView for
reuse by the API endpoint.

Refs VDY-38