### PR TITLE
ref(avatarButton): Skip chonk override for fill images with very dark colors

### DIFF
--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -258,6 +258,12 @@ async function resolveImageAvatarColors(
 
   if (!sampled?.hex) return null;
 
+  // If the image fills all edges and the inferred color is very dark,
+  // fall back to the default button color rather than deriving an unusable chonk.
+  if (sampled.style === 'fill' && color(sampled.hex).lightness() < 15) {
+    return {chonk: undefined, style: sampled.style};
+  }
+
   const chonk = color(sampled.hex)
     .darken(theme === 'dark' ? 0.85 : 0.45)
     .hex();


### PR DESCRIPTION
Skip the chonk color override when an image touches all edges and its sampled average color is very dark (HSL lightness < 15%).

Previously, full-bleed images with predominantly dark content (e.g. a black logo on a black background) would produce a near-black chonk that is visually indistinguishable from the button shadow — resulting in no perceivable contrast effect. Returning `undefined` for `chonk` in this case lets the button fall back to its default styling.