### PR TITLE
ref(issue-ownership): allow all assignments when open membership is on

### DIFF
--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -94,14 +94,16 @@ class GroupValidator(serializers.Serializer[Group]):
             elif not project.member_set.filter(user_id=value.id).exists():
                 raise serializers.ValidationError("Cannot assign to non-team member")
 
-        if (
-            value
-            and value.is_team
-            and not self.context["project"].teams.filter(id=value.id).exists()
-        ):
-            raise serializers.ValidationError(
-                "Cannot assign to a team without access to the project"
-            )
+        if value and value.is_team:
+            organization = self.context["organization"]
+            project = self.context["project"]
+            # With open membership, allow assigning any org team. The team's
+            # org membership is already validated by ActorField.to_internal_value.
+            if not organization.flags.allow_joinleave:
+                if not project.teams.filter(id=value.id).exists():
+                    raise serializers.ValidationError(
+                        "Cannot assign to a team without access to the project"
+                    )
 
         return value
 

--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -83,12 +83,16 @@ class GroupValidator(serializers.Serializer[Group]):
     snoozeDuration = serializers.IntegerField(allow_null=True)
 
     def validate_assignedTo(self, value: Actor) -> Actor:
-        if (
-            value
-            and value.is_user
-            and not self.context["project"].member_set.filter(user_id=value.id).exists()
-        ):
-            raise serializers.ValidationError("Cannot assign to non-team member")
+        if value and value.is_user:
+            organization = self.context["organization"]
+            project = self.context["project"]
+            # With open membership, any org member can be assigned since they
+            # can join any team (and thus gain project access) at will.
+            if organization.flags.allow_joinleave:
+                if not organization.member_set.filter(user_id=value.id).exists():
+                    raise serializers.ValidationError("Cannot assign to non-organization member")
+            elif not project.member_set.filter(user_id=value.id).exists():
+                raise serializers.ValidationError("Cannot assign to non-team member")
 
         if (
             value


### PR DESCRIPTION
Issue ownership assignment permissions have a lot of edge cases around open membership / non-open membership orgs right now ([more details](https://www.notion.so/sentry/Issue-ownership-permissions-32c8b10e4b5d80a3bd55ebbba2cdeff1?source=copy_link)). Proposed solution here is to allow all assignments when open membership is on, which significantly simplifies the number of cases and is more in line with user expectations. No changes for non-open membership (yet).