### PR TITLE
ref(dashboards): Update generate dashboard endpoint permission check

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -18,7 +18,7 @@ from sentry.dashboards.on_completion_hook import DashboardOnCompletionHook
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.explorer.client import SeerExplorerClient
-from sentry.seer.explorer.client_utils import has_seer_explorer_access_with_detail
+from sentry.seer.explorer.client_utils import has_seer_access_with_detail
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -63,7 +63,7 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
         ):
             return Response({"detail": "Feature not enabled"}, status=403)
 
-        has_access, error = has_seer_explorer_access_with_detail(organization, request.user)
+        has_access, error = has_seer_access_with_detail(organization, request.user)
         if not has_access:
             raise PermissionDenied(error)
 

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -18,8 +18,8 @@ from sentry.dashboards.on_completion_hook import DashboardOnCompletionHook
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.explorer.client import SeerExplorerClient
-from sentry.seer.explorer.client_utils import has_seer_access_with_detail
 from sentry.seer.models import SeerApiError, SeerPermissionError
+from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -11,7 +11,6 @@ from sentry.testutils.helpers.features import with_feature
 
 @with_feature("organizations:dashboards-ai-generate")
 @with_feature("organizations:gen-ai-features")
-@with_feature("organizations:seer-explorer")
 class OrganizationDashboardGenerateEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-dashboards-generate"
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -64,10 +64,13 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         assert response.status_code == 403
 
     @patch(
-        "sentry.dashboards.endpoints.organization_dashboard_generate.has_seer_explorer_access_with_detail"
+        "sentry.dashboards.endpoints.organization_dashboard_generate.has_seer_access_with_detail"
     )
-    def test_post_without_seer_access_returns_403(self, mock_has_access: MagicMock) -> None:
-        mock_has_access.return_value = (False, "AI features are disabled for this organization.")
+    def test_post_without_seer_access_returns_403(self, mock_has_seer_access: MagicMock) -> None:
+        mock_has_seer_access.return_value = (
+            False,
+            "AI features are disabled for this organization.",
+        )
         data = {"prompt": "Show me error rates"}
         response = self.client.post(self.url, data, format="json")
         assert response.status_code == 403


### PR DESCRIPTION
Update permission check to look for `gen-ai-features`, instead of using `has_seer_explorer_access_with_detail` which checks for `seer-explorer` flags.