### PR TITLE
fix(workflow-engine): Handle non-numeric DataCondition comparisons in combined-rules serializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
@@ -80,10 +80,12 @@ class WorkflowEngineDataConditionSerializer(Serializer):
         # Map (condition_group_id, comparison) → action-filter DC exists in that DCG
         # We need: for a given detector's DCGs + priority level → matching DCG IDs
         # NOTE: Assumes DataConditions are limited to what would be dual written.
-        dcg_comparison_pairs: dict[int, set[int]] = defaultdict(set)
+        dcg_comparison_pairs: dict[int, set[int | float]] = defaultdict(set)
         for dc in DataCondition.objects.filter(condition_group__in=all_dcg_ids):
-            # Map comparison value → set of DCG IDs that have an action filter at that level
-            dcg_comparison_pairs[dc.condition_group_id].add(dc.comparison)
+            # Only collect numeric comparison values; non-numeric values (e.g. dicts
+            # from anomaly detection conditions) don't match condition_result levels.
+            if isinstance(dc.comparison, (int, float)):
+                dcg_comparison_pairs[dc.condition_group_id].add(dc.comparison)
 
         # Bulk-fetch all DCG → action mappings
         dcg_to_action_ids: dict[int, list[int]] = defaultdict(list)

--- a/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
@@ -15,6 +15,8 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_metric_data_conditions,
     migrate_resolve_threshold_data_condition,
 )
+from sentry.workflow_engine.models import DataCondition, WorkflowDataConditionGroup
+from sentry.workflow_engine.models.data_condition import Condition
 from tests.sentry.incidents.serializers.test_workflow_engine_base import (
     TestWorkflowEngineSerializer,
 )
@@ -152,6 +154,36 @@ class TestDataConditionSerializer(TestWorkflowEngineSerializer):
         )
         assert serialized_data_condition["alertThreshold"] == 0
         assert serialized_data_condition["resolveThreshold"] is None
+
+    def test_anomaly_detection_with_workflow_actions(self) -> None:
+        dynamic_rule = self.create_dynamic_alert()
+        critical_trigger = self.create_alert_rule_trigger(
+            alert_rule=dynamic_rule, label="critical", alert_threshold=0
+        )
+        trigger_action = self.create_alert_rule_trigger_action(alert_rule_trigger=critical_trigger)
+        _, _, _, detector, _, _, _, _ = migrate_alert_rule(dynamic_rule)
+        detector_trigger, _, _ = migrate_metric_data_conditions(critical_trigger)
+        migrate_metric_action(trigger_action)
+
+        workflow_dcg = WorkflowDataConditionGroup.objects.filter(
+            workflow__detectorworkflow__detector=detector,
+        ).first()
+        assert workflow_dcg is not None
+        DataCondition.objects.create(
+            type=Condition.ANOMALY_DETECTION,
+            comparison={"sensitivity": "high", "seasonality": "auto", "threshold_type": 2},
+            condition_result=True,
+            condition_group=workflow_dcg.condition_group,
+        )
+
+        serialized = serialize(
+            detector_trigger,
+            self.user,
+            WorkflowEngineDataConditionSerializer(),
+        )
+        assert serialized["thresholdType"] == AlertRuleThresholdType.ABOVE_AND_BELOW.value
+        assert serialized["alertThreshold"] == 0
+        assert serialized["resolveThreshold"] is None
 
     def test_multiple_rules(self) -> None:
         # create another comprehensive alert rule in the DB


### PR DESCRIPTION
The WorkflowEngineDataConditionSerializer assumed all DataCondition comparison values in workflow DCGs were numeric, which holds for dual-written rules but not for single-written rules where anomaly detection conditions can store dict comparisons. Filter to numeric values only when building the comparison lookup.


Fixes SENTRY-5MHW.