### PR TITLE
perf(workflows): Batch ActionAlertRuleTriggerAction lookup in WorkflowEngineActionSerializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Sequence
 
 from django.contrib.auth.models import AnonymousUser
 
@@ -20,6 +20,17 @@ from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction
 
 
 class WorkflowEngineActionSerializer(Serializer):
+    def get_attrs(
+        self, item_list: Sequence[Action], user: User | RpcUser | AnonymousUser, **kwargs: Any
+    ) -> dict[Action, dict[str, Any]]:
+        aarta_by_action_id = {
+            aarta.action_id: aarta
+            for aarta in ActionAlertRuleTriggerAction.objects.filter(
+                action__in=[item.id for item in item_list]
+            )
+        }
+        return {item: {"aarta": aarta_by_action_id.get(item.id)} for item in item_list}
+
     def serialize(
         self, obj: Action, attrs: Mapping[str, Any], user: User | RpcUser | AnonymousUser, **kwargs
     ) -> dict[str, Any]:
@@ -30,10 +41,7 @@ class WorkflowEngineActionSerializer(Serializer):
 
         alert_rule_trigger_id = kwargs.get("alert_rule_trigger_id", -1)
 
-        try:
-            aarta = ActionAlertRuleTriggerAction.objects.get(action=obj.id)
-        except ActionAlertRuleTriggerAction.DoesNotExist:
-            aarta = None
+        aarta = attrs.get("aarta")
         priority = obj.data.get("priority")
         type_value = ActionService.get_value(obj.type)
         target = MetricAlertRegistryHandler.target(obj)


### PR DESCRIPTION
Avoids a query per action, and makes further refactors to improve batching more effective.