### PR TITLE
feat(logs): Add "Copy message" and "Copy as JSON" to log row actions

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -327,7 +327,7 @@ function getInternalLinkActionLabel(field: string): string {
  * Potentially temporary as design and product need more time to determine how logs table should trigger the dropdown.
  * Currently, the agreed default for every table should be bold hover. Logs is the only table to use the ellipsis trigger.
  */
-export enum ActionTriggerType {
+enum ActionTriggerType {
   ELLIPSIS = 'ellipsis',
   BOLD_HOVER = 'bold_hover',
 }
@@ -357,7 +357,7 @@ export function CellAction({
 
   if (triggerType === ActionTriggerType.BOLD_HOVER) {
     return (
-      <Container
+      <CellActionContainer
         data-test-id={cellActions === null ? undefined : 'cell-action-container'}
       >
         {cellActions?.length ? (
@@ -413,45 +413,45 @@ export function CellAction({
         ) : (
           children
         )}
-      </Container>
+      </CellActionContainer>
     );
   }
 
   return (
-    <Container data-test-id={cellActions === null ? undefined : 'cell-action-container'}>
+    <CellActionContainer
+      data-test-id={cellActions === null ? undefined : 'cell-action-container'}
+    >
       {children}
-      {cellActions?.length && (
-        <DropdownMenu
-          items={cellActions}
-          usePortal
-          size="sm"
-          offset={4}
-          position="bottom"
-          preventOverflowOptions={{padding: 4}}
-          flipOptions={{
-            fallbackPlacements: [
-              'top',
-              'right-start',
-              'right-end',
-              'left-start',
-              'left-end',
-            ],
-          }}
-          trigger={triggerProps => (
-            <ActionMenuTrigger
-              {...triggerProps}
-              aria-label={t('Actions')}
-              icon={<IconEllipsis size="xs" />}
-              size="zero"
-            />
-          )}
-        />
-      )}
-    </Container>
+      {cellActions?.length && <EllipsisActionMenu items={cellActions} />}
+    </CellActionContainer>
   );
 }
 
-const Container = styled('div')`
+export function EllipsisActionMenu({items}: {items: MenuItemProps[]}) {
+  return (
+    <DropdownMenu
+      items={items}
+      usePortal
+      size="sm"
+      offset={4}
+      position="bottom"
+      preventOverflowOptions={{padding: 4}}
+      flipOptions={{
+        fallbackPlacements: ['top', 'right-start', 'right-end', 'left-start', 'left-end'],
+      }}
+      trigger={triggerProps => (
+        <CellActionMenuTrigger
+          {...triggerProps}
+          aria-label={t('Actions')}
+          icon={<IconEllipsis size="xs" />}
+          size="zero"
+        />
+      )}
+    />
+  );
+}
+
+export const CellActionContainer = styled('div')`
   position: relative;
   width: 100%;
   height: 100%;
@@ -460,7 +460,7 @@ const Container = styled('div')`
   justify-content: center;
 `;
 
-const ActionMenuTrigger = styled(Button)`
+const CellActionMenuTrigger = styled(Button)`
   position: absolute;
   top: 50%;
   right: -1px;
@@ -474,7 +474,7 @@ const ActionMenuTrigger = styled(Button)`
   transition: opacity 0.1s;
   &:focus-visible,
   &[aria-expanded='true'],
-  ${Container}:hover & {
+  ${CellActionContainer}:hover & {
     opacity: 1;
   }
 `;

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -160,14 +160,6 @@ export const LogDetailTableActionsCell = styled(TableBodyCell)`
     padding: ${p => p.theme.space.xs} ${p => p.theme.space.xl};
   }
 `;
-export const LogDetailTableActionsButtonBar = styled('div')`
-  display: flex;
-  gap: ${p => p.theme.space.md};
-  & button {
-    font-weight: ${p => p.theme.font.weight.sans.regular};
-  }
-`;
-
 export const DetailsWrapper = styled('tr')`
   align-items: center;
   background-color: ${p => p.theme.colors.gray100};

--- a/static/app/views/explore/logs/tables/logCellAction.spec.tsx
+++ b/static/app/views/explore/logs/tables/logCellAction.spec.tsx
@@ -1,0 +1,175 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {TraceItemDetailsResponse} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {LogCellAction} from 'sentry/views/explore/logs/tables/logCellAction';
+import {ourlogToJson} from 'sentry/views/explore/logs/utils';
+
+jest.mock('sentry/utils/analytics');
+
+const mockAddSearchFilter = jest.fn();
+
+const mockCopyToClipboard = jest.fn().mockResolvedValue(undefined);
+const mockCopyTextToClipboard = jest.fn();
+
+jest.mock('sentry/utils/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({copy: mockCopyToClipboard}),
+  get copyToClipboard() {
+    return mockCopyTextToClipboard;
+  },
+}));
+
+function makeFullLogData(
+  overrides: Partial<TraceItemDetailsResponse> = {}
+): TraceItemDetailsResponse {
+  return {
+    itemId: 'log-123',
+    timestamp: '2025-04-10T19:21:10.049Z',
+    meta: {},
+    attributes: [
+      {name: 'message', value: 'test log body', type: 'str'},
+      {name: 'severity', value: 'info', type: 'str'},
+      {name: 'trace', value: 'abc123', type: 'str'},
+    ],
+    ...overrides,
+  };
+}
+
+describe('LogCellAction', () => {
+  const organization = OrganizationFixture();
+
+  it('copies message to clipboard when the message copy button is clicked', async () => {
+    const message = 'Hello, world!';
+    render(
+      <LogCellAction
+        field="message"
+        value={message}
+        fullLogData={undefined}
+        logId="log-1"
+        addSearchFilter={mockAddSearchFilter}
+      >
+        <span>cell</span>
+      </LogCellAction>,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Actions'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Copy message'}));
+
+    expect(mockCopyTextToClipboard).toHaveBeenCalledWith(message, expect.any(Object));
+  });
+
+  it('copies JSON immediately when the JSON copy button is clicked and fullLogData is already available', async () => {
+    const fullLogData = makeFullLogData();
+
+    render(
+      <LogCellAction
+        field="message"
+        value="hello"
+        fullLogData={fullLogData}
+        logId="log-123"
+        addSearchFilter={mockAddSearchFilter}
+      >
+        <span>cell</span>
+      </LogCellAction>,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Actions'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Copy as JSON'}));
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      ourlogToJson(fullLogData),
+      expect.any(Object)
+    );
+  });
+
+  it('defers copying JSON when the JSON copy button is clicked and fullLogData is not yet available', async () => {
+    const {rerender} = render(
+      <LogCellAction
+        field="message"
+        value="hello"
+        fullLogData={undefined}
+        logId="log-123"
+        addSearchFilter={mockAddSearchFilter}
+      >
+        <span>cell</span>
+      </LogCellAction>,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Actions'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Copy as JSON'}));
+
+    expect(mockCopyToClipboard).not.toHaveBeenCalled();
+
+    const fullLogData = makeFullLogData();
+
+    rerender(
+      <LogCellAction
+        field="message"
+        value="hello"
+        fullLogData={fullLogData}
+        logId="log-123"
+        addSearchFilter={mockAddSearchFilter}
+      >
+        <span>cell</span>
+      </LogCellAction>
+    );
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      ourlogToJson(fullLogData),
+      expect.any(Object)
+    );
+  });
+
+  it('calls addSearchFilter without negation when the add button is clicked', async () => {
+    render(
+      <LogCellAction
+        field="severity"
+        value="error"
+        fullLogData={undefined}
+        logId="log-1"
+        addSearchFilter={mockAddSearchFilter}
+      >
+        <span>cell</span>
+      </LogCellAction>,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Actions'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
+
+    expect(mockAddSearchFilter).toHaveBeenCalledWith({
+      key: 'severity',
+      value: 'error',
+    });
+  });
+
+  it('calls addSearchFilter with negation when the exclude button is clicked', async () => {
+    render(
+      <LogCellAction
+        field="severity"
+        value="error"
+        fullLogData={undefined}
+        logId="log-1"
+        addSearchFilter={mockAddSearchFilter}
+      >
+        <span>cell</span>
+      </LogCellAction>,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Actions'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+    );
+
+    expect(mockAddSearchFilter).toHaveBeenCalledWith({
+      key: 'severity',
+      value: 'error',
+      negated: true,
+    });
+  });
+});

--- a/static/app/views/explore/logs/tables/logCellAction.tsx
+++ b/static/app/views/explore/logs/tables/logCellAction.tsx
@@ -1,0 +1,95 @@
+import React, {useEffect, useMemo, useState} from 'react';
+
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {
+  copyToClipboard as copyTextToClipboard,
+  useCopyToClipboard,
+} from 'sentry/utils/useCopyToClipboard';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  CellActionContainer,
+  EllipsisActionMenu,
+} from 'sentry/views/discover/table/cellAction';
+import type {TraceItemDetailsResponse} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {ourlogToJson} from 'sentry/views/explore/logs/utils';
+import type {AddSearchFilter} from 'sentry/views/explore/queryParams/context';
+
+type LogCellActionProps = {
+  addSearchFilter: AddSearchFilter;
+  children: React.ReactNode;
+  field: string;
+  fullLogData: TraceItemDetailsResponse | undefined;
+  logId: string;
+  value: string | number | boolean;
+};
+
+export function LogCellAction({
+  children,
+  field,
+  value,
+  fullLogData,
+  logId,
+  addSearchFilter,
+}: LogCellActionProps) {
+  const organization = useOrganization();
+  const {copy} = useCopyToClipboard();
+  const [pendingCopyJson, setPendingCopyJson] = useState(false);
+
+  const json = useMemo(() => ourlogToJson(fullLogData), [fullLogData]);
+
+  useEffect(() => {
+    if (json && pendingCopyJson) {
+      setPendingCopyJson(false);
+      copy(json, {
+        successMessage: t('Copied as JSON'),
+        errorMessage: t('Failed to copy'),
+      }).then(() => {
+        trackAnalytics('logs.table.row_copied_as_json', {
+          log_id: logId,
+          organization,
+        });
+      });
+    }
+  }, [copy, json, logId, organization, pendingCopyJson]);
+
+  const items = useMemo(() => {
+    return [
+      {
+        key: 'copy-message',
+        label: t('Copy message'),
+        onAction: () => {
+          const text = typeof value === 'object' ? JSON.stringify(value) : `${value}`;
+          copyTextToClipboard(text, {
+            successMessage: t('Copied message'),
+            errorMessage: t('Failed to copy'),
+          });
+        },
+      },
+      {
+        key: 'copy-json',
+        label: t('Copy as JSON'),
+        onAction: () => {
+          setPendingCopyJson(true);
+        },
+      },
+      {
+        key: 'add-to-filter',
+        label: t('Add to filter'),
+        onAction: () => addSearchFilter({key: field, value}),
+      },
+      {
+        key: 'exclude-from-filter',
+        label: t('Exclude from filter'),
+        onAction: () => addSearchFilter({key: field, value, negated: true}),
+      },
+    ];
+  }, [addSearchFilter, field, value]);
+
+  return (
+    <CellActionContainer>
+      {children}
+      <EllipsisActionMenu items={items} />
+    </CellActionContainer>
+  );
+}

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -522,9 +522,9 @@ describe('logsTableRow', () => {
     const actionsButton = screen.getAllByRole('button', {name: 'Actions'})[0]!;
     await userEvent.click(actionsButton);
 
-    // Click "Copy to clipboard" in the dropdown menu
+    // Click "Copy message" in the dropdown menu
     const copyItem = await screen.findByRole('menuitemradio', {
-      name: 'Copy to clipboard',
+      name: 'Copy message',
     });
     await userEvent.click(copyItem);
 

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -18,28 +18,22 @@ import {Flex} from '@sentry/scraps/layout';
 import {EmptyStreamWrapper} from 'sentry/components/emptyStateWarning';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {IconAdd, IconJson, IconSubtract, IconWarning} from 'sentry/icons';
+import {IconAdd, IconCopy, IconJson, IconSubtract, IconWarning} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
-import {FieldValueType} from 'sentry/utils/fields';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
-import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {
+  copyToClipboard as copyTextToClipboard,
+  useCopyToClipboard,
+} from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useProjects} from 'sentry/utils/useProjects';
-import {
-  Actions,
-  ActionTriggerType,
-  CellAction,
-  copyToClipboard,
-} from 'sentry/views/discover/table/cellAction';
-import type {TableColumn} from 'sentry/views/discover/table/types';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {
   useLogsAutoRefreshEnabled,
@@ -70,7 +64,6 @@ import {
   DetailsWrapper,
   getLogColors,
   LogAttributeTreeWrapper,
-  LogDetailTableActionsButtonBar,
   LogDetailTableActionsCell,
   LogDetailTableBodyCell,
   LogFirstCellContent,
@@ -104,6 +97,8 @@ import {
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
 
+import {LogCellAction} from './logCellAction';
+
 type LogsRowProps = {
   dataRow: LogTableRowItem;
   highlightTerms: string[];
@@ -123,12 +118,6 @@ type LogsRowProps = {
   onExpand?: (logItemId: string) => void;
   onExpandHeight?: (logItemId: string, estimatedHeight: number) => void;
 };
-
-const ALLOWED_CELL_ACTIONS: Actions[] = [
-  Actions.ADD,
-  Actions.EXCLUDE,
-  Actions.COPY_TO_CLIPBOARD,
-];
 
 function isInsideButton(element: Element | null): boolean {
   let i = 10;
@@ -394,17 +383,6 @@ export const LogRowContent = memo(function LogRowContent({
             />
           );
 
-          const discoverColumn: TableColumn<keyof TableDataRow> = {
-            column: {
-              field,
-              kind: 'field',
-            },
-            name: field,
-            key: field,
-            isSortable: true,
-            type: FieldValueType.STRING,
-          };
-
           const shouldRenderActions =
             !embedded &&
             field !== OurLogKnownFieldKey.TIMESTAMP &&
@@ -413,36 +391,15 @@ export const LogRowContent = memo(function LogRowContent({
           return (
             <LogTableBodyCell key={field} data-test-id={'log-table-cell-' + field}>
               {shouldRenderActions ? (
-                <CellAction
-                  column={discoverColumn}
-                  dataRow={dataRow as unknown as TableDataRow}
-                  handleCellAction={(actions, cellValue) => {
-                    switch (actions) {
-                      case Actions.ADD:
-                        addSearchFilter({
-                          key: field,
-                          value: cellValue,
-                        });
-                        break;
-                      case Actions.EXCLUDE:
-                        addSearchFilter({
-                          key: field,
-                          value: cellValue,
-                          negated: true,
-                        });
-                        break;
-                      case Actions.COPY_TO_CLIPBOARD:
-                        copyToClipboard(cellValue);
-                        break;
-                      default:
-                        break;
-                    }
-                  }}
-                  allowActions={ALLOWED_CELL_ACTIONS}
-                  triggerType={ActionTriggerType.ELLIPSIS}
+                <LogCellAction
+                  field={field}
+                  value={value}
+                  fullLogData={traceItemsResult?.data}
+                  logId={String(dataRow[OurLogKnownFieldKey.ID])}
+                  addSearchFilter={addSearchFilter}
                 >
                   {renderedField}
-                </CellAction>
+                </LogCellAction>
               ) : (
                 renderedField
               )}
@@ -612,13 +569,14 @@ function LogRowDetails({
 }
 
 function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowItem}) {
-  const theme = useTheme();
   const addSearchFilter = useAddSearchFilter();
   return (
-    <LogDetailTableActionsButtonBar>
+    <Flex gap="xl">
       <Button
         priority="link"
         size="sm"
+        style={{fontWeight: 'normal'}}
+        icon={<IconAdd />}
         onClick={() => {
           addSearchFilter({
             key: OurLogKnownFieldKey.MESSAGE,
@@ -626,12 +584,13 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
           });
         }}
       >
-        <IconAdd size="md" style={{paddingRight: theme.space.xs}} />
         {t('Add to filter')}
       </Button>
       <Button
         priority="link"
         size="sm"
+        style={{fontWeight: 'normal'}}
+        icon={<IconSubtract />}
         onClick={() => {
           addSearchFilter({
             key: OurLogKnownFieldKey.MESSAGE,
@@ -640,10 +599,9 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
           });
         }}
       >
-        <IconSubtract size="md" style={{paddingRight: theme.space.xs}} />
         {t('Exclude from filter')}
       </Button>
-    </LogDetailTableActionsButtonBar>
+    </Flex>
   );
 }
 
@@ -654,7 +612,6 @@ function LogRowDetailsActions({
   fullLogDataResult: UseApiQueryResult<TraceItemDetailsResponse, RequestError>;
   tableDataRow: LogTableRowItem;
 }) {
-  const theme = useTheme();
   const {data, isPending, isError} = fullLogDataResult;
   const isFrozen = useLogsFrozenIsFrozen();
   const organization = useOrganization();
@@ -665,12 +622,12 @@ function LogRowDetailsActions({
   // Memoize in case we are attempting to copy large JSON objects.
   const json = useMemo(() => ourlogToJson(data), [data]);
 
-  const betterCopyToClipboard = useCallback(() => {
+  const copyAsJson = useCallback(() => {
     if (!json) {
       return;
     }
     copy(json, {
-      successMessage: t('Copied!'),
+      successMessage: t('Copied as JSON'),
       errorMessage: t('Failed to copy'),
     }).then(() => {
       trackAnalytics('logs.table.row_copied_as_json', {
@@ -680,6 +637,19 @@ function LogRowDetailsActions({
     });
   }, [copy, organization, tableDataRow, json]);
 
+  const copyText = useCallback(() => {
+    const message = String(tableDataRow[OurLogKnownFieldKey.MESSAGE] ?? '');
+    if (!message) {
+      return;
+    }
+    copyTextToClipboard(message, {
+      successMessage: t('Copied message'),
+      errorMessage: t('Failed to copy'),
+    });
+  }, [tableDataRow]);
+
+  const message = tableDataRow[OurLogKnownFieldKey.MESSAGE];
+
   return (
     <Fragment>
       {showFilterButtons ? (
@@ -687,17 +657,28 @@ function LogRowDetailsActions({
       ) : (
         <span />
       )}
-      <LogDetailTableActionsButtonBar>
+      <Flex gap="xl">
         <Button
           priority="link"
           size="sm"
-          onClick={betterCopyToClipboard}
+          style={{fontWeight: 'normal'}}
+          icon={<IconCopy />}
+          onClick={copyText}
+          disabled={!message}
+        >
+          {t('Copy message')}
+        </Button>
+        <Button
+          priority="link"
+          size="sm"
+          style={{fontWeight: 'normal'}}
+          icon={<IconJson />}
+          onClick={copyAsJson}
           disabled={isPending || isError || !json}
         >
-          <IconJson size="md" style={{paddingRight: theme.space.xs}} />
           {t('Copy as JSON')}
         </Button>
-      </LogDetailTableActionsButtonBar>
+      </Flex>
     </Fragment>
   );
 }

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -180,20 +180,22 @@ export function useSetQueryParamsSearch() {
   );
 }
 
-export function useAddSearchFilter() {
+export type AddSearchFilter = (filter: SearchFilter) => void;
+
+export type SearchFilter = {
+  key: string;
+  value: SearchFilterValue;
+  negated?: boolean;
+};
+
+export type SearchFilterValue = string | number | boolean;
+
+export function useAddSearchFilter(): AddSearchFilter {
   const setSearch = useSetQueryParamsSearch();
   const search = useQueryParamsSearch();
 
   return useCallback(
-    ({
-      key,
-      value,
-      negated,
-    }: {
-      key: string;
-      value: string | number | boolean;
-      negated?: boolean;
-    }) => {
+    ({key, value, negated}) => {
       const newSearch = search.copy();
       newSearch.addFilterValue(`${negated ? '!' : ''}${key}`, String(value));
       setSearch(newSearch);


### PR DESCRIPTION
Expand the log row ellipsis dropdown to offer two copy actions instead of the single "Copy to clipboard":

* _Copy Message_: copies just the primary cell value (i.e. message) 
* _Copy as JSON_: copies the full log payload as formatted JSON (copies the full log payload as formatted JSON)

Also adds an equivalent _Copy Message_ button alongside the existing _Copy as JSON_ button below full log attribute tree views.

Each action shows a distinct success toast ("Copied message" / "Copied as JSON") so users know which copy succeeded.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="377" height="233" alt="image" src="https://github.com/user-attachments/assets/1d5c41f7-8e94-463f-b2c2-c6d8de901e86" />
</td>
<td>
<img width="377" height="233" alt="image" src="https://github.com/user-attachments/assets/7eae20b6-c0bc-43cd-9300-38035fea6aea" />
</td>
</tr>
<tr>
<td>
<img width="377" height="233" alt="image" src="https://github.com/user-attachments/assets/b431499b-db64-431d-9e4d-228ea7c3b0dc" />
</td>
<td>
<img width="377" height="233" alt="image" src="https://github.com/user-attachments/assets/35a1a0a2-97ee-4a77-b75d-8c63dbe08236" />
</td>
</tr>
</tbody>
</table>


I tried to switch from custom components and style overrides to mostly use the equivalent code and Scraps where possible. This does make a couple of new components:

* A new single-use `LogCellAction` component separate from the existing `CellAction` component
* A shared `EllipsisActionMenu` component to hold this particular variant of dropdown menu options and trigger

Long-term I bet we'll want to overhaul this area to be more in line with Scraps / maybe even push to Scraps some of its ad hoc components. I'll ask around in Slack.

Fixes LOGS-637

Made with [Cursor](https://cursor.com)