### PR TITLE
ref(cells): Rename regions to cells in users models

### DIFF
--- a/src/sentry/api/endpoints/user_organizations.py
+++ b/src/sentry/api/endpoints/user_organizations.py
@@ -13,6 +13,8 @@ from sentry.users.api.bases.user import RegionSiloUserEndpoint
 from sentry.users.services.user import RpcUser
 
 
+# TODO(cells): Non-routable by Synapse (no org slug in URL). Fix by moving to
+# @control_silo_endpoint and querying OrganizationMemberMapping + OrganizationMapping.
 @cell_silo_endpoint
 class UserOrganizationsEndpoint(RegionSiloUserEndpoint):
     publish_status = {

--- a/src/sentry/users/api/endpoints/user_regions.py
+++ b/src/sentry/users/api/endpoints/user_regions.py
@@ -40,8 +40,8 @@ class UserRegionEndpointPermissions(UserPermission):
         return False
 
 
-# TODO(cells): Deprecate once Synapse handles cross-cell fan-out for organization
-# listing and the frontend no longer needs locality URLs for client-side fan-out.
+# TODO(cells): Deprecate once organization listing is moved to control and the frontend
+# no longer needs locality URLs for client-side fan-out.
 @control_silo_endpoint
 class UserRegionsEndpoint(UserEndpoint):
     owner = ApiOwner.HYBRID_CLOUD

--- a/src/sentry/users/api/endpoints/user_regions.py
+++ b/src/sentry/users/api/endpoints/user_regions.py
@@ -40,6 +40,8 @@ class UserRegionEndpointPermissions(UserPermission):
         return False
 
 
+# TODO(cells): Deprecate once Synapse handles cross-cell fan-out for organization
+# listing and the frontend no longer needs locality URLs for client-side fan-out.
 @control_silo_endpoint
 class UserRegionsEndpoint(UserEndpoint):
     owner = ApiOwner.HYBRID_CLOUD

--- a/src/sentry/users/models/authenticator.py
+++ b/src/sentry/users/models/authenticator.py
@@ -184,9 +184,9 @@ class Authenticator(ControlOutboxProducingModel):
         unique_together = (("user", "type"),)
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = find_cells_for_user(self.user_id)
+        cells = find_cells_for_user(self.user_id)
         return OutboxCategory.USER_UPDATE.as_control_outboxes(
-            cell_names=regions,
+            cell_names=cells,
             shard_identifier=self.user_id,
             object_identifier=self.user_id,
         )

--- a/src/sentry/users/models/identity.py
+++ b/src/sentry/users/models/identity.py
@@ -115,7 +115,7 @@ class IdentityManager(BaseManager["Identity"]):
             SlackIntegrationIdentityLinked(
                 provider=IntegrationProviderSlug.SLACK.value,
                 # Note that prior to circa March 2023 this was user.actor_id. It changed
-                # when actor ids were no longer stable between regions for the same user
+                # when actor ids were no longer stable between cells for the same user
                 actor_id=user.id,
                 actor_type="user",
             )
@@ -218,15 +218,15 @@ class Identity(Model):
 
     def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
         with outbox_context(transaction.atomic(router.db_for_write(Identity))):
-            # Fan out to all regions to ensure HybridCloudForeignKey cascade works even without org memberships
-            region_names = find_all_cell_names()
-            for region_name in region_names:
+            # Fan out to all cells to ensure HybridCloudForeignKey cascade works even without org memberships
+            cell_names = find_all_cell_names()
+            for cell_name in cell_names:
                 ControlOutbox(
                     shard_scope=OutboxScope.USER_SCOPE,
                     shard_identifier=self.user_id,
                     object_identifier=self.id,
                     category=OutboxCategory.IDENTITY_UPDATE,
-                    cell_name=region_name,
+                    cell_name=cell_name,
                 ).save()
             return super().delete(*args, **kwargs)
 

--- a/src/sentry/users/models/user.py
+++ b/src/sentry/users/models/user.py
@@ -367,16 +367,16 @@ class User(Model, AbstractBaseUser):
     def outboxes_for_user_update(
         identifier: int, is_user_delete: bool = False
     ) -> list[ControlOutboxBase]:
-        # User deletions must fan out to all regions to ensure cascade behavior
+        # User deletions must fan out to all cells to ensure cascade behavior
         # of anything with a HybridCloudForeignKey, even if the user is no longer
-        # a member of any organizations in that region.
+        # a member of any organizations in that cell.
         if is_user_delete:
-            user_regions = set(find_all_cell_names())
+            user_cells = set(find_all_cell_names())
         else:
-            user_regions = find_cells_for_user(identifier)
+            cells = find_cells_for_user(identifier)
 
         return OutboxCategory.USER_UPDATE.as_control_outboxes(
-            cell_names=user_regions,
+            cell_names=cells,
             object_identifier=identifier,
             shard_identifier=identifier,
         )

--- a/src/sentry/users/models/user.py
+++ b/src/sentry/users/models/user.py
@@ -373,10 +373,10 @@ class User(Model, AbstractBaseUser):
         if is_user_delete:
             user_cells = set(find_all_cell_names())
         else:
-            cells = find_cells_for_user(identifier)
+            user_cells = find_cells_for_user(identifier)
 
         return OutboxCategory.USER_UPDATE.as_control_outboxes(
-            cell_names=cells,
+            cell_names=user_cells,
             object_identifier=identifier,
             shard_identifier=identifier,
         )

--- a/src/sentry/users/models/user_avatar.py
+++ b/src/sentry/users/models/user_avatar.py
@@ -55,9 +55,9 @@ class UserAvatar(ControlAvatarBase):
     url_path = "avatar"
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = find_cells_for_user(self.user_id)
+        cells = find_cells_for_user(self.user_id)
         return OutboxCategory.USER_UPDATE.as_control_outboxes(
-            cell_names=regions,
+            cell_names=cells,
             shard_identifier=self.user_id,
             object_identifier=self.user_id,
         )

--- a/src/sentry/users/models/useremail.py
+++ b/src/sentry/users/models/useremail.py
@@ -78,11 +78,11 @@ class UserEmail(ControlOutboxProducingModel):
     __repr__ = sane_repr("user_id", "email")
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = find_cells_for_user(self.user_id)
+        cells = find_cells_for_user(self.user_id)
         return [
             outbox
             for outbox in OutboxCategory.USER_UPDATE.as_control_outboxes(
-                cell_names=regions,
+                cell_names=cells,
                 shard_identifier=self.user_id,
                 object_identifier=self.user_id,
             )

--- a/src/sentry/users/models/userpermission.py
+++ b/src/sentry/users/models/userpermission.py
@@ -43,11 +43,11 @@ class UserPermission(OverwritableConfigMixin, ControlOutboxProducingModel):
         return frozenset(cls.objects.filter(user=user_id).values_list("permission", flat=True))
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = find_cells_for_user(self.user_id)
+        cells = find_cells_for_user(self.user_id)
         return [
             outbox
             for outbox in OutboxCategory.USER_UPDATE.as_control_outboxes(
-                cell_names=regions,
+                cell_names=cells,
                 shard_identifier=self.user_id,
                 object_identifier=self.user_id,
             )

--- a/src/sentry/users/models/userrole.py
+++ b/src/sentry/users/models/userrole.py
@@ -44,12 +44,12 @@ class UserRole(OverwritableConfigMixin, ControlOutboxProducingModel):
     __repr__ = sane_repr("name", "permissions")
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = list(find_all_cell_names())
+        cells = list(find_all_cell_names())
         return [
             outbox
             for user_id in self.users.values_list("id", flat=True)
             for outbox in OutboxCategory.USER_UPDATE.as_control_outboxes(
-                cell_names=regions,
+                cell_names=cells,
                 shard_identifier=user_id,
                 object_identifier=user_id,
             )
@@ -67,9 +67,9 @@ class UserRoleUser(ControlOutboxProducingModel):
     role = FlexibleForeignKey("sentry.UserRole")
 
     def outboxes_for_update(self, shard_identifier: int | None = None) -> list[ControlOutboxBase]:
-        regions = list(find_all_cell_names())
+        cells = list(find_all_cell_names())
         return OutboxCategory.USER_UPDATE.as_control_outboxes(
-            cell_names=regions,
+            cell_names=cells,
             shard_identifier=self.user_id,
             object_identifier=self.user_id,
         )

--- a/src/sentry/users/services/user/impl.py
+++ b/src/sentry/users/services/user/impl.py
@@ -151,16 +151,16 @@ class DatabaseBackedUserService(UserService):
             org_query = org_query.filter(status=OrganizationStatus.ACTIVE)
         return [serialize_organization_mapping(o) for o in org_query]
 
-    def get_member_region_names(self, *, user_id: int) -> list[str]:
+    def get_member_cell_names(self, *, user_id: int) -> list[str]:
         org_ids = OrganizationMemberMapping.objects.filter(user_id=user_id).values_list(
             "organization_id", flat=True
         )
-        region_query = (
+        cell_query = (
             OrganizationMapping.objects.filter(organization_id__in=org_ids)
             .values_list("cell_name", flat=True)
             .distinct()
         )
-        return list(region_query)
+        return list(cell_query)
 
     def flush_nonce(self, *, user_id: int) -> None:
         user = User.objects.filter(id=user_id).first()

--- a/src/sentry/users/services/user/service.py
+++ b/src/sentry/users/services/user/service.py
@@ -112,8 +112,8 @@ class UserService(RpcService):
         """
         Get many users by id.
 
-        Will use region local cache to minimize network overhead.
-        Cache keys in regions will be expired as users are updated via outbox receivers.
+        Will use cell local cache to minimize network overhead.
+        Cache keys in cells will be expired as users are updated via outbox receivers.
 
         :param ids: A list of user ids to fetch
         """
@@ -152,7 +152,7 @@ class UserService(RpcService):
         """
         Get summary data for all organizations of which the user is a member.
 
-        The organizations may span multiple regions.
+        The organizations may span multiple cells.
 
         :param user_id: The user to find organizations from.
         :param only_visible: Whether or not to only fetch visible organizations
@@ -160,11 +160,11 @@ class UserService(RpcService):
 
     @rpc_method
     @abstractmethod
-    def get_member_region_names(self, *, user_id: int) -> list[str]:
+    def get_member_cell_names(self, *, user_id: int) -> list[str]:
         """
-        Get a list of region names where the user is a member of at least one org.
+        Get a list of cell names where the user is a member of at least one org.
 
-        :param user_id: The user to fetch region names for.
+        :param user_id: The user to fetch cell names for.
         """
 
     @rpc_method

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -237,7 +237,7 @@ def recover_confirm(
             if mode == "relocate":
                 # Relocation form requires users to accept TOS and privacy policy with an org
                 # associated. We only need the first membership, since all of user's orgs will be in
-                # the same region.
+                # the same cell.
                 membership = OrganizationMemberMapping.objects.filter(user=user).first()
                 assert membership is not None
                 mapping = OrganizationMapping.objects.get(

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -343,7 +343,7 @@ class _ClientConfig:
         if not self.user or not self.user.id:
             return frozenset()
 
-        cell_names = user_service.get_member_region_names(user_id=self.user.id)
+        cell_names = user_service.get_member_cell_names(user_id=self.user.id)
         directory = get_global_directory()
         return frozenset(
             loc.name


### PR DESCRIPTION
Also adds TODO comments and details about the user endpoints that need to be changed:
- UserRegions should be deprecated
- UserOrganizationsEndpoint needs to move to control
