### PR TITLE
chore(autofix): Remove unneeded seat based seer check

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -23,7 +23,6 @@ from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import (
     get_autofix_repos_from_project_code_mappings,
     has_project_connected_repos,
-    is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
 from sentry.seer.models import SeerApiError
@@ -151,11 +150,9 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
             org_id=org.id, data_category=DataCategory.SEER_AUTOFIX
         )
 
-        seer_seat_based_tier_enabled = is_seer_seat_based_tier_enabled(org)
-
         seer_repos_linked = False
         # Check if org has github integration and is on seat-based tier.
-        if integration_check is None and seer_seat_based_tier_enabled:
+        if integration_check is None:
             try:
                 # Check if project has repos linked in Seer.
                 # Skip cache to ensure latest data from Seer API.
@@ -168,12 +165,11 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
 
         autofix_enabled = False
         autofix_automation_tuning = group.project.get_option("sentry:autofix_automation_tuning")
-        if seer_seat_based_tier_enabled:
-            if (
-                autofix_automation_tuning
-                and autofix_automation_tuning != AutofixAutomationTuningSettings.OFF
-            ):
-                autofix_enabled = True
+        if (
+            autofix_automation_tuning
+            and autofix_automation_tuning != AutofixAutomationTuningSettings.OFF
+        ):
+            autofix_enabled = True
 
         return Response(
             {

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -274,7 +274,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
     def test_autofix_automation_tuning_non_seat_based(self) -> None:
         self.login_as(user=self.user)
 
-        for setting in [None] + list(AutofixAutomationTuningSettings):
+        for setting in [None, *list(AutofixAutomationTuningSettings)]:
             self.project.update_option("sentry:autofix_automation_tuning", setting)
             group = self.create_group()
             url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -281,7 +281,11 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             response = self.client.get(url, format="json")
 
             assert response.status_code == 200
-            assert response.data["autofixEnabled"] is False
+            if setting is None or setting == AutofixAutomationTuningSettings.OFF:
+                expected = False
+            else:
+                expected = True
+            assert response.data["autofixEnabled"] is expected
 
     def test_autofix_automation_tuning_off(self) -> None:
         self._set_seat_based_tier_cache(True)


### PR DESCRIPTION
This check already exists on the frontend, no need to check it twice. This also lets us use to for non seat based seer plans.