### PR TITLE
fix(replays): update stats link to new path

### DIFF
--- a/static/app/components/replays/alerts/missingReplayAlert.tsx
+++ b/static/app/components/replays/alerts/missingReplayAlert.tsx
@@ -18,7 +18,9 @@ export function MissingReplayAlert({orgSlug}: Props) {
     tct(
       'The replay was rate-limited and could not be accepted. [link:View the stats page] for more information.',
       {
-        link: <Link to={`/organizations/${orgSlug}/stats/?dataCategory=replays`} />,
+        link: (
+          <Link to={`/organizations/${orgSlug}/settings/stats/?dataCategory=replays`} />
+        ),
       }
     ),
     t('The replay has been deleted by a member in your organization.'),

--- a/static/app/components/replays/alerts/missingReplayAlert.tsx
+++ b/static/app/components/replays/alerts/missingReplayAlert.tsx
@@ -7,6 +7,7 @@ import {ExternalLink, Link} from '@sentry/scraps/link';
 import {List} from 'sentry/components/list';
 import {ListItem} from 'sentry/components/list/listItem';
 import {t, tct} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 
 interface Props {
   orgSlug: string;
@@ -19,7 +20,7 @@ export function MissingReplayAlert({orgSlug}: Props) {
       'The replay was rate-limited and could not be accepted. [link:View the stats page] for more information.',
       {
         link: (
-          <Link to={`/organizations/${orgSlug}/settings/stats/?dataCategory=replays`} />
+          <Link to={normalizeUrl(`/settings/${orgSlug}/stats/?dataCategory=replays`)} />
         ),
       }
     ),


### PR DESCRIPTION
Update the stats page link in `MissingReplayAlert` from `/stats/` to `/settings/stats/`.

The `navigation-sidebar-v2` feature flag has been GA'd and removed, but this link was still pointing to the old `/stats/` route, causing unnecessary redirects logged as `Unexpected navigation redirect` in Sentry. The `last_known_route` was `/issues/:groupId/`, confirming users hit this from the issue detail page.