### PR TITLE
fix(preprod): Prefer display_name for snapshot sidebar labels

### DIFF
--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -129,8 +129,8 @@ export default function SnapshotsPage() {
         }
         for (const [groupKey, groupedPairs] of groups) {
           const label =
-            groupedPairs[0]!.head_image.display_name ??
             groupedPairs[0]!.head_image.group ??
+            groupedPairs[0]!.head_image.display_name ??
             groupedPairs[0]!.head_image.image_file_name;
           items.push({
             type,
@@ -158,7 +158,7 @@ export default function SnapshotsPage() {
         }
         for (const [groupKey, images] of groups) {
           const label =
-            images[0]!.display_name ?? images[0]!.group ?? images[0]!.image_file_name;
+            images[0]!.group ?? images[0]!.display_name ?? images[0]!.image_file_name;
           items.push({
             type,
             key: `${type}:${groupKey}`,
@@ -198,7 +198,7 @@ export default function SnapshotsPage() {
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([groupKey, images]) => {
         const label =
-          images[0]!.display_name ?? images[0]!.group ?? images[0]!.image_file_name;
+          images[0]!.group ?? images[0]!.display_name ?? images[0]!.image_file_name;
         return {
           type: 'solo' as const,
           key: `solo:${groupKey}`,

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -129,6 +129,7 @@ export default function SnapshotsPage() {
         }
         for (const [groupKey, groupedPairs] of groups) {
           const label =
+            groupedPairs[0]!.head_image.display_name ??
             groupedPairs[0]!.head_image.group ??
             groupedPairs[0]!.head_image.image_file_name;
           items.push({
@@ -156,7 +157,8 @@ export default function SnapshotsPage() {
           }
         }
         for (const [groupKey, images] of groups) {
-          const label = images[0]!.group ?? images[0]!.image_file_name;
+          const label =
+            images[0]!.display_name ?? images[0]!.group ?? images[0]!.image_file_name;
           items.push({
             type,
             key: `${type}:${groupKey}`,
@@ -195,7 +197,8 @@ export default function SnapshotsPage() {
     return [...groups.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([groupKey, images]) => {
-        const label = images[0]!.group ?? images[0]!.image_file_name;
+        const label =
+          images[0]!.display_name ?? images[0]!.group ?? images[0]!.image_file_name;
         return {
           type: 'solo' as const,
           key: `solo:${groupKey}`,


### PR DESCRIPTION
The snapshot sidebar label fallback chain was `group → image_file_name`, which meant `display_name` was never shown even when set. This updates all three label sites to prefer `display_name` first: `display_name → group → image_file_name`.

Grouping logic (`getImageGroup`) is unchanged — only the displayed label is affected.

Before:
<img width="1016" height="911" alt="Screenshot 2026-03-30 at 11 09 02" src="https://github.com/user-attachments/assets/35c5d152-6dab-4199-b455-46e8797ab3be" />

After:
<img width="1156" height="1144" alt="Screenshot 2026-03-30 at 10 59 49" src="https://github.com/user-attachments/assets/470f4d0e-0d3f-4d7f-aa82-2e73fa550310" />
