### PR TITLE
fix(seer-explorer): Display correct label for metrics queries

### DIFF
--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -622,6 +622,13 @@ export function buildToolLinkUrl(
       }
 
       if (dataset === 'metrics' || dataset === 'tracemetrics') {
+        // TODO: The metrics explore page reads metric-specific state (metric name,
+        // type, aggregations, group bys) from a JSON-encoded `metric` URL param.
+        // Currently we only pass page filter params (project, statsPeriod, etc.)
+        // which means the search query context is lost on navigation. To fully
+        // preserve context, the Seer backend should include structured metric
+        // metadata (name, type, unit) in tool_link params so we can build the
+        // `metric` param here via encodeMetricsQueryParams().
         return {
           pathname: `/organizations/${orgSlug}/explore/metrics/`,
           query: queryParams,

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -93,6 +93,12 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
         : `Queried logs${projectInfo}: '${question}'`;
     }
 
+    if (dataset === 'metrics' || dataset === 'tracemetrics') {
+      return isLoading
+        ? `Querying metrics${projectInfo}: '${question}'...`
+        : `Queried metrics${projectInfo}: '${question}'`;
+    }
+
     // Default to spans dataset
     return isLoading
       ? `Querying spans${projectInfo}: '${question}'...`

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -621,6 +621,13 @@ export function buildToolLinkUrl(
         };
       }
 
+      if (dataset === 'metrics' || dataset === 'tracemetrics') {
+        return {
+          pathname: `/organizations/${orgSlug}/explore/metrics/`,
+          query: queryParams,
+        };
+      }
+
       // Default to spans (traces) search
       const {y_axes, group_by, mode} = toolLink.params;
       const aggregateFields: string[] = [];


### PR DESCRIPTION
## Summary
- The `telemetry_live_search` tool formatter in Seer Explorer was missing a case for the `metrics`/`tracemetrics` dataset, causing metrics queries to display as "Queried spans" instead of "Queried metrics".

## Test plan
- [x] Open Seer Explorer and run a natural language query targeting metrics (e.g. "Show me the count of all metrics in the last hour")
- [x] Verify the tool output label reads "Querying metrics" / "Queried metrics" instead of "Queried spans"