### PR TITLE
fix(aci): Show empty state in Alerts list projects column when no detectors are connected

### DIFF
--- a/static/app/views/automations/components/automationListTable/projectsCell.tsx
+++ b/static/app/views/automations/components/automationListTable/projectsCell.tsx
@@ -1,0 +1,20 @@
+import {Placeholder} from 'sentry/components/placeholder';
+import {ProjectList} from 'sentry/components/projectList';
+import {EmptyCell} from 'sentry/components/workflowEngine/gridCell/emptyCell';
+import type {Automation} from 'sentry/types/workflowEngine/automations';
+import {useAutomationProjectSlugs} from 'sentry/views/automations/hooks/utils';
+
+export function ProjectsCell({automation}: {automation: Automation}) {
+  const {projectSlugs, isLoading: isProjectsLoading} =
+    useAutomationProjectSlugs(automation);
+
+  if (isProjectsLoading) {
+    return <Placeholder height="20px" />;
+  }
+
+  if (projectSlugs.length === 0) {
+    return <EmptyCell />;
+  }
+
+  return <ProjectList projectSlugs={projectSlugs} />;
+}

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -5,20 +5,15 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Placeholder} from 'sentry/components/placeholder';
-import {ProjectList} from 'sentry/components/projectList';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import {AutomationTitleCell} from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
-import {EmptyCell} from 'sentry/components/workflowEngine/gridCell/emptyCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
-import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AutomationListConnectedDetectors} from 'sentry/views/automations/components/automationListTable/connectedDetectors';
-import {
-  getAutomationActions,
-  useAutomationProjectIds,
-} from 'sentry/views/automations/hooks/utils';
+import {ProjectsCell} from 'sentry/views/automations/components/automationListTable/projectsCell';
+import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
 
 type AutomationListRowProps = {
   automation: Automation;
@@ -36,10 +31,6 @@ export function AutomationListRow({
 
   const actions = getAutomationActions(automation);
   const {enabled, lastTriggered, detectorIds = []} = automation;
-  const {projectIds, isLoading: isProjectsLoading} = useAutomationProjectIds(automation);
-  const projectSlugs = projectIds.map(
-    projectId => ProjectsStore.getById(projectId)?.slug
-  ) as string[];
 
   return (
     <AutomationSimpleTableRow
@@ -67,13 +58,7 @@ export function AutomationListRow({
         <ActionCell actions={actions} disabled={!enabled} />
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="projects">
-        {isProjectsLoading ? (
-          <Placeholder height="20px" />
-        ) : projectSlugs.length > 0 ? (
-          <ProjectList projectSlugs={projectSlugs} />
-        ) : (
-          <EmptyCell />
-        )}
+        <ProjectsCell automation={automation} />
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="connected-monitors">
         <AutomationListConnectedDetectors detectorIds={detectorIds} />

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -9,6 +9,7 @@ import {ProjectList} from 'sentry/components/projectList';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import {AutomationTitleCell} from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
+import {EmptyCell} from 'sentry/components/workflowEngine/gridCell/emptyCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
@@ -66,7 +67,11 @@ export function AutomationListRow({
         <ActionCell actions={actions} disabled={!enabled} />
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="projects">
-        <ProjectList projectSlugs={projectSlugs} />
+        {projectSlugs.length > 0 ? (
+          <ProjectList projectSlugs={projectSlugs} />
+        ) : (
+          <EmptyCell />
+        )}
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="connected-monitors">
         <AutomationListConnectedDetectors detectorIds={detectorIds} />

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -36,7 +36,7 @@ export function AutomationListRow({
 
   const actions = getAutomationActions(automation);
   const {enabled, lastTriggered, detectorIds = []} = automation;
-  const projectIds = useAutomationProjectIds(automation);
+  const {projectIds, isLoading: isProjectsLoading} = useAutomationProjectIds(automation);
   const projectSlugs = projectIds.map(
     projectId => ProjectsStore.getById(projectId)?.slug
   ) as string[];
@@ -67,7 +67,9 @@ export function AutomationListRow({
         <ActionCell actions={actions} disabled={!enabled} />
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="projects">
-        {projectSlugs.length > 0 ? (
+        {isProjectsLoading ? (
+          <Placeholder height="20px" />
+        ) : projectSlugs.length > 0 ? (
           <ProjectList projectSlugs={projectSlugs} />
         ) : (
           <EmptyCell />

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -53,7 +53,10 @@ export function getAutomationActionsWarning(
 }
 
 export function useAutomationProjectIds(automation: Automation): string[] {
-  const {data: detectors} = useDetectorsQuery({ids: automation.detectorIds});
+  const {data: detectors} = useDetectorsQuery(
+    {ids: automation.detectorIds},
+    {enabled: automation.detectorIds.length > 0}
+  );
   return [
     ...new Set(detectors?.map(detector => detector.projectId).filter(x => x) ?? []),
   ] as string[];

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 import type {Automation, StatusWarning} from 'sentry/types/workflowEngine/automations';
 import type {DataConditionGroup} from 'sentry/types/workflowEngine/dataConditions';
@@ -52,18 +53,21 @@ export function getAutomationActionsWarning(
   return null;
 }
 
-export function useAutomationProjectIds(automation: Automation): {
-  isLoading: boolean;
-  projectIds: string[];
-} {
+export function useAutomationProjectSlugs(automation: Automation) {
   const {data: detectors, isLoading} = useDetectorsQuery(
     {ids: automation.detectorIds},
     {enabled: automation.detectorIds.length > 0}
   );
+
   const projectIds = [
     ...new Set(detectors?.map(detector => detector.projectId).filter(x => x) ?? []),
   ] as string[];
-  return {projectIds, isLoading};
+
+  const projectSlugs = projectIds.map(
+    projectId => ProjectsStore.getById(projectId)?.slug
+  ) as string[];
+
+  return {projectSlugs, isLoading};
 }
 
 export function findConflictingConditions(

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -52,14 +52,18 @@ export function getAutomationActionsWarning(
   return null;
 }
 
-export function useAutomationProjectIds(automation: Automation): string[] {
-  const {data: detectors} = useDetectorsQuery(
+export function useAutomationProjectIds(automation: Automation): {
+  isLoading: boolean;
+  projectIds: string[];
+} {
+  const {data: detectors, isLoading} = useDetectorsQuery(
     {ids: automation.detectorIds},
     {enabled: automation.detectorIds.length > 0}
   );
-  return [
+  const projectIds = [
     ...new Set(detectors?.map(detector => detector.projectId).filter(x => x) ?? []),
   ] as string[];
+  return {projectIds, isLoading};
 }
 
 export function findConflictingConditions(

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -7,6 +7,7 @@ import {
   DataConditionGroupLogicType,
   DataConditionType,
 } from 'sentry/types/workflowEngine/dataConditions';
+import {defined} from 'sentry/utils';
 import {AgeComparison} from 'sentry/views/automations/components/actionFilters/constants';
 import type {ConflictingConditions} from 'sentry/views/automations/components/automationBuilderConflictContext';
 import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
@@ -60,12 +61,12 @@ export function useAutomationProjectSlugs(automation: Automation) {
   );
 
   const projectIds = [
-    ...new Set(detectors?.map(detector => detector.projectId).filter(x => x) ?? []),
-  ] as string[];
+    ...new Set(detectors?.map(detector => detector.projectId).filter(defined) ?? []),
+  ];
 
-  const projectSlugs = projectIds.map(
-    projectId => ProjectsStore.getById(projectId)?.slug
-  ) as string[];
+  const projectSlugs = projectIds
+    .map(projectId => ProjectsStore.getById(projectId)?.slug)
+    .filter(defined);
 
   return {projectSlugs, isLoading};
 }


### PR DESCRIPTION
Fixes ISWF-2161

When an automation has no connected detectors, the projects column in the automation list view shows all org projects. This happens because `useAutomationProjectIds` calls `useDetectorsQuery({ids: []})`, which sends an empty `id` filter to the API and gets back all detectors.

<img width="1237" height="117" alt="CleanShot 2026-03-27 at 13 24 36" src="https://github.com/user-attachments/assets/76a6992e-13af-4f0a-a03f-55e3d02e11df" />

While looking at this, I noticed that there is a perf improvement we can make here (these requests can be batched) which I filed on our backlog: https://linear.app/getsentry/issue/ISWF-2324/performance-improvement-batch-fetch-requests-for-connected