### PR TITLE
fix(repos): Make it clearer when repos are disabled or connected properly

### DIFF
--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -1,7 +1,7 @@
-import {useEffect, useState, type CSSProperties, type ReactNode} from 'react';
+import {Fragment, useEffect, useState, type CSSProperties, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
-import {Badge} from '@sentry/scraps/badge';
+import {Badge, Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 import {Flex} from '@sentry/scraps/layout';
@@ -182,12 +182,20 @@ export function ScmIntegrationTreeRow({
               <Flex align="center" gap="sm">
                 {node.isReposPending ? (
                   <LoadingReposMessage />
+                ) : node.repoCount === 0 ? (
+                  <Tag variant="muted">{t('disabled')}</Tag>
                 ) : (
-                  <Badge variant="muted">
-                    {t('%s/%s repos connected', node.connectedRepoCount, node.repoCount)}
-                  </Badge>
+                  <Fragment>
+                    <Badge variant="muted">
+                      {t(
+                        '%s/%s repos connected',
+                        node.connectedRepoCount,
+                        node.repoCount
+                      )}
+                    </Badge>
+                    <ProviderConfigLink integration={node.integration} />
+                  </Fragment>
                 )}
-                <ProviderConfigLink integration={node.integration} />
               </Flex>
             </Flex>
           </Flex>

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -1,13 +1,13 @@
 import {Component, Fragment} from 'react';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Tag} from '@sentry/scraps/badge';
 import {Button, LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Access} from 'sentry/components/acl/access';
-import {CircleIndicator} from 'sentry/components/circleIndicator';
 import {Confirm} from 'sentry/components/confirm';
 import {IconDelete, IconSettings, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -188,7 +188,7 @@ export class InstalledIntegration extends Component<Props> {
                   </Confirm>
                 </Tooltip>
               </div>
-              <StyledIntegrationStatus
+              <IntegrationStatus
                 status={this.integrationStatus}
                 // Let the hook handle the alert for disabled org integrations
                 hideTooltip={integration.organizationIntegrationStatus === 'disabled'}
@@ -213,33 +213,23 @@ const IntegrationItemBox = styled('div')`
   flex: 1;
 `;
 
-function IntegrationStatus(
-  props: React.HTMLAttributes<HTMLDivElement> & {
-    status: ObjectStatus;
-    hideTooltip?: boolean;
-  }
-) {
-  const theme = useTheme();
-  const {status, hideTooltip, ...p} = props;
-  const color = status === 'active' ? theme.tokens.content.success : theme.colors.gray400;
-  const inner = (
-    <div {...p}>
-      <CircleIndicator size={6} color={color} />
-      <IntegrationStatusText data-test-id="integration-status">
-        {status === 'active'
-          ? t('enabled')
-          : status === 'pending_deletion'
-            ? t('pending deletion')
-            : status === 'disabled'
-              ? t('disabled')
-              : t('unknown')}
-      </IntegrationStatusText>
-    </div>
-  );
-  return hideTooltip ? (
-    inner
-  ) : (
+function IntegrationStatus({
+  status,
+  hideTooltip,
+}: {
+  status: ObjectStatus;
+  hideTooltip?: boolean;
+}) {
+  const label = {
+    active: <Tag variant="success">{t('enabled')}</Tag>,
+    pending_deletion: <Tag variant="info">{t('pending deletion')}</Tag>,
+    disabled: <Tag variant="muted">{t('disabled')}</Tag>,
+    deletion_in_progress: <Tag variant="muted">{t('unknown')}</Tag>,
+  }[status] ?? <Tag variant="muted">{t('unknown')}</Tag>;
+
+  return (
     <Tooltip
+      disabled={hideTooltip}
       title={
         status === 'active'
           ? t('This integration can be disabled by clicking the Uninstall button')
@@ -247,25 +237,16 @@ function IntegrationStatus(
             ? t('This integration has been disconnected from the external provider')
             : t('Deletion takes a few minutes to complete.')
       }
+      skipWrapper
     >
-      {inner}
+      <Flex align="center">
+        <IntegrationStatusText data-test-id="integration-status">
+          {label}
+        </IntegrationStatusText>
+      </Flex>
     </Tooltip>
   );
 }
-
-const StyledIntegrationStatus = styled(IntegrationStatus)`
-  display: flex;
-  align-items: center;
-  color: ${p => p.theme.tokens.content.secondary};
-  font-weight: light;
-  text-transform: capitalize;
-  &:before {
-    content: '|';
-    color: ${p => p.theme.colors.gray200};
-    margin-right: ${p => p.theme.space.md};
-    font-weight: ${p => p.theme.font.weight.sans.regular};
-  }
-`;
 
 const IntegrationStatusText = styled('div')`
   margin: 0 ${p => p.theme.space.sm} 0 ${p => p.theme.space.xs};

--- a/tests/acceptance/test_organization_integration_detail_view.py
+++ b/tests/acceptance/test_organization_integration_detail_view.py
@@ -74,5 +74,5 @@ class OrganizationIntegrationDetailView(AcceptanceTestCase):
         detail_view_page.uninstall()
 
         assert (
-            self.browser.element('[data-test-id="integration-status"]').text == "Pending Deletion"
+            self.browser.element('[data-test-id="integration-status"]').text == "pending deletion"
         )


### PR DESCRIPTION
Before it was really hard to scan the list of repos at a page like `/settings/integrations/github/?tab=configurations`

the "enabled" and "disabled" labels look basically the same. Now we've removed some bespoke elements, and make it easier to scan the list:

| List size | Before | After |
| --- | --- | --- |
| Short list | <img width="987" height="170" alt="SCR-20260327-okra" src="https://github.com/user-attachments/assets/33235a6d-0955-4943-8c99-c9be32b6d768" /> | <img width="977" height="160" alt="SCR-20260327-oknu" src="https://github.com/user-attachments/assets/189baed1-a7e4-44e6-8b3a-3c864168307a" />
| longer | <img width="1167" height="583" alt="SCR-20260327-olag" src="https://github.com/user-attachments/assets/b15ba1b8-5944-4429-9b45-c036d414ad2d" /> | <img width="1174" height="581" alt="SCR-20260327-okmi" src="https://github.com/user-attachments/assets/535b13d4-12e9-4b73-b187-1ef2edf53a7a" />

---

I also brought this over to the newer `/settings/repos/` page. Before we didn't show status at all, and the link to github could be broken because the integration on the remote side is disabled or deleted already.
Now we replace the `0/0 repos` count and link to github with the status label.

| Before | After |
| --- | --- |
| <img width="1148" height="207" alt="SCR-20260327-nuaj" src="https://github.com/user-attachments/assets/a716235d-a4ca-48fe-9edf-9d913dbcee0c" /> | <img width="993" height="186" alt="SCR-20260327-ojky" src="https://github.com/user-attachments/assets/5bc6ed37-2afa-47ed-83c0-42858a2ee372" />
