### PR TITLE
feat(errors): add sidebar item and routes for new Errors ui

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1742,6 +1742,19 @@ function buildRoutes(): RouteObject[] {
     children: discoverChildren,
   };
 
+  const errorsChildren: SentryRouteObject[] = [
+    {
+      index: true,
+      component: make(() => import('sentry/views/explore/errors/content')),
+    },
+  ];
+  const errorsRoutes: SentryRouteObject = {
+    path: '/errors/',
+    component: make(() => import('sentry/views/explore/errors')),
+    withOrgPath: true,
+    children: errorsChildren,
+  };
+
   // Redirects for old LLM monitoring routes
   const llmMonitoringRedirects: SentryRouteObject = {
     children: [
@@ -2325,6 +2338,11 @@ function buildRoutes(): RouteObject[] {
       ],
     },
     {
+      path: 'errors/',
+      component: make(() => import('sentry/views/explore/errors')),
+      children: errorsChildren,
+    },
+    {
       path: 'saved-queries/',
       component: make(() => import('sentry/views/explore/savedQueries')),
     },
@@ -2786,6 +2804,7 @@ function buildRoutes(): RouteObject[] {
       releasesRoutes,
       statsRoutes,
       discoverRoutes,
+      errorsRoutes,
       performanceRoutes,
       domainViewRoutes,
       tracesRoutes,

--- a/static/app/views/explore/errors/content.spec.tsx
+++ b/static/app/views/explore/errors/content.spec.tsx
@@ -1,0 +1,13 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ErrorsContent from './content';
+
+describe('ErrorsContent', () => {
+  it('renders the Errors page title', () => {
+    const organization = OrganizationFixture();
+    render(<ErrorsContent />, {organization});
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/errors/content.tsx
+++ b/static/app/views/explore/errors/content.tsx
@@ -1,0 +1,27 @@
+import * as Layout from 'sentry/components/layouts/thirds';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export default function ErrorsContent() {
+  const organization = useOrganization();
+
+  return (
+    <SentryDocumentTitle title={t('Errors')} orgSlug={organization?.slug}>
+      <Layout.Page>
+        <ErrorsHeader />
+      </Layout.Page>
+    </SentryDocumentTitle>
+  );
+}
+
+function ErrorsHeader() {
+  return (
+    <Layout.Header unified>
+      <Layout.HeaderContent unified>
+        <Layout.Title>{t('Errors')}</Layout.Title>
+      </Layout.HeaderContent>
+      <Layout.HeaderActions />
+    </Layout.Header>
+  );
+}

--- a/static/app/views/explore/errors/index.spec.tsx
+++ b/static/app/views/explore/errors/index.spec.tsx
@@ -1,0 +1,21 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ErrorsPage from './index';
+
+describe('ErrorsPage', () => {
+  it('renders the outlet when the feature is enabled', () => {
+    const organization = OrganizationFixture({features: ['explore-errors']});
+    render(<ErrorsPage />, {organization});
+    expect(
+      screen.queryByText("You don't have access to this feature")
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders NoAccess when the feature is disabled', () => {
+    const organization = OrganizationFixture({features: []});
+    render(<ErrorsPage />, {organization});
+    expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/errors/index.tsx
+++ b/static/app/views/explore/errors/index.tsx
@@ -1,0 +1,22 @@
+import {Outlet} from 'react-router-dom';
+
+import Feature from 'sentry/components/acl/feature';
+import {NoAccess} from 'sentry/components/noAccess';
+import {NoProjectMessage} from 'sentry/components/noProjectMessage';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export default function ErrorsPage() {
+  const organization = useOrganization();
+
+  return (
+    <Feature
+      features={['explore-errors']}
+      organization={organization}
+      renderDisabled={NoAccess}
+    >
+      <NoProjectMessage organization={organization}>
+        <Outlet />
+      </NoProjectMessage>
+    </Feature>
+  );
+}

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -105,6 +105,17 @@ export function ExploreSecondaryNavigation() {
                 </SecondaryNavigation.ListItem>
               </Feature>
             )}
+            <Feature features="organizations:explore-errors">
+              <SecondaryNavigation.ListItem>
+                <SecondaryNavigation.Link
+                  to={`${baseUrl}/errors/`}
+                  activeTo={`${baseUrl}/errors/`}
+                  analyticsItemName="explore_errors"
+                >
+                  {t('Errors')}
+                </SecondaryNavigation.Link>
+              </SecondaryNavigation.ListItem>
+            </Feature>
             <Feature
               features="discover-basic"
               hookName="feature-disabled:discover2-sidebar-item"


### PR DESCRIPTION
This PR just adds a feature flag gated nav item for Errors and registers the new explore routes!

there's nothing much to see here but if you're curious:

<img width="834" height="611" alt="image" src="https://github.com/user-attachments/assets/b217b5e8-6d72-4e5d-8f0a-fb3da8bcad06" />
