### PR TITLE
fix(tracemetrics): Allow delete for big number when more than 1 field

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -1023,12 +1023,16 @@ export function Visualize({error, setError}: VisualizeProps) {
                                 />
                               </Tooltip>
                             )}
-                          {fields.length > 1 && (
+                          {(!isBigNumberWidget ||
+                            datasetConfig.enableEquations ||
+                            (isBigNumberWidget && fields.length > 1)) && (
                             <Button
                               priority="transparent"
                               icon={<IconDelete />}
                               size="zero"
-                              disabled={!canDelete || isOnlyFieldOrAggregate}
+                              disabled={
+                                fields.length <= 1 || !canDelete || isOnlyFieldOrAggregate
+                              }
                               onClick={() => {
                                 dispatch({
                                   type: BuilderStateAction.DELETE_AGGREGATE,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -1023,14 +1023,12 @@ export function Visualize({error, setError}: VisualizeProps) {
                                 />
                               </Tooltip>
                             )}
-                          {(!isBigNumberWidget || datasetConfig.enableEquations) && (
+                          {fields.length > 1 && (
                             <Button
                               priority="transparent"
                               icon={<IconDelete />}
                               size="zero"
-                              disabled={
-                                fields.length <= 1 || !canDelete || isOnlyFieldOrAggregate
-                              }
+                              disabled={!canDelete || isOnlyFieldOrAggregate}
                               onClick={() => {
                                 dispatch({
                                   type: BuilderStateAction.DELETE_AGGREGATE,


### PR DESCRIPTION
There's a state for metric widgets and release health widgets where if you have multiple y-axes selected, then switch to a big number widget, we don't trim off the y-axes that are selected, instead we just render them with a radio button. This is meant for datasets that support equations, but at the moment a user can get "stuck" in the big number widget flow since this delete button is hidden. I figured we should just show it if there are more than 1 fields, even if equations aren't supported.

One day we should fix how big numbers are stored if there are multiply y-axes, but this just patches the behaviour so we can release multi-metric selection because I imagine it'll raise feedback.