### PR TITLE
feat(profiling): Use spans data source for profiles search bar in EAP mode

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
@@ -95,6 +95,7 @@ export function TransactionProfilesContent(props: TransactionProfilesContentProp
 
   const {data, status} = useAggregateFlamegraphQuery({
     query,
+    ...(isEAP ? {dataSource: 'spans' as const} : {}),
   });
 
   const [frameFilter, setFrameFilter] = useLocalStorageState<

--- a/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
@@ -5,6 +5,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
+import {useSpanSearchQueryBuilderProps} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {TransactionSearchQueryBuilder} from 'sentry/components/performance/transactionSearchQueryBuilder';
 import {DataCategory} from 'sentry/types/core';
 import {isAggregateField} from 'sentry/utils/discover/fields';
@@ -16,9 +17,32 @@ import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {useTransactionSummaryEAP} from 'sentry/views/performance/eap/useTransactionSummaryEAP';
 import {redirectToPerformanceHomepage} from 'sentry/views/performance/transactionSummary/pageLayout';
 
 import {TransactionProfilesContent} from './content';
+
+function EAPSearchBar({
+  projects,
+  initialQuery,
+  onSearch,
+}: {
+  initialQuery: string;
+  onSearch: (query: string) => void;
+  projects: number[];
+}) {
+  const {spanSearchQueryBuilderProps} = useSpanSearchQueryBuilderProps({
+    projects,
+    initialQuery,
+    onSearch,
+    searchSource: 'transaction_profiles',
+  });
+
+  return (
+    <TraceItemSearchQueryBuilder {...spanSearchQueryBuilderProps} disallowFreeText />
+  );
+}
 
 interface ProfilesProps {
   transaction: string;
@@ -28,6 +52,7 @@ function Profiles({transaction}: ProfilesProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const {projects} = useProjects();
+  const shouldUseEAP = useTransactionSummaryEAP();
 
   const project = projects.find(p => p.id === location.query.project);
 
@@ -38,7 +63,11 @@ function Profiles({transaction}: ProfilesProps) {
 
   const query = useMemo(() => {
     const conditions = new MutableSearch(rawQuery);
-    conditions.setFilterValues('event.type', ['transaction']);
+    if (shouldUseEAP) {
+      conditions.setFilterValues('is_transaction', ['true']);
+    } else {
+      conditions.setFilterValues('event.type', ['transaction']);
+    }
     conditions.setFilterValues('transaction', [transaction]);
 
     Object.keys(conditions.filters).forEach(field => {
@@ -48,7 +77,7 @@ function Profiles({transaction}: ProfilesProps) {
     });
 
     return conditions.formatString();
-  }, [transaction, rawQuery]);
+  }, [transaction, rawQuery, shouldUseEAP]);
 
   const handleSearch = useCallback(
     (searchQuery: string) => {
@@ -81,12 +110,20 @@ function Profiles({transaction}: ProfilesProps) {
           <EnvironmentPageFilter />
           <DatePageFilter {...datePageFilterProps} />
         </PageFilterBar>
-        <TransactionSearchQueryBuilder
-          projects={projectIds}
-          initialQuery={rawQuery}
-          onSearch={handleSearch}
-          searchSource="transaction_profiles"
-        />
+        {shouldUseEAP ? (
+          <EAPSearchBar
+            projects={projectIds ?? []}
+            initialQuery={rawQuery}
+            onSearch={handleSearch}
+          />
+        ) : (
+          <TransactionSearchQueryBuilder
+            projects={projectIds}
+            initialQuery={rawQuery}
+            onSearch={handleSearch}
+            searchSource="transaction_profiles"
+          />
+        )}
       </FilterActions>
       <TransactionProfilesContent query={query} transaction={transaction} />
     </StyledMain>


### PR DESCRIPTION
When useTransactionSummaryEAP is enabled, use TraceItemSearchQueryBuilder with the spans data source instead of TransactionSearchQueryBuilder. Also pass dataSource: 'spans' to useAggregateFlamegraphQuery and use is_transaction:true instead of event.type:transaction in the query filter.

Follows the same pattern established in [transactionEvents/content.tsx](https://github.com/getsentry/sentry/blob/master/static/app/views/performance/transactionSummary/transactionEvents/content.tsx).