### PR TITLE
feat(assisted-query): Add AI search bar and built-in fields for metrics

### DIFF
--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -48,12 +48,28 @@ _LOG_BUILT_IN_NUMBER_FIELDS = [
 ]
 
 
+_METRIC_BUILT_IN_STRING_FIELDS = [
+    "metric.name",
+    "metric.type",
+    "metric.unit",
+    "timestamp",
+    "project",
+    "environment",
+    "release",
+    "trace",
+]
+
+_METRIC_BUILT_IN_NUMBER_FIELDS = [
+    "value",
+]
+
+
 def _get_built_in_fields(item_type: str = "spans") -> list[dict[str, Any]]:
     """
     Get built-in fields for the specified item type.
 
     Args:
-        item_type: Type of trace item ("spans" or "logs")
+        item_type: Type of trace item ("spans", "logs", or "tracemetrics")
 
     Returns:
         List of built-in field definitions with key and type.
@@ -61,6 +77,9 @@ def _get_built_in_fields(item_type: str = "spans") -> list[dict[str, Any]]:
     if item_type == "logs":
         string_fields = _LOG_BUILT_IN_STRING_FIELDS
         number_fields = _LOG_BUILT_IN_NUMBER_FIELDS
+    elif item_type == "tracemetrics":
+        string_fields = _METRIC_BUILT_IN_STRING_FIELDS
+        number_fields = _METRIC_BUILT_IN_NUMBER_FIELDS
     else:
         string_fields = _SPAN_BUILT_IN_STRING_FIELDS
         number_fields = _SPAN_BUILT_IN_NUMBER_FIELDS

--- a/static/app/utils/analytics/metricsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/metricsAnalyticsEvent.tsx
@@ -2,6 +2,21 @@ import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/project';
 
 export type MetricsAnalyticsEventParameters = {
+  'metrics.ai_query_applied': {
+    group_by_count: number;
+    query: string;
+    visualize_count: number;
+  };
+  'metrics.ai_query_interface': {
+    action: 'opened' | 'closed' | 'consent_accepted';
+  };
+  'metrics.ai_query_rejected': {
+    natural_language_query: string;
+    num_queries_returned: number;
+  };
+  'metrics.ai_query_submitted': {
+    natural_language_query: string;
+  };
   'metrics.explorer.metadata': {
     datetime_selection: string;
     environment_count: number;
@@ -72,6 +87,10 @@ export type MetricsAnalyticsEventParameters = {
 type MetricsAnalyticsEventKey = keyof MetricsAnalyticsEventParameters;
 
 export const metricsAnalyticsEventMap: Record<MetricsAnalyticsEventKey, string | null> = {
+  'metrics.ai_query_applied': 'Metrics AI Query Applied',
+  'metrics.ai_query_interface': 'Metrics AI Query Interface',
+  'metrics.ai_query_rejected': 'Metrics AI Query Rejected',
+  'metrics.ai_query_submitted': 'Metrics AI Query Submitted',
   'metrics.explorer.metadata': 'Metric Explorer Pageload Metadata',
   'metrics.explorer.panel.metadata': 'Metric Explorer Panel Metadata',
   'metrics.issue_details.drawer_opened': 'Metrics Issue Details Drawer Opened',

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -1,8 +1,12 @@
 import {useMemo} from 'react';
 
-import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {
+  SearchQueryBuilderProvider,
+  useSearchQueryBuilder,
+} from 'sentry/components/searchQueryBuilder/context';
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
@@ -16,6 +20,7 @@ import {
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {MetricsTabSeerComboBox} from 'sentry/views/explore/metrics/metricsTabSeerComboBox';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsQuery,
@@ -30,9 +35,28 @@ interface FilterProps {
   traceMetric: TraceMetric;
 }
 
+interface MetricsSearchBarProps {
+  tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps;
+}
+
+function MetricsSearchBar({tracesItemSearchQueryBuilderProps}: MetricsSearchBarProps) {
+  const {displayAskSeer} = useSearchQueryBuilder();
+
+  if (displayAskSeer) {
+    return <MetricsTabSeerComboBox />;
+  }
+
+  return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;
+}
+
 export function Filter({traceMetric}: FilterProps) {
   const query = useQueryParamsQuery();
   const setQuery = useSetQueryParamsQuery();
+  const organization = useOrganization();
+
+  const hasTranslateEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
 
@@ -142,9 +166,13 @@ export function Filter({traceMetric}: FilterProps) {
       // Use the metric name as a key to force remount when it changes
       // This prevents race conditions when navigating between different metrics
       key={traceMetric.name}
+      enableAISearch={hasTranslateEndpoint}
+      aiSearchBadgeType="alpha"
       {...searchQueryBuilderProviderProps}
     >
-      <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
+      <MetricsSearchBar
+        tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}
+      />
     </SearchQueryBuilderProvider>
   );
 }

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -1,0 +1,368 @@
+import {useCallback, useMemo} from 'react';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
+import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+import {Token} from 'sentry/components/searchSyntax/parser';
+import {stringifyToken} from 'sentry/components/searchSyntax/utils';
+import {ConfigStore} from 'sentry/stores/configStore';
+import type {DateString} from 'sentry/types/core';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {getFieldDefinition} from 'sentry/utils/fields';
+import {fetchMutation, mutationOptions} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import type {WritableAggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {
+  useQueryParams,
+  useSetQueryParams,
+} from 'sentry/views/explore/queryParams/context';
+import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
+import type {ChartType} from 'sentry/views/insights/common/components/chart';
+
+interface Visualization {
+  chartType: ChartType;
+  yAxes: string[];
+}
+
+interface AskSeerSearchQuery {
+  end: string | null;
+  groupBys: string[];
+  mode: string;
+  query: string;
+  sort: string;
+  start: string | null;
+  statsPeriod: string;
+  visualizations: Visualization[];
+}
+
+interface MetricsAskSeerTranslateResponse {
+  responses: Array<{
+    end: string | null;
+    group_by: string[];
+    mode: string;
+    query: string;
+    sort: string;
+    start: string | null;
+    stats_period: string;
+    visualization: Array<{
+      chart_type: number;
+      y_axes: string[];
+    }>;
+  }>;
+  unsupported_reason: string | null;
+}
+
+export function MetricsTabSeerComboBox() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const {projects} = useProjects();
+  const pageFilters = usePageFilters();
+  const organization = useOrganization();
+  const queryParams = useQueryParams();
+  const setQueryParams = useSetQueryParams();
+  const {
+    currentInputValueRef,
+    query,
+    committedQuery,
+    askSeerSuggestedQueryRef,
+    enableAISearch,
+  } = useSearchQueryBuilder();
+
+  let initialSeerQuery = '';
+  const queryDetails = useMemo(() => {
+    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
+    const parsedQuery = parseQueryBuilderValue(queryToUse, getFieldDefinition);
+    return {parsedQuery, queryToUse};
+  }, [committedQuery, query]);
+
+  const inputValue = currentInputValueRef.current.trim();
+
+  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
+  const filteredCommittedQuery = queryDetails?.parsedQuery
+    ?.filter(
+      token =>
+        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
+    )
+    ?.map(token => stringifyToken(token))
+    ?.join(' ')
+    ?.trim();
+
+  // Use filteredCommittedQuery if it exists and has content, otherwise fall back to queryToUse
+  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
+    initialSeerQuery = filteredCommittedQuery;
+  } else if (queryDetails?.queryToUse) {
+    initialSeerQuery = queryDetails.queryToUse;
+  }
+
+  if (inputValue) {
+    initialSeerQuery =
+      initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
+  }
+
+  const metricsTabAskSeerMutationOptions = mutationOptions({
+    mutationFn: async (queryToSubmit: string) => {
+      const selectedProjects =
+        pageFilters.selection.projects?.length > 0 &&
+        pageFilters.selection.projects?.[0] !== -1
+          ? pageFilters.selection.projects
+          : projects.filter(p => p.isMember).map(p => p.id);
+
+      const user = ConfigStore.get('user');
+      const data = await fetchMutation<MetricsAskSeerTranslateResponse>({
+        url: `/organizations/${organization.slug}/search-agent/translate/`,
+        method: 'POST',
+        data: {
+          org_id: organization.id,
+          org_slug: organization.slug,
+          natural_language_query: queryToSubmit,
+          project_ids: selectedProjects,
+          strategy: 'Metrics',
+          user_email: user?.email,
+        },
+      });
+
+      return {
+        status: 'ok',
+        unsupported_reason: data.unsupported_reason,
+        queries: data.responses.map(r => ({
+          visualizations:
+            r?.visualization?.map(v => ({
+              chartType: v?.chart_type,
+              yAxes: v?.y_axes ?? [],
+            })) ?? [],
+          query: r?.query ?? '',
+          sort: r?.sort ?? '',
+          groupBys: r?.group_by ?? [],
+          statsPeriod: r?.stats_period ?? '',
+          start: r?.start ?? null,
+          end: r?.end ?? null,
+          mode: r?.mode ?? 'metrics',
+        })),
+      };
+    },
+  });
+
+  const applySeerSearchQuery = useCallback(
+    (result: AskSeerSearchQuery) => {
+      if (!result) return;
+      const {
+        query: queryToUse,
+        groupBys,
+        statsPeriod,
+        start: resultStart,
+        end: resultEnd,
+        visualizations,
+      } = result;
+
+      let start: DateString = null;
+      let end: DateString = null;
+
+      if (resultStart && resultEnd) {
+        // Strip 'Z' suffix to treat UTC dates as local time
+        const startLocal = resultStart.endsWith('Z')
+          ? resultStart.slice(0, -1)
+          : resultStart;
+        const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
+        start = new Date(startLocal).toISOString();
+        end = new Date(endLocal).toISOString();
+      } else {
+        start = pageFilters.selection.datetime.start;
+        end = pageFilters.selection.datetime.end;
+      }
+
+      // Update mode based on groupBys or response mode
+      const mode =
+        groupBys.length > 0
+          ? Mode.AGGREGATE
+          : result.mode === 'aggregates'
+            ? Mode.AGGREGATE
+            : Mode.SAMPLES;
+
+      // Build aggregateFields array (same merge logic as LogsTabSeerComboBox)
+      // This combines groupBys with existing visualizations
+      let seenVisualizes = false;
+      let groupByAfterVisualizes = false;
+
+      for (const aggregateField of queryParams.aggregateFields) {
+        if (isGroupBy(aggregateField) && seenVisualizes) {
+          groupByAfterVisualizes = true;
+          break;
+        } else if (isVisualize(aggregateField)) {
+          seenVisualizes = true;
+        }
+      }
+
+      const aggregateFields: WritableAggregateField[] = [];
+      const iter = groupBys[Symbol.iterator]();
+
+      for (const aggregateField of queryParams.aggregateFields) {
+        if (isVisualize(aggregateField)) {
+          if (!groupByAfterVisualizes) {
+            // Insert group bys before visualizes
+            for (const groupBy of iter) {
+              aggregateFields.push({groupBy});
+            }
+          }
+          aggregateFields.push(aggregateField.serialize());
+        } else if (isGroupBy(aggregateField)) {
+          const {value: groupBy, done} = iter.next();
+          if (!done) {
+            aggregateFields.push({groupBy});
+          }
+        }
+      }
+
+      // Add any remaining group bys
+      for (const groupBy of iter) {
+        aggregateFields.push({groupBy});
+      }
+
+      // Update per-query state atomically (query, aggregateFields, mode)
+      setQueryParams({query: queryToUse, aggregateFields, mode});
+
+      // Update global time range via navigation
+      const selection = {
+        ...pageFilters.selection,
+        datetime: {
+          start,
+          end,
+          utc: pageFilters.selection.datetime.utc,
+          period:
+            resultStart && resultEnd
+              ? null
+              : statsPeriod || pageFilters.selection.datetime.period,
+        },
+      };
+
+      askSeerSuggestedQueryRef.current = JSON.stringify({
+        selection,
+        query: queryToUse,
+        groupBys,
+        mode,
+      });
+
+      trackAnalytics('metrics.ai_query_applied', {
+        organization,
+        query: queryToUse,
+        group_by_count: groupBys.length,
+        visualize_count: visualizations?.length ?? 0,
+      });
+
+      // Navigate to update global time range params
+      navigate(
+        {
+          ...location,
+          query: {
+            ...location.query,
+            start: selection.datetime.start,
+            end: selection.datetime.end,
+            statsPeriod: selection.datetime.period,
+            utc: selection.datetime.utc,
+          },
+        },
+        {replace: true, preventScrollReset: true}
+      );
+    },
+    [
+      askSeerSuggestedQueryRef,
+      location,
+      navigate,
+      organization,
+      pageFilters.selection,
+      queryParams.aggregateFields,
+      setQueryParams,
+    ]
+  );
+
+  const usePollingEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
+
+  // Get selected project IDs for the polling variant
+  const selectedProjectIds = useMemo(() => {
+    if (
+      pageFilters.selection.projects?.length > 0 &&
+      pageFilters.selection.projects?.[0] !== -1
+    ) {
+      return pageFilters.selection.projects;
+    }
+    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
+  }, [pageFilters.selection.projects, projects]);
+
+  // Transform the final_response from Seer to match the expected format
+  const transformResponse = useCallback(
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const seerResponse = response as unknown as {
+        responses?: Array<{
+          end: string | null;
+          group_by: string[];
+          mode: string;
+          query: string;
+          sort: string;
+          start: string | null;
+          stats_period: string;
+          visualization: Array<{
+            chart_type: number;
+            y_axes: string[];
+          }>;
+        }>;
+      };
+
+      if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
+        return seerResponse.responses.map(r => ({
+          visualizations:
+            r?.visualization?.map(v => ({
+              chartType: v?.chart_type,
+              yAxes: v?.y_axes ?? [],
+            })) ?? [],
+          query: r?.query ?? '',
+          sort: r?.sort ?? '',
+          groupBys: r?.group_by ?? [],
+          statsPeriod: r?.stats_period ?? '',
+          start: r?.start ?? null,
+          end: r?.end ?? null,
+          mode: r?.mode ?? 'metrics',
+        }));
+      }
+
+      return [response];
+    },
+    []
+  );
+
+  if (!enableAISearch) {
+    return null;
+  }
+
+  if (usePollingEndpoint) {
+    return (
+      <AskSeerPollingComboBox<AskSeerSearchQuery>
+        initialQuery={initialSeerQuery}
+        projectIds={selectedProjectIds}
+        strategy="Metrics"
+        applySeerSearchQuery={applySeerSearchQuery}
+        transformResponse={transformResponse}
+        analyticsSource="metrics"
+        feedbackSource="metrics_ai_query"
+        fallbackMutationOptions={metricsTabAskSeerMutationOptions}
+      />
+    );
+  }
+
+  return (
+    <AskSeerComboBox
+      initialQuery={initialSeerQuery}
+      askSeerMutationOptions={metricsTabAskSeerMutationOptions}
+      applySeerSearchQuery={applySeerSearchQuery}
+      analyticsSource="metrics"
+      feedbackSource="metrics_ai_query"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add tracemetrics built-in fields (`metric.name`, `metric.type`, `metric.unit`, `value`) to `_get_built_in_fields` so the Seer assisted query agent can discover them
- Integrate the Seer AI search combobox into the metrics tab filter bar, enabling natural language to metrics query translation
- Register metrics AI query analytics events (`ai_query_applied`, `ai_query_submitted`, `ai_query_rejected`, `ai_query_interface`)

## Details
The Seer backend already has a fully implemented `MetricsStrategy` for the assisted query agent. This PR wires up the frontend by:
1. Creating `MetricsTabSeerComboBox` — follows the established `LogsTabSeerComboBox` / `SpansTabSeerComboBox` pattern with metrics-specific adaptations (per-query state updates via `useSetQueryParams`, global time range via `navigate()`, default mode `'metrics'`)
2. Modifying the metrics `Filter` component to add `enableAISearch` to `SearchQueryBuilderProvider` and conditionally render the seer combobox when `displayAskSeer` is true
3. Gated behind the existing `gen-ai-search-agent-translate` feature flag

## Test plan
- [ ] Enable `gen-ai-features` and `gen-ai-search-agent-translate` feature flags for org
- [ ] Navigate to Explore > Metrics tab
- [ ] Verify sparkle icon (AI search toggle) appears in the filter bar
- [ ] Submit a natural language query (e.g., "count of http.request.duration by environment last 7 days")
- [ ] Verify query, group-bys, mode, and time range update for the specific metric row
- [ ] Verify other metric query rows are unaffected
- [ ] Test "None of these" feedback flow
- [ ] Verify analytics events fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)