### PR TITLE
chore(dashboards): Add consistent settings files to all prebuilt dashboard configs

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs.tsx
@@ -10,7 +10,7 @@ import {MCP_TOOLS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltC
 import {BACKEND_OVERVIEW_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview';
 import {CACHES_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/caches/caches';
 import {FRONTEND_ASSETS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssets';
-import {FRONTEND_ASSETS_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssetsSummary';
+import {FRONTEND_ASSETS_DETAILS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssetsDetails';
 import {FRONTEND_OVERVIEW_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview';
 import {HTTP_DOMAIN_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/http/domainSummary';
 import {HTTP_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/http/http';
@@ -22,11 +22,11 @@ import {MOBILE_VITALS_SCREEN_LOADS_PREBUILT_CONFIG} from 'sentry/views/dashboard
 import {MOBILE_VITALS_SCREEN_RENDERING_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenRendering';
 import {NEXTJS_FRONTEND_OVERVIEW_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview';
 import {QUERIES_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/queries';
-import {QUERIES_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/querySummary';
+import {QUERIES_DETAILS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/queryDetails';
+import {QUEUE_DETAILS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/queueDetails';
 import {QUEUES_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/queues';
-import {QUEUE_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/queueSummary';
 import {SESSION_HEALTH_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/sessionHealth';
-import {WEB_VITALS_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/pageSummary';
+import {WEB_VITALS_DETAILS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/pageDetails';
 import {WEB_VITALS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals';
 import type {ModulesWithOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 
@@ -97,11 +97,11 @@ export type PrebuiltDashboard = Omit<DashboardDetails, 'id'> & {
 export const PREBUILT_DASHBOARDS: Record<PrebuiltDashboardId, PrebuiltDashboard> = {
   [PrebuiltDashboardId.FRONTEND_SESSION_HEALTH]: SESSION_HEALTH_PREBUILT_CONFIG,
   [PrebuiltDashboardId.BACKEND_QUERIES]: QUERIES_PREBUILT_CONFIG,
-  [PrebuiltDashboardId.BACKEND_QUERIES_SUMMARY]: QUERIES_SUMMARY_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.BACKEND_QUERIES_SUMMARY]: QUERIES_DETAILS_PREBUILT_CONFIG,
   [PrebuiltDashboardId.HTTP]: HTTP_PREBUILT_CONFIG,
   [PrebuiltDashboardId.HTTP_DOMAIN_SUMMARY]: HTTP_DOMAIN_SUMMARY_PREBUILT_CONFIG,
   [PrebuiltDashboardId.WEB_VITALS]: WEB_VITALS_PREBUILT_CONFIG,
-  [PrebuiltDashboardId.WEB_VITALS_SUMMARY]: WEB_VITALS_SUMMARY_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.WEB_VITALS_SUMMARY]: WEB_VITALS_DETAILS_PREBUILT_CONFIG,
   [PrebuiltDashboardId.MOBILE_VITALS]: MOBILE_VITALS_PREBUILT_CONFIG,
   [PrebuiltDashboardId.BACKEND_OVERVIEW]: BACKEND_OVERVIEW_PREBUILT_CONFIG,
   [PrebuiltDashboardId.MOBILE_VITALS_APP_STARTS]:
@@ -123,8 +123,8 @@ export const PREBUILT_DASHBOARDS: Record<PrebuiltDashboardId, PrebuiltDashboard>
   [PrebuiltDashboardId.MCP_OVERVIEW]: MCP_OVERVIEW_PREBUILT_CONFIG,
   [PrebuiltDashboardId.LARAVEL_OVERVIEW]: LARAVEL_OVERVIEW_PREBUILT_CONFIG,
   [PrebuiltDashboardId.FRONTEND_ASSETS]: FRONTEND_ASSETS_PREBUILT_CONFIG,
-  [PrebuiltDashboardId.FRONTEND_ASSETS_SUMMARY]: FRONTEND_ASSETS_SUMMARY_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.FRONTEND_ASSETS_SUMMARY]: FRONTEND_ASSETS_DETAILS_PREBUILT_CONFIG,
   [PrebuiltDashboardId.BACKEND_QUEUES]: QUEUES_PREBUILT_CONFIG,
-  [PrebuiltDashboardId.BACKEND_QUEUE_SUMMARY]: QUEUE_SUMMARY_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.BACKEND_QUEUE_SUMMARY]: QUEUE_DETAILS_PREBUILT_CONFIG,
   [PrebuiltDashboardId.BACKEND_CACHES]: CACHES_PREBUILT_CONFIG,
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {AI_AGENTS_MODELS_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -157,7 +158,7 @@ const MODELS_TABLE = {
 export const AI_AGENTS_MODELS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'AI Agents Model Details',
+  title: AI_AGENTS_MODELS_DASHBOARD_TITLE,
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -3,6 +3,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, MAX_TABLE_LIMIT, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {AI_AGENTS_OVERVIEW_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/settings';
 import {
   WIDGET_COLUMN_LABELS,
   TABLE_MIN_HEIGHT,
@@ -225,7 +226,7 @@ const AGENTS_TRACES_TABLE = {
 export const AI_AGENTS_OVERVIEW_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'AI Agents Overview',
+  title: AI_AGENTS_OVERVIEW_DASHBOARD_TITLE,
   filters: {
     globalFilter: DEFAULT_GLOBAL_FILTERS,
   },

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsTools.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsTools.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {AI_AGENTS_TOOLS_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -101,7 +102,7 @@ const TOOLS_TABLE = {
 export const AI_AGENTS_TOOLS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'AI Agents Tool Details',
+  title: AI_AGENTS_TOOLS_DASHBOARD_TITLE,
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpOverview.ts
@@ -1,6 +1,7 @@
 import {t} from 'sentry/locale';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {MCP_OVERVIEW_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
@@ -212,7 +213,7 @@ const OVERVIEW_TABLE = {
 export const MCP_OVERVIEW_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'MCP Overview',
+  title: MCP_OVERVIEW_DASHBOARD_TITLE,
   filters: {},
   widgets: [...FIRST_ROW_WIDGETS, ...SECOND_ROW_WIDGETS, OVERVIEW_TABLE],
   onboarding: {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpPrompts.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpPrompts.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {MCP_PROMPTS_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
@@ -124,7 +125,7 @@ const PROMPTS_TABLE = {
 export const MCP_PROMPTS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'MCP Prompt Details',
+  title: MCP_PROMPTS_DASHBOARD_TITLE,
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpResources.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpResources.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {MCP_RESOURCES_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
@@ -124,7 +125,7 @@ const RESOURCES_TABLE = {
 export const MCP_RESOURCES_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'MCP Resource Details',
+  title: MCP_RESOURCES_DASHBOARD_TITLE,
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpTools.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/mcpTools.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {MCP_TOOLS_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
@@ -124,7 +125,7 @@ const TOOLS_TABLE = {
 export const MCP_TOOLS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'MCP Tool Details',
+  title: MCP_TOOLS_DASHBOARD_TITLE,
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/settings.ts
@@ -1,0 +1,9 @@
+import {t} from 'sentry/locale';
+
+export const AI_AGENTS_OVERVIEW_DASHBOARD_TITLE = t('AI Agents Overview');
+export const AI_AGENTS_MODELS_DASHBOARD_TITLE = t('AI Agents Model Details');
+export const AI_AGENTS_TOOLS_DASHBOARD_TITLE = t('AI Agents Tool Details');
+export const MCP_OVERVIEW_DASHBOARD_TITLE = t('MCP Overview');
+export const MCP_TOOLS_DASHBOARD_TITLE = t('MCP Tool Details');
+export const MCP_PROMPTS_DASHBOARD_TITLE = t('MCP Prompt Details');
+export const MCP_RESOURCES_DASHBOARD_TITLE = t('MCP Resource Details');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssetsDetails.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssetsDetails.ts
@@ -2,7 +2,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
-import {SUMMARY_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendAssets/settings';
+import {DETAILS_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendAssets/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
@@ -271,7 +271,7 @@ const ASSETS_TABLE_WIDGET: Widget = {
   },
 };
 
-export const FRONTEND_ASSETS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
+export const FRONTEND_ASSETS_DETAILS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
   filters: {
@@ -296,7 +296,7 @@ export const FRONTEND_ASSETS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
       },
     ],
   },
-  title: SUMMARY_DASHBOARD_TITLE,
+  title: DETAILS_DASHBOARD_TITLE,
   widgets: [
     ASSET_DESCRIPTION_WIDGET,
     ...SECOND_ROW_WIDGETS,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/settings.ts
@@ -1,4 +1,4 @@
 import {t} from 'sentry/locale';
 
 export const DASHBOARD_TITLE = t('Frontend Assets');
-export const SUMMARY_DASHBOARD_TITLE = t('Frontend Assets Summary');
+export const DETAILS_DASHBOARD_TITLE = t('Frontend Assets Summary');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/appStarts.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/appStarts.ts
@@ -3,6 +3,7 @@ import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {APP_STARTS_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
@@ -315,7 +316,7 @@ const SECOND_ROW_WIDGETS: Widget[] = [
 
 export const MOBILE_VITALS_APP_STARTS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
-  title: t('Mobile Vitals App Starts'),
+  title: APP_STARTS_DASHBOARD_TITLE,
   projects: [],
   widgets: [
     ...HEADER_ROW_WIDGETS,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
@@ -3,6 +3,7 @@ import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/settings';
 import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
@@ -426,7 +427,7 @@ const SECOND_ROW_WIDGETS: Widget[] = [
 
 export const MOBILE_VITALS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
-  title: t('Mobile Vitals'),
+  title: DASHBOARD_TITLE,
   projects: [],
   widgets: [
     ...FIRST_ROW_WIDGETS,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads.ts
@@ -3,6 +3,7 @@ import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {SCREEN_LOADS_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/settings';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 const TRANSACTION_CONDITION = `is_transaction:true ${SpanFields.TRANSACTION_OP}:[ui.load,navigation]`;
@@ -298,7 +299,7 @@ const THIRD_ROW_WIDGETS: Widget[] = [TTID_BAR_CHART_WIDGET, TTFD_BAR_CHART_WIDGE
 
 export const MOBILE_VITALS_SCREEN_LOADS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
-  title: t('Mobile Vitals Screen Loads'),
+  title: SCREEN_LOADS_DASHBOARD_TITLE,
   projects: [],
   widgets: [
     ...HEADER_ROW_WIDGETS,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenRendering.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenRendering.ts
@@ -3,6 +3,7 @@ import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {SCREEN_RENDERING_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/settings';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 const SPAN_OPERATIONS_CONDITION = `${SpanFields.SPAN_OP}:[app.start.cold,app.start.warm,contentprovider.load,application.load,activity.load,ui.load,process.load]`;
@@ -52,7 +53,7 @@ const SPAN_OPERATIONS_TABLE: Widget = {
 
 export const MOBILE_VITALS_SCREEN_RENDERING_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
-  title: t('Mobile Vitals Screen Rendering'),
+  title: SCREEN_RENDERING_DASHBOARD_TITLE,
   projects: [],
   widgets: [SPAN_OPERATIONS_TABLE],
   filters: {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/settings.ts
@@ -1,0 +1,6 @@
+import {t} from 'sentry/locale';
+
+export const DASHBOARD_TITLE = t('Mobile Vitals');
+export const APP_STARTS_DASHBOARD_TITLE = t('Mobile Vitals App Starts');
+export const SCREEN_LOADS_DASHBOARD_TITLE = t('Mobile Vitals Screen Loads');
+export const SCREEN_RENDERING_DASHBOARD_TITLE = t('Mobile Vitals Screen Rendering');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/constants.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/constants.ts
@@ -1,4 +1,0 @@
-import {t} from 'sentry/locale';
-
-export const QUERIES_PER_MINUTE_TEXT = t('Queries Per Minute');
-export const AVERAGE_DURATION_TEXT = t('Average Duration');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/queries.ts
@@ -5,16 +5,17 @@ import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {
   AVERAGE_DURATION_TEXT,
+  BASE_FILTER_STRING,
+  DASHBOARD_TITLE,
   QUERIES_PER_MINUTE_TEXT,
-} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/constants';
-import {BASE_FILTER_STRING} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/settings';
+} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/settings';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 export const QUERIES_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'Queries',
+  title: DASHBOARD_TITLE,
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/queryDetails.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/queryDetails.ts
@@ -6,15 +6,15 @@ import {
   AVERAGE_DURATION_TEXT,
   BASE_FILTER_STRING,
   QUERIES_PER_MINUTE_TEXT,
-  SUMMARY_DASHBOARD_TITLE,
+  DETAILS_DASHBOARD_TITLE,
 } from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
-export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
+export const QUERIES_DETAILS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: SUMMARY_DASHBOARD_TITLE,
+  title: DETAILS_DASHBOARD_TITLE,
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/querySummary.ts
@@ -4,16 +4,17 @@ import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {
   AVERAGE_DURATION_TEXT,
+  BASE_FILTER_STRING,
   QUERIES_PER_MINUTE_TEXT,
-} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/constants';
-import {BASE_FILTER_STRING} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/settings';
+  SUMMARY_DASHBOARD_TITLE,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/settings';
 import {WIDGET_COLUMN_LABELS} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 export const QUERIES_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'Query Details',
+  title: SUMMARY_DASHBOARD_TITLE,
   filters: {
     globalFilter: [
       {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/settings.ts
@@ -1,5 +1,12 @@
+import {t} from 'sentry/locale';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
+
+export const DASHBOARD_TITLE = t('Queries');
+export const SUMMARY_DASHBOARD_TITLE = t('Query Details');
+
+export const QUERIES_PER_MINUTE_TEXT = t('Queries Per Minute');
+export const AVERAGE_DURATION_TEXT = t('Average Duration');
 
 const BASE_FILTERS = {
   [SpanFields.SPAN_CATEGORY]: ModuleName.DB,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queries/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queries/settings.ts
@@ -3,7 +3,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
 export const DASHBOARD_TITLE = t('Queries');
-export const SUMMARY_DASHBOARD_TITLE = t('Query Details');
+export const DETAILS_DASHBOARD_TITLE = t('Query Details');
 
 export const QUERIES_PER_MINUTE_TEXT = t('Queries Per Minute');
 export const AVERAGE_DURATION_TEXT = t('Average Duration');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queues/queueDetails.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queues/queueDetails.ts
@@ -2,7 +2,7 @@ import {t} from 'sentry/locale';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {QUEUE_CHARTS} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/queueCharts';
-import {SUMMARY_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/settings';
+import {DETAILS_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 
@@ -208,10 +208,10 @@ const CONSUMER_TABLE: Widget = {
   },
 };
 
-export const QUEUE_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
+export const QUEUE_DETAILS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: SUMMARY_DASHBOARD_TITLE,
+  title: DETAILS_DASHBOARD_TITLE,
   filters: {},
   widgets: [...FIRST_ROW_WIDGTS, ...SECOND_ROW_WIDGETS, CONSUMER_TABLE, PRODUCER_TABLE],
   onboarding: {type: 'module', moduleName: ModuleName.QUEUE},

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queues/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queues/settings.ts
@@ -1,4 +1,4 @@
 import {t} from 'sentry/locale';
 
 export const DASHBOARD_TITLE = t('Queues');
-export const SUMMARY_DASHBOARD_TITLE = t('Queue Summary');
+export const DETAILS_DASHBOARD_TITLE = t('Queue Summary');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/pageDetails.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/pageDetails.ts
@@ -1,15 +1,15 @@
 import {t} from 'sentry/locale';
 import {DisplayType, SlideoutId, WidgetType} from 'sentry/views/dashboards/types';
 import {type PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
-import {SUMMARY_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/settings';
+import {DETAILS_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/settings';
 import {ISSUE_TYPES} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
-export const WEB_VITALS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
+export const WEB_VITALS_DETAILS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: SUMMARY_DASHBOARD_TITLE,
+  title: DETAILS_DASHBOARD_TITLE,
   filters: {
     globalFilter: [],
   },

--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/pageSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/pageSummary.ts
@@ -1,6 +1,7 @@
 import {t} from 'sentry/locale';
 import {DisplayType, SlideoutId, WidgetType} from 'sentry/views/dashboards/types';
 import {type PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {SUMMARY_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/settings';
 import {ISSUE_TYPES} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -8,7 +9,7 @@ import {ModuleName} from 'sentry/views/insights/types';
 export const WEB_VITALS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'Web Vitals Page Summary',
+  title: SUMMARY_DASHBOARD_TITLE,
   filters: {
     globalFilter: [],
   },

--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/settings.ts
@@ -1,0 +1,4 @@
+import {t} from 'sentry/locale';
+
+export const DASHBOARD_TITLE = t('Web Vitals');
+export const SUMMARY_DASHBOARD_TITLE = t('Web Vitals Page Summary');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/settings.ts
@@ -1,4 +1,4 @@
 import {t} from 'sentry/locale';
 
 export const DASHBOARD_TITLE = t('Web Vitals');
-export const SUMMARY_DASHBOARD_TITLE = t('Web Vitals Page Summary');
+export const DETAILS_DASHBOARD_TITLE = t('Web Vitals Page Summary');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, SlideoutId, WidgetType} from 'sentry/views/dashboards/types';
 import {type PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/settings';
 import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
@@ -20,7 +21,7 @@ export const ISSUE_TYPES = [
 export const WEB_VITALS_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
-  title: 'Web Vitals',
+  title: DASHBOARD_TITLE,
   filters: {
     globalFilter: [
       {


### PR DESCRIPTION
## Summary
- Add `settings.ts` files to `ai/`, `mobileVitals/`, and `webVitals/` prebuilt dashboard config folders that were missing them
- Consolidate `queries/constants.ts` into `queries/settings.ts` so titles and constants live in one place
- All dashboard titles are now centralized in settings files with proper `t()` i18n wrapping (previously AI and webVitals titles were plain strings)
- Updated 15 config files to import their dashboard titles from the new settings files

## Test plan
- [ ] Verify prebuilt dashboards still render correctly with their expected titles
- [ ] Confirm no regressions in dashboard creation flow