### PR TITLE
chore(workflows): Stop scheduling sentry.workflow_engine.tasks.cleanup.prune_old_fire_history

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1007,10 +1007,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "workflow_engine:sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         "schedule": timedelta(seconds=15),
     },
-    "prune-old-fire-history": {
-        "task": "workflow_engine:sentry.workflow_engine.tasks.cleanup.prune_old_fire_history",
-        "schedule": timedelta(minutes=2),
-    },
     "resolve-stale-sourcemap-detectors": {
         "task": "workflow_engine:sentry.processing_errors.tasks.resolve_stale_sourcemap_detectors",
         "schedule": crontab("*/5", "*", "*", "*", "*"),


### PR DESCRIPTION
It has done the backlog clearing that was necessary; now we can lean on incinerator.
