### PR TITLE
feat(ACI): Release rule stats and group history wfe endpoints

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -434,6 +434,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for OrganizationCombinedRuleIndexEndpoint.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-combinedruleindex-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use workflow engine exclusively for ProjectRuleGroupHistoryIndexEndpoint.get and ProjectRuleStatsIndexEndpoint.get results.
+    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
+    manager.add("organizations:workflow-engine-projectrulegroupstats-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -57,6 +57,9 @@ class RuleGroupHistorySerializer(Serializer):
 @extend_schema(tags=["issue_alerts"])
 @cell_silo_endpoint
 class ProjectRuleGroupHistoryIndexEndpoint(WorkflowEngineRuleEndpoint):
+    workflow_engine_method_flags = {
+        "GET": "organizations:workflow-engine-projectrulegroupstats-get",
+    }
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -40,6 +40,9 @@ class TimeSeriesValueSerializer(Serializer):
 @extend_schema(tags=["issue_alerts"])
 @cell_silo_endpoint
 class ProjectRuleStatsIndexEndpoint(WorkflowEngineRuleEndpoint):
+    workflow_engine_method_flags = {
+        "GET": "organizations:workflow-engine-projectrulegroupstats-get",
+    }
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -197,6 +197,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest, BaseWorkf
         )
 
     @with_feature("organizations:workflow-engine-rule-serializers")
+    @with_feature("organizations:workflow-engine-projectrulegroupstats-get")
     def test_single_written_workflow_history(self) -> None:
         """Test using WorkflowFireHistory when feature flag is enabled"""
         workflow_triggers = self.create_data_condition_group()
@@ -276,6 +277,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest, BaseWorkf
         )
 
     @with_feature("organizations:workflow-engine-rule-serializers")
+    @with_feature("organizations:workflow-engine-projectrulegroupstats-get")
     def test_combined_rule_and_workflow_history(self) -> None:
         """Test combining RuleFireHistory and WorkflowFireHistory when both exist"""
         rule = self.create_project_rule(project=self.event.project)
@@ -416,6 +418,7 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         assert [r.count for r in results[-5:]] == [0, 0, 1, 1, 0]
 
     @with_feature("organizations:workflow-engine-rule-serializers")
+    @with_feature("organizations:workflow-engine-projectrulegroupstats-get")
     def test_single_written_workflow_history(self) -> None:
         """Test using WorkflowFireHistory when feature flag is enabled"""
         workflow_triggers = self.create_data_condition_group()
@@ -452,6 +455,7 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         assert [r.count for r in results[-5:]] == [0, 2, 0, 1, 0]
 
     @with_feature("organizations:workflow-engine-rule-serializers")
+    @with_feature("organizations:workflow-engine-projectrulegroupstats-get")
     def test_combined_rule_and_workflow_history(self) -> None:
         """Test combining RuleFireHistory and WorkflowFireHistory when both exist"""
         rule = self.create_project_rule(project=self.event.project)


### PR DESCRIPTION
Add a flag to release the rule stats and group history workflow engine versions of the endpoints. These complement the `ProjectRuleDetailsEndpoint` which is [about to be released to GA](https://github.com/getsentry/sentry-options-automator/pull/7008) as they provide additional context for rendering the page. 