### PR TITLE
chore(ACI): Document detector filter params

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -431,7 +431,13 @@ class DetectorParams:
         location="query",
         required=False,
         type=str,
-        description="An optional search query for filtering monitors.",
+        description="""An optional search query for filtering monitors.
+
+Available fields are:
+- `name`
+- `type`: e.g. `error`, `metric_issue`, `issue_stream`
+- `assignee`: email, username, #team, me, none
+        """,
     )
 
     SORT = OpenApiParameter(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -413,6 +413,12 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         )
         assert {d["name"] for d in response.data} == {detector2.name}
 
+        issue_stream_resp = self.get_success_response(
+            self.organization.slug,
+            qs_params={"project": self.project.id, "query": "type:issue_stream"},
+        )
+        assert {d["name"] for d in issue_stream_resp.data} == {self.issue_stream_detector.name}
+
         # Query for multiple types.
         response2 = self.get_success_response(
             self.organization.slug,


### PR DESCRIPTION
I didn't realize you already could filter by detector type so this PR just documents it better and adds a test to make sure filtering by `type:issue_stream` works.