### PR TITLE
feat(autofix): Support optional repo name when creating PRs

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -507,6 +507,7 @@ def trigger_push_changes(
     run_id: int,
     referrer: AutofixReferrer,
     state: SeerRunState | None = None,
+    repo_name: str | None = None,
 ):
     client = get_autofix_explorer_client(group)
 
@@ -520,7 +521,7 @@ def trigger_push_changes(
     if group_id != group.id:
         raise SeerPermissionError("Unknown run id for group")
 
-    client.push_changes(run_id, blocking=False)
+    client.push_changes(run_id, repo_name=repo_name, blocking=False)
 
     metrics.incr(
         "autofix.explorer.trigger",

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -125,6 +125,10 @@ class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
         help_text="Optional user context to append to the step prompt.",
         allow_blank=True,
     )
+    repo_name = serializers.CharField(
+        required=False,
+        help_text="Optional repository name for which to create the pull request. Do not pass a repository name to create pull requests in all relevant repositories.",
+    )
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
         stopping_point = data.get("stopping_point", None)
@@ -263,11 +267,13 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 return Response(
                     {"detail": "run_id is required for open_pr"}, status=status.HTTP_400_BAD_REQUEST
                 )
+            repo_name = data.get("repo_name")
             try:
                 trigger_push_changes(
                     group,
                     run_id,
                     referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
+                    repo_name=repo_name,
                 )
             except SeerPermissionError:
                 return Response(status=status.HTTP_404_NOT_FOUND)

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -527,7 +527,7 @@ class SeerExplorerClient:
         self,
         run_id: int,
         repo_name: str | None = None,
-        blocking=True,
+        blocking: bool = True,
         poll_interval: float = 2.0,
         poll_timeout: float = 120.0,
     ) -> SeerRunState | None:

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -1031,6 +1031,93 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
             assert response.status_code == 202, f"Failed for {flag}: {response.data}"
             assert response.data == {"run_id": 123}
 
+    @patch("sentry.seer.explorer.client_utils.make_explorer_state_request")
+    @patch("sentry.seer.explorer.client.make_explorer_update_request")
+    def test_open_pr_with_repo_name(
+        self, mock_explorer_update_request, mock_explorer_state_request
+    ):
+        self.login_as(user=self.user)
+        group = self.create_group()
+
+        mock_explorer_update_response = Mock()
+        mock_explorer_update_response.status = 200
+        mock_explorer_update_request.return_value = mock_explorer_update_response
+
+        mock_explorer_state_response = Mock()
+        mock_explorer_state_response.status = 200
+        mock_explorer_state_response.json = Mock(
+            return_value={
+                "session": SeerRunState(
+                    run_id=123,
+                    blocks=[],
+                    status="completed",
+                    updated_at="2023-07-18T12:00:00Z",
+                    metadata={"group_id": group.id},
+                ).dict()
+            }
+        )
+        mock_explorer_state_request.return_value = mock_explorer_state_response
+
+        for flag in EXPLORER_FLAGS:
+            with self.feature(flag):
+                response = self.client.post(
+                    self._get_url(group.id, mode="explorer"),
+                    data={
+                        "step": "open_pr",
+                        "run_id": 123,
+                        "repo_name": "my-org/my-repo",
+                    },
+                    format="json",
+                )
+
+            assert response.status_code == 202, f"Failed for {flag}: {response.data}"
+            call_body = mock_explorer_update_request.call_args[0][0]
+            assert call_body["payload"]["type"] == "create_pr"
+            assert call_body["payload"]["repo_name"] == "my-org/my-repo"
+
+    @patch("sentry.seer.explorer.client_utils.make_explorer_state_request")
+    @patch("sentry.seer.explorer.client.make_explorer_update_request")
+    def test_open_pr_without_repo_name(
+        self, mock_explorer_update_request, mock_explorer_state_request
+    ):
+        self.login_as(user=self.user)
+        group = self.create_group()
+
+        mock_explorer_update_response = Mock()
+        mock_explorer_update_response.status = 200
+        mock_explorer_update_request.return_value = mock_explorer_update_response
+
+        mock_explorer_state_response = Mock()
+        mock_explorer_state_response.status = 200
+        mock_explorer_state_response.json = Mock(
+            return_value={
+                "session": SeerRunState(
+                    run_id=123,
+                    blocks=[],
+                    status="completed",
+                    updated_at="2023-07-18T12:00:00Z",
+                    metadata={"group_id": group.id},
+                ).dict()
+            }
+        )
+        mock_explorer_state_request.return_value = mock_explorer_state_response
+
+        for flag in EXPLORER_FLAGS:
+            with self.feature(flag):
+                response = self.client.post(
+                    self._get_url(group.id, mode="explorer"),
+                    data={
+                        "step": "open_pr",
+                        "run_id": 123,
+                    },
+                    format="json",
+                )
+
+            assert response.status_code == 202, f"Failed for {flag}: {response.data}"
+            call_body = mock_explorer_update_request.call_args[0][0]
+            assert call_body["payload"]["type"] == "create_pr"
+            assert "repo_name" not in call_body["payload"]
+
     def test_open_pr_no_run_id(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
When creating PRs, we should allow passing a specific repo that we want to create PRs for.