### PR TITLE
fix(ownership): cast owner IDs to string in schema serialization

### DIFF
--- a/src/sentry/issues/ownership/grammar.py
+++ b/src/sentry/issues/ownership/grammar.py
@@ -542,7 +542,7 @@ def add_owner_ids_to_schema(rules: list[OwnershipRule], owners_id: dict[str, int
     for rule in rules:
         for rule_owner in rule["owners"]:
             if rule_owner["identifier"] in owners_id.keys():
-                rule_owner["id"] = owners_id[rule_owner["identifier"]]
+                rule_owner["id"] = str(owners_id[rule_owner["identifier"]])
 
 
 def create_schema_from_issue_owners(

--- a/tests/sentry/issues/endpoints/test_project_codeowners_index.py
+++ b/tests/sentry/issues/endpoints/test_project_codeowners_index.py
@@ -342,8 +342,8 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 {
                     "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
-                        {"id": self.user.id, "identifier": self.user.email, "type": "user"},
-                        {"id": self.team.id, "identifier": self.team.slug, "type": "team"},
+                        {"id": str(self.user.id), "identifier": self.user.email, "type": "user"},
+                        {"id": str(self.team.id), "identifier": self.team.slug, "type": "team"},
                     ],
                 }
             ],
@@ -431,8 +431,8 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 {
                     "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
-                        {"id": self.user.id, "identifier": self.user.email, "type": "user"},
-                        {"id": self.team.id, "identifier": self.team.slug, "type": "team"},
+                        {"id": str(self.user.id), "identifier": self.user.email, "type": "user"},
+                        {"id": str(self.team.id), "identifier": self.team.slug, "type": "team"},
                     ],
                 }
             ],
@@ -455,8 +455,8 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 {
                     "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
-                        {"id": self.user.id, "identifier": self.user.email, "type": "user"},
-                        {"id": self.team.id, "identifier": self.team.slug, "type": "team"},
+                        {"id": str(self.user.id), "identifier": self.user.email, "type": "user"},
+                        {"id": str(self.team.id), "identifier": self.team.slug, "type": "team"},
                     ],
                 }
             ],
@@ -588,8 +588,8 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             {
                 "matcher": {"type": "codeowners", "pattern": "docs/*"},
                 "owners": [
-                    {"type": "user", "identifier": "admin@sentry.io", "id": self.user.id},
-                    {"type": "team", "identifier": "tiger-team", "id": self.team.id},
+                    {"type": "user", "identifier": "admin@sentry.io", "id": str(self.user.id)},
+                    {"type": "team", "identifier": "tiger-team", "id": str(self.team.id)},
                 ],
             }
         ]

--- a/tests/sentry/issues/endpoints/test_project_ownership.py
+++ b/tests/sentry/issues/endpoints/test_project_ownership.py
@@ -200,8 +200,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             {
                 "matcher": {"type": "path", "pattern": "*.js"},
                 "owners": [
-                    {"type": "user", "identifier": "admin@localhost", "id": self.user.id},
-                    {"type": "team", "identifier": "tiger-team", "id": self.team.id},
+                    {"type": "user", "identifier": "admin@localhost", "id": str(self.user.id)},
+                    {"type": "team", "identifier": "tiger-team", "id": str(self.team.id)},
                 ],
             }
         ]

--- a/tests/sentry/tasks/test_code_owners.py
+++ b/tests/sentry/tasks/test_code_owners.py
@@ -69,7 +69,7 @@ class CodeOwnersTest(TestCase):
                 {
                     "matcher": {"type": "codeowners", "pattern": "docs/*"},
                     "owners": [
-                        {"type": "team", "identifier": "tiger-team", "id": self.team.id},
+                        {"type": "team", "identifier": "tiger-team", "id": str(self.team.id)},
                     ],
                 }
             ],
@@ -120,14 +120,14 @@ class CodeOwnersTest(TestCase):
                 {
                     "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
-                        {"identifier": "admin@localhost", "type": "user", "id": self.user.id},
-                        {"identifier": "tiger-team", "type": "team", "id": self.team.id},
+                        {"identifier": "admin@localhost", "type": "user", "id": str(self.user.id)},
+                        {"identifier": "tiger-team", "type": "team", "id": str(self.team.id)},
                     ],
                 },
                 {
                     "matcher": {"pattern": "*", "type": "codeowners"},
                     "owners": [
-                        {"identifier": "admin@localhost", "type": "user", "id": self.user.id}
+                        {"identifier": "admin@localhost", "type": "user", "id": str(self.user.id)}
                     ],
                 },
             ],


### PR DESCRIPTION
Owner IDs were stored as raw Python int in the ownership schema, but the frontend Actor type expects string. This caused a trim() crash when rendering team avatars for teams not in TeamStore. Casts to str() at the point of schema construction.

Fixes #110594