### PR TITLE
feat(perforce): Implement get_file() for source context

### DIFF
--- a/src/sentry/integrations/perforce/client.py
+++ b/src/sentry/integrations/perforce/client.py
@@ -652,10 +652,13 @@ class PerforceClient(RepositoryClient, CommitContextClient):
 
             # p4 print returns a list: first element is file metadata dict,
             # remaining elements are file content strings/bytes
-            if len(result) < 2:
+            if not result or not isinstance(result[0], dict):
                 raise ApiError(f"File not found: {depot_path}", code=404)
 
             content_parts = result[1:]
+            if not content_parts:
+                return ""
+
             return "".join(
                 part.decode("utf-8", errors="replace") if isinstance(part, bytes) else part
                 for part in content_parts

--- a/src/sentry/integrations/perforce/client.py
+++ b/src/sentry/integrations/perforce/client.py
@@ -608,10 +608,57 @@ class PerforceClient(RepositoryClient, CommitContextClient):
         self, repo: Repository, path: str, ref: str | None, codeowners: bool = False
     ) -> str:
         """
-        Get file contents from Perforce depot.
-        Required by abstract base class but not used (CODEOWNERS).
+        Get file contents from Perforce depot using ``p4 print``.
+
+        API docs: https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_print.html
+
+        Perforce supports two revision specifiers:
+        - ``@N`` — changelist number (global point-in-time snapshot)
+        - ``#N`` — file revision (per-file version counter)
+
+        Args:
+            repo: Repository object containing depot path config
+            path: File path relative to depot root
+            ref: Revision specifier. Accepts:
+                 - ``"#3"`` → file revision 3
+                 - ``"@42"`` → changelist 42
+                 - ``"42"`` → treated as changelist (``@42``)
+                 - ``None`` → head revision
+            codeowners: Not used for Perforce
+
+        Returns:
+            File contents as a UTF-8 string
+
+        Raises:
+            ApiError(404): File not found in depot
+            ApiError(500): Perforce connection or command error
         """
-        raise NotImplementedError("get_file is not supported for Perforce")
+        from sentry.shared_integrations.exceptions import ApiError
+
+        with self._connect() as p4:
+            depot_path = self.build_depot_path(repo, path)
+
+            if ref and "#" not in depot_path and "@" not in depot_path:
+                if ref.startswith("#") or ref.startswith("@"):
+                    depot_path = f"{depot_path}{ref}"
+                else:
+                    depot_path = f"{depot_path}@{ref}"
+
+            try:
+                result = p4.run("print", depot_path)
+            except P4Exception as e:
+                raise ApiError(str(e), code=404)
+
+            # p4 print returns a list: first element is file metadata dict,
+            # remaining elements are file content strings/bytes
+            if len(result) < 2:
+                raise ApiError(f"File not found: {depot_path}", code=404)
+
+            content_parts = result[1:]
+            return "".join(
+                part.decode("utf-8", errors="replace") if isinstance(part, bytes) else part
+                for part in content_parts
+            )
 
     def create_comment(self, repo: str, issue_id: str, data: dict[str, Any]) -> Any:
         """Create comment. Not applicable for Perforce."""

--- a/src/sentry/integrations/perforce/client.py
+++ b/src/sentry/integrations/perforce/client.py
@@ -633,8 +633,6 @@ class PerforceClient(RepositoryClient, CommitContextClient):
             ApiError(404): File not found in depot
             ApiError(500): Perforce connection or command error
         """
-        from sentry.shared_integrations.exceptions import ApiError
-
         with self._connect() as p4:
             depot_path = self.build_depot_path(repo, path)
 
@@ -647,7 +645,10 @@ class PerforceClient(RepositoryClient, CommitContextClient):
             try:
                 result = p4.run("print", depot_path)
             except P4Exception as e:
-                raise ApiError(str(e), code=404)
+                error_msg = str(e)
+                if "no such file" in error_msg.lower() or "not in client view" in error_msg.lower():
+                    raise ApiError(error_msg, code=404)
+                raise ApiError(error_msg, code=500)
 
             # p4 print returns a list: first element is file metadata dict,
             # remaining elements are file content strings/bytes


### PR DESCRIPTION
Implement get_file() in PerforceClient using p4 print to fetch file contents from the depot. This enables the SCM source context feature to display inline code in stack traces for Perforce-hosted projects.

Converts P4Exception to ApiError(404) so the source context caller handles errors consistently with other integrations.