### PR TITLE
feat(snapshots): Wire up status check setting fields into snapshot status_check task

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1181,7 +1181,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 "sentry:preprod_snapshot_status_checks_fail_on_added", False
             ),
             "sentry:preprod_snapshot_status_checks_fail_on_removed": options.get(
-                "sentry:preprod_snapshot_status_checks_fail_on_removed", False
+                "sentry:preprod_snapshot_status_checks_fail_on_removed", True
             ),
             "quotas:spike-protection-disabled": options.get("quotas:spike-protection-disabled"),
             "sentry:preprod_size_enabled_query": options.get("sentry:preprod_size_enabled_query"),

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -35,6 +35,10 @@ logger = logging.getLogger(__name__)
 # Action identifier for the "Approve" button on snapshot GitHub check runs.
 APPROVE_SNAPSHOT_ACTION_IDENTIFIER = "approve_snapshots"
 
+ENABLED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_enabled"
+FAIL_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_added"
+FAIL_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_removed"
+
 
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_snapshot_status_check",
@@ -89,7 +93,19 @@ def create_preprod_snapshot_status_check_task(
         )
         return
 
-    # TODO(EME-911) Wireup enabled options once gating/billing comes into play
+    status_checks_enabled = preprod_artifact.project.get_option(ENABLED_OPTION_KEY, default=True)
+    if not status_checks_enabled:
+        logger.info(
+            "preprod.snapshot_status_checks.create.disabled",
+            extra={
+                "artifact_id": preprod_artifact.id,
+                "project_id": preprod_artifact.project.id,
+            },
+        )
+        return
+
+    fail_on_added = preprod_artifact.project.get_option(FAIL_ON_ADDED_OPTION_KEY, default=False)
+    fail_on_removed = preprod_artifact.project.get_option(FAIL_ON_REMOVED_OPTION_KEY, default=False)
 
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
@@ -182,8 +198,19 @@ def create_preprod_snapshot_status_check_task(
                 snapshot_metrics_map,
             )
     else:
+        changes_map = _build_changes_map(
+            all_artifacts,
+            snapshot_metrics_map,
+            comparisons_map,
+            fail_on_added=fail_on_added,
+            fail_on_removed=fail_on_removed,
+        )
         status = _compute_snapshot_status(
-            all_artifacts, snapshot_metrics_map, comparisons_map, approvals_map
+            all_artifacts,
+            snapshot_metrics_map,
+            comparisons_map,
+            approvals_map,
+            changes_map,
         )
         title, subtitle, summary = format_snapshot_status_check_messages(
             all_artifacts,
@@ -191,8 +218,9 @@ def create_preprod_snapshot_status_check_task(
             comparisons_map,
             status,
             base_artifact_map,
+            changes_map,
         )
-        if _has_snapshot_changes(all_artifacts, snapshot_metrics_map, comparisons_map):
+        if any(changes_map.values()):
             approve_action_identifier = APPROVE_SNAPSHOT_ACTION_IDENTIFIER
 
     completed_at: datetime | None = None
@@ -266,12 +294,27 @@ def create_preprod_snapshot_status_check_task(
     )
 
 
-def _has_snapshot_changes(
+def _comparison_has_changes(
+    comparison: PreprodSnapshotComparison,
+    fail_on_added: bool = False,
+    fail_on_removed: bool = False,
+) -> bool:
+    return (
+        comparison.images_changed > 0
+        or comparison.images_renamed > 0
+        or (fail_on_added and comparison.images_added > 0)
+        or (fail_on_removed and comparison.images_removed > 0)
+    )
+
+
+def _build_changes_map(
     artifacts: list[PreprodArtifact],
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
     comparisons_map: dict[int, PreprodSnapshotComparison],
-) -> bool:
-    """Check if any artifact has snapshot changes (added/removed/changed)."""
+    fail_on_added: bool = False,
+    fail_on_removed: bool = False,
+) -> dict[int, bool]:
+    changes_map: dict[int, bool] = {}
     for artifact in artifacts:
         metrics = snapshot_metrics_map.get(artifact.id)
         if not metrics:
@@ -279,15 +322,10 @@ def _has_snapshot_changes(
         comparison = comparisons_map.get(metrics.id)
         if not comparison or comparison.state != PreprodSnapshotComparison.State.SUCCESS:
             continue
-
-        if (
-            comparison.images_changed > 0
-            or comparison.images_added > 0
-            or comparison.images_removed > 0
-            or comparison.images_renamed > 0
-        ):
-            return True
-    return False
+        changes_map[artifact.id] = _comparison_has_changes(
+            comparison, fail_on_added, fail_on_removed
+        )
+    return changes_map
 
 
 def _compute_snapshot_status(
@@ -295,13 +333,8 @@ def _compute_snapshot_status(
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
     comparisons_map: dict[int, PreprodSnapshotComparison],
     approvals_map: dict[int, PreprodComparisonApproval],
+    changes_map: dict[int, bool],
 ) -> StatusCheckStatus:
-    """Compute the overall snapshot status check status.
-
-    - IN_PROGRESS if any comparison is pending/processing
-    - FAILURE if any comparison failed, or if any has changes and not approved
-    - SUCCESS if all comparisons succeeded with no changes, or all approved
-    """
     has_in_progress = False
 
     for artifact in artifacts:
@@ -320,12 +353,7 @@ def _compute_snapshot_status(
             case PreprodSnapshotComparison.State.FAILED:
                 return StatusCheckStatus.FAILURE
             case PreprodSnapshotComparison.State.SUCCESS:
-                if (
-                    comparison.images_changed > 0
-                    or comparison.images_added > 0
-                    or comparison.images_removed > 0
-                    or comparison.images_renamed > 0
-                ) and artifact.id not in approvals_map:
+                if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:
                     return StatusCheckStatus.FAILURE
 
     if has_in_progress:

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -105,7 +105,7 @@ def create_preprod_snapshot_status_check_task(
         return
 
     fail_on_added = preprod_artifact.project.get_option(FAIL_ON_ADDED_OPTION_KEY, default=False)
-    fail_on_removed = preprod_artifact.project.get_option(FAIL_ON_REMOVED_OPTION_KEY, default=False)
+    fail_on_removed = preprod_artifact.project.get_option(FAIL_ON_REMOVED_OPTION_KEY, default=True)
 
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
@@ -297,7 +297,7 @@ def create_preprod_snapshot_status_check_task(
 def _comparison_has_changes(
     comparison: PreprodSnapshotComparison,
     fail_on_added: bool = False,
-    fail_on_removed: bool = False,
+    fail_on_removed: bool = True,
 ) -> bool:
     return (
         comparison.images_changed > 0
@@ -312,7 +312,7 @@ def _build_changes_map(
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
     comparisons_map: dict[int, PreprodSnapshotComparison],
     fail_on_added: bool = False,
-    fail_on_removed: bool = False,
+    fail_on_removed: bool = True,
 ) -> dict[int, bool]:
     changes_map: dict[int, bool] = {}
     for artifact in artifacts:

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -18,6 +18,7 @@ def format_snapshot_status_check_messages(
     comparisons_map: dict[int, PreprodSnapshotComparison],
     overall_status: StatusCheckStatus,
     base_artifact_map: dict[int, PreprodArtifact],
+    changes_map: dict[int, bool],
 ) -> tuple[str, str, str]:
     if not artifacts:
         raise ValueError("Cannot format messages for empty artifact list")
@@ -108,6 +109,7 @@ def format_snapshot_status_check_messages(
         snapshot_metrics_map,
         comparisons_map,
         base_artifact_map,
+        changes_map,
     )
 
     return str(title), str(subtitle), str(summary)
@@ -219,6 +221,7 @@ def _format_snapshot_summary(
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
     comparisons_map: dict[int, PreprodSnapshotComparison],
     base_artifact_map: dict[int, PreprodArtifact],
+    changes_map: dict[int, bool],
 ) -> str:
     table_rows = []
 
@@ -264,7 +267,7 @@ def _format_snapshot_summary(
             modified = comparison.images_changed
             renamed = comparison.images_renamed
             unchanged = comparison.images_unchanged
-            has_changes = modified > 0 or added > 0 or removed > 0 or renamed > 0
+            has_changes = changes_map.get(artifact.id, False)
             status = "⏳ Needs approval" if has_changes else "✅ Unchanged"
 
             def _section_cell(count: int, section: str) -> str:

--- a/static/app/views/settings/project/preprod/useSnapshotStatusChecks.ts
+++ b/static/app/views/settings/project/preprod/useSnapshotStatusChecks.ts
@@ -26,7 +26,7 @@ export function useSnapshotStatusChecks(project: Project) {
 
   const failOnRemoved =
     project.preprodSnapshotStatusChecksFailOnRemoved ??
-    project.options?.[FAIL_ON_REMOVED_KEY] === true;
+    project.options?.[FAIL_ON_REMOVED_KEY] !== false;
 
   const setEnabled = useCallback(
     (value: boolean) => {

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from sentry.integrations.source_code_management.status_check import StatusCheckStatus
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.vcs.status_checks.snapshots.tasks import (
+    _build_changes_map,
+    _compute_snapshot_status,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import cell_silo_test
+
+
+class SnapshotTasksTestBase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.commit_comparison = self.create_commit_comparison()
+
+    def _make_artifact_with_comparison(
+        self,
+        images_changed=0,
+        images_added=0,
+        images_removed=0,
+        images_renamed=0,
+        state=PreprodSnapshotComparison.State.SUCCESS,
+    ):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=self.commit_comparison,
+        )
+        head_metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact, image_count=10
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=self.commit_comparison,
+        )
+        base_metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=base_artifact, image_count=10
+        )
+        comparison = PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=state,
+            images_changed=images_changed,
+            images_added=images_added,
+            images_removed=images_removed,
+            images_renamed=images_renamed,
+            images_unchanged=10,
+        )
+        return artifact, head_metrics, comparison
+
+
+@cell_silo_test
+class ComputeSnapshotStatusTest(SnapshotTasksTestBase):
+    def _status_with_changes_map(self, artifact, metrics, approvals=None, **flags):
+        artifacts = [artifact]
+        metrics_map = {artifact.id: metrics}
+        comparisons_map = {metrics.id: _get_comparison(metrics)}
+        changes_map = _build_changes_map(artifacts, metrics_map, comparisons_map, **flags)
+        return _compute_snapshot_status(
+            artifacts, metrics_map, comparisons_map, approvals or {}, changes_map
+        )
+
+    def test_images_added_ignored_when_flag_off(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_added=5)
+        assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.SUCCESS
+
+    def test_images_added_fails_when_flag_on(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_added=5)
+        assert (
+            self._status_with_changes_map(artifact, metrics, fail_on_added=True)
+            == StatusCheckStatus.FAILURE
+        )
+
+    def test_images_removed_ignored_when_flag_off(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
+        assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.SUCCESS
+
+    def test_images_removed_fails_when_flag_on(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
+        assert (
+            self._status_with_changes_map(artifact, metrics, fail_on_removed=True)
+            == StatusCheckStatus.FAILURE
+        )
+
+    def test_images_changed_always_fails(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
+        assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.FAILURE
+
+    def test_images_renamed_always_fails(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_renamed=1)
+        assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.FAILURE
+
+    def test_no_changes_succeeds(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison()
+        assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.SUCCESS
+
+
+@cell_silo_test
+class BuildChangesMapTest(SnapshotTasksTestBase):
+    def test_added_ignored_when_flag_off(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_added=5)
+        changes_map = _build_changes_map(
+            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
+        )
+        assert not any(changes_map.values())
+
+    def test_added_detected_when_flag_on(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_added=5)
+        changes_map = _build_changes_map(
+            [artifact],
+            {artifact.id: metrics},
+            {metrics.id: _get_comparison(metrics)},
+            fail_on_added=True,
+        )
+        assert changes_map[artifact.id] is True
+
+    def test_removed_ignored_when_flag_off(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
+        changes_map = _build_changes_map(
+            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
+        )
+        assert not any(changes_map.values())
+
+    def test_removed_detected_when_flag_on(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
+        changes_map = _build_changes_map(
+            [artifact],
+            {artifact.id: metrics},
+            {metrics.id: _get_comparison(metrics)},
+            fail_on_removed=True,
+        )
+        assert changes_map[artifact.id] is True
+
+    def test_changed_always_detected(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
+        changes_map = _build_changes_map(
+            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
+        )
+        assert changes_map[artifact.id] is True
+
+
+def _get_comparison(metrics: PreprodSnapshotMetrics) -> PreprodSnapshotComparison:
+    return PreprodSnapshotComparison.objects.get(head_snapshot_metrics=metrics)

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
@@ -76,14 +76,14 @@ class ComputeSnapshotStatusTest(SnapshotTasksTestBase):
 
     def test_images_removed_ignored_when_flag_off(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
-        assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.SUCCESS
-
-    def test_images_removed_fails_when_flag_on(self):
-        artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
         assert (
-            self._status_with_changes_map(artifact, metrics, fail_on_removed=True)
-            == StatusCheckStatus.FAILURE
+            self._status_with_changes_map(artifact, metrics, fail_on_removed=False)
+            == StatusCheckStatus.SUCCESS
         )
+
+    def test_images_removed_fails_by_default(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
+        assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.FAILURE
 
     def test_images_changed_always_fails(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
@@ -120,17 +120,17 @@ class BuildChangesMapTest(SnapshotTasksTestBase):
     def test_removed_ignored_when_flag_off(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
         changes_map = _build_changes_map(
-            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
-        )
-        assert not any(changes_map.values())
-
-    def test_removed_detected_when_flag_on(self):
-        artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
-        changes_map = _build_changes_map(
             [artifact],
             {artifact.id: metrics},
             {metrics.id: _get_comparison(metrics)},
-            fail_on_removed=True,
+            fail_on_removed=False,
+        )
+        assert not any(changes_map.values())
+
+    def test_removed_detected_by_default(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
+        changes_map = _build_changes_map(
+            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
         )
         assert changes_map[artifact.id] is True
 

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -77,7 +77,7 @@ class SnapshotStatusCheckTestBase(TestCase):
 class SnapshotEmptyArtifactsTest(SnapshotStatusCheckTestBase):
     def test_empty_artifacts_raises_error(self) -> None:
         with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
-            format_snapshot_status_check_messages([], {}, {}, StatusCheckStatus.SUCCESS, {})
+            format_snapshot_status_check_messages([], {}, {}, StatusCheckStatus.SUCCESS, {}, {})
 
 
 @cell_silo_test
@@ -92,7 +92,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         title, subtitle, summary = format_snapshot_status_check_messages(
-            [artifact], {}, {}, StatusCheckStatus.IN_PROGRESS, {}
+            [artifact], {}, {}, StatusCheckStatus.IN_PROGRESS, {}, {}
         )
 
         assert title == "Snapshot Testing"
@@ -106,7 +106,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         snapshot_metrics_map = {artifact.id: metrics}
 
         title, subtitle, summary = format_snapshot_status_check_messages(
-            [artifact], snapshot_metrics_map, {}, StatusCheckStatus.IN_PROGRESS, {}
+            [artifact], snapshot_metrics_map, {}, StatusCheckStatus.IN_PROGRESS, {}, {}
         )
 
         assert title == "Snapshot Testing"
@@ -130,6 +130,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.IN_PROGRESS,
             {},
+            {},
         )
 
         assert title == "Snapshot Testing"
@@ -152,6 +153,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.IN_PROGRESS,
+            {},
             {},
         )
 
@@ -184,6 +186,7 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.SUCCESS,
             {},
+            {},
         )
 
         assert title == "Snapshot Testing"
@@ -207,6 +210,7 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
+            {},
             {},
         )
 
@@ -235,6 +239,7 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
+            {},
             {},
         )
 
@@ -268,6 +273,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.FAILURE,
             {},
+            {head_artifact.id: True},
         )
 
         assert title == "Snapshot Testing"
@@ -294,6 +300,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.FAILURE,
             {},
+            {head_artifact.id: True},
         )
 
         assert subtitle == "1 modified, 9 unchanged"
@@ -320,6 +327,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.FAILURE,
             {},
+            {},
         )
 
         assert subtitle == "2 added, 1 removed, 8 unchanged"
@@ -344,6 +352,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.FAILURE,
             {},
+            {head_artifact.id: True},
         )
 
         assert subtitle == "4 renamed, 6 unchanged"
@@ -371,6 +380,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.FAILURE,
             {},
+            {head_artifact.id: True},
         )
 
         assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 5 unchanged"
@@ -397,6 +407,7 @@ class SnapshotFailureStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.FAILURE,
+            {},
             {},
         )
 
@@ -442,6 +453,7 @@ class SnapshotFailureStateFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.FAILURE,
             {},
+            {},
         )
 
         assert subtitle == "We had trouble comparing snapshots, our team is investigating."
@@ -485,6 +497,7 @@ class SnapshotMixedStateFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.IN_PROGRESS,
             {},
+            {},
         )
 
         assert subtitle == "Comparing snapshots..."
@@ -508,6 +521,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.SUCCESS,
             {},
+            {},
         )
 
         assert "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |" in summary
@@ -526,6 +540,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
+            {},
             {},
         )
 
@@ -559,6 +574,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.SUCCESS,
             base_artifact_map,
+            {},
         )
 
         expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{head_artifact.id}"
@@ -577,6 +593,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
+            {},
             {},
         )
 
@@ -608,6 +625,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
+            {},
             {},
         )
 
@@ -650,6 +668,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             comparisons_map,
             StatusCheckStatus.FAILURE,
             {},
+            {head_artifact.id: True},
         )
 
         assert title == "Snapshot Testing"


### PR DESCRIPTION
Add a Snapshots - Status Checks settings panel to the preprod project settings page with three toggles: enabled, fail on added, and fail on removed. Wire up these project options in the backend so the snapshot status check task respects them.

related PR: https://github.com/getsentry/sentry/pull/111794

Closes EME-911