### PR TITLE
feat(dashboards): Add tableWidths to backend overview transactions table

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -200,28 +200,31 @@ export const BACKEND_OVERVIEW_SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   {h: 3, minH: 3}
 );
 
+const TABLE_FIELDS = [
+  SpanFields.IS_STARRED_TRANSACTION,
+  SpanFields.REQUEST_METHOD,
+  SpanFields.TRANSACTION,
+  SpanFields.SPAN_OP,
+  SpanFields.PROJECT,
+  'epm()',
+  `p50(${SpanFields.SPAN_DURATION})`,
+  `p95(${SpanFields.SPAN_DURATION})`,
+  `equation|failure_count() / count(${SpanFields.SPAN_DURATION})`,
+  `count_unique(${SpanFields.USER})`,
+  `sum(${SpanFields.SPAN_DURATION})`,
+];
+
 const TRANSACTIONS_TABLE: Widget = {
   id: 'backend-overview-transactions-table',
   title: t('Transactions'),
   description: '',
   displayType: DisplayType.TABLE,
   interval: '5m',
+  tableWidths: TABLE_FIELDS.map(() => -1),
   queries: [
     {
       name: '',
-      fields: [
-        SpanFields.IS_STARRED_TRANSACTION,
-        SpanFields.REQUEST_METHOD,
-        SpanFields.TRANSACTION,
-        SpanFields.SPAN_OP,
-        SpanFields.PROJECT,
-        'epm()',
-        `p50(${SpanFields.SPAN_DURATION})`,
-        `p95(${SpanFields.SPAN_DURATION})`,
-        `equation|failure_count() / count(${SpanFields.SPAN_DURATION})`,
-        `count_unique(${SpanFields.USER})`,
-        `sum(${SpanFields.SPAN_DURATION})`,
-      ],
+      fields: TABLE_FIELDS,
       aggregates: [
         'epm()',
         `p50(${SpanFields.SPAN_DURATION})`,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -1,3 +1,4 @@
+import {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -220,7 +221,7 @@ const TRANSACTIONS_TABLE: Widget = {
   description: '',
   displayType: DisplayType.TABLE,
   interval: '5m',
-  tableWidths: TABLE_FIELDS.map(() => -1),
+  tableWidths: TABLE_FIELDS.map(() => COL_WIDTH_UNDEFINED),
   queries: [
     {
       name: '',


### PR DESCRIPTION
Add `tableWidths` to the backend overview transactions table widget to prevent column overflow.

Before
<img width="1424" height="288" alt="image" src="https://github.com/user-attachments/assets/1bc1ae9c-a8d0-46d8-8231-358565f438ae" />

After
<img width="1407" height="263" alt="image" src="https://github.com/user-attachments/assets/a2cf8284-f988-4e89-b462-3a079cc9904b" />


Refs BROWSE-475