### PR TITLE
fix(grouping): Fix kitchen time regex bugs

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -142,12 +142,19 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
                 (\d{4}-?[01]\d-?[0-3]\d[\sT][0-2]\d:?[0-5]\d) # no seconds
             )
             |
-            # Kitchen
+            # Kitchen, 12-hr
             (
-                [1-9]\d? # Hour
+                ([1-9]|1[0-2]) # Hour, no leading zero, 1-12 hours
                 :\d{2} # Minute
                 (:\d{2})? # Optional second
                 (?:\s?[aApP][Mm])? # Optional, optionally-space-separated AM/PM
+            )
+            |
+            # Kitchen, 24-hr
+            (
+                (0?\d|1\d|2[0-3]) # Hour, optional leading zero, 0-23 hours
+                :\d{2} # Minute
+                (:\d{2})? # Optional second
             )
             |
             # Date

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -143,7 +143,12 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             )
             |
             # Kitchen
-            ([1-9]\d?:\d{2}(:\d{2})?(?:\s?[aApP][Mm])?)
+            (
+                [1-9]\d? # Hour
+                :\d{2} # Minute
+                (:\d{2})? # Optional second
+                (?:\s?[aApP][Mm])? # Optional, optionally-space-separated AM/PM
+            )
             |
             # Date
             (\d{4}-[01]\d-[0-3]\d)

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -144,17 +144,24 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             |
             # Kitchen, 12-hr
             (
+                (?<!\d) # Negative lookbehind to ensure hour has at most two digits
                 ([1-9]|1[0-2]) # Hour, no leading zero, 1-12 hours
                 :\d{2} # Minute
                 (:\d{2})? # Optional second
+                (?![\d:]) # Negative lookahead to ensure second (or minute, if there are no seconds)
+                          # has at most two digits, and to make sure that if there are seconds, they
+                          # get consumed by the optional seconds part of the pattern (and are
+                          # thereby forced to abide by its restrictions on possible values)
                 (?:\s?[aApP][Mm])? # Optional, optionally-space-separated AM/PM
             )
             |
             # Kitchen, 24-hr
             (
+                (?<!\d) # Negative lookbehind (same logic as 12-hr pattern above)
                 (0?\d|1\d|2[0-3]) # Hour, optional leading zero, 0-23 hours
                 :\d{2} # Minute
                 (:\d{2})? # Optional second
+                (?![\d:]) # Negative lookahead (same logic as in 12-hr pattern above)
             )
             |
             # Date

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -146,8 +146,8 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             (
                 (?<!\d) # Negative lookbehind to ensure hour has at most two digits
                 ([1-9]|1[0-2]) # Hour, no leading zero, 1-12 hours
-                :\d{2} # Minute
-                (:\d{2})? # Optional second
+                :[0-5]\d # Minute
+                (:[0-5]\d)? # Optional second
                 (?![\d:]) # Negative lookahead to ensure second (or minute, if there are no seconds)
                           # has at most two digits, and to make sure that if there are seconds, they
                           # get consumed by the optional seconds part of the pattern (and are
@@ -159,8 +159,8 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             (
                 (?<!\d) # Negative lookbehind (same logic as 12-hr pattern above)
                 (0?\d|1\d|2[0-3]) # Hour, optional leading zero, 0-23 hours
-                :\d{2} # Minute
-                (:\d{2})? # Optional second
+                :[0-5]\d # Minute
+                (:[0-5]\d)? # Optional second
                 (?![\d:]) # Negative lookahead (same logic as in 12-hr pattern above)
             )
             |

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -43,6 +43,8 @@ standard_cases = [
         "traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
         "traceparent: <traceparent>",
     ),
+    ("ip - too many initial characters", "12345:6:789", "<int>:<int>:<int>"),
+    ("ip - too many final characters", "123:4:56789", "<int>:<int>:<int>"),
     ("traceparent - aws", "1-67891233-abcdef012345678912345678", "<traceparent>"),
     (
         "traceparent - aws, but not word boundary",
@@ -98,8 +100,15 @@ standard_cases = [
     ("date - kitchen lowercase with space", "12:31 pm", "<date>"),
     ("date - kitchen 24-hour", "23:21", "<date>"),
     ("date - kitchen 24-hour with seconds", "23:21:12", "<date>"),
+    ("date - kitchen 24-hour with leading zero", "09:08", "<date>"),
     ("date - kitchen 24-hour no leading zero", "9:08", "<date>"),
+    ("date - kitchen 24-hour midnight with leading zero", "00:31", "<date>"),
+    ("date - kitchen 24-hour midnight no leading zero", "0:12", "<date>"),
     ("date - kitchen too many initial digits", "908:31", "<int>:<int>"),
+    ("date - kitchen too many final digits", "11:2112", "<int>:<int>"),
+    ("date - kitchen hour too big", "31:21", "<int>:<int>"),
+    ("date - kitchen minute too big", "12:99", "<int>:<int>"),
+    ("date - kitchen second too big", "12:31:99", "<int>:<int>:<int>"),
     ("date - time", "15:04:05", "<date>"),
     ("date - basic", "Mon Jan 02, 1999", "<date>"),
     ("date - datetime compressed date", "20240220 11:55:33.546593", "<date>"),
@@ -233,48 +242,6 @@ def test_experimental_parameterization(name: str, input: str, expected: str) -> 
 incorrect_cases = [
     # ("name", "input", "desired", "actual")
     (
-        "date - kitchen 24-hour with leading zero",
-        "09:08",
-        "<date>",
-        "<int>:<int>",
-    ),
-    (
-        "date - kitchen 24-hour midnight with leading zero",
-        "00:31",
-        "<date>",
-        "<int>:<int>",
-    ),
-    (
-        "date - kitchen 24-hour midnight no leading zero",
-        "0:12",
-        "<date>",
-        "<int>:<int>",
-    ),
-    (
-        "date - kitchen hour too big",
-        "31:21",
-        "<int>:<int>",
-        "<date>",
-    ),
-    (
-        "date - kitchen minute too big",
-        "12:99",
-        "<int>:<int>",
-        "<date>",
-    ),
-    (
-        "date - kitchen second too big",
-        "12:31:99",
-        "<int>:<int>:<int>",
-        "<date>",
-    ),
-    (
-        "date - kitchen too many final digits",
-        "11:2112",
-        "<int>:<int>",
-        "<date>12",
-    ),
-    (
         "hex without prefix - no letters, 8+ digits, negative",
         "-12345678",
         "<hex>",
@@ -309,18 +276,6 @@ incorrect_cases = [
         "Fee::add() called too early",
         "Fee::add() called too early",
         "<ip>() called too early",
-    ),
-    (
-        "ip - too many initial characters",
-        "12345:6:789",
-        "<int>:<int>:<int>",
-        "<int>:<date>9",
-    ),
-    (
-        "ip - too many final characters",
-        "123:4:56789",
-        "<int>:<int>:<int>",
-        "<int>:<date>789",
     ),
     (
         "ip - v4 mapped to v6",


### PR DESCRIPTION
This fixes two bugs with our "kitchen" (digital clock) time regex.

- Allow 24-hour time to include leading zeros.

- Restrict allowable values in each spot (no more 3-digit hours, no more minutes and seconds > 59, etc.).