### PR TITLE
fix(typing): Codemod `-> None` to a bunch of tests

### DIFF
--- a/.github/codeowners-coverage-baseline.txt
+++ b/.github/codeowners-coverage-baseline.txt
@@ -184,6 +184,7 @@ src/sentry/runner/commands/cleanup.py
 src/sentry/runner/commands/config.py
 src/sentry/runner/commands/configoptions.py
 src/sentry/runner/commands/createflag.py
+src/sentry/runner/commands/createorg.py
 src/sentry/runner/commands/createuser.py
 src/sentry/runner/commands/devserver.py
 src/sentry/runner/commands/devservices.py
@@ -225,9 +226,6 @@ src/sentry/scripts/quotas/is_rate_limited.lua
 src/sentry/scripts/ratelimits/api_limiter.lua
 src/sentry/scripts/ratelimits/leaky_bucket.lua
 src/sentry/scripts/similarity/index.lua
-src/sentry/scripts/spans/add-buffer.lua
-src/sentry/scripts/spans/done-flush-segment-data.lua
-src/sentry/scripts/spans/done-flush-segment.lua
 src/sentry/scripts/tsdb/cmsketch.lua
 src/sentry/scripts/utils/locking/delete_lock.lua
 src/sentry/scripts/utils/sadd_capped.lua
@@ -552,7 +550,6 @@ static/app/components/discover/transactionsList.spec.tsx
 static/app/components/discover/transactionsList.tsx
 static/app/components/discover/transactionsTable.tsx
 static/app/components/discoverButton.tsx
-static/app/components/dnd/dragReorderButton.tsx
 static/app/components/dropdownButton.tsx
 static/app/components/dropdownMenu/footer.tsx
 static/app/components/dropdownMenu/index.spec.tsx
@@ -1023,18 +1020,6 @@ static/app/components/replaysOnboarding/replayConfigToggle.tsx
 static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
 static/app/components/replaysOnboarding/sidebar.tsx
 static/app/components/replaysOnboarding/utils.tsx
-static/app/components/repositories/getRepoStatusLabel.tsx
-static/app/components/repositories/repoProviderIcon.tsx
-static/app/components/repositories/scmIntegrationTree/providerConfigLink.tsx
-static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
-static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeNodes.ts
-static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
-static/app/components/repositories/scmIntegrationTree/scmTreeFilters.tsx
-static/app/components/repositories/scmIntegrationTree/types.ts
-static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.spec.tsx
-static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
-static/app/components/repositories/scmIntegrationTree/useScmTreeFilters.tsx
-static/app/components/repositories/scmRepoTreeModal.tsx
 static/app/components/repositoryRow.spec.tsx
 static/app/components/repositoryRow.tsx
 static/app/components/resolutionBox.spec.tsx
@@ -2318,6 +2303,7 @@ tests/sentry/runner/commands/test_cleanup.py
 tests/sentry/runner/commands/test_config.py
 tests/sentry/runner/commands/test_configoptions.py
 tests/sentry/runner/commands/test_createflag.py
+tests/sentry/runner/commands/test_createorg.py
 tests/sentry/runner/commands/test_createuser.py
 tests/sentry/runner/commands/test_init.py
 tests/sentry/runner/commands/test_migrations.py

--- a/tests/sentry/api/endpoints/test_dsn_lookup.py
+++ b/tests/sentry/api/endpoints/test_dsn_lookup.py
@@ -6,7 +6,7 @@ from sentry.testutils.silo import cell_silo_test
 class DsnLookupEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-dsn-lookup"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.org = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.org)
@@ -15,7 +15,7 @@ class DsnLookupEndpointTest(APITestCase):
         self.dsn = self.key.dsn_public
         self.login_as(self.user)
 
-    def test_valid_dsn_returns_project_info(self):
+    def test_valid_dsn_returns_project_info(self) -> None:
         with self.feature("organizations:cmd-k-dsn-lookup"):
             response = self.get_success_response(self.org.slug, qs_params={"dsn": self.dsn})
         assert response.data["organizationSlug"] == self.org.slug
@@ -23,17 +23,17 @@ class DsnLookupEndpointTest(APITestCase):
         assert response.data["projectId"] == str(self.project.id)
         assert response.data["projectName"] == self.project.name
 
-    def test_missing_dsn_param_returns_400(self):
+    def test_missing_dsn_param_returns_400(self) -> None:
         with self.feature("organizations:cmd-k-dsn-lookup"):
             response = self.get_response(self.org.slug, qs_params={})
         assert response.status_code == 400
 
-    def test_invalid_dsn_format_returns_404(self):
+    def test_invalid_dsn_format_returns_404(self) -> None:
         with self.feature("organizations:cmd-k-dsn-lookup"):
             response = self.get_response(self.org.slug, qs_params={"dsn": "not-a-dsn"})
         assert response.status_code == 404
 
-    def test_dsn_from_other_org_returns_404(self):
+    def test_dsn_from_other_org_returns_404(self) -> None:
         other_user = self.create_user()
         other_org = self.create_organization(owner=other_user)
         other_project = self.create_project(organization=other_org)
@@ -44,6 +44,6 @@ class DsnLookupEndpointTest(APITestCase):
             response = self.get_response(self.org.slug, qs_params={"dsn": other_key.dsn_public})
         assert response.status_code == 404
 
-    def test_feature_flag_disabled_returns_404(self):
+    def test_feature_flag_disabled_returns_404(self) -> None:
         response = self.get_response(self.org.slug, qs_params={"dsn": self.dsn})
         assert response.status_code == 404

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -23,11 +23,11 @@ from .test_organization_ai_conversations_base import (
 class TestExtractContentFromParts:
     """Unit tests for _extract_content_from_parts helper function"""
 
-    def test_single_text_part(self):
+    def test_single_text_part(self) -> None:
         msg = {"parts": [{"type": "text", "content": "Hello, world!"}]}
         assert _extract_content_from_parts(msg) == "Hello, world!"
 
-    def test_multiple_text_parts(self):
+    def test_multiple_text_parts(self) -> None:
         msg = {
             "parts": [
                 {"type": "text", "content": "First part."},
@@ -36,7 +36,7 @@ class TestExtractContentFromParts:
         }
         assert _extract_content_from_parts(msg) == "First part.\nSecond part."
 
-    def test_mixed_part_types(self):
+    def test_mixed_part_types(self) -> None:
         msg = {
             "parts": [
                 {"type": "text", "content": "User question"},
@@ -47,23 +47,23 @@ class TestExtractContentFromParts:
         # Should only extract text parts
         assert _extract_content_from_parts(msg) == "User question\nMore text"
 
-    def test_empty_parts(self):
+    def test_empty_parts(self) -> None:
         msg: dict[str, Any] = {"parts": []}
         assert _extract_content_from_parts(msg) is None
 
-    def test_no_parts_key(self):
+    def test_no_parts_key(self) -> None:
         msg = {"content": "old format"}
         assert _extract_content_from_parts(msg) is None
 
-    def test_parts_not_list(self):
+    def test_parts_not_list(self) -> None:
         msg = {"parts": "invalid"}
         assert _extract_content_from_parts(msg) is None
 
-    def test_empty_content(self):
+    def test_empty_content(self) -> None:
         msg = {"parts": [{"type": "text", "content": ""}]}
         assert _extract_content_from_parts(msg) is None
 
-    def test_missing_content(self):
+    def test_missing_content(self) -> None:
         msg = {"parts": [{"type": "text"}]}
         assert _extract_content_from_parts(msg) is None
 
@@ -71,38 +71,38 @@ class TestExtractContentFromParts:
 class TestExtractFirstUserMessage:
     """Unit tests for _extract_first_user_message helper function"""
 
-    def test_old_format_content(self):
+    def test_old_format_content(self) -> None:
         messages = '[{"role": "user", "content": "Hello"}]'
         assert _extract_first_user_message(messages) == "Hello"
 
-    def test_new_format_parts(self):
+    def test_new_format_parts(self) -> None:
         messages = '[{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]'
         assert _extract_first_user_message(messages) == "Hello"
 
-    def test_prefers_old_format_when_both_exist(self):
+    def test_prefers_old_format_when_both_exist(self) -> None:
         messages = (
             '[{"role": "user", "content": "Old", "parts": [{"type": "text", "content": "New"}]}]'
         )
         assert _extract_first_user_message(messages) == "Old"
 
-    def test_finds_first_user_message(self):
+    def test_finds_first_user_message(self) -> None:
         messages = '[{"role": "system", "content": "System"}, {"role": "user", "content": "First"}, {"role": "user", "content": "Second"}]'
         assert _extract_first_user_message(messages) == "First"
 
-    def test_returns_none_for_no_user_messages(self):
+    def test_returns_none_for_no_user_messages(self) -> None:
         messages = (
             '[{"role": "system", "content": "System"}, {"role": "assistant", "content": "Hi"}]'
         )
         assert _extract_first_user_message(messages) is None
 
-    def test_returns_none_for_invalid_json(self):
+    def test_returns_none_for_invalid_json(self) -> None:
         messages = "invalid json"
         assert _extract_first_user_message(messages) is None
 
-    def test_returns_none_for_none_input(self):
+    def test_returns_none_for_none_input(self) -> None:
         assert _extract_first_user_message(None) is None
 
-    def test_returns_none_for_empty_list(self):
+    def test_returns_none_for_empty_list(self) -> None:
         messages = "[]"
         assert _extract_first_user_message(messages) is None
 
@@ -110,22 +110,22 @@ class TestExtractFirstUserMessage:
 class TestGetFirstInputMessage:
     """Unit tests for _get_first_input_message helper function"""
 
-    def test_prefers_new_format(self):
+    def test_prefers_new_format(self) -> None:
         row = {
             "gen_ai.input.messages": '[{"role": "user", "parts": [{"type": "text", "content": "New"}]}]',
             "gen_ai.request.messages": '[{"role": "user", "content": "Old"}]',
         }
         assert _get_first_input_message(row) == "New"
 
-    def test_falls_back_to_old_format(self):
+    def test_falls_back_to_old_format(self) -> None:
         row = {"gen_ai.request.messages": '[{"role": "user", "content": "Old"}]'}
         assert _get_first_input_message(row) == "Old"
 
-    def test_returns_none_when_both_empty(self):
+    def test_returns_none_when_both_empty(self) -> None:
         row: dict[str, Any] = {}
         assert _get_first_input_message(row) is None
 
-    def test_skips_invalid_new_format(self):
+    def test_skips_invalid_new_format(self) -> None:
         row = {
             "gen_ai.input.messages": "invalid",
             "gen_ai.request.messages": '[{"role": "user", "content": "Old"}]',
@@ -136,35 +136,35 @@ class TestGetFirstInputMessage:
 class TestGetLastOutput:
     """Unit tests for _get_last_output helper function"""
 
-    def test_prefers_new_format_text_part(self):
+    def test_prefers_new_format_text_part(self) -> None:
         row = {
             "gen_ai.output.messages": '[{"role": "assistant", "parts": [{"type": "text", "content": "New"}]}]',
             "gen_ai.response.text": "Old",
         }
         assert _get_last_output(row) == "New"
 
-    def test_prefers_new_format_content(self):
+    def test_prefers_new_format_content(self) -> None:
         row = {
             "gen_ai.output.messages": '[{"role": "assistant", "content": "New content"}]',
             "gen_ai.response.text": "Old",
         }
         assert _get_last_output(row) == "New content"
 
-    def test_falls_back_to_old_format(self):
+    def test_falls_back_to_old_format(self) -> None:
         row = {"gen_ai.response.text": "Old response"}
         assert _get_last_output(row) == "Old response"
 
-    def test_returns_none_when_empty(self):
+    def test_returns_none_when_empty(self) -> None:
         row: dict[str, Any] = {}
         assert _get_last_output(row) is None
 
-    def test_finds_last_assistant_message(self):
+    def test_finds_last_assistant_message(self) -> None:
         row = {
             "gen_ai.output.messages": '[{"role": "assistant", "content": "First"}, {"role": "user", "content": "Question"}, {"role": "assistant", "content": "Last"}]'
         }
         assert _get_last_output(row) == "Last"
 
-    def test_skips_invalid_new_format(self):
+    def test_skips_invalid_new_format(self) -> None:
         row = {
             "gen_ai.output.messages": "invalid",
             "gen_ai.response.text": "Fallback",

--- a/tests/sentry/api/endpoints/test_organization_attribute_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_attribute_mappings.py
@@ -8,7 +8,7 @@ from sentry.testutils.cases import APITestCase
 class OrganizationAttributeMappingsEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-attribute-mappings"
 
-    def test_get_all_mappings(self):
+    def test_get_all_mappings(self) -> None:
         """Test that endpoint returns all attribute mappings when no filter is provided."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -41,7 +41,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
             assert "internalName" in item
             assert "searchType" in item
 
-    def test_known_span_mapping(self):
+    def test_known_span_mapping(self) -> None:
         """Test that a known span mapping is returned correctly."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -64,7 +64,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
         assert id_mapping["internalName"] == SPAN_ATTRIBUTE_DEFINITIONS["id"].internal_name
         assert id_mapping["searchType"] == SPAN_ATTRIBUTE_DEFINITIONS["id"].search_type
 
-    def test_known_log_mapping(self):
+    def test_known_log_mapping(self) -> None:
         """Test that a known log mapping is returned correctly."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -89,7 +89,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
         )
         assert message_mapping["searchType"] == OURLOG_ATTRIBUTE_DEFINITIONS["message"].search_type
 
-    def test_single_type_filter(self):
+    def test_single_type_filter(self) -> None:
         """Test filtering by a single type."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -103,7 +103,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
         for item in data:
             assert item["type"] == "spans"
 
-    def test_multiple_type_filter(self):
+    def test_multiple_type_filter(self) -> None:
         """Test filtering by multiple types using repeated query params."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -117,7 +117,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
         types_present = {item["type"] for item in data}
         assert types_present == {"spans", "logs"}
 
-    def test_invalid_type_returns_400(self):
+    def test_invalid_type_returns_400(self) -> None:
         """Test that an invalid type returns a 400 error."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -128,7 +128,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
         assert "detail" in data
         assert "invalid_type" in data["detail"]
 
-    def test_mixed_valid_invalid_types_returns_400(self):
+    def test_mixed_valid_invalid_types_returns_400(self) -> None:
         """Test that mixing valid and invalid types returns a 400 error."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -139,7 +139,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
         assert "detail" in data
         assert "invalid_type" in data["detail"]
 
-    def test_includes_secondary_aliases(self):
+    def test_includes_secondary_aliases(self) -> None:
         """Test that secondary aliases are included in the response."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -164,7 +164,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
             == SPAN_ATTRIBUTE_DEFINITIONS["description"].internal_name
         )
 
-    def test_camelcase_keys(self):
+    def test_camelcase_keys(self) -> None:
         """Test that response uses camelCase keys."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -183,7 +183,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
         assert "internal_name" not in item
         assert "search_type" not in item
 
-    def test_excludes_private_attributes(self):
+    def test_excludes_private_attributes(self) -> None:
         """Test that private attributes are not included in the response."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})
@@ -214,7 +214,7 @@ class OrganizationAttributeMappingsEndpointTest(APITestCase):
         )
         assert item_type_mapping is None
 
-    def test_duplicate_type_parameters_deduplicated(self):
+    def test_duplicate_type_parameters_deduplicated(self) -> None:
         """Test that duplicate type parameters are deduplicated."""
         self.login_as(user=self.user)
         url = reverse(self.endpoint, kwargs={"organization_id_or_slug": self.organization.slug})

--- a/tests/sentry/api/endpoints/test_organization_member_reinvite.py
+++ b/tests/sentry/api/endpoints/test_organization_member_reinvite.py
@@ -13,7 +13,7 @@ class OrganizationMemberReinviteTest(APITestCase):
     endpoint = "sentry-api-0-organization-member-reinvite"
     method = "put"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
         self.regular_user = self.create_user("member@email.com")
@@ -94,7 +94,7 @@ class OrganizationMemberReinviteTest(APITestCase):
 
         assert not mock_send_invite_email.mock_calls
 
-    def test_member_cannot_regenerate_pending_invite(self):
+    def test_member_cannot_regenerate_pending_invite(self) -> None:
         self.login_as(self.regular_user)
         self.organization.flags.disable_member_invite = True
         self.organization.save()
@@ -163,7 +163,7 @@ class OrganizationMemberReinviteTest(APITestCase):
         invite = OrganizationMemberInvite.objects.get(id=invite.id)
         assert invite.token_expired is False
 
-    def test_cannot_reinvite_unapproved_invite(self):
+    def test_cannot_reinvite_unapproved_invite(self) -> None:
         invite = self.create_member_invite(
             organization=self.organization,
             email="sencha@tea.com",
@@ -174,7 +174,7 @@ class OrganizationMemberReinviteTest(APITestCase):
         invite.update(invite_status=InviteStatus.REQUESTED_TO_JOIN.value)
         self.get_error_response(self.organization.slug, invite.id, status_code=400)
 
-    def test_cannot_regenerate_unapproved_invite(self):
+    def test_cannot_regenerate_unapproved_invite(self) -> None:
         invite = self.create_member_invite(
             organization=self.organization,
             email="sencha@tea.com",
@@ -189,7 +189,7 @@ class OrganizationMemberReinviteTest(APITestCase):
             self.organization.slug, invite.id, trigger_regenerate_token=1, status_code=400
         )
 
-    def test_other_org_admin_cannot_resend_invite(self):
+    def test_other_org_admin_cannot_resend_invite(self) -> None:
         org = self.create_organization(slug="other-org")
         other_admin_user = self.create_user("other-admin@email.com")
         self.create_member(organization=org, role="owner", user=other_admin_user)

--- a/tests/sentry/api/endpoints/test_organization_plugin_deprecation_info.py
+++ b/tests/sentry/api/endpoints/test_organization_plugin_deprecation_info.py
@@ -34,7 +34,7 @@ class OrganizationPluginDeprecationInfoEndpointTest(APITestCase):
             },
         )
 
-    def test_project_with_linked_issue(self):
+    def test_project_with_linked_issue(self) -> None:
         group_with_plugin = self.create_group(project=self.project_with_plugin)
         group_without_plugin = self.create_group(project=self.project_without_plugin)
 
@@ -56,7 +56,7 @@ class OrganizationPluginDeprecationInfoEndpointTest(APITestCase):
         assert len(affected_groups) == 1
         assert f"/issues/{group_with_plugin.id}/" in affected_groups[0]
 
-    def test_project_with_plugin_rule(self):
+    def test_project_with_plugin_rule(self) -> None:
         rule_action_data = [
             {
                 "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
@@ -82,7 +82,7 @@ class OrganizationPluginDeprecationInfoEndpointTest(APITestCase):
         expected_rule_url = f"/organizations/{self.organization.slug}/issues/alerts/rules/{self.project_with_plugin.slug}/{rule.id}/details/"
         assert expected_rule_url in affected_rules[0]
 
-    def test_permission_denied_for_non_member(self):
+    def test_permission_denied_for_non_member(self) -> None:
         non_member_user = self.create_user("non-member@example.com")
         self.login_as(non_member_user)
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -2996,7 +2996,7 @@ class OrganizationReleasesBaseEndpointGetProjectsTest(TestCase):
     def endpoint(self) -> OrganizationReleasesBaseEndpoint:
         return OrganizationReleasesBaseEndpoint()
 
-    def test_api_token_cross_organization_returns_empty(self):
+    def test_api_token_cross_organization_returns_empty(self) -> None:
         """
         Test that an API token with project:releases scope cannot access
         projects in an organization where the token owner is not a member.
@@ -3034,7 +3034,7 @@ class OrganizationReleasesBaseEndpointGetProjectsTest(TestCase):
         # Should return empty list - no cross-org access allowed
         assert projects == []
 
-    def test_api_token_same_organization_returns_projects(self):
+    def test_api_token_same_organization_returns_projects(self) -> None:
         """
         Test that an API token with project:releases scope CAN access
         projects in an organization where the token owner IS a member.

--- a/tests/sentry/api/endpoints/test_project_web_vitals_detection.py
+++ b/tests/sentry/api/endpoints/test_project_web_vitals_detection.py
@@ -7,7 +7,7 @@ class ProjectWebVitalsDetectionTest(APITestCase):
     endpoint = "sentry-api-0-project-web-vitals-detection"
     method = "get"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
@@ -23,7 +23,7 @@ class ProjectWebVitalsDetectionTest(APITestCase):
         assert response.data == {"status": "dispatched"}
         mock_dispatch.assert_called_once_with([self.project.id])
 
-    def test_get_requires_project_access(self):
+    def test_get_requires_project_access(self) -> None:
         other_user = self.create_user()
         self.login_as(user=other_user)
 

--- a/tests/sentry/api/helpers/test_default_symbol_sources.py
+++ b/tests/sentry/api/helpers/test_default_symbol_sources.py
@@ -20,11 +20,11 @@ SENTRY_BUILTIN_SOURCES_TEST = {
 
 
 class SetDefaultSymbolSourcesTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
 
-    def test_no_platform(self):
+    def test_no_platform(self) -> None:
         """Projects without a platform should keep their epoch defaults"""
         project = self.create_project(organization=self.organization, platform=None)
         # Capture epoch defaults before calling set_default_symbol_sources
@@ -36,7 +36,7 @@ class SetDefaultSymbolSourcesTest(TestCase):
         sources = project.get_option("sentry:builtin_symbol_sources")
         assert sources == epoch_defaults
 
-    def test_unknown_platform(self):
+    def test_unknown_platform(self) -> None:
         """Projects with unknown platforms should keep their epoch defaults"""
         project = self.create_project(organization=self.organization, platform="unknown-platform")
         # Capture epoch defaults before calling set_default_symbol_sources
@@ -48,7 +48,7 @@ class SetDefaultSymbolSourcesTest(TestCase):
         sources = project.get_option("sentry:builtin_symbol_sources")
         assert sources == epoch_defaults
 
-    def test_electron_platform(self):
+    def test_electron_platform(self) -> None:
         """Electron projects should get the correct default sources"""
         project = self.create_project(organization=self.organization, platform="electron")
         set_default_symbol_sources(project, self.organization)
@@ -59,7 +59,7 @@ class SetDefaultSymbolSourcesTest(TestCase):
         assert "microsoft" in sources
         assert "electron" in sources
 
-    def test_unity_platform(self):
+    def test_unity_platform(self) -> None:
         """Unity projects should get the correct default sources"""
         project = self.create_project(organization=self.organization, platform="unity")
         set_default_symbol_sources(project, self.organization)
@@ -74,7 +74,7 @@ class SetDefaultSymbolSourcesTest(TestCase):
         assert "nvidia" in sources
         assert "ubuntu" in sources
 
-    def test_organization_auto_fetch_from_project(self):
+    def test_organization_auto_fetch_from_project(self) -> None:
         """Function should auto-fetch organization from project if not provided"""
         project = self.create_project(organization=self.organization, platform="electron")
         # Don't pass organization parameter
@@ -88,12 +88,12 @@ class SetDefaultSymbolSourcesTest(TestCase):
 class PlatformRestrictedSymbolSourcesTest(TestCase):
     """Tests for platform-restricted symbol sources (e.g., console platforms)"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
-    def test_nintendo_switch_with_org_access(self):
+    def test_nintendo_switch_with_org_access(self) -> None:
         """Nintendo Switch project should get nintendo source if org has access"""
         # Grant org access to nintendo-switch console platform
         self.organization.update_option("sentry:enabled_console_platforms", ["nintendo-switch"])
@@ -106,7 +106,7 @@ class PlatformRestrictedSymbolSourcesTest(TestCase):
         assert "nintendo" in sources
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
-    def test_nintendo_switch_without_org_access(self):
+    def test_nintendo_switch_without_org_access(self) -> None:
         """Nintendo Switch project should NOT get nintendo source if org lacks access"""
         # Org has no enabled console platforms (default is empty list)
         project = self.create_project(organization=self.organization, platform="nintendo-switch")
@@ -116,7 +116,7 @@ class PlatformRestrictedSymbolSourcesTest(TestCase):
         # Should be empty since no sources are available (nintendo is restricted)
         assert sources == []
 
-    def test_unity_not_affected_by_console_restrictions(self):
+    def test_unity_not_affected_by_console_restrictions(self) -> None:
         """Unity projects should get sources regardless of console platform access"""
         # Org has no enabled console platforms
         project = self.create_project(organization=self.organization, platform="unity")

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -991,7 +991,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
         assert isinstance(search_filter, SearchFilter)
         assert search_filter.value.value == 'a"b'
 
-    def test_has_in_filter(self):
+    def test_has_in_filter(self) -> None:
         assert parse_search_query("release:['some_text', 'some_other_text']") == [
             SearchFilter(
                 key=SearchKey(name="release"),

--- a/tests/sentry/billing/platform/core/test_service.py
+++ b/tests/sentry/billing/platform/core/test_service.py
@@ -11,7 +11,7 @@ from sentry.billing.platform.core import BillingService, service_method
 class TestBillingService:
     """Tests for the BillingService base class and service_method decorator."""
 
-    def test_service_inheritance_and_basic_method(self):
+    def test_service_inheritance_and_basic_method(self) -> None:
         """Services inherit from BillingService and methods accept/return protobufs."""
 
         class TestService(BillingService):
@@ -26,7 +26,7 @@ class TestBillingService:
         assert isinstance(response, StringValue)
         assert response.value == "hello"
 
-    def test_service_method_validates_input_type(self):
+    def test_service_method_validates_input_type(self) -> None:
         """Service methods reject non-protobuf input."""
 
         class TestService(BillingService):
@@ -39,7 +39,7 @@ class TestBillingService:
         with pytest.raises(TypeError, match="expects a protobuf Message"):
             service.process("not a protobuf")  # type: ignore[arg-type]
 
-    def test_service_method_validates_return_type(self):
+    def test_service_method_validates_return_type(self) -> None:
         """Service methods reject non-protobuf return values."""
 
         class TestService(BillingService):
@@ -103,7 +103,7 @@ class TestBillingService:
             },
         )
 
-    def test_multiple_methods_on_same_service(self):
+    def test_multiple_methods_on_same_service(self) -> None:
         """A service can have multiple service methods."""
 
         class UserService(BillingService):

--- a/tests/sentry/billing/platform/services/usage/test_service.py
+++ b/tests/sentry/billing/platform/services/usage/test_service.py
@@ -20,11 +20,11 @@ from sentry.billing.platform.services.usage.service import (
 class TestUsageService:
     """Tests for the UsageService."""
 
-    def test_inherits_from_billing_service(self):
+    def test_inherits_from_billing_service(self) -> None:
         service = UsageService()
         assert isinstance(service, BillingService)
 
-    def test_get_usage_returns_empty_response(self):
+    def test_get_usage_returns_empty_response(self) -> None:
         service = UsageService()
         request = GetUsageRequest()
         response = service.get_usage(request)
@@ -33,7 +33,7 @@ class TestUsageService:
         assert list(response.days) == []
         assert list(response.seats) == []
 
-    def test_get_usage_with_populated_request(self):
+    def test_get_usage_with_populated_request(self) -> None:
         service = UsageService()
 
         start = Timestamp()
@@ -48,7 +48,7 @@ class TestUsageService:
         assert list(response.days) == []
         assert list(response.seats) == []
 
-    def test_get_usage_rejects_non_protobuf_input(self):
+    def test_get_usage_rejects_non_protobuf_input(self) -> None:
         service = UsageService()
 
         with pytest.raises(TypeError, match="expects a protobuf Message"):
@@ -70,5 +70,5 @@ class TestUsageService:
         )
         mock_metrics.timing.assert_called()
 
-    def test_package_reexport(self):
+    def test_package_reexport(self) -> None:
         assert UsageService is UsageServiceDirect

--- a/tests/sentry/cache/test_reconnectingmemcache.py
+++ b/tests/sentry/cache/test_reconnectingmemcache.py
@@ -24,7 +24,7 @@ def _make_cache(reconnect_age=300):
     return cache
 
 
-def test_each_thread_gets_own_client():
+def test_each_thread_gets_own_client() -> None:
     """Plain ThreadPoolExecutor workers should each get their own client."""
     cache = _make_cache()
     parent_client = cache._cache
@@ -44,7 +44,7 @@ def test_each_thread_gets_own_client():
     assert results == [False, False, False]
 
 
-def test_context_propagating_executor_isolates_clients():
+def test_context_propagating_executor_isolates_clients() -> None:
     """ContextPropagatingThreadPoolExecutor must not share the parent's
     pymemcache client across threads, even though it copies contextvars."""
     cache = _make_cache()
@@ -65,7 +65,7 @@ def test_context_propagating_executor_isolates_clients():
     assert results == [False, False, False]
 
 
-def test_same_thread_reuses_client():
+def test_same_thread_reuses_client() -> None:
     """Repeated accesses on the same thread should return the same client."""
     cache = _make_cache()
 
@@ -77,7 +77,7 @@ def test_same_thread_reuses_client():
     assert cache._class.call_count == 1
 
 
-def test_reconnects_after_age():
+def test_reconnects_after_age() -> None:
     """Client should be replaced after reconnect_age seconds."""
     cache = _make_cache(reconnect_age=10)
 
@@ -94,7 +94,7 @@ def test_reconnects_after_age():
     client1.close.assert_called_once()
 
 
-def test_workers_in_same_context_run_get_own_clients():
+def test_workers_in_same_context_run_get_own_clients() -> None:
     """Multiple workers spawned from the same context should each get
     independent clients (not share one via the copied contextvar)."""
     cache = _make_cache()

--- a/tests/sentry/conduit/test_auth.py
+++ b/tests/sentry/conduit/test_auth.py
@@ -11,7 +11,7 @@ from tests.sentry.utils.test_jwt import RS256_KEY, RS256_PUB_KEY
 RS256_KEY_B64 = base64.b64encode(RS256_KEY.encode()).decode()
 
 
-def test_generate_channel_id_is_valid_uuid():
+def test_generate_channel_id_is_valid_uuid() -> None:
     """Should generate a valid uuid."""
     channel_id = generate_channel_id()
 
@@ -21,12 +21,12 @@ def test_generate_channel_id_is_valid_uuid():
     assert channel_id.count("-") == 4
 
 
-def test_generate_channel_id_is_unique():
+def test_generate_channel_id_is_unique() -> None:
     """Should generate unique channel_ids."""
     assert generate_channel_id() != generate_channel_id()
 
 
-def test_generate_conduit_token_is_valid_jwt():
+def test_generate_conduit_token_is_valid_jwt() -> None:
     """Should generate a valid JWT token with RS256."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
@@ -52,7 +52,7 @@ def test_generate_conduit_token_is_valid_jwt():
     assert "exp" in claims
 
 
-def test_generate_conduit_token_has_expiration():
+def test_generate_conduit_token_has_expiration() -> None:
     """Token should expire in 10 minutes."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
@@ -83,7 +83,7 @@ def test_generate_conduit_token_has_expiration():
     assert exp_time == iat_time + 600
 
 
-def test_generate_conduit_token_uses_settings():
+def test_generate_conduit_token_uses_settings() -> None:
     """Should use settings when parameters are not provided."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
@@ -110,7 +110,7 @@ def test_generate_conduit_token_uses_settings():
         assert claims["aud"] == "test-audience"
 
 
-def test_generate_conduit_token_raises_when_missing():
+def test_generate_conduit_token_raises_when_missing() -> None:
     """Should raise an error if the private key is not configured."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
@@ -121,7 +121,7 @@ def test_generate_conduit_token_raises_when_missing():
         )
 
 
-def test_generate_conduit_token_raises_when_invalid_base64():
+def test_generate_conduit_token_raises_when_invalid_base64() -> None:
     """Should raise an error if the private key isn't valid base64."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
@@ -133,7 +133,7 @@ def test_generate_conduit_token_raises_when_invalid_base64():
         )
 
 
-def test_generate_conduit_token_raises_when_invalid_utf8():
+def test_generate_conduit_token_raises_when_invalid_utf8() -> None:
     """Should raise an error if the private key isn't valid UTF-8 after base64 decode."""
     org_id = 123
     channel_id = "ad342057-d66b-4ed4-ab01-3415dd2cb1ce"
@@ -146,7 +146,7 @@ def test_generate_conduit_token_raises_when_invalid_utf8():
         )
 
 
-def test_get_conduit_credentials_returns_all_credentials():
+def test_get_conduit_credentials_returns_all_credentials() -> None:
     """Should return a url, token, and channel_id."""
     gateway_url = "https://conduit.example.com"
     with patch("sentry.conduit.auth.settings") as mock_settings:
@@ -166,7 +166,7 @@ def test_get_conduit_credentials_returns_all_credentials():
         assert result.url == f"{gateway_url}/events/{org_id}"
 
 
-def test_get_conduit_credentials_uses_custom_url():
+def test_get_conduit_credentials_uses_custom_url() -> None:
     """Should use provided gateway_url instead of settings."""
     gateway_url = "https://custom.conduit.io"
     with patch("sentry.conduit.auth.settings") as mock_settings:
@@ -185,7 +185,7 @@ def test_get_conduit_credentials_uses_custom_url():
         assert result.url == f"{gateway_url}/events/{org_id}"
 
 
-def test_get_conduit_credentials_token_is_valid():
+def test_get_conduit_credentials_token_is_valid() -> None:
     """Generated token should be decodable with correct claims."""
     gateway_url = "https://conduit.example.com"
     with patch("sentry.conduit.auth.settings") as mock_settings:

--- a/tests/sentry/conduit/test_tasks.py
+++ b/tests/sentry/conduit/test_tasks.py
@@ -28,7 +28,7 @@ class GenerateJWTTest(TestCase):
         CONDUIT_PUBLISH_JWT_ISSUER="test-issuer",
         CONDUIT_PUBLISH_JWT_AUDIENCE="test-audience",
     )
-    def test_generate_jwt_uses_settings(self):
+    def test_generate_jwt_uses_settings(self) -> None:
         """Test that generate_jwt uses settings when parameters are not provided."""
         token = generate_jwt(subject="test-subject")
 
@@ -39,7 +39,7 @@ class GenerateJWTTest(TestCase):
         assert claims["aud"] == "test-audience"
         assert "exp" in claims
 
-    def test_generate_jwt_uses_provided_parameters(self):
+    def test_generate_jwt_uses_provided_parameters(self) -> None:
         """Test that generate_jwt uses parameters when provided."""
         token = generate_jwt(
             subject="test-subject",
@@ -55,7 +55,7 @@ class GenerateJWTTest(TestCase):
         assert claims["aud"] == "custom-audience"
         assert "exp" in claims
 
-    def test_generate_jwt_raises_when_secret_missing(self):
+    def test_generate_jwt_raises_when_secret_missing(self) -> None:
         """Test that generate_jwt raises ValueError when secret is not configured."""
         with pytest.raises(ValueError) as context:
             generate_jwt(subject="test-subject")
@@ -65,7 +65,7 @@ class GenerateJWTTest(TestCase):
 
 class GetTimestampTest(TestCase):
     @freeze_time("2025-01-01T12:00:00Z")
-    def test_get_timestamp_uses_current_time(self):
+    def test_get_timestamp_uses_current_time(self) -> None:
         """Test that get_timestamp generates a valid timestamp."""
         timestamp = get_timestamp()
 
@@ -73,7 +73,7 @@ class GetTimestampTest(TestCase):
         expected = datetime.datetime(2025, 1, 1, 12, 0, 0)
         assert dt == expected
 
-    def test_get_timestamp_uses_provided_datetime(self):
+    def test_get_timestamp_uses_provided_datetime(self) -> None:
         """Test that get_timestamp uses provided datetime."""
         custom_dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
         timestamp = get_timestamp(custom_dt)
@@ -90,7 +90,7 @@ class PublishDataTest(TestCase):
         CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
         CONDUIT_PUBLISH_URL="http://localhost:9093",
     )
-    def test_publish_data_success(self):
+    def test_publish_data_success(self) -> None:
         """Test successful publish request."""
         org_id = 123
         channel_id = str(uuid4())
@@ -131,7 +131,7 @@ class PublishDataTest(TestCase):
         CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
         CONDUIT_PUBLISH_URL="http://localhost:9093",
     )
-    def test_publish_data_retry_on_failure(self):
+    def test_publish_data_retry_on_failure(self) -> None:
         """Test that publish_data retries on RequestException."""
         org_id = 123
         channel_id = str(uuid4())
@@ -179,7 +179,7 @@ class PublishDataTest(TestCase):
         CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
         CONDUIT_PUBLISH_URL="http://localhost:9093",
     )
-    def test_publish_data_max_retries_exceeded(self):
+    def test_publish_data_max_retries_exceeded(self) -> None:
         """Test that publish_data raises after max retries."""
         org_id = 123
         channel_id = str(uuid4())
@@ -216,7 +216,7 @@ class PublishDataTest(TestCase):
         CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
         CONDUIT_PUBLISH_URL="http://localhost:9093",
     )
-    def test_publish_data_uses_custom_url(self):
+    def test_publish_data_uses_custom_url(self) -> None:
         """Test that publish_data uses provided publish_url."""
         org_id = 123
         channel_id = str(uuid4())

--- a/tests/sentry/core/endpoints/test_organization_member_invite_details.py
+++ b/tests/sentry/core/endpoints/test_organization_member_invite_details.py
@@ -254,7 +254,7 @@ class UpdateOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
 class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
     method = "delete"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.regular_user = self.create_user("member@email.com")
         self.curr_member = self.create_member(
@@ -269,7 +269,7 @@ class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
         )
         self.placeholder_om = self.approved_invite.organization_member
 
-    def test_simple(self):
+    def test_simple(self) -> None:
         with outbox_runner():
             self.get_success_response(self.organization.slug, self.approved_invite.id)
         assert not OrganizationMember.objects.filter(id=self.placeholder_om.id).exists()
@@ -279,7 +279,7 @@ class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
             event=audit_log.get_event_id("INVITE_REMOVE"),
         )
 
-    def test_reject_invite_request(self):
+    def test_reject_invite_request(self) -> None:
         invite_request = self.create_member_invite(
             organization=self.organization,
             email="oolong@tea.com",
@@ -296,7 +296,7 @@ class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
             event=audit_log.get_event_id("INVITE_REQUEST_REMOVE"),
         )
 
-    def test_member_can_remove_invite(self):
+    def test_member_can_remove_invite(self) -> None:
         """
         Members can remove invites that they sent
         """
@@ -310,7 +310,7 @@ class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
             event=audit_log.get_event_id("INVITE_REMOVE"),
         )
 
-    def test_member_can_remove_invite_request(self):
+    def test_member_can_remove_invite_request(self) -> None:
         """
         Members can remove invite requests that they sent
         """
@@ -331,7 +331,7 @@ class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
             event=audit_log.get_event_id("INVITE_REQUEST_REMOVE"),
         )
 
-    def test_member_cannot_remove_other_invite(self):
+    def test_member_cannot_remove_other_invite(self) -> None:
         """
         Members cannot remove invitations that they didn't send
         """
@@ -345,7 +345,7 @@ class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
         assert response.data["detail"] == "You cannot modify invitations sent by someone else."
         assert OrganizationMemberInvite.objects.filter(id=invite.id).exists()
 
-    def test_cannot_remove_idp_provisioned_invite(self):
+    def test_cannot_remove_idp_provisioned_invite(self) -> None:
         invite = self.create_member_invite(
             organization=self.organization,
             email="oolong@tea.com",
@@ -359,7 +359,7 @@ class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
         )
         assert OrganizationMemberInvite.objects.filter(id=invite.id).exists()
 
-    def test_cannot_remove_partnership_restricted_invite(self):
+    def test_cannot_remove_partnership_restricted_invite(self) -> None:
         invite = self.create_member_invite(
             organization=self.organization,
             email="oolong@tea.com",
@@ -375,7 +375,7 @@ class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
 
     @override_settings(SENTRY_SELF_HOSTED=False)
     @override_options({"superuser.read-write.ga-rollout": True})
-    def test_cannot_delete_as_superuser_read(self):
+    def test_cannot_delete_as_superuser_read(self) -> None:
         superuser = self.create_user(is_superuser=True)
         self.login_as(superuser, superuser=True)
 
@@ -384,14 +384,14 @@ class DeleteOrganizationMemberInviteTest(OrganizationMemberInviteTestBase):
 
     @override_settings(SENTRY_SELF_HOSTED=False)
     @override_options({"superuser.read-write.ga-rollout": True})
-    def test_can_delete_as_superuser_write(self):
+    def test_can_delete_as_superuser_write(self) -> None:
         superuser = self.create_user(is_superuser=True)
         self.add_user_permission(superuser, "superuser.write")
         self.login_as(superuser, superuser=True)
 
         self.get_success_response(self.organization.slug, self.approved_invite.id)
 
-    def test_non_member_user_cannot_hit_endpoint(self):
+    def test_non_member_user_cannot_hit_endpoint(self) -> None:
         other_user = self.create_user(email="other@email.com")
         self.login_as(other_user)
 

--- a/tests/sentry/core/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/core/endpoints/test_organization_member_team_details.py
@@ -763,7 +763,7 @@ class DeleteOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
             team=idp_team, organizationmember=member
         ).exists()
 
-    def test_unsubscribe_user_from_team_issues_legacy(self):
+    def test_unsubscribe_user_from_team_issues_legacy(self) -> None:
         """
         We have some legacy DB rows from before the GroupSubscription table had a team_id
         where there is a row for each user_id of all team members. If a user leaves the team

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -262,7 +262,7 @@ class ProjectDetailsTest(APITestCase):
             resp = self.get_success_response(self.project.organization.slug, self.project.slug)
             assert resp.data["isDynamicallySampled"]
 
-    def test_filter_options(self):
+    def test_filter_options(self) -> None:
         self.project.update_option("sentry:releases", ["1.*", "2.1.*"])
         self.project.update_option(
             "sentry:error_messages", ["TypeError*", "*: integer division by modulo or zero"]

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -14,7 +14,7 @@ from sentry.testutils.helpers.features import with_feature
 class OrganizationDashboardGenerateEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-dashboards-generate"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.url = f"/api/0/organizations/{self.organization.slug}/dashboards/generate/"

--- a/tests/sentry/dashboards/test_on_completion_hook.py
+++ b/tests/sentry/dashboards/test_on_completion_hook.py
@@ -94,7 +94,7 @@ INVALID_SERIALIZER_ARTIFACT = {
 
 
 class DashboardOnCompletionHookTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.project
 

--- a/tests/sentry/db/models/fields/encryption/test_base.py
+++ b/tests/sentry/db/models/fields/encryption/test_base.py
@@ -11,7 +11,7 @@ from sentry.utils.security.encrypted_field_key_store import FernetKeyStore
 ENCRYPTION_METHODS = ("plaintext", "fernet")
 
 
-def test_plaintext_encryption():
+def test_plaintext_encryption() -> None:
     with override_options({"database.encryption.method": "plaintext"}):
         field = EncryptedField()
 
@@ -28,7 +28,7 @@ def test_plaintext_encryption():
         assert isinstance(decrypted, bytes)
 
 
-def test_fernet_encryption_without_key():
+def test_fernet_encryption_without_key() -> None:
     """Test that Fernet encryption raises an error without key."""
     # Reset the key store to simulate no keys loaded
     original_keys = FernetKeyStore._keys
@@ -193,7 +193,7 @@ def test_fernet_non_utf_8_chars(fernet_keys_store):
         assert decrypted_text == invalid_utf_8
 
 
-def test_keysets_not_implemented():
+def test_keysets_not_implemented() -> None:
     """Test that keysets method raises NotImplementedError."""
     with override_options({"database.encryption.method": "keysets"}):
         field = EncryptedField()
@@ -227,7 +227,7 @@ def test_fernet_marker_handling(fernet_keys_store):
         assert decrypted == test_value.encode("utf-8")
 
 
-def test_data_without_marker():
+def test_data_without_marker() -> None:
     """Test handling of unencrypted data without method marker."""
     with override_options({"database.encryption.method": "plaintext"}):
         field = EncryptedField()
@@ -238,7 +238,7 @@ def test_data_without_marker():
         assert decrypted == plain_value
 
 
-def test_to_python_conversion():
+def test_to_python_conversion() -> None:
     """Test the to_python method."""
     field = EncryptedField()
 

--- a/tests/sentry/db/models/fields/encryption/test_encrypted_char_field.py
+++ b/tests/sentry/db/models/fields/encryption/test_encrypted_char_field.py
@@ -48,7 +48,7 @@ def test_encrypted_char_field_fernet_end_to_end(fernet_keys_store):
 
 
 @pytest.mark.django_db
-def test_encrypted_char_field_plaintext_end_to_end():
+def test_encrypted_char_field_plaintext_end_to_end() -> None:
     """Test complete save/retrieve cycle with EncryptedCharField."""
     with override_options({"database.encryption.method": "plaintext"}):
         test_data = "This is plain text data"
@@ -72,7 +72,7 @@ def test_encrypted_char_field_plaintext_end_to_end():
 
 
 @pytest.mark.django_db
-def test_encrypted_char_field_null_value():
+def test_encrypted_char_field_null_value() -> None:
     with override_options({"database.encryption.method": "plaintext"}):
         model_instance = EncryptedFieldModel.objects.create(data=None)
         assert model_instance.id is not None
@@ -90,7 +90,7 @@ def test_encrypted_char_field_null_value():
 
 
 @pytest.mark.django_db
-def test_encrypted_char_field_metrics_on_encrypt():
+def test_encrypted_char_field_metrics_on_encrypt() -> None:
     """Test that encryption sends metrics with correct tags including table_name."""
     with (
         override_options({"database.encryption.method": "plaintext"}),

--- a/tests/sentry/db/models/fields/encryption/test_encrypted_json_field.py
+++ b/tests/sentry/db/models/fields/encryption/test_encrypted_json_field.py
@@ -10,7 +10,7 @@ from sentry.utils import json
 ENCRYPTION_METHODS = ("plaintext", "fernet")
 
 
-def test_encrypted_json_field_plaintext_encryption():
+def test_encrypted_json_field_plaintext_encryption() -> None:
     """Test EncryptedJSONField encryption with plaintext method."""
     with override_options({"database.encryption.method": "plaintext"}):
         field = EncryptedJSONField()
@@ -86,7 +86,7 @@ def test_encrypted_json_field_roundtrip(encryption_method, test_value, fernet_ke
         assert decrypted == test_value
 
 
-def test_encrypted_json_field_fallback_unencrypted():
+def test_encrypted_json_field_fallback_unencrypted() -> None:
     """Test that EncryptedJSONField falls back to unencrypted JSON."""
     field = EncryptedJSONField()
 
@@ -98,7 +98,7 @@ def test_encrypted_json_field_fallback_unencrypted():
     assert decrypted == {"legacy": "data", "from": "migration"}
 
 
-def test_encrypted_json_field_fallback_with_similar_structure():
+def test_encrypted_json_field_fallback_with_similar_structure() -> None:
     """Test fallback when JSON has similar but not exact encryption structure."""
     field = EncryptedJSONField()
 
@@ -157,7 +157,7 @@ def test_encrypted_json_field_fernet_end_to_end(fernet_keys_store):
 
 
 @pytest.mark.django_db
-def test_encrypted_json_field_plaintext_end_to_end():
+def test_encrypted_json_field_plaintext_end_to_end() -> None:
     """Test complete save/retrieve cycle with EncryptedJSONField and plaintext."""
     with override_options({"database.encryption.method": "plaintext"}):
         test_data = {"plain": "data", "numbers": [1, 2, 3]}

--- a/tests/sentry/db/models/fields/encryption/test_encrypted_text_field.py
+++ b/tests/sentry/db/models/fields/encryption/test_encrypted_text_field.py
@@ -32,7 +32,7 @@ class EncryptedTextFieldWithDefaultModel(models.Model):
 
 
 @pytest.mark.django_db
-def test_encrypted_text_field_default_method():
+def test_encrypted_text_field_default_method() -> None:
     """Test that EncryptedTextField works with the default encryption method (plaintext)."""
     test_data = "This is sensitive data using default encryption method"
 
@@ -85,7 +85,7 @@ def test_encrypted_text_field_fernet_end_to_end(fernet_keys_store):
 
 
 @pytest.mark.django_db
-def test_encrypted_text_field_plaintext_end_to_end():
+def test_encrypted_text_field_plaintext_end_to_end() -> None:
     """Test complete save/retrieve cycle with EncryptedTextField using plaintext."""
     with override_options({"database.encryption.method": "plaintext"}):
         test_data = "This is plain text data"
@@ -109,7 +109,7 @@ def test_encrypted_text_field_plaintext_end_to_end():
 
 
 @pytest.mark.django_db
-def test_encrypted_text_field_null_value():
+def test_encrypted_text_field_null_value() -> None:
     """Test that null values are handled correctly."""
     with override_options({"database.encryption.method": "plaintext"}):
         model_instance = EncryptedTextFieldModel.objects.create(data=None)
@@ -128,7 +128,7 @@ def test_encrypted_text_field_null_value():
 
 
 @pytest.mark.django_db
-def test_encrypted_text_field_long_text():
+def test_encrypted_text_field_long_text() -> None:
     """Test that EncryptedTextField handles long text correctly (TextField behavior)."""
     with override_options({"database.encryption.method": "plaintext"}):
         # Create a long text that would exceed typical varchar limits
@@ -143,7 +143,7 @@ def test_encrypted_text_field_long_text():
 
 
 @pytest.mark.django_db
-def test_encrypted_text_field_empty_string():
+def test_encrypted_text_field_empty_string() -> None:
     """Test that empty strings are handled correctly."""
     with override_options({"database.encryption.method": "plaintext"}):
         model_instance = EncryptedTextFieldModel.objects.create(data="")
@@ -154,7 +154,7 @@ def test_encrypted_text_field_empty_string():
 
 
 @pytest.mark.django_db
-def test_encrypted_text_field_with_callable_default():
+def test_encrypted_text_field_with_callable_default() -> None:
     """Test that EncryptedTextField works with a callable default (like generate_token)."""
     with override_options({"database.encryption.method": "plaintext"}):
         # Create instance without providing 'secret' - should use callable default
@@ -181,7 +181,7 @@ def test_encrypted_text_field_with_callable_default():
 
 
 @pytest.mark.django_db
-def test_encrypted_text_field_with_static_default():
+def test_encrypted_text_field_with_static_default() -> None:
     """Test that EncryptedTextField works with a static default value."""
     with override_options({"database.encryption.method": "plaintext"}):
         # Create instance without providing 'static_default' - should use static default
@@ -206,7 +206,7 @@ def test_encrypted_text_field_with_static_default():
 
 
 @pytest.mark.django_db
-def test_encrypted_text_field_callable_default_generates_unique_values():
+def test_encrypted_text_field_callable_default_generates_unique_values() -> None:
     """Test that callable default generates unique values for each instance."""
     with override_options({"database.encryption.method": "plaintext"}):
         instance1 = EncryptedTextFieldWithDefaultModel.objects.create()

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -584,7 +584,7 @@ class GroupHashCachingTest(TestCase):
             cache_use_expected=False,
         )
 
-    def test_cache_invalidation_error_handling(self):
+    def test_cache_invalidation_error_handling(self) -> None:
         # We don't want the cache invalidation triggered by saving, updating, or deleting a
         # grouphash to ever make those processes crash
 

--- a/tests/sentry/explore/migrations/test_0007_update_numeric_attrs_to_bools.py
+++ b/tests/sentry/explore/migrations/test_0007_update_numeric_attrs_to_bools.py
@@ -118,7 +118,7 @@ class UpdateNumericToBooleanTest(TestMigrations, SnubaTestCase, SpanTestCase):
 
         return super().setup_before_migration(apps)
 
-    def test_migration(self):
+    def test_migration(self) -> None:
         # Test state after migration
         self.query_1.refresh_from_db()
         assert self.query_1.query == {

--- a/tests/sentry/explore/translation/test_discover_translation.py
+++ b/tests/sentry/explore/translation/test_discover_translation.py
@@ -26,7 +26,7 @@ class DiscoverToExploreTranslationTest(TestCase):
 
         return discover_saved_query
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization(owner=self.user)
@@ -58,7 +58,7 @@ class DiscoverToExploreTranslationTest(TestCase):
             query=self.existing_explore_query,
         )
 
-    def test_translate_simple_discover_to_explore_query(self):
+    def test_translate_simple_discover_to_explore_query(self) -> None:
         self.simple_query = {
             "query": "event.type:transaction",
             "range": "14d",
@@ -93,7 +93,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert query["aggregateOrderby"] is None
         assert query["orderby"] == "-timestamp"
 
-    def test_translate_multiple_axis_discover_to_explore_query(self):
+    def test_translate_multiple_axis_discover_to_explore_query(self) -> None:
         self.multiple_axis_query = {
             "query": "",
             "range": "14d",
@@ -123,7 +123,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert query["aggregateOrderby"] is None
         assert query["orderby"] == "-timestamp"
 
-    def test_translate_function_orderby_discover_to_explore_query(self):
+    def test_translate_function_orderby_discover_to_explore_query(self) -> None:
         self.function_orderby_query = {
             "query": "",
             "range": "14d",
@@ -154,7 +154,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert query["aggregateOrderby"] == "-p50(span.duration)"
         assert query["orderby"] is None
 
-    def test_translate_filter_swap_discover_to_explore_query(self):
+    def test_translate_filter_swap_discover_to_explore_query(self) -> None:
         self.filter_swap_query = {
             "query": "geo.country_code:CA AND geo.city:Toronto",
             "range": "14d",
@@ -184,7 +184,9 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert query["aggregateOrderby"] is None
         assert query["orderby"] == "-timestamp"
 
-    def test_translate_drop_swap_function_field_orderby_filter_discover_to_explore_query(self):
+    def test_translate_drop_swap_function_field_orderby_filter_discover_to_explore_query(
+        self,
+    ) -> None:
         self.drop_swap_function_field_orderby_filter_query = {
             "query": "platform.name:python AND count_miserable(users):>100",
             "range": "14d",
@@ -241,7 +243,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert query["aggregateOrderby"] is None
         assert query["orderby"] is None
 
-    def test_translate_non_default_display_discover_to_explore_query(self):
+    def test_translate_non_default_display_discover_to_explore_query(self) -> None:
         self.non_default_display_query = {
             "query": "",
             "range": "14d",
@@ -271,7 +273,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert query["aggregateOrderby"] is None
         assert query["orderby"] == "-timestamp"
 
-    def test_translate_start_end_time_discover_to_explore_query(self):
+    def test_translate_start_end_time_discover_to_explore_query(self) -> None:
         self.start_end_time_query = {
             "query": "",
             "start": "2025-01-01",
@@ -294,7 +296,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert new_explore_query.query["end"] == "2025-01-20"
         assert new_explore_query.query["environment"] == [self.env.name]
 
-    def test_translate_equation_indexed_orderby_discover_to_explore_query(self):
+    def test_translate_equation_indexed_orderby_discover_to_explore_query(self) -> None:
         self.equation_indexed_orderby_query = {
             "query": "",
             "range": "14d",
@@ -317,7 +319,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert query["aggregateOrderby"] == "-equation|count(span.duration) + 5"
         assert query["orderby"] is None
 
-    def test_translate_discover_query_to_explore_query_with_existing_explore_query(self):
+    def test_translate_discover_query_to_explore_query_with_existing_explore_query(self) -> None:
         self.existing_explore_discover_query = {
             "query": "event.type:transaction",
             "range": "14d",
@@ -348,7 +350,7 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert query["aggregateOrderby"] is None
         assert query["orderby"] == "-timestamp"
 
-    def test_translate_dicover_query_with_count_web_vitals_orderby(self):
+    def test_translate_dicover_query_with_count_web_vitals_orderby(self) -> None:
         self.count_web_vitals_query = {
             "query": "",
             "range": "14d",

--- a/tests/sentry/incidents/endpoints/test_organization_detector_anomaly_data.py
+++ b/tests/sentry/incidents/endpoints/test_organization_detector_anomaly_data.py
@@ -13,7 +13,7 @@ pytestmark = [requires_snuba]
 class OrganizationDetectorAnomalyDataEndpointTest(BaseWorkflowTest, APITestCase):
     endpoint = "sentry-api-0-organization-detector-anomaly-data"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -38,7 +38,7 @@ class OrganizationDetectorAnomalyDataEndpointTest(BaseWorkflowTest, APITestCase)
             data_source=self.data_source, detector=self.detector
         )
 
-    def test_missing_parameters(self):
+    def test_missing_parameters(self) -> None:
         response = self.get_error_response(
             self.organization.slug, self.detector.id, end="1729179000.0", status_code=400
         )
@@ -49,7 +49,7 @@ class OrganizationDetectorAnomalyDataEndpointTest(BaseWorkflowTest, APITestCase)
         )
         assert response.data["detail"] == "start and end parameters are required"
 
-    def test_invalid_parameters(self):
+    def test_invalid_parameters(self) -> None:
         response = self.get_error_response(
             self.organization.slug,
             self.detector.id,
@@ -59,7 +59,7 @@ class OrganizationDetectorAnomalyDataEndpointTest(BaseWorkflowTest, APITestCase)
         )
         assert response.data["detail"] == "start and end must be valid timestamps"
 
-    def test_no_subscription_found(self):
+    def test_no_subscription_found(self) -> None:
         # Delete the data source to simulate missing subscription
         DataSourceDetector.objects.filter(detector=self.detector).delete()
         response = self.get_error_response(
@@ -112,7 +112,7 @@ class OrganizationDetectorAnomalyDataEndpointTest(BaseWorkflowTest, APITestCase)
         assert mock_get_data.call_args.kwargs["start"] == 1729178100.0
         assert mock_get_data.call_args.kwargs["end"] == 1729179000.0
 
-    def test_permission_denied(self):
+    def test_permission_denied(self) -> None:
         self.login_as(self.create_user())
 
         self.get_error_response(
@@ -123,7 +123,7 @@ class OrganizationDetectorAnomalyDataEndpointTest(BaseWorkflowTest, APITestCase)
             status_code=403,
         )
 
-    def test_invalid_detector_id(self):
+    def test_invalid_detector_id(self) -> None:
         """Test that non-numeric detector IDs return 404"""
         self.get_error_response(
             self.organization.slug,
@@ -139,7 +139,7 @@ class OrganizationDetectorAnomalyDataLegacyAlertTest(BaseWorkflowTest, APITestCa
 
     endpoint = "sentry-api-0-organization-detector-anomaly-data"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -189,7 +189,7 @@ class OrganizationDetectorAnomalyDataLegacyAlertTest(BaseWorkflowTest, APITestCa
         # Verify the subscription passed to seer is the one linked to the alert rule
         assert mock_get_data.call_args.kwargs["subscription"] == self.subscription
 
-    def test_legacy_alert_not_found(self):
+    def test_legacy_alert_not_found(self) -> None:
         """Test that non-existent alert rule ID returns 404."""
         self.get_error_response(
             self.organization.slug,
@@ -200,7 +200,7 @@ class OrganizationDetectorAnomalyDataLegacyAlertTest(BaseWorkflowTest, APITestCa
             status_code=404,
         )
 
-    def test_legacy_alert_missing_subscription(self):
+    def test_legacy_alert_missing_subscription(self) -> None:
         """Test error when alert rule has no query subscription."""
         # Delete the subscription to simulate missing subscription
         self.subscription.delete()
@@ -232,7 +232,7 @@ class OrganizationDetectorAnomalyDataLegacyAlertTest(BaseWorkflowTest, APITestCa
         )
         assert response.data["detail"] == "Unable to fetch anomaly detection threshold data"
 
-    def test_legacy_alert_permission_denied(self):
+    def test_legacy_alert_permission_denied(self) -> None:
         """Test that users without access get 403."""
         self.login_as(self.create_user())
 

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -916,7 +916,7 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
         # Verify the mock was called with correct project IDs
         mock_are_any_projects_error_upsampled.assert_called_once_with([self.project.id])
 
-    def test_update_marks_query_as_user_updated_when_snapshot_exists(self):
+    def test_update_marks_query_as_user_updated_when_snapshot_exists(self) -> None:
         alert_rule = self.create_alert_rule()
 
         alert_rule.snuba_query.query_snapshot = {
@@ -941,7 +941,7 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
         assert updated_alert_rule.snuba_query.query_snapshot is not None
         assert updated_alert_rule.snuba_query.query_snapshot.get("user_updated") is True
 
-    def test_update_does_not_mark_user_updated_when_no_snapshot(self):
+    def test_update_does_not_mark_user_updated_when_no_snapshot(self) -> None:
         alert_rule = self.create_alert_rule()
 
         alert_rule.snuba_query.query_snapshot = None

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -7,7 +7,7 @@ from sentry.testutils.cases import TestCase
 
 
 class AutoResolveSnapshotIncidentsTest(TestCase):
-    def test_resolves_open_incidents(self):
+    def test_resolves_open_incidents(self) -> None:
         alert_rule = self.create_alert_rule()
         AlertRule.objects.filter(id=alert_rule.id).update(status=AlertRuleStatus.SNAPSHOT.value)
         incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.OPEN.value)

--- a/tests/sentry/incidents/utils/test_process_update_helpers.py
+++ b/tests/sentry/incidents/utils/test_process_update_helpers.py
@@ -14,7 +14,7 @@ from sentry.testutils.cases import TestCase
 
 
 class InvalidIssueSearchQueryTest(TestCase):
-    def test_exception_stores_and_renders_invalid_ids(self):
+    def test_exception_stores_and_renders_invalid_ids(self) -> None:
         invalid_ids = ["PROJECT-123", "PROJECT-456"]
         exc = InvalidIssueSearchQuery(invalid_ids)
 
@@ -25,7 +25,7 @@ class InvalidIssueSearchQueryTest(TestCase):
 
 
 class GetAggregationValueTest(TestCase):
-    def test_missing_issue_ids_returns_none_gracefully(self):
+    def test_missing_issue_ids_returns_none_gracefully(self) -> None:
         now = timezone.now()
         start = now - timedelta(minutes=5)
         end = now

--- a/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
+++ b/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
@@ -348,12 +348,12 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         assert self.endpoint_cls._validate_sender(self.valid_request)
 
     @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test__validate_request(self):
+    def test__validate_request(self) -> None:
         request = self.factory.get(self.path)
         assert not self.endpoint_cls._validate_request(request)
 
     @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test__validate_header_data(self):
+    def test__validate_header_data(self) -> None:
         self.org_integration.update(status=ObjectStatus.DISABLED)
         header_kwargs = SiloHttpHeaders(
             HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
@@ -362,7 +362,7 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         assert not self.endpoint_cls._validate_request(request)
 
     @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test__validate_organization_integration(self):
+    def test__validate_organization_integration(self) -> None:
         header_kwargs = SiloHttpHeaders(
             HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION="None",
         )

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -85,7 +85,7 @@ class BaseOrganizationCodingAgentsTest(APITestCase):
 
     endpoint = "sentry-api-0-organization-coding-agents"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
         self._setup_mock_integration()
@@ -196,7 +196,7 @@ class BaseOrganizationCodingAgentsTest(APITestCase):
 
 
 class StoreCodingAgentStatesToSeerTest(APITestCase):
-    def test_batch_function_posts_correct_payload(self):
+    def test_batch_function_posts_correct_payload(self) -> None:
         from datetime import UTC, datetime
         from unittest.mock import MagicMock, patch
 
@@ -244,7 +244,7 @@ class StoreCodingAgentStatesToSeerTest(APITestCase):
 class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
     """Test class for GET endpoint functionality."""
 
-    def test_no_integrations(self):
+    def test_no_integrations(self) -> None:
         """Test GET request with no coding agent integrations."""
         organization = self.create_organization(owner=self.user)
 
@@ -253,7 +253,7 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         assert response.status_code == 200
         assert response.data["integrations"] == []
 
-    def test_with_mock_integration(self):
+    def test_with_mock_integration(self) -> None:
         """Test GET request with mocked coding agent integration."""
         organization = self.create_organization(owner=self.user)
 
@@ -332,7 +332,7 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         assert "integrations" in response.data
         assert len(response.data["integrations"]) == 0
 
-    def test_github_copilot_shown_with_feature_flag(self):
+    def test_github_copilot_shown_with_feature_flag(self) -> None:
         """Test GET endpoint shows GitHub Copilot when feature flag is enabled."""
         with (
             self.feature("organizations:integrations-github-copilot-agent"),
@@ -417,7 +417,7 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
                 user_id=self.user.id
             )
 
-    def test_github_copilot_not_shown_without_feature_flag(self):
+    def test_github_copilot_not_shown_without_feature_flag(self) -> None:
         """Test GET endpoint does not show GitHub Copilot without feature flag."""
         with (
             self.feature({"organizations:integrations-github-copilot-agent": False}),
@@ -432,7 +432,7 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
 class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCodingAgentsTest):
     """Test class for POST endpoint parameter validation."""
 
-    def test_missing_integration_id_and_provider(self):
+    def test_missing_integration_id_and_provider(self) -> None:
         """Test POST endpoint with missing integration_id and provider."""
         data = {"run_id": 123}
         response = self.get_error_response(
@@ -443,7 +443,7 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
             response.data["non_field_errors"]
         )
 
-    def test_both_integration_id_and_provider_provided(self):
+    def test_both_integration_id_and_provider_provided(self) -> None:
         """Test POST endpoint with both integration_id and provider provided."""
         data = {"run_id": 123, "integration_id": "123", "provider": "github_copilot"}
         response = self.get_error_response(
@@ -454,7 +454,7 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
             response.data["non_field_errors"]
         )
 
-    def test_invalid_integration_id(self):
+    def test_invalid_integration_id(self) -> None:
         """Test POST endpoint with invalid integration_id."""
         data = {"integration_id": "invalid_id", "run_id": 123}
 
@@ -463,7 +463,7 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
         )
         assert "integration_id" in response.data
 
-    def test_invalid_provider(self):
+    def test_invalid_provider(self) -> None:
         """Test POST endpoint with invalid provider (not enabled)."""
         data = {"provider": "github_copilot", "run_id": 123}
 
@@ -472,7 +472,7 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
         )
         assert "GitHub Copilot is not enabled" in response.data["detail"]
 
-    def test_non_coding_agent_integration(self):
+    def test_non_coding_agent_integration(self) -> None:
         """Test POST endpoint with non-coding agent integration."""
         # Create a non-coding agent integration (e.g., Slack)
         slack_integration = self.create_integration(

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_channel_validate.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_channel_validate.py
@@ -23,7 +23,7 @@ class BaseChannelValidateTest(APITestCase):
 
 @control_silo_test
 class SlackChannelValidateTest(BaseChannelValidateTest):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -47,7 +47,7 @@ class SlackChannelValidateTest(BaseChannelValidateTest):
 
 @control_silo_test
 class MsTeamsChannelValidateTest(BaseChannelValidateTest):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -70,7 +70,7 @@ class MsTeamsChannelValidateTest(BaseChannelValidateTest):
 
 @control_silo_test
 class DiscordChannelValidateTest(BaseChannelValidateTest):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -129,18 +129,18 @@ class DiscordChannelValidateTest(BaseChannelValidateTest):
 
 @control_silo_test
 class ChannelValidateErrorCasesTest(BaseChannelValidateTest):
-    def test_missing_channel_param(self):
+    def test_missing_channel_param(self) -> None:
         integration = self.create_integration(
             organization=self.organization, provider="slack", name="Slack", external_id="slack:1"
         )
         resp = self.get_error_response(self.organization.slug, integration.id, status_code=400)
         assert "channel" in resp.data
 
-    def test_integration_not_found(self):
+    def test_integration_not_found(self) -> None:
         resp = self.get_error_response(self.organization.slug, 99999, status_code=404, channel="#x")
         assert resp.status_code == 404
 
-    def test_unsupported_provider(self):
+    def test_unsupported_provider(self) -> None:
         integration = self.create_integration(
             organization=self.organization, provider="github", name="GitHub", external_id="github:1"
         )

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_channels.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_channels.py
@@ -160,11 +160,11 @@ class OrganizationIntegrationChannelsMsTeamsTest(OrganizationIntegrationChannels
 
 @control_silo_test
 class OrganizationIntegrationChannelsErrorTest(OrganizationIntegrationChannelsTest):
-    def test_integration_not_found(self):
+    def test_integration_not_found(self) -> None:
         response = self.get_error_response(self.organization.slug, 9999, status_code=404)
         assert response.status_code == 404
 
-    def test_unsupported_provider(self):
+    def test_unsupported_provider(self) -> None:
         integration = self.create_integration(
             organization=self.organization,
             provider="github",

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -62,7 +62,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
     # ── Provider metadata ────────────────────────────────────────────
 
-    def test_provider_metadata(self):
+    def test_provider_metadata(self) -> None:
         p = self.provider()
         assert p.key == PROVIDER_KEY
         assert p.name == PROVIDER_NAME
@@ -71,7 +71,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
     # ── build_integration ────────────────────────────────────────────
 
-    def test_build_integration(self):
+    def test_build_integration(self) -> None:
         mock_cls, mock_client = _mock_client_class()
         state: Mapping[str, Any] = {"api_key": "sk-ant-test-api-key-123"}
 
@@ -89,7 +89,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         assert metadata["agent_id"] is None
         assert metadata["agent_version"] is None
 
-    def test_build_integration_creates_unique_external_ids(self):
+    def test_build_integration_creates_unique_external_ids(self) -> None:
         mock_cls, _ = _mock_client_class()
         state: Mapping[str, Any] = {"api_key": "sk-ant-test-api-key-123"}
 
@@ -99,11 +99,11 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
         assert r1["external_id"] != r2["external_id"]
 
-    def test_build_integration_missing_api_key(self):
+    def test_build_integration_missing_api_key(self) -> None:
         with pytest.raises(IntegrationConfigurationError, match="Missing API key"):
             self.provider().build_integration({})
 
-    def test_build_integration_invalid_api_key(self):
+    def test_build_integration_invalid_api_key(self) -> None:
         mock_cls, _ = _mock_client_class(validate_return=False)
 
         with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
@@ -113,7 +113,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             ):
                 self.provider().build_integration({"api_key": "invalid-key"})
 
-    def test_build_integration_validation_network_error(self):
+    def test_build_integration_validation_network_error(self) -> None:
         mock_cls, _ = _mock_client_class(validate_side_effect=Exception("Network error"))
 
         with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
@@ -125,7 +125,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
     # ── get_client ───────────────────────────────────────────────────
 
-    def test_get_client(self):
+    def test_get_client(self) -> None:
         mock_cls, mock_client = _mock_client_class()
         integration = self.create_provider_integration(
             provider="claude_code",
@@ -147,7 +147,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_version=None,
         )
 
-    def test_get_client_with_environment_and_workspace(self):
+    def test_get_client_with_environment_and_workspace(self) -> None:
         mock_cls, mock_client = _mock_client_class()
         integration = self.create_provider_integration(
             provider="claude_code",
@@ -174,7 +174,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_version="v1",
         )
 
-    def test_get_client_class_not_configured(self):
+    def test_get_client_class_not_configured(self) -> None:
         installation = self._create_installation()
 
         with self.settings(CLAUDE_CODE_CLIENT_CLASS=None):
@@ -183,7 +183,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
     # ── Property getters ─────────────────────────────────────────────
 
-    def test_property_getters(self):
+    def test_property_getters(self) -> None:
         installation = self._create_installation(
             api_key="sk-ant-prop-key",
             environment_id="env-prop-123",
@@ -192,31 +192,31 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         assert installation.api_key == "sk-ant-prop-key"
         assert installation.model.metadata["environment_id"] == "env-prop-123"
 
-    def test_environment_id_defaults_to_none(self):
+    def test_environment_id_defaults_to_none(self) -> None:
         installation = self._create_installation()
         assert installation.model.metadata.get("environment_id") is None
 
     # ── update_organization_config ───────────────────────────────────
 
-    def test_update_organization_config_sets_environment_id(self):
+    def test_update_organization_config_sets_environment_id(self) -> None:
         installation = self._create_installation()
         installation.update_organization_config({"environment_id": "env-new-456"})
 
         assert installation.model.metadata["environment_id"] == "env-new-456"
 
-    def test_update_organization_config_clears_environment_id(self):
+    def test_update_organization_config_clears_environment_id(self) -> None:
         installation = self._create_installation(environment_id="env-old")
         installation.update_organization_config({"environment_id": ""})
 
         assert installation.model.metadata["environment_id"] is None
 
-    def test_update_organization_config_sets_workspace_name(self):
+    def test_update_organization_config_sets_workspace_name(self) -> None:
         installation = self._create_installation()
         installation.update_organization_config({"workspace_name": "my-workspace"})
 
         assert installation.model.metadata["workspace_name"] == "my-workspace"
 
-    def test_update_organization_config_clears_workspace_name(self):
+    def test_update_organization_config_clears_workspace_name(self) -> None:
         installation = self._create_installation(workspace_name="old-ws")
         installation.update_organization_config({"workspace_name": ""})
 
@@ -224,7 +224,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
     # ── get_config_data ──────────────────────────────────────────────
 
-    def test_get_config_data(self):
+    def test_get_config_data(self) -> None:
         installation = self._create_installation(
             environment_id="env-cfg",
             workspace_name="ws-cfg",
@@ -234,7 +234,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         assert data["environment_id"] == "env-cfg"
         assert data["workspace_name"] == "ws-cfg"
 
-    def test_get_config_data_defaults_to_empty_strings_except_workspace(self):
+    def test_get_config_data_defaults_to_empty_strings_except_workspace(self) -> None:
         installation = self._create_installation()
         data = installation.get_config_data()
 
@@ -306,7 +306,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
         return installation, mock_client, mock_cls, request
 
-    def test_launch_calls_client_with_webhook_url(self):
+    def test_launch_calls_client_with_webhook_url(self) -> None:
         installation, mock_client, mock_cls, request = self._setup_launch()
 
         with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
@@ -319,7 +319,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         assert "/extensions/claude_code/" in call_kwargs["webhook_url"]
         assert call_kwargs["request"] is request
 
-    def test_launch_updates_environment_id_when_changed(self):
+    def test_launch_updates_environment_id_when_changed(self) -> None:
         """When the client resolves a new environment_id, it should be persisted."""
         installation, mock_client, mock_cls, request = self._setup_launch(
             environment_id=None,
@@ -331,7 +331,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
         assert installation.model.metadata["environment_id"] == "env-resolved-123"
 
-    def test_launch_does_not_update_metadata_when_unchanged(self):
+    def test_launch_does_not_update_metadata_when_unchanged(self) -> None:
         """When client IDs match stored ones, metadata should not be persisted."""
         installation, mock_client, mock_cls, request = self._setup_launch(
             environment_id="env-same",
@@ -348,7 +348,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
         mock_persist.assert_not_called()
 
-    def test_launch_does_not_update_when_client_has_no_ids(self):
+    def test_launch_does_not_update_when_client_has_no_ids(self) -> None:
         """When client IDs are None, no update should happen."""
         installation, mock_client, mock_cls, request = self._setup_launch(
             environment_id="env-existing",
@@ -365,7 +365,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
         mock_persist.assert_not_called()
 
-    def test_launch_updates_agent_id_when_changed(self):
+    def test_launch_updates_agent_id_when_changed(self) -> None:
         """When the client resolves a new agent, it should be persisted."""
         installation, mock_client, mock_cls, request = self._setup_launch(
             agent_id=None,
@@ -379,7 +379,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         assert installation.model.metadata["agent_id"] == "agent-new-123"
         assert installation.model.metadata["agent_version"] == "v-new"
 
-    def test_launch_updates_both_environment_and_agent_when_changed(self):
+    def test_launch_updates_both_environment_and_agent_when_changed(self) -> None:
         """When both IDs change, both should be persisted in a single update."""
         installation, mock_client, mock_cls, request = self._setup_launch(
             environment_id=None,

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -143,7 +143,7 @@ def test_build_integration_stores_api_key_and_webhook_secret(provider):
 class CursorIntegrationTest(IntegrationTestCase):
     provider = CursorAgentIntegrationProvider
 
-    def test_build_integration(self):
+    def test_build_integration(self) -> None:
         state: Mapping[str, Any] = {"config": {"api_key": "test_api_key_123"}}
         fake_uuid = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
@@ -167,21 +167,21 @@ class CursorIntegrationTest(IntegrationTestCase):
         assert metadata["api_key"] == "test_api_key_123"
         assert metadata["webhook_secret"] == "secret123"
 
-    def test_build_integration_missing_config(self):
+    def test_build_integration_missing_config(self) -> None:
         """Test that build_integration raises error when config is missing"""
         state: Mapping[str, Any] = {}
 
         with pytest.raises(IntegrationConfigurationError, match="Missing configuration data"):
             self.provider().build_integration(state)
 
-    def test_build_integration_empty_config(self):
+    def test_build_integration_empty_config(self) -> None:
         """Test that build_integration raises error when config is empty"""
         state: Mapping[str, Any] = {"config": {}}
 
         with pytest.raises(IntegrationConfigurationError, match="Missing configuration data"):
             self.provider().build_integration(state)
 
-    def test_get_client(self):
+    def test_get_client(self) -> None:
         metadata = {
             "api_key": "test_api_key_123",
             "webhook_secret": "test_secret_123",
@@ -299,7 +299,7 @@ class CursorIntegrationTest(IntegrationTestCase):
             )
             assert org_integration.config == {}
 
-    def test_update_organization_config_missing_api_key_raises(self):
+    def test_update_organization_config_missing_api_key_raises(self) -> None:
         integration = self.create_integration(
             organization=self.organization,
             provider="cursor",
@@ -367,7 +367,7 @@ class CursorIntegrationTest(IntegrationTestCase):
         integration.refresh_from_db()
         assert integration.metadata["api_key"] == "old_key"
 
-    def test_property_getters(self):
+    def test_property_getters(self) -> None:
         """Test that api_key and webhook_secret property getters return correct values"""
         integration = self.create_integration(
             organization=self.organization,
@@ -422,7 +422,7 @@ class CursorIntegrationTest(IntegrationTestCase):
         webhook_secrets = {webhook_secret_1, webhook_secret_2, webhook_secret_3}
         assert len(webhook_secrets) == 3, "Each integration should have a unique webhook secret"
 
-    def test_get_dynamic_display_information(self):
+    def test_get_dynamic_display_information(self) -> None:
         """Test that get_dynamic_display_information returns metadata"""
         integration = self.create_integration(
             organization=self.organization,
@@ -449,7 +449,7 @@ class CursorIntegrationTest(IntegrationTestCase):
         assert display_info["api_key_name"] == "Production Key"
         assert display_info["user_email"] == "dev@example.com"
 
-    def test_get_dynamic_display_information_returns_none_when_no_metadata(self):
+    def test_get_dynamic_display_information_returns_none_when_no_metadata(self) -> None:
         """Test that get_dynamic_display_information returns None when metadata is missing"""
         integration = self.create_integration(
             organization=self.organization,

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -14,7 +14,7 @@ from sentry.testutils.cases import APITestCase
 class TestCursorWebhook(APITestCase):
     endpoint = "sentry-extensions-cursor-webhook"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         # Create a Cursor integration linked to this organization
         self.integration = self.create_integration(
@@ -86,23 +86,23 @@ class TestCursorWebhook(APITestCase):
         assert result.repo_provider == "github"
         assert result.pr_url == "https://github.com/testorg/testrepo/pull/1"
 
-    def test_invalid_method(self):
+    def test_invalid_method(self) -> None:
         with pytest.raises(MethodNotAllowed):
             self.client.get(self._url())
 
-    def test_invalid_json(self):
+    def test_invalid_json(self) -> None:
         body = b"{bad json}"
         headers = self._signed_headers(body)
         response = self._post_with_headers(body, headers)
         assert response.status_code == 400
 
-    def test_missing_signature(self):
+    def test_missing_signature(self) -> None:
         payload = self._build_status_payload()
         body = orjson.dumps(payload)
         response = self.client.post(self._url(), data=body, content_type="application/json")
         assert response.status_code == 403
 
-    def test_invalid_signature(self):
+    def test_invalid_signature(self) -> None:
         payload = self._build_status_payload()
         body = orjson.dumps(payload)
         headers = {"HTTP_X_WEBHOOK_SIGNATURE": "sha256=deadbeef"}
@@ -146,7 +146,7 @@ class TestCursorWebhook(APITestCase):
         args, kwargs = mock_update_state.call_args
         assert kwargs["status"].name == "FAILED"
 
-    def test_missing_agent_id_or_status(self):
+    def test_missing_agent_id_or_status(self) -> None:
         # Missing id
         body = orjson.dumps(self._build_status_payload(id=None))
         headers = self._signed_headers(body)

--- a/tests/sentry/integrations/data_forwarding/amazon_sqs/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/amazon_sqs/test_forwarder.py
@@ -12,7 +12,7 @@ from sentry.testutils.cases import TestCase
 
 
 class AmazonSQSDataForwarderTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.data_forwarder = DataForwarder.objects.create(
             organization=self.organization,

--- a/tests/sentry/integrations/data_forwarding/segment/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/segment/test_forwarder.py
@@ -10,7 +10,7 @@ from sentry.testutils.cases import TestCase
 
 
 class SegmentDataForwarderTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.data_forwarder = DataForwarder.objects.create(
             organization=self.organization,
@@ -26,7 +26,7 @@ class SegmentDataForwarderTest(TestCase):
         self.forwarder = SegmentForwarder()
 
     @responses.activate
-    def test_simple_notification(self):
+    def test_simple_notification(self) -> None:
         responses.add(responses.POST, "https://api.segment.io/v1/track")
 
         event = self.store_event(
@@ -63,7 +63,7 @@ class SegmentDataForwarderTest(TestCase):
         } == payload
 
     @responses.activate
-    def test_forward_event_http_error(self):
+    def test_forward_event_http_error(self) -> None:
         responses.add(responses.POST, "https://api.segment.io/v1/track", status=500)
 
         event = self.store_event(

--- a/tests/sentry/integrations/data_forwarding/splunk/test_forwarder.py
+++ b/tests/sentry/integrations/data_forwarding/splunk/test_forwarder.py
@@ -9,7 +9,7 @@ from sentry.testutils.cases import TestCase
 
 
 class SplunkDataForwarderTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.data_forwarder = DataForwarder.objects.create(
             organization=self.organization,
@@ -30,7 +30,7 @@ class SplunkDataForwarderTest(TestCase):
         self.forwarder = SplunkForwarder()
 
     @responses.activate
-    def test_simple_notification(self):
+    def test_simple_notification(self) -> None:
         responses.add(responses.POST, "https://splunk.example.com:8088/services/collector")
 
         event = self.store_event(
@@ -50,7 +50,7 @@ class SplunkDataForwarderTest(TestCase):
         assert request.headers["Authorization"] == "Splunk 12345678-1234-1234-1234-1234567890AB"
 
     @responses.activate
-    def test_dont_reraise_error(self):
+    def test_dont_reraise_error(self) -> None:
         responses.add(
             responses.POST, "https://splunk.example.com:8088/services/collector", status=404
         )
@@ -61,7 +61,7 @@ class SplunkDataForwarderTest(TestCase):
 
         self.forwarder.post_process(event, self.data_forwarder_project)
 
-    def test_http_payload(self):
+    def test_http_payload(self) -> None:
         event = self.store_event(
             data={
                 "request": {
@@ -79,7 +79,7 @@ class SplunkDataForwarderTest(TestCase):
         assert result["event"]["request_method"] == "POST"
         assert result["event"]["request_referer"] == "http://example.com/foo"
 
-    def test_error_payload(self):
+    def test_error_payload(self) -> None:
         event = self.store_event(
             data={
                 "exception": {"values": [{"type": "ValueError", "value": "foo bar"}]},
@@ -94,7 +94,7 @@ class SplunkDataForwarderTest(TestCase):
         assert result["event"]["exception_type"] == "ValueError"
         assert result["event"]["exception_value"] == "foo bar"
 
-    def test_csp_payload(self):
+    def test_csp_payload(self) -> None:
         event = self.store_event(
             data={
                 "csp": {
@@ -116,7 +116,7 @@ class SplunkDataForwarderTest(TestCase):
         assert result["event"]["csp_blocked_uri"] == "http://example.com/style.css"
         assert result["event"]["csp_effective_directive"] == "style-src"
 
-    def test_user_payload(self):
+    def test_user_payload(self) -> None:
         event = self.store_event(
             data={"user": {"id": "1", "email": "foo@example.com", "ip_address": "127.0.0.1"}},
             project_id=self.project.id,

--- a/tests/sentry/integrations/github/tasks/test_codecov_account_link.py
+++ b/tests/sentry/integrations/github/tasks/test_codecov_account_link.py
@@ -16,7 +16,7 @@ from sentry.testutils.silo import control_silo_test
 class CodecovAccountLinkTestCase(IntegrationTestCase):
     provider = GitHubIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -61,7 +61,7 @@ class CodecovAccountLinkTestCase(IntegrationTestCase):
         )
         mock_response.raise_for_status.assert_called_once()
 
-    def test_codecov_account_link_missing_integration(self):
+    def test_codecov_account_link_missing_integration(self) -> None:
         with patch("sentry.integrations.github.tasks.codecov_account_link.logger") as mock_logger:
             codecov_account_link(
                 integration_id=99999,  # Non-existent integration
@@ -72,7 +72,7 @@ class CodecovAccountLinkTestCase(IntegrationTestCase):
                 "codecov.account_link.missing_integration", extra={"integration_id": 99999}
             )
 
-    def test_codecov_account_link_missing_organization(self):
+    def test_codecov_account_link_missing_organization(self) -> None:
         with patch("sentry.integrations.github.tasks.codecov_account_link.logger") as mock_logger:
             codecov_account_link(
                 integration_id=self.integration.id,
@@ -152,7 +152,7 @@ class CodecovAccountLinkTestCase(IntegrationTestCase):
                 },
             )
 
-    def test_codecov_account_link_inactive_integration(self):
+    def test_codecov_account_link_inactive_integration(self) -> None:
         self.integration.update(status=ObjectStatus.DISABLED)
 
         with patch("sentry.integrations.github.tasks.codecov_account_link.logger") as mock_logger:

--- a/tests/sentry/integrations/github/tasks/test_codecov_account_unlink.py
+++ b/tests/sentry/integrations/github/tasks/test_codecov_account_unlink.py
@@ -16,7 +16,7 @@ from sentry.testutils.silo import control_silo_test
 class CodecovAccountUnlinkTestCase(IntegrationTestCase):
     provider = GitHubIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -53,7 +53,7 @@ class CodecovAccountUnlinkTestCase(IntegrationTestCase):
         )
         mock_response.raise_for_status.assert_called_once()
 
-    def test_codecov_account_unlink_missing_integration(self):
+    def test_codecov_account_unlink_missing_integration(self) -> None:
         with patch("sentry.integrations.github.tasks.codecov_account_unlink.logger") as mock_logger:
             codecov_account_unlink(
                 integration_id=99999,  # Non-existent integration

--- a/tests/sentry/integrations/github/test_post_install.py
+++ b/tests/sentry/integrations/github/test_post_install.py
@@ -9,7 +9,7 @@ from sentry.testutils.silo import control_silo_test
 class GitHubIntegrationPostInstallTest(IntegrationTestCase):
     provider = GitHubIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,

--- a/tests/sentry/integrations/github/test_utils.py
+++ b/tests/sentry/integrations/github/test_utils.py
@@ -46,17 +46,17 @@ def test_parse_github_blob_url(repo_url, source_url, expected_branch, expected_p
 
 
 class IsGithubRateLimitSensitiveTest(TestCase):
-    def test_returns_true_when_organization_slug_in_list(self):
+    def test_returns_true_when_organization_slug_in_list(self) -> None:
         org = self.create_organization(slug="org-1")
         with self.options({"github-app.rate-limit-sensitive-orgs": ["org-1", "org-2"]}):
             assert is_github_rate_limit_sensitive(org.slug) is True
 
-    def test_returns_false_when_organization_slug_not_in_list(self):
+    def test_returns_false_when_organization_slug_not_in_list(self) -> None:
         org = self.create_organization(slug="org-3")
         with self.options({"github-app.rate-limit-sensitive-orgs": ["org-1", "org-2"]}):
             assert is_github_rate_limit_sensitive(org.slug) is False
 
-    def test_returns_false_when_list_is_empty(self):
+    def test_returns_false_when_list_is_empty(self) -> None:
         org = self.create_organization(slug="org-1")
         with self.options({"github-app.rate-limit-sensitive-orgs": []}):
             assert is_github_rate_limit_sensitive(org.slug) is False

--- a/tests/sentry/integrations/gitlab/tasks/test_update_all_project_webhooks.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_update_all_project_webhooks.py
@@ -17,7 +17,7 @@ from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test
 class UpdateAllProjectWebhooksTest(GitLabTestCase):
     """Tests for the main orchestration task that spawns individual webhook update tasks"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         # Create repositories with webhook config
         with assume_test_silo_mode(SiloMode.CELL):
@@ -213,7 +213,7 @@ class UpdateAllProjectWebhooksTest(GitLabTestCase):
 class UpdateProjectWebhookTest(GitLabTestCase):
     """Tests for the individual webhook update task"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         with assume_test_silo_mode(SiloMode.CELL):
             self.repo = self.create_gitlab_repo(

--- a/tests/sentry/integrations/perforce/test_client.py
+++ b/tests/sentry/integrations/perforce/test_client.py
@@ -11,7 +11,7 @@ from sentry.testutils.cases import TestCase
 
 
 class PerforceClientTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -561,7 +561,7 @@ class PerforceClientTest(TestCase):
         # Should return None when no depotFile in result
         assert result is None
 
-    def test_build_depot_path_relative(self):
+    def test_build_depot_path_relative(self) -> None:
         """Test build_depot_path with relative path"""
         # Test with simple relative path
         path = self.p4_client.build_depot_path(self.repo, "app/services/processor.py")
@@ -571,19 +571,19 @@ class PerforceClientTest(TestCase):
         path = self.p4_client.build_depot_path(self.repo, "depot/app/services/processor.py")
         assert path == "//depot/app/services/processor.py"
 
-    def test_build_depot_path_absolute(self):
+    def test_build_depot_path_absolute(self) -> None:
         """Test build_depot_path with absolute path"""
         path = self.p4_client.build_depot_path(self.repo, "//depot/app/services/processor.py")
         assert path == "//depot/app/services/processor.py"
 
-    def test_build_depot_path_with_stream(self):
+    def test_build_depot_path_with_stream(self) -> None:
         """Test build_depot_path with stream parameter"""
         path = self.p4_client.build_depot_path(
             self.repo, "app/services/processor.py", stream="main"
         )
         assert path == "//depot/main/app/services/processor.py"
 
-    def test_build_depot_path_with_revision(self):
+    def test_build_depot_path_with_revision(self) -> None:
         """Test build_depot_path preserves #revision syntax"""
         # Test with relative path
         path = self.p4_client.build_depot_path(self.repo, "app/services/processor.py#42")
@@ -597,7 +597,7 @@ class PerforceClientTest(TestCase):
         path = self.p4_client.build_depot_path(self.repo, "app/main.cpp#5", stream="dev")
         assert path == "//depot/dev/app/main.cpp#5"
 
-    def test_build_depot_path_nested_depot(self):
+    def test_build_depot_path_nested_depot(self) -> None:
         """Test build_depot_path with nested depot paths"""
         nested_repo = Repository.objects.create(
             organization_id=self.organization.id,
@@ -686,7 +686,7 @@ class PerforceClientTest(TestCase):
 
         mock_p4.set_env.assert_not_called()
 
-    def test_p4config_isolates_p4trust_per_instance(self):
+    def test_p4config_isolates_p4trust_per_instance(self) -> None:
         """Verify P4CONFIG + p4.cwd gives each P4 instance its own P4TRUST."""
         import shutil
         import tempfile
@@ -714,6 +714,6 @@ class PerforceClientTest(TestCase):
             shutil.rmtree(dir_a)
             shutil.rmtree(dir_b)
 
-    def test_module_level_p4config_is_set(self):
+    def test_module_level_p4config_is_set(self) -> None:
         """Verify that importing the client module sets P4CONFIG."""
         assert os.environ.get("P4CONFIG") == ".p4config"

--- a/tests/sentry/integrations/perforce/test_code_mapping.py
+++ b/tests/sentry/integrations/perforce/test_code_mapping.py
@@ -19,7 +19,7 @@ class PerforceCodeMappingTest(IntegrationTestCase):
     provider = PerforceIntegrationProvider
     installation: PerforceIntegration
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -36,7 +36,7 @@ class PerforceCodeMappingTest(IntegrationTestCase):
     def tearDown(self):
         super().tearDown()
 
-    def test_code_mapping_depot_root_to_slash(self):
+    def test_code_mapping_depot_root_to_slash(self) -> None:
         """
         Test code mapping: depot/ -> /
         This is the correct mapping for Perforce where depot name is part of path.
@@ -72,7 +72,7 @@ class PerforceCodeMappingTest(IntegrationTestCase):
         # Should strip "depot/" leaving "app/services/processor.py"
         assert result == "app/services/processor.py"
 
-    def test_code_mapping_with_symbolic_revision_syntax(self):
+    def test_code_mapping_with_symbolic_revision_syntax(self) -> None:
         """
         Test code mapping with Symbolic's @revision syntax.
         The @revision should be preserved in the output.
@@ -107,7 +107,7 @@ class PerforceCodeMappingTest(IntegrationTestCase):
         # Should strip "depot/" and preserve "@42"
         assert result == "game/src/main.cpp@42"
 
-    def test_code_mapping_multiple_depots(self):
+    def test_code_mapping_multiple_depots(self) -> None:
         """Test code mappings for multiple depots (depot and myproject)"""
         depot_repo = Repository.objects.create(
             name="//depot",
@@ -170,7 +170,7 @@ class PerforceCodeMappingTest(IntegrationTestCase):
         )
         assert result2 == "app/services/handler.py"
 
-    def test_code_mapping_no_match_different_depot(self):
+    def test_code_mapping_no_match_different_depot(self) -> None:
         """Test that code mapping doesn't match paths from different depots"""
         repo = Repository.objects.create(
             name="//depot",
@@ -203,7 +203,7 @@ class PerforceCodeMappingTest(IntegrationTestCase):
         # Should not match
         assert result is None
 
-    def test_code_mapping_abs_path_fallback(self):
+    def test_code_mapping_abs_path_fallback(self) -> None:
         """Test that code mapping works with abs_path when filename is just basename"""
         repo = Repository.objects.create(
             name="//depot",
@@ -233,7 +233,7 @@ class PerforceCodeMappingTest(IntegrationTestCase):
         # Should use abs_path and strip "depot/"
         assert result == "app/services/processor.py"
 
-    def test_code_mapping_nested_depot_paths(self):
+    def test_code_mapping_nested_depot_paths(self) -> None:
         """Test code mapping with nested depot paths"""
         repo = Repository.objects.create(
             name="//depot/game/project",
@@ -264,7 +264,7 @@ class PerforceCodeMappingTest(IntegrationTestCase):
 
         assert result == "src/main.cpp"
 
-    def test_code_mapping_preserves_windows_backslash_conversion(self):
+    def test_code_mapping_preserves_windows_backslash_conversion(self) -> None:
         """
         Test that code mapping handles Windows-style paths.
 
@@ -310,7 +310,7 @@ class PerforceEndToEndCodeMappingTest(IntegrationTestCase):
 
     provider = PerforceIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -353,7 +353,7 @@ class PerforceEndToEndCodeMappingTest(IntegrationTestCase):
         self.check_file_patcher.stop()
         super().tearDown()
 
-    def test_python_sdk_path_full_flow(self):
+    def test_python_sdk_path_full_flow(self) -> None:
         """Test full flow: Python SDK -> code mapping -> format_source_url"""
         # 1. Python SDK sends this path
         frame = EventFrame(
@@ -374,7 +374,7 @@ class PerforceEndToEndCodeMappingTest(IntegrationTestCase):
         url = self.installation.format_source_url(repo=self.repo, filepath=mapped_path, branch=None)
         assert url == "p4://depot/app/services/processor.py"
 
-    def test_symbolic_cpp_path_full_flow(self):
+    def test_symbolic_cpp_path_full_flow(self) -> None:
         """Test full flow: Symbolic C++ -> code mapping -> format_source_url"""
         # 1. Symbolic transformer sends this path
         frame = EventFrame(
@@ -391,7 +391,7 @@ class PerforceEndToEndCodeMappingTest(IntegrationTestCase):
         url = self.installation.format_source_url(repo=self.repo, filepath=mapped_path, branch=None)
         assert url == "p4://depot/game/src/main.cpp@42"
 
-    def test_full_flow_with_web_viewer(self):
+    def test_full_flow_with_web_viewer(self) -> None:
         """Test full flow with P4Web viewer configuration"""
         integration_with_web = self.create_integration(
             organization=self.organization,

--- a/tests/sentry/integrations/perforce/test_integration.py
+++ b/tests/sentry/integrations/perforce/test_integration.py
@@ -13,7 +13,7 @@ class PerforceIntegrationTest(IntegrationTestCase):
     provider = PerforceIntegrationProvider
     installation: PerforceIntegration
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -30,21 +30,21 @@ class PerforceIntegrationTest(IntegrationTestCase):
             config={"depot_path": "//depot"},
         )
 
-    def test_format_source_url_absolute_path(self):
+    def test_format_source_url_absolute_path(self) -> None:
         """Test formatting URL with absolute depot path"""
         url = self.installation.format_source_url(
             repo=self.repo, filepath="//depot/app/services/processor.cpp", branch=None
         )
         assert url == "p4://depot/app/services/processor.cpp"
 
-    def test_format_source_url_relative_path(self):
+    def test_format_source_url_relative_path(self) -> None:
         """Test formatting URL with relative path - should prepend depot_path"""
         url = self.installation.format_source_url(
             repo=self.repo, filepath="app/services/processor.cpp", branch=None
         )
         assert url == "p4://depot/app/services/processor.cpp"
 
-    def test_format_source_url_path_starting_with_depot_name(self):
+    def test_format_source_url_path_starting_with_depot_name(self) -> None:
         """Test that paths starting with depot name don't get duplicated (depot/app -> //depot/app not //depot/depot/app)"""
         url = self.installation.format_source_url(
             repo=self.repo, filepath="depot/app/services/processor.cpp", branch=None
@@ -52,7 +52,7 @@ class PerforceIntegrationTest(IntegrationTestCase):
         # Should strip "depot/" prefix and prepend "//depot/" -> "//depot/app/services/processor.cpp"
         assert url == "p4://depot/app/services/processor.cpp"
 
-    def test_format_source_url_absolute_path_starting_with_depot_name(self):
+    def test_format_source_url_absolute_path_starting_with_depot_name(self) -> None:
         """Test that absolute paths with depot name are handled correctly (//depot/app stays as //depot/app)"""
         url = self.installation.format_source_url(
             repo=self.repo, filepath="//depot/app/services/processor.cpp", branch=None
@@ -60,7 +60,7 @@ class PerforceIntegrationTest(IntegrationTestCase):
         # Should preserve as-is (already absolute)
         assert url == "p4://depot/app/services/processor.cpp"
 
-    def test_format_source_url_with_revision_in_filename(self):
+    def test_format_source_url_with_revision_in_filename(self) -> None:
         """
         Test formatting URL with revision in filename (from Symbolic transformer).
         Perforce uses # for file revisions, which should be preserved.
@@ -70,7 +70,7 @@ class PerforceIntegrationTest(IntegrationTestCase):
         )
         assert url == "p4://depot/app/services/processor.cpp#1"
 
-    def test_format_source_url_swarm_viewer(self):
+    def test_format_source_url_swarm_viewer(self) -> None:
         """Test formatting URL for Swarm viewer with revision"""
         integration_with_swarm = self.create_integration(
             organization=self.organization,
@@ -93,7 +93,7 @@ class PerforceIntegrationTest(IntegrationTestCase):
         )
         assert url == "https://swarm.example.com/files//depot/app/services/processor.cpp?v=1"
 
-    def test_format_source_url_swarm_viewer_no_revision(self):
+    def test_format_source_url_swarm_viewer_no_revision(self) -> None:
         """Test formatting URL for Swarm viewer without revision"""
         integration_with_swarm = self.create_integration(
             organization=self.organization,
@@ -116,7 +116,7 @@ class PerforceIntegrationTest(IntegrationTestCase):
         )
         assert url == "https://swarm.example.com/files//depot/app/services/processor.cpp"
 
-    def test_format_source_url_swarm_viewer_absolute_path(self):
+    def test_format_source_url_swarm_viewer_absolute_path(self) -> None:
         """Test Swarm viewer with absolute path (//depot/...)"""
         integration_with_swarm = self.create_integration(
             organization=self.organization,
@@ -140,7 +140,7 @@ class PerforceIntegrationTest(IntegrationTestCase):
         assert url == "https://swarm.example.com/files//depot/app/services/processor.cpp"
         assert "depot/depot" not in url
 
-    def test_format_source_url_swarm_viewer_depot_name_path(self):
+    def test_format_source_url_swarm_viewer_depot_name_path(self) -> None:
         """Test Swarm viewer with path starting with depot name (depot/...)"""
         integration_with_swarm = self.create_integration(
             organization=self.organization,
@@ -164,14 +164,14 @@ class PerforceIntegrationTest(IntegrationTestCase):
         assert url == "https://swarm.example.com/files//depot/app/services/processor.cpp"
         assert "depot/depot" not in url
 
-    def test_format_source_url_strips_leading_slash_from_relative_path(self):
+    def test_format_source_url_strips_leading_slash_from_relative_path(self) -> None:
         """Test that leading slash is stripped from relative paths"""
         url = self.installation.format_source_url(
             repo=self.repo, filepath="/app/services/processor.cpp", branch=None
         )
         assert url == "p4://depot/app/services/processor.cpp"
 
-    def test_format_source_url_uses_repo_name_as_fallback_depot(self):
+    def test_format_source_url_uses_repo_name_as_fallback_depot(self) -> None:
         """Test that repo name is used as depot_path fallback"""
         repo_without_config = Repository.objects.create(
             name="//myproject",
@@ -249,11 +249,11 @@ class PerforceIntegrationTest(IntegrationTestCase):
         assert url == "p4://depot/app/services/processor.cpp#1"
         assert "#1" in url
 
-    def test_integration_name(self):
+    def test_integration_name(self) -> None:
         """Test integration has correct name"""
         assert self.installation.model.name == "Perforce"
 
-    def test_integration_provider(self):
+    def test_integration_provider(self) -> None:
         """Test integration has correct provider"""
         assert self.installation.model.provider == "perforce"
 
@@ -263,7 +263,7 @@ class PerforceIntegrationCodeMappingTest(IntegrationTestCase):
 
     provider = PerforceIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -280,7 +280,7 @@ class PerforceIntegrationCodeMappingTest(IntegrationTestCase):
             config={"depot_path": "//depot"},
         )
 
-    def test_format_source_url_from_code_mapping_output(self):
+    def test_format_source_url_from_code_mapping_output(self) -> None:
         """
         Test that paths coming from code mapping (depot/ -> /) work correctly.
         Code mapping strips 'depot/' and leaves 'app/services/processor.cpp',
@@ -296,7 +296,7 @@ class PerforceIntegrationCodeMappingTest(IntegrationTestCase):
         # Should prepend depot_path to create full depot path
         assert url == "p4://depot/app/services/processor.cpp"
 
-    def test_format_source_url_preserves_revision_in_filename(self):
+    def test_format_source_url_preserves_revision_in_filename(self) -> None:
         """
         Test that #revision syntax in filename is preserved.
         This tests the Symbolic transformer output format.
@@ -311,7 +311,7 @@ class PerforceIntegrationCodeMappingTest(IntegrationTestCase):
         # The #1 should be preserved in the path
         assert url == "p4://depot/app/services/processor.cpp#1"
 
-    def test_format_source_url_python_path_without_revision(self):
+    def test_format_source_url_python_path_without_revision(self) -> None:
         """Test Python SDK paths without revision"""
         # Python SDK typically doesn't include revisions
         python_path = "app/services/processor.py"
@@ -326,7 +326,7 @@ class PerforceIntegrationDepotPathTest(IntegrationTestCase):
 
     provider = PerforceIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -336,7 +336,7 @@ class PerforceIntegrationDepotPathTest(IntegrationTestCase):
         )
         self.installation = self.integration.get_installation(self.organization.id)
 
-    def test_multiple_depots(self):
+    def test_multiple_depots(self) -> None:
         """Test handling multiple depot configurations"""
         depot_repo = Repository.objects.create(
             name="//depot",
@@ -364,7 +364,7 @@ class PerforceIntegrationDepotPathTest(IntegrationTestCase):
         )
         assert url2 == "p4://myproject/app/services/processor.cpp"
 
-    def test_nested_depot_paths(self):
+    def test_nested_depot_paths(self) -> None:
         """Test handling nested depot paths"""
         repo = Repository.objects.create(
             name="//depot/game/project",
@@ -376,7 +376,7 @@ class PerforceIntegrationDepotPathTest(IntegrationTestCase):
         url = self.installation.format_source_url(repo=repo, filepath="src/main.cpp", branch=None)
         assert url == "p4://depot/game/project/src/main.cpp"
 
-    def test_depot_path_with_trailing_slash(self):
+    def test_depot_path_with_trailing_slash(self) -> None:
         """Test depot_path with trailing slash is handled correctly"""
         repo = Repository.objects.create(
             name="//depot",
@@ -397,7 +397,7 @@ class PerforceIntegrationWebViewersTest(IntegrationTestCase):
 
     provider = PerforceIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -414,7 +414,7 @@ class PerforceIntegrationWebViewersTest(IntegrationTestCase):
             config={"depot_path": "//depot"},
         )
 
-    def test_swarm_extracts_revision_from_filename(self):
+    def test_swarm_extracts_revision_from_filename(self) -> None:
         """Test Swarm viewer correctly extracts and formats revision from #revision syntax"""
         integration_with_swarm = self.create_integration(
             organization=self.organization,
@@ -452,7 +452,7 @@ class PerforceIntegrationEndToEndTest(IntegrationTestCase):
 
     provider = PerforceIntegrationProvider
 
-    def test_integration_lifecycle(self):
+    def test_integration_lifecycle(self) -> None:
         """Test complete integration lifecycle from installation to updates"""
 
         # Step 1: Simulate installation with build_integration

--- a/tests/sentry/integrations/perforce/test_stacktrace_link.py
+++ b/tests/sentry/integrations/perforce/test_stacktrace_link.py
@@ -13,7 +13,7 @@ class PerforceStacktraceLinkTest(IntegrationTestCase):
 
     provider = PerforceIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -54,7 +54,7 @@ class PerforceStacktraceLinkTest(IntegrationTestCase):
         self.check_file_patcher.stop()
         super().tearDown()
 
-    def test_get_stacktrace_config_python_path(self):
+    def test_get_stacktrace_config_python_path(self) -> None:
         """Test stacktrace link generation for Python SDK path"""
         self.check_file_patcher.stop()
         self.check_file_patcher = patch(
@@ -109,7 +109,7 @@ class PerforceStacktraceLinkTest(IntegrationTestCase):
         assert result["error"] is None
         assert result["src_path"] == "game/src/main.cpp#1"
 
-    def test_get_stacktrace_config_no_matching_code_mapping(self):
+    def test_get_stacktrace_config_no_matching_code_mapping(self) -> None:
         """Test stacktrace link when no code mapping matches"""
         ctx: StacktraceLinkContext = {
             "file": "other/app/services/processor.py",
@@ -354,7 +354,7 @@ class PerforceStacktraceLinkEdgeCasesTest(IntegrationTestCase):
 
     provider = PerforceIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.integration = self.create_integration(
             organization=self.organization,
@@ -376,7 +376,7 @@ class PerforceStacktraceLinkEdgeCasesTest(IntegrationTestCase):
         self.check_file_patcher.stop()
         super().tearDown()
 
-    def test_stacktrace_link_empty_stack_root(self):
+    def test_stacktrace_link_empty_stack_root(self) -> None:
         """Test stacktrace link with empty stack_root (shouldn't match anything)"""
         self.check_file_patcher.stop()
         self.check_file_patcher = patch(

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -903,7 +903,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
     @override_options({"alerts.issue_summary_timeout": 5})
     @with_feature({"organizations:gen-ai-features"})
-    def test_build_group_block_with_ai_summary(self):
+    def test_build_group_block_with_ai_summary(self) -> None:
         event = self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -962,7 +962,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
     @override_options({"alerts.issue_summary_timeout": 5})
     @with_feature({"organizations:gen-ai-features"})
-    def test_build_group_block_with_ai_summary_text_truncation(self):
+    def test_build_group_block_with_ai_summary_text_truncation(self) -> None:
         # Test case for multi-line exception text
         multiline_text = "First line of text\nSecond line of text\nThird line of text"
         event1 = self.store_event(

--- a/tests/sentry/lang/java/test_exceptions.py
+++ b/tests/sentry/lang/java/test_exceptions.py
@@ -7,7 +7,7 @@ def build_event(exceptions_values):
     return {"exception": {"values": exceptions_values}}
 
 
-def test_get_processable_exceptions_filters_by_module_and_type():
+def test_get_processable_exceptions_filters_by_module_and_type() -> None:
     data = build_event(
         [
             {"type": "RuntimeException", "module": "java.lang", "value": "boom"},
@@ -25,7 +25,7 @@ def test_get_processable_exceptions_filters_by_module_and_type():
     assert processable[0]["module"] == "java.lang"
 
 
-def test_value_class_names_matches_fqcn_inner_and_quoted_multiple_values():
+def test_value_class_names_matches_fqcn_inner_and_quoted_multiple_values() -> None:
     data = build_event(
         [
             {
@@ -49,7 +49,7 @@ def test_value_class_names_matches_fqcn_inner_and_quoted_multiple_values():
     assert "Tf.k" in class_names
 
 
-def test_deobfuscate_and_save_deobfuscates_types_and_values_multiple_values():
+def test_deobfuscate_and_save_deobfuscates_types_and_values_multiple_values() -> None:
     # First exception is processable by type/module mapping
     exc1 = {"type": "g$a", "module": "org.a.b", "value": "something with org.a.b.g$a"}
     # Next exceptions only have value matches, spread across multiple exceptions
@@ -92,7 +92,7 @@ def test_deobfuscate_and_save_deobfuscates_types_and_values_multiple_values():
     assert exc3["raw_value"].startswith("Caused by com.example.myapp.MainActivity")
 
 
-def test_deobfuscate_value_replaces_longest_tokens_first():
+def test_deobfuscate_value_replaces_longest_tokens_first() -> None:
     # Overlapping tokens: a.b$c$1 (longer) and a.b$c (shorter)
     exc = {"value": "Found both inner a.b$c$1 and outer a.b$c in text"}
     data = build_event([exc])
@@ -116,7 +116,7 @@ def test_deobfuscate_value_replaces_longest_tokens_first():
     assert exc["raw_value"].startswith("Found both inner a.b$c$1")
 
 
-def test_deobfuscate_value_preserves_quotes_in_replacements():
+def test_deobfuscate_value_preserves_quotes_in_replacements() -> None:
     exc = {"value": "Got 'o' and \"j4\" in message"}
     data = build_event([exc])
 
@@ -134,7 +134,7 @@ def test_deobfuscate_value_preserves_quotes_in_replacements():
     assert exc["raw_value"].startswith("Got '")
 
 
-def test_deobfuscate_is_noop_when_no_classes_mapping():
+def test_deobfuscate_is_noop_when_no_classes_mapping() -> None:
     # Only value matches; no module/type entries and no classes mapping
     original = "Refs com.example.A and a.b$c$1 and 'o'"
     exc = {"value": original}

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -132,7 +132,7 @@ class NotifyEmailFormTest(TestCase):
 class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
     rule_cls = NotifyEmailAction
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.one_min_ago = before_now(minutes=1).isoformat()
         self.event = self.store_event(
             data={
@@ -302,7 +302,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase, BaseWorkflowTest):
 
 
 class NotifyLegacyEmailTest(NotifyEmailTest):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.condition_data = {
             "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -170,7 +170,7 @@ class GithubRequestParserTest(TestCase):
         }
     )
     @override_cells(region_config)
-    def test_webhook_for_codecov(self):
+    def test_webhook_for_codecov(self) -> None:
         integration = self.get_integration()
         request = self.factory.post(
             self.path,
@@ -206,7 +206,7 @@ class GithubRequestParserTest(TestCase):
         }
     )
     @override_cells(region_config)
-    def test_webhook_for_codecov_no_regions(self):
+    def test_webhook_for_codecov_no_regions(self) -> None:
         integration = self.get_integration()
         request = self.factory.post(
             self.path,
@@ -246,7 +246,7 @@ class GithubRequestParserTest(TestCase):
         }
     )
     @override_cells(region_config)
-    def test_webhook_no_codecov_payload_when_forwarding_disabled(self):
+    def test_webhook_no_codecov_payload_when_forwarding_disabled(self) -> None:
         """When codecov.forward-webhooks.disabled is True, only region payload is created."""
         integration = self.get_integration()
         request = self.factory.post(

--- a/tests/sentry/middleware/test_ai_agent.py
+++ b/tests/sentry/middleware/test_ai_agent.py
@@ -8,33 +8,33 @@ from sentry.testutils.cases import TestCase
 
 
 class AcceptsMarkdownTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.factory = RequestFactory()
 
-    def test_accepts_text_markdown(self):
+    def test_accepts_text_markdown(self) -> None:
         request = self.factory.get("/", HTTP_ACCEPT="text/markdown")
         assert _accepts_markdown(request) is True
 
-    def test_accepts_text_x_markdown(self):
+    def test_accepts_text_x_markdown(self) -> None:
         request = self.factory.get("/", HTTP_ACCEPT="text/x-markdown")
         assert _accepts_markdown(request) is True
 
-    def test_rejects_other_types(self):
+    def test_rejects_other_types(self) -> None:
         request = self.factory.get("/", HTTP_ACCEPT="text/plain")
         assert _accepts_markdown(request) is False
 
-    def test_case_insensitive(self):
+    def test_case_insensitive(self) -> None:
         request = self.factory.get("/", HTTP_ACCEPT="TEXT/MARKDOWN")
         assert _accepts_markdown(request) is True
 
-    def test_case_insensitive_mixed(self):
+    def test_case_insensitive_mixed(self) -> None:
         request = self.factory.get("/", HTTP_ACCEPT="Text/Markdown")
         assert _accepts_markdown(request) is True
 
 
 class AIAgentMiddlewareTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.factory = RequestFactory()
         self.middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
@@ -45,7 +45,7 @@ class AIAgentMiddlewareTest(TestCase):
         request.auth = None
         return request
 
-    def test_returns_guidance_for_anonymous_markdown_request(self):
+    def test_returns_guidance_for_anonymous_markdown_request(self) -> None:
         request = self.make_anonymous_request(
             "/organizations/test-org/issues/", HTTP_ACCEPT="text/markdown"
         )
@@ -58,7 +58,7 @@ class AIAgentMiddlewareTest(TestCase):
         assert "# Sentry" in content
         assert "https://mcp.sentry.dev/mcp/test-org" in content
 
-    def test_includes_project_in_mcp_url(self):
+    def test_includes_project_in_mcp_url(self) -> None:
         request = self.make_anonymous_request(
             "/organizations/my-org/projects/my-project/", HTTP_ACCEPT="text/markdown"
         )
@@ -68,7 +68,7 @@ class AIAgentMiddlewareTest(TestCase):
         assert response.status_code == 200
         assert "https://mcp.sentry.dev/mcp/my-org/my-project" in response.content.decode()
 
-    def test_base_mcp_url_without_org_context(self):
+    def test_base_mcp_url_without_org_context(self) -> None:
         request = self.make_anonymous_request("/settings/", HTTP_ACCEPT="text/markdown")
 
         response = self.middleware(request)
@@ -76,31 +76,31 @@ class AIAgentMiddlewareTest(TestCase):
         assert response.status_code == 200
         assert "https://mcp.sentry.dev/mcp" in response.content.decode()
 
-    def test_authenticated_user_passes_through(self):
+    def test_authenticated_user_passes_through(self) -> None:
         request = self.factory.get("/organizations/test-org/", HTTP_ACCEPT="text/markdown")
         request.user = self.create_user()
         request.auth = None
 
         assert self.middleware(request).status_code == 401
 
-    def test_auth_token_passes_through(self):
+    def test_auth_token_passes_through(self) -> None:
         request = self.factory.get("/organizations/test-org/", HTTP_ACCEPT="text/markdown")
         request.user = AnonymousUser()
         request.auth = MagicMock()
 
         assert self.middleware(request).status_code == 401
 
-    def test_non_markdown_accept_passes_through(self):
+    def test_non_markdown_accept_passes_through(self) -> None:
         request = self.make_anonymous_request("/organizations/test-org/", HTTP_ACCEPT="text/html")
 
         assert self.middleware(request).status_code == 401
 
-    def test_api_path_passes_through(self):
+    def test_api_path_passes_through(self) -> None:
         request = self.make_anonymous_request("/api/0/projects/", HTTP_ACCEPT="text/markdown")
 
         assert self.middleware(request).status_code == 401
 
-    def test_oauth_path_passes_through(self):
+    def test_oauth_path_passes_through(self) -> None:
         request = self.make_anonymous_request("/oauth/token/", HTTP_ACCEPT="text/markdown")
 
         assert self.middleware(request).status_code == 401

--- a/tests/sentry/models/test_authidentity.py
+++ b/tests/sentry/models/test_authidentity.py
@@ -10,7 +10,7 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 @control_silo_test
 class AuthIdentityUpdateLoggingTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.auth_provider = self.create_auth_provider(
             organization_id=self.organization.id, provider="dummy"

--- a/tests/sentry/models/test_groupreaction.py
+++ b/tests/sentry/models/test_groupreaction.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import TestCase
 
 
 class GroupReactionTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         repo = self.create_repo(project=self.project)
         self.commit = self.create_commit(
@@ -15,7 +15,7 @@ class GroupReactionTest(TestCase):
             key="pretend this is a sha",
         )
 
-    def test_check_constraint_both_null_fails(self):
+    def test_check_constraint_both_null_fails(self) -> None:
         with pytest.raises(IntegrityError):
             GroupReaction.objects.create(
                 project=self.project,
@@ -26,7 +26,7 @@ class GroupReactionTest(TestCase):
                 source=GroupReactionType.USER_SUSPECT_COMMIT_REACTION.value,
             )
 
-    def test_unique_constraint_commit_group(self):
+    def test_unique_constraint_commit_group(self) -> None:
         GroupReaction.objects.create(
             project=self.project,
             commit=self.commit,
@@ -58,7 +58,7 @@ class GroupReactionTest(TestCase):
                 source=GroupReactionType.USER_SUSPECT_COMMIT_REACTION.value,
             )
 
-    def test_unique_constraint_project_wide_exclusion(self):
+    def test_unique_constraint_project_wide_exclusion(self) -> None:
         GroupReaction.objects.create(
             project=self.project,
             commit=self.commit,
@@ -78,7 +78,7 @@ class GroupReactionTest(TestCase):
                 source=GroupReactionType.USER_SUSPECT_COMMIT_REACTION.value,
             )
 
-    def test_unique_constraint_group_exclusion(self):
+    def test_unique_constraint_group_exclusion(self) -> None:
         GroupReaction.objects.create(
             project=self.project,
             commit=None,
@@ -98,7 +98,7 @@ class GroupReactionTest(TestCase):
                 source=GroupReactionType.USER_SUSPECT_COMMIT_REACTION.value,
             )
 
-    def test_user_can_react_to_different_commits_same_group(self):
+    def test_user_can_react_to_different_commits_same_group(self) -> None:
         repo = self.create_repo(project=self.project)
         commit2 = self.create_commit(
             repo=repo,
@@ -127,7 +127,7 @@ class GroupReactionTest(TestCase):
         assert reaction2.reaction is True
         assert GroupReaction.objects.count() == 2
 
-    def test_user_can_react_to_multiple_groups(self):
+    def test_user_can_react_to_multiple_groups(self) -> None:
         group2 = self.create_group(project=self.project)
 
         GroupReaction.objects.create(
@@ -151,7 +151,7 @@ class GroupReactionTest(TestCase):
         assert reaction2.group == group2
         assert GroupReaction.objects.count() == 2
 
-    def test_multiple_deleted_users_can_react(self):
+    def test_multiple_deleted_users_can_react(self) -> None:
         user2 = self.create_user()
 
         reaction1 = GroupReaction.objects.create(

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -77,7 +77,7 @@ class FindReferencedGroupsTest(TestCase):
 
 
 class PullRequestRetentionTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.now = timezone.now()
         self.old_date = self.now - timedelta(days=100)
@@ -109,17 +109,17 @@ class PullRequestRetentionTest(TestCase):
         pr.refresh_from_db()
         return pr
 
-    def test_old_pr_with_no_references_is_unused(self):
+    def test_old_pr_with_no_references_is_unused(self) -> None:
         """An old PR with no references should be marked as unused"""
         pr = self.create_pr(date_added=self.old_date)
         assert pr.is_unused(self.cutoff_date)
 
-    def test_recent_pr_is_not_unused(self):
+    def test_recent_pr_is_not_unused(self) -> None:
         """A PR created after cutoff date should not be unused (though this shouldn't be queried)"""
         pr = self.create_pr(date_added=self.recent_date)
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_recent_comment_is_not_unused(self):
+    def test_pr_with_recent_comment_is_not_unused(self) -> None:
         """PR with a comment created after cutoff should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
 
@@ -131,7 +131,7 @@ class PullRequestRetentionTest(TestCase):
 
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_recently_updated_comment_is_not_unused(self):
+    def test_pr_with_recently_updated_comment_is_not_unused(self) -> None:
         """PR with a comment updated after cutoff should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
 
@@ -143,7 +143,7 @@ class PullRequestRetentionTest(TestCase):
 
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_old_commit_only_is_unused(self):
+    def test_pr_with_old_commit_only_is_unused(self) -> None:
         """PR with only an old commit (not in release) should be unused"""
         pr = self.create_pr(date_added=self.old_date)
         commit = self.create_commit(
@@ -155,7 +155,7 @@ class PullRequestRetentionTest(TestCase):
         self.create_pull_request_commit(pr, commit)
         assert pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_recent_commit_is_not_unused(self):
+    def test_pr_with_recent_commit_is_not_unused(self) -> None:
         """PR with a commit created after cutoff should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
         commit = self.create_commit(
@@ -169,7 +169,7 @@ class PullRequestRetentionTest(TestCase):
         self.create_pull_request_commit(pr, commit)
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_commit_in_release_is_not_unused(self):
+    def test_pr_with_commit_in_release_is_not_unused(self) -> None:
         """PR with a commit that's part of a release should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
         commit = self.create_commit(
@@ -188,7 +188,7 @@ class PullRequestRetentionTest(TestCase):
         )
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_commit_as_release_head_is_not_unused(self):
+    def test_pr_with_commit_as_release_head_is_not_unused(self) -> None:
         """PR with a commit that's a release head should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
         commit = self.create_commit(
@@ -207,7 +207,7 @@ class PullRequestRetentionTest(TestCase):
         )
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_linked_to_existing_group_is_not_unused(self):
+    def test_pr_linked_to_existing_group_is_not_unused(self) -> None:
         """PR linked to an existing group via GroupLink should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
         group = self.create_group(project=self.project)
@@ -220,7 +220,7 @@ class PullRequestRetentionTest(TestCase):
         )
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_linked_to_deleted_group_is_unused(self):
+    def test_pr_linked_to_deleted_group_is_unused(self) -> None:
         """PR linked to a non-existent group should be unused"""
         pr = self.create_pr(date_added=self.old_date)
         GroupLink.objects.create(
@@ -232,7 +232,7 @@ class PullRequestRetentionTest(TestCase):
         )
         assert pr.is_unused(self.cutoff_date)
 
-    def test_pr_comment_with_existing_group_is_not_unused(self):
+    def test_pr_comment_with_existing_group_is_not_unused(self) -> None:
         """PR with a comment referencing an existing group should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
         group = self.create_group(project=self.project)
@@ -244,7 +244,7 @@ class PullRequestRetentionTest(TestCase):
         )
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_comment_with_deleted_group_is_unused(self):
+    def test_pr_comment_with_deleted_group_is_unused(self) -> None:
         """PR with a comment referencing only non-existent groups should be unused"""
         pr = self.create_pr(date_added=self.old_date)
         self.create_pull_request_comment(
@@ -255,7 +255,7 @@ class PullRequestRetentionTest(TestCase):
         )
         assert pr.is_unused(self.cutoff_date)
 
-    def test_pr_comment_with_mixed_groups_is_not_unused(self):
+    def test_pr_comment_with_mixed_groups_is_not_unused(self) -> None:
         """PR with comment referencing both existing and non-existent groups should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
         group = self.create_group(project=self.project)
@@ -267,7 +267,7 @@ class PullRequestRetentionTest(TestCase):
         )
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_comment_with_empty_groups_is_unused(self):
+    def test_pr_comment_with_empty_groups_is_unused(self) -> None:
         """PR with comment that has empty group_ids should be unused"""
         pr = self.create_pr(date_added=self.old_date)
         self.create_pull_request_comment(
@@ -278,7 +278,7 @@ class PullRequestRetentionTest(TestCase):
         )
         assert pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_deleted_commit_is_unused(self):
+    def test_pr_with_deleted_commit_is_unused(self) -> None:
         """PR with a PullRequestCommit pointing to non-existent commit should be unused"""
         pr = self.create_pr(date_added=self.old_date)
         # Create PullRequestCommit with non-existent commit_id. This simulates a commit that was deleted
@@ -288,7 +288,7 @@ class PullRequestRetentionTest(TestCase):
         )
         assert pr.is_unused(self.cutoff_date)
 
-    def test_complex_pr_with_multiple_references(self):
+    def test_complex_pr_with_multiple_references(self) -> None:
         """Test a complex scenario with multiple types of references"""
         pr = self.create_pr(date_added=self.old_date)
         # Add old comment with deleted group

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -1557,12 +1557,12 @@ class ClearCommitsTestCase(TestCase):
 class ReleaseGetUnusedFilterTestCase(TestCase):
     """Test the Release.get_unused_filter() method logic"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
         self.cutoff_date = timezone.now() - timedelta(days=30)
 
-    def test_get_unused_filter_includes_old_releases_without_dependencies(self):
+    def test_get_unused_filter_includes_old_releases_without_dependencies(self) -> None:
         """Old releases with no dependencies should be included in unused filter"""
         old_release = self.create_release(
             project=self.project,
@@ -1575,7 +1575,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
 
         assert old_release in unused_releases
 
-    def test_get_unused_filter_excludes_recently_added_releases(self):
+    def test_get_unused_filter_excludes_recently_added_releases(self) -> None:
         """Recently added releases should be excluded from unused filter"""
         recent_release = self.create_release(
             project=self.project,
@@ -1588,7 +1588,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
 
         assert recent_release not in unused_releases
 
-    def test_get_unused_filter_excludes_releases_with_groups(self):
+    def test_get_unused_filter_excludes_releases_with_groups(self) -> None:
         """Releases referenced by groups should be excluded from unused filter"""
         old_release = self.create_release(
             project=self.project,
@@ -1602,7 +1602,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
 
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_excludes_releases_with_group_environments(self):
+    def test_get_unused_filter_excludes_releases_with_group_environments(self) -> None:
         """Releases referenced by GroupEnvironment should be excluded from unused filter"""
         old_release = self.create_release(
             project=self.project,
@@ -1622,7 +1622,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
 
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_excludes_releases_with_group_history(self):
+    def test_get_unused_filter_excludes_releases_with_group_history(self) -> None:
         """Releases referenced by GroupHistory should be excluded from unused filter"""
         old_release = self.create_release(
             project=self.project,
@@ -1642,7 +1642,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
 
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_excludes_releases_with_group_resolutions(self):
+    def test_get_unused_filter_excludes_releases_with_group_resolutions(self) -> None:
         """Releases referenced by GroupResolution should be excluded from unused filter"""
         old_release = self.create_release(
             project=self.project,
@@ -1660,7 +1660,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
 
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_excludes_releases_with_distributions(self):
+    def test_get_unused_filter_excludes_releases_with_distributions(self) -> None:
         """Releases with distributions should be excluded from unused filter"""
         old_release = self.create_release(
             project=self.project,
@@ -1678,7 +1678,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
 
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_excludes_releases_with_deploys(self):
+    def test_get_unused_filter_excludes_releases_with_deploys(self) -> None:
         """Releases with deploys should be excluded from unused filter"""
         old_release = self.create_release(
             project=self.project,
@@ -1697,7 +1697,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
 
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_ignores_safe_child_relations(self):
+    def test_get_unused_filter_ignores_safe_child_relations(self) -> None:
         """Safe child relations should not prevent inclusion in unused filter"""
         old_release = self.create_release(
             project=self.project,
@@ -1730,7 +1730,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         # These relations should not prevent the release from being considered unused
         assert old_release in unused_releases
 
-    def test_get_unused_filter_multiple_releases_mixed_dependencies(self):
+    def test_get_unused_filter_multiple_releases_mixed_dependencies(self) -> None:
         """Test filter correctly handles multiple releases with different dependency patterns"""
         # Create various releases with different dependency patterns
         unused_old_release = self.create_release(
@@ -1773,7 +1773,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         assert release_with_group not in unused_releases
         assert release_with_deploy not in unused_releases
 
-    def test_get_unused_filter_with_latest_repo_release_environment(self):
+    def test_get_unused_filter_with_latest_repo_release_environment(self) -> None:
         """Test that LatestRepoReleaseEnvironment subquery works correctly"""
         old_release = self.create_release(
             project=self.project,
@@ -1799,7 +1799,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         unused_releases = Release.objects.filter(unused_filter)
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_with_recent_activity(self):
+    def test_get_unused_filter_with_recent_activity(self) -> None:
         """Test that ReleaseProjectEnvironment last_seen subquery works correctly"""
         old_release = self.create_release(
             project=self.project,
@@ -1825,7 +1825,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         unused_releases = Release.objects.filter(unused_filter)
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_excludes_release_that_is_first_release_of_group(self):
+    def test_get_unused_filter_excludes_release_that_is_first_release_of_group(self) -> None:
         """Test that a release is not considered unused if it is the first_release of any group"""
         old_release = self.create_release(
             project=self.project,
@@ -1851,7 +1851,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
 
         assert Group.objects.filter(first_release=old_release).exists() is True
 
-    def test_get_unused_filter_excludes_releases_with_recent_deploys(self):
+    def test_get_unused_filter_excludes_releases_with_recent_deploys(self) -> None:
         """Test that releases with recent deploys are not considered unused"""
         old_release = self.create_release(
             project=self.project,
@@ -1879,7 +1879,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         unused_releases = Release.objects.filter(unused_filter)
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_allows_cleanup_with_old_deploys(self):
+    def test_get_unused_filter_allows_cleanup_with_old_deploys(self) -> None:
         """Test that releases with old deploys can be cleaned up"""
         old_release = self.create_release(
             project=self.project,
@@ -1902,7 +1902,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         unused_releases = Release.objects.filter(unused_filter)
         assert old_release in unused_releases
 
-    def test_get_unused_filter_excludes_releases_with_recent_distributions(self):
+    def test_get_unused_filter_excludes_releases_with_recent_distributions(self) -> None:
         """Test that releases with recent distributions are not considered unused"""
         old_release = self.create_release(
             project=self.project,
@@ -1929,7 +1929,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         unused_releases = Release.objects.filter(unused_filter)
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_allows_cleanup_with_old_distributions(self):
+    def test_get_unused_filter_allows_cleanup_with_old_distributions(self) -> None:
         """Test that releases with old distributions can be cleaned up"""
         old_release = self.create_release(
             project=self.project,
@@ -1951,7 +1951,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         unused_releases = Release.objects.filter(unused_filter)
         assert old_release in unused_releases
 
-    def test_get_unused_filter_excludes_releases_with_recent_group_releases(self):
+    def test_get_unused_filter_excludes_releases_with_recent_group_releases(self) -> None:
         """Test that releases with recent group releases are not considered unused"""
         old_release = self.create_release(
             project=self.project,
@@ -1981,7 +1981,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         unused_releases = Release.objects.filter(unused_filter)
         assert old_release not in unused_releases
 
-    def test_get_unused_filter_allows_cleanup_with_old_group_releases(self):
+    def test_get_unused_filter_allows_cleanup_with_old_group_releases(self) -> None:
         """Test that releases with old group releases can be cleaned up"""
         old_release = self.create_release(
             project=self.project,
@@ -2007,7 +2007,7 @@ class ReleaseGetUnusedFilterTestCase(TestCase):
         unused_releases = Release.objects.filter(unused_filter)
         assert old_release in unused_releases
 
-    def test_get_unused_filter_excludes_releases_with_old_group_resolutions(self):
+    def test_get_unused_filter_excludes_releases_with_old_group_resolutions(self) -> None:
         """Test that releases with old GroupResolutions are still protected"""
         old_release = self.create_release(
             project=self.project,

--- a/tests/sentry/models/test_repository.py
+++ b/tests/sentry/models/test_repository.py
@@ -77,7 +77,7 @@ class RepositoryDeleteEmailTest(TestCase):
 class RepositoryCodeReviewSettingsTest(TestCase):
     """Tests for auto-enabling code review settings on repository creation."""
 
-    def test_settings_created_when_no_auto_enable(self):
+    def test_settings_created_when_no_auto_enable(self) -> None:
         org = self.create_organization()
 
         repo = Repository.objects.create(
@@ -90,7 +90,7 @@ class RepositoryCodeReviewSettingsTest(TestCase):
         assert settings.enabled_code_review is False
         assert settings.code_review_triggers == DEFAULT_CODE_REVIEW_TRIGGERS
 
-    def test_settings_created_when_auto_enable_disabled(self):
+    def test_settings_created_when_auto_enable_disabled(self) -> None:
         org = self.create_organization()
 
         OrganizationOption.objects.set_value(
@@ -114,7 +114,7 @@ class RepositoryCodeReviewSettingsTest(TestCase):
         assert settings.enabled_code_review is False
         assert settings.code_review_triggers == ["on_new_commit"]
 
-    def test_settings_created_when_auto_enable_enabled(self):
+    def test_settings_created_when_auto_enable_enabled(self) -> None:
         org = self.create_organization()
 
         OrganizationOption.objects.set_value(
@@ -133,7 +133,7 @@ class RepositoryCodeReviewSettingsTest(TestCase):
         assert settings.enabled_code_review is True
         assert settings.code_review_triggers == DEFAULT_CODE_REVIEW_TRIGGERS
 
-    def test_settings_created_with_triggers(self):
+    def test_settings_created_with_triggers(self) -> None:
         org = self.create_organization()
 
         OrganizationOption.objects.set_value(
@@ -157,7 +157,7 @@ class RepositoryCodeReviewSettingsTest(TestCase):
         assert settings.enabled_code_review is True
         assert settings.code_review_triggers == ["on_new_commit", "on_ready_for_review"]
 
-    def test_no_settings_for_unsupported_provider(self):
+    def test_no_settings_for_unsupported_provider(self) -> None:
         org = self.create_organization()
 
         OrganizationOption.objects.set_value(
@@ -174,7 +174,7 @@ class RepositoryCodeReviewSettingsTest(TestCase):
 
         assert not RepositorySettings.objects.filter(repository=repo).exists()
 
-    def test_invalid_triggers_type_defaults_to_empty_list(self):
+    def test_invalid_triggers_type_defaults_to_empty_list(self) -> None:
         org = self.create_organization()
 
         OrganizationOption.objects.set_value(
@@ -198,7 +198,7 @@ class RepositoryCodeReviewSettingsTest(TestCase):
         settings = RepositorySettings.objects.get(repository=repo)
         assert settings.code_review_triggers == DEFAULT_CODE_REVIEW_TRIGGERS
 
-    def test_settings_not_duplicated_on_update(self):
+    def test_settings_not_duplicated_on_update(self) -> None:
         org = self.create_organization()
 
         OrganizationOption.objects.set_value(
@@ -218,7 +218,7 @@ class RepositoryCodeReviewSettingsTest(TestCase):
 
         assert RepositorySettings.objects.filter(repository=repo).count() == 1
 
-    def test_transaction_rollback_on_auto_enable_failure(self):
+    def test_transaction_rollback_on_auto_enable_failure(self) -> None:
         org = self.create_organization()
 
         OrganizationOption.objects.set_value(
@@ -245,7 +245,7 @@ class RepositoryCodeReviewSettingsTest(TestCase):
         assert Repository.objects.filter(organization_id=org.id).count() == initial_repo_count
         assert not RepositorySettings.objects.filter(repository__organization_id=org.id).exists()
 
-    def test_both_repository_and_settings_saved_atomically(self):
+    def test_both_repository_and_settings_saved_atomically(self) -> None:
         org = self.create_organization()
 
         OrganizationOption.objects.set_value(

--- a/tests/sentry/models/test_rulesnooze.py
+++ b/tests/sentry/models/test_rulesnooze.py
@@ -104,7 +104,7 @@ class RuleSnoozeTest(APITestCase):
 
 
 class GetSnoozedForAllDetectorIdsTest(TestCase):
-    def test_returns_snoozed_detector_ids(self):
+    def test_returns_snoozed_detector_ids(self) -> None:
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         detector = self.create_detector(project=self.project)
         self.create_alert_rule_detector(alert_rule_id=alert_rule.id, detector=detector)
@@ -113,7 +113,7 @@ class GetSnoozedForAllDetectorIdsTest(TestCase):
         result = RuleSnooze.objects.get_snoozed_for_all_detector_ids({detector.id})
         assert result == {detector.id}
 
-    def test_excludes_user_specific_snooze(self):
+    def test_excludes_user_specific_snooze(self) -> None:
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         detector = self.create_detector(project=self.project)
         self.create_alert_rule_detector(alert_rule_id=alert_rule.id, detector=detector)
@@ -122,7 +122,7 @@ class GetSnoozedForAllDetectorIdsTest(TestCase):
         result = RuleSnooze.objects.get_snoozed_for_all_detector_ids({detector.id})
         assert result == set()
 
-    def test_excludes_unsnoozed_detector(self):
+    def test_excludes_unsnoozed_detector(self) -> None:
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         detector = self.create_detector(project=self.project)
         self.create_alert_rule_detector(alert_rule_id=alert_rule.id, detector=detector)
@@ -130,6 +130,6 @@ class GetSnoozedForAllDetectorIdsTest(TestCase):
         result = RuleSnooze.objects.get_snoozed_for_all_detector_ids({detector.id})
         assert result == set()
 
-    def test_empty_input(self):
+    def test_empty_input(self) -> None:
         result = RuleSnooze.objects.get_snoozed_for_all_detector_ids(set())
         assert result == set()

--- a/tests/sentry/monitors/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_detector_details.py
@@ -17,7 +17,7 @@ class OrganizationMonitorIncidentDetectorDetailsTest(APITestCase):
 
     endpoint = "sentry-api-0-organization-detector-details"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.monitor = Monitor.objects.create(
@@ -47,7 +47,7 @@ class OrganizationMonitorIncidentDetectorDetailsTest(APITestCase):
             detector=self.detector,
         )
 
-    def test_get_monitor_incident_detector_details(self):
+    def test_get_monitor_incident_detector_details(self) -> None:
         """Test getting a monitor incident detector details with proper monitor serialization."""
         response = self.get_success_response(
             self.organization.slug,
@@ -91,7 +91,7 @@ class OrganizationMonitorIncidentDetectorDetailsTest(APITestCase):
             "openIssues": 0,
         }
 
-    def test_update_monitor_incident_detector(self):
+    def test_update_monitor_incident_detector(self) -> None:
         """Test updating a monitor incident detector name and owner."""
         team = self.create_team(organization=self.organization)
 
@@ -138,7 +138,7 @@ class OrganizationMonitorIncidentDetectorDetailsTest(APITestCase):
         assert self.monitor.name == original_monitor_name
         assert self.monitor.config == original_monitor_config
 
-    def test_update_monitor_incident_detector_with_data_sources(self):
+    def test_update_monitor_incident_detector_with_data_sources(self) -> None:
         """Test updating a monitor detector with dataSources field (including existing slug)."""
         data = {
             "name": "Updated Name",
@@ -174,7 +174,7 @@ class OrganizationMonitorIncidentDetectorDetailsTest(APITestCase):
         assert self.monitor.slug == "test-monitor"  # Slug unchanged
         assert self.monitor.config["schedule"] == "0 0 * * 5"
 
-    def test_delete_monitor_incident_detector(self):
+    def test_delete_monitor_incident_detector(self) -> None:
         """Test deleting a monitor incident detector."""
         with outbox_runner():
             self.get_success_response(

--- a/tests/sentry/monitors/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_detector_index.py
@@ -13,7 +13,7 @@ from sentry.workflow_engine.models import DataSource, DataSourceDetector, Detect
 
 @cell_silo_test
 class BaseDetectorTestCase(APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.monitor = Monitor.objects.create(
@@ -48,7 +48,7 @@ class BaseDetectorTestCase(APITestCase):
 class OrganizationDetectorIndexGetTest(BaseDetectorTestCase):
     endpoint = "sentry-api-0-organization-detector-index"
 
-    def test_list_monitor_incident_detectors(self):
+    def test_list_monitor_incident_detectors(self) -> None:
         response = self.get_success_response(self.organization.slug)
 
         detector_data = response.data[2]
@@ -90,7 +90,7 @@ class OrganizationDetectorIndexPostTest(APITestCase):
     endpoint = "sentry-api-0-organization-detector-index"
     method = "post"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
@@ -112,7 +112,7 @@ class OrganizationDetectorIndexPostTest(APITestCase):
         data.update(overrides)
         return data
 
-    def test_create_monitor_incident_detector_validates_correctly(self):
+    def test_create_monitor_incident_detector_validates_correctly(self) -> None:
         data = self._get_detector_post_data()
         response = self.get_success_response(
             self.organization.slug,
@@ -153,7 +153,7 @@ class OrganizationDetectorIndexPostTest(APITestCase):
         expected_monitor_data = serialize(monitor, user=self.user, serializer=MonitorSerializer())
         assert data_source_data["queryObj"] == expected_monitor_data
 
-    def test_create_monitor_incident_detector_validation_error(self):
+    def test_create_monitor_incident_detector_validation_error(self) -> None:
         data = self._get_detector_post_data(
             dataSources=[
                 {
@@ -172,7 +172,7 @@ class OrganizationDetectorIndexPostTest(APITestCase):
         assert "dataSources" in response.data
         assert "Either name or slug must be provided" in str(response.data["dataSources"])
 
-    def test_create_monitor_with_optional_fields(self):
+    def test_create_monitor_with_optional_fields(self) -> None:
         data = self._get_detector_post_data(
             dataSources=[
                 {
@@ -217,7 +217,7 @@ class OrganizationDetectorIndexPutTest(BaseDetectorTestCase):
     endpoint = "sentry-api-0-organization-detector-details"
     method = "put"
 
-    def test_update_monitor_incident_detector(self):
+    def test_update_monitor_incident_detector(self) -> None:
         new_user = self.create_user()
         self.create_member(user=new_user, organization=self.organization)
         data = {
@@ -249,7 +249,7 @@ class OrganizationDetectorIndexPutTest(BaseDetectorTestCase):
         assert self.monitor.name == "Original Monitor"
         assert self.monitor.slug == "original-monitor"
 
-    def test_update_monitor_config_through_detector(self):
+    def test_update_monitor_config_through_detector(self) -> None:
         data = {
             "name": "Updated Detector With Monitor Config",
             "dataSources": [
@@ -286,7 +286,7 @@ class OrganizationDetectorDeleteTest(BaseDetectorTestCase):
     endpoint = "sentry-api-0-organization-detector-details"
     method = "delete"
 
-    def test_delete_monitor_incident_detector(self):
+    def test_delete_monitor_incident_detector(self) -> None:
         detector_id = self.detector.id
         monitor_id = self.monitor.id
         self.get_success_response(

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -284,7 +284,7 @@ class MonitorEnvironmentTestCase(TestCase):
         assert len(cm.records) == 1
         assert "invalid config" in cm.records[0].message
 
-    def test_build_occurrence_fingerprint(self):
+    def test_build_occurrence_fingerprint(self) -> None:
         """Test that build_occurrence_fingerprint returns the expected format"""
         monitor = self.create_monitor()
         monitor_environment = self.create_monitor_environment(
@@ -294,7 +294,7 @@ class MonitorEnvironmentTestCase(TestCase):
         fingerprint = monitor_environment.build_occurrence_fingerprint()
         assert fingerprint == f"crons:{monitor_environment.id}"
 
-    def test_build_occurrence_fingerprint_different_environments(self):
+    def test_build_occurrence_fingerprint_different_environments(self) -> None:
         """Test that different MonitorEnvironments get different fingerprints"""
         monitor = self.create_monitor()
         env1 = self.create_environment(name="production")
@@ -314,7 +314,7 @@ class MonitorEnvironmentTestCase(TestCase):
         assert fingerprint1 == f"crons:{monitor_env1.id}"
         assert fingerprint2 == f"crons:{monitor_env2.id}"
 
-    def test_ensure_environment_matches_monitor_muted_state(self):
+    def test_ensure_environment_matches_monitor_muted_state(self) -> None:
         """Test that new environments match the monitor's computed is_muted state.
 
         When creating a new environment, it will be muted if the monitor's is_muted
@@ -436,7 +436,7 @@ class CronMonitorDataSourceHandlerTest(TestCase):
 class MonitorIsMutedPropertyTestCase(TestCase):
     """Test the is_muted computed property for Monitor."""
 
-    def test_is_muted_all_environments_muted(self):
+    def test_is_muted_all_environments_muted(self) -> None:
         """Test that monitor.is_muted returns True when all environments are muted."""
         monitor = self.create_monitor()
         env1 = self.create_environment(name="production")
@@ -457,7 +457,7 @@ class MonitorIsMutedPropertyTestCase(TestCase):
         # Verify monitor.is_muted is True
         assert is_monitor_muted(monitor) is True
 
-    def test_is_muted_some_environments_unmuted(self):
+    def test_is_muted_some_environments_unmuted(self) -> None:
         """Test that monitor.is_muted returns False when any environment is unmuted."""
         monitor = self.create_monitor()
         env1 = self.create_environment(name="production")
@@ -478,7 +478,7 @@ class MonitorIsMutedPropertyTestCase(TestCase):
         # Verify monitor.is_muted is False
         assert is_monitor_muted(monitor) is False
 
-    def test_is_muted_all_environments_unmuted(self):
+    def test_is_muted_all_environments_unmuted(self) -> None:
         """Test that monitor.is_muted returns False when all environments are unmuted."""
         monitor = self.create_monitor()
         env1 = self.create_environment(name="production")
@@ -499,12 +499,12 @@ class MonitorIsMutedPropertyTestCase(TestCase):
         # Verify monitor.is_muted is False
         assert is_monitor_muted(monitor) is False
 
-    def test_is_muted_no_environments(self):
+    def test_is_muted_no_environments(self) -> None:
         """Test that monitor.is_muted returns False when there are no environments."""
         monitor = self.create_monitor()
         assert is_monitor_muted(monitor) is False
 
-    def test_is_muted_single_environment(self):
+    def test_is_muted_single_environment(self) -> None:
         """Test is_muted works correctly with a single environment."""
         # Test with muted environment
         monitor = self.create_monitor()

--- a/tests/sentry/monitors/test_serializers.py
+++ b/tests/sentry/monitors/test_serializers.py
@@ -5,7 +5,7 @@ from sentry.testutils.cases import TestCase
 
 
 class MonitorEnvironmentSerializerTest(TestCase):
-    def test_serialize_with_deleted_environment(self):
+    def test_serialize_with_deleted_environment(self) -> None:
         """
         Test that MonitorEnvironmentSerializer handles missing environments gracefully.
         This can happen when an environment is deleted but MonitorEnvironment records still reference it.
@@ -29,7 +29,7 @@ class MonitorEnvironmentSerializerTest(TestCase):
 
 
 class MonitorCheckInSerializerTest(TestCase):
-    def test_serialize_with_deleted_environment(self):
+    def test_serialize_with_deleted_environment(self) -> None:
         """
         Test that MonitorCheckInSerializer handles missing environments gracefully.
         This can happen when an environment is deleted but check-ins still reference it.

--- a/tests/sentry/monitors/test_validators.py
+++ b/tests/sentry/monitors/test_validators.py
@@ -99,7 +99,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
             ),
         )
 
-    def test_slug(self):
+    def test_slug(self) -> None:
         data = {
             "project": self.project.slug,
             "name": "My Monitor",
@@ -113,7 +113,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         monitor = validator.save()
         assert monitor.slug == "my-monitor"
 
-    def test_invalid_numeric_slug(self):
+    def test_invalid_numeric_slug(self) -> None:
         data = {
             "project": self.project.slug,
             "name": "My Monitor",
@@ -126,7 +126,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         assert "slug" in validator.errors
         assert validator.errors["slug"][0] == DEFAULT_SLUG_ERROR_MESSAGE
 
-    def test_generated_slug_not_entirely_numeric(self):
+    def test_generated_slug_not_entirely_numeric(self) -> None:
         data = {
             "project": self.project.slug,
             "name": "1234",
@@ -140,7 +140,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         assert monitor.slug.startswith("1234-")
         assert not monitor.slug.isdecimal()
 
-    def test_crontab_whitespace(self):
+    def test_crontab_whitespace(self) -> None:
         data = {
             "project": self.project.slug,
             "name": "1234",
@@ -154,7 +154,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         assert monitor.config["schedule"] == "* * * * *"
 
     @override_settings(MAX_MONITORS_PER_ORG=2)
-    def test_monitor_organization_limit(self):
+    def test_monitor_organization_limit(self) -> None:
         for i in range(settings.MAX_MONITORS_PER_ORG):
             Monitor.objects.create(
                 organization_id=self.organization.id,
@@ -184,7 +184,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
             )
         ]
 
-    def test_simple_with_alert_rule(self):
+    def test_simple_with_alert_rule(self) -> None:
         data = {
             "project": self.project.slug,
             "name": "My Monitor",
@@ -207,7 +207,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         assert rule is not None
         assert rule.environment_id == self.environment.id
 
-    def test_checkin_margin_zero(self):
+    def test_checkin_margin_zero(self) -> None:
         # Invalid checkin margin
         #
         # XXX(epurkhiser): We currently transform 0 -> 1 for backwards
@@ -268,7 +268,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         assert detector is not None
         assert detector.enabled is False
 
-    def test_invalid_schedule(self):
+    def test_invalid_schedule(self) -> None:
         data = {
             "project": self.project.slug,
             "name": "My Monitor",
@@ -282,7 +282,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         assert "schedule" in validator.errors["config"]
         assert validator.errors["config"]["schedule"][0] == "Schedule is invalid"
 
-    def test_create_with_owner_team(self):
+    def test_create_with_owner_team(self) -> None:
         """Test creating a monitor with a team owner."""
         team = self.create_team(organization=self.organization)
         data = {
@@ -300,7 +300,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
         assert monitor.owner_user_id is None
         assert monitor.owner_team_id == team.id
 
-    def test_create_with_status_disabled(self):
+    def test_create_with_status_disabled(self) -> None:
         """Test creating a monitor with disabled status."""
         data = {
             "project": self.project.slug,
@@ -316,7 +316,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
 
         assert monitor.status == ObjectStatus.DISABLED
 
-    def test_create_with_is_muted_noop(self):
+    def test_create_with_is_muted_noop(self) -> None:
         """Test that creating a monitor with is_muted does nothing.
 
         Since is_muted is computed from MonitorEnvironment.is_muted, setting is_muted=True
@@ -342,7 +342,7 @@ class MonitorValidatorCreateTest(MonitorTestCase):
 
 
 class MonitorValidatorUpdateTest(MonitorTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
 
@@ -366,7 +366,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         self.access = MagicMock()
         self.access.has_project_scope.return_value = True
 
-    def test_update_name(self):
+    def test_update_name(self) -> None:
         """Test updating monitor name."""
         validator = MonitorValidator(
             instance=self.monitor,
@@ -384,7 +384,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.name == "Updated Monitor Name"
         assert updated_monitor.slug == "test-monitor"  # Slug unchanged
 
-    def test_update_slug(self):
+    def test_update_slug(self) -> None:
         """Test updating monitor slug."""
         validator = MonitorValidator(
             instance=self.monitor,
@@ -402,7 +402,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.slug == "new-monitor-slug"
         assert updated_monitor.name == "Test Monitor"  # Name unchanged
 
-    def test_update_config(self):
+    def test_update_config(self) -> None:
         """Test updating monitor config."""
         new_config = {
             "schedule": "*/30 * * * *",
@@ -429,7 +429,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.config["max_runtime"] == 60
         assert updated_monitor.config["timezone"] == "America/New_York"
 
-    def test_partial_config_update_different_field(self):
+    def test_partial_config_update_different_field(self) -> None:
         """Test that updating a config field doesn't trigger false positive margin/runtime changes."""
         now = timezone.now().replace(second=0, microsecond=0)
         env = self.create_monitor_environment(
@@ -469,7 +469,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         env.refresh_from_db()
         assert env.next_checkin_latest == original_next_checkin_latest
 
-    def test_update_owner_to_user(self):
+    def test_update_owner_to_user(self) -> None:
         """Test updating monitor owner to a user."""
         validator = MonitorValidator(
             instance=self.monitor,
@@ -487,7 +487,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.owner_user_id == self.user.id
         assert updated_monitor.owner_team_id is None
 
-    def test_update_owner_to_team(self):
+    def test_update_owner_to_team(self) -> None:
         """Test updating monitor owner to a team."""
         validator = MonitorValidator(
             instance=self.monitor,
@@ -505,7 +505,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.owner_user_id is None
         assert updated_monitor.owner_team_id == self.team.id
 
-    def test_update_owner_to_none(self):
+    def test_update_owner_to_none(self) -> None:
         """Test removing monitor owner."""
         # First set an owner
         self.monitor.update(owner_user_id=self.user.id)
@@ -526,7 +526,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.owner_user_id is None
         assert updated_monitor.owner_team_id is None
 
-    def test_update_is_muted(self):
+    def test_update_is_muted(self) -> None:
         """Test updating is_muted field."""
         # Create an environment first so the monitor can be muted
         env = self.create_monitor_environment(
@@ -554,7 +554,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         env.refresh_from_db()
         assert env.is_muted is True
 
-    def test_update_is_muted_propagates_to_environments(self):
+    def test_update_is_muted_propagates_to_environments(self) -> None:
         """Test that muting a monitor propagates to all its environments."""
         # Create two monitor environments
         env1 = self.create_monitor_environment(
@@ -590,7 +590,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert env1.is_muted is True
         assert env2.is_muted is True
 
-    def test_update_is_muted_false_propagates_to_environments(self):
+    def test_update_is_muted_false_propagates_to_environments(self) -> None:
         """Test that unmuting a monitor propagates to all its environments."""
         # Create two muted monitor environments
         env1 = self.create_monitor_environment(
@@ -629,7 +629,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert env1.is_muted is False
         assert env2.is_muted is False
 
-    def test_update_status_to_disabled(self):
+    def test_update_status_to_disabled(self) -> None:
         """Test updating monitor status to disabled."""
         validator = MonitorValidator(
             instance=self.monitor,
@@ -699,7 +699,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert not validator.is_valid()
         assert "Monitor quota exceeded" in str(validator.errors["status"])
 
-    def test_update_multiple_fields(self):
+    def test_update_multiple_fields(self) -> None:
         """Test updating multiple fields at once."""
         validator = MonitorValidator(
             instance=self.monitor,
@@ -723,7 +723,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert is_monitor_muted(updated_monitor) is False
         assert updated_monitor.owner_team_id == self.team.id
 
-    def test_update_slug_already_exists(self):
+    def test_update_slug_already_exists(self) -> None:
         """Test updating slug to one that already exists fails."""
         # Create another monitor with target slug
         Monitor.objects.create(
@@ -750,7 +750,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert not validator.is_valid()
         assert 'The slug "existing-slug" is already in use.' in str(validator.errors["slug"])
 
-    def test_update_preserves_unchanged_fields(self):
+    def test_update_preserves_unchanged_fields(self) -> None:
         """Test that update preserves fields that aren't being updated."""
         original_config = self.monitor.config.copy()
 
@@ -771,7 +771,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.slug == "test-monitor"
         assert updated_monitor.config == original_config
 
-    def test_partial_config_update_preserves_existing_fields(self):
+    def test_partial_config_update_preserves_existing_fields(self) -> None:
         """Test that partial config updates preserve fields not included in the update."""
         # Set up a monitor with a complete config
         original_config = {
@@ -806,7 +806,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert updated_monitor.config["failure_issue_threshold"] == 3
         assert updated_monitor.config["recovery_threshold"] == 1
 
-    def test_update_schedule_recomputes_next_checkin(self):
+    def test_update_schedule_recomputes_next_checkin(self) -> None:
         """Test that updating the schedule recomputes next_checkin for all environments."""
         # Create monitor environments with specific next_checkin times
         now = timezone.now().replace(second=0, microsecond=0)
@@ -857,7 +857,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         assert env2.next_checkin == expected_next_checkin
         assert env2.next_checkin_latest == expected_next_checkin_latest
 
-    def test_partial_config_update_does_not_trigger_schedule_recompute(self):
+    def test_partial_config_update_does_not_trigger_schedule_recompute(self) -> None:
         """Test that updating only checkin_margin doesn't trigger schedule recomputation."""
         # Create a monitor environment with specific next_checkin times
         now = timezone.now().replace(second=0, microsecond=0)
@@ -896,7 +896,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
         env.refresh_from_db()
         assert env.next_checkin == original_next_checkin
 
-    def test_update_schedule_type_recomputes_next_checkin(self):
+    def test_update_schedule_type_recomputes_next_checkin(self) -> None:
         """Test that changing schedule_type from crontab to interval recomputes next_checkin."""
         # Create a monitor environment
         now = timezone.now().replace(second=0, microsecond=0)
@@ -939,7 +939,7 @@ class MonitorValidatorUpdateTest(MonitorTestCase):
 class BaseMonitorValidatorTestCase(MonitorTestCase):
     """Base class for monitor validator tests with common setup."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
         self.request = RequestFactory().get("/")
@@ -970,7 +970,7 @@ class BaseMonitorValidatorTestCase(MonitorTestCase):
 
 
 class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.valid_data = self._get_valid_data()
 
@@ -1002,13 +1002,13 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
         assert validated_data["config"]["schedule"] == expected_schedule
         assert validated_data["config"]["schedule_type"] == expected_type
 
-    def test_valid_crontab_config(self):
+    def test_valid_crontab_config(self) -> None:
         validator = self._create_validator()
         self._assert_valid_monitor_data(
             validator, "Test Monitor", "test-monitor", "0 * * * *", ScheduleType.CRONTAB
         )
 
-    def test_valid_interval_config(self):
+    def test_valid_interval_config(self) -> None:
         data = self._get_valid_data(
             name="Interval Monitor",
             slug="interval-monitor",
@@ -1019,7 +1019,7 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
             validator, "Interval Monitor", "interval-monitor", [1, "hour"], ScheduleType.INTERVAL
         )
 
-    def test_only_slug_provided(self):
+    def test_only_slug_provided(self) -> None:
         data = {
             "slug": "my-monitor-slug",
             "config": self.valid_data["config"],
@@ -1030,7 +1030,7 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
         assert validated_data["name"] == "my-monitor-slug"
         assert validated_data["slug"] == "my-monitor-slug"
 
-    def test_only_name_provided(self):
+    def test_only_name_provided(self) -> None:
         data = {
             "name": "My Monitor Name",
             "config": self.valid_data["config"],
@@ -1041,26 +1041,26 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
         assert validated_data["name"] == "My Monitor Name"
         assert validated_data["slug"] == "my-monitor-name"
 
-    def test_missing_name_and_slug(self):
+    def test_missing_name_and_slug(self) -> None:
         data = {"config": self.valid_data["config"]}
         validator = self._create_validator(data)
         assert not validator.is_valid()
         assert "Either name or slug must be provided" in str(validator.errors)
 
-    def test_invalid_crontab_schedule(self):
+    def test_invalid_crontab_schedule(self) -> None:
         data = self._get_valid_data()
         data["config"]["schedule"] = "invalid cron"
         validator = self._create_validator(data)
         assert not validator.is_valid()
         assert "schedule" in validator.errors["config"]
 
-    def test_invalid_interval_schedule(self):
+    def test_invalid_interval_schedule(self) -> None:
         data = self._get_valid_data(config=self._get_base_config("interval", schedule=[0, "hour"]))
         validator = self._create_validator(data)
         assert not validator.is_valid()
         assert "schedule" in validator.errors["config"]
 
-    def test_nonstandard_crontab_schedules(self):
+    def test_nonstandard_crontab_schedules(self) -> None:
         data = self._get_valid_data()
         data["config"]["schedule"] = "@hourly"
         validator = self._create_validator(data)
@@ -1080,7 +1080,7 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
         assert monitor.owner_user_id is None
         assert monitor.owner_team_id is None
 
-    def test_validate_with_owner(self):
+    def test_validate_with_owner(self) -> None:
         team = self.create_team(organization=self.organization)
         data = self._get_valid_data(owner=f"team:{team.id}")
         validator = self._create_validator(data)
@@ -1090,21 +1090,21 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
         assert validated_data["owner"].is_team
         assert validated_data["owner"].id == team.id
 
-    def test_validate_with_status(self):
+    def test_validate_with_status(self) -> None:
         data = self._get_valid_data(status="disabled")
         validator = self._create_validator(data)
         assert validator.is_valid(), validator.errors
         validated_data = validator.validated_data
         assert validated_data["status"] == ObjectStatus.DISABLED
 
-    def test_validate_with_is_muted(self):
+    def test_validate_with_is_muted(self) -> None:
         data = self._get_valid_data(isMuted=True)
         validator = self._create_validator(data)
         assert validator.is_valid(), validator.errors
         validated_data = validator.validated_data
         assert validated_data["is_muted"] is True
 
-    def test_slug_uniqueness_validation(self):
+    def test_slug_uniqueness_validation(self) -> None:
         Monitor.objects.create(
             organization_id=self.organization.id,
             project_id=self.project.id,
@@ -1120,7 +1120,7 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
         assert "slug" in validator.errors
         assert 'The slug "test-monitor" is already in use.' in str(validator.errors["slug"])
 
-    def test_update_monitor(self):
+    def test_update_monitor(self) -> None:
         monitor = Monitor.objects.create(
             organization_id=self.organization.id,
             project_id=self.project.id,
@@ -1155,7 +1155,7 @@ class MonitorDataSourceValidatorTest(BaseMonitorValidatorTestCase):
 
 
 class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.valid_data = self._get_valid_detector_data()
 
@@ -1182,7 +1182,7 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
             context=self.context,
         )
 
-    def test_valid_detector_with_monitor(self):
+    def test_valid_detector_with_monitor(self) -> None:
         validator = self._create_validator()
         assert validator.is_valid(), validator.errors
         validated_data = validator.validated_data
@@ -1192,7 +1192,7 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
         assert validated_data["data_sources"][0]["slug"] == "test-monitor"
 
     @pytest.mark.skip("Not required yet, migrating to dataSources")
-    def test_detector_requires_data_source(self):
+    def test_detector_requires_data_source(self) -> None:
         data = {
             "type": "monitor_check_in_failure",
             "name": "Test Monitor Detector",
@@ -1201,7 +1201,7 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
         assert not validator.is_valid()
         assert "dataSources" in validator.errors
 
-    def test_rejects_multiple_data_sources(self):
+    def test_rejects_multiple_data_sources(self) -> None:
         """Test that multiple data sources are rejected for cron monitors."""
         data = self._get_valid_detector_data(
             dataSources=[
@@ -1222,7 +1222,7 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
         assert "dataSources" in validator.errors
         assert "Only one data source is allowed" in str(validator.errors["dataSources"])
 
-    def test_create_detector_validates_data_source(self):
+    def test_create_detector_validates_data_source(self) -> None:
         condition_group = DataConditionGroup.objects.create(
             organization_id=self.organization.id,
             logic_type=DataConditionGroup.Type.ANY,

--- a/tests/sentry/notifications/notification_action/test_grouptype.py
+++ b/tests/sentry/notifications/notification_action/test_grouptype.py
@@ -6,7 +6,7 @@ pytestmark = [requires_snuba]
 
 
 class TestGetTestNotificationEventData(TestCase):
-    def test_returns_group_event_with_occurrence(self):
+    def test_returns_group_event_with_occurrence(self) -> None:
         project = self.create_project()
         group_event = get_test_notification_event_data(project)
 
@@ -14,7 +14,7 @@ class TestGetTestNotificationEventData(TestCase):
         assert group_event.occurrence is not None
         assert group_event.occurrence.issue_title == "Test Issue"
 
-    def test_email_subject_uses_occurrence_title(self):
+    def test_email_subject_uses_occurrence_title(self) -> None:
         project = self.create_project()
         group_event = get_test_notification_event_data(project)
 

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -755,14 +755,14 @@ class TestInvokeFutureWithErrorHandling(BaseWorkflowTest):
         self.mock_callback = mock.Mock()
         self.mock_futures = [mock.Mock()]
 
-    def test_happy_path(self):
+    def test_happy_path(self) -> None:
         from sentry.notifications.notification_action.types import invoke_future_with_error_handling
 
         invoke_future_with_error_handling(self.event_data, self.mock_callback, self.mock_futures)
 
         self.mock_callback.assert_called_once_with(self.group_event, self.mock_futures)
 
-    def test_invalid_event_data(self):
+    def test_invalid_event_data(self) -> None:
         from sentry.notifications.notification_action.types import invoke_future_with_error_handling
         from sentry.workflow_engine.types import WorkflowEventData
 
@@ -777,7 +777,7 @@ class TestInvokeFutureWithErrorHandling(BaseWorkflowTest):
 
         assert "Expected a GroupEvent" in str(excinfo.value)
 
-    def test_ignores_integration_form_error(self):
+    def test_ignores_integration_form_error(self) -> None:
         from sentry.notifications.notification_action.types import invoke_future_with_error_handling
         from sentry.shared_integrations.exceptions import IntegrationFormError
 
@@ -789,7 +789,7 @@ class TestInvokeFutureWithErrorHandling(BaseWorkflowTest):
 
         self.mock_callback.assert_called_once()
 
-    def test_ignores_integration_configuration_error(self):
+    def test_ignores_integration_configuration_error(self) -> None:
         from sentry.notifications.notification_action.types import invoke_future_with_error_handling
         from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 
@@ -799,7 +799,7 @@ class TestInvokeFutureWithErrorHandling(BaseWorkflowTest):
 
         self.mock_callback.assert_called_once()
 
-    def test_reraises_processing_deadline_exceeded(self):
+    def test_reraises_processing_deadline_exceeded(self) -> None:
         from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
         from sentry.notifications.notification_action.types import invoke_future_with_error_handling
@@ -813,7 +813,7 @@ class TestInvokeFutureWithErrorHandling(BaseWorkflowTest):
 
         self.mock_callback.assert_called_once()
 
-    def test_raises_retry_error_for_api_error(self):
+    def test_raises_retry_error_for_api_error(self) -> None:
         from taskbroker_client.retry import RetryTaskError
 
         from sentry.notifications.notification_action.types import invoke_future_with_error_handling

--- a/tests/sentry/notifications/notifications/test_suspect_commits_activity.py
+++ b/tests/sentry/notifications/notifications/test_suspect_commits_activity.py
@@ -56,7 +56,7 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
             context={"commitId": commit.id},
         )
 
-    def test_assigned_notification_includes_suspect_commits(self):
+    def test_assigned_notification_includes_suspect_commits(self) -> None:
         self._create_suspect_commit_owner(self.commit1)
 
         activity = Activity.objects.create(
@@ -81,7 +81,7 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert context["commits"][0]["shortId"] == "abc123d"
         assert context["commits"][0]["author"]["name"] == self.user.get_display_name()
 
-    def test_unassigned_notification_includes_suspect_commits(self):
+    def test_unassigned_notification_includes_suspect_commits(self) -> None:
         # First assign, then unassign
         GroupAssignee.objects.create(
             group=self.group,
@@ -112,7 +112,7 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert len(context["commits"]) == 1
         assert context["commits"][0]["subject"] == "feat: Add new feature"
 
-    def test_resolved_notification_includes_suspect_commits(self):
+    def test_resolved_notification_includes_suspect_commits(self) -> None:
         self._create_suspect_commit_owner(self.commit1)
 
         activity = Activity.objects.create(
@@ -130,7 +130,7 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert len(context["commits"]) == 1
         assert context["commits"][0]["subject"] == "feat: Add new feature"
 
-    def test_note_notification_includes_suspect_commits(self):
+    def test_note_notification_includes_suspect_commits(self) -> None:
         self._create_suspect_commit_owner(self.commit1)
 
         activity = Activity.objects.create(
@@ -148,7 +148,7 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert len(context["commits"]) == 1
         assert context["commits"][0]["subject"] == "feat: Add new feature"
 
-    def test_multiple_suspect_commits_in_notification(self):
+    def test_multiple_suspect_commits_in_notification(self) -> None:
         """Test that when multiple suspect commits exist, only the most recent one is returned."""
         # Create GroupOwner records for both commits
         self._create_suspect_commit_owner(self.commit1)
@@ -179,7 +179,7 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert commit["subject"] == "fix: Critical bug fix"
         assert commit["id"] == "def456ghi789"
 
-    def test_notification_without_suspect_commits(self):
+    def test_notification_without_suspect_commits(self) -> None:
         activity = Activity.objects.create(
             project=self.project,
             group=self.group,
@@ -199,7 +199,7 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert "commits" in context
         assert context["commits"] == []
 
-    def test_graceful_handling_of_invalid_commit_ids(self):
+    def test_graceful_handling_of_invalid_commit_ids(self) -> None:
         # Create GroupOwner with invalid commit ID
         GroupOwner.objects.create(
             group=self.group,
@@ -230,7 +230,7 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert "commits" in context
         assert context["commits"] == []
 
-    def test_enhanced_privacy_hides_suspect_commits(self):
+    def test_enhanced_privacy_hides_suspect_commits(self) -> None:
         """Test that suspect commits are hidden when enhanced privacy is enabled."""
         self._create_suspect_commit_owner(self.commit1)
         self.organization.update(flags=F("flags").bitor(Organization.flags.enhanced_privacy))

--- a/tests/sentry/objectstore/endpoints/test_organization.py
+++ b/tests/sentry/objectstore/endpoints/test_organization.py
@@ -65,13 +65,13 @@ class OrganizationObjectstoreEndpointTest(TransactionTestCase):
         return session
 
     @with_feature("organizations:objectstore-endpoint")
-    def test_health(self):
+    def test_health(self) -> None:
         url = self.get_endpoint_url() + "health"
         res = requests.get(url, headers=self.get_auth_headers())
         res.raise_for_status()
 
     @with_feature("organizations:objectstore-endpoint")
-    def test_full_cycle(self):
+    def test_full_cycle(self) -> None:
         session = self.get_session()
 
         object_key = session.put(b"test data")
@@ -92,7 +92,7 @@ class OrganizationObjectstoreEndpointTest(TransactionTestCase):
             session.get(object_key)
 
     @with_feature("organizations:objectstore-endpoint")
-    def test_uncompressed(self):
+    def test_uncompressed(self) -> None:
         session = self.get_session()
 
         object_key = session.put(b"test data", compression="none")
@@ -102,7 +102,7 @@ class OrganizationObjectstoreEndpointTest(TransactionTestCase):
         assert retrieved.payload.read() == b"test data"
 
     @with_feature("organizations:objectstore-endpoint")
-    def test_accept_encoding_passthrough(self):
+    def test_accept_encoding_passthrough(self) -> None:
         data = os.urandom(10 * 1024)
         ctx = zstandard.ZstdCompressor()
         compressed = ctx.compress(data)
@@ -149,7 +149,7 @@ class OrganizationObjectstoreEndpointTest(TransactionTestCase):
             assert reader.read() == data
 
     @with_feature("organizations:objectstore-endpoint")
-    def test_large_payload(self):
+    def test_large_payload(self) -> None:
         session = self.get_session()
         data = b"A" * 1_000_000
 
@@ -195,7 +195,7 @@ class OrganizationObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
         )
         return path
 
-    def test_health(self):
+    def test_health(self) -> None:
         config = asdict(test_region)
         config["address"] = self.live_server.url
         with override_cells([Cell(**config)]):
@@ -208,7 +208,7 @@ class OrganizationObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
                 # consume body to close connection
                 b"".join(response.streaming_content)  # type: ignore[attr-defined]
 
-    def test_full_cycle(self):
+    def test_full_cycle(self) -> None:
         config = asdict(test_region)
         config["address"] = self.live_server.url
         auth_header = self.create_basic_auth_header(self.api_key.key).decode()
@@ -275,7 +275,7 @@ class OrganizationObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
                 # consume body to close connection
                 b"".join(response.streaming_content)  # type: ignore[attr-defined]
 
-    def test_roundtrip_compressed(self):
+    def test_roundtrip_compressed(self) -> None:
         config = asdict(test_region)
         config["address"] = self.live_server.url
         auth_header = self.create_basic_auth_header(self.api_key.key).decode()

--- a/tests/sentry/preprod/api/bases/test_preprod_artifact_endpoint.py
+++ b/tests/sentry/preprod/api/bases/test_preprod_artifact_endpoint.py
@@ -4,7 +4,7 @@ from sentry.testutils.helpers.features import with_feature
 
 
 class PreprodArtifactEndpointTest(APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
         self.artifact = self.create_preprod_artifact(project=self.project)
@@ -13,17 +13,17 @@ class PreprodArtifactEndpointTest(APITestCase):
         return f"/api/0/organizations/{org_slug}/preprodartifacts/{artifact_id}/build-details/"
 
     @with_feature("organizations:preprod-frontend-routes")
-    def test_extracts_project_from_artifact(self):
+    def test_extracts_project_from_artifact(self) -> None:
         url = self._get_url(self.organization.slug, self.artifact.id)
         response = self.client.get(url)
         assert response.status_code == 200
 
-    def test_artifact_not_found_returns_404(self):
+    def test_artifact_not_found_returns_404(self) -> None:
         url = self._get_url(self.organization.slug, 999999)
         response = self.client.get(url)
         assert response.status_code == 404
 
-    def test_artifact_from_different_org_returns_404(self):
+    def test_artifact_from_different_org_returns_404(self) -> None:
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)
         other_artifact = self.create_preprod_artifact(project=other_project)
@@ -32,7 +32,7 @@ class PreprodArtifactEndpointTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 404
 
-    def test_user_without_project_access_returns_404(self):
+    def test_user_without_project_access_returns_404(self) -> None:
         # Disable open membership so users without team membership truly lack project access
         self.organization.flags.allow_joinleave = False
         self.organization.save()
@@ -45,7 +45,7 @@ class PreprodArtifactEndpointTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 404
 
-    def test_artifact_from_inactive_project_returns_404(self):
+    def test_artifact_from_inactive_project_returns_404(self) -> None:
         self.project.status = ObjectStatus.PENDING_DELETION
         self.project.save()
 

--- a/tests/sentry/preprod/api/endpoints/public/test_organization_preprod_artifact_install_details.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_organization_preprod_artifact_install_details.py
@@ -7,7 +7,7 @@ from sentry.testutils.cases import APITestCase
 class OrganizationPreprodArtifactPublicInstallDetailsEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-preprod-artifact-public-install-details"
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
@@ -41,18 +41,18 @@ class OrganizationPreprodArtifactPublicInstallDetailsEndpointTest(APITestCase):
             args=[self.organization.slug, artifact_id],
         )
 
-    def test_feature_flag_disabled(self):
+    def test_feature_flag_disabled(self) -> None:
         with self.feature({"organizations:preprod-frontend-routes": False}):
             response = self.client.get(self._get_url())
             assert response.status_code == 403
             assert response.json()["detail"] == "Feature not enabled"
 
-    def test_artifact_not_found(self):
+    def test_artifact_not_found(self) -> None:
         response = self.client.get(self._get_url(artifact_id=999999))
         assert response.status_code == 404
         assert "The requested preprod artifact does not exist" in response.json()["detail"]
 
-    def test_cross_org_artifact_access(self):
+    def test_cross_org_artifact_access(self) -> None:
         other_org = self.create_organization(owner=self.user)
         other_project = self.create_project(organization=other_org)
         other_file = self.create_file(name="other.apk", type="application/octet-stream")
@@ -66,7 +66,7 @@ class OrganizationPreprodArtifactPublicInstallDetailsEndpointTest(APITestCase):
         response = self.client.get(self._get_url(artifact_id=other_artifact.id))
         assert response.status_code == 404
 
-    def test_not_installable_artifact(self):
+    def test_not_installable_artifact(self) -> None:
         response = self.client.get(self._get_url())
         assert response.status_code == 200
         data = response.json()
@@ -93,7 +93,7 @@ class OrganizationPreprodArtifactPublicInstallDetailsEndpointTest(APITestCase):
         assert data["profileName"] is None
         assert data["codesigningType"] is None
 
-    def test_installable_android_artifact(self):
+    def test_installable_android_artifact(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             file_id=self.file.id,
@@ -114,7 +114,7 @@ class OrganizationPreprodArtifactPublicInstallDetailsEndpointTest(APITestCase):
         assert data["releaseNotes"] == "Bug fixes and improvements"
         assert data["isCodeSignatureValid"] is None
 
-    def test_installable_ios_artifact_valid_signature(self):
+    def test_installable_ios_artifact_valid_signature(self) -> None:
         ios_file = self.create_file(name="test.xcarchive", type="application/octet-stream")
         installable_file = self.create_file(name="test.ipa", type="application/octet-stream")
         artifact = self.create_preprod_artifact(
@@ -142,7 +142,7 @@ class OrganizationPreprodArtifactPublicInstallDetailsEndpointTest(APITestCase):
         assert data["profileName"] == "iOS Team Provisioning Profile"
         assert data["codesigningType"] == "development"
 
-    def test_ios_artifact_invalid_signature(self):
+    def test_ios_artifact_invalid_signature(self) -> None:
         ios_file = self.create_file(name="test.xcarchive", type="application/octet-stream")
         installable_file = self.create_file(name="test.ipa", type="application/octet-stream")
         artifact = self.create_preprod_artifact(

--- a/tests/sentry/preprod/api/endpoints/public/test_organization_preprod_size_analysis.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_organization_preprod_size_analysis.py
@@ -14,7 +14,7 @@ from sentry.utils import json
 class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-preprod-artifact-public-size-analysis"
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
@@ -67,18 +67,18 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         defaults.update(overrides)
         return defaults
 
-    def test_feature_flag_disabled(self):
+    def test_feature_flag_disabled(self) -> None:
         with self.feature({"organizations:preprod-frontend-routes": False}):
             response = self.client.get(self._get_url())
             assert response.status_code == 403
             assert response.json()["detail"] == "Feature not enabled"
 
-    def test_artifact_not_found(self):
+    def test_artifact_not_found(self) -> None:
         response = self.client.get(self._get_url(artifact_id=999999))
         assert response.status_code == 404
         assert "The requested preprod artifact does not exist" in response.json()["detail"]
 
-    def test_no_size_metrics_returns_pending(self):
+    def test_no_size_metrics_returns_pending(self) -> None:
         response = self.client.get(self._get_url())
         assert response.status_code == 200
         data = response.json()
@@ -89,7 +89,7 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         assert data["errorCode"] is None
         assert data["errorMessage"] is None
 
-    def test_pending_state(self):
+    def test_pending_state(self) -> None:
         self.create_preprod_artifact_size_metrics(
             self.preprod_artifact,
             metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
@@ -105,7 +105,7 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         assert data["downloadSize"] is None
         assert data["installSize"] is None
 
-    def test_processing_state(self):
+    def test_processing_state(self) -> None:
         self.create_preprod_artifact_size_metrics(
             self.preprod_artifact,
             metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
@@ -117,7 +117,7 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         data = response.json()
         assert data["state"] == "PROCESSING"
 
-    def test_failed_state(self):
+    def test_failed_state(self) -> None:
         self.create_preprod_artifact_size_metrics(
             self.preprod_artifact,
             metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
@@ -135,7 +135,7 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         assert data["downloadSize"] is None
         assert data["installSize"] is None
 
-    def test_completed_state(self):
+    def test_completed_state(self) -> None:
         analysis_data = self._make_analysis_data(
             insights={"platform": "android", "duplicate_files": None},
             app_components=[
@@ -188,7 +188,7 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         assert "treemap" not in data
         assert "fileAnalysis" not in data
 
-    def test_completed_state_with_base_build(self):
+    def test_completed_state_with_base_build(self) -> None:
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
             head_sha="1234567890098765432112345678900987654321",
@@ -273,7 +273,7 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         assert comparison["sizeMetricDiff"] is not None
         assert comparison["sizeMetricDiff"]["metricsArtifactType"] == "MAIN_ARTIFACT"
 
-    def test_completed_state_with_explicit_base_id(self):
+    def test_completed_state_with_explicit_base_id(self) -> None:
         base_file = self.create_file(name="base_artifact.apk", type="application/octet-stream")
         base_artifact = self.create_preprod_artifact(
             project=self.project,
@@ -336,7 +336,7 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         assert data["baseBuildId"] == str(base_artifact.id)
         assert data["comparisons"] is not None
 
-    def test_invalid_base_id(self):
+    def test_invalid_base_id(self) -> None:
         analysis_file = self._create_analysis_file(self._make_analysis_data())
 
         self.create_preprod_artifact_size_metrics(
@@ -353,7 +353,7 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         assert response.status_code == 404
         assert "base preprod artifact does not exist" in response.json()["detail"]
 
-    def test_cross_org_artifact_access(self):
+    def test_cross_org_artifact_access(self) -> None:
         other_org = self.create_organization(owner=self.user)
         other_project = self.create_project(organization=other_org)
         other_file = self.create_file(name="other_artifact.apk", type="application/octet-stream")
@@ -368,7 +368,7 @@ class ProjectPreprodPublicSizeAnalysisEndpointTest(APITestCase):
         assert response.status_code == 404
         assert "The requested preprod artifact does not exist" in response.json()["detail"]
 
-    def test_base_artifact_different_org(self):
+    def test_base_artifact_different_org(self) -> None:
         other_org = self.create_organization(owner=self.user)
         other_project = self.create_project(organization=other_org)
         other_file = self.create_file(name="other_artifact.apk", type="application/octet-stream")

--- a/tests/sentry/preprod/api/endpoints/public/test_project_preprod_build_distribution_latest.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_project_preprod_build_distribution_latest.py
@@ -11,7 +11,7 @@ from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 class LatestBuildTestBase(APITestCase):
     endpoint = "sentry-api-0-project-preprod-public-builds"
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
@@ -61,7 +61,7 @@ class LatestBuildTestBase(APITestCase):
 
 
 class LatestBuildValidationTest(LatestBuildTestBase):
-    def test_validation(self):
+    def test_validation(self) -> None:
         # Missing all required params
         assert self._get(self._get_url()).status_code == 400
 
@@ -84,7 +84,7 @@ class LatestBuildValidationTest(LatestBuildTestBase):
 class LatestBuildModeTest(LatestBuildTestBase):
     """Tests for latest-only mode (no buildVersion parameter)."""
 
-    def test_response_fields(self):
+    def test_response_fields(self) -> None:
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
             head_ref="feature/test",
@@ -125,7 +125,7 @@ class LatestBuildModeTest(LatestBuildTestBase):
         assert build["profileName"] is None
         assert build["codesigningType"] is None
 
-    def test_no_matching_build(self):
+    def test_no_matching_build(self) -> None:
         response = self._get(
             self._get_url(), {"appId": "com.nonexistent.app", "platform": "android"}
         )
@@ -134,7 +134,7 @@ class LatestBuildModeTest(LatestBuildTestBase):
         assert data["latestArtifact"] is None
         assert data["currentArtifact"] is None
 
-    def test_version_ordering_and_build_number_tiebreaker(self):
+    def test_version_ordering_and_build_number_tiebreaker(self) -> None:
         # Semver comparison picks highest version
         self._create_installable_artifact(build_version="1.0.0", build_number=1)
         self._create_installable_artifact(build_version="2.0.0", build_number=1)
@@ -148,7 +148,7 @@ class LatestBuildModeTest(LatestBuildTestBase):
         response = self._get(self._get_url(), {"appId": "com.example.app", "platform": "android"})
         assert response.json()["latestArtifact"]["buildId"] == str(highest.id)
 
-    def test_excludes_non_installable_builds(self):
+    def test_excludes_non_installable_builds(self) -> None:
         # No installable file
         self.create_preprod_artifact(
             project=self.project,
@@ -170,7 +170,7 @@ class LatestBuildModeTest(LatestBuildTestBase):
         response = self._get(self._get_url(), {"appId": "com.example.app", "platform": "android"})
         assert response.json()["latestArtifact"]["buildId"] == str(installable.id)
 
-    def test_only_returns_builds_for_this_project(self):
+    def test_only_returns_builds_for_this_project(self) -> None:
         other_project = self.create_project(organization=self.organization)
         self._create_installable_artifact(
             project=other_project, build_version="99.0.0", build_number=1
@@ -184,7 +184,7 @@ class LatestBuildModeTest(LatestBuildTestBase):
 class LatestBuildFilteringTest(LatestBuildTestBase):
     """Tests for explicit filter parameters (platform, buildConfiguration, etc.)."""
 
-    def test_platform_filter_apple(self):
+    def test_platform_filter_apple(self) -> None:
         ios_file = self.create_file(name="test.xcarchive", type="application/octet-stream")
         ios_artifact = self._create_installable_artifact(
             file_id=ios_file.id,
@@ -211,7 +211,7 @@ class LatestBuildFilteringTest(LatestBuildTestBase):
         assert data["latestArtifact"]["buildId"] == str(ios_artifact.id)
         assert data["latestArtifact"]["platform"] == "APPLE"
 
-    def test_platform_filter_android_includes_aab(self):
+    def test_platform_filter_android_includes_aab(self) -> None:
         self._create_installable_artifact(
             artifact_type=PreprodArtifact.ArtifactType.AAB,
             build_version="2.0.0",
@@ -226,7 +226,7 @@ class LatestBuildFilteringTest(LatestBuildTestBase):
         response = self._get(self._get_url(), {"appId": "com.example.app", "platform": "android"})
         assert response.json()["latestArtifact"]["buildId"] == str(apk_artifact.id)
 
-    def test_explicit_filters(self):
+    def test_explicit_filters(self) -> None:
         debug_config = self.create_preprod_build_configuration(project=self.project, name="debug")
 
         self._create_installable_artifact(
@@ -285,7 +285,7 @@ class LatestBuildFilteringTest(LatestBuildTestBase):
         )
         assert response.json()["latestArtifact"]["buildId"] == str(combo.id)
 
-    def test_filter_no_match(self):
+    def test_filter_no_match(self) -> None:
         self._create_installable_artifact(
             build_version="1.0.0",
             build_number=1,
@@ -298,7 +298,7 @@ class LatestBuildFilteringTest(LatestBuildTestBase):
         )
         assert response.json()["latestArtifact"] is None
 
-    def test_install_groups_multiple_and_query_param_array(self):
+    def test_install_groups_multiple_and_query_param_array(self) -> None:
         self._create_installable_artifact(
             build_version="1.0.0",
             build_number=1,
@@ -321,7 +321,7 @@ class LatestBuildFilteringTest(LatestBuildTestBase):
 class CheckForUpdatesTest(LatestBuildTestBase):
     """Tests for check-for-updates mode (buildVersion parameter provided)."""
 
-    def test_update_available(self):
+    def test_update_available(self) -> None:
         current = self._create_installable_artifact(build_version="1.0.0", build_number=1)
         newer = self._create_installable_artifact(build_version="2.0.0", build_number=1)
 
@@ -340,7 +340,7 @@ class CheckForUpdatesTest(LatestBuildTestBase):
         assert data["currentArtifact"]["buildId"] == str(current.id)
         assert data["currentArtifact"]["appInfo"]["version"] == "1.0.0"
 
-    def test_already_on_latest(self):
+    def test_already_on_latest(self) -> None:
         artifact = self._create_installable_artifact(build_version="2.0.0", build_number=1)
 
         response = self._get(
@@ -357,7 +357,7 @@ class CheckForUpdatesTest(LatestBuildTestBase):
         assert data["latestArtifact"]["buildId"] == str(artifact.id)
         assert data["currentArtifact"]["buildId"] == str(artifact.id)
 
-    def test_current_not_found(self):
+    def test_current_not_found(self) -> None:
         latest = self._create_installable_artifact(build_version="2.0.0", build_number=1)
 
         response = self._get(
@@ -374,7 +374,7 @@ class CheckForUpdatesTest(LatestBuildTestBase):
         assert data["latestArtifact"]["buildId"] == str(latest.id)
         assert data["currentArtifact"] is None
 
-    def test_no_builds_exist(self):
+    def test_no_builds_exist(self) -> None:
         response = self._get(
             self._get_url(),
             {
@@ -388,7 +388,7 @@ class CheckForUpdatesTest(LatestBuildTestBase):
         assert data["latestArtifact"] is None
         assert data["currentArtifact"] is None
 
-    def test_main_binary_identifier_matching(self):
+    def test_main_binary_identifier_matching(self) -> None:
         current = self._create_installable_artifact(
             build_version="1.0.0",
             build_number=1,
@@ -409,7 +409,7 @@ class CheckForUpdatesTest(LatestBuildTestBase):
         assert data["currentArtifact"]["buildId"] == str(current.id)
         assert data["latestArtifact"]["buildId"] == str(newer.id)
 
-    def test_filter_inheritance_build_configuration(self):
+    def test_filter_inheritance_build_configuration(self) -> None:
         debug_config = self.create_preprod_build_configuration(project=self.project, name="debug")
 
         current = self._create_installable_artifact(
@@ -443,7 +443,7 @@ class CheckForUpdatesTest(LatestBuildTestBase):
         assert data["latestArtifact"]["buildId"] == str(newer_release.id)
         assert data["currentArtifact"]["buildId"] == str(current.id)
 
-    def test_filter_inheritance_codesigning_type(self):
+    def test_filter_inheritance_codesigning_type(self) -> None:
         current = self._create_installable_artifact(
             build_version="1.0.0",
             build_number=1,
@@ -474,7 +474,7 @@ class CheckForUpdatesTest(LatestBuildTestBase):
         assert data["latestArtifact"]["buildId"] == str(newer_dev.id)
         assert data["currentArtifact"]["buildId"] == str(current.id)
 
-    def test_filter_inheritance_install_groups(self):
+    def test_filter_inheritance_install_groups(self) -> None:
         current = self._create_installable_artifact(
             build_version="1.0.0",
             build_number=1,
@@ -505,7 +505,7 @@ class CheckForUpdatesTest(LatestBuildTestBase):
         assert data["latestArtifact"]["buildId"] == str(newer.id)
         assert data["currentArtifact"]["buildId"] == str(current.id)
 
-    def test_combined_filter_inheritance(self):
+    def test_combined_filter_inheritance(self) -> None:
         current = self._create_installable_artifact(
             build_version="1.0.0",
             build_number=1,

--- a/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_comments.py
+++ b/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_comments.py
@@ -12,7 +12,7 @@ from sentry.testutils.helpers.features import with_feature
 
 
 class OrganizationPrCommentsEndpointTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.factory = APIRequestFactory()
 
@@ -303,7 +303,7 @@ class OrganizationPrCommentsEndpointTest(TestCase):
         assert helper_comments[0]["body"] == "This could be simplified"
 
     @with_feature("organizations:pr-page")
-    def test_no_github_client(self):
+    def test_no_github_client(self) -> None:
         """Test when no GitHub client is available (no integration set up)."""
         Repository.objects.create(
             organization_id=self.organization.id,
@@ -332,7 +332,7 @@ class OrganizationPrCommentsEndpointTest(TestCase):
         assert "Failed to fetch pull request comments from GitHub" in response.data["message"]
 
     @with_feature("organizations:pr-page")
-    def test_repository_not_found(self):
+    def test_repository_not_found(self) -> None:
         """Test when repository doesn't exist in the database."""
         response = self._make_request(repo_name="does-not/exist")
 

--- a/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_details.py
+++ b/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_details.py
@@ -12,7 +12,7 @@ from sentry.testutils.helpers.features import with_feature
 
 
 class OrganizationPullRequestDetailsEndpointTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.factory = APIRequestFactory()
 
@@ -169,7 +169,7 @@ class OrganizationPullRequestDetailsEndpointTest(TestCase):
         assert renamed_file["previous_filename"] == "old-component.tsx"
 
     @with_feature("organizations:pr-page")
-    def test_no_github_client(self):
+    def test_no_github_client(self) -> None:
         """Test when no GitHub client is available (no integration set up)."""
         Repository.objects.create(
             organization_id=self.organization.id,
@@ -212,7 +212,7 @@ class OrganizationPullRequestDetailsEndpointTest(TestCase):
         assert response.data["pull_request"]["changed_files_count"] == 0
 
     @with_feature("organizations:pr-page")
-    def test_repository_not_found(self):
+    def test_repository_not_found(self) -> None:
         """Test when repository doesn't exist in the database."""
         response = self._make_request(repo_name="does-not/exist")
 

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -17,7 +17,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
     endpoint = "sentry-api-0-organization-preprod-artifact-size-analysis-compare"
     method = "get"
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
@@ -86,7 +86,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_success_with_completed_comparison(self):
+    def test_get_comparison_success_with_completed_comparison(self) -> None:
         """Test GET endpoint returns successful comparison when comparison exists and is completed"""
         # Create a successful comparison
         comparison = self.create_preprod_artifact_size_comparison(
@@ -122,7 +122,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_message"] is None
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_success_with_failed_comparison(self):
+    def test_get_comparison_success_with_failed_comparison(self) -> None:
         """Test GET endpoint returns failed comparison when comparison exists and failed"""
         # Create a failed comparison
         comparison = self.create_preprod_artifact_size_comparison(
@@ -147,7 +147,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_message"] == "Comparison failed due to processing error"
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_success_with_pending_comparison(self):
+    def test_get_comparison_success_with_pending_comparison(self) -> None:
         """Test GET endpoint returns processing state for pending comparison"""
         # Create a pending comparison (which should be shown as PROCESSING to frontend)
         comparison = self.create_preprod_artifact_size_comparison(
@@ -171,7 +171,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_message"] is None
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_success_with_processing_comparison(self):
+    def test_get_comparison_success_with_processing_comparison(self) -> None:
         """Test GET endpoint returns processing comparison when comparison is in progress"""
         # Create a processing comparison
         comparison = self.create_preprod_artifact_size_comparison(
@@ -194,7 +194,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_message"] is None
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_success_with_no_comparison(self):
+    def test_get_comparison_success_with_no_comparison(self) -> None:
         """Test GET endpoint returns no comparison when no comparison exists yet"""
         response = self.get_success_response(
             self.organization.slug,
@@ -205,7 +205,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert len(data["comparisons"]) == 0
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_success_with_no_matching_base_metric(self):
+    def test_get_comparison_success_with_no_matching_base_metric(self) -> None:
         """Test GET endpoint handles case where no matching base metric exists"""
         self.create_preprod_artifact_size_comparison(
             head_size_analysis=self.head_size_metric,
@@ -244,7 +244,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert watch_comparison["error_message"] == "No matching base artifact size metric found."
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_head_artifact_not_found(self):
+    def test_get_comparison_head_artifact_not_found(self) -> None:
         """Test GET endpoint returns 404 when head artifact doesn't exist"""
         response = self.get_error_response(
             self.organization.slug,
@@ -255,7 +255,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "The requested head preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_base_artifact_not_found(self):
+    def test_get_comparison_base_artifact_not_found(self) -> None:
         """Test GET endpoint returns 404 when base artifact doesn't exist"""
         response = self.get_error_response(
             self.organization.slug,
@@ -266,7 +266,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "The requested base preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_artifacts_different_projects(self):
+    def test_get_comparison_artifacts_different_projects(self) -> None:
         """Test GET endpoint returns 404 when head and base artifacts belong to different projects"""
         other_project = self.create_project(organization=self.organization)
         other_artifact = self.create_preprod_artifact(
@@ -286,7 +286,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert response.data["detail"] == "The requested base preprod artifact does not exist"
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_base_artifact_wrong_project(self):
+    def test_get_comparison_base_artifact_wrong_project(self) -> None:
         """Test GET endpoint returns 404 when base artifact belongs to different project"""
         other_project = self.create_project(organization=self.organization)
         other_artifact = self.create_preprod_artifact(
@@ -306,7 +306,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert response.data["detail"] == "The requested base preprod artifact does not exist"
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_head_artifact_no_size_metrics(self):
+    def test_get_comparison_head_artifact_no_size_metrics(self) -> None:
         """Test GET endpoint returns 404 when head artifact has no size metrics"""
         # Create artifact without size metrics
         artifact_no_metrics = self.create_preprod_artifact(
@@ -329,7 +329,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_base_artifact_no_size_metrics(self):
+    def test_get_comparison_base_artifact_no_size_metrics(self) -> None:
         """Test GET endpoint returns 404 when base artifact has no size metrics"""
         # Create artifact without size metrics
         artifact_no_metrics = self.create_preprod_artifact(
@@ -352,7 +352,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": False})
-    def test_get_comparison_feature_disabled(self):
+    def test_get_comparison_feature_disabled(self) -> None:
         """Test GET endpoint returns 403 when feature flag is disabled"""
         response = self.get_error_response(
             self.organization.slug,
@@ -363,7 +363,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert response.data["detail"] == "Feature not enabled"
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_get_comparison_multiple_metrics(self):
+    def test_get_comparison_multiple_metrics(self) -> None:
         """Test GET endpoint handles multiple size metrics correctly"""
         self.create_preprod_artifact_size_comparison(
             head_size_analysis=self.head_size_metric,
@@ -468,7 +468,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison.organization_id == self.organization.id
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_head_artifact_not_found(self):
+    def test_post_comparison_head_artifact_not_found(self) -> None:
         """Test POST endpoint returns 404 when head artifact doesn't exist"""
         response = self.get_error_response(
             self.organization.slug,
@@ -480,7 +480,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "The requested head preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_base_artifact_not_found(self):
+    def test_post_comparison_base_artifact_not_found(self) -> None:
         """Test POST endpoint returns 404 when base artifact doesn't exist"""
         response = self.get_error_response(
             self.organization.slug,
@@ -492,7 +492,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "The requested base preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_head_artifact_no_size_metrics(self):
+    def test_post_comparison_head_artifact_no_size_metrics(self) -> None:
         """Test POST endpoint returns 404 when head artifact has no size metrics"""
         artifact_no_metrics = self.create_preprod_artifact(
             project=self.project,
@@ -511,7 +511,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_base_artifact_no_size_metrics(self):
+    def test_post_comparison_base_artifact_no_size_metrics(self) -> None:
         """Test POST endpoint returns 404 when base artifact has no size metrics"""
         artifact_no_metrics = self.create_preprod_artifact(
             project=self.project,
@@ -530,7 +530,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_head_artifact_processing(self):
+    def test_post_comparison_head_artifact_processing(self) -> None:
         self.head_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
         self.head_size_metric.save()
 
@@ -542,7 +542,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "not completed size analysis yet" in data["message"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_base_artifact_processing(self):
+    def test_post_comparison_base_artifact_processing(self) -> None:
         self.base_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
         self.base_size_metric.save()
 
@@ -554,7 +554,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "not completed size analysis yet" in data["message"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_mixed_completed_and_pending_returns_202(self):
+    def test_post_comparison_mixed_completed_and_pending_returns_202(self) -> None:
         self.create_preprod_artifact_size_metrics(
             self.head_artifact,
             analysis_file_id=self.head_analysis_file.id,
@@ -579,7 +579,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "not completed size analysis yet" in data["message"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_existing_comparison(self):
+    def test_post_comparison_existing_comparison(self) -> None:
         """Test POST endpoint returns existing comparison when comparison already exists"""
         # Create an existing comparison
         comparison = self.create_preprod_artifact_size_comparison(
@@ -600,7 +600,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert data["comparisons"][0]["comparison_id"] == comparison.id
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_existing_failed_comparison(self):
+    def test_post_comparison_existing_failed_comparison(self) -> None:
         """Test POST endpoint returns existing failed comparison when comparison exists and failed"""
         # Create a failed comparison
         comparison = self.create_preprod_artifact_size_comparison(
@@ -624,7 +624,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_message"] == comparison.error_message
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_cannot_compare_size_metrics(self):
+    def test_post_comparison_cannot_compare_size_metrics(self) -> None:
         """Test POST endpoint returns 400 when size metrics cannot be compared"""
         # Create additional head metric to make the lists different lengths
         self.create_preprod_artifact_size_metrics(
@@ -702,7 +702,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_no_matching_base_metric(self):
+    def test_post_comparison_no_matching_base_metric(self) -> None:
         """Test POST endpoint returns 400 when head has more metrics than base"""
         # Create head metric with different identifier that won't match base
         self.create_preprod_artifact_size_metrics(
@@ -723,7 +723,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "base has 1 metric(s)" in detail
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_mismatched_metric_types(self):
+    def test_post_comparison_mismatched_metric_types(self) -> None:
         """Test POST endpoint returns detailed error when comparing mismatched metric types/identifiers"""
         # Replace the default head metric with one that has a different identifier
         self.head_size_metric.delete()
@@ -752,7 +752,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "release" in detail.lower() or "main" in detail.lower()
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_different_build_configurations(self):
+    def test_post_comparison_different_build_configurations(self) -> None:
         """Test POST endpoint returns 400 when artifacts have different build configurations"""
         # Create a build configuration for the base artifact
         debug_config = self.create_preprod_build_configuration(project=self.project, name="debug")

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_download.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_download.py
@@ -17,7 +17,7 @@ from sentry.testutils.cases import APITestCase
 class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-preprod-artifact-size-analysis-download"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
         self.artifact_file = self.create_file(
@@ -29,13 +29,13 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
             state=PreprodArtifact.ArtifactState.UPLOADED,
         )
 
-    def test_no_size_metrics_returns_404(self):
+    def test_no_size_metrics_returns_404(self) -> None:
         """When no size metrics exist, should return 404"""
         response = self.get_response(self.organization.slug, self.artifact.id)
         assert response.status_code == 404
         assert response.data["detail"] == "Size analysis results not available for this artifact"
 
-    def test_pending_state_returns_200(self):
+    def test_pending_state_returns_200(self) -> None:
         """When size metrics exist but are in PENDING state, should return 200 with state info"""
         self.create_preprod_artifact_size_metrics(
             self.artifact,
@@ -48,7 +48,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
         assert response.data["state"] == "pending"
         assert response.data["message"] == "Size analysis is still processing"
 
-    def test_processing_state_returns_200(self):
+    def test_processing_state_returns_200(self) -> None:
         """When size metrics exist but are in PROCESSING state, should return 200 with state info"""
         self.create_preprod_artifact_size_metrics(
             self.artifact,
@@ -61,7 +61,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
         assert response.data["state"] == "processing"
         assert response.data["message"] == "Size analysis is still processing"
 
-    def test_failed_state_returns_422(self):
+    def test_failed_state_returns_422(self) -> None:
         """When size metrics failed, should return 422 with error details"""
         self.create_preprod_artifact_size_metrics(
             self.artifact,
@@ -78,7 +78,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
         assert response.data["error_code"] == PreprodArtifactSizeMetrics.ErrorCode.PROCESSING_ERROR
         assert response.data["error_message"] == "Test error message"
 
-    def test_completed_without_file_returns_500(self):
+    def test_completed_without_file_returns_500(self) -> None:
         """When size metrics is COMPLETED but analysis_file_id is None, should return 500"""
         self.create_preprod_artifact_size_metrics(
             self.artifact,
@@ -91,7 +91,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
         assert response.status_code == 500
         assert response.data["detail"] == "Size analysis completed but results are unavailable"
 
-    def test_completed_with_missing_file_returns_404(self):
+    def test_completed_with_missing_file_returns_404(self) -> None:
         """When size metrics is COMPLETED but the File object was deleted, should return 404"""
         deleted_file_id = 999999
 
@@ -106,7 +106,7 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
         assert response.status_code == 404
         assert response.data["detail"] == "Analysis file not found"
 
-    def test_completed_with_file_returns_200(self):
+    def test_completed_with_file_returns_200(self) -> None:
         """When size metrics is COMPLETED with a file, should return 200 with file content"""
         analysis_file = self.create_file(name="size_analysis.json", type="application/json")
         with BytesIO(b'{"treemap": {"root": {"name": "root", "size": 1000}}}') as file_content:

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
@@ -7,7 +7,7 @@ from sentry.testutils.cases import APITestCase
 
 
 class ProjectPreprodArtifactImageTest(APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
@@ -104,7 +104,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         mock_get_session.assert_called_once_with(self.org.id, self.project.id)
         mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
 
-    def test_endpoint_requires_project_access(self):
+    def test_endpoint_requires_project_access(self) -> None:
         other_user = self.create_user()
         self.login_as(user=other_user)
         self.api_token = self.create_user_auth_token(

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_analysis.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_analysis.py
@@ -12,7 +12,7 @@ from sentry.testutils.cases import APITestCase
 class BaseRerunAnalysisTest(APITestCase):
     """Base class with shared test logic for rerun analysis endpoints"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
@@ -85,7 +85,7 @@ class PreprodArtifactRerunAnalysisTest(BaseRerunAnalysisTest):
     endpoint = "sentry-api-0-organization-preprod-artifact-rerun-analysis"
     method = "post"
 
-    def test_rerun_analysis_cleans_up_metrics_and_comparisons(self):
+    def test_rerun_analysis_cleans_up_metrics_and_comparisons(self) -> None:
         artifact, main_file, analysis_files, comparison = self.create_artifact_with_metrics()
 
         response = self.get_success_response(self.organization.slug, artifact.id, status_code=200)
@@ -98,7 +98,7 @@ class PreprodArtifactRerunAnalysisTest(BaseRerunAnalysisTest):
         self.assert_artifact_reset(artifact)
         assert File.objects.filter(id=main_file.id).exists()
 
-    def test_rerun_analysis_with_no_metrics(self):
+    def test_rerun_analysis_with_no_metrics(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             app_name="test_artifact",
@@ -116,7 +116,7 @@ class PreprodArtifactRerunAnalysisTest(BaseRerunAnalysisTest):
         assert PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact).count() == 1
         self.assert_artifact_reset(artifact)
 
-    def test_rerun_analysis_cleans_up_base_comparisons(self):
+    def test_rerun_analysis_cleans_up_base_comparisons(self) -> None:
         artifact1 = self.create_preprod_artifact(
             project=self.project,
             app_name="test_artifact",
@@ -151,7 +151,7 @@ class PreprodArtifactRerunAnalysisTest(BaseRerunAnalysisTest):
         assert not PreprodArtifactSizeComparison.objects.filter(id=comparison.id).exists()
         assert PreprodArtifactSizeMetrics.objects.filter(id=size_metric_2.id).exists()
 
-    def test_rerun_analysis_clears_distribution_error_fields(self):
+    def test_rerun_analysis_clears_distribution_error_fields(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             app_name="test_artifact",
@@ -307,7 +307,7 @@ class PreprodArtifactAdminRerunAnalysisTest(BaseRerunAnalysisTest):
     endpoint = "sentry-admin-preprod-artifact-rerun-analysis"
     method = "post"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user(is_staff=True)
         self.organization = self.create_organization(owner=self.user)
@@ -318,7 +318,7 @@ class PreprodArtifactAdminRerunAnalysisTest(BaseRerunAnalysisTest):
         with patch("sentry.api.permissions.is_active_staff", return_value=True):
             return super().get_response(*args, **params)
 
-    def test_rerun_analysis_cleans_up_metrics_and_comparisons(self):
+    def test_rerun_analysis_cleans_up_metrics_and_comparisons(self) -> None:
         artifact, main_file, analysis_files, comparison = self.create_artifact_with_metrics()
 
         response = self.get_success_response(preprod_artifact_id=artifact.id, status_code=200)
@@ -333,7 +333,7 @@ class PreprodArtifactAdminRerunAnalysisTest(BaseRerunAnalysisTest):
         self.assert_artifact_reset(artifact)
         assert File.objects.filter(id=main_file.id).exists()
 
-    def test_rerun_analysis_with_no_metrics(self):
+    def test_rerun_analysis_with_no_metrics(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             app_name="test_artifact",
@@ -354,7 +354,7 @@ class PreprodArtifactAdminRerunAnalysisTest(BaseRerunAnalysisTest):
         assert PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact).count() == 1
         self.assert_artifact_reset(artifact)
 
-    def test_rerun_analysis_cleans_up_base_comparisons(self):
+    def test_rerun_analysis_cleans_up_base_comparisons(self) -> None:
         artifact1 = self.create_preprod_artifact(
             project=self.project,
             app_name="test_artifact",
@@ -390,11 +390,11 @@ class PreprodArtifactAdminRerunAnalysisTest(BaseRerunAnalysisTest):
         assert not PreprodArtifactSizeComparison.objects.filter(id=comparison.id).exists()
         assert PreprodArtifactSizeMetrics.objects.filter(id=size_metric_2.id).exists()
 
-    def test_rerun_analysis_not_found(self):
+    def test_rerun_analysis_not_found(self) -> None:
         response = self.get_error_response(preprod_artifact_id=999999, status_code=404)
         assert "not found" in response.data["error"]
 
-    def test_rerun_analysis_invalid_id(self):
+    def test_rerun_analysis_invalid_id(self) -> None:
         response = self.get_error_response(preprod_artifact_id="invalid", status_code=400)
         assert (
             "preprod_artifact_id is required and must be a valid integer" in response.data["error"]

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_status_checks.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_status_checks.py
@@ -7,13 +7,13 @@ class PreprodArtifactRerunStatusChecksTest(APITestCase):
     endpoint = "sentry-api-0-organization-preprod-artifact-rerun-status-checks"
     method = "post"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
         self.login_as(user=self.user)
 
-    def test_success(self):
+    def test_success(self) -> None:
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
             provider="github",
@@ -44,7 +44,7 @@ class PreprodArtifactRerunStatusChecksTest(APITestCase):
                 preprod_artifact_id=artifact.id, caller="rerun_endpoint"
             )
 
-    def test_invalid_check_types(self):
+    def test_invalid_check_types(self) -> None:
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
             provider="github",
@@ -69,7 +69,7 @@ class PreprodArtifactRerunStatusChecksTest(APITestCase):
 
         assert "No supported check types" in response.data["error"]
 
-    def test_non_string_check_types(self):
+    def test_non_string_check_types(self) -> None:
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
             provider="github",
@@ -94,7 +94,7 @@ class PreprodArtifactRerunStatusChecksTest(APITestCase):
 
         assert "All check_types must be strings" in response.data["error"]
 
-    def test_no_commit_comparison(self):
+    def test_no_commit_comparison(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             app_name="test_artifact",
@@ -111,7 +111,7 @@ class PreprodArtifactRerunStatusChecksTest(APITestCase):
 
         assert "no commit comparison" in response.data["error"]
 
-    def test_task_failure(self):
+    def test_task_failure(self) -> None:
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
             provider="github",
@@ -141,7 +141,7 @@ class PreprodArtifactRerunStatusChecksTest(APITestCase):
             assert "Failed to queue status checks" in response.data["error"]
             assert response.data["failed_check_types"] == ["size"]
 
-    def test_permission_denied(self):
+    def test_permission_denied(self) -> None:
         other_user = self.create_user()
         self.login_as(user=other_user)
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -10,7 +10,7 @@ from sentry.testutils.cases import APITestCase
 
 
 class ProjectPreprodSnapshotTest(APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
@@ -28,7 +28,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             args=[self.org.slug, snapshot_id],
         )
 
-    def test_successful_snapshot_upload(self):
+    def test_successful_snapshot_upload(self) -> None:
         url = self._get_create_url()
         data = {
             "app_id": "com.example.app",
@@ -60,7 +60,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert snapshot_metrics.preprod_artifact == artifact
         assert snapshot_metrics.image_count == 1
 
-    def test_snapshot_upload_creates_commit_comparison(self):
+    def test_snapshot_upload_creates_commit_comparison(self) -> None:
         url = self._get_create_url()
         data = {
             "app_id": "com.example.app",
@@ -96,7 +96,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert commit_comparison.head_repo_name == "owner/repo"
         assert commit_comparison.pr_number == 123
 
-    def test_snapshot_upload_stores_manifest_key(self):
+    def test_snapshot_upload_stores_manifest_key(self) -> None:
         url = self._get_create_url()
         data = {
             "app_id": "com.example.app",
@@ -125,7 +125,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         )
         assert snapshot_metrics.extras["manifest_key"] == expected_key
 
-    def test_snapshot_with_empty_images(self):
+    def test_snapshot_with_empty_images(self) -> None:
         url = self._get_create_url()
         data = {
             "app_id": "com.example.app",
@@ -138,7 +138,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert response.status_code == 200
         assert response.data["imageCount"] == 0
 
-    def test_snapshot_missing_required_field(self):
+    def test_snapshot_missing_required_field(self) -> None:
         url = self._get_create_url()
         data: dict[str, str] = {}
 
@@ -148,7 +148,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert response.status_code == 400
         assert "detail" in response.data
 
-    def test_snapshot_invalid_image_schema(self):
+    def test_snapshot_invalid_image_schema(self) -> None:
         url = self._get_create_url()
         data = {
             "app_id": "com.example.app",
@@ -166,7 +166,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert response.status_code == 400
         assert "detail" in response.data
 
-    def test_snapshot_negative_dimensions(self):
+    def test_snapshot_negative_dimensions(self) -> None:
         url = self._get_create_url()
         data = {
             "app_id": "com.example.app",
@@ -186,7 +186,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert response.status_code == 400
         assert "detail" in response.data
 
-    def test_snapshot_without_feature_flag(self):
+    def test_snapshot_without_feature_flag(self) -> None:
         url = self._get_create_url()
         data = {
             "app_id": "com.example.app",
@@ -198,7 +198,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert response.status_code == 403
         assert response.data["detail"] == "Feature not enabled"
 
-    def test_snapshot_invalid_json(self):
+    def test_snapshot_invalid_json(self) -> None:
         url = self._get_create_url()
 
         with self.feature("organizations:preprod-snapshots"):
@@ -207,7 +207,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert response.status_code == 400
         assert "detail" in response.data
 
-    def test_snapshot_requires_authentication(self):
+    def test_snapshot_requires_authentication(self) -> None:
         from rest_framework.test import APIClient
 
         unauthenticated_client = APIClient()
@@ -222,7 +222,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
 
         assert response.status_code == 401
 
-    def test_snapshot_requires_project_access(self):
+    def test_snapshot_requires_project_access(self) -> None:
         other_user = self.create_user()
         self.login_as(user=other_user)
 
@@ -237,7 +237,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
 
         assert response.status_code == 403
 
-    def test_snapshot_invalid_sha_format(self):
+    def test_snapshot_invalid_sha_format(self) -> None:
         url = self._get_create_url()
         data = {
             "app_id": "com.example.app",
@@ -252,7 +252,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
 
 
 class ProjectPreprodSnapshotGetTest(APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
@@ -375,7 +375,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.data["images"][0]["key"] == "img000"
         assert response.data["images"][9]["key"] == "img009"
 
-    def test_get_snapshot_not_found(self):
+    def test_get_snapshot_not_found(self) -> None:
         url = self._get_detail_url(99999)
         with self.feature("organizations:preprod-snapshots"):
             response = self.client.get(url)
@@ -383,7 +383,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.status_code == 404
         assert response.data["detail"] == "Snapshot not found"
 
-    def test_get_snapshot_wrong_organization(self):
+    def test_get_snapshot_wrong_organization(self) -> None:
         """Artifact belonging to a different organization should return 404 (IDOR protection)."""
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)
@@ -399,7 +399,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
 
         assert response.status_code == 404
 
-    def test_get_snapshot_without_feature_flag(self):
+    def test_get_snapshot_without_feature_flag(self) -> None:
         artifact, _, _, _, _ = self._create_artifact_with_manifest()
 
         url = self._get_detail_url(artifact.id)
@@ -422,7 +422,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.status_code == 500
         assert response.data["detail"] == "Internal server error"
 
-    def test_get_snapshot_no_metrics(self):
+    def test_get_snapshot_no_metrics(self) -> None:
         """Artifact without snapshot metrics should return 404."""
         artifact = PreprodArtifact.objects.create(
             project=self.project,

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_delete.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_delete.py
@@ -13,14 +13,14 @@ class ProjectPreprodArtifactDeleteTest(APITestCase):
     endpoint = "sentry-api-0-organization-preprod-artifact-delete"
     method = "delete"
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
         self.login_as(user=self.user)
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_delete_artifact_success(self):
+    def test_delete_artifact_success(self) -> None:
         main_file = self.create_file(name="test_artifact.zip", type="application/zip")
         installable_file = self.create_file(name="test_app.ipa", type="application/octet-stream")
         artifact = self.create_preprod_artifact(
@@ -71,7 +71,7 @@ class ProjectPreprodArtifactDeleteTest(APITestCase):
         assert not InstallablePreprodArtifact.objects.filter(id=installable.id).exists()
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_delete_artifact_not_found(self):
+    def test_delete_artifact_not_found(self) -> None:
         response = self.get_error_response(
             self.organization.slug,
             "999999",  # Non-existent artifact ID
@@ -81,7 +81,7 @@ class ProjectPreprodArtifactDeleteTest(APITestCase):
         assert "The requested head preprod artifact does not exist" in response.data["detail"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": False})
-    def test_delete_artifact_feature_disabled(self):
+    def test_delete_artifact_feature_disabled(self) -> None:
         artifact = self.create_preprod_artifact(
             app_name="test_artifact",
             app_id="com.test.app",
@@ -97,7 +97,7 @@ class ProjectPreprodArtifactDeleteTest(APITestCase):
         assert response.data["error"] == "Feature not enabled"
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_delete_artifact_minimal(self):
+    def test_delete_artifact_minimal(self) -> None:
         """Test deleting an artifact with only the minimum required fields"""
         # Create the preprod artifact without optional files
         artifact = self.create_preprod_artifact(

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -673,7 +673,7 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
 
 
 class FindOrCreateReleaseTest(TestCase):
-    def test_exact_version_matching_prevents_incorrect_matches(self):
+    def test_exact_version_matching_prevents_incorrect_matches(self) -> None:
         package = "com.hackernews"
         version = "1.2.3"
 
@@ -686,7 +686,7 @@ class FindOrCreateReleaseTest(TestCase):
         assert result is not None
         assert result.version == f"{package}@{version}"
 
-    def test_finds_existing_release_regardless_of_build_number(self):
+    def test_finds_existing_release_regardless_of_build_number(self) -> None:
         package = "com.example.app"
         version = "2.1.0"
 

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_check_for_updates.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_check_for_updates.py
@@ -99,7 +99,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         )
         return self.preprod_artifact
 
-    def test_missing_required_parameters(self):
+    def test_missing_required_parameters(self) -> None:
         """Test that missing required parameters return 400"""
         url = self._get_url()
         response = self.client.get(
@@ -108,7 +108,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert response.status_code == 400
         assert "Missing required parameters" in response.json()["error"]
 
-    def test_current_artifact_not_found(self):
+    def test_current_artifact_not_found(self) -> None:
         """Test when main_binary_identifier is provided but artifact doesn't exist"""
         url = self._get_url()
         response = self.client.get(
@@ -120,7 +120,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.json()["current"] is None
 
-    def test_current_artifact_success_ios(self):
+    def test_current_artifact_success_ios(self) -> None:
         """Test successful current artifact retrieval for iOS"""
         self._create_ios_artifact(
             main_binary_identifier="test-identifier",
@@ -146,7 +146,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["current"]["download_url"] != ""
         assert "created_date" in data["current"]
 
-    def test_update_detection_android(self):
+    def test_update_detection_android(self) -> None:
         """Test update detection for Android with higher version"""
         # Create current artifact
         self._create_android_artifact(
@@ -183,7 +183,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["download_url"] != ""
         assert "created_date" in data["update"]
 
-    def test_update_detection_ios(self):
+    def test_update_detection_ios(self) -> None:
         """Test update detection for iOS with higher version"""
         # Create current artifact
         self._create_ios_artifact(
@@ -217,7 +217,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.1.0"
         assert data["update"]["build_number"] == 1
 
-    def test_platform_specific_filtering_android(self):
+    def test_platform_specific_filtering_android(self) -> None:
         """Test that Android platform only returns AAB/APK artifacts"""
         # Create Android artifact
         self._create_android_artifact(
@@ -251,7 +251,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
             data["current"]["build_version"] == "1.0.0"
         )  # Should find the Android artifact, not iOS
 
-    def test_installable_artifact_filtering(self):
+    def test_installable_artifact_filtering(self) -> None:
         """Test that only installable artifacts are considered for updates"""
         # Create non-installable artifact (no installable_app_file_id)
         self._create_android_artifact(
@@ -284,7 +284,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"] is not None
         assert data["update"]["build_version"] == "1.1.0"
 
-    def test_highest_build_number_selection(self):
+    def test_highest_build_number_selection(self) -> None:
         """Test that the artifact with highest build_number is selected when versions are equal"""
         # Create multiple artifacts with same version but different build numbers
         self._create_android_artifact(
@@ -323,7 +323,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.1.0"
         assert data["update"]["build_number"] == 60
 
-    def test_no_update_available(self):
+    def test_no_update_available(self) -> None:
         """Test when no higher version is available"""
         # Create only current artifact
         self._create_android_artifact(
@@ -346,7 +346,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["current"] is not None
         assert data["update"] is None  # No update available
 
-    def test_multiple_artifacts_same_version_different_build_configurations(self):
+    def test_multiple_artifacts_same_version_different_build_configurations(self) -> None:
         """Test handling of multiple artifacts with same version but different build configurations"""
 
         debug_config = self.create_preprod_build_configuration(project=self.project, name="debug")
@@ -384,7 +384,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["current"] is not None
         assert data["current"]["id"] == str(debug_artifact.id)
 
-    def test_build_number_filtering(self):
+    def test_build_number_filtering(self) -> None:
         """Test that build_number parameter filters correctly"""
         # Create artifacts with same version but different build numbers
         self._create_android_artifact(
@@ -414,7 +414,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["current"] is not None
         assert data["current"]["build_number"] == 42
 
-    def test_invalid_build_number_format(self):
+    def test_invalid_build_number_format(self) -> None:
         """Test that invalid build_number format returns 400"""
         url = self._get_url()
         response = self.client.get(
@@ -426,7 +426,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert response.status_code == 400
         assert "Invalid build_number format" in response.json()["error"]
 
-    def test_without_main_binary_identifier_with_build_number(self):
+    def test_without_main_binary_identifier_with_build_number(self) -> None:
         """Test that main_binary_identifier is optional when build_number is provided"""
         self._create_android_artifact(
             main_binary_identifier="test-identifier",
@@ -446,7 +446,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["current"] is not None
         assert data["current"]["build_version"] == "1.0.0"
 
-    def test_missing_both_main_binary_identifier_and_build_number(self):
+    def test_missing_both_main_binary_identifier_and_build_number(self) -> None:
         """Test that either main_binary_identifier or build_number must be provided"""
         url = self._get_url()
         response = self.client.get(
@@ -461,7 +461,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
             in response.json()["error"]
         )
 
-    def test_codesigning_type_filters_current_artifact(self):
+    def test_codesigning_type_filters_current_artifact(self) -> None:
         """Test that codesigning_type parameter filters the current artifact correctly"""
         # Create an iOS artifact with development codesigning
         self._create_ios_artifact(
@@ -495,7 +495,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["current"]["build_version"] == "1.0.0"
         assert data["current"]["build_number"] == 42
 
-    def test_codesigning_type_filters_updates(self):
+    def test_codesigning_type_filters_updates(self) -> None:
         """Test that updates are filtered by the same codesigning_type as the current artifact"""
         # Create current iOS artifact with development codesigning
         self._create_ios_artifact(
@@ -540,7 +540,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.1.0"
         assert data["update"]["build_number"] == 50
 
-    def test_codesigning_type_no_matching_update(self):
+    def test_codesigning_type_no_matching_update(self) -> None:
         """Test that no update is returned when codesigning_type doesn't match"""
         # Create current iOS artifact with development codesigning
         self._create_ios_artifact(
@@ -575,7 +575,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         # Should not return update because codesigning_type doesn't match
         assert data["update"] is None
 
-    def test_codesigning_type_with_build_configuration(self):
+    def test_codesigning_type_with_build_configuration(self) -> None:
         """Test that codesigning_type works correctly with build configurations"""
         debug_config = self.create_preprod_build_configuration(project=self.project, name="debug")
 
@@ -625,7 +625,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.1.0"
         assert data["update"]["build_number"] == 50
 
-    def test_codesigning_type_provided_explicitly(self):
+    def test_codesigning_type_provided_explicitly(self) -> None:
         """Test that explicitly provided codesigning_type parameter is used for filtering"""
         # Create artifact with development codesigning
         self._create_ios_artifact(
@@ -658,7 +658,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         # Should find the app-store artifact
         assert data["current"] is not None
 
-    def test_install_groups_filters_updates(self):
+    def test_install_groups_filters_updates(self) -> None:
         """Test that updates are filtered by the same install_groups as the current artifact"""
         # Create current artifact with alpha install_groups
         self._create_android_artifact(
@@ -703,7 +703,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.1.0"
         assert data["update"]["build_number"] == 50
 
-    def test_install_groups_no_matching_update(self):
+    def test_install_groups_no_matching_update(self) -> None:
         """Test that no update is returned when install_groups doesn't match"""
         # Create current artifact with alpha install_groups
         self._create_android_artifact(
@@ -738,7 +738,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         # Should not return update because install_groups doesn't match
         assert data["update"] is None
 
-    def test_install_groups_with_build_configuration(self):
+    def test_install_groups_with_build_configuration(self) -> None:
         """Test that install_groups works correctly with build configurations"""
         debug_config = self.create_preprod_build_configuration(project=self.project, name="debug")
 
@@ -788,7 +788,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.1.0"
         assert data["update"]["build_number"] == 50
 
-    def test_install_groups_with_codesigning_type(self):
+    def test_install_groups_with_codesigning_type(self) -> None:
         """Test that install_groups works correctly combined with codesigning_type"""
         # Create current artifact with development codesigning and alpha install_groups
         self._create_ios_artifact(
@@ -841,7 +841,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.1.0"
         assert data["update"]["build_number"] == 50
 
-    def test_no_install_groups_returns_all_updates(self):
+    def test_no_install_groups_returns_all_updates(self) -> None:
         """Test that artifacts without install_groups can see updates without install_groups"""
         # Create current artifact without install_groups
         self._create_android_artifact(
@@ -884,7 +884,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.2.0"
         assert data["update"]["build_number"] == 60
 
-    def test_install_groups_branch_based_updates(self):
+    def test_install_groups_branch_based_updates(self) -> None:
         """Test the branch-based update use case: only see updates from same branch"""
         # Create artifacts for feature-branch-1 install_groups
         self._create_android_artifact(
@@ -928,7 +928,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.0.1"
         assert data["update"]["build_number"] == 101
 
-    def test_install_groups_multiple_groups_overlap(self):
+    def test_install_groups_multiple_groups_overlap(self) -> None:
         """Test that artifacts with overlapping install_groupss can update each other"""
         # Create current artifact with alpha and gamma install_groupss
         self._create_android_artifact(
@@ -973,7 +973,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.1.0"
         assert data["update"]["build_number"] == 50
 
-    def test_install_groups_multiple_groups_second_group_overlap(self):
+    def test_install_groups_multiple_groups_second_group_overlap(self) -> None:
         """Test that updates match when the second group in the array overlaps"""
         # Create current artifact with alpha and beta install_groupss
         self._create_android_artifact(
@@ -1010,7 +1010,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         assert data["update"]["build_version"] == "1.1.0"
         assert data["update"]["build_number"] == 50
 
-    def test_install_groups_query_param_array(self):
+    def test_install_groups_query_param_array(self) -> None:
         """Test that multiple install_groups can be passed as query parameters"""
         # Create artifact with alpha install_group
         self._create_android_artifact(
@@ -1056,7 +1056,7 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
         # (install_groups query param does not filter the current artifact lookup)
         assert data["current"]["build_number"] == 44
 
-    def test_install_groups_query_param_array_with_update(self):
+    def test_install_groups_query_param_array_with_update(self) -> None:
         """Test that query param array works correctly for finding updates"""
         # Create current artifact with alpha install_group
         self._create_android_artifact(

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import APITestCase
 
 
 class ProjectPreprodUploadOptionsTest(APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
@@ -16,7 +16,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
             args=[self.org.slug, self.project.slug],
         )
 
-    def test_returns_upload_options(self):
+    def test_returns_upload_options(self) -> None:
         with self.feature("organizations:preprod-snapshots"):
             response = self.client.get(self.url)
 
@@ -29,7 +29,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
 
         assert data["expirationPolicy"] == "ttl:30 days"
 
-    def test_objectstore_url_uses_region_endpoint(self):
+    def test_objectstore_url_uses_region_endpoint(self) -> None:
         with (
             self.feature("organizations:preprod-snapshots"),
             self.options({"system.region-api-url-template": "https://{region}.testserver"}),
@@ -42,13 +42,13 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
         assert url.startswith(f"https://{region}.testserver/")
         assert url.endswith(f"/api/0/organizations/{self.org.id}/objectstore")
 
-    def test_without_feature_flag(self):
+    def test_without_feature_flag(self) -> None:
         response = self.client.get(self.url)
 
         assert response.status_code == 403
         assert response.data["detail"] == "Feature not enabled"
 
-    def test_requires_authentication(self):
+    def test_requires_authentication(self) -> None:
         unauthenticated_client = APIClient()
 
         with self.feature("organizations:preprod-snapshots"):
@@ -56,7 +56,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
 
         assert response.status_code == 401
 
-    def test_requires_project_access(self):
+    def test_requires_project_access(self) -> None:
         other_user = self.create_user()
         self.login_as(user=other_user)
 

--- a/tests/sentry/preprod/api/models/test_project_preprod_build_details_models.py
+++ b/tests/sentry/preprod/api/models/test_project_preprod_build_details_models.py
@@ -16,12 +16,12 @@ from sentry.testutils.silo import cell_silo_test
 
 @cell_silo_test
 class TestToSizeInfo(TestCase):
-    def test_to_size_info_none_input(self):
+    def test_to_size_info_none_input(self) -> None:
         """Test to_size_info returns None when given None input."""
         result = to_size_info([])
         assert result is None
 
-    def test_to_size_info_pending_state(self):
+    def test_to_size_info_pending_state(self) -> None:
         """Test to_size_info returns SizeInfoPending for PENDING state."""
         size_metrics = PreprodArtifactSizeMetrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING
@@ -32,7 +32,7 @@ class TestToSizeInfo(TestCase):
         assert isinstance(result, SizeInfoPending)
         assert result.state == PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING
 
-    def test_to_size_info_processing_state(self):
+    def test_to_size_info_processing_state(self) -> None:
         """Test to_size_info returns SizeInfoProcessing for PROCESSING state."""
         size_metrics = PreprodArtifactSizeMetrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
@@ -43,7 +43,7 @@ class TestToSizeInfo(TestCase):
         assert isinstance(result, SizeInfoProcessing)
         assert result.state == PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
 
-    def test_to_size_info_completed_state(self):
+    def test_to_size_info_completed_state(self) -> None:
         """Test to_size_info returns SizeInfoCompleted for COMPLETED state."""
         size_metrics = PreprodArtifactSizeMetrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
@@ -59,7 +59,7 @@ class TestToSizeInfo(TestCase):
         assert result.install_size_bytes == 1024000
         assert result.download_size_bytes == 512000
 
-    def test_to_size_info_completed_state_with_multiple_metrics(self):
+    def test_to_size_info_completed_state_with_multiple_metrics(self) -> None:
         """Test to_size_info returns SizeInfoCompleted for COMPLETED state with multiple metrics."""
         size_metrics = [
             PreprodArtifactSizeMetrics(
@@ -95,7 +95,7 @@ class TestToSizeInfo(TestCase):
         assert result.size_metrics[1].install_size_bytes == 512000
         assert result.size_metrics[1].download_size_bytes == 256000
 
-    def test_to_size_info_completed_state_with_base_metrics(self):
+    def test_to_size_info_completed_state_with_base_metrics(self) -> None:
         """Test to_size_info includes base size metrics when provided."""
         size_metrics = [
             PreprodArtifactSizeMetrics(
@@ -126,7 +126,7 @@ class TestToSizeInfo(TestCase):
         assert base_metric.install_size_bytes == 512000
         assert base_metric.download_size_bytes == 256000
 
-    def test_to_size_info_failed_state(self):
+    def test_to_size_info_failed_state(self) -> None:
         """Test to_size_info returns SizeInfoFailed for FAILED state."""
         size_metrics = PreprodArtifactSizeMetrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
@@ -141,7 +141,7 @@ class TestToSizeInfo(TestCase):
         assert result.error_code == PreprodArtifactSizeMetrics.ErrorCode.TIMEOUT
         assert result.error_message == "Analysis timed out after 30 minutes"
 
-    def test_to_size_info_failed_state_with_different_error_codes(self):
+    def test_to_size_info_failed_state_with_different_error_codes(self) -> None:
         """Test to_size_info handles different error codes correctly."""
         error_cases = [
             (PreprodArtifactSizeMetrics.ErrorCode.UNKNOWN, "Unknown error occurred"),
@@ -165,7 +165,7 @@ class TestToSizeInfo(TestCase):
             assert result.error_code == error_code
             assert result.error_message == error_message
 
-    def test_to_size_info_completed_with_zero_sizes(self):
+    def test_to_size_info_completed_with_zero_sizes(self) -> None:
         """Test to_size_info handles completed state with zero sizes."""
         size_metrics = PreprodArtifactSizeMetrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
@@ -180,7 +180,7 @@ class TestToSizeInfo(TestCase):
         assert result.install_size_bytes == 0
         assert result.download_size_bytes == 0
 
-    def test_to_size_info_completed_with_large_sizes(self):
+    def test_to_size_info_completed_with_large_sizes(self) -> None:
         """Test to_size_info handles completed state with large file sizes."""
         size_metrics = PreprodArtifactSizeMetrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
@@ -195,14 +195,14 @@ class TestToSizeInfo(TestCase):
         assert result.install_size_bytes == 5000000000
         assert result.download_size_bytes == 2000000000
 
-    def test_to_size_info_invalid_state_raises_error(self):
+    def test_to_size_info_invalid_state_raises_error(self) -> None:
         """Test to_size_info raises ValueError for unknown state."""
         size_metrics = PreprodArtifactSizeMetrics(state=999)  # Invalid state
 
         with pytest.raises(ValueError, match="Unknown SizeAnalysisState 999"):
             to_size_info(list([size_metrics]))
 
-    def test_to_size_info_completed_state_missing_size_fields(self):
+    def test_to_size_info_completed_state_missing_size_fields(self) -> None:
         """Test to_size_info raises ValueError when COMPLETED state has None size fields."""
         size_metrics = PreprodArtifactSizeMetrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
@@ -216,7 +216,7 @@ class TestToSizeInfo(TestCase):
         ):
             to_size_info(list([size_metrics]))
 
-    def test_to_size_info_failed_state_no_error_code(self):
+    def test_to_size_info_failed_state_no_error_code(self) -> None:
         """Test to_size_info raises ValueError when FAILED state has only error_code."""
         size_metrics = PreprodArtifactSizeMetrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
@@ -229,7 +229,7 @@ class TestToSizeInfo(TestCase):
         ):
             to_size_info(list([size_metrics]))
 
-    def test_to_size_info_failed_state_no_error_message(self):
+    def test_to_size_info_failed_state_no_error_message(self) -> None:
         """Test to_size_info raises ValueError when FAILED state has only error_message."""
         size_metrics = PreprodArtifactSizeMetrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,

--- a/tests/sentry/preprod/migrations/test_0022_backfill_preprod_artifact_mobile_app_info.py
+++ b/tests/sentry/preprod/migrations/test_0022_backfill_preprod_artifact_mobile_app_info.py
@@ -46,7 +46,7 @@ class BackfillPreprodArtifactMobileAppInfoTest(TestMigrations):
             state=0,
         )
 
-    def test_backfills_mobile_app_info(self):
+    def test_backfills_mobile_app_info(self) -> None:
         # Check artifact with all fields
         mobile_app_info_all = PreprodArtifactMobileAppInfo.objects.get(
             preprod_artifact_id=self.artifact_all_fields.id

--- a/tests/sentry/preprod/pull_request/test_comment_types.py
+++ b/tests/sentry/preprod/pull_request/test_comment_types.py
@@ -7,7 +7,7 @@ from sentry.preprod.pull_request.comment_types import (
 
 
 class TestPullRequestCommentTypes:
-    def test_parse_github_issue_comments_real_data(self):
+    def test_parse_github_issue_comments_real_data(self) -> None:
         """Test parsing real GitHub issue comments from actual PR data."""
         raw_comments = [
             {
@@ -163,7 +163,7 @@ class TestPullRequestCommentTypes:
         )
         assert comment2.author_association == AuthorAssociation.MEMBER
 
-    def test_parse_github_review_comments_real_data(self):
+    def test_parse_github_review_comments_real_data(self) -> None:
         """Test parsing real GitHub review comments from test-org/test-repo PR."""
         raw_comments = [
             {

--- a/tests/sentry/preprod/size_analysis/test_compare.py
+++ b/tests/sentry/preprod/size_analysis/test_compare.py
@@ -33,7 +33,7 @@ from sentry.testutils.cases import TestCase
 
 
 class CompareSizeAnalysisTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
@@ -86,7 +86,7 @@ class CompareSizeAnalysisTest(TestCase):
             analysis_version=analysis_version,
         )
 
-    def test_compare_size_analysis_no_treemaps(self):
+    def test_compare_size_analysis_no_treemaps(self) -> None:
         """Test compare_size_analysis with no treemap data."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -116,7 +116,7 @@ class CompareSizeAnalysisTest(TestCase):
         assert result.size_metric_diff_item.base_install_size == 1500
         assert result.size_metric_diff_item.base_download_size == 800
 
-    def test_compare_size_analysis_file_added(self):
+    def test_compare_size_analysis_file_added(self) -> None:
         """Test compare_size_analysis with a file added."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -148,7 +148,7 @@ class CompareSizeAnalysisTest(TestCase):
         assert diff_item.base_size is None
         assert diff_item.type == DiffType.ADDED
 
-    def test_compare_size_analysis_file_removed(self):
+    def test_compare_size_analysis_file_removed(self) -> None:
         """Test compare_size_analysis with a file removed."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -180,7 +180,7 @@ class CompareSizeAnalysisTest(TestCase):
         assert diff_item.base_size == 100
         assert diff_item.type == DiffType.REMOVED
 
-    def test_compare_size_analysis_file_increased(self):
+    def test_compare_size_analysis_file_increased(self) -> None:
         """Test compare_size_analysis with a file size increased."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -213,7 +213,7 @@ class CompareSizeAnalysisTest(TestCase):
         assert diff_item.base_size == 100
         assert diff_item.type == DiffType.INCREASED
 
-    def test_compare_size_analysis_file_decreased(self):
+    def test_compare_size_analysis_file_decreased(self) -> None:
         """Test compare_size_analysis with a file size decreased."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -246,7 +246,7 @@ class CompareSizeAnalysisTest(TestCase):
         assert diff_item.base_size == 100
         assert diff_item.type == DiffType.DECREASED
 
-    def test_compare_size_analysis_file_unchanged(self):
+    def test_compare_size_analysis_file_unchanged(self) -> None:
         """Test compare_size_analysis with a file size unchanged (should be skipped)."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -274,7 +274,7 @@ class CompareSizeAnalysisTest(TestCase):
         # Should skip files with no size difference
         assert len(result.diff_items) == 0
 
-    def test_compare_size_analysis_multiple_files(self):
+    def test_compare_size_analysis_multiple_files(self) -> None:
         """Test compare_size_analysis with multiple files."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -334,7 +334,7 @@ class CompareSizeAnalysisTest(TestCase):
         assert diff_items[2].size_diff == -300
         assert diff_items[2].type == DiffType.REMOVED
 
-    def test_compare_size_analysis_zero_size_diffs_skipped(self):
+    def test_compare_size_analysis_zero_size_diffs_skipped(self) -> None:
         """Test that zero size diffs are skipped for all diff types."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -367,7 +367,7 @@ class CompareSizeAnalysisTest(TestCase):
         result = compare_size_analysis(head_metrics, head_results, base_metrics, base_results)
         assert len(result.diff_items) == 0
 
-    def test_compare_size_analysis_different_artifact_types(self):
+    def test_compare_size_analysis_different_artifact_types(self) -> None:
         """Test compare_size_analysis with different artifact types."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -395,7 +395,7 @@ class CompareSizeAnalysisTest(TestCase):
         )
         assert result.size_metric_diff_item.identifier == "watch"
 
-    def test_compare_size_analysis_complex_nested_structure(self):
+    def test_compare_size_analysis_complex_nested_structure(self) -> None:
         """Test compare_size_analysis with complex nested directory structure."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -475,7 +475,7 @@ class CompareSizeAnalysisTest(TestCase):
         assert diff_items[2].size_diff == 200
         assert diff_items[2].type == DiffType.ADDED
 
-    def test_compare_size_analysis_duplicate_paths(self):
+    def test_compare_size_analysis_duplicate_paths(self) -> None:
         """Test compare_size_analysis with duplicate paths (e.g., Assets.car with multiple entries)."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -579,7 +579,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
             analysis_version=analysis_version,
         )
 
-    def test_skip_on_major_version_mismatch(self):
+    def test_skip_on_major_version_mismatch(self) -> None:
         """Should skip diff comparison when major versions differ."""
         head_results = self._create_size_analysis_results(analysis_version="2.0.0")
         base_results = self._create_size_analysis_results(analysis_version="1.0.0")
@@ -588,7 +588,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is True
 
-    def test_skip_on_minor_version_mismatch(self):
+    def test_skip_on_minor_version_mismatch(self) -> None:
         """Should skip diff comparison when minor versions differ."""
         head_results = self._create_size_analysis_results(analysis_version="1.2.0")
         base_results = self._create_size_analysis_results(analysis_version="1.1.0")
@@ -597,7 +597,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is True
 
-    def test_no_skip_on_patch_version_mismatch(self):
+    def test_no_skip_on_patch_version_mismatch(self) -> None:
         """Should NOT skip diff comparison when only patch versions differ."""
         head_results = self._create_size_analysis_results(analysis_version="1.0.1")
         base_results = self._create_size_analysis_results(analysis_version="1.0.0")
@@ -606,7 +606,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is False
 
-    def test_no_skip_on_same_versions(self):
+    def test_no_skip_on_same_versions(self) -> None:
         """Should NOT skip diff comparison when versions are identical."""
         head_results = self._create_size_analysis_results(analysis_version="1.2.3")
         base_results = self._create_size_analysis_results(analysis_version="1.2.3")
@@ -615,7 +615,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is False
 
-    def test_no_skip_when_head_version_missing(self):
+    def test_no_skip_when_head_version_missing(self) -> None:
         """Should NOT skip diff comparison when head version is None."""
         head_results = self._create_size_analysis_results(analysis_version=None)
         base_results = self._create_size_analysis_results(analysis_version="1.0.0")
@@ -624,7 +624,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is False
 
-    def test_no_skip_when_base_version_missing(self):
+    def test_no_skip_when_base_version_missing(self) -> None:
         """Should NOT skip diff comparison when base version is None."""
         head_results = self._create_size_analysis_results(analysis_version="1.0.0")
         base_results = self._create_size_analysis_results(analysis_version=None)
@@ -633,7 +633,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is False
 
-    def test_no_skip_when_both_versions_missing(self):
+    def test_no_skip_when_both_versions_missing(self) -> None:
         """Should NOT skip diff comparison when both versions are None."""
         head_results = self._create_size_analysis_results(analysis_version=None)
         base_results = self._create_size_analysis_results(analysis_version=None)
@@ -642,7 +642,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is False
 
-    def test_no_skip_on_invalid_head_version(self):
+    def test_no_skip_on_invalid_head_version(self) -> None:
         """Should NOT skip diff comparison when head version is invalid."""
         head_results = self._create_size_analysis_results(analysis_version="invalid-version")
         base_results = self._create_size_analysis_results(analysis_version="1.0.0")
@@ -651,7 +651,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is False
 
-    def test_no_skip_on_invalid_base_version(self):
+    def test_no_skip_on_invalid_base_version(self) -> None:
         """Should NOT skip diff comparison when base version is invalid."""
         head_results = self._create_size_analysis_results(analysis_version="1.0.0")
         base_results = self._create_size_analysis_results(analysis_version="not-a-version")
@@ -660,7 +660,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is False
 
-    def test_no_skip_when_both_versions_invalid(self):
+    def test_no_skip_when_both_versions_invalid(self) -> None:
         """Should NOT skip diff comparison when both versions are invalid."""
         head_results = self._create_size_analysis_results(analysis_version="bad-version")
         base_results = self._create_size_analysis_results(analysis_version="also-bad")
@@ -669,7 +669,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is False
 
-    def test_skip_with_prerelease_versions(self):
+    def test_skip_with_prerelease_versions(self) -> None:
         """Should skip when major/minor differ even with pre-release tags."""
         head_results = self._create_size_analysis_results(analysis_version="2.0.0-alpha")
         base_results = self._create_size_analysis_results(analysis_version="1.0.0-beta")
@@ -678,7 +678,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
         assert result is True
 
-    def test_no_skip_with_same_major_minor_prerelease(self):
+    def test_no_skip_with_same_major_minor_prerelease(self) -> None:
         """Should NOT skip when major/minor match despite different pre-release tags."""
         head_results = self._create_size_analysis_results(analysis_version="1.2.0-alpha")
         base_results = self._create_size_analysis_results(analysis_version="1.2.0-beta")
@@ -689,7 +689,7 @@ class ShouldSkipDiffItemComparisonTest(TestCase):
 
 
 class CompareWithVersionSkippingTest(CompareSizeAnalysisTest):
-    def test_compare_skips_diff_items_on_major_version_mismatch(self):
+    def test_compare_skips_diff_items_on_major_version_mismatch(self) -> None:
         """Integration test: diff items should be skipped when major versions differ."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -728,7 +728,7 @@ class CompareWithVersionSkippingTest(CompareSizeAnalysisTest):
         assert result.size_metric_diff_item.head_install_size == 2000
         assert result.size_metric_diff_item.base_install_size == 1500
 
-    def test_compare_skips_diff_items_on_minor_version_mismatch(self):
+    def test_compare_skips_diff_items_on_minor_version_mismatch(self) -> None:
         """Integration test: diff items should be skipped when minor versions differ."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -762,7 +762,7 @@ class CompareWithVersionSkippingTest(CompareSizeAnalysisTest):
         assert result.head_analysis_version == "1.2.0"
         assert result.base_analysis_version == "1.1.0"
 
-    def test_compare_includes_diff_items_on_patch_version_mismatch(self):
+    def test_compare_includes_diff_items_on_patch_version_mismatch(self) -> None:
         """Integration test: diff items should be included when only patch versions differ."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -799,7 +799,7 @@ class CompareWithVersionSkippingTest(CompareSizeAnalysisTest):
 
 
 class CompareWithRenameDetectionTest(CompareSizeAnalysisTest):
-    def test_renamed_file_excluded_from_diff(self):
+    def test_renamed_file_excluded_from_diff(self) -> None:
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
             metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
@@ -840,7 +840,7 @@ class CompareWithRenameDetectionTest(CompareSizeAnalysisTest):
 
         assert len(result.diff_items) == 0
 
-    def test_mixed_renames_and_real_changes(self):
+    def test_mixed_renames_and_real_changes(self) -> None:
         """Test rename detection with mix of renamed and actually changed files."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -925,7 +925,7 @@ class CompareWithRenameDetectionTest(CompareSizeAnalysisTest):
         assert diff_items[1].type == DiffType.REMOVED
         assert diff_items[1].size_diff == -300
 
-    def test_no_file_analysis_falls_back_to_default_behavior(self):
+    def test_no_file_analysis_falls_back_to_default_behavior(self) -> None:
         """Test that when file_analysis is None, default behavior is used."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -964,7 +964,7 @@ class CompareWithRenameDetectionTest(CompareSizeAnalysisTest):
         types = {item.type for item in result.diff_items}
         assert types == {DiffType.ADDED, DiffType.REMOVED}
 
-    def test_rename_with_duplication_shows_additions(self):
+    def test_rename_with_duplication_shows_additions(self) -> None:
         """Test that when a file is renamed AND duplicated, only one rename is detected.
 
         Scenario: Base has 1 file, head has 3 files with same hash at different paths.
@@ -1045,7 +1045,7 @@ class CompareWithRenameDetectionTest(CompareSizeAnalysisTest):
             assert item.type == DiffType.ADDED
             assert item.size_diff == 100
 
-    def test_rename_selection_is_deterministic(self):
+    def test_rename_selection_is_deterministic(self) -> None:
         """Test that rename selection is deterministic when multiple paths share the same hash.
 
         When multiple files on each side share the same hash, we need to deterministically
@@ -1123,7 +1123,7 @@ class CompareWithRenameDetectionTest(CompareSizeAnalysisTest):
         assert result.diff_items[0].path == "z.txt"
         assert result.diff_items[0].type == DiffType.ADDED
 
-    def test_duplicate_treemap_elements_at_renamed_path_all_skipped(self):
+    def test_duplicate_treemap_elements_at_renamed_path_all_skipped(self) -> None:
         """Test that duplicate treemap elements at a renamed path are all skipped.
 
         iOS Assets.car files can have duplicate treemap entries for the same image at the
@@ -1235,7 +1235,7 @@ class CompareWithRenameDetectionTest(CompareSizeAnalysisTest):
             "Bug: not all duplicate treemap elements are being skipped for renamed files."
         )
 
-    def test_rename_detection_with_nested_children(self):
+    def test_rename_detection_with_nested_children(self) -> None:
         """Test rename detection works with nested file_analysis children (e.g., Assets.car).
 
         Assets.car files contain nested images as children in file_analysis.
@@ -1311,7 +1311,7 @@ class CompareWithRenameDetectionTest(CompareSizeAnalysisTest):
 
 
 class CompareInsightsTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
@@ -1334,7 +1334,7 @@ class CompareInsightsTest(TestCase):
             app_components=None,
         )
 
-    def test_compare_insights_new_insight_in_head(self):
+    def test_compare_insights_new_insight_in_head(self) -> None:
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
             metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
@@ -1395,7 +1395,7 @@ class CompareInsightsTest(TestCase):
         assert file_diff.type.value == "added"
         assert file_diff.size_diff == 500
 
-    def test_compare_insights_resolved_insight_in_base(self):
+    def test_compare_insights_resolved_insight_in_base(self) -> None:
         """Test that insights only in base are marked as 'resolved'."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -1443,7 +1443,7 @@ class CompareInsightsTest(TestCase):
         assert file_diff.size_diff == -2000
         assert insight_diff.group_diffs == []
 
-    def test_compare_insights_unresolved_insight_in_both(self):
+    def test_compare_insights_unresolved_insight_in_both(self) -> None:
         """Test that insights in both head and base are marked as 'unresolved'."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -1503,7 +1503,7 @@ class CompareInsightsTest(TestCase):
         assert file_diff.size_diff == 500
         assert insight_diff.group_diffs == []
 
-    def test_compare_insights_multiple_insights(self):
+    def test_compare_insights_multiple_insights(self) -> None:
         """Test comparison with multiple insights in different states."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -1581,7 +1581,7 @@ class CompareInsightsTest(TestCase):
         assert insight_diffs[2].insight_type == "webp_optimization"
         assert insight_diffs[2].status == "unresolved"
 
-    def test_compare_insights_zero_savings_excluded(self):
+    def test_compare_insights_zero_savings_excluded(self) -> None:
         """Test that insights with zero total_savings are excluded."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -1626,7 +1626,7 @@ class CompareInsightsTest(TestCase):
         # Should have no insight diff items since all have zero savings
         assert len(result.insight_diff_items) == 0
 
-    def test_compare_insights_version_mismatch_skips_comparison(self):
+    def test_compare_insights_version_mismatch_skips_comparison(self) -> None:
         """Test that insight comparison is skipped when analysis versions mismatch."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -1675,7 +1675,7 @@ class CompareInsightsTest(TestCase):
         assert len(result.insight_diff_items) == 0
         assert result.skipped_diff_item_comparison is True
 
-    def test_compare_insights_apple_platform(self):
+    def test_compare_insights_apple_platform(self) -> None:
         """Test insight comparison works with Apple platform insights."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -1758,7 +1758,7 @@ class CompareInsightsTest(TestCase):
         assert insight_diffs[1].insight_type == "large_images"
         assert insight_diffs[1].status == "resolved"
 
-    def test_compare_insights_files_insight_with_diffs(self):
+    def test_compare_insights_files_insight_with_diffs(self) -> None:
         """Test FilesInsightResult with file-level differences."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -1837,7 +1837,7 @@ class CompareInsightsTest(TestCase):
         assert file_diffs_by_path["/path/image4.png"].type.value == "added"
         assert file_diffs_by_path["/path/image4.png"].size_diff == 1500
 
-    def test_compare_insights_groups_insight_with_diffs(self):
+    def test_compare_insights_groups_insight_with_diffs(self) -> None:
         """Test GroupsInsightResult with group-level differences."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -1945,7 +1945,7 @@ class CompareInsightsTest(TestCase):
         assert group_diffs_by_path["logo.png"].diff_items is not None
         assert len(group_diffs_by_path["logo.png"].diff_items) == 1
 
-    def test_compare_insights_groups_with_within_group_file_differences(self):
+    def test_compare_insights_groups_with_within_group_file_differences(self) -> None:
         """Test GroupsInsightResult with file-level differences within the same group."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -2040,7 +2040,7 @@ class CompareInsightsTest(TestCase):
         assert file_diff.type.value == "added"
         assert file_diff.size_diff == 1000
 
-    def test_compare_insights_groups_with_identical_groups(self):
+    def test_compare_insights_groups_with_identical_groups(self) -> None:
         """Test GroupsInsightResult with identical groups between head and base."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -2120,7 +2120,7 @@ class CompareInsightsTest(TestCase):
         # No insight diff items should be returned
         assert len(result.insight_diff_items) == 0
 
-    def test_compare_insights_image_optimization_with_diffs(self):
+    def test_compare_insights_image_optimization_with_diffs(self) -> None:
         """Test ImageOptimizationInsightResult with file-level differences."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -2233,7 +2233,7 @@ class CompareInsightsTest(TestCase):
         assert file_diffs_by_path["/path/logo.png"].type.value == "removed"
         assert file_diffs_by_path["/path/logo.png"].size_diff == -3000
 
-    def test_compare_insights_strip_binary_with_diffs(self):
+    def test_compare_insights_strip_binary_with_diffs(self) -> None:
         """Test StripBinaryInsightResult with file-level differences."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,
@@ -2350,7 +2350,7 @@ class CompareInsightsTest(TestCase):
         assert file_diffs_by_path["/path/OldFramework"].type.value == "removed"
         assert file_diffs_by_path["/path/OldFramework"].size_diff == -5000
 
-    def test_compare_insights_video_compression_with_diffs(self):
+    def test_compare_insights_video_compression_with_diffs(self) -> None:
         """Test VideoCompressionInsightResult with file-level differences."""
         head_metrics = PreprodArtifactSizeMetrics(
             preprod_artifact_id=1,

--- a/tests/sentry/preprod/size_analysis/test_comparison_utils.py
+++ b/tests/sentry/preprod/size_analysis/test_comparison_utils.py
@@ -4,7 +4,7 @@ from sentry.testutils.cases import TestCase
 
 
 class CanCompareSizeMetricsTest(TestCase):
-    def test_can_compare_when_metrics_match(self):
+    def test_can_compare_when_metrics_match(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -32,7 +32,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is None
         assert result.error_type is None
 
-    def test_cannot_compare_empty_lists(self):
+    def test_cannot_compare_empty_lists(self) -> None:
         result = can_compare_size_metrics([], [])
 
         assert result.can_compare is False
@@ -40,7 +40,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is not None
         assert "no completed size metrics" in result.error_message
 
-    def test_cannot_compare_empty_head(self):
+    def test_cannot_compare_empty_head(self) -> None:
         base_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=2,
@@ -58,7 +58,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
         assert result.error_message is not None
 
-    def test_cannot_compare_empty_base(self):
+    def test_cannot_compare_empty_base(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -76,7 +76,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
         assert result.error_message is not None
 
-    def test_different_length_error_type(self):
+    def test_different_length_error_type(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -113,7 +113,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is not None
         assert "Head has 2 metric(s), base has 1 metric(s)" in result.error_message
 
-    def test_different_app_ids_error_type(self):
+    def test_different_app_ids_error_type(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -144,7 +144,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert "com.example.app" in result.error_message
         assert "com.example.app.debug" in result.error_message
 
-    def test_different_build_configurations_error_type(self):
+    def test_different_build_configurations_error_type(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -175,7 +175,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is not None
         assert "mismatched metrics" in result.error_message
 
-    def test_cannot_compare_when_metrics_not_completed(self):
+    def test_cannot_compare_when_metrics_not_completed(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -204,7 +204,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is not None
         assert "not completed" in result.error_message
 
-    def test_cannot_compare_when_all_metrics_pending(self):
+    def test_cannot_compare_when_all_metrics_pending(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -233,7 +233,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is not None
         assert "2 metric(s)" in result.error_message
 
-    def test_cannot_compare_when_metric_failed(self):
+    def test_cannot_compare_when_metric_failed(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -262,7 +262,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is not None
         assert "failed" in result.error_message
 
-    def test_cannot_compare_when_metric_not_ran(self):
+    def test_cannot_compare_when_metric_not_ran(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -291,7 +291,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is not None
         assert "failed" in result.error_message
 
-    def test_failed_takes_priority_over_pending(self):
+    def test_failed_takes_priority_over_pending(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
@@ -318,7 +318,7 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.can_compare is False
         assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
 
-    def test_different_metrics_error_type(self):
+    def test_different_metrics_error_type(self) -> None:
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -32,7 +32,7 @@ class PreprodSizeAnalysisDetectorValidatorTest(TestCase):
             "request": self.make_request(),
         }
 
-    def test_create_detector(self):
+    def test_create_detector(self) -> None:
         condition_group = self.create_data_condition_group(organization=self.project.organization)
         data = {
             "name": "Test Detector",
@@ -71,7 +71,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
             condition_result=DetectorPriorityLevel.HIGH,
         )
 
-    def test_evaluate_creates_occurrence_when_condition_met(self):
+    def test_evaluate_creates_occurrence_when_condition_met(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -95,7 +95,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
         assert result.priority == DetectorPriorityLevel.HIGH
         assert result.result is not None
 
-    def test_evaluate_no_occurrence_when_condition_not_met(self):
+    def test_evaluate_no_occurrence_when_condition_not_met(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -116,7 +116,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
 
         assert evaluation_result == {}
 
-    def test_evaluate_returns_highest_matched_priority(self):
+    def test_evaluate_returns_highest_matched_priority(self) -> None:
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
@@ -154,7 +154,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
         assert None in evaluation_result
         assert evaluation_result[None].priority == DetectorPriorityLevel.HIGH
 
-    def test_evaluate_returns_medium_when_only_medium_condition_met(self):
+    def test_evaluate_returns_medium_when_only_medium_condition_met(self) -> None:
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
@@ -192,7 +192,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
         assert None in evaluation_result
         assert evaluation_result[None].priority == DetectorPriorityLevel.MEDIUM
 
-    def test_evaluate_no_occurrence_when_no_condition_group(self):
+    def test_evaluate_no_occurrence_when_no_condition_group(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -212,7 +212,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
 
         assert evaluation_result == {}
 
-    def test_evaluate_absolute_diff(self):
+    def test_evaluate_absolute_diff(self) -> None:
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
@@ -246,7 +246,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
         assert None in evaluation_result
         assert evaluation_result[None].priority == DetectorPriorityLevel.HIGH
 
-    def test_evaluate_absolute_diff_no_trigger_when_below_threshold(self):
+    def test_evaluate_absolute_diff_no_trigger_when_below_threshold(self) -> None:
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
@@ -279,7 +279,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
 
         assert evaluation_result == {}
 
-    def test_evaluate_relative_diff(self):
+    def test_evaluate_relative_diff(self) -> None:
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
@@ -314,7 +314,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
         assert None in evaluation_result
         assert evaluation_result[None].priority == DetectorPriorityLevel.HIGH
 
-    def test_evaluate_relative_diff_no_trigger_when_below_threshold(self):
+    def test_evaluate_relative_diff_no_trigger_when_below_threshold(self) -> None:
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
@@ -348,7 +348,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
 
         assert evaluation_result == {}
 
-    def test_evaluate_diff_raises_when_base_missing(self):
+    def test_evaluate_diff_raises_when_base_missing(self) -> None:
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
@@ -426,7 +426,7 @@ class PreprodSizeAnalysisDetectorQueryFilterTest(TestCase):
             },
         )
 
-    def test_no_query_evaluates_normally(self):
+    def test_no_query_evaluates_normally(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -440,7 +440,7 @@ class PreprodSizeAnalysisDetectorQueryFilterTest(TestCase):
         assert None in result
         assert result[None].priority == DetectorPriorityLevel.HIGH
 
-    def test_empty_query_evaluates_normally(self):
+    def test_empty_query_evaluates_normally(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -454,7 +454,7 @@ class PreprodSizeAnalysisDetectorQueryFilterTest(TestCase):
         assert None in result
         assert result[None].priority == DetectorPriorityLevel.HIGH
 
-    def test_whitespace_query_evaluates_normally(self):
+    def test_whitespace_query_evaluates_normally(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -468,7 +468,7 @@ class PreprodSizeAnalysisDetectorQueryFilterTest(TestCase):
         assert None in result
         assert result[None].priority == DetectorPriorityLevel.HIGH
 
-    def test_matching_query_evaluates_normally(self):
+    def test_matching_query_evaluates_normally(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -486,7 +486,7 @@ class PreprodSizeAnalysisDetectorQueryFilterTest(TestCase):
         assert None in result
         assert result[None].priority == DetectorPriorityLevel.HIGH
 
-    def test_non_matching_query_skips_evaluation(self):
+    def test_non_matching_query_skips_evaluation(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -503,7 +503,7 @@ class PreprodSizeAnalysisDetectorQueryFilterTest(TestCase):
 
         assert result == {}
 
-    def test_invalid_query_skips_evaluation_and_logs_exception(self):
+    def test_invalid_query_skips_evaluation_and_logs_exception(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -526,7 +526,7 @@ class PreprodSizeAnalysisDetectorQueryFilterTest(TestCase):
             extra={"detector_id": detector.id, "query": "foo OR bar"},
         )
 
-    def test_no_metadata_with_query_raises_error(self):
+    def test_no_metadata_with_query_raises_error(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -552,7 +552,7 @@ class PreprodSizeAnalysisDetectorQueryFilterTest(TestCase):
 
 @cell_silo_test
 class PreprodSizeAnalysisDetectorHandlerIntegrationTest(TestCase):
-    def test_e2e(self):
+    def test_e2e(self) -> None:
         condition_group = self.create_data_condition_group(
             organization=self.project.organization,
         )
@@ -621,7 +621,7 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         handler = PreprodSizeAnalysisDetectorHandler(detector)
         return handler.evaluate(data_packet)
 
-    def test_create_occurrence_install_size_with_metadata(self):
+    def test_create_occurrence_install_size_with_metadata(self) -> None:
         commit_comparison = self.create_commit_comparison(
             organization=self.project.organization,
             head_sha="a" * 40,
@@ -684,7 +684,7 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert occurrence.evidence_data["head_size_metric_id"] == 100
         assert occurrence.evidence_data["base_size_metric_id"] == 200
 
-    def test_create_occurrence_download_size_with_metadata(self):
+    def test_create_occurrence_download_size_with_metadata(self) -> None:
         commit_comparison = self.create_commit_comparison(
             organization=self.project.organization,
             head_sha="c" * 40,
@@ -736,7 +736,7 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert event_data["tags"]["git.repo"] == "owner/repo"
         assert occurrence.evidence_data["head_artifact_id"] == head_artifact.id
 
-    def test_create_occurrence_with_metadata_no_commit_comparison(self):
+    def test_create_occurrence_with_metadata_no_commit_comparison(self) -> None:
         head_artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",
@@ -774,7 +774,7 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert "git.branch" not in event_data["tags"]
         assert "git.repo" not in event_data["tags"]
 
-    def test_create_occurrence_without_metadata(self):
+    def test_create_occurrence_without_metadata(self) -> None:
         detector = self.create_detector(
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
@@ -861,7 +861,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
         assert isinstance(occurrence, IssueOccurrence)
         return occurrence
 
-    def test_evidence_absolute_install_size(self):
+    def test_evidence_absolute_install_size(self) -> None:
         self._create_condition(Condition.GREATER, 1000000)
         occurrence = self._evaluate(
             "absolute",
@@ -874,7 +874,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
         assert evidence.important is True
         assert evidence.value == "Install Size, Absolute Size > 1.0 MB (5.0 MB)"
 
-    def test_evidence_absolute_diff_install_size(self):
+    def test_evidence_absolute_diff_install_size(self) -> None:
         self._create_condition(Condition.GREATER_OR_EQUAL, 500000)
         occurrence = self._evaluate(
             "absolute_diff",
@@ -887,7 +887,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
         evidence = occurrence.evidence_display[0]
         assert evidence.value == "Install Size, Absolute Diff > 500.0 KB (+1.0 MB)"
 
-    def test_evidence_relative_diff_download_size(self):
+    def test_evidence_relative_diff_download_size(self) -> None:
         self._create_condition(Condition.GREATER_OR_EQUAL, 5)
         occurrence = self._evaluate(
             "relative_diff",
@@ -927,7 +927,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
             "base_artifact": base_artifact,
         }
 
-    def test_evidence_android_shows_uncompressed_size(self):
+    def test_evidence_android_shows_uncompressed_size(self) -> None:
         self._create_condition(Condition.GREATER, 1000000)
         metadata = self._make_metadata("android", PreprodArtifact.ArtifactType.APK)
         occurrence = self._evaluate(
@@ -940,7 +940,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
         evidence = occurrence.evidence_display[0]
         assert evidence.value == "Uncompressed Size, Absolute Size > 1.0 MB (5.0 MB)"
 
-    def test_evidence_apple_shows_install_size(self):
+    def test_evidence_apple_shows_install_size(self) -> None:
         self._create_condition(Condition.GREATER, 1000000)
         metadata = self._make_metadata("apple", PreprodArtifact.ArtifactType.XCARCHIVE)
         occurrence = self._evaluate(

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -69,7 +69,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
             workflow_condition_group=condition_group,
         )
 
-    def test_triggers_detector_evaluation(self):
+    def test_triggers_detector_evaluation(self) -> None:
         now = timezone.now()
         self._create_artifact_with_metrics(
             max_install_size=4000000,
@@ -89,7 +89,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
 
             assert mock_produce.call_count == 1
 
-    def test_no_detectors(self):
+    def test_no_detectors(self) -> None:
         now = timezone.now()
         self._create_artifact_with_metrics(date_added=now - timedelta(hours=2))
         head = self._create_artifact_with_metrics(date_added=now - timedelta(hours=1))
@@ -102,7 +102,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
 
             assert mock_produce.call_count == 0
 
-    def test_feature_flag_disabled(self):
+    def test_feature_flag_disabled(self) -> None:
         now = timezone.now()
         self._create_artifact_with_metrics(date_added=now - timedelta(hours=2))
         head = self._create_artifact_with_metrics(date_added=now - timedelta(hours=1))
@@ -115,7 +115,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
 
         assert mock_produce.call_count == 0
 
-    def test_populates_metadata(self):
+    def test_populates_metadata(self) -> None:
         now = timezone.now()
         base = self._create_artifact_with_metrics(
             max_install_size=4000000,
@@ -151,7 +151,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
             assert packet["base_install_size_bytes"] == 4000000
             assert packet["base_download_size_bytes"] == 1500000
 
-    def test_skips_absolute_detectors(self):
+    def test_skips_absolute_detectors(self) -> None:
         now = timezone.now()
         self._create_artifact_with_metrics(date_added=now - timedelta(hours=2))
         head = self._create_artifact_with_metrics(date_added=now - timedelta(hours=1))
@@ -181,7 +181,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
 
             assert mock_produce.call_count == 0
 
-    def test_skips_when_no_base(self):
+    def test_skips_when_no_base(self) -> None:
         head = self._create_artifact_with_metrics()
         self._create_diff_detector()
 
@@ -193,7 +193,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
 
             assert mock_produce.call_count == 0
 
-    def test_skips_when_no_head_metrics(self):
+    def test_skips_when_no_head_metrics(self) -> None:
         head = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
         self._create_diff_detector()
 
@@ -205,7 +205,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
 
             assert mock_produce.call_count == 0
 
-    def test_batches_queries(self):
+    def test_batches_queries(self) -> None:
         now = timezone.now()
         self._create_artifact_with_metrics(date_added=now - timedelta(hours=2))
         head = self._create_artifact_with_metrics(date_added=now - timedelta(hours=1))
@@ -224,7 +224,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
             # Should only be called once for the shared empty query
             assert mock_lookup.call_count == 1
 
-    def test_creates_comparison_record(self):
+    def test_creates_comparison_record(self) -> None:
         now = timezone.now()
         self._create_artifact_with_metrics(
             max_install_size=4000000,
@@ -247,7 +247,7 @@ class MaybeEmitIssuesFromDiffSizeResultsTest(TestCase):
 class MaybeEmitIssuesFromSizeResultsTest(TestCase):
     """Tests for the maybe_emit_issues_from_absolute_size_results function."""
 
-    def test_triggers_absolute_detector(self):
+    def test_triggers_absolute_detector(self) -> None:
         artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
         metric = self.create_preprod_artifact_size_metrics(
             artifact,
@@ -283,7 +283,7 @@ class MaybeEmitIssuesFromSizeResultsTest(TestCase):
 
             assert mock_produce.call_count == 1
 
-    def test_skips_diff_detectors(self):
+    def test_skips_diff_detectors(self) -> None:
         """Diff-based detectors should not fire from the single-build path."""
         artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
         metric = self.create_preprod_artifact_size_metrics(
@@ -320,7 +320,7 @@ class MaybeEmitIssuesFromSizeResultsTest(TestCase):
 
             assert mock_produce.call_count == 0
 
-    def test_feature_flag_disabled(self):
+    def test_feature_flag_disabled(self) -> None:
         artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
         metric = self.create_preprod_artifact_size_metrics(
             artifact,
@@ -355,7 +355,7 @@ class MaybeEmitIssuesFromSizeResultsTest(TestCase):
 
         assert mock_produce.call_count == 0
 
-    def test_populates_metadata_without_base(self):
+    def test_populates_metadata_without_base(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",
@@ -404,7 +404,7 @@ class MaybeEmitIssuesFromSizeResultsTest(TestCase):
             assert "base_artifact_id" not in metadata
             assert "base_artifact" not in metadata
 
-    def test_no_detectors(self):
+    def test_no_detectors(self) -> None:
         artifact = self.create_preprod_artifact(project=self.project, app_id="com.example.app")
         metric = self.create_preprod_artifact_size_metrics(
             artifact,
@@ -431,21 +431,21 @@ class GetPlatformTest(TestCase):
             project=self.project, file_id=file.id, artifact_type=artifact_type
         )
 
-    def test_xcarchive_returns_apple(self):
+    def test_xcarchive_returns_apple(self) -> None:
         assert _get_platform(self._make_artifact(PreprodArtifact.ArtifactType.XCARCHIVE)) == "apple"
 
-    def test_aab_returns_android(self):
+    def test_aab_returns_android(self) -> None:
         assert _get_platform(self._make_artifact(PreprodArtifact.ArtifactType.AAB)) == "android"
 
-    def test_apk_returns_android(self):
+    def test_apk_returns_android(self) -> None:
         assert _get_platform(self._make_artifact(PreprodArtifact.ArtifactType.APK)) == "android"
 
-    def test_none_returns_unknown(self):
+    def test_none_returns_unknown(self) -> None:
         assert _get_platform(self._make_artifact(None)) == "unknown"
 
 
 class ArtifactToTagsTest(TestCase):
-    def test_full_artifact_data(self):
+    def test_full_artifact_data(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",
@@ -465,7 +465,7 @@ class ArtifactToTagsTest(TestCase):
         assert tags["build_number"] == "42"
         assert tags["artifact_type"] == "apk"
 
-    def test_minimal_artifact_data(self):
+    def test_minimal_artifact_data(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",

--- a/tests/sentry/preprod/size_analysis/test_webhooks.py
+++ b/tests/sentry/preprod/size_analysis/test_webhooks.py
@@ -109,7 +109,7 @@ class BuildWebhookPayloadTest(TestCase):
     # Completed standalone builds
     # ------------------------------------------------------------------
 
-    def test_standalone_build_success(self):
+    def test_standalone_build_success(self) -> None:
         """Completed standalone build produces API-subset payload."""
         artifact, _ = self._create_artifact_with_completed_analysis()
 
@@ -144,7 +144,7 @@ class BuildWebhookPayloadTest(TestCase):
 
         self._assert_no_api_heavy_fields(payload)
 
-    def test_standalone_build_with_git_context(self):
+    def test_standalone_build_with_git_context(self) -> None:
         """Standalone build on main branch has gitInfo but no comparison."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -180,7 +180,7 @@ class BuildWebhookPayloadTest(TestCase):
     # PR builds with comparisons
     # ------------------------------------------------------------------
 
-    def test_pr_build_comparison_succeeded(self):
+    def test_pr_build_comparison_succeeded(self) -> None:
         """PR build with successful comparison includes per-artifact comparisons."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -250,7 +250,7 @@ class BuildWebhookPayloadTest(TestCase):
 
         self._assert_no_api_heavy_fields(payload)
 
-    def test_pr_build_comparison_failed(self):
+    def test_pr_build_comparison_failed(self) -> None:
         """PR build with failed comparison: top-level state stays COMPLETED."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -294,7 +294,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert len(payload["comparisons"]) == 1
         assert payload["comparisons"][0]["state"] == "FAILED"
 
-    def test_multi_metric_comparison(self):
+    def test_multi_metric_comparison(self) -> None:
         """Multiple artifacts (main + watch) produce multiple comparison entries."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -420,7 +420,7 @@ class BuildWebhookPayloadTest(TestCase):
     # Analysis failures
     # ------------------------------------------------------------------
 
-    def test_analysis_failed(self):
+    def test_analysis_failed(self) -> None:
         """Analysis failure produces FAILED payload with error details."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -454,7 +454,7 @@ class BuildWebhookPayloadTest(TestCase):
 
         self._assert_no_api_heavy_fields(payload)
 
-    def test_analysis_timeout_error_code(self):
+    def test_analysis_timeout_error_code(self) -> None:
         """Timeout error code is mapped correctly."""
         artifact = self.create_preprod_artifact(project=self.project)
         self.create_preprod_artifact_size_metrics(
@@ -470,7 +470,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload is not None
         assert payload["errorCode"] == "TIMEOUT"
 
-    def test_unsupported_artifact_error_code(self):
+    def test_unsupported_artifact_error_code(self) -> None:
         """Unsupported artifact error code is mapped correctly."""
         artifact = self.create_preprod_artifact(project=self.project)
         self.create_preprod_artifact_size_metrics(
@@ -490,7 +490,7 @@ class BuildWebhookPayloadTest(TestCase):
     # Suppressed states
     # ------------------------------------------------------------------
 
-    def test_not_ran_returns_none(self):
+    def test_not_ran_returns_none(self) -> None:
         """NOT_RAN state should not produce a webhook payload."""
         artifact = self.create_preprod_artifact(project=self.project)
         self.create_preprod_artifact_size_metrics(
@@ -502,7 +502,7 @@ class BuildWebhookPayloadTest(TestCase):
 
         assert build_webhook_payload(artifact) is None
 
-    def test_pending_returns_none(self):
+    def test_pending_returns_none(self) -> None:
         """PENDING state should not produce a webhook payload."""
         artifact = self.create_preprod_artifact(project=self.project)
         self.create_preprod_artifact_size_metrics(
@@ -512,7 +512,7 @@ class BuildWebhookPayloadTest(TestCase):
 
         assert build_webhook_payload(artifact) is None
 
-    def test_processing_returns_none(self):
+    def test_processing_returns_none(self) -> None:
         """PROCESSING state should not produce a webhook payload."""
         artifact = self.create_preprod_artifact(project=self.project)
         self.create_preprod_artifact_size_metrics(
@@ -522,7 +522,7 @@ class BuildWebhookPayloadTest(TestCase):
 
         assert build_webhook_payload(artifact) is None
 
-    def test_no_metrics_returns_none(self):
+    def test_no_metrics_returns_none(self) -> None:
         """No size metrics at all should not produce a webhook payload."""
         artifact = self.create_preprod_artifact(project=self.project)
 
@@ -532,7 +532,7 @@ class BuildWebhookPayloadTest(TestCase):
     # Edge cases
     # ------------------------------------------------------------------
 
-    def test_no_mobile_app_info(self):
+    def test_no_mobile_app_info(self) -> None:
         """Artifact without mobile app info has null appInfo fields."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -553,7 +553,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload["appInfo"]["version"] is None
         assert payload["appInfo"]["buildNumber"] is None
 
-    def test_build_id_is_string(self):
+    def test_build_id_is_string(self) -> None:
         """buildId should always be a string, not an integer."""
         artifact, _ = self._create_artifact_with_completed_analysis()
 
@@ -562,7 +562,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload is not None
         assert isinstance(payload["buildId"], str)
 
-    def test_android_apk_artifact_type(self):
+    def test_android_apk_artifact_type(self) -> None:
         """Android APK artifact has correct appInfo.artifactType."""
         artifact, _ = self._create_artifact_with_completed_analysis(
             artifact_type=PreprodArtifact.ArtifactType.APK,
@@ -573,7 +573,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload is not None
         assert payload["appInfo"]["artifactType"] == "APK"
 
-    def test_android_aab_artifact_type(self):
+    def test_android_aab_artifact_type(self) -> None:
         """Android AAB artifact has correct appInfo.artifactType."""
         artifact, _ = self._create_artifact_with_completed_analysis(
             artifact_type=PreprodArtifact.ArtifactType.AAB,

--- a/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
+++ b/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
@@ -12,14 +12,14 @@ def _make_solid_image(width: int, height: int, color: tuple[int, int, int, int])
 
 
 class TestCompareImages:
-    def test_identical_images(self):
+    def test_identical_images(self) -> None:
         img = _make_solid_image(100, 100, (128, 128, 128, 255))
         result = compare_images(img, img.copy())
         assert result is not None
         assert result.changed_pixels == 0
         assert result.total_pixels == 100 * 100
 
-    def test_different_sizes(self):
+    def test_different_sizes(self) -> None:
         small = _make_solid_image(30, 30, (100, 100, 100, 255))
         large = _make_solid_image(50, 50, (100, 100, 100, 255))
         result = compare_images(small, large)
@@ -32,7 +32,7 @@ class TestCompareImages:
         assert result.after_width == 50
         assert result.after_height == 50
 
-    def test_modified_block(self):
+    def test_modified_block(self) -> None:
         before = _make_solid_image(100, 100, (100, 100, 100, 255))
         after = _make_solid_image(100, 100, (100, 100, 100, 255))
         draw = ImageDraw.Draw(after)
@@ -42,7 +42,7 @@ class TestCompareImages:
         assert result.changed_pixels > 0
         assert result.total_pixels == 100 * 100
 
-    def test_bytes_input(self):
+    def test_bytes_input(self) -> None:
         img = _make_solid_image(30, 30, (128, 128, 128, 255))
         buf = io.BytesIO()
         img.save(buf, format="PNG")
@@ -55,7 +55,7 @@ class TestCompareImages:
 
 
 class TestCompareImagesBatch:
-    def test_batch_returns_correct_count(self):
+    def test_batch_returns_correct_count(self) -> None:
         img1 = _make_solid_image(50, 50, (100, 100, 100, 255))
         img2 = _make_solid_image(50, 50, (200, 200, 200, 255))
 
@@ -72,7 +72,7 @@ class TestCompareImagesBatch:
         assert results[0].changed_pixels == 0
         assert results[1].changed_pixels == results[1].total_pixels
 
-    def test_batch_single_pair_matches_single(self):
+    def test_batch_single_pair_matches_single(self) -> None:
         before = _make_solid_image(50, 50, (100, 100, 100, 255))
         after = _make_solid_image(50, 50, (200, 200, 200, 255))
 

--- a/tests/sentry/preprod/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_tasks.py
@@ -7,7 +7,7 @@ def _meta(content_hash: str) -> ImageMetadata:
 
 
 class TestCategorizeImageDiff:
-    def test_basic_rename(self):
+    def test_basic_rename(self) -> None:
         head = SnapshotManifest(images={"new.png": _meta("hash_a")})
         base = SnapshotManifest(images={"old.png": _meta("hash_a")})
 
@@ -17,7 +17,7 @@ class TestCategorizeImageDiff:
         assert result.added == set()
         assert result.removed == set()
 
-    def test_no_rename_when_hashes_differ(self):
+    def test_no_rename_when_hashes_differ(self) -> None:
         head = SnapshotManifest(images={"a.png": _meta("hash_1")})
         base = SnapshotManifest(images={"b.png": _meta("hash_2")})
 
@@ -27,7 +27,7 @@ class TestCategorizeImageDiff:
         assert result.added == {"a.png"}
         assert result.removed == {"b.png"}
 
-    def test_same_name_same_hash_is_matched_not_renamed(self):
+    def test_same_name_same_hash_is_matched_not_renamed(self) -> None:
         head = SnapshotManifest(images={"screen.png": _meta("hash_a")})
         base = SnapshotManifest(images={"screen.png": _meta("hash_a")})
 
@@ -38,7 +38,7 @@ class TestCategorizeImageDiff:
         assert result.removed == set()
         assert result.matched == {"screen.png"}
 
-    def test_mixed_renames_adds_removes(self):
+    def test_mixed_renames_adds_removes(self) -> None:
         head = SnapshotManifest(
             images={
                 "renamed.png": _meta("hash_shared"),
@@ -60,7 +60,7 @@ class TestCategorizeImageDiff:
         assert result.added == {"brand_new.png"}
         assert result.removed == {"deleted.png"}
 
-    def test_multiple_independent_renames(self):
+    def test_multiple_independent_renames(self) -> None:
         head = SnapshotManifest(images={"new_a.png": _meta("hash_a"), "new_b.png": _meta("hash_b")})
         base = SnapshotManifest(images={"old_a.png": _meta("hash_a"), "old_b.png": _meta("hash_b")})
 

--- a/tests/sentry/preprod/test_artifact_search.py
+++ b/tests/sentry/preprod/test_artifact_search.py
@@ -37,7 +37,7 @@ class GetSequentialBaseArtifactTest(TestCase):
         )
         return artifact
 
-    def test_returns_most_recent_matching_artifact(self):
+    def test_returns_most_recent_matching_artifact(self) -> None:
         now = timezone.now()
         oldest = self._create_artifact_with_metrics(date_added=now - timedelta(hours=3))
         middle = self._create_artifact_with_metrics(date_added=now - timedelta(hours=2))
@@ -48,19 +48,19 @@ class GetSequentialBaseArtifactTest(TestCase):
         assert result.id == middle.id
         assert result.id != oldest.id
 
-    def test_returns_none_when_no_prior_artifact(self):
+    def test_returns_none_when_no_prior_artifact(self) -> None:
         head = self._create_artifact_with_metrics()
 
         result = get_sequential_base_artifact(head, "", self.organization)
         assert result is None
 
-    def test_excludes_self(self):
+    def test_excludes_self(self) -> None:
         head = self._create_artifact_with_metrics()
 
         result = get_sequential_base_artifact(head, "", self.organization)
         assert result is None
 
-    def test_requires_completed_size_metrics(self):
+    def test_requires_completed_size_metrics(self) -> None:
         self._create_artifact_with_metrics(
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
             date_added=timezone.now() - timedelta(hours=2),
@@ -72,7 +72,7 @@ class GetSequentialBaseArtifactTest(TestCase):
         result = get_sequential_base_artifact(head, "", self.organization)
         assert result is None
 
-    def test_matches_on_app_id(self):
+    def test_matches_on_app_id(self) -> None:
         self._create_artifact_with_metrics(
             app_id="com.other.app",
             date_added=timezone.now() - timedelta(hours=2),
@@ -85,7 +85,7 @@ class GetSequentialBaseArtifactTest(TestCase):
         result = get_sequential_base_artifact(head, "", self.organization)
         assert result is None
 
-    def test_matches_on_artifact_type(self):
+    def test_matches_on_artifact_type(self) -> None:
         self._create_artifact_with_metrics(
             artifact_type=PreprodArtifact.ArtifactType.AAB,
             date_added=timezone.now() - timedelta(hours=2),
@@ -98,7 +98,7 @@ class GetSequentialBaseArtifactTest(TestCase):
         result = get_sequential_base_artifact(head, "", self.organization)
         assert result is None
 
-    def test_matches_on_build_configuration(self):
+    def test_matches_on_build_configuration(self) -> None:
         config_release = self.create_preprod_build_configuration(
             project=self.project, name="release"
         )
@@ -116,7 +116,7 @@ class GetSequentialBaseArtifactTest(TestCase):
         result = get_sequential_base_artifact(head, "", self.organization)
         assert result is None
 
-    def test_applies_query_filter(self):
+    def test_applies_query_filter(self) -> None:
         now = timezone.now()
         # This one matches the query
         matching = self._create_artifact_with_metrics(
@@ -137,7 +137,7 @@ class GetSequentialBaseArtifactTest(TestCase):
         assert result is not None
         assert result.id == matching.id
 
-    def test_empty_query_matches_all(self):
+    def test_empty_query_matches_all(self) -> None:
         now = timezone.now()
         base = self._create_artifact_with_metrics(date_added=now - timedelta(hours=2))
         head = self._create_artifact_with_metrics(date_added=now - timedelta(hours=1))
@@ -146,7 +146,7 @@ class GetSequentialBaseArtifactTest(TestCase):
         assert result is not None
         assert result.id == base.id
 
-    def test_handles_null_build_configuration(self):
+    def test_handles_null_build_configuration(self) -> None:
         now = timezone.now()
         base = self._create_artifact_with_metrics(
             build_configuration=None,

--- a/tests/sentry/preprod/test_build_distribution_utils.py
+++ b/tests/sentry/preprod/test_build_distribution_utils.py
@@ -37,27 +37,27 @@ class IsInstallableArtifactTest(TestCase):
         )
         return PreprodArtifact.objects.select_related("mobile_app_info").get(id=artifact.id)
 
-    def test_xcarchive_with_valid_signature_is_installable(self):
+    def test_xcarchive_with_valid_signature_is_installable(self) -> None:
         artifact = self._create_artifact(extras={"is_code_signature_valid": True})
         assert is_installable_artifact(artifact) is True
 
-    def test_xcarchive_without_valid_signature_is_not_installable(self):
+    def test_xcarchive_without_valid_signature_is_not_installable(self) -> None:
         artifact = self._create_artifact(extras={"is_code_signature_valid": False})
         assert is_installable_artifact(artifact) is False
 
-    def test_xcarchive_with_app_store_codesigning_is_not_installable(self):
+    def test_xcarchive_with_app_store_codesigning_is_not_installable(self) -> None:
         artifact = self._create_artifact(
             extras={"is_code_signature_valid": True, "codesigning_type": "app-store"}
         )
         assert is_installable_artifact(artifact) is False
 
-    def test_xcarchive_without_installable_app_file_is_not_installable(self):
+    def test_xcarchive_without_installable_app_file_is_not_installable(self) -> None:
         artifact = self._create_artifact(
             installable_app_file_id=None, extras={"is_code_signature_valid": True}
         )
         assert is_installable_artifact(artifact) is False
 
-    def test_aab_is_installable(self):
+    def test_aab_is_installable(self) -> None:
         artifact = self._create_artifact(
             artifact_type=PreprodArtifact.ArtifactType.AAB,
             extras=None,

--- a/tests/sentry/preprod/test_build_distribution_webhooks.py
+++ b/tests/sentry/preprod/test_build_distribution_webhooks.py
@@ -79,7 +79,7 @@ class BuildWebhookPayloadTest(TestCase):
     # Completed (success) builds
     # ------------------------------------------------------------------
 
-    def test_completed_android_build(self):
+    def test_completed_android_build(self) -> None:
         """Completed Android build produces correct payload."""
         artifact = self._create_installable_artifact()
 
@@ -114,7 +114,7 @@ class BuildWebhookPayloadTest(TestCase):
 
         self._assert_no_transient_fields(payload)
 
-    def test_completed_apple_build(self):
+    def test_completed_apple_build(self) -> None:
         """Completed Apple build includes code-signing fields."""
         artifact = self._create_installable_artifact(
             artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
@@ -131,7 +131,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert "profileName" in payload
         assert "codesigningType" in payload
 
-    def test_completed_build_with_git_context(self):
+    def test_completed_build_with_git_context(self) -> None:
         """Completed build with commit comparison has gitInfo."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -156,7 +156,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload["gitInfo"]["headRepoName"] == "org/repo"
         assert payload["gitInfo"]["prNumber"] == 42
 
-    def test_completed_but_not_installable(self):
+    def test_completed_but_not_installable(self) -> None:
         """Completed build that is not installable (e.g. missing build number)."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -177,7 +177,7 @@ class BuildWebhookPayloadTest(TestCase):
     # Failed builds
     # ------------------------------------------------------------------
 
-    def test_failed_build(self):
+    def test_failed_build(self) -> None:
         """Failed build produces FAILED payload with error details."""
         artifact = self._create_failed_artifact(
             error_code=PreprodArtifact.InstallableAppErrorCode.PROCESSING_ERROR,
@@ -195,7 +195,7 @@ class BuildWebhookPayloadTest(TestCase):
 
         self._assert_no_transient_fields(payload)
 
-    def test_failed_no_quota(self):
+    def test_failed_no_quota(self) -> None:
         """NO_QUOTA error code is mapped correctly."""
         artifact = self._create_failed_artifact(
             error_code=PreprodArtifact.InstallableAppErrorCode.NO_QUOTA,
@@ -208,7 +208,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload["state"] == "FAILED"
         assert payload["errorCode"] == "NO_QUOTA"
 
-    def test_failed_skipped(self):
+    def test_failed_skipped(self) -> None:
         """SKIPPED error code is mapped correctly."""
         artifact = self._create_failed_artifact(
             error_code=PreprodArtifact.InstallableAppErrorCode.SKIPPED,
@@ -221,7 +221,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload["state"] == "FAILED"
         assert payload["errorCode"] == "SKIPPED"
 
-    def test_failed_unknown(self):
+    def test_failed_unknown(self) -> None:
         """UNKNOWN error code is mapped correctly."""
         artifact = self._create_failed_artifact(
             error_code=PreprodArtifact.InstallableAppErrorCode.UNKNOWN,
@@ -238,13 +238,13 @@ class BuildWebhookPayloadTest(TestCase):
     # Suppressed states
     # ------------------------------------------------------------------
 
-    def test_non_terminal_returns_none(self):
+    def test_non_terminal_returns_none(self) -> None:
         """Artifact with neither file nor error returns None."""
         artifact = self.create_preprod_artifact(project=self.project)
 
         assert build_webhook_payload(artifact) is None
 
-    def test_deleted_artifact_returns_none(self):
+    def test_deleted_artifact_returns_none(self) -> None:
         """Deleted artifact returns None."""
         artifact = self._create_installable_artifact()
         artifact_id = artifact.id
@@ -258,7 +258,7 @@ class BuildWebhookPayloadTest(TestCase):
     # Edge cases
     # ------------------------------------------------------------------
 
-    def test_build_id_is_string(self):
+    def test_build_id_is_string(self) -> None:
         """buildId should always be a string, not an integer."""
         artifact = self._create_installable_artifact()
 
@@ -267,7 +267,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload is not None
         assert isinstance(payload["buildId"], str)
 
-    def test_project_id_is_string(self):
+    def test_project_id_is_string(self) -> None:
         """projectId should always be a string, not an integer."""
         artifact = self._create_installable_artifact()
 
@@ -276,7 +276,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload is not None
         assert isinstance(payload["projectId"], str)
 
-    def test_no_mobile_app_info(self):
+    def test_no_mobile_app_info(self) -> None:
         """Artifact without mobile app info has null appInfo fields."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -292,7 +292,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload["appInfo"]["version"] is None
         assert payload["appInfo"]["buildNumber"] is None
 
-    def test_android_apk_artifact_type(self):
+    def test_android_apk_artifact_type(self) -> None:
         """Android APK artifact has correct appInfo.artifactType."""
         artifact = self._create_installable_artifact(
             artifact_type=PreprodArtifact.ArtifactType.APK,
@@ -304,7 +304,7 @@ class BuildWebhookPayloadTest(TestCase):
         assert payload["appInfo"]["artifactType"] == "APK"
         assert payload["platform"] == "ANDROID"
 
-    def test_both_file_and_error_treats_as_failed(self):
+    def test_both_file_and_error_treats_as_failed(self) -> None:
         """Artifact with both file and error is treated as FAILED."""
         artifact = self._create_installable_artifact()
         artifact.installable_app_error_code = (

--- a/tests/sentry/preprod/test_models.py
+++ b/tests/sentry/preprod/test_models.py
@@ -8,7 +8,7 @@ from sentry.testutils.silo import cell_silo_test
 class PreprodArtifactModelTestBase(TestCase):
     """Base test class with common setup for PreprodArtifact model tests."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.organization)
@@ -21,7 +21,7 @@ class PreprodArtifactModelTestBase(TestCase):
 class PreprodArtifactSiblingArtifactsTest(PreprodArtifactModelTestBase):
     """Tests for get_sibling_artifacts_for_commit method."""
 
-    def test_get_sibling_artifacts_for_commit_single_artifact(self):
+    def test_get_sibling_artifacts_for_commit_single_artifact(self) -> None:
         """Test getting artifacts when there's only one artifact for the commit."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -46,7 +46,7 @@ class PreprodArtifactSiblingArtifactsTest(PreprodArtifactModelTestBase):
         assert len(artifacts) == 1
         assert artifacts[0] == artifact
 
-    def test_get_sibling_artifacts_for_commit_multiple_artifacts_same_commit(self):
+    def test_get_sibling_artifacts_for_commit_multiple_artifacts_same_commit(self) -> None:
         """Test getting artifacts when multiple artifacts exist for the same commit (monorepo)."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -75,7 +75,7 @@ class PreprodArtifactSiblingArtifactsTest(PreprodArtifactModelTestBase):
         assert len(sibling_artifacts) == 3
         assert set(sibling_artifacts) == set(artifacts)
 
-    def test_get_sibling_artifacts_for_commit_different_commits_excluded(self):
+    def test_get_sibling_artifacts_for_commit_different_commits_excluded(self) -> None:
         """Test that artifacts from different commits are excluded."""
         commit_comparison_1 = self.create_commit_comparison(
             organization=self.organization,
@@ -121,7 +121,7 @@ class PreprodArtifactSiblingArtifactsTest(PreprodArtifactModelTestBase):
         assert len(artifacts_2) == 1
         assert artifacts_2[0] == artifact_2
 
-    def test_get_sibling_artifacts_for_commit_cross_org_security(self):
+    def test_get_sibling_artifacts_for_commit_cross_org_security(self) -> None:
         """Test that artifacts from different organizations are excluded for security."""
         # Create second organization
         other_org = self.create_organization(name="other_org")
@@ -176,7 +176,7 @@ class PreprodArtifactSiblingArtifactsTest(PreprodArtifactModelTestBase):
         assert len(artifacts_org2) == 1
         assert artifacts_org2[0] == artifact_org2
 
-    def test_get_sibling_artifacts_for_commit_no_commit_comparison(self):
+    def test_get_sibling_artifacts_for_commit_no_commit_comparison(self) -> None:
         """Test that method returns empty queryset when artifact has no commit_comparison."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -188,7 +188,7 @@ class PreprodArtifactSiblingArtifactsTest(PreprodArtifactModelTestBase):
         artifacts = list(artifact.get_sibling_artifacts_for_commit())
         assert len(artifacts) == 0
 
-    def test_get_sibling_artifacts_for_commit_different_build_configurations(self):
+    def test_get_sibling_artifacts_for_commit_different_build_configurations(self) -> None:
         """Test that artifacts with same app_id/artifact_type but different build configs are all returned."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -240,7 +240,7 @@ class PreprodArtifactSiblingArtifactsTest(PreprodArtifactModelTestBase):
 class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
     """Tests for base artifact related methods."""
 
-    def test_get_base_artifact_for_commit_single_artifact(self):
+    def test_get_base_artifact_for_commit_single_artifact(self) -> None:
         """Test getting base artifact when there's only one base artifact."""
         base_commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -283,7 +283,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         result = head_artifact.get_base_artifact_for_commit().first()
         assert result == base_artifact
 
-    def test_get_base_artifact_for_commit_multiple_artifacts_same_commit(self):
+    def test_get_base_artifact_for_commit_multiple_artifacts_same_commit(self) -> None:
         """Test getting base artifact when multiple artifacts exist for the same base commit (monorepo)."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -335,7 +335,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         assert result.app_id == head_artifact.app_id
         assert result.app_id == "com.example.android"
 
-    def test_get_base_artifact_for_commit_no_matching_app_id(self):
+    def test_get_base_artifact_for_commit_no_matching_app_id(self) -> None:
         """Test that method returns None when no base artifact has matching app_id."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -385,7 +385,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         result = head_artifact.get_base_artifact_for_commit().first()
         assert result is None
 
-    def test_get_base_artifact_for_commit_no_base_commit(self):
+    def test_get_base_artifact_for_commit_no_base_commit(self) -> None:
         """Test that method returns None when no base commit comparison exists."""
         # Create head commit comparison with a base_sha that doesn't exist
         head_commit_comparison = self.create_commit_comparison(
@@ -411,7 +411,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         artifacts = list(head_artifact.get_base_artifact_for_commit())
         assert len(artifacts) == 0
 
-    def test_get_base_artifact_for_commit_cross_org_security(self):
+    def test_get_base_artifact_for_commit_cross_org_security(self) -> None:
         """Test that base artifacts from different organizations are excluded for security."""
         # Create second organization
         other_org = self.create_organization(name="other_org")
@@ -480,7 +480,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         assert result == base_artifact_org1
         assert result != base_artifact_org2
 
-    def test_get_base_artifact_for_commit_no_commit_comparison(self):
+    def test_get_base_artifact_for_commit_no_commit_comparison(self) -> None:
         """Test that method returns None when artifact has no commit_comparison."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -492,7 +492,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         artifacts = list(artifact.get_base_artifact_for_commit())
         assert len(artifacts) == 0
 
-    def test_get_base_artifact_multiple_commit_comparisons_uses_oldest(self):
+    def test_get_base_artifact_multiple_commit_comparisons_uses_oldest(self) -> None:
         """Test that the oldest commit_comparison is used when more than one is found."""
         # Create multiple base commit comparisons with the same head_sha but different date_added
         # The older one (created first)
@@ -562,7 +562,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         result = head_artifact.get_base_artifact_for_commit().first()
         assert result == base_artifact_old
 
-    def test_get_head_artifacts_for_commit_single_artifact(self):
+    def test_get_head_artifacts_for_commit_single_artifact(self) -> None:
         """Test getting head artifacts when there's only one head artifact."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -609,7 +609,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         assert len(head_artifacts) == 1
         assert head_artifacts[0] == head_artifact
 
-    def test_get_head_artifacts_for_commit_multiple_artifacts_same_commit(self):
+    def test_get_head_artifacts_for_commit_multiple_artifacts_same_commit(self) -> None:
         """Test getting head artifacts when multiple head artifacts exist for the same base commit (monorepo)."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -670,7 +670,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         for artifact in result_artifacts:
             assert artifact.app_id == base_artifact.app_id
 
-    def test_get_head_artifacts_for_commit_no_matching_app_id(self):
+    def test_get_head_artifacts_for_commit_no_matching_app_id(self) -> None:
         """Test that method returns empty queryset when no head artifacts have matching app_id."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -716,7 +716,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         head_artifacts = list(base_artifact.get_head_artifacts_for_commit())
         assert len(head_artifacts) == 0
 
-    def test_get_head_artifacts_for_commit_no_head_commits(self):
+    def test_get_head_artifacts_for_commit_no_head_commits(self) -> None:
         """Test that method returns empty queryset when no head commit comparisons exist."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -742,7 +742,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         head_artifacts = list(base_artifact.get_head_artifacts_for_commit())
         assert len(head_artifacts) == 0
 
-    def test_get_head_artifacts_for_commit_cross_org_security(self):
+    def test_get_head_artifacts_for_commit_cross_org_security(self) -> None:
         """Test that head artifacts from different organizations are excluded for security."""
         # Create second organization
         other_org = self.create_organization(name="other_org")
@@ -838,7 +838,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         assert head_artifacts_org2[0] == head_artifact_org2
         assert head_artifact_org1 not in head_artifacts_org2
 
-    def test_get_head_artifacts_for_commit_no_commit_comparison(self):
+    def test_get_head_artifacts_for_commit_no_commit_comparison(self) -> None:
         """Test that method returns empty queryset when artifact has no commit_comparison."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -850,7 +850,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         head_artifacts = list(artifact.get_head_artifacts_for_commit())
         assert len(head_artifacts) == 0
 
-    def test_get_base_artifact_for_commit_with_artifact_type_filter(self):
+    def test_get_base_artifact_for_commit_with_artifact_type_filter(self) -> None:
         """Test getting base artifact with specific artifact type filter."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -922,7 +922,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         ).first()
         assert result is None
 
-    def test_get_base_artifact_for_commit_with_default_artifact_type(self):
+    def test_get_base_artifact_for_commit_with_default_artifact_type(self) -> None:
         """Test getting base artifact using default artifact type from the artifact itself."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -971,7 +971,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         assert result == base_artifact
         assert result.artifact_type == PreprodArtifact.ArtifactType.AAB
 
-    def test_get_head_artifacts_for_commit_with_artifact_type_filter(self):
+    def test_get_head_artifacts_for_commit_with_artifact_type_filter(self) -> None:
         """Test getting head artifacts with specific artifact type filter."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -1064,7 +1064,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         assert result_artifacts[0] == head_artifact_xcarchive
         assert result_artifacts[0].artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE
 
-    def test_get_head_artifacts_for_commit_with_default_artifact_type(self):
+    def test_get_head_artifacts_for_commit_with_default_artifact_type(self) -> None:
         """Test getting head artifacts using default artifact type from the artifact itself."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -1114,7 +1114,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         assert result_artifacts[0] == head_artifact
         assert result_artifacts[0].artifact_type == PreprodArtifact.ArtifactType.AAB
 
-    def test_get_base_artifact_for_commit_artifact_type_no_matches(self):
+    def test_get_base_artifact_for_commit_artifact_type_no_matches(self) -> None:
         """Test getting base artifact when no artifacts match the specified artifact type."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -1164,7 +1164,7 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
         ).first()
         assert result is None
 
-    def test_get_head_artifacts_for_commit_artifact_type_no_matches(self):
+    def test_get_head_artifacts_for_commit_artifact_type_no_matches(self) -> None:
         """Test getting head artifacts when no artifacts match the specified artifact type."""
         # Create base commit comparison
         base_commit_comparison = self.create_commit_comparison(
@@ -1221,12 +1221,12 @@ class PreprodArtifactBaseArtifactTest(PreprodArtifactModelTestBase):
 class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
     """Tests for get_base_artifacts_for_commit classmethod."""
 
-    def test_get_base_artifacts_for_commit_empty_list(self):
+    def test_get_base_artifacts_for_commit_empty_list(self) -> None:
         """Test that empty input returns empty dict."""
         result = PreprodArtifact.get_base_artifacts_for_commit([])
         assert result == {}
 
-    def test_get_base_artifacts_for_commit_no_commit_comparison(self):
+    def test_get_base_artifacts_for_commit_no_commit_comparison(self) -> None:
         """Test that artifacts without commit_comparison return empty dict."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -1238,7 +1238,7 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
         result = PreprodArtifact.get_base_artifacts_for_commit([artifact])
         assert result == {}
 
-    def test_get_base_artifacts_for_commit_no_base_sha(self):
+    def test_get_base_artifacts_for_commit_no_base_sha(self) -> None:
         """Test that artifacts with commit_comparison but no base_sha return empty dict."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -1258,7 +1258,7 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
         result = PreprodArtifact.get_base_artifacts_for_commit([artifact])
         assert result == {}
 
-    def test_get_base_artifacts_for_commit_single_artifact(self):
+    def test_get_base_artifacts_for_commit_single_artifact(self) -> None:
         """Test batch lookup with a single artifact."""
         base_commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -1297,7 +1297,7 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
         assert len(result) == 1
         assert result[head_artifact.id] == base_artifact
 
-    def test_get_base_artifacts_for_commit_multiple_artifacts(self):
+    def test_get_base_artifacts_for_commit_multiple_artifacts(self) -> None:
         """Test batch lookup with multiple artifacts (monorepo scenario)."""
         base_commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -1342,7 +1342,7 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
         for head_artifact in head_artifacts:
             assert result[head_artifact.id] == base_artifacts[head_artifact.id]
 
-    def test_get_base_artifacts_for_commit_no_matching_base(self):
+    def test_get_base_artifacts_for_commit_no_matching_base(self) -> None:
         """Test that artifacts without matching base artifacts are not in result."""
         base_commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -1379,7 +1379,7 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
 
         assert len(result) == 0
 
-    def test_get_base_artifacts_for_commit_different_commit_comparison_raises(self):
+    def test_get_base_artifacts_for_commit_different_commit_comparison_raises(self) -> None:
         """Test that artifacts with different commit_comparisons raise ValueError."""
         commit_comparison_1 = self.create_commit_comparison(
             organization=self.organization,
@@ -1416,7 +1416,7 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
         with pytest.raises(ValueError, match="All artifacts must share the same commit_comparison"):
             PreprodArtifact.get_base_artifacts_for_commit([artifact_1, artifact_2])
 
-    def test_get_base_artifacts_for_commit_returns_newest_base(self):
+    def test_get_base_artifacts_for_commit_returns_newest_base(self) -> None:
         """Test that newest base artifact is returned when duplicates exist."""
         base_commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -1465,7 +1465,7 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
         assert len(result) == 1
         assert result[head_artifact.id] == base_artifact_new
 
-    def test_get_base_artifacts_for_commit_cross_org_security(self):
+    def test_get_base_artifacts_for_commit_cross_org_security(self) -> None:
         """Test that base artifacts from other organizations are excluded."""
         other_org = self.create_organization(name="other_org")
         other_project = self.create_project(organization=other_org, name="other_project")
@@ -1507,7 +1507,7 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
         result = PreprodArtifact.get_base_artifacts_for_commit([head_artifact])
         assert len(result) == 0
 
-    def test_get_base_artifacts_for_commit_different_repo_excluded(self):
+    def test_get_base_artifacts_for_commit_different_repo_excluded(self) -> None:
         """Test that base artifacts from different repos are excluded."""
         # Create base commit comparison in different repo
         base_commit_comparison = self.create_commit_comparison(
@@ -1545,7 +1545,7 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
         result = PreprodArtifact.get_base_artifacts_for_commit([head_artifact])
         assert len(result) == 0
 
-    def test_get_base_artifacts_for_commit_matches_by_build_configuration(self):
+    def test_get_base_artifacts_for_commit_matches_by_build_configuration(self) -> None:
         """Test that matching includes build_configuration_id."""
         base_commit_comparison = self.create_commit_comparison(
             organization=self.organization,

--- a/tests/sentry/preprod/test_models_size_metrics.py
+++ b/tests/sentry/preprod/test_models_size_metrics.py
@@ -9,7 +9,7 @@ from sentry.testutils.silo import cell_silo_test
 class PreprodArtifactSizeMetricsTest(TestCase):
     """Tests for PreprodArtifact size metrics related methods."""
 
-    def test_get_size_metrics_filtering(self):
+    def test_get_size_metrics_filtering(self) -> None:
         """Test the get_size_metrics method with various filters."""
         artifact = self.create_preprod_artifact(app_id="com.example.filtering")
 
@@ -83,7 +83,7 @@ class PreprodArtifactSizeMetricsTest(TestCase):
         no_matches = artifact.get_size_metrics(identifier="nonexistent")
         assert no_matches.count() == 0
 
-    def test_get_size_metrics_for_artifacts_bulk(self):
+    def test_get_size_metrics_for_artifacts_bulk(self) -> None:
         """Test the bulk get_size_metrics_for_artifacts classmethod."""
         artifact1 = self.create_preprod_artifact(app_id="com.example.bulk1")
         artifact2 = self.create_preprod_artifact(app_id="com.example.bulk2")
@@ -157,7 +157,7 @@ class PreprodArtifactSizeMetricsTest(TestCase):
         empty_results = PreprodArtifact.get_size_metrics_for_artifacts([])
         assert empty_results == {}
 
-    def test_get_size_metrics_ignores_other_artifacts(self):
+    def test_get_size_metrics_ignores_other_artifacts(self) -> None:
         """Test that get_size_metrics only returns metrics for the specific artifact."""
         artifact1 = self.create_preprod_artifact(app_id="com.example.app1")
         artifact2 = self.create_preprod_artifact(app_id="com.example.app2")

--- a/tests/sentry/preprod/test_quotas.py
+++ b/tests/sentry/preprod/test_quotas.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import TestCase
 
 
 class ShouldRunSizeTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.artifact = self.create_preprod_artifact(project=self.project)
 
@@ -46,7 +46,7 @@ class ShouldRunSizeTest(TestCase):
 
 
 class ShouldRunDistributionTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.artifact = self.create_preprod_artifact(project=self.project)
 

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -1051,7 +1051,7 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
 
 
 class DetectExpiredPreprodArtifactsTest(TestCase):
-    def test_detect_expired_preprod_artifacts_no_expired(self):
+    def test_detect_expired_preprod_artifacts_no_expired(self) -> None:
         """Test that no artifacts are marked as expired when none are expired"""
         recent_artifact = self.create_preprod_artifact(
             project=self.project,
@@ -1092,7 +1092,7 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
         assert recent_size_metric.state == PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
         assert recent_size_comparison.state == PreprodArtifactSizeComparison.State.PROCESSING
 
-    def test_detect_expired_preprod_artifacts_with_expired(self):
+    def test_detect_expired_preprod_artifacts_with_expired(self) -> None:
         """Test that expired artifacts are marked as failed"""
         current_time = timezone.now()
         old_time = current_time - timedelta(minutes=35)  # 35 minutes ago (expired)
@@ -1183,7 +1183,7 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
             and "30 minutes" in expired_size_comparison.error_message
         )
 
-    def test_detect_expired_preprod_artifacts_captures_sentry_message(self):
+    def test_detect_expired_preprod_artifacts_captures_sentry_message(self) -> None:
         """Test that Sentry messages are captured for each expired artifact"""
         current_time = timezone.now()
         old_time = current_time - timedelta(minutes=35)
@@ -1219,7 +1219,7 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
                 assert call[1]["level"] == "error"
                 assert "artifact_id" in call[1]["extras"]
 
-    def test_detect_expired_preprod_artifacts_mixed_states(self):
+    def test_detect_expired_preprod_artifacts_mixed_states(self) -> None:
         """Test that only artifacts in the right states are considered for expiration"""
         current_time = timezone.now()
         old_time = current_time - timedelta(minutes=35)  # 35 minutes ago (expired)
@@ -1285,7 +1285,7 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
         assert processing_size_metric.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
         assert completed_size_metric.state == PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
 
-    def test_detect_expired_preprod_artifacts_boundary_time(self):
+    def test_detect_expired_preprod_artifacts_boundary_time(self) -> None:
         """Test the 30-minute boundary for expiration"""
         current_time = timezone.now()
         exactly_30_min_ago = current_time - timedelta(minutes=30)
@@ -1329,7 +1329,7 @@ class DetectExpiredPreprodArtifactsTest(TestCase):
         )  # Still processing
         assert just_over_30_artifact.state == PreprodArtifact.ArtifactState.FAILED
 
-    def test_detect_expired_preprod_artifacts_skips_snapshot_artifacts(self):
+    def test_detect_expired_preprod_artifacts_skips_snapshot_artifacts(self) -> None:
         from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 
         current_time = timezone.now()

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -22,7 +22,7 @@ _sentinel = object()
 
 @cell_silo_test
 class CreatePreprodPrCommentTaskTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.organization)
@@ -529,7 +529,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         assert build_dist["success"] is True
         assert build_dist["comment_id"] == "55555"
 
-    def test_skips_xcarchive_without_valid_code_signature(self):
+    def test_skips_xcarchive_without_valid_code_signature(self) -> None:
         artifact = self._create_artifact(extras={"is_code_signature_valid": False})
 
         with self.feature("organizations:preprod-build-distribution-pr-comments"):

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -14,7 +14,7 @@ from sentry.testutils.silo import cell_silo_test
 
 @cell_silo_test
 class FormatPrCommentTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.organization)
@@ -53,7 +53,7 @@ class FormatPrCommentTest(TestCase):
             "mobile_app_info", "build_configuration", "project", "project__organization"
         ).get(id=artifact.id)
 
-    def test_single_ios_artifact(self):
+    def test_single_ios_artifact(self) -> None:
         artifact = self._create_artifact()
 
         result = format_pr_comment([artifact])
@@ -68,7 +68,7 @@ class FormatPrCommentTest(TestCase):
         # Single platform — no subheader
         assert "### iOS" not in result
 
-    def test_single_android_artifact(self):
+    def test_single_android_artifact(self) -> None:
         artifact = self._create_artifact(
             artifact_type=PreprodArtifact.ArtifactType.AAB,
             app_name="AndroidApp",
@@ -79,7 +79,7 @@ class FormatPrCommentTest(TestCase):
         assert "AndroidApp" in result
         assert "### Android" not in result
 
-    def test_multiple_platforms_shows_subheaders(self):
+    def test_multiple_platforms_shows_subheaders(self) -> None:
         ios_artifact = self._create_artifact(app_name="iOSApp")
         android_artifact = self._create_artifact(
             artifact_type=PreprodArtifact.ArtifactType.APK,
@@ -94,6 +94,6 @@ class FormatPrCommentTest(TestCase):
         assert "iOSApp" in result
         assert "AndroidApp" in result
 
-    def test_empty_list_raises(self):
+    def test_empty_list_raises(self) -> None:
         with pytest.raises(ValueError, match="No installable artifacts"):
             format_pr_comment([])

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -22,7 +22,7 @@ from sentry.testutils.silo import cell_silo_test
 
 @cell_silo_test
 class StatusCheckFiltersTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.organization)
@@ -51,7 +51,7 @@ class StatusCheckFiltersTest(TestCase):
             name="Release",
         )
 
-    def test_filter_context_includes_build_configuration(self):
+    def test_filter_context_includes_build_configuration(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -68,7 +68,7 @@ class StatusCheckFiltersTest(TestCase):
         assert context["app_id"] == "com.example.app"
         assert context["build_configuration_name"] == "Debug"
 
-    def test_filter_context_without_build_configuration(self):
+    def test_filter_context_without_build_configuration(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -84,7 +84,7 @@ class StatusCheckFiltersTest(TestCase):
         assert context["app_id"] == "com.example.android"
         assert "build_configuration_name" not in context
 
-    def test_rule_matches_build_configuration_single_value(self):
+    def test_rule_matches_build_configuration_single_value(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -115,7 +115,7 @@ class StatusCheckFiltersTest(TestCase):
         assert _rule_matches_artifact(rule_debug, context) is True
         assert _rule_matches_artifact(rule_release, context) is False
 
-    def test_rule_matches_build_configuration_multiple_values(self):
+    def test_rule_matches_build_configuration_multiple_values(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -137,7 +137,7 @@ class StatusCheckFiltersTest(TestCase):
 
         assert _rule_matches_artifact(rule, context) is True
 
-    def test_rule_matches_build_configuration_negated(self):
+    def test_rule_matches_build_configuration_negated(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -168,7 +168,7 @@ class StatusCheckFiltersTest(TestCase):
         assert _rule_matches_artifact(rule_not_release, context) is True
         assert _rule_matches_artifact(rule_not_debug, context) is False
 
-    def test_rule_matches_combined_filters(self):
+    def test_rule_matches_combined_filters(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -208,7 +208,7 @@ class StatusCheckFiltersTest(TestCase):
         assert _rule_matches_artifact(rule_android_release, context) is False
         assert _rule_matches_artifact(rule_ios_debug, context) is False
 
-    def test_status_check_fails_when_rule_matches_and_exceeds_threshold(self):
+    def test_status_check_fails_when_rule_matches_and_exceeds_threshold(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -247,7 +247,7 @@ class StatusCheckFiltersTest(TestCase):
         assert len(triggered_rules) == 1
         assert triggered_rules[0].rule == rule
 
-    def test_status_check_succeeds_when_rule_matches_but_under_threshold(self):
+    def test_status_check_succeeds_when_rule_matches_but_under_threshold(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -285,7 +285,7 @@ class StatusCheckFiltersTest(TestCase):
         assert status == StatusCheckStatus.SUCCESS
         assert triggered_rules == []
 
-    def test_status_check_succeeds_when_rule_does_not_match(self):
+    def test_status_check_succeeds_when_rule_does_not_match(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -323,7 +323,7 @@ class StatusCheckFiltersTest(TestCase):
         assert status == StatusCheckStatus.SUCCESS
         assert triggered_rules == []
 
-    def test_parse_rules_from_project_options(self):
+    def test_parse_rules_from_project_options(self) -> None:
         self.project.update_option(
             "sentry:preprod_size_status_checks_enabled",
             True,
@@ -345,7 +345,7 @@ class StatusCheckFiltersTest(TestCase):
         assert rules[0].filter_query == "build_configuration_name:Debug"
         assert rules[0].artifact_type == "watch_artifact"
 
-    def test_parse_rules_defaults_missing_artifact_type_to_main(self):
+    def test_parse_rules_defaults_missing_artifact_type_to_main(self) -> None:
         self.project.update_option(
             "sentry:preprod_size_status_checks_rules",
             '[{"id": "rule1", "metric": "install_size", "measurement": "absolute", "value": 100}]',
@@ -356,7 +356,7 @@ class StatusCheckFiltersTest(TestCase):
         assert len(rules) == 1
         assert rules[0].artifact_type == "main_artifact"
 
-    def test_parse_rules_with_app_clip_artifact_type(self):
+    def test_parse_rules_with_app_clip_artifact_type(self) -> None:
         self.project.update_option(
             "sentry:preprod_size_status_checks_rules",
             '[{"id": "rule1", "metric": "install_size", "measurement": "absolute", '
@@ -368,7 +368,7 @@ class StatusCheckFiltersTest(TestCase):
         assert len(rules) == 1
         assert rules[0].artifact_type == RuleArtifactType.APP_CLIP_ARTIFACT
 
-    def test_evaluate_absolute_diff_threshold_exceeds(self):
+    def test_evaluate_absolute_diff_threshold_exceeds(self) -> None:
         head_artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -416,7 +416,7 @@ class StatusCheckFiltersTest(TestCase):
 
         assert _evaluate_rule_threshold(rule, head_metrics, base_metrics) is True
 
-    def test_evaluate_absolute_diff_threshold_under(self):
+    def test_evaluate_absolute_diff_threshold_under(self) -> None:
         head_artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -464,7 +464,7 @@ class StatusCheckFiltersTest(TestCase):
 
         assert _evaluate_rule_threshold(rule, head_metrics, base_metrics) is False
 
-    def test_evaluate_relative_diff_threshold_exceeds(self):
+    def test_evaluate_relative_diff_threshold_exceeds(self) -> None:
         head_artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -512,7 +512,7 @@ class StatusCheckFiltersTest(TestCase):
 
         assert _evaluate_rule_threshold(rule, head_metrics, base_metrics) is True
 
-    def test_evaluate_relative_diff_threshold_under(self):
+    def test_evaluate_relative_diff_threshold_under(self) -> None:
         head_artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -560,7 +560,7 @@ class StatusCheckFiltersTest(TestCase):
 
         assert _evaluate_rule_threshold(rule, head_metrics, base_metrics) is False
 
-    def test_evaluate_rule_with_no_base_metrics_returns_false(self):
+    def test_evaluate_rule_with_no_base_metrics_returns_false(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -594,7 +594,7 @@ class StatusCheckFiltersTest(TestCase):
         assert _evaluate_rule_threshold(rule_absolute_diff, size_metrics, None) is False
         assert _evaluate_rule_threshold(rule_relative_diff, size_metrics, None) is False
 
-    def test_fetch_base_size_metrics_with_matching_build_config(self):
+    def test_fetch_base_size_metrics_with_matching_build_config(self) -> None:
         base_commit_comparison = CommitComparison.objects.create(
             organization_id=self.organization.id,
             head_sha="b" * 40,
@@ -648,7 +648,7 @@ class StatusCheckFiltersTest(TestCase):
         assert len(metrics_list) == 1
         assert metrics_list[0].id == base_metrics.id
 
-    def test_fetch_base_size_metrics_with_different_build_config(self):
+    def test_fetch_base_size_metrics_with_different_build_config(self) -> None:
         base_commit_comparison = CommitComparison.objects.create(
             organization_id=self.organization.id,
             head_sha="b" * 40,
@@ -696,7 +696,7 @@ class StatusCheckFiltersTest(TestCase):
 
         assert base_size_metrics_map == {}
 
-    def test_status_check_with_absolute_diff_rule(self):
+    def test_status_check_with_absolute_diff_rule(self) -> None:
         base_commit_comparison = CommitComparison.objects.create(
             organization_id=self.organization.id,
             head_sha="b" * 40,
@@ -774,7 +774,7 @@ class StatusCheckFiltersTest(TestCase):
         assert len(triggered_rules) == 1
         assert triggered_rules[0].rule == rule
 
-    def test_rules_only_evaluate_main_artifact_not_watch_app(self):
+    def test_rules_only_evaluate_main_artifact_not_watch_app(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -815,7 +815,7 @@ class StatusCheckFiltersTest(TestCase):
         assert status == StatusCheckStatus.SUCCESS
         assert triggered_rules == []
 
-    def test_rules_evaluate_watch_artifact_when_explicitly_selected(self):
+    def test_rules_evaluate_watch_artifact_when_explicitly_selected(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -861,7 +861,7 @@ class StatusCheckFiltersTest(TestCase):
             == PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT
         )
 
-    def test_rules_evaluate_app_clip_artifact_when_explicitly_selected(self):
+    def test_rules_evaluate_app_clip_artifact_when_explicitly_selected(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -907,7 +907,7 @@ class StatusCheckFiltersTest(TestCase):
             == PreprodArtifactSizeMetrics.MetricsArtifactType.APP_CLIP_ARTIFACT
         )
 
-    def test_rules_evaluate_all_app_clips_with_all_artifacts_rule(self):
+    def test_rules_evaluate_all_app_clips_with_all_artifacts_rule(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -966,7 +966,7 @@ class StatusCheckFiltersTest(TestCase):
             "com.example.app.clip.b",
         }
 
-    def test_rules_with_missing_targeted_artifact_type_do_not_fail(self):
+    def test_rules_with_missing_targeted_artifact_type_do_not_fail(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -1000,7 +1000,7 @@ class StatusCheckFiltersTest(TestCase):
         assert status == StatusCheckStatus.SUCCESS
         assert triggered_rules == []
 
-    def test_rules_evaluate_all_artifacts_when_all_selected(self):
+    def test_rules_evaluate_all_artifacts_when_all_selected(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -1046,7 +1046,7 @@ class StatusCheckFiltersTest(TestCase):
             == PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT
         )
 
-    def test_rules_evaluate_dynamic_feature_by_identifier(self):
+    def test_rules_evaluate_dynamic_feature_by_identifier(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -1095,7 +1095,7 @@ class StatusCheckFiltersTest(TestCase):
         )
         assert triggered_rules[0].identifier == "feature.b"
 
-    def test_filters_on_missing_fields_do_not_match(self):
+    def test_filters_on_missing_fields_do_not_match(self) -> None:
         artifact_no_build_config = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -1133,7 +1133,7 @@ class StatusCheckFiltersTest(TestCase):
         assert _rule_matches_artifact(negated_rule, context) is False
         assert _rule_matches_artifact(negated_in_rule, context) is False
 
-    def test_negated_filters_still_work_when_field_present(self):
+    def test_negated_filters_still_work_when_field_present(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -1163,7 +1163,7 @@ class StatusCheckFiltersTest(TestCase):
         assert _rule_matches_artifact(rule_not_release, context) is True
         assert _rule_matches_artifact(rule_not_debug, context) is False
 
-    def test_combined_filters_fail_when_any_field_missing(self):
+    def test_combined_filters_fail_when_any_field_missing(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
@@ -24,7 +24,7 @@ from sentry.utils import json
 
 @cell_silo_test
 class CreatePreprodStatusCheckTaskTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.organization)
@@ -115,7 +115,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
 
         return mock_client, mock_provider, patcher_client, patcher_provider
 
-    def test_create_preprod_status_check_task_nonexistent_artifact(self):
+    def test_create_preprod_status_check_task_nonexistent_artifact(self) -> None:
         """Test task handles nonexistent PreprodArtifact gracefully and makes no API calls."""
         _, mock_provider, client_patch, provider_patch = self._create_no_api_calls_setup()
 
@@ -126,7 +126,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             # Verify no API calls were made since artifact doesn't exist
             mock_provider.create_status_check.assert_not_called()
 
-    def test_create_preprod_status_check_task_no_commit_comparison(self):
+    def test_create_preprod_status_check_task_no_commit_comparison(self) -> None:
         """Test task returns early when PreprodArtifact has no CommitComparison and makes no API calls."""
         preprod_artifact = self._create_preprod_artifact(with_commit_comparison=False)
         _, mock_provider, client_patch, provider_patch = self._create_no_api_calls_setup()
@@ -138,7 +138,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             # Verify no API calls were made since there's no commit comparison
             mock_provider.create_status_check.assert_not_called()
 
-    def test_create_preprod_status_check_task_missing_git_info(self):
+    def test_create_preprod_status_check_task_missing_git_info(self) -> None:
         """Test task handles missing git info in CommitComparison and makes no API calls."""
         preprod_artifact = PreprodArtifact.objects.create(
             project=self.project,
@@ -168,7 +168,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             # Verify no API calls were made due to missing git info
             mock_provider.create_status_check.assert_not_called()
 
-    def test_create_preprod_status_check_task_missing_head_repo_name(self):
+    def test_create_preprod_status_check_task_missing_head_repo_name(self) -> None:
         """Test task handles missing head_repo_name in CommitComparison and makes no API calls."""
         preprod_artifact = PreprodArtifact.objects.create(
             project=self.project,
@@ -198,7 +198,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             # Verify no API calls were made due to missing head_repo_name
             mock_provider.create_status_check.assert_not_called()
 
-    def test_create_preprod_status_check_task_no_repository_integration(self):
+    def test_create_preprod_status_check_task_no_repository_integration(self) -> None:
         """Test task handles missing repository integration gracefully and makes no API calls."""
         preprod_artifact = self._create_preprod_artifact()
 
@@ -211,7 +211,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             # Verify no API calls were made due to missing repository integration
             mock_provider.create_status_check.assert_not_called()
 
-    def test_create_preprod_status_check_task_repository_no_integration_id(self):
+    def test_create_preprod_status_check_task_repository_no_integration_id(self) -> None:
         """Test task handles repository with no integration_id and makes no API calls."""
         preprod_artifact = self._create_preprod_artifact()
 
@@ -232,7 +232,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             # Verify no API calls were made due to missing integration_id
             mock_provider.create_status_check.assert_not_called()
 
-    def test_create_preprod_status_check_task_unsupported_provider(self):
+    def test_create_preprod_status_check_task_unsupported_provider(self) -> None:
         """Test task handles unsupported VCS provider gracefully and makes no API calls."""
         preprod_artifact = self._create_preprod_artifact()
         # Change provider to unsupported one (GitLab is not supported)
@@ -248,7 +248,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             # Verify no API calls were made due to unsupported provider
             mock_provider.create_status_check.assert_not_called()
 
-    def test_create_preprod_status_check_task_all_artifact_states(self):
+    def test_create_preprod_status_check_task_all_artifact_states(self) -> None:
         """Test task handles all valid artifact states and creates correct status checks."""
         test_cases = [
             (PreprodArtifact.ArtifactState.UPLOADING, StatusCheckStatus.IN_PROGRESS, None),
@@ -306,7 +306,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
                 assert call_kwargs["summary"]  # Just check it exists
                 assert call_kwargs["external_id"] == str(preprod_artifact.id)
 
-    def test_create_preprod_status_check_task_api_failure_handling(self):
+    def test_create_preprod_status_check_task_api_failure_handling(self) -> None:
         """Test task handles status check API failures gracefully."""
         preprod_artifact = self._create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED
@@ -336,7 +336,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         # Verify API was called but task completed without exception
         mock_provider.create_status_check.assert_called_once()
 
-    def test_create_preprod_status_check_task_multiple_artifacts_same_commit(self):
+    def test_create_preprod_status_check_task_multiple_artifacts_same_commit(self) -> None:
         """Test task handles multiple artifacts for the same commit (monorepo scenario)."""
         # Create base commit comparison (represents the previous commit)
         base_commit_comparison = CommitComparison.objects.create(
@@ -426,7 +426,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert "com.example.app1" in summary
         assert "com.example.app2" in summary
 
-    def test_create_preprod_status_check_task_mixed_states_monorepo(self):
+    def test_create_preprod_status_check_task_mixed_states_monorepo(self) -> None:
         """Test task handles mixed artifact states in monorepo scenario."""
         from sentry.preprod.models import PreprodArtifactSizeMetrics
 
@@ -499,7 +499,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert "Upload timeout" in summary
 
     @responses.activate
-    def test_create_preprod_status_check_task_github_permission_error(self):
+    def test_create_preprod_status_check_task_github_permission_error(self) -> None:
         """Test task handles GitHub permission errors without retrying."""
         preprod_artifact = self._create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED
@@ -554,7 +554,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         )
 
     @responses.activate
-    def test_create_preprod_status_check_task_github_non_permission_403(self):
+    def test_create_preprod_status_check_task_github_non_permission_403(self) -> None:
         """Test task re-raises non-permission 403 errors (allows retry for transient issues)."""
         preprod_artifact = self._create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED
@@ -610,7 +610,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         )
 
     @responses.activate
-    def test_create_preprod_status_check_task_github_400_error(self):
+    def test_create_preprod_status_check_task_github_400_error(self) -> None:
         """Test task converts 400 errors to IntegrationConfigurationError (no retry)."""
         preprod_artifact = self._create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED
@@ -661,7 +661,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert len(responses.calls) == 1
 
     @responses.activate
-    def test_create_preprod_status_check_task_github_429_error(self):
+    def test_create_preprod_status_check_task_github_429_error(self) -> None:
         """Test task allows 429 rate limit errors to retry"""
         preprod_artifact = self._create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED
@@ -714,7 +714,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert len(responses.calls) == 1
 
     @responses.activate
-    def test_create_preprod_status_check_task_github_403_rate_limit_error(self):
+    def test_create_preprod_status_check_task_github_403_rate_limit_error(self) -> None:
         """Test task converts 403 rate limit errors to ApiRateLimitedError (allows retry).
 
         GitHub sometimes returns 403 instead of 429 for rate limiting. This test ensures
@@ -769,7 +769,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert len(responses.calls) == 1
 
     @responses.activate
-    def test_create_preprod_status_check_task_truncates_long_summary(self):
+    def test_create_preprod_status_check_task_truncates_long_summary(self) -> None:
         """Test task truncates summary when it exceeds GitHub's byte limit."""
         commit_comparison = CommitComparison.objects.create(
             organization_id=self.organization.id,
@@ -832,7 +832,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert summary.endswith("..."), "Truncated summary should end with '...'"
 
     @responses.activate
-    def test_create_preprod_status_check_task_github_enterprise(self):
+    def test_create_preprod_status_check_task_github_enterprise(self) -> None:
         """Test that status checks work with GitHub Enterprise integration."""
         commit_comparison = self.create_commit_comparison(
             organization=self.organization,
@@ -908,7 +908,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         request_body = json.loads(responses.calls[0].request.body)
         assert request_body["head_sha"] == commit_comparison.head_sha
 
-    def test_sibling_deduplication_after_reprocessing(self):
+    def test_sibling_deduplication_after_reprocessing(self) -> None:
         """Test that get_sibling_artifacts_for_commit() deduplicates by (app_id, artifact_type, build_configuration_id).
 
         When artifacts are reprocessed (e.g., CI retry), new artifacts are created
@@ -1043,7 +1043,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert ios_old.id in sibling_ids_from_ios_old
         assert android_old.id in sibling_ids_from_ios_old
 
-    def test_sibling_deduplication_with_same_app_id_different_platforms(self):
+    def test_sibling_deduplication_with_same_app_id_different_platforms(self) -> None:
         """Test that iOS and Android builds with the same app_id are not deduplicated.
 
         Users can upload both Android and iOS builds with the same app_id (e.g., "com.example.app").
@@ -1166,7 +1166,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             "Old iOS artifact should be deduplicated (not the triggering artifact)"
         )
 
-    def test_posted_status_check_success(self):
+    def test_posted_status_check_success(self) -> None:
         """Test that successful status check posts are recorded in artifact extras."""
         preprod_artifact = self._create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED
@@ -1198,7 +1198,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert preprod_artifact.extras["posted_status_checks"]["size"]["success"] is True
         assert preprod_artifact.extras["posted_status_checks"]["size"]["check_id"] == "check_12345"
 
-    def test_posted_status_check_failure_null_check_id(self):
+    def test_posted_status_check_failure_null_check_id(self) -> None:
         """Test that failed status check posts (null check_id) are recorded in artifact extras."""
         preprod_artifact = self._create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED
@@ -1234,7 +1234,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         )
 
     @responses.activate
-    def test_posted_status_check_failure_integration_error(self):
+    def test_posted_status_check_failure_integration_error(self) -> None:
         """Test that integration errors during status check creation are recorded in artifact extras."""
         preprod_artifact = self._create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED
@@ -1290,7 +1290,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             == StatusCheckErrorType.INTEGRATION_ERROR.value
         )
 
-    def test_posted_status_check_preserves_existing_extras(self):
+    def test_posted_status_check_preserves_existing_extras(self) -> None:
         """Test that recording status check result preserves other fields in extras."""
         preprod_artifact = self._create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED
@@ -1328,7 +1328,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert preprod_artifact.extras["posted_status_checks"]["size"]["success"] is True
         assert preprod_artifact.extras["posted_status_checks"]["size"]["check_id"] == "check_67890"
 
-    def test_with_rules_configured_preserves_actual_status(self):
+    def test_with_rules_configured_preserves_actual_status(self) -> None:
         """Test that actual status is preserved when rules are configured.
 
         When users configure rules, they want to see the real status (IN_PROGRESS, FAILURE, SUCCESS)
@@ -1379,7 +1379,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
                 call_kwargs = mock_provider.create_status_check.call_args.kwargs
                 assert call_kwargs["status"] == expected_status
 
-    def test_skipped_artifacts_not_included_in_status_check(self):
+    def test_skipped_artifacts_not_included_in_status_check(self) -> None:
         """SKIPPED artifacts are filtered out from the status check."""
         commit_comparison = CommitComparison.objects.create(
             organization_id=self.organization.id,
@@ -1432,7 +1432,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             assert "com.valid" in kwargs["summary"]
             assert "com.skipped" not in kwargs["summary"]
 
-    def test_all_skipped_artifacts_no_status_check(self):
+    def test_all_skipped_artifacts_no_status_check(self) -> None:
         """No status check created when all artifacts are SKIPPED."""
         artifact = self._create_preprod_artifact(state=PreprodArtifact.ArtifactState.PROCESSED)
         PreprodArtifactSizeMetrics.objects.create(
@@ -1451,7 +1451,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
                 create_preprod_status_check_task(artifact.id)
             mock_provider.create_status_check.assert_not_called()
 
-    def test_no_quota_shows_neutral_status(self):
+    def test_no_quota_shows_neutral_status(self) -> None:
         """NO_QUOTA artifacts trigger neutral status with quota exceeded message."""
         artifact = self._create_preprod_artifact(state=PreprodArtifact.ArtifactState.PROCESSED)
         PreprodArtifactSizeMetrics.objects.create(
@@ -1475,7 +1475,7 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
             assert "Quota exceeded" in kwargs["subtitle"]
             assert "No quota available" in kwargs["summary"]
 
-    def test_skipped_triggering_artifact_uses_sibling_url(self):
+    def test_skipped_triggering_artifact_uses_sibling_url(self) -> None:
         """When triggering artifact is SKIPPED, target_url points to a non-SKIPPED sibling."""
         commit_comparison = CommitComparison.objects.create(
             organization_id=self.organization.id,

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -18,7 +18,7 @@ from sentry.testutils.silo import cell_silo_test
 class StatusCheckTestBase(TestCase):
     """Base test class with common setup for status check formatting tests."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.organization)
@@ -31,7 +31,7 @@ class StatusCheckTestBase(TestCase):
 class ProcessingStateFormattingTest(StatusCheckTestBase):
     """Tests for formatting artifacts in processing/loading states."""
 
-    def test_processing_state_formatting(self):
+    def test_processing_state_formatting(self) -> None:
         """Test formatting for processing (uploading/uploaded) states."""
         for state in [
             PreprodArtifact.ArtifactState.UPLOADING,
@@ -56,7 +56,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
                 assert "com.example.app" in summary
                 assert "1.0.0 (1)" in summary
 
-    def test_processed_state_without_metrics(self):
+    def test_processed_state_without_metrics(self) -> None:
         """Test that processed state without size metrics raises an error."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -71,7 +71,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
                 [artifact], {}, StatusCheckStatus.SUCCESS, self.project, {}, {}
             )
 
-    def test_processed_state_with_metrics_no_previous(self):
+    def test_processed_state_with_metrics_no_previous(self) -> None:
         """Test formatting for processed state with metrics but no previous build."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -104,7 +104,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         assert "N/A" in summary
         assert "com.example.app" in summary
 
-    def test_version_string_formatting(self):
+    def test_version_string_formatting(self) -> None:
         """Test version string formatting with different combinations."""
         test_cases = [
             ("1.0.0", None, "1.0.0"),
@@ -129,7 +129,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
 
                 assert expected in summary
 
-    def test_multiple_artifacts_all_processing(self):
+    def test_multiple_artifacts_all_processing(self) -> None:
         """Test formatting for multiple artifacts all in processing states."""
         artifacts = []
         for i, state in enumerate(
@@ -158,7 +158,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         assert "com.example.app0" in summary
         assert "com.example.app1" in summary
 
-    def test_mixed_processing_and_completed_metric_states_per_artifact(self):
+    def test_mixed_processing_and_completed_metric_states_per_artifact(self) -> None:
         """Test formatting when one metric is completed and another is processing."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -204,7 +204,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
         assert "1.0 MB" in summary  # Main app completed
         assert "Processing..." in summary  # Watch app processing
 
-    def test_size_metrics_still_processing(self):
+    def test_size_metrics_still_processing(self) -> None:
         """Test formatting when size metrics are in processing states (PENDING/RUNNING)."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -249,7 +249,7 @@ class ProcessingStateFormattingTest(StatusCheckTestBase):
 class ErrorStateFormattingTest(StatusCheckTestBase):
     """Tests for formatting artifacts in error/failure states."""
 
-    def test_failed_state_formatting(self):
+    def test_failed_state_formatting(self) -> None:
         """Test formatting for failed state."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -271,7 +271,7 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
         assert "1.0.0 (1)" in summary
         assert "Error" in summary  # Column header
 
-    def test_error_message_handling(self):
+    def test_error_message_handling(self) -> None:
         """Test error message handling including None case."""
         test_cases = [
             ("Custom error message", "Custom error message"),
@@ -294,7 +294,7 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
 
                 assert expected_error in summary
 
-    def test_multiple_artifacts_mixed_states(self):
+    def test_multiple_artifacts_mixed_states(self) -> None:
         """Test formatting for mixed states (some analyzed, some processing, some failed)."""
         artifacts = []
         size_metrics_map = {}
@@ -355,7 +355,7 @@ class ErrorStateFormattingTest(StatusCheckTestBase):
 class SuccessStateFormattingTest(StatusCheckTestBase):
     """Tests for formatting artifacts in successful/analyzed states."""
 
-    def test_multiple_artifacts_all_analyzed(self):
+    def test_multiple_artifacts_all_analyzed(self) -> None:
         """Test formatting for multiple artifacts all analyzed."""
         artifacts = []
         size_metrics_map = {}
@@ -392,7 +392,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert "com.example.app0" in summary
         assert "com.example.app1" in summary
 
-    def test_multiple_metric_types_per_artifact(self):
+    def test_multiple_metric_types_per_artifact(self) -> None:
         """Test formatting with multiple metric types per artifact (main app + watch)."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -449,7 +449,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert watch_row_idx is not None
         assert abs(main_row_idx - watch_row_idx) == 1  # Should be adjacent rows
 
-    def test_android_dynamic_feature_metrics(self):
+    def test_android_dynamic_feature_metrics(self) -> None:
         """Test formatting with Android dynamic features."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -496,7 +496,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert "8.4 MB" in summary  # Main app install
         assert "2.1 MB" in summary  # Dynamic feature install (note: rounds to 2.1 not 2.0)
 
-    def test_app_clip_metrics(self):
+    def test_app_clip_metrics(self) -> None:
         """Test formatting with App Clip metrics."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -540,7 +540,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert "4.2 MB" in summary
         assert "1.0 MB" in summary
 
-    def test_size_changes_with_base_artifacts(self):
+    def test_size_changes_with_base_artifacts(self) -> None:
         """Test size change calculations when base artifacts exist for comparison."""
         head_commit_comparison = CommitComparison.objects.create(
             head_repo_name="test/repo",
@@ -619,7 +619,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert "com.example.android" in summary
         assert "1.0.3 (42)" in summary
 
-    def test_size_changes_no_base_artifacts(self):
+    def test_size_changes_no_base_artifacts(self) -> None:
         """Test that N/A is shown when no base artifacts exist for comparison."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -654,7 +654,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         data_line = next(line for line in lines if "com.example.app" in line)
         assert "N/A" in data_line  # Change columns show N/A
 
-    def test_size_changes_with_different_artifact_types(self):
+    def test_size_changes_with_different_artifact_types(self) -> None:
         """Test that size changes only compare the same artifact types (Watch-to-Watch, Main-to-Main)."""
 
         head_commit_comparison = CommitComparison.objects.create(
@@ -746,7 +746,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         na_count = watch_line.count("N/A")
         assert na_count == 2  # 2 N/A for the change columns
 
-    def test_size_changes_with_watch_base_metrics(self):
+    def test_size_changes_with_watch_base_metrics(self) -> None:
         """Test that Watch-to-Watch comparison works when base Watch metrics exist."""
 
         head_commit_comparison = CommitComparison.objects.create(
@@ -844,7 +844,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert "+114.7 KB" in watch_line
         assert "+229.4 KB" in watch_line
 
-    def test_android_app_shows_uncompressed_label(self):
+    def test_android_app_shows_uncompressed_label(self) -> None:
         """Test that Android apps show 'Uncompressed' instead of 'Install' in column header."""
         # Test Android app
         android_artifact = self.create_preprod_artifact(
@@ -911,7 +911,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
         assert "Install" in ios_summary
         assert "Uncompressed" not in ios_summary
 
-    def test_mixed_platforms_render_separate_tables(self):
+    def test_mixed_platforms_render_separate_tables(self) -> None:
         """Mixed Android/iOS artifacts should render separate tables with platform-specific labels."""
         android_artifact = self.create_preprod_artifact(
             project=self.project,
@@ -990,7 +990,7 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
 class BuildConfigurationComparisonTest(StatusCheckTestBase):
     """Tests for ensuring artifacts with different build configurations are not compared."""
 
-    def test_different_build_configurations_not_compared(self):
+    def test_different_build_configurations_not_compared(self) -> None:
         """Test that artifacts with different build configurations (Debug vs Release) don't get compared."""
         debug_config = PreprodBuildConfiguration.objects.create(project=self.project, name="Debug")
         release_config = PreprodBuildConfiguration.objects.create(
@@ -1103,7 +1103,7 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
         assert "+3.4 MB" not in summary  # This would indicate wrong comparison to release base
         assert "+6.6 MB" not in summary  # This would indicate wrong comparison to release base
 
-    def test_same_build_configuration_comparison_works(self):
+    def test_same_build_configuration_comparison_works(self) -> None:
         """Test that artifacts with same build configuration are properly compared."""
         release_config = PreprodBuildConfiguration.objects.create(
             project=self.project, name="Release"
@@ -1182,7 +1182,7 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
         assert "+104.9 KB" in summary  # 3.3MB - 3.1MB = 104.9KB
         assert "+209.7 KB" in summary  # 6.5MB - 6.3MB = 209.7KB
 
-    def test_no_matching_build_configuration_shows_na(self):
+    def test_no_matching_build_configuration_shows_na(self) -> None:
         """Test that when no matching build configuration exists, N/A is shown for changes."""
         debug_config = PreprodBuildConfiguration.objects.create(project=self.project, name="Debug")
         release_config = PreprodBuildConfiguration.objects.create(
@@ -1265,7 +1265,7 @@ class BuildConfigurationComparisonTest(StatusCheckTestBase):
 class TriggeredRulesFormattingTest(StatusCheckTestBase):
     """Tests for formatting status checks with triggered rules."""
 
-    def test_single_triggered_rule_shows_details_section(self):
+    def test_single_triggered_rule_shows_details_section(self) -> None:
         """Test that a single triggered rule shows a details section with rule info."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -1339,7 +1339,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         assert subtitle == ""
         assert summary == expected
 
-    def test_triggered_rule_includes_artifact_type_details(self):
+    def test_triggered_rule_includes_artifact_type_details(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -1388,7 +1388,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 
         assert "— Watch App" in summary
 
-    def test_multiple_triggered_rules_url_formatting(self):
+    def test_multiple_triggered_rules_url_formatting(self) -> None:
         """Test that multiple triggered rules format the URL correctly with expanded params."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -1490,7 +1490,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         assert subtitle == ""
         assert summary == expected
 
-    def test_multiple_apps_with_triggered_rules(self):
+    def test_multiple_apps_with_triggered_rules(self) -> None:
         """Test formatting when multiple apps fail with different rules."""
         artifact1 = self.create_preprod_artifact(
             project=self.project,
@@ -1609,7 +1609,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         assert subtitle == ""
         assert summary == expected
 
-    def test_mixed_pass_fail_with_triggered_rules(self):
+    def test_mixed_pass_fail_with_triggered_rules(self) -> None:
         """Test formatting when some apps pass and some fail due to triggered rules."""
         failed_artifact = self.create_preprod_artifact(
             project=self.project,
@@ -1713,7 +1713,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         assert subtitle == ""
         assert summary == expected
 
-    def test_single_triggered_rule_with_build_configuration(self):
+    def test_single_triggered_rule_with_build_configuration(self) -> None:
         """Test that a triggered rule with build_configuration shows config in header."""
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -1762,7 +1762,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         assert "`com.example.app` | Release (iOS)" in summary
         assert "<summary>1 Failed Check</summary>" in summary
 
-    def test_same_app_different_configurations_grouped_separately(self):
+    def test_same_app_different_configurations_grouped_separately(self) -> None:
         """Test that same app with different build configs shows separate groups."""
         artifact1 = self.create_preprod_artifact(
             project=self.project,
@@ -1847,7 +1847,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         assert "`com.emergetools.hackernews` | AdHoc (iOS)" in summary
         assert "<summary>2 Failed Checks</summary>" in summary
 
-    def test_triggered_rule_without_build_configuration_unchanged(self):
+    def test_triggered_rule_without_build_configuration_unchanged(self) -> None:
         """Test that None build_configuration renders header same as before."""
         artifact = self.create_preprod_artifact(
             project=self.project,

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -17,7 +17,7 @@ from sentry.testutils.silo import cell_silo_test
 
 
 class SnapshotStatusCheckTestBase(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.organization)
@@ -75,14 +75,14 @@ class SnapshotStatusCheckTestBase(TestCase):
 
 @cell_silo_test
 class SnapshotEmptyArtifactsTest(SnapshotStatusCheckTestBase):
-    def test_empty_artifacts_raises_error(self):
+    def test_empty_artifacts_raises_error(self) -> None:
         with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
             format_snapshot_status_check_messages([], {}, {}, StatusCheckStatus.SUCCESS, {})
 
 
 @cell_silo_test
 class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
-    def test_artifact_without_metrics_shows_processing(self):
+    def test_artifact_without_metrics_shows_processing(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -100,7 +100,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         assert "Processing" in summary
         assert "com.example.app" in summary
 
-    def test_artifact_with_metrics_but_no_comparison_shows_processing(self):
+    def test_artifact_with_metrics_but_no_comparison_shows_processing(self) -> None:
         artifact, metrics = self._create_artifact_with_metrics()
 
         snapshot_metrics_map = {artifact.id: metrics}
@@ -113,7 +113,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "Comparing snapshots..."
         assert "Processing" in summary
 
-    def test_comparison_in_pending_state_shows_comparing(self):
+    def test_comparison_in_pending_state_shows_comparing(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics(app_id="com.example.head")
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -136,7 +136,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "Comparing snapshots..."
         assert "Processing" in summary
 
-    def test_comparison_in_processing_state_shows_comparing(self):
+    def test_comparison_in_processing_state_shows_comparing(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics(app_id="com.example.head")
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -160,7 +160,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
 
 @cell_silo_test
 class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
-    def test_all_images_match_shows_success(self):
+    def test_all_images_match_shows_success(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", app_name="My App"
         )
@@ -191,7 +191,7 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
         assert "✅ Unchanged" in summary
         assert "My App" in summary
 
-    def test_app_id_shown_in_name_cell(self):
+    def test_app_id_shown_in_name_cell(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics(
             app_id="com.example.noname"
         )
@@ -212,7 +212,7 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
 
         assert "`com.example.noname`" in summary
 
-    def test_multiple_artifacts_all_match(self):
+    def test_multiple_artifacts_all_match(self) -> None:
         artifacts = []
         snapshot_metrics_map = {}
         comparisons_map = {}
@@ -246,7 +246,7 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
 
 @cell_silo_test
 class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
-    def test_images_changed_shows_failure_subtitle(self):
+    def test_images_changed_shows_failure_subtitle(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -274,7 +274,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "3 modified, 7 unchanged"
         assert "⏳ Needs approval" in summary
 
-    def test_single_image_changed(self):
+    def test_single_image_changed(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -298,7 +298,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
 
         assert subtitle == "1 modified, 9 unchanged"
 
-    def test_images_added_and_removed(self):
+    def test_images_added_and_removed(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -324,7 +324,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
 
         assert subtitle == "2 added, 1 removed, 8 unchanged"
 
-    def test_images_renamed(self):
+    def test_images_renamed(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -348,7 +348,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
 
         assert subtitle == "4 renamed, 6 unchanged"
 
-    def test_all_change_types_combined(self):
+    def test_all_change_types_combined(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -379,7 +379,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
 
 @cell_silo_test
 class SnapshotFailureStateFormattingTest(SnapshotStatusCheckTestBase):
-    def test_failed_comparison_returns_error_message(self):
+    def test_failed_comparison_returns_error_message(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -404,7 +404,7 @@ class SnapshotFailureStateFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "We had trouble comparing snapshots, our team is investigating."
         assert summary == ""
 
-    def test_failed_comparison_early_returns_ignoring_other_artifacts(self):
+    def test_failed_comparison_early_returns_ignoring_other_artifacts(self) -> None:
         # First artifact has a failed comparison
         head1, head1_metrics = self._create_artifact_with_metrics(
             app_id="com.example.failed", build_number=1
@@ -450,7 +450,7 @@ class SnapshotFailureStateFormattingTest(SnapshotStatusCheckTestBase):
 
 @cell_silo_test
 class SnapshotMixedStateFormattingTest(SnapshotStatusCheckTestBase):
-    def test_mixed_success_and_processing(self):
+    def test_mixed_success_and_processing(self) -> None:
         head1, head1_metrics = self._create_artifact_with_metrics(
             app_id="com.example.done", build_number=1
         )
@@ -494,7 +494,7 @@ class SnapshotMixedStateFormattingTest(SnapshotStatusCheckTestBase):
 
 @cell_silo_test
 class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
-    def test_summary_table_has_correct_headers(self):
+    def test_summary_table_has_correct_headers(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
         comparison = self._create_comparison(head_metrics, base_metrics)
@@ -513,7 +513,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         assert "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |" in summary
         assert "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |" in summary
 
-    def test_summary_has_no_settings_link(self):
+    def test_summary_has_no_settings_link(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
         comparison = self._create_comparison(head_metrics, base_metrics)
@@ -532,7 +532,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         assert "Configure" not in summary
         assert "settings" not in summary
 
-    def test_summary_uses_comparison_url_when_base_artifact_exists(self):
+    def test_summary_uses_comparison_url_when_base_artifact_exists(self) -> None:
         head_commit_comparison = CommitComparison.objects.create(
             head_repo_name="test/repo",
             head_sha="head_sha_123",
@@ -564,7 +564,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{head_artifact.id}"
         assert expected_url in summary
 
-    def test_summary_uses_artifact_url_when_no_base(self):
+    def test_summary_uses_artifact_url_when_no_base(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
         comparison = self._create_comparison(head_metrics, base_metrics)
@@ -583,7 +583,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{head_artifact.id}"
         assert expected_url in summary
 
-    def test_full_success_summary_format(self):
+    def test_full_success_summary_format(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", app_name="My App"
         )
@@ -624,7 +624,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         )
         assert summary == expected
 
-    def test_full_failure_summary_format(self):
+    def test_full_failure_summary_format(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", app_name="My App"
         )
@@ -671,7 +671,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
 
 @cell_silo_test
 class SnapshotFirstUploadFormattingTest(SnapshotStatusCheckTestBase):
-    def test_first_upload_single_artifact(self):
+    def test_first_upload_single_artifact(self) -> None:
         artifact, metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", app_name="My App", image_count=24
         )
@@ -688,7 +688,7 @@ class SnapshotFirstUploadFormattingTest(SnapshotStatusCheckTestBase):
         assert "✅ Uploaded" in summary
         assert "first snapshot upload" in summary
 
-    def test_first_upload_multiple_artifacts(self):
+    def test_first_upload_multiple_artifacts(self) -> None:
         artifacts = []
         snapshot_metrics_map: dict[int, PreprodSnapshotMetrics] = {}
 
@@ -711,7 +711,7 @@ class SnapshotFirstUploadFormattingTest(SnapshotStatusCheckTestBase):
             assert f"com.example.app{i}" in summary
         assert "first snapshot upload" in summary
 
-    def test_first_upload_artifact_without_metrics(self):
+    def test_first_upload_artifact_without_metrics(self) -> None:
         artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -728,11 +728,11 @@ class SnapshotFirstUploadFormattingTest(SnapshotStatusCheckTestBase):
         assert "com.example.app" in summary
         assert "first snapshot upload" in summary
 
-    def test_first_upload_empty_artifacts_raises(self):
+    def test_first_upload_empty_artifacts_raises(self) -> None:
         with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
             format_first_snapshot_status_check_messages([], {})
 
-    def test_first_upload_summary_table_format(self):
+    def test_first_upload_summary_table_format(self) -> None:
         artifact, metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", app_name="My App", image_count=15
         )
@@ -755,7 +755,7 @@ class SnapshotFirstUploadFormattingTest(SnapshotStatusCheckTestBase):
 
 @cell_silo_test
 class SnapshotGeneratedFormattingTest(SnapshotStatusCheckTestBase):
-    def test_generated_single_artifact(self):
+    def test_generated_single_artifact(self) -> None:
         artifact, metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", app_name="My App", image_count=24
         )
@@ -771,7 +771,7 @@ class SnapshotGeneratedFormattingTest(SnapshotStatusCheckTestBase):
         assert "24" in summary
         assert "✅ Uploaded" in summary
 
-    def test_generated_multiple_artifacts(self):
+    def test_generated_multiple_artifacts(self) -> None:
         artifacts = []
         snapshot_metrics_map: dict[int, PreprodSnapshotMetrics] = {}
 
@@ -793,7 +793,7 @@ class SnapshotGeneratedFormattingTest(SnapshotStatusCheckTestBase):
         for i in range(3):
             assert f"com.example.app{i}" in summary
 
-    def test_generated_single_snapshot_singular(self):
+    def test_generated_single_snapshot_singular(self) -> None:
         artifact, metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", image_count=1
         )
@@ -805,11 +805,11 @@ class SnapshotGeneratedFormattingTest(SnapshotStatusCheckTestBase):
 
         assert subtitle == "Generated 1 snapshot"
 
-    def test_generated_empty_artifacts_raises(self):
+    def test_generated_empty_artifacts_raises(self) -> None:
         with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
             format_generated_snapshot_status_check_messages([], {})
 
-    def test_generated_summary_table_format(self):
+    def test_generated_summary_table_format(self) -> None:
         artifact, metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", app_name="My App", image_count=15
         )
@@ -831,7 +831,7 @@ class SnapshotGeneratedFormattingTest(SnapshotStatusCheckTestBase):
 
 @cell_silo_test
 class SnapshotMissingBaseFormattingTest(SnapshotStatusCheckTestBase):
-    def test_missing_base_single_artifact(self):
+    def test_missing_base_single_artifact(self) -> None:
         artifact, metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", app_name="My App", image_count=24
         )
@@ -848,7 +848,7 @@ class SnapshotMissingBaseFormattingTest(SnapshotStatusCheckTestBase):
         assert "✅ Uploaded" in summary
         assert "No base snapshots found to compare against" in summary
 
-    def test_missing_base_multiple_artifacts(self):
+    def test_missing_base_multiple_artifacts(self) -> None:
         artifacts = []
         snapshot_metrics_map: dict[int, PreprodSnapshotMetrics] = {}
 
@@ -871,11 +871,11 @@ class SnapshotMissingBaseFormattingTest(SnapshotStatusCheckTestBase):
             assert f"com.example.app{i}" in summary
         assert "No base snapshots found to compare against" in summary
 
-    def test_missing_base_empty_artifacts_raises(self):
+    def test_missing_base_empty_artifacts_raises(self) -> None:
         with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
             format_missing_base_snapshot_status_check_messages([], {})
 
-    def test_missing_base_summary_table_format(self):
+    def test_missing_base_summary_table_format(self) -> None:
         artifact, metrics = self._create_artifact_with_metrics(
             app_id="com.example.app", app_name="My App", image_count=15
         )

--- a/tests/sentry/preprod/vcs/webhooks/test_github_check_run.py
+++ b/tests/sentry/preprod/vcs/webhooks/test_github_check_run.py
@@ -16,7 +16,7 @@ from sentry.testutils.silo import cell_silo_test
 
 @cell_silo_test
 class HandlePreprodCheckRunEventTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.organization)
@@ -96,7 +96,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             },
         }
 
-    def test_ignores_non_check_run_events(self):
+    def test_ignores_non_check_run_events(self) -> None:
         artifact = self._create_preprod_artifact()
         event = self._create_webhook_event(
             action="requested_action",
@@ -118,7 +118,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             == 0
         )
 
-    def test_ignores_non_requested_action(self):
+    def test_ignores_non_requested_action(self) -> None:
         artifact = self._create_preprod_artifact()
         event = self._create_webhook_event(
             action="completed",
@@ -140,7 +140,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             == 0
         )
 
-    def test_ignores_non_approve_size_identifier(self):
+    def test_ignores_non_approve_size_identifier(self) -> None:
         artifact = self._create_preprod_artifact()
         event = self._create_webhook_event(
             action="requested_action",
@@ -162,7 +162,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             == 0
         )
 
-    def test_creates_approval_for_valid_request(self):
+    def test_creates_approval_for_valid_request(self) -> None:
         artifact = self._create_preprod_artifact()
         event = self._create_webhook_event(
             action="requested_action",
@@ -200,7 +200,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             }
         )
 
-    def test_creates_approvals_for_all_sibling_artifacts(self):
+    def test_creates_approvals_for_all_sibling_artifacts(self) -> None:
         artifact1 = self._create_preprod_artifact(app_id="com.example.app1")
         commit_comparison = artifact1.commit_comparison
 
@@ -234,7 +234,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             == 2
         )
 
-    def test_handles_missing_external_id(self):
+    def test_handles_missing_external_id(self) -> None:
         event = self._create_webhook_event(
             action="requested_action",
             identifier=APPROVE_SIZE_ACTION_IDENTIFIER,
@@ -256,7 +256,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             == 0
         )
 
-    def test_handles_invalid_external_id(self):
+    def test_handles_invalid_external_id(self) -> None:
         event = self._create_webhook_event(
             action="requested_action",
             identifier=APPROVE_SIZE_ACTION_IDENTIFIER,
@@ -277,7 +277,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             == 0
         )
 
-    def test_handles_nonexistent_artifact(self):
+    def test_handles_nonexistent_artifact(self) -> None:
         event = self._create_webhook_event(
             action="requested_action",
             identifier=APPROVE_SIZE_ACTION_IDENTIFIER,
@@ -298,7 +298,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             == 0
         )
 
-    def test_artifact_not_found_for_different_organization(self):
+    def test_artifact_not_found_for_different_organization(self) -> None:
         """Artifact belonging to a different org is not found (org filter is part of query)."""
         other_org = self.create_organization(owner=self.user)
         other_project = self.create_project(organization=other_org, name="other_project")
@@ -341,7 +341,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
             == 0
         )
 
-    def test_skips_duplicate_approval_from_same_user(self):
+    def test_skips_duplicate_approval_from_same_user(self) -> None:
         """Same GitHub user clicking approve twice should not create duplicate."""
         artifact = self._create_preprod_artifact()
 
@@ -374,7 +374,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
         # Should still be 1 (no duplicate created)
         assert PreprodComparisonApproval.objects.filter(preprod_artifact=artifact).count() == 1
 
-    def test_allows_different_user_to_create_new_approval(self):
+    def test_allows_different_user_to_create_new_approval(self) -> None:
         """Different GitHub user approving should create a new approval record."""
         artifact = self._create_preprod_artifact()
 
@@ -416,7 +416,7 @@ class HandlePreprodCheckRunEventTest(TestCase):
         assert latest_approval is not None
         assert latest_approval.extras == {"github": {"id": 12345, "login": "octocat"}}
 
-    def test_checks_latest_approval_not_first(self):
+    def test_checks_latest_approval_not_first(self) -> None:
         """When multiple approvals exist, check against the latest one, not the first."""
         artifact = self._create_preprod_artifact()
 

--- a/tests/sentry/processing_errors/test_detection.py
+++ b/tests/sentry/processing_errors/test_detection.py
@@ -41,7 +41,7 @@ def _sourcemap_config():
 
 
 class TestDetectSourcemapIssues(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         config = _sourcemap_config()
         cache.delete(_cache_key_triggered(config.slug, self.project.id))

--- a/tests/sentry/receivers/test_analytics.py
+++ b/tests/sentry/receivers/test_analytics.py
@@ -21,7 +21,7 @@ class CreateDefaultProjectsTest(TestCase):
         )
 
     @assume_test_silo_mode(SiloMode.CONTROL)
-    def test_user_modified_does_not_record_analytics(self):
+    def test_user_modified_does_not_record_analytics(self) -> None:
         user: User = self.create_user()
         with patch("sentry.analytics.record") as mock_record:
             user.email = "new@example.com"

--- a/tests/sentry/receivers/test_default_detector.py
+++ b/tests/sentry/receivers/test_default_detector.py
@@ -27,7 +27,7 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
 class TestEnsureMetricDetector(TestCase):
-    def test_creates_detector_with_all_components(self):
+    def test_creates_detector_with_all_components(self) -> None:
         """Test that ensure_default_anomaly_detector creates detector with all required components."""
         project = self.create_project()
         team = self.create_team(organization=project.organization)
@@ -73,7 +73,7 @@ class TestEnsureMetricDetector(TestCase):
         assert snuba_query.aggregate == "count()"
         assert snuba_query.time_window == 60 * 15  # 15 minutes in seconds
 
-    def test_creates_detector_without_team(self):
+    def test_creates_detector_without_team(self) -> None:
         """Test that detector can be created without an owner team."""
         project = self.create_project()
 
@@ -84,7 +84,7 @@ class TestEnsureMetricDetector(TestCase):
         assert detector.owner_team_id is None
         assert detector.enabled is True
 
-    def test_send_new_detector_data_failure_blocks_creation(self):
+    def test_send_new_detector_data_failure_blocks_creation(self) -> None:
         """Test that detector is NOT created if sending data to Seer fails."""
         project = self.create_project()
 
@@ -98,7 +98,7 @@ class TestEnsureMetricDetector(TestCase):
         # Transaction was rolled back, so no detector should exist
         assert not Detector.objects.filter(project=project, type=MetricIssue.slug).exists()
 
-    def test_returns_existing_detector_without_creating_duplicates(self):
+    def test_returns_existing_detector_without_creating_duplicates(self) -> None:
         """Test that calling ensure_default_anomaly_detector twice returns the same detector."""
         project = self.create_project()
 
@@ -117,7 +117,7 @@ class TestEnsureMetricDetector(TestCase):
 class TestCreateDefaultAnomalyDetector(TestCase):
     @with_feature("organizations:default-anomaly-detector")
     @with_feature("organizations:anomaly-detection-alerts")
-    def test_creates_enabled_detector_when_both_features_enabled(self):
+    def test_creates_enabled_detector_when_both_features_enabled(self) -> None:
         """Test that detector is created and enabled when both feature flags are enabled."""
         project = self.create_project()
         # Get the team that was auto-created with the project
@@ -133,7 +133,7 @@ class TestCreateDefaultAnomalyDetector(TestCase):
         assert detector.enabled is True
 
     @with_feature("organizations:default-anomaly-detector")
-    def test_creates_disabled_detector_when_plan_feature_missing(self):
+    def test_creates_disabled_detector_when_plan_feature_missing(self) -> None:
         """Test that detector is created but disabled when anomaly-detection-alerts is off."""
         project = self.create_project()
 
@@ -144,7 +144,7 @@ class TestCreateDefaultAnomalyDetector(TestCase):
         assert detector.enabled is False
 
     @with_feature({"organizations:default-anomaly-detector": False})
-    def test_does_not_create_detector_when_feature_disabled(self):
+    def test_does_not_create_detector_when_feature_disabled(self) -> None:
         """Test that detector is not created when feature flag is disabled."""
         project = self.create_project()
 
@@ -153,7 +153,7 @@ class TestCreateDefaultAnomalyDetector(TestCase):
         assert not Detector.objects.filter(project=project, type=MetricIssue.slug).exists()
 
     @with_feature("organizations:default-anomaly-detector")
-    def test_creates_detector_without_team(self):
+    def test_creates_detector_without_team(self) -> None:
         """Test that detector is created even when project has no teams."""
         project = self.create_project()
         # Remove all teams
@@ -167,7 +167,7 @@ class TestCreateDefaultAnomalyDetector(TestCase):
 
 
 class TestDisableDefaultDetectorCreation(TestCase):
-    def test_context_manager_disables_signal(self):
+    def test_context_manager_disables_signal(self) -> None:
         """Test that disable_default_detector_creation prevents default detectors."""
         with disable_default_detector_creation():
             project = self.create_project(create_default_detectors=True)
@@ -176,7 +176,7 @@ class TestDisableDefaultDetectorCreation(TestCase):
         assert not Detector.objects.filter(project=project, type=ErrorGroupType.slug).exists()
         assert not Detector.objects.filter(project=project, type=IssueStreamGroupType.slug).exists()
 
-    def test_context_manager_reconnects_on_exception(self):
+    def test_context_manager_reconnects_on_exception(self) -> None:
         """Test that signals are reconnected even if exception occurs."""
         try:
             with disable_default_detector_creation():
@@ -193,7 +193,7 @@ class TestDisableDefaultDetectorCreation(TestCase):
         assert "create_default_anomaly_detector" in project_created_uids
 
     @with_feature("organizations:default-anomaly-detector")
-    def test_context_manager_disables_metric_detector_signal(self):
+    def test_context_manager_disables_metric_detector_signal(self) -> None:
         """Test that disable_default_detector_creation also prevents metric detector creation."""
         with (
             disable_default_detector_creation(),
@@ -208,13 +208,13 @@ class TestDisableDefaultDetectorCreation(TestCase):
 
 class TestCreatePerformanceDetectors(TestCase):
     @with_feature("projects:workflow-engine-performance-detectors")
-    def test_creates_detectors_on_project_creation(self):
+    def test_creates_detectors_on_project_creation(self) -> None:
         project = self.create_project()
 
         for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values():
             assert Detector.objects.filter(project=project, type=mapping.wfe_detector_type).exists()
 
-    def test_does_not_create_detectors_when_flag_disabled(self):
+    def test_does_not_create_detectors_when_flag_disabled(self) -> None:
         project = self.create_project()
 
         for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values():
@@ -223,7 +223,7 @@ class TestCreatePerformanceDetectors(TestCase):
             ).exists()
 
     @with_feature("projects:workflow-engine-performance-detectors")
-    def test_idempotent_no_duplicates(self):
+    def test_idempotent_no_duplicates(self) -> None:
         with disable_default_detector_creation():
             project = self.create_project()
 
@@ -237,7 +237,7 @@ class TestCreatePerformanceDetectors(TestCase):
             )
 
     @with_feature("projects:workflow-engine-performance-detectors")
-    def test_disable_default_detector_creation_prevents_performance_detectors(self):
+    def test_disable_default_detector_creation_prevents_performance_detectors(self) -> None:
         with disable_default_detector_creation():
             project = self.create_project()
 

--- a/tests/sentry/releases/use_cases/test_release_serializer.py
+++ b/tests/sentry/releases/use_cases/test_release_serializer.py
@@ -15,7 +15,7 @@ class ReleaseSerializerUseCaseTest(TestCase):
     as opposed to the old model-based serializer in api.serializers.models.release.
     """
 
-    def test_new_groups_single_release_per_project(self):
+    def test_new_groups_single_release_per_project(self) -> None:
         """
         Test new groups counts for one release with multiple projects, each having different issue counts.
         """
@@ -60,7 +60,7 @@ class ReleaseSerializerUseCaseTest(TestCase):
         assert projects[project_b.id]["name"] == "Project B"
         assert projects[project_b.id]["slug"] == "project-b"
 
-    def test_new_groups_multiple_releases_per_project(self):
+    def test_new_groups_multiple_releases_per_project(self) -> None:
         """
         Test new groups count for multiple releases per project.
         """
@@ -146,7 +146,7 @@ class ReleaseSerializerUseCaseTest(TestCase):
         assert projects_2[project_a.id]["newGroups"] == 1
         assert projects_2[project_b.id]["newGroups"] == 4
 
-    def test_new_groups_environment_filtering(self):
+    def test_new_groups_environment_filtering(self) -> None:
         """
         Test new group counts for a single release with environment filtering.
         """
@@ -242,7 +242,7 @@ class ReleaseSerializerUseCaseTest(TestCase):
         assert projects[project_b.id]["newGroups"] == 2
         assert serialized_release["newGroups"] == 6
 
-    def test_new_groups_cross_project_release_environment(self):
+    def test_new_groups_cross_project_release_environment(self) -> None:
         """
         Test new group counts for multiple releases with different environments.
         """

--- a/tests/sentry/replays/unit/lib/eap/test_snuba_transpiler.py
+++ b/tests/sentry/replays/unit/lib/eap/test_snuba_transpiler.py
@@ -238,7 +238,7 @@ def test_column_expressions(column, eap_type):  # type: ignore[no-untyped-def]
     )
 
 
-def test_literal_expressions() -> None:  # type: ignore[no-untyped-def]
+def test_literal_expressions() -> None:
     assert expression(1, SETTINGS) == EAPColumn(literal=Literal(val_double=1.0))
     assert expression(1.0, SETTINGS) == EAPColumn(literal=Literal(val_double=1.0))
     assert expression(True, SETTINGS) == EAPColumn(literal=Literal(val_double=1.0))
@@ -338,7 +338,7 @@ def test_orderby(snuba_fn, direction):  # type: ignore[no-untyped-def]
     ]
 
 
-def test_groupby() -> None:  # type: ignore[no-untyped-def]
+def test_groupby() -> None:
     cols = [Column("int"), Column("float"), Column("bool"), Column("str")]
     assert groupby(cols, SETTINGS) == [
         AttributeKey(type=AttributeKey.TYPE_INT, name="int"),

--- a/tests/sentry/replays/unit/lib/eap/test_snuba_transpiler.py
+++ b/tests/sentry/replays/unit/lib/eap/test_snuba_transpiler.py
@@ -238,7 +238,7 @@ def test_column_expressions(column, eap_type):  # type: ignore[no-untyped-def]
     )
 
 
-def test_literal_expressions():  # type: ignore[no-untyped-def]
+def test_literal_expressions() -> None:  # type: ignore[no-untyped-def]
     assert expression(1, SETTINGS) == EAPColumn(literal=Literal(val_double=1.0))
     assert expression(1.0, SETTINGS) == EAPColumn(literal=Literal(val_double=1.0))
     assert expression(True, SETTINGS) == EAPColumn(literal=Literal(val_double=1.0))
@@ -338,7 +338,7 @@ def test_orderby(snuba_fn, direction):  # type: ignore[no-untyped-def]
     ]
 
 
-def test_groupby():  # type: ignore[no-untyped-def]
+def test_groupby() -> None:  # type: ignore[no-untyped-def]
     cols = [Column("int"), Column("float"), Column("bool"), Column("str")]
     assert groupby(cols, SETTINGS) == [
         AttributeKey(type=AttributeKey.TYPE_INT, name="int"),

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -50,7 +50,7 @@ class NotifyEventServiceActionTest(RuleTestCase, BaseWorkflowTest):
 
 
 class NotifyEventServiceWebhookActionTest(NotifyEventServiceActionTest):
-    def setUp(self):
+    def setUp(self) -> None:
         self.event = self.get_event()
         self.webhook = WebHooksPlugin()
         self.webhook.set_option(
@@ -72,7 +72,7 @@ class NotifyEventServiceWebhookActionTest(NotifyEventServiceActionTest):
         }
 
     @responses.activate
-    def test_applies_correctly_for_legacy_webhooks_aci(self):
+    def test_applies_correctly_for_legacy_webhooks_aci(self) -> None:
         responses.add(responses.POST, "http://my-fake-webhook.io")
 
         (
@@ -127,7 +127,7 @@ class NotifyEventServiceWebhookActionTest(NotifyEventServiceActionTest):
         assert payload["triggering_rules"] == ["error_detector"]
 
     @responses.activate
-    def test_legacy_webhooks_uneven_dual_write_aci(self):
+    def test_legacy_webhooks_uneven_dual_write_aci(self) -> None:
         """
         Test that if a dual written Rule has it's Action updated to email instead that we do not fire a response to the webhook
         """

--- a/tests/sentry/scm/integration/test_github_provider_integration.py
+++ b/tests/sentry/scm/integration/test_github_provider_integration.py
@@ -589,7 +589,7 @@ class TestGitHubProviderIntegration(TestCase):
 
         assert len(responses.calls) == 1
 
-    def test_repository_conversion_preserves_fields(self):
+    def test_repository_conversion_preserves_fields(self) -> None:
         assert self.repository["name"] == REPO_NAME
         assert self.repository["organization_id"] == self.organization.id
         assert self.repository["integration_id"] == self.integration.id

--- a/tests/sentry/scm/integration/test_helpers_integration.py
+++ b/tests/sentry/scm/integration/test_helpers_integration.py
@@ -19,7 +19,7 @@ from sentry.testutils.cases import TestCase
 
 
 class TestFetchRepository(TestCase):
-    def test_fetch_by_id_returns_repository(self):
+    def test_fetch_by_id_returns_repository(self) -> None:
         repo = RepositoryModel.objects.create(
             organization_id=self.organization.id,
             name="test-org/test-repo",
@@ -35,12 +35,12 @@ class TestFetchRepository(TestCase):
         assert result["organization_id"] == self.organization.id
         assert result["is_active"] is True
 
-    def test_fetch_by_id_returns_none_for_nonexistent(self):
+    def test_fetch_by_id_returns_none_for_nonexistent(self) -> None:
         result = fetch_repository(self.organization.id, 99999)
 
         assert result is None
 
-    def test_fetch_by_id_returns_none_for_wrong_organization(self):
+    def test_fetch_by_id_returns_none_for_wrong_organization(self) -> None:
         other_org = self.create_organization()
         repo = RepositoryModel.objects.create(
             organization_id=other_org.id,
@@ -54,7 +54,7 @@ class TestFetchRepository(TestCase):
 
         assert result is None
 
-    def test_fetch_by_provider_and_external_id_returns_repository(self):
+    def test_fetch_by_provider_and_external_id_returns_repository(self) -> None:
         RepositoryModel.objects.create(
             organization_id=self.organization.id,
             name="test-org/test-repo",
@@ -68,14 +68,14 @@ class TestFetchRepository(TestCase):
         assert result is not None
         assert result["name"] == "test-org/test-repo"
 
-    def test_fetch_by_provider_and_external_id_returns_none_for_nonexistent(self):
+    def test_fetch_by_provider_and_external_id_returns_none_for_nonexistent(self) -> None:
         result = fetch_repository(self.organization.id, ("github", "nonexistent"))
 
         assert result is None
 
 
 class TestMapRepositoryModelToRepository(TestCase):
-    def test_maps_all_fields_correctly(self):
+    def test_maps_all_fields_correctly(self) -> None:
         integration = self.create_integration(
             organization=self.organization,
             provider="github",
@@ -100,7 +100,7 @@ class TestMapRepositoryModelToRepository(TestCase):
 
 
 class TestMapIntegrationToProvider(TestCase):
-    def test_returns_github_provider_for_github_integration(self):
+    def test_returns_github_provider_for_github_integration(self) -> None:
         integration = self.create_integration(
             organization=self.organization,
             provider="github",
@@ -124,7 +124,7 @@ class TestMapIntegrationToProvider(TestCase):
 
         assert isinstance(provider, GitHubProvider)
 
-    def test_raises_error_for_unsupported_provider(self):
+    def test_raises_error_for_unsupported_provider(self) -> None:
         integration = self.create_integration(
             organization=self.organization,
             provider="integrations:github",
@@ -151,7 +151,7 @@ class TestMapIntegrationToProvider(TestCase):
 
 
 class TestFetchServiceProvider(TestCase):
-    def test_returns_provider_from_map_to_provider(self):
+    def test_returns_provider_from_map_to_provider(self) -> None:
         integration = self.create_integration(
             organization=self.organization,
             provider="github",
@@ -176,7 +176,7 @@ class TestFetchServiceProvider(TestCase):
 
         assert isinstance(provider, GitHubProvider)
 
-    def test_returns_none_for_nonexistent_integration(self):
+    def test_returns_none_for_nonexistent_integration(self) -> None:
         repository: Repository = {
             "integration_id": 99999,
             "name": "test-org/test-repo",
@@ -205,7 +205,7 @@ def _make_provider(is_rate_limited: bool = False):
 
 
 class TestInitializeProvider(TestCase):
-    def test_raises_repository_not_found(self):
+    def test_raises_repository_not_found(self) -> None:
         with pytest.raises(SCMCodedError) as exc_info:
             initialize_provider(
                 self.organization.id,
@@ -214,7 +214,7 @@ class TestInitializeProvider(TestCase):
             )
         assert exc_info.value.code == "repository_not_found"
 
-    def test_raises_repository_inactive(self):
+    def test_raises_repository_inactive(self) -> None:
         repository: Repository = {
             "integration_id": 1,
             "name": "test-org/test-repo",
@@ -231,7 +231,7 @@ class TestInitializeProvider(TestCase):
             )
         assert exc_info.value.code == "repository_inactive"
 
-    def test_raises_repository_organization_mismatch(self):
+    def test_raises_repository_organization_mismatch(self) -> None:
         repository = _make_active_repository(organization_id=99999)
 
         with pytest.raises(SCMCodedError) as exc_info:
@@ -242,7 +242,7 @@ class TestInitializeProvider(TestCase):
             )
         assert exc_info.value.code == "repository_organization_mismatch"
 
-    def test_raises_integration_not_found(self):
+    def test_raises_integration_not_found(self) -> None:
         repository = _make_active_repository(self.organization.id)
 
         with pytest.raises(SCMCodedError) as exc_info:
@@ -256,7 +256,7 @@ class TestInitializeProvider(TestCase):
 
 
 class TestExecProviderFn(TestCase):
-    def test_returns_provider_fn_result(self):
+    def test_returns_provider_fn_result(self) -> None:
         provider = _make_provider()
 
         result = exec_provider_fn(
@@ -266,7 +266,7 @@ class TestExecProviderFn(TestCase):
 
         assert result == "success"
 
-    def test_raises_rate_limit_exceeded(self):
+    def test_raises_rate_limit_exceeded(self) -> None:
         with pytest.raises(SCMCodedError) as exc_info:
             exec_provider_fn(
                 _make_provider(is_rate_limited=True),
@@ -274,7 +274,7 @@ class TestExecProviderFn(TestCase):
             )
         assert exc_info.value.code == "rate_limit_exceeded"
 
-    def test_scm_provider_exception_is_reraised(self):
+    def test_scm_provider_exception_is_reraised(self) -> None:
         """SCMError subclasses from provider_fn should pass through unwrapped."""
 
         def raise_scm_provider_exception():
@@ -286,7 +286,7 @@ class TestExecProviderFn(TestCase):
                 provider_fn=raise_scm_provider_exception,
             )
 
-    def test_scm_coded_error_is_reraised(self):
+    def test_scm_coded_error_is_reraised(self) -> None:
         """SCMCodedError from provider_fn should pass through unwrapped."""
 
         def raise_scm_coded_error():
@@ -299,7 +299,7 @@ class TestExecProviderFn(TestCase):
             )
         assert exc_info.value.code == "unsupported_integration"
 
-    def test_generic_exception_wrapped_in_scm_unhandled_exception(self):
+    def test_generic_exception_wrapped_in_scm_unhandled_exception(self) -> None:
         """Non-SCMError exceptions should be wrapped in SCMUnhandledException."""
 
         def raise_value_error():
@@ -313,7 +313,7 @@ class TestExecProviderFn(TestCase):
         assert isinstance(exc_info.value.__cause__, ValueError)
         assert "something unexpected" in str(exc_info.value.__cause__)
 
-    def test_key_error_wrapped_in_scm_unhandled_exception(self):
+    def test_key_error_wrapped_in_scm_unhandled_exception(self) -> None:
         """KeyError (e.g. from malformed response) should be wrapped."""
 
         def raise_key_error():
@@ -326,7 +326,7 @@ class TestExecProviderFn(TestCase):
             )
         assert isinstance(exc_info.value.__cause__, KeyError)
 
-    def test_runtime_error_wrapped_in_scm_unhandled_exception(self):
+    def test_runtime_error_wrapped_in_scm_unhandled_exception(self) -> None:
         """RuntimeError should be wrapped in SCMUnhandledException."""
 
         def raise_runtime_error():

--- a/tests/sentry/scm/integration/test_ipc_integration.py
+++ b/tests/sentry/scm/integration/test_ipc_integration.py
@@ -25,7 +25,7 @@ def _valid_check_run_message() -> str:
 
 
 class TestProduceToListenerIntegration(TestCase):
-    def test_produce_to_listener_control_silo(self):
+    def test_produce_to_listener_control_silo(self) -> None:
         """Test that produce_to_listener calls control silo task delay correctly."""
         with patch(
             "sentry.scm.private.ipc.run_webhook_handler_control_task.delay"
@@ -33,7 +33,7 @@ class TestProduceToListenerIntegration(TestCase):
             produce_to_listener("", "check_run", "test_listener", "control")
             mock_control_delay.assert_called_once_with("test_listener", "", "check_run")
 
-    def test_produce_to_listener_region_silo(self):
+    def test_produce_to_listener_region_silo(self) -> None:
         """Test that produce_to_listener calls region silo task delay correctly."""
         with patch(
             "sentry.scm.private.ipc.run_webhook_handler_region_task.delay"
@@ -44,7 +44,7 @@ class TestProduceToListenerIntegration(TestCase):
 
 @control_silo_test
 class TestWebhookHandlerControlTaskIntegration(TestCase):
-    def test_run_webhook_handler_control_task_success(self):
+    def test_run_webhook_handler_control_task_success(self) -> None:
         """Test the task can be delayed without error."""
         with TaskRunner():
             run_webhook_handler_control_task.delay(
@@ -54,7 +54,7 @@ class TestWebhookHandlerControlTaskIntegration(TestCase):
 
 @cell_silo_test
 class TestWebhookHandlerRegionTaskIntegration(TestCase):
-    def test_run_webhook_handler_region_task_success(self):
+    def test_run_webhook_handler_region_task_success(self) -> None:
         """Test the task can be delayed without error."""
         with TaskRunner():
             run_webhook_handler_region_task.delay(

--- a/tests/sentry/scm/integration/test_rate_limit_integration.py
+++ b/tests/sentry/scm/integration/test_rate_limit_integration.py
@@ -14,7 +14,7 @@ def _client():
 
 
 class TestRedisRateLimitProviderGetAndSet(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.provider = RedisRateLimitProvider()
         self.total_key = total_limit_key("github", self.organization.id)
@@ -23,14 +23,14 @@ class TestRedisRateLimitProviderGetAndSet(TestCase):
         client.delete(self.total_key)
         client.delete(self.usage_key)
 
-    def test_returns_none_limit_when_total_key_missing(self):
+    def test_returns_none_limit_when_total_key_missing(self) -> None:
         limit, usage = self.provider.get_and_set_rate_limit(
             self.total_key, self.usage_key, expiration=60
         )
         assert limit is None
         assert usage == 1
 
-    def test_returns_limit_when_total_key_set(self):
+    def test_returns_limit_when_total_key_set(self) -> None:
         _client().set(self.total_key, 500)
         limit, usage = self.provider.get_and_set_rate_limit(
             self.total_key, self.usage_key, expiration=60
@@ -38,7 +38,7 @@ class TestRedisRateLimitProviderGetAndSet(TestCase):
         assert limit == 500
         assert usage == 1
 
-    def test_increments_usage_on_each_call(self):
+    def test_increments_usage_on_each_call(self) -> None:
         _client().set(self.total_key, 100)
         self.provider.get_and_set_rate_limit(self.total_key, self.usage_key, expiration=60)
         self.provider.get_and_set_rate_limit(self.total_key, self.usage_key, expiration=60)
@@ -47,14 +47,14 @@ class TestRedisRateLimitProviderGetAndSet(TestCase):
         )
         assert usage == 3
 
-    def test_usage_key_has_ttl_set(self):
+    def test_usage_key_has_ttl_set(self) -> None:
         self.provider.get_and_set_rate_limit(self.total_key, self.usage_key, expiration=60)
         ttl = _client().ttl(self.usage_key)
         assert 0 < ttl <= 60
 
 
 class TestRedisRateLimitProviderGetAccountedUsage(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.provider = RedisRateLimitProvider()
         self.keys = [
@@ -65,25 +65,25 @@ class TestRedisRateLimitProviderGetAccountedUsage(TestCase):
         for key in self.keys:
             client.delete(key)
 
-    def test_returns_zero_for_missing_keys(self):
+    def test_returns_zero_for_missing_keys(self) -> None:
         assert self.provider.get_accounted_usage(self.keys) == 0
 
-    def test_returns_zero_for_empty_keys(self):
+    def test_returns_zero_for_empty_keys(self) -> None:
         assert self.provider.get_accounted_usage([]) == 0
 
-    def test_sums_existing_keys(self):
+    def test_sums_existing_keys(self) -> None:
         client = _client()
         client.set(self.keys[0], 10)
         client.set(self.keys[1], 25)
         assert self.provider.get_accounted_usage(self.keys) == 35
 
-    def test_ignores_missing_keys_in_sum(self):
+    def test_ignores_missing_keys_in_sum(self) -> None:
         _client().set(self.keys[0], 7)
         assert self.provider.get_accounted_usage(self.keys) == 7
 
 
 class TestRedisRateLimitProviderSetKeyValues(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.provider = RedisRateLimitProvider()
         self.limit_key = total_limit_key("github", self.organization.id)
@@ -92,19 +92,19 @@ class TestRedisRateLimitProviderSetKeyValues(TestCase):
         client.delete(self.limit_key)
         client.delete(self.usage_key)
 
-    def test_sets_persistent_key_without_ttl(self):
+    def test_sets_persistent_key_without_ttl(self) -> None:
         self.provider.set_key_values({self.limit_key: (500, None)})
         client = _client()
         assert client.get(self.limit_key) == "500"
         assert client.ttl(self.limit_key) == -1
 
-    def test_sets_usage_key_with_ttl(self):
+    def test_sets_usage_key_with_ttl(self) -> None:
         self.provider.set_key_values({self.usage_key: (10, 60)})
         client = _client()
         assert client.get(self.usage_key) == "10"
         assert 0 < client.ttl(self.usage_key) <= 60
 
-    def test_sets_multiple_keys(self):
+    def test_sets_multiple_keys(self) -> None:
         self.provider.set_key_values(
             {
                 self.limit_key: (200, None),
@@ -117,7 +117,7 @@ class TestRedisRateLimitProviderSetKeyValues(TestCase):
         assert client.get(self.usage_key) == "15"
         assert 0 < client.ttl(self.usage_key) <= 60
 
-    def test_overwrites_existing_value(self):
+    def test_overwrites_existing_value(self) -> None:
         _client().set(self.limit_key, 100)
         self.provider.set_key_values({self.limit_key: (999, None)})
         assert _client().get(self.limit_key) == "999"

--- a/tests/sentry/scm/integration/test_scm_actions_integration.py
+++ b/tests/sentry/scm/integration/test_scm_actions_integration.py
@@ -62,7 +62,7 @@ class TestMakeFromRepositoryId(TestCase):
 
         assert scm.referrer == "emerge"
 
-    def test_raises_repository_not_found_for_nonexistent_id(self):
+    def test_raises_repository_not_found_for_nonexistent_id(self) -> None:
         with pytest.raises(SCMCodedError) as exc_info:
             SourceCodeManager.make_from_repository_id(
                 self.organization.id,
@@ -71,7 +71,7 @@ class TestMakeFromRepositoryId(TestCase):
 
         assert exc_info.value.code == "repository_not_found"
 
-    def test_raises_repository_not_found_for_nonexistent_composite_id(self):
+    def test_raises_repository_not_found_for_nonexistent_composite_id(self) -> None:
         with pytest.raises(SCMCodedError) as exc_info:
             SourceCodeManager.make_from_repository_id(
                 self.organization.id,
@@ -80,7 +80,7 @@ class TestMakeFromRepositoryId(TestCase):
 
         assert exc_info.value.code == "repository_not_found"
 
-    def test_raises_repository_inactive(self):
+    def test_raises_repository_inactive(self) -> None:
         self.repo.status = ObjectStatus.DISABLED
         self.repo.save()
 
@@ -92,7 +92,7 @@ class TestMakeFromRepositoryId(TestCase):
 
         assert exc_info.value.code == "repository_inactive"
 
-    def test_raises_repository_not_found_for_wrong_organization(self):
+    def test_raises_repository_not_found_for_wrong_organization(self) -> None:
         other_org = self.create_organization()
 
         with pytest.raises(SCMCodedError) as exc_info:
@@ -103,7 +103,7 @@ class TestMakeFromRepositoryId(TestCase):
 
         assert exc_info.value.code == "repository_not_found"
 
-    def test_raises_integration_not_found_when_no_integration_exists(self):
+    def test_raises_integration_not_found_when_no_integration_exists(self) -> None:
         repo = self.create_repo(
             name="test-org/orphan-repo",
             provider="integrations:github",

--- a/tests/sentry/scm/unit/private/test_ipc.py
+++ b/tests/sentry/scm/unit/private/test_ipc.py
@@ -35,7 +35,7 @@ from sentry.scm.types import (
 )
 
 
-def test_exec_listener():
+def test_exec_listener() -> None:
     """
     Test successful execution of a listener.
     """
@@ -49,7 +49,7 @@ def test_exec_listener():
     assert count == 0, "Listener could not be executed or failed"
 
 
-def test_exec_listener_missing_listener():
+def test_exec_listener_missing_listener() -> None:
     """
     Assert the developers listener was removed prior to channel drain.
     """
@@ -66,7 +66,7 @@ def test_exec_listener_missing_listener():
     assert tags == {"reason": "not-found", "fn": "name"}
 
 
-def test_exec_listener_failed():
+def test_exec_listener_failed() -> None:
     """
     Assert the developers listener failed.
     """
@@ -87,7 +87,7 @@ def test_exec_listener_failed():
         assert tags == {"reason": "internal", "fn": "name"}
 
 
-def test_run_check_run_listener():
+def test_run_check_run_listener() -> None:
     event = None
 
     scm = SourceCodeManagerEventStream()
@@ -117,7 +117,7 @@ def test_run_check_run_listener():
     assert isinstance(event, CheckRunEvent), "Parsing from type hint failed."
 
 
-def test_run_comment_listener():
+def test_run_comment_listener() -> None:
     """
     Test that comment events are properly deserialized and routed to comment listeners.
     """
@@ -160,7 +160,7 @@ def test_run_comment_listener():
     assert event.comment["author"]["username"] == "testuser"
 
 
-def test_run_pull_request_listener():
+def test_run_pull_request_listener() -> None:
     """
     Test that pull request events are properly deserialized and routed to PR listeners.
     """
@@ -206,7 +206,7 @@ def test_run_pull_request_listener():
     assert event.pull_request["base"]["ref"] == "main"
 
 
-def test_run_listener_metrics_recorded():
+def test_run_listener_metrics_recorded() -> None:
     """
     Test that success metrics and timing metrics are properly recorded.
     """
@@ -260,7 +260,7 @@ def test_run_listener_metrics_recorded():
     assert any(key == "sentry.scm.run_listener.real_time" for key, _, _ in timers)
 
 
-def test_run_listener_not_found():
+def test_run_listener_not_found() -> None:
     """
     Test that calling a non-existent listener doesn't raise an exception.
     """
@@ -294,7 +294,7 @@ def test_run_listener_not_found():
     ) in metrics
 
 
-def test_run_listener_exception_propagates():
+def test_run_listener_exception_propagates() -> None:
     """
     Test that exceptions from listeners are properly propagated and metrics recorded.
     """
@@ -334,7 +334,7 @@ def test_run_listener_exception_propagates():
     ) in metrics
 
 
-def test_run_listener_malformed_input():
+def test_run_listener_malformed_input() -> None:
     metrics = []
 
     def record_count(a, b, c):
@@ -354,7 +354,7 @@ def test_run_listener_malformed_input():
     assert metrics == [("sentry.scm.run_listener.failed", 1, {"reason": "parse", "fn": "t"})]
 
 
-def test_serialize_deserialize_check_run_event():
+def test_serialize_deserialize_check_run_event() -> None:
     """
     Test round-trip serialization and deserialization of check run events.
     """
@@ -386,7 +386,7 @@ def test_serialize_deserialize_check_run_event():
     assert deserialized.subscription_event["sentry_meta"] == event.subscription_event["sentry_meta"]
 
 
-def test_serialize_deserialize_comment_event():
+def test_serialize_deserialize_comment_event() -> None:
     """
     Test round-trip serialization and deserialization of comment events.
     """
@@ -421,7 +421,7 @@ def test_serialize_deserialize_comment_event():
     assert deserialized.comment["author"]["username"] == event.comment["author"]["username"]
 
 
-def test_serialize_deserialize_comment_event_no_author():
+def test_serialize_deserialize_comment_event_no_author() -> None:
     """
     Test serialization/deserialization of comment events with null author.
     """
@@ -450,7 +450,7 @@ def test_serialize_deserialize_comment_event_no_author():
     assert deserialized.comment["body"] is None
 
 
-def test_serialize_deserialize_pull_request_event():
+def test_serialize_deserialize_pull_request_event() -> None:
     """
     Test round-trip serialization and deserialization of pull request events.
     """
@@ -487,7 +487,7 @@ def test_serialize_deserialize_pull_request_event():
     assert deserialized.pull_request["is_private_repo"] is True
 
 
-def test_serialize_deserialize_pull_request_event_no_author():
+def test_serialize_deserialize_pull_request_event_no_author() -> None:
     """
     Test serialization/deserialization of PR events with null author and description.
     """
@@ -519,7 +519,7 @@ def test_serialize_deserialize_pull_request_event_no_author():
     assert deserialized.pull_request["description"] is None
 
 
-def test_serialize_event_dispatches_correctly():
+def test_serialize_event_dispatches_correctly() -> None:
     """
     Test that serialize_event dispatches to the correct serializer based on event type.
     """
@@ -585,7 +585,7 @@ def test_serialize_event_dispatches_correctly():
     assert isinstance(deserialize_pull_request_event(pr_bytes), PullRequestEvent)
 
 
-def test_deserialize_event_dispatches_correctly():
+def test_deserialize_event_dispatches_correctly() -> None:
     """
     Test that deserialize_event dispatches to the correct deserializer based on type hint.
     """
@@ -624,7 +624,7 @@ def test_deserialize_event_dispatches_correctly():
     assert isinstance(deserialize_event(pr_bytes, "pull_request"), PullRequestEvent)
 
 
-def test_produce_to_listeners_check_run():
+def test_produce_to_listeners_check_run() -> None:
     """
     Test that produce_to_listeners correctly routes check run events to registered listeners.
     """
@@ -669,7 +669,7 @@ def test_produce_to_listeners_check_run():
         assert listener_names == {"listener_one", "listener_two"}
 
 
-def test_produce_to_listeners_comment():
+def test_produce_to_listeners_comment() -> None:
     """
     Test that produce_to_listeners correctly routes comment events to registered listeners.
     """
@@ -709,7 +709,7 @@ def test_produce_to_listeners_comment():
         assert produced_messages[0][3] == "region"
 
 
-def test_produce_to_listeners_pull_request():
+def test_produce_to_listeners_pull_request() -> None:
     """
     Test that produce_to_listeners correctly routes PR events to registered listeners.
     """
@@ -756,7 +756,7 @@ def test_produce_to_listeners_pull_request():
         assert produced_messages[0][3] == "control"
 
 
-def test_produce_to_listeners_returns_none_for_unsupported_events():
+def test_produce_to_listeners_returns_none_for_unsupported_events() -> None:
     """
     Test that produce_to_listeners returns None when deserialize_raw_event returns None.
     """

--- a/tests/sentry/scm/unit/private/test_rate_limit.py
+++ b/tests/sentry/scm/unit/private/test_rate_limit.py
@@ -48,7 +48,7 @@ def make_limiter(
 
 
 class TestIsRateLimited:
-    def test_allocated_referrer_with_excess_quota(self):
+    def test_allocated_referrer_with_excess_quota(self) -> None:
         """Referrer with remaining quota is not rate limited."""
         limiter, _ = make_limiter(
             get_and_set_return=(100, 10),
@@ -56,7 +56,7 @@ class TestIsRateLimited:
         )
         assert limiter.is_rate_limited("my_referrer") is False
 
-    def test_allocated_referrer_exhausted_quota(self):
+    def test_allocated_referrer_exhausted_quota(self) -> None:
         """Referrer at quota limit is rate limited."""
         limiter, _ = make_limiter(
             get_and_set_return=(10, 10),
@@ -64,23 +64,23 @@ class TestIsRateLimited:
         )
         assert limiter.is_rate_limited("my_referrer") is True
 
-    def test_shared_referrer_with_excess_quota(self):
+    def test_shared_referrer_with_excess_quota(self) -> None:
         """Shared referrer with remaining quota is not rate limited."""
         limiter, _ = make_limiter(get_and_set_return=(100, 10))
         assert limiter.is_rate_limited("shared") is False
 
-    def test_shared_referrer_exhausted_quota(self):
+    def test_shared_referrer_exhausted_quota(self) -> None:
         """Shared referrer at quota limit is rate limited."""
         limiter, _ = make_limiter(get_and_set_return=(10, 10))
         assert limiter.is_rate_limited("shared") is True
 
-    def test_unregistered_referrer_raises(self):
+    def test_unregistered_referrer_raises(self) -> None:
         """A referrer not in the allocation pool must not be passed."""
         limiter, _ = make_limiter(get_and_set_return=(10, 10))
         with pytest.raises(AssertionError):
             limiter.is_rate_limited("other")
 
-    def test_fails_open_when_limit_not_set(self):
+    def test_fails_open_when_limit_not_set(self) -> None:
         """Rate limit fails open if no limit is cached."""
         limiter, _ = make_limiter(
             get_and_set_return=(None, 100_000_000),
@@ -88,13 +88,13 @@ class TestIsRateLimited:
         )
         assert limiter.is_rate_limited("my_referrer") is False
 
-    def test_caches_recorded_capacity_after_check(self):
+    def test_caches_recorded_capacity_after_check(self) -> None:
         """is_rate_limited stores the service capacity on the instance."""
         limiter, _ = make_limiter(get_and_set_return=(500, 1))
         limiter.is_rate_limited("shared")
         assert limiter.recorded_capacity == 500
 
-    def test_fully_reserved_quota(self):
+    def test_fully_reserved_quota(self) -> None:
         """Assert fully allocated referrer pool exhausts shared referrer by default."""
         limiter, _ = make_limiter(
             get_and_set_return=(100, 10),
@@ -104,7 +104,7 @@ class TestIsRateLimited:
 
 
 class TestUpdateRateLimitMeta:
-    def test_updates_limit_and_shared_usage(self):
+    def test_updates_limit_and_shared_usage(self) -> None:
         """Limit and shared usage are written when provider reports new values."""
         limiter, provider = make_limiter(
             accounted_usage=40,
@@ -124,7 +124,7 @@ class TestUpdateRateLimitMeta:
             usage_count_key("github", 1, 0, "shared"): (10, 3527),
         }, provider.set_kvs
 
-    def test_accounted_keys_include_all_allocated_referrers(self):
+    def test_accounted_keys_include_all_allocated_referrers(self) -> None:
         """get_accounted_usage is called with all allocated referrer keys."""
         limiter, provider = make_limiter(
             accounted_usage=40,
@@ -142,14 +142,14 @@ class TestUpdateRateLimitMeta:
             usage_count_key("github", 1, 0, "shared"): (10, 3527),
         }, provider.set_kvs
 
-    def test_shared_usage_floored_at_zero(self):
+    def test_shared_usage_floored_at_zero(self) -> None:
         """Shared usage is never negative when accounted exceeds reported."""
         limiter, provider = make_limiter(accounted_usage=100, recorded_capacity=100)
         limiter.update_rate_limit_meta(capacity=110, consumed=50, next_window_start=3601)
 
         assert provider.set_kvs[usage_count_key("github", 1, 0, "shared")] == (0, 3527)
 
-    def test_window_miss_skips_shared_usage_update(self):
+    def test_window_miss_skips_shared_usage_update(self) -> None:
         """Shared usage is not written when provider window does not match."""
         limiter, provider = make_limiter(recorded_capacity=100)
         limiter.update_rate_limit_meta(capacity=110, consumed=50, next_window_start=0)
@@ -157,7 +157,7 @@ class TestUpdateRateLimitMeta:
         # Only the new capacity value was written.
         assert provider.set_kvs == {total_limit_key("github", 1): (110, None)}
 
-    def test_matching_limits_skips_total_key_write(self):
+    def test_matching_limits_skips_total_key_write(self) -> None:
         """Capacity key is not written when recorded and specified capacities match."""
         limiter, provider = make_limiter(recorded_capacity=110, accounted_usage=0)
         limiter.update_rate_limit_meta(capacity=110, consumed=50, next_window_start=3601)
@@ -165,7 +165,7 @@ class TestUpdateRateLimitMeta:
         # Service limit not overwritten.
         assert provider.set_kvs == {usage_count_key("github", 1, 0, "shared"): (50, 3527)}
 
-    def test_matching_limits_and_window_miss_writes_nothing(self):
+    def test_matching_limits_and_window_miss_writes_nothing(self) -> None:
         """No writes when capacities match and windows differ."""
         limiter, provider = make_limiter(accounted_usage=50, recorded_capacity=110)
         limiter.update_rate_limit_meta(capacity=110, consumed=50, next_window_start=0)

--- a/tests/sentry/scm/unit/test_github_provider.py
+++ b/tests/sentry/scm/unit/test_github_provider.py
@@ -994,7 +994,7 @@ def _make_api_client() -> GitHubProviderApiClient:
 
 
 class TestGitHubProviderApiClientGraphql:
-    def test_returns_data_on_success(self):
+    def test_returns_data_on_success(self) -> None:
         api_client = _make_api_client()
         api_client.post = MagicMock(  # type: ignore[method-assign]
             return_value=FakeResponse({"data": {"viewer": {"login": "octocat"}}})
@@ -1007,7 +1007,7 @@ class TestGitHubProviderApiClientGraphql:
             "/graphql", data={"query": "{ viewer { login } }"}, headers={}
         )
 
-    def test_includes_variables_when_provided(self):
+    def test_includes_variables_when_provided(self) -> None:
         api_client = _make_api_client()
         api_client.post = MagicMock(  # type: ignore[method-assign]
             return_value=FakeResponse({"data": {"node": {"id": "123"}}})
@@ -1022,7 +1022,7 @@ class TestGitHubProviderApiClientGraphql:
         )
         assert call_data["variables"] == {"id": "123"}
 
-    def test_excludes_variables_when_empty(self):
+    def test_excludes_variables_when_empty(self) -> None:
         api_client = _make_api_client()
         api_client.post = MagicMock(  # type: ignore[method-assign]
             return_value=FakeResponse({"data": {}})
@@ -1037,7 +1037,7 @@ class TestGitHubProviderApiClientGraphql:
         )
         assert "variables" not in call_data
 
-    def test_raises_on_non_dict_response(self):
+    def test_raises_on_non_dict_response(self) -> None:
         api_client = _make_api_client()
         api_client.post = MagicMock(  # type: ignore[method-assign]
             return_value=FakeResponse([{"unexpected": "list"}])
@@ -1046,7 +1046,7 @@ class TestGitHubProviderApiClientGraphql:
         with pytest.raises(SCMProviderException, match="not in expected format"):
             api_client.graphql("{ viewer { login } }", {})
 
-    def test_raises_on_response_missing_data_and_errors(self):
+    def test_raises_on_response_missing_data_and_errors(self) -> None:
         api_client = _make_api_client()
         api_client.post = MagicMock(  # type: ignore[method-assign]
             return_value=FakeResponse({"something": "else"})
@@ -1055,7 +1055,7 @@ class TestGitHubProviderApiClientGraphql:
         with pytest.raises(SCMProviderException, match="not in expected format"):
             api_client.graphql("{ viewer { login } }", {})
 
-    def test_raises_on_errors_without_data(self):
+    def test_raises_on_errors_without_data(self) -> None:
         api_client = _make_api_client()
         api_client.post = MagicMock(  # type: ignore[method-assign]
             return_value=FakeResponse(
@@ -1066,7 +1066,7 @@ class TestGitHubProviderApiClientGraphql:
         with pytest.raises(SCMProviderException, match="Field not found\nUnauthorized"):
             api_client.graphql("{ viewer { login } }", {})
 
-    def test_returns_data_on_partial_success_with_errors(self):
+    def test_returns_data_on_partial_success_with_errors(self) -> None:
         api_client = _make_api_client()
         api_client.post = MagicMock(  # type: ignore[method-assign]
             return_value=FakeResponse(
@@ -1081,7 +1081,7 @@ class TestGitHubProviderApiClientGraphql:
 
         assert result == {"viewer": {"login": "octocat"}}
 
-    def test_returns_empty_dict_when_data_key_missing_but_errors_empty(self):
+    def test_returns_empty_dict_when_data_key_missing_but_errors_empty(self) -> None:
         api_client = _make_api_client()
         api_client.post = MagicMock(  # type: ignore[method-assign]
             return_value=FakeResponse({"errors": []})

--- a/tests/sentry/scm/unit/test_helpers.py
+++ b/tests/sentry/scm/unit/test_helpers.py
@@ -2,7 +2,7 @@ from sentry.scm.private.helpers import exec_provider_fn
 from tests.sentry.scm.test_fixtures import BaseTestProvider
 
 
-def test_exec_provider_fn():
+def test_exec_provider_fn() -> None:
     metrics = []
 
     def record_count(k, a, t):

--- a/tests/sentry/scm/unit/test_scm_actions.py
+++ b/tests/sentry/scm/unit/test_scm_actions.py
@@ -197,7 +197,7 @@ def test_rate_limited_action(action: Callable[..., Any], kwargs: dict[str, Any])
         action(scm, **kwargs)
 
 
-def test_scm_is_instance_of_scm():
+def test_scm_is_instance_of_scm() -> None:
     # This weird test is justified by the creation of the dynamic Facade subclass in SourceCodeManager.__new__.
     # In a previous version, it was returning a subclass of Facade, but not of SourceCodeManager.
     provider = BaseTestProvider()
@@ -206,7 +206,7 @@ def test_scm_is_instance_of_scm():
     assert scm.provider is provider
 
 
-def test_repository_not_found():
+def test_repository_not_found() -> None:
     with raises_with_code(SCMCodedError, "repository_not_found"):
         SourceCodeManager.make_from_repository_id(
             organization_id=1,
@@ -215,7 +215,7 @@ def test_repository_not_found():
         )
 
 
-def test_repository_inactive():
+def test_repository_inactive() -> None:
     with raises_with_code(SCMCodedError, "repository_inactive"):
         SourceCodeManager.make_from_repository_id(
             organization_id=1,
@@ -230,7 +230,7 @@ def test_repository_inactive():
         )
 
 
-def test_repository_organization_mismatch():
+def test_repository_organization_mismatch() -> None:
     with raises_with_code(SCMCodedError, "repository_organization_mismatch"):
         SourceCodeManager.make_from_repository_id(
             organization_id=2,
@@ -677,7 +677,7 @@ def test_action_success(method, kwargs: dict[str, Any], check):
     ]
 
 
-def test_provider_exception_is_not_wrapped():
+def test_provider_exception_is_not_wrapped() -> None:
     """SCMProviderException should pass through exec_provider_fn, not be wrapped as SCMUnhandledException."""
 
     class FailingProvider(BaseTestProvider):
@@ -721,7 +721,7 @@ def test_exec_raises_provider_not_supported_for_all_actions(
         action(scm, **kwargs)
 
 
-def test_exec_wraps_unhandled_exception():
+def test_exec_wraps_unhandled_exception() -> None:
     """Non-SCM exceptions raised by the provider are wrapped as SCMUnhandledException."""
 
     class ExplodingProvider(BaseTestProvider):
@@ -735,7 +735,7 @@ def test_exec_wraps_unhandled_exception():
         scm.get_branch(branch="main")
 
 
-def test_exec_records_failure_metric_on_unhandled_exception():
+def test_exec_records_failure_metric_on_unhandled_exception() -> None:
     """record_count is called with the failure metric when a non-SCM exception occurs."""
     metrics: list[tuple[str, int, dict[str, str]]] = []
 
@@ -757,7 +757,7 @@ def test_exec_records_failure_metric_on_unhandled_exception():
     ]
 
 
-def test_exec_passes_custom_referrer():
+def test_exec_passes_custom_referrer() -> None:
     """The referrer set on SourceCodeManager is forwarded through _exec to exec_provider_fn."""
     metrics: list[tuple[str, int, dict[str, str]]] = []
 
@@ -775,7 +775,7 @@ def test_exec_passes_custom_referrer():
     ]
 
 
-def test_exec_passes_custom_record_count():
+def test_exec_passes_custom_record_count() -> None:
     """A custom record_count callable provided at construction is used by _exec."""
     calls: list[tuple[str, int, dict[str, str]]] = []
 
@@ -795,7 +795,7 @@ def test_exec_passes_custom_record_count():
     assert calls[1] == ("sentry.scm.actions.success_by_referrer", 1, {"referrer": "shared"})
 
 
-def test_get_capabilities():
+def test_get_capabilities() -> None:
     assert list(get_capabilities(SourceCodeManager(BaseTestProvider()))) == [
         "CompareCommitsProtocol",
         "CreateBranchProtocol",

--- a/tests/sentry/scm/unit/test_stream.py
+++ b/tests/sentry/scm/unit/test_stream.py
@@ -1,7 +1,7 @@
 from sentry.scm.private.event_stream import SourceCodeManagerEventStream
 
 
-def test_listener_registration():
+def test_listener_registration() -> None:
     scm = SourceCodeManagerEventStream()
 
     @scm.listen_for("check_run")

--- a/tests/sentry/scm/unit/test_stream_producer.py
+++ b/tests/sentry/scm/unit/test_stream_producer.py
@@ -5,7 +5,7 @@ from sentry.scm.private.stream_producer import produce_event_to_scm_stream
 from sentry.scm.types import SubscriptionEvent
 
 
-def test_produce_to_scm_stream():
+def test_produce_to_scm_stream() -> None:
     metrics = []
 
     def record_count(k, a, t):
@@ -29,7 +29,7 @@ def test_produce_to_scm_stream():
     assert metrics == [("sentry.scm.produce_event_to_scm_stream.success", 1, {})]
 
 
-def test_produce_to_scm_stream_unsupported_provider():
+def test_produce_to_scm_stream_unsupported_provider() -> None:
     metrics = []
 
     def record_count(k, a, t):
@@ -59,7 +59,7 @@ def test_produce_to_scm_stream_unsupported_provider():
     ]
 
 
-def test_produce_to_scm_stream_invalid_payload():
+def test_produce_to_scm_stream_invalid_payload() -> None:
     metrics = []
     reported_exception = None
 
@@ -92,7 +92,7 @@ def test_produce_to_scm_stream_invalid_payload():
     ]
 
 
-def test_produce_to_scm_stream_rollout_disabled():
+def test_produce_to_scm_stream_rollout_disabled() -> None:
     metrics = []
     reported_exception = None
 

--- a/tests/sentry/search/test_detector_filter.py
+++ b/tests/sentry/search/test_detector_filter.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import TestCase
 
 
 class DetectorFilterTest(TestCase):
-    def test_detector_filter_with_invalid_values(self):
+    def test_detector_filter_with_invalid_values(self) -> None:
         """Test that non-numeric detector IDs are gracefully handled"""
         # Empty string should return empty Q
         with pytest.raises(InvalidSearchQuery):
@@ -20,7 +20,7 @@ class DetectorFilterTest(TestCase):
         with pytest.raises(InvalidSearchQuery):
             _make_detector_filter(["https://example.com/detector/123"])
 
-    def test_detector_filter_with_valid_values(self):
+    def test_detector_filter_with_valid_values(self) -> None:
         """Test that numeric detector IDs work correctly"""
         # Valid numeric string
         result = _make_detector_filter(["123"])
@@ -35,7 +35,7 @@ class DetectorFilterTest(TestCase):
         result = _make_detector_filter(["*"])
         assert "id__in" in str(result)
 
-    def test_detector_filter_with_mixed_values(self):
+    def test_detector_filter_with_mixed_values(self) -> None:
         """Test mix of valid and invalid detector IDs"""
         # Mix of valid and invalid - should raise exception
         with pytest.raises(InvalidSearchQuery):

--- a/tests/sentry/seer/assisted_query/test_discover_tools.py
+++ b/tests/sentry/seer/assisted_query/test_discover_tools.py
@@ -9,11 +9,11 @@ from sentry.testutils.helpers.datetime import before_now
 
 
 class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
 
-    def test_get_event_filter_keys_with_feature_flags(self):
+    def test_get_event_filter_keys_with_feature_flags(self) -> None:
         """Test that get_event_filter_keys returns tags, feature flags, and static fields"""
         # Create an error event with custom tags
         self.store_event(
@@ -66,7 +66,7 @@ class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
             expected_type = _SPECIAL_FIELD_VALUE_TYPES.get(k, "tag")
             assert result[k]["type"] == expected_type
 
-    def test_get_event_filter_keys_exclude_feature_flags(self):
+    def test_get_event_filter_keys_exclude_feature_flags(self) -> None:
         """Test that get_event_filter_keys excludes feature flags when include_feature_flags is False"""
         # Create an error event with custom tags
         self.store_event(
@@ -118,7 +118,7 @@ class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
             expected_type = _SPECIAL_FIELD_VALUE_TYPES.get(k, "tag")
             assert result[k]["type"] == expected_type
 
-    def test_get_event_filter_keys_multiple_projects(self):
+    def test_get_event_filter_keys_multiple_projects(self) -> None:
         """Test with multiple projects"""
         project2 = self.create_project(organization=self.organization)
 
@@ -155,11 +155,11 @@ class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
 
 
 class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
 
-    def test_get_event_filter_key_values_tag_key(self):
+    def test_get_event_filter_key_values_tag_key(self) -> None:
         """Test getting values for a tag key"""
         # Create events with the same tag key but different values
         self.store_event(
@@ -214,7 +214,7 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
         assert value_counts["production"] == 2
         assert value_counts["staging"] == 1
 
-    def test_get_event_filter_key_values_feature_flag(self):
+    def test_get_event_filter_key_values_feature_flag(self) -> None:
         """Test getting values for a feature flag"""
         # Create events with feature flags
         self.store_event(
@@ -265,7 +265,7 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
         assert "true" in values
         assert "false" in values
 
-    def test_get_event_filter_key_values_has_key(self):
+    def test_get_event_filter_key_values_has_key(self) -> None:
         """Test that 'has' key returns all available tag keys"""
         # Create event with custom tag
         self.store_event(
@@ -291,7 +291,7 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
         assert "custom_tag" in values
         assert "custom2" in values
 
-    def test_get_event_filter_key_values_aggregate_function_returns_empty(self):
+    def test_get_event_filter_key_values_aggregate_function_returns_empty(self) -> None:
         """Test that aggregate functions return empty list"""
         result = get_event_filter_key_values(
             org_id=self.organization.id,
@@ -302,7 +302,7 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
 
         assert result == []
 
-    def test_get_event_filter_key_values_with_substring_filter(self):
+    def test_get_event_filter_key_values_with_substring_filter(self) -> None:
         """Test substring filtering of filter key values"""
         # Create events with different environment values
         self.store_event(
@@ -358,7 +358,7 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
         assert "staging" not in values
         assert "development" not in values
 
-    def test_get_event_filter_key_values_nonexistent_tag(self):
+    def test_get_event_filter_key_values_nonexistent_tag(self) -> None:
         """Test that nonexistent filter key returns empty list"""
         result = get_event_filter_key_values(
             org_id=self.organization.id,
@@ -369,7 +369,7 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
         # Should return empty list, not None
         assert result == []
 
-    def test_get_event_filter_key_values_multiple_projects(self):
+    def test_get_event_filter_key_values_multiple_projects(self) -> None:
         """Test getting filter key values across multiple projects"""
         project2 = self.create_project(organization=self.organization)
 
@@ -409,7 +409,7 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             assert "us-east" in values
             assert "us-west" in values
 
-    def test_get_event_filter_key_values_different_stats_periods(self):
+    def test_get_event_filter_key_values_different_stats_periods(self) -> None:
         """Test that different stats periods affect results"""
         # Create an event 2 days ago
         two_days_ago = before_now(days=2)

--- a/tests/sentry/seer/assisted_query/test_issues_tools.py
+++ b/tests/sentry/seer/assisted_query/test_issues_tools.py
@@ -20,11 +20,11 @@ from tests.sentry.issues.test_utils import OccurrenceTestMixin
 class TestGetIssueFilterKeys(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     databases = {"default", "control"}
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
 
-    def test_get_issue_filter_keys_success(self):
+    def test_get_issue_filter_keys_success(self) -> None:
         """Test that get_issue_filter_keys returns tags and feature flags"""
         # Create an error event with custom tags
         self.store_event(
@@ -103,7 +103,7 @@ class TestGetIssueFilterKeys(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             assert "feature_a" in flag_keys
             assert "feature_b" in flag_keys
 
-    def test_get_issue_filter_keys_nonexistent_organization(self):
+    def test_get_issue_filter_keys_nonexistent_organization(self) -> None:
         """Test that nonexistent organization returns None"""
         result = get_issue_filter_keys(
             org_id=99999,
@@ -112,7 +112,7 @@ class TestGetIssueFilterKeys(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         )
         assert result is None
 
-    def test_get_issue_filter_keys_empty_projects(self):
+    def test_get_issue_filter_keys_empty_projects(self) -> None:
         """Test with empty project list"""
         result = get_issue_filter_keys(
             org_id=self.organization.id,
@@ -126,7 +126,7 @@ class TestGetIssueFilterKeys(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert isinstance(result["tags"], list)
         assert isinstance(result["feature_flags"], list)
 
-    def test_get_issue_filter_keys_multiple_projects(self):
+    def test_get_issue_filter_keys_multiple_projects(self) -> None:
         """Test with multiple projects"""
         project2 = self.create_project(organization=self.organization)
 
@@ -169,11 +169,11 @@ class TestGetIssueFilterKeys(APITestCase, SnubaTestCase, OccurrenceTestMixin):
 class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     databases = {"default", "control"}
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
 
-    def test_get_filter_key_values_events_dataset(self):
+    def test_get_filter_key_values_events_dataset(self) -> None:
         """Test getting values for a filter key in the events dataset"""
         # Create events with the same tag key but different values
         self.store_event(
@@ -231,7 +231,7 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert value_counts["production"] == 2
         assert value_counts["staging"] == 1
 
-    def test_get_filter_key_values_search_issues_dataset(self):
+    def test_get_filter_key_values_search_issues_dataset(self) -> None:
         """Test getting values for a filter key in the search_issues dataset (automatically detected)"""
         # Create issue platform events with tags
         self.process_occurrence(
@@ -273,7 +273,7 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
                 assert "value" in item
                 assert "count" in item
 
-    def test_get_filter_key_values_with_flags_backend(self):
+    def test_get_filter_key_values_with_flags_backend(self) -> None:
         """Test getting feature flag values (automatically detected by 'feature.' prefix)"""
         # Create events with feature flags
         self.store_event(
@@ -320,7 +320,7 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
                 assert "value" in item
                 assert "count" in item
 
-    def test_get_filter_key_values_nonexistent_organization(self):
+    def test_get_filter_key_values_nonexistent_organization(self) -> None:
         """Test that nonexistent organization returns None"""
         result = get_filter_key_values(
             org_id=99999,
@@ -330,7 +330,7 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         )
         assert result is None
 
-    def test_get_filter_key_values_nonexistent_attribute(self):
+    def test_get_filter_key_values_nonexistent_attribute(self) -> None:
         """Test that nonexistent filter key returns empty list"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -341,7 +341,7 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         # Should return empty list, not None
         assert result == []
 
-    def test_get_filter_key_values_multiple_projects(self):
+    def test_get_filter_key_values_multiple_projects(self) -> None:
         """Test getting filter key values across multiple projects"""
         project2 = self.create_project(organization=self.organization)
 
@@ -379,7 +379,7 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert "us-east" in values
         assert "us-west" in values
 
-    def test_get_filter_key_values_merges_across_datasets(self):
+    def test_get_filter_key_values_merges_across_datasets(self) -> None:
         """Test that values from multiple datasets are merged correctly"""
         # Create the same tag value in both events and issue platform
         # to test that counts are summed
@@ -449,7 +449,7 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             "Results should be sorted by count descending"
         )
 
-    def test_get_filter_key_values_with_substring_filter(self):
+    def test_get_filter_key_values_with_substring_filter(self) -> None:
         """Test substring filtering of filter key values"""
         # Create events with different environment values
         self.store_event(
@@ -510,11 +510,11 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
 class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
     databases = {"default", "control"}
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
 
-    def test_execute_issues_query_basic(self):
+    def test_execute_issues_query_basic(self) -> None:
         """Test basic issues query"""
         # Create some issues
         self.store_event(
@@ -557,7 +557,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
             assert "status" in issue
             assert "project" in issue
 
-    def test_execute_issues_query_with_filter(self):
+    def test_execute_issues_query_with_filter(self) -> None:
         """Test issues query with specific filter"""
         # Create an error event
         self.store_event(
@@ -582,7 +582,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         # Should have at least our error event
         assert len(result) >= 1
 
-    def test_execute_issues_query_with_sort(self):
+    def test_execute_issues_query_with_sort(self) -> None:
         """Test issues query with sorting"""
         # Create multiple issues
         for i in range(3):
@@ -608,7 +608,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         assert isinstance(result, list)
         assert len(result) >= 3
 
-    def test_execute_issues_query_with_limit(self):
+    def test_execute_issues_query_with_limit(self) -> None:
         """Test issues query with limit"""
         # Create multiple issues
         for i in range(5):
@@ -634,7 +634,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         # Should respect limit
         assert len(result) <= 2
 
-    def test_execute_issues_query_nonexistent_organization(self):
+    def test_execute_issues_query_nonexistent_organization(self) -> None:
         """Test that nonexistent organization returns None"""
         result = execute_issues_query(
             org_id=99999,
@@ -644,7 +644,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
         assert result is None
 
-    def test_execute_issues_query_multiple_projects(self):
+    def test_execute_issues_query_multiple_projects(self) -> None:
         """Test issues query across multiple projects"""
         project2 = self.create_project(organization=self.organization)
 
@@ -686,11 +686,11 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
 class TestGetIssuesStats(APITestCase, SnubaTestCase):
     databases = {"default", "control"}
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
 
-    def test_get_issues_stats_success(self):
+    def test_get_issues_stats_success(self) -> None:
         """Test that get_issues_stats returns stats for issues"""
         # Store two events to create issues
         event1 = self.store_event(
@@ -769,7 +769,7 @@ class TestGetIssuesStats(APITestCase, SnubaTestCase):
                 stat["lifetime"]["lastSeen"], datetime
             )
 
-    def test_get_issues_stats_with_multiple_projects(self):
+    def test_get_issues_stats_with_multiple_projects(self) -> None:
         """Test that get_issues_stats works with multiple project IDs"""
         project2 = self.create_project(organization=self.organization)
 
@@ -808,7 +808,7 @@ class TestGetIssuesStats(APITestCase, SnubaTestCase):
         assert str(event1.group_id) in returned_issue_ids
         assert str(event2.group_id) in returned_issue_ids
 
-    def test_get_issues_stats_nonexistent_org(self):
+    def test_get_issues_stats_nonexistent_org(self) -> None:
         """Test that get_issues_stats returns None for nonexistent org"""
         result = get_issues_stats(
             org_id=999999,
@@ -820,7 +820,7 @@ class TestGetIssuesStats(APITestCase, SnubaTestCase):
 
         assert result is None
 
-    def test_get_issues_stats_empty_issue_ids(self):
+    def test_get_issues_stats_empty_issue_ids(self) -> None:
         """Test that get_issues_stats handles empty issue IDs"""
         result = get_issues_stats(
             org_id=self.organization.id,
@@ -834,7 +834,7 @@ class TestGetIssuesStats(APITestCase, SnubaTestCase):
         assert isinstance(result, list)
         assert len(result) == 0
 
-    def test_get_issues_stats_stats_and_lifetime_structure(self):
+    def test_get_issues_stats_stats_and_lifetime_structure(self) -> None:
         """Test that stats and lifetime fields have the correct structure"""
         # Create an issue
         event = self.store_event(
@@ -913,7 +913,7 @@ class TestGetIssuesStats(APITestCase, SnubaTestCase):
 class TestGetStaticValues(APITestCase):
     """Tests for _get_static_values() function"""
 
-    def test_boolean_field_returns_true_false(self):
+    def test_boolean_field_returns_true_false(self) -> None:
         """Test that boolean fields return true/false values"""
         # Test all boolean fields
         boolean_fields = [
@@ -930,7 +930,7 @@ class TestGetStaticValues(APITestCase):
             values = {item["value"] for item in result}
             assert values == {"true", "false"}
 
-    def test_device_class_returns_enum_values(self):
+    def test_device_class_returns_enum_values(self) -> None:
         """Test that device.class returns high/medium/low values"""
         result = _get_static_values("device.class")
         assert result is not None
@@ -941,7 +941,7 @@ class TestGetStaticValues(APITestCase):
         assert "medium" in values
         assert "low" in values
 
-    def test_datetime_fields_return_empty_list(self):
+    def test_datetime_fields_return_empty_list(self) -> None:
         """Test that datetime fields return empty list (no suggested values)"""
         datetime_fields = [
             "lastSeen",
@@ -954,29 +954,29 @@ class TestGetStaticValues(APITestCase):
             result = _get_static_values(field)
             assert result == []
 
-    def test_uuid_field_returns_empty_list(self):
+    def test_uuid_field_returns_empty_list(self) -> None:
         """Test that uuid field returns empty list"""
         result = _get_static_values("id")
         assert result == []
 
-    def test_issue_short_id_returns_empty_list(self):
+    def test_issue_short_id_returns_empty_list(self) -> None:
         """Test that issue short id field returns empty list"""
         result = _get_static_values("issue")
         assert result == []
 
-    def test_integer_field_returns_empty_list(self):
+    def test_integer_field_returns_empty_list(self) -> None:
         """Test that integer field returns empty list"""
         result = _get_static_values("timesSeen")
         assert result == []
 
-    def test_text_fields_return_none(self):
+    def test_text_fields_return_none(self) -> None:
         """Test that text fields return None (fall through to API query)"""
         text_fields = ["message", "title", "location"]
         for field in text_fields:
             result = _get_static_values(field)
             assert result is None
 
-    def test_unknown_field_returns_none(self):
+    def test_unknown_field_returns_none(self) -> None:
         """Test that unknown fields return None (fall through to API query)"""
         result = _get_static_values("unknown_field")
         assert result is None
@@ -988,7 +988,7 @@ class TestEventContextFields(APITestCase, SnubaTestCase):
 
     databases = {"default", "control"}
 
-    def test_event_context_fields_included_in_built_in_fields(self):
+    def test_event_context_fields_included_in_built_in_fields(self) -> None:
         """Test that event context fields are included in get_issue_filter_keys"""
         result = get_issue_filter_keys(
             org_id=self.organization.id,
@@ -1038,7 +1038,7 @@ class TestEventContextFields(APITestCase, SnubaTestCase):
         for field in expected_event_context_fields:
             assert field in built_in_keys, f"Expected '{field}' to be in built_in_fields"
 
-    def test_event_context_fields_list_completeness(self):
+    def test_event_context_fields_list_completeness(self) -> None:
         """Test that _EVENT_CONTEXT_FIELDS contains expected fields"""
         # Check that the list contains key categories of fields
         assert "device.class" in _EVENT_CONTEXT_FIELDS
@@ -1052,7 +1052,7 @@ class TestEventContextFields(APITestCase, SnubaTestCase):
         assert "os.build" in _EVENT_CONTEXT_FIELDS
         assert "transaction" in _EVENT_CONTEXT_FIELDS
 
-    def test_boolean_event_fields_have_values(self):
+    def test_boolean_event_fields_have_values(self) -> None:
         """Test that boolean event context fields have true/false values in built-in fields"""
         result = get_issue_filter_keys(
             org_id=self.organization.id,
@@ -1077,7 +1077,7 @@ class TestEventContextFields(APITestCase, SnubaTestCase):
         assert error_unhandled_field is not None
         assert error_unhandled_field["values"] == ["true", "false"]
 
-    def test_device_class_field_has_enum_values(self):
+    def test_device_class_field_has_enum_values(self) -> None:
         """Test that device.class field has high/medium/low values in built-in fields"""
         result = get_issue_filter_keys(
             org_id=self.organization.id,
@@ -1100,7 +1100,7 @@ class TestGetFilterKeyValuesStaticFields(APITestCase, SnubaTestCase):
 
     databases = {"default", "control"}
 
-    def test_get_filter_key_values_boolean_field(self):
+    def test_get_filter_key_values_boolean_field(self) -> None:
         """Test that boolean fields return true/false values"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1114,7 +1114,7 @@ class TestGetFilterKeyValuesStaticFields(APITestCase, SnubaTestCase):
         values = {item["value"] for item in result}
         assert values == {"true", "false"}
 
-    def test_get_filter_key_values_device_class(self):
+    def test_get_filter_key_values_device_class(self) -> None:
         """Test that device.class returns enum values"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1128,7 +1128,7 @@ class TestGetFilterKeyValuesStaticFields(APITestCase, SnubaTestCase):
         values = [item["value"] for item in result]
         assert values == DEVICE_CLASS_VALUES
 
-    def test_get_filter_key_values_datetime_field(self):
+    def test_get_filter_key_values_datetime_field(self) -> None:
         """Test that datetime fields return empty list"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1139,7 +1139,7 @@ class TestGetFilterKeyValuesStaticFields(APITestCase, SnubaTestCase):
 
         assert result == []
 
-    def test_get_filter_key_values_uuid_field(self):
+    def test_get_filter_key_values_uuid_field(self) -> None:
         """Test that uuid field returns empty list"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1150,7 +1150,7 @@ class TestGetFilterKeyValuesStaticFields(APITestCase, SnubaTestCase):
 
         assert result == []
 
-    def test_get_filter_key_values_boolean_with_substring_filter(self):
+    def test_get_filter_key_values_boolean_with_substring_filter(self) -> None:
         """Test that substring filtering works on boolean fields"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1171,11 +1171,11 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
 
     databases = {"default", "control"}
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
 
-    def test_get_filter_key_values_message_field(self):
+    def test_get_filter_key_values_message_field(self) -> None:
         """Test that message field queries the API and returns actual event messages"""
         # Store events with different messages
         self.store_event(
@@ -1217,7 +1217,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
         # The API should return values (may be empty if message isn't indexed as a tag)
         # At minimum, verify we got a list back (not None which would indicate built-in handling)
 
-    def test_get_filter_key_values_message_with_substring(self):
+    def test_get_filter_key_values_message_with_substring(self) -> None:
         """Test that message field supports substring filtering via API"""
         # Store events with different messages
         self.store_event(
@@ -1258,7 +1258,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
         assert result is not None
         assert isinstance(result, list)
 
-    def test_get_filter_key_values_title_field(self):
+    def test_get_filter_key_values_title_field(self) -> None:
         """Test that title field queries the API and returns actual event titles"""
         # Store events - title is derived from the event
         self.store_event(
@@ -1290,7 +1290,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
         assert result is not None
         assert isinstance(result, list)
 
-    def test_get_filter_key_values_location_field(self):
+    def test_get_filter_key_values_location_field(self) -> None:
         """Test that location field queries the API"""
         # Store events with stack traces that have locations
         self.store_event(
@@ -1331,7 +1331,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
         assert result is not None
         assert isinstance(result, list)
 
-    def test_text_fields_not_in_field_value_types(self):
+    def test_text_fields_not_in_field_value_types(self) -> None:
         """Verify text fields are not in _FIELD_VALUE_TYPES so they fall through to API query"""
         from sentry.seer.assisted_query.issues_tools import _FIELD_VALUE_TYPES
 
@@ -1340,7 +1340,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
         assert "title" not in _FIELD_VALUE_TYPES
         assert "location" not in _FIELD_VALUE_TYPES
 
-    def test_release_fields_query_api(self):
+    def test_release_fields_query_api(self) -> None:
         """Test that release fields fall through to API query"""
         # Store event with release
         self.store_event(
@@ -1385,7 +1385,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
 
     databases = {"default", "control"}
 
-    def test_get_filter_key_values_assigned_field(self):
+    def test_get_filter_key_values_assigned_field(self) -> None:
         """Test that assigned field returns assignee values including special values and team slugs"""
         # Create a team in the organization
         team = self.create_team(organization=self.organization, slug="backend-team")
@@ -1411,7 +1411,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         # Should include team slug prefixed with #
         assert f"#{team.slug}" in values
 
-    def test_get_filter_key_values_assigned_or_suggested_field(self):
+    def test_get_filter_key_values_assigned_or_suggested_field(self) -> None:
         """Test that assigned_or_suggested field returns same values as assigned"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1429,7 +1429,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         assert "my_teams" in values
         assert "none" in values
 
-    def test_get_filter_key_values_assigned_includes_member_usernames(self):
+    def test_get_filter_key_values_assigned_includes_member_usernames(self) -> None:
         """Test that assigned field includes organization member usernames"""
         # The test user is automatically a member of the organization
         result = get_filter_key_values(
@@ -1446,7 +1446,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         # The test user from APITestCase should be included
         assert len(values) > 3  # More than just special values (me, my_teams, none)
 
-    def test_get_filter_key_values_bookmarks_field(self):
+    def test_get_filter_key_values_bookmarks_field(self) -> None:
         """Test that bookmarks field returns usernames"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1459,7 +1459,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         assert isinstance(result, list)
         # Should have usernames (at least the test user)
 
-    def test_get_filter_key_values_subscribed_field(self):
+    def test_get_filter_key_values_subscribed_field(self) -> None:
         """Test that subscribed field returns usernames"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1471,7 +1471,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         assert result is not None
         assert isinstance(result, list)
 
-    def test_get_filter_key_values_assigned_with_substring_filter(self):
+    def test_get_filter_key_values_assigned_with_substring_filter(self) -> None:
         """Test that substring filtering works on assigned field"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1487,7 +1487,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         for item in result:
             assert "my_" in item["value"].lower()
 
-    def test_get_issue_filter_keys_includes_assignee_values(self):
+    def test_get_issue_filter_keys_includes_assignee_values(self) -> None:
         """Test that get_issue_filter_keys includes assignee values in built_in_fields"""
         # Create a team
         team = self.create_team(organization=self.organization, slug="test-team")
@@ -1528,7 +1528,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         assert subscribed_field is not None
         assert "values" in subscribed_field
 
-    def test_format_username_uuid_username_uses_email(self):
+    def test_format_username_uuid_username_uses_email(self) -> None:
         """Test that users with UUID usernames (32 hex chars) return email instead"""
         # Create a user with a UUID username (SAML users get UUID usernames)
         uuid_username = "01e2eb9a75174388a63daa4afcf782de"  # 32 hex characters
@@ -1556,7 +1556,7 @@ class TestReleaseFieldValues(APITestCase, SnubaTestCase):
 
     databases = {"default", "control"}
 
-    def test_get_filter_key_values_release_field(self):
+    def test_get_filter_key_values_release_field(self) -> None:
         """Test that release field returns actual release versions"""
         # Create releases
         release1 = self.create_release(
@@ -1579,7 +1579,7 @@ class TestReleaseFieldValues(APITestCase, SnubaTestCase):
         assert release1.version in values
         assert release2.version in values
 
-    def test_get_filter_key_values_first_release_field(self):
+    def test_get_filter_key_values_first_release_field(self) -> None:
         """Test that firstRelease field returns actual release versions"""
         # Create releases
         release1 = self.create_release(project=self.project, version="myapp@1.0.0")
@@ -1596,7 +1596,7 @@ class TestReleaseFieldValues(APITestCase, SnubaTestCase):
         values = [item["value"] for item in result]
         assert release1.version in values
 
-    def test_get_filter_key_values_release_stage_field(self):
+    def test_get_filter_key_values_release_stage_field(self) -> None:
         """Test that release.stage field returns static enum values"""
         result = get_filter_key_values(
             org_id=self.organization.id,
@@ -1612,7 +1612,7 @@ class TestReleaseFieldValues(APITestCase, SnubaTestCase):
         assert "low_adoption" in values
         assert "replaced" in values
 
-    def test_get_filter_key_values_release_with_substring(self):
+    def test_get_filter_key_values_release_with_substring(self) -> None:
         """Test that release field supports substring filtering"""
         self.create_release(project=self.project, version="myapp@1.0.0")
         self.create_release(project=self.project, version="myapp@2.0.0")
@@ -1631,7 +1631,7 @@ class TestReleaseFieldValues(APITestCase, SnubaTestCase):
         for item in result:
             assert "myapp" in item["value"]
 
-    def test_get_issue_filter_keys_includes_release_values(self):
+    def test_get_issue_filter_keys_includes_release_values(self) -> None:
         """Test that get_issue_filter_keys includes actual release values"""
         release = self.create_release(project=self.project, version="myapp@3.0.0")
 

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1540,7 +1540,7 @@ class TestPreResolveStacktraceFrames(TestCase):
             ],
         }
 
-    def test_resolves_frames_with_code_mapping(self):
+    def test_resolves_frames_with_code_mapping(self) -> None:
         project = self.create_project()
         repo = self.create_repo(
             name="getsentry/sentry", provider="github", external_id="123", integration_id=234
@@ -1567,7 +1567,7 @@ class TestPreResolveStacktraceFrames(TestCase):
         # Non in-app frames should not be resolved
         assert "repo_name" not in frames[2]
 
-    def test_no_code_mappings_is_noop(self):
+    def test_no_code_mappings_is_noop(self) -> None:
         event = self._make_serialized_event([{"filename": "src/utils.py", "inApp": True}])
 
         _pre_resolve_stacktrace_frames(event, [])
@@ -1575,7 +1575,7 @@ class TestPreResolveStacktraceFrames(TestCase):
         frames = event["entries"][0]["data"]["values"][0]["stacktrace"]["frames"]
         assert "repo_name" not in frames[0]
 
-    def test_unmatched_frames_left_unresolved(self):
+    def test_unmatched_frames_left_unresolved(self) -> None:
         project = self.create_project()
         repo = self.create_repo(
             name="getsentry/sentry", provider="github", external_id="123", integration_id=234
@@ -1597,7 +1597,7 @@ class TestPreResolveStacktraceFrames(TestCase):
         assert frames[0]["repo_name"] == "getsentry/sentry"
         assert "repo_name" not in frames[1]
 
-    def test_multiple_repos(self):
+    def test_multiple_repos(self) -> None:
         project = self.create_project()
         repo1 = self.create_repo(
             name="getsentry/sentry", provider="github", external_id="123", integration_id=234
@@ -1627,7 +1627,7 @@ class TestPreResolveStacktraceFrames(TestCase):
         assert frames[1]["repo_name"] == "getsentry/seer"
         assert frames[1]["filename"] == "src/seer/models.py"
 
-    def test_resolves_thread_frames(self):
+    def test_resolves_thread_frames(self) -> None:
         project = self.create_project()
         repo = self.create_repo(
             name="getsentry/sentry", provider="github", external_id="123", integration_id=234

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -37,7 +37,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
             updated_at="2024-01-01T00:00:00Z",
         )
 
-    def test_basic_prompt_without_artifacts(self):
+    def test_basic_prompt_without_artifacts(self) -> None:
         """Test prompt generation with no artifacts."""
         state = SeerRunState(
             run_id=123,
@@ -52,7 +52,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
         assert "Root Cause" not in prompt
         assert "Solution" not in prompt
 
-    def test_prompt_with_instruction(self):
+    def test_prompt_with_instruction(self) -> None:
         """Test that custom instruction is included in prompt."""
         state = SeerRunState(
             run_id=123,
@@ -65,7 +65,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
 
         assert "Focus on the database layer" in prompt
 
-    def test_prompt_with_root_cause_artifact(self):
+    def test_prompt_with_root_cause_artifact(self) -> None:
         """Test prompt includes root cause details."""
         state = self._make_state_with_artifacts(
             [
@@ -90,7 +90,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
         assert "- Step 1" in prompt
         assert "- Step 2" in prompt
 
-    def test_prompt_with_solution_artifact(self):
+    def test_prompt_with_solution_artifact(self) -> None:
         """Test prompt includes solution details."""
         state = self._make_state_with_artifacts(
             [
@@ -115,7 +115,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
         assert "**Step 1**: Add TTL parameter" in prompt
         assert "**Step 2**: Update cache config" in prompt
 
-    def test_prompt_with_both_artifacts(self):
+    def test_prompt_with_both_artifacts(self) -> None:
         """Test prompt includes both root cause and solution."""
         state = self._make_state_with_artifacts(
             [
@@ -139,7 +139,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
         assert "## Proposed Solution" in prompt
         assert "Fix the handler" in prompt
 
-    def test_prompt_with_short_id(self):
+    def test_prompt_with_short_id(self) -> None:
         """Test that short_id is included in prompt when provided."""
         state = SeerRunState(
             run_id=123,
@@ -152,7 +152,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
 
         assert "Include 'Fixes AIML-2301' in the commit message" in prompt
 
-    def test_prompt_without_short_id(self):
+    def test_prompt_without_short_id(self) -> None:
         """Test that 'Fixes' is not in prompt when short_id is None."""
         state = SeerRunState(
             run_id=123,
@@ -165,7 +165,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
 
         assert "Fixes" not in prompt
 
-    def test_prompt_with_short_id_and_instruction(self):
+    def test_prompt_with_short_id_and_instruction(self) -> None:
         """Test that both short_id and instruction are included."""
         state = SeerRunState(
             run_id=123,
@@ -183,7 +183,7 @@ class TestGenerateAutofixHandoffPrompt(TestCase):
 
 
 class TestBuildStepPrompt(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.group = self.create_group(
             project=self.project,
@@ -192,7 +192,7 @@ class TestBuildStepPrompt(TestCase):
         self.group.culprit = "app.views.handler"
         self.group.save()
 
-    def test_root_cause_prompt_contains_issue_details(self):
+    def test_root_cause_prompt_contains_issue_details(self) -> None:
         prompt = build_step_prompt(AutofixStep.ROOT_CAUSE, self.group)
 
         assert self.group.qualified_short_id in prompt
@@ -201,7 +201,7 @@ class TestBuildStepPrompt(TestCase):
         assert "ROOT CAUSE" in prompt
         assert "root_cause artifact" in prompt
 
-    def test_solution_prompt_contains_issue_details(self):
+    def test_solution_prompt_contains_issue_details(self) -> None:
         prompt = build_step_prompt(AutofixStep.SOLUTION, self.group)
 
         assert self.group.qualified_short_id in prompt
@@ -210,7 +210,7 @@ class TestBuildStepPrompt(TestCase):
         assert "solution" in prompt.lower()
         assert "Do NOT implement" in prompt
 
-    def test_code_changes_prompt_contains_issue_details(self):
+    def test_code_changes_prompt_contains_issue_details(self) -> None:
         prompt = build_step_prompt(AutofixStep.CODE_CHANGES, self.group)
 
         assert self.group.qualified_short_id in prompt
@@ -218,7 +218,7 @@ class TestBuildStepPrompt(TestCase):
         assert "app.views.handler" in prompt
         assert "Implement the fix" in prompt
 
-    def test_impact_assessment_prompt_contains_issue_details(self):
+    def test_impact_assessment_prompt_contains_issue_details(self) -> None:
         prompt = build_step_prompt(AutofixStep.IMPACT_ASSESSMENT, self.group)
 
         assert self.group.qualified_short_id in prompt
@@ -227,7 +227,7 @@ class TestBuildStepPrompt(TestCase):
         assert "impact" in prompt.lower()
         assert "impact_assessment artifact" in prompt
 
-    def test_triage_prompt_contains_issue_details(self):
+    def test_triage_prompt_contains_issue_details(self) -> None:
         prompt = build_step_prompt(AutofixStep.TRIAGE, self.group)
 
         assert self.group.qualified_short_id in prompt
@@ -236,7 +236,7 @@ class TestBuildStepPrompt(TestCase):
         assert "triage" in prompt.lower()
         assert "suspect_commit" in prompt
 
-    def test_prompt_with_missing_culprit_uses_default(self):
+    def test_prompt_with_missing_culprit_uses_default(self) -> None:
         self.group.culprit = None
         self.group.save()
 
@@ -244,7 +244,7 @@ class TestBuildStepPrompt(TestCase):
 
         assert "unknown" in prompt
 
-    def test_all_prompts_are_dedented(self):
+    def test_all_prompts_are_dedented(self) -> None:
         for step in AutofixStep:
             prompt = build_step_prompt(step, self.group)
             # Dedented prompts should not start with whitespace
@@ -253,7 +253,7 @@ class TestBuildStepPrompt(TestCase):
 
 
 class TestTriggerAutofixExplorer(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.group = self.create_group(project=self.project)
 
@@ -358,7 +358,7 @@ class TestTriggerAutofixExplorer(TestCase):
 class TestTriggerCodingAgentHandoff(TestCase):
     """Tests for trigger_coding_agent_handoff function."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.group = self.create_group(project=self.project)
 

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -136,19 +136,19 @@ def impact_assessment_memory_block() -> MemoryBlock:
 class TestAutofixOnCompletionHookHelpers(TestCase):
     """Tests for helper methods in AutofixOnCompletionHook."""
 
-    def test_get_current_step_root_cause(self):
+    def test_get_current_step_root_cause(self) -> None:
         """Returns ROOT_CAUSE when root_cause artifact exists."""
         state = run_state(blocks=[root_cause_memory_block()])
         result = AutofixOnCompletionHook._get_current_step(state)
         assert result == AutofixStep.ROOT_CAUSE
 
-    def test_get_current_step_solution(self):
+    def test_get_current_step_solution(self) -> None:
         """Returns SOLUTION when solution artifact exists."""
         state = run_state(blocks=[root_cause_memory_block(), solution_memory_block()])
         result = AutofixOnCompletionHook._get_current_step(state)
         assert result == AutofixStep.SOLUTION
 
-    def test_get_current_step_code_changes(self):
+    def test_get_current_step_code_changes(self) -> None:
         """Returns CODE_CHANGES when code changes exist."""
         state = run_state(
             blocks=[
@@ -160,28 +160,28 @@ class TestAutofixOnCompletionHookHelpers(TestCase):
         result = AutofixOnCompletionHook._get_current_step(state)
         assert result == AutofixStep.CODE_CHANGES
 
-    def test_get_current_step_none(self):
+    def test_get_current_step_none(self) -> None:
         """Returns None when no artifacts or code changes exist."""
         state = run_state()
         result = AutofixOnCompletionHook._get_current_step(state)
         assert result is None
 
-    def test_get_next_step_root_cause_to_solution(self):
+    def test_get_next_step_root_cause_to_solution(self) -> None:
         """Returns SOLUTION after ROOT_CAUSE."""
         result = AutofixOnCompletionHook._get_next_step(AutofixStep.ROOT_CAUSE)
         assert result == AutofixStep.SOLUTION
 
-    def test_get_next_step_solution_to_code_changes(self):
+    def test_get_next_step_solution_to_code_changes(self) -> None:
         """Returns CODE_CHANGES after SOLUTION."""
         result = AutofixOnCompletionHook._get_next_step(AutofixStep.SOLUTION)
         assert result == AutofixStep.CODE_CHANGES
 
-    def test_get_next_step_code_changes_is_last(self):
+    def test_get_next_step_code_changes_is_last(self) -> None:
         """Returns None after CODE_CHANGES (last step)."""
         result = AutofixOnCompletionHook._get_next_step(AutofixStep.CODE_CHANGES)
         assert result is None
 
-    def test_get_next_step_unknown_step(self):
+    def test_get_next_step_unknown_step(self) -> None:
         """Returns None for steps not in pipeline."""
         result = AutofixOnCompletionHook._get_next_step(AutofixStep.TRIAGE)
         assert result is None
@@ -190,7 +190,7 @@ class TestAutofixOnCompletionHookHelpers(TestCase):
 class TestAutofixOnCompletionHookPipeline(TestCase):
     """Tests for pipeline continuation logic."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -270,7 +270,7 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
 class TestPipelineConstants(TestCase):
     """Tests for pipeline constants."""
 
-    def test_pipeline_order(self):
+    def test_pipeline_order(self) -> None:
         """Pipeline order is root_cause -> solution -> code_changes."""
         assert PIPELINE_ORDER == [
             AutofixStep.ROOT_CAUSE,
@@ -278,7 +278,7 @@ class TestPipelineConstants(TestCase):
             AutofixStep.CODE_CHANGES,
         ]
 
-    def test_stopping_point_to_step_mapping(self):
+    def test_stopping_point_to_step_mapping(self) -> None:
         """Stopping points map to correct steps."""
         assert STOPPING_POINT_TO_STEP[AutofixStoppingPoint.ROOT_CAUSE] == AutofixStep.ROOT_CAUSE
         assert STOPPING_POINT_TO_STEP[AutofixStoppingPoint.SOLUTION] == AutofixStep.SOLUTION
@@ -287,7 +287,7 @@ class TestPipelineConstants(TestCase):
 
 
 class TestAutofixOnCompletionHookWebhooks(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -381,7 +381,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
 class TestAutofixOnCompletionHookSupergroups(TestCase):
     """Tests for supergroups embedding trigger in AutofixOnCompletionHook."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -452,7 +452,7 @@ class TestAutofixOnCompletionHookSupergroups(TestCase):
 class TestAutofixOnCompletionHookHandoff(TestCase):
     """Tests for coding agent handoff logic in AutofixOnCompletionHook."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -37,7 +37,7 @@ from sentry.utils.cache import cache
 
 
 class TestGetAutofixPrompt(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.run_id = 12345
         self.mock_response_data = {
@@ -247,7 +247,7 @@ class TestGetCodingAgentPrompt(TestCase):
 
 
 class TestAutofixStateParsing(TestCase):
-    def test_autofix_state_validate_parses_nested_structures(self):
+    def test_autofix_state_validate_parses_nested_structures(self) -> None:
         state_data = {
             "run_id": 1,
             "request": {
@@ -302,13 +302,13 @@ class TestAutofixStateParsing(TestCase):
 class TestIsIssueEligibleForSeerAutomation(TestCase):
     """Test the is_issue_eligible_for_seer_automation function."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(name="test-org")
         self.project = self.create_project(organization=self.organization)
         self.group = self.create_group(project=self.project)
 
-    def test_returns_false_for_unsupported_issue_categories(self):
+    def test_returns_false_for_unsupported_issue_categories(self) -> None:
         """Test returns False for unsupported issue categories like REPLAY and FEEDBACK."""
         from sentry.issues.grouptype import FeedbackGroup, ReplayRageClickType
 
@@ -319,7 +319,7 @@ class TestIsIssueEligibleForSeerAutomation(TestCase):
         assert is_issue_eligible_for_seer_automation(replay_group) is False
         assert is_issue_eligible_for_seer_automation(feedback_group) is False
 
-    def test_returns_true_for_supported_issue_categories(self):
+    def test_returns_true_for_supported_issue_categories(self) -> None:
         """Test returns True for supported issue categories when all conditions are met."""
         with self.feature("organizations:gen-ai-features"):
             with patch("sentry.quotas.backend.check_seer_quota") as mock_budget:
@@ -331,19 +331,19 @@ class TestIsIssueEligibleForSeerAutomation(TestCase):
 
                 assert result is True
 
-    def test_returns_false_when_gen_ai_features_not_enabled(self):
+    def test_returns_false_when_gen_ai_features_not_enabled(self) -> None:
         """Test returns False when organizations:gen-ai-features feature flag is not enabled."""
         result = is_issue_eligible_for_seer_automation(self.group)
         assert result is False
 
-    def test_returns_false_when_ai_features_hidden(self):
+    def test_returns_false_when_ai_features_hidden(self) -> None:
         """Test returns False when sentry:hide_ai_features option is enabled."""
         with self.feature("organizations:gen-ai-features"):
             self.organization.update_option("sentry:hide_ai_features", True)
             result = is_issue_eligible_for_seer_automation(self.group)
             assert result is False
 
-    def test_returns_false_when_scanner_automation_disabled_and_not_always_trigger(self):
+    def test_returns_false_when_scanner_automation_disabled_and_not_always_trigger(self) -> None:
         """Test returns False when scanner automation is disabled and issue type doesn't always trigger."""
         with self.feature("organizations:gen-ai-features"):
             self.project.update_option("sentry:seer_scanner_automation", False)
@@ -401,7 +401,7 @@ class TestIsIssueEligibleForSeerAutomation(TestCase):
 class TestIsSeerSeatBasedTierEnabled(TestCase):
     """Test the is_seer_seat_based_tier_enabled function."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(name="test-org")
 
@@ -427,7 +427,7 @@ class TestIsSeerSeatBasedTierEnabled(TestCase):
         cache_key = f"seer:seat-based-tier:{self.organization.id}"
         assert cache.get(cache_key) is True
 
-    def test_returns_false_when_no_flags_enabled(self):
+    def test_returns_false_when_no_flags_enabled(self) -> None:
         """Test returns False when neither feature flag is enabled and caches the result."""
         result = is_seer_seat_based_tier_enabled(self.organization)
         assert result is False
@@ -436,7 +436,7 @@ class TestIsSeerSeatBasedTierEnabled(TestCase):
         cache_key = f"seer:seat-based-tier:{self.organization.id}"
         assert cache.get(cache_key) is False
 
-    def test_returns_cached_value(self):
+    def test_returns_cached_value(self) -> None:
         """Test returns cached value without checking feature flags."""
         cache_key = f"seer:seat-based-tier:{self.organization.id}"
         cache.set(cache_key, True, timeout=60)
@@ -449,7 +449,7 @@ class TestIsSeerSeatBasedTierEnabled(TestCase):
 class TestHasProjectConnectedRepos(TestCase):
     """Test the has_project_connected_repos function."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -609,7 +609,7 @@ class TestHasProjectConnectedRepos(TestCase):
 class TestSetProjectSeerPreference(TestCase):
     """Test the set_project_seer_preference function."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -680,7 +680,7 @@ class TestSetProjectSeerPreference(TestCase):
 
 
 class TestResolveRepositoryIds(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -697,7 +697,7 @@ class TestResolveRepositoryIds(TestCase):
             name="test-org/test-repo-2",
         )
 
-    def test_resolves_when_input_and_stored_providers_are_bare(self):
+    def test_resolves_when_input_and_stored_providers_are_bare(self) -> None:
         preferences = [
             SeerProjectPreference(
                 organization_id=self.organization.id,
@@ -714,7 +714,7 @@ class TestResolveRepositoryIds(TestCase):
 
         assert result[0].repositories[0].repository_id == self.repo_bare_provider.id
 
-    def test_resolves_when_input_and_stored_providers_are_prefixed(self):
+    def test_resolves_when_input_and_stored_providers_are_prefixed(self) -> None:
         preferences = [
             SeerProjectPreference(
                 organization_id=self.organization.id,
@@ -734,7 +734,7 @@ class TestResolveRepositoryIds(TestCase):
 
         assert result[0].repositories[0].repository_id == self.repo_prefixed_provider.id
 
-    def test_resolves_when_input_provider_is_bare_and_stored_provider_is_prefixed(self):
+    def test_resolves_when_input_provider_is_bare_and_stored_provider_is_prefixed(self) -> None:
         preferences = [
             SeerProjectPreference(
                 organization_id=self.organization.id,
@@ -754,7 +754,7 @@ class TestResolveRepositoryIds(TestCase):
 
         assert result[0].repositories[0].repository_id == self.repo_prefixed_provider.id
 
-    def test_resolves_when_input_provider_is_prefixed_and_stored_provider_is_bare(self):
+    def test_resolves_when_input_provider_is_prefixed_and_stored_provider_is_bare(self) -> None:
         preferences = [
             SeerProjectPreference(
                 organization_id=self.organization.id,
@@ -774,7 +774,7 @@ class TestResolveRepositoryIds(TestCase):
 
         assert result[0].repositories[0].repository_id == self.repo_bare_provider.id
 
-    def test_skips_unresolvable_repos(self):
+    def test_skips_unresolvable_repos(self) -> None:
         """Repos with empty provider, empty external_id, existing repository_id, or inactive status are skipped."""
         from sentry.constants import ObjectStatus
 
@@ -821,7 +821,7 @@ class TestResolveRepositoryIds(TestCase):
 
 
 class TestDeduplicateRepositories(TestCase):
-    def test_keys_by_provider_and_external_id(self):
+    def test_keys_by_provider_and_external_id(self) -> None:
         repositories: list[dict[str, Any]] = [
             {
                 "provider": "github",
@@ -851,7 +851,7 @@ class TestDeduplicateRepositories(TestCase):
             }
         ]
 
-    def test_also_keys_by_org_id(self):
+    def test_also_keys_by_org_id(self) -> None:
         repositories: list[dict[str, Any]] = [
             {
                 "provider": "github",
@@ -888,7 +888,7 @@ class TestDeduplicateRepositories(TestCase):
             },
         ]
 
-    def test_normalizes_provider_alias_in_key(self):
+    def test_normalizes_provider_alias_in_key(self) -> None:
         repositories: list[dict[str, Any]] = [
             {
                 "provider": "github",
@@ -920,7 +920,7 @@ class TestWritePreferencesToSentryDb(TestCase):
     """Tests for _write_preferences_to_sentry_db via write_preference_to_sentry_db
     and bulk_write_preferences_to_sentry_db."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -931,7 +931,7 @@ class TestWritePreferencesToSentryDb(TestCase):
             name="test-org/test-repo",
         )
 
-    def test_writes_project_options(self):
+    def test_writes_project_options(self) -> None:
         preference = SeerProjectPreference(
             organization_id=self.organization.id,
             project_id=self.project.id,
@@ -957,7 +957,7 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
         assert SeerProjectRepository.objects.filter(project=self.project).count() == 0
 
-    def test_deletes_project_options_when_defaults(self):
+    def test_deletes_project_options_when_defaults(self) -> None:
         preference = SeerProjectPreference(
             organization_id=self.organization.id, project_id=self.project.id, repositories=[]
         )
@@ -970,7 +970,7 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
         assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
 
-    def test_creates_seer_project_repository_with_branch_overrides(self):
+    def test_creates_seer_project_repository_with_branch_overrides(self) -> None:
         preference = SeerProjectPreference(
             organization_id=self.organization.id,
             project_id=self.project.id,
@@ -1017,7 +1017,7 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert overrides[1].tag_value == "staging"
         assert overrides[1].branch_name == "staging"
 
-    def test_replaces_existing_preference_on_write(self):
+    def test_replaces_existing_preference_on_write(self) -> None:
         preference_to_replace = SeerProjectPreference(
             organization_id=self.organization.id,
             project_id=self.project.id,
@@ -1080,7 +1080,7 @@ class TestWritePreferencesToSentryDb(TestCase):
             == 0
         )
 
-    def test_multiple_repos_for_one_project(self):
+    def test_multiple_repos_for_one_project(self) -> None:
         repo2 = self.create_repo(
             project=self.project,
             provider="integrations:github",
@@ -1120,7 +1120,7 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert repos[1].repository_id == repo2.id
         assert repos[1].instructions == "Deploy carefully"
 
-    def test_bulk_write_multiple_projects(self):
+    def test_bulk_write_multiple_projects(self) -> None:
         project2 = self.create_project(organization=self.organization)
         repo2 = self.create_repo(
             project=project2,
@@ -1176,7 +1176,7 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert p2_repos[0].instructions == "Be careful"
         assert project2.get_option("sentry:seer_automated_run_stopping_point") == "code_changes"
 
-    def test_bulk_write_replaces_per_project(self):
+    def test_bulk_write_replaces_per_project(self) -> None:
         project2 = self.create_project(organization=self.organization)
         repo2 = self.create_repo(
             project=project2,

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -28,7 +28,7 @@ from sentry.testutils.cases import TestCase
 
 
 class TestLaunchAgentsForRepos(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -410,7 +410,7 @@ class TestLaunchAgentsForRepos(TestCase):
 
 
 class TestPollGithubCopilotAgents(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -441,14 +441,14 @@ class TestPollGithubCopilotAgents(TestCase):
             coding_agents=agents,
         )
 
-    def test_poll_skips_when_no_coding_agents(self):
+    def test_poll_skips_when_no_coding_agents(self) -> None:
         """Test that polling does nothing when there are no coding agents"""
         autofix_state = self._create_autofix_state_with_agents({})
 
         # Should not raise and should not call any external services
         poll_github_copilot_agents(autofix_state, user_id=self.user.id)
 
-    def test_poll_skips_non_github_copilot_agents(self):
+    def test_poll_skips_non_github_copilot_agents(self) -> None:
         """Test that polling skips agents that are not GitHub Copilot agents"""
         agents = {
             "cursor-agent-123": CodingAgentState(
@@ -464,7 +464,7 @@ class TestPollGithubCopilotAgents(TestCase):
         # Should not raise and should not call any external services
         poll_github_copilot_agents(autofix_state, user_id=self.user.id)
 
-    def test_poll_skips_completed_agents(self):
+    def test_poll_skips_completed_agents(self) -> None:
         """Test that polling skips agents that are already completed"""
         agents = {
             "getsentry:sentry:task-123": CodingAgentState(
@@ -676,7 +676,7 @@ class TestPollGithubCopilotAgents(TestCase):
         # State should not be updated when there's an error
         mock_update_state.assert_not_called()
 
-    def test_poll_skips_invalid_agent_id(self):
+    def test_poll_skips_invalid_agent_id(self) -> None:
         """Test that polling skips agents with invalid IDs"""
         agents = {
             "invalid-agent-id": CodingAgentState(
@@ -704,41 +704,41 @@ def _make_agent_event(text: str) -> ClaudeSessionEvent:
 
 
 class TestExtractResultFromEvents(TestCase):
-    def test_extracts_pr_url(self):
+    def test_extracts_pr_url(self) -> None:
         text = "PR created: https://github.com/org/repo/pull/123"
         events = [_make_agent_event(text)]
         url, block = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/pull/123"
         assert block == text
 
-    def test_extracts_branch_url(self):
+    def test_extracts_branch_url(self) -> None:
         text = "Pushed to https://github.com/org/repo/tree/my-branch"
         events = [_make_agent_event(text)]
         url, block = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/my-branch"
         assert block == text
 
-    def test_strips_trailing_period(self):
+    def test_strips_trailing_period(self) -> None:
         events = [_make_agent_event("See https://github.com/org/repo/tree/my-branch.")]
         url, _ = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/my-branch"
 
-    def test_strips_trailing_comma(self):
+    def test_strips_trailing_comma(self) -> None:
         events = [_make_agent_event("https://github.com/org/repo/tree/my-branch, ready")]
         url, _ = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/my-branch"
 
-    def test_branch_with_slashes(self):
+    def test_branch_with_slashes(self) -> None:
         events = [_make_agent_event("https://github.com/org/repo/tree/feat/sub/thing")]
         url, _ = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/feat/sub/thing"
 
-    def test_branch_with_dots_in_name(self):
+    def test_branch_with_dots_in_name(self) -> None:
         events = [_make_agent_event("https://github.com/org/repo/tree/v1.2.3-fix")]
         url, _ = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/v1.2.3-fix"
 
-    def test_pr_preferred_over_branch(self):
+    def test_pr_preferred_over_branch(self) -> None:
         events = [
             _make_agent_event(
                 "Branch https://github.com/org/repo/tree/my-branch "
@@ -748,18 +748,18 @@ class TestExtractResultFromEvents(TestCase):
         url, _ = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/pull/42"
 
-    def test_returns_none_when_no_url(self):
+    def test_returns_none_when_no_url(self) -> None:
         events = [_make_agent_event("All done, no link.")]
         url, block = extract_result_from_events(events)
         assert url is None
         assert block is None
 
-    def test_returns_none_for_empty_events(self):
+    def test_returns_none_for_empty_events(self) -> None:
         url, block = extract_result_from_events([])
         assert url is None
         assert block is None
 
-    def test_searches_most_recent_event_first(self):
+    def test_searches_most_recent_event_first(self) -> None:
         events = [
             _make_agent_event("https://github.com/org/repo/tree/old-branch"),
             _make_agent_event("https://github.com/org/repo/tree/new-branch"),
@@ -767,7 +767,7 @@ class TestExtractResultFromEvents(TestCase):
         url, _ = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/new-branch"
 
-    def test_skips_non_agent_events(self):
+    def test_skips_non_agent_events(self) -> None:
         events = [
             ClaudeSessionEvent(
                 type="tool_result",
@@ -781,7 +781,7 @@ class TestExtractResultFromEvents(TestCase):
 
 
 class TestPollClaudeCodeAgents(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -808,7 +808,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)
 
-    def test_ai_autofix_post_invalid_stopping_point_string(self):
+    def test_ai_autofix_post_invalid_stopping_point_string(self) -> None:
         group = self.create_group()
 
         self.login_as(user=self.user)
@@ -822,7 +822,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert "stoppingPoint" in response.data
         assert "not a valid choice" in str(response.data["stoppingPoint"])
 
-    def test_ai_autofix_post_invalid_stopping_point_type(self):
+    def test_ai_autofix_post_invalid_stopping_point_type(self) -> None:
         group = self.create_group()
 
         self.login_as(user=self.user)
@@ -971,7 +971,7 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         assert response.status_code == 202, response.data
         mock_call_autofix.assert_called_once()
 
-    def test_post_coding_agent_handoff_errors_with_both_provider_and_integration_id(self):
+    def test_post_coding_agent_handoff_errors_with_both_provider_and_integration_id(self) -> None:
         """POST returns 400 when both provider and integration_id are specified for coding_agent_handoff."""
         for flag in EXPLORER_FLAGS:
             group = self.create_group()
@@ -1118,7 +1118,7 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
             assert call_body["payload"]["type"] == "create_pr"
             assert "repo_name" not in call_body["payload"]
 
-    def test_open_pr_no_run_id(self):
+    def test_open_pr_no_run_id(self) -> None:
         self.login_as(user=self.user)
 
         for flag in EXPLORER_FLAGS:

--- a/tests/sentry/seer/endpoints/test_issue_view_title_generate.py
+++ b/tests/sentry/seer/endpoints/test_issue_view_title_generate.py
@@ -9,7 +9,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 class IssueViewTitleGenerateEndpointTest(APITestCase):
     endpoint = "sentry-api-0-issue-view-title-generate"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
         self.url = f"/api/0/organizations/{self.organization.slug}/issue-view-title/generate/"

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -14,7 +14,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 
 
 class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.url = reverse(
@@ -248,7 +248,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             }
         ]
 
-    def test_post_requires_one_or_more_project_ids(self):
+    def test_post_requires_one_or_more_project_ids(self) -> None:
         response = self.client.post(
             self.url,
             {"automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value},
@@ -264,7 +264,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
 
-    def test_post_rejects_invalid_project_ids(self):
+    def test_post_rejects_invalid_project_ids(self) -> None:
         response = self.client.post(
             self.url,
             {
@@ -274,7 +274,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 403
 
-    def test_post_rejects_invalid_tuning(self):
+    def test_post_rejects_invalid_tuning(self) -> None:
         response = self.client.post(
             self.url,
             {
@@ -284,7 +284,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
 
-    def test_post_rejects_invalid_stopping_point(self):
+    def test_post_rejects_invalid_stopping_point(self) -> None:
         response = self.client.post(
             self.url,
             {
@@ -294,7 +294,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
 
-    def test_post_rejects_projects_not_in_organization(self):
+    def test_post_rejects_projects_not_in_organization(self) -> None:
         project = self.create_project(organization=self.organization)
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -9,7 +9,7 @@ from sentry.testutils.helpers.features import with_feature
 @with_feature("organizations:gen-ai-features")
 @with_feature("organizations:gen-ai-consent-flow-removal")
 class OrganizationSeerExplorerChatEndpointTest(APITestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization.flags.allow_joinleave = True
         self.organization.save()
@@ -232,7 +232,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
 class OrganizationSeerExplorerChatContextEngineTest(APITestCase):
     """End-to-end tests verifying is_context_engine_enabled reaches make_explorer_chat_request."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
         self.url = f"/api/0/organizations/{self.organization.slug}/seer/explorer-chat/"

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_setup.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_setup.py
@@ -85,7 +85,7 @@ class TraceExplorerAISetupTest(APITestCase):
             },
         )
 
-    def test_requires_feature_flag(self):
+    def test_requires_feature_flag(self) -> None:
         self.login_as(self.user)
 
         response = self.get_error_response(
@@ -127,7 +127,7 @@ class TraceExplorerAISetupTest(APITestCase):
         mock_fire_setup_request.assert_not_called()
 
     @with_feature("organizations:gen-ai-features")
-    def test_requires_authentication(self):
+    def test_requires_authentication(self) -> None:
         response = self.get_error_response(
             self.organization.slug,
             status_code=401,

--- a/tests/sentry/seer/entrypoints/slack/test_mention.py
+++ b/tests/sentry/seer/entrypoints/slack/test_mention.py
@@ -10,37 +10,37 @@ BOT_USER_ID = "U0BOT123"
 
 
 class ExtractPromptTest(TestCase):
-    def test_removes_bot_mention(self):
+    def test_removes_bot_mention(self) -> None:
         text = "<@U0BOT123> fix this issue"
         assert extract_prompt(text, BOT_USER_ID) == "fix this issue"
 
-    def test_removes_bot_mention_in_middle(self):
+    def test_removes_bot_mention_in_middle(self) -> None:
         text = "hey <@U0BOT123> fix this issue"
         assert extract_prompt(text, BOT_USER_ID) == "hey fix this issue"
 
-    def test_preserves_other_user_mentions(self):
+    def test_preserves_other_user_mentions(self) -> None:
         text = "<@U0BOT123> ask <@U0USER456> about this"
         assert extract_prompt(text, BOT_USER_ID) == "ask <@U0USER456> about this"
 
-    def test_preserves_non_mention_content(self):
+    def test_preserves_non_mention_content(self) -> None:
         text = "<@U0BOT123> What is causing https://sentry.io/issues/123/ ?"
         assert (
             extract_prompt(text, BOT_USER_ID) == "What is causing https://sentry.io/issues/123/ ?"
         )
 
-    def test_empty_after_mention(self):
+    def test_empty_after_mention(self) -> None:
         text = "<@U0BOT123>"
         assert extract_prompt(text, BOT_USER_ID) == ""
 
-    def test_no_mentions(self):
+    def test_no_mentions(self) -> None:
         text = "just a regular message"
         assert extract_prompt(text, BOT_USER_ID) == "just a regular message"
 
-    def test_collapses_extra_spaces(self):
+    def test_collapses_extra_spaces(self) -> None:
         text = "<@U0BOT123>  fix  this"
         assert extract_prompt(text, BOT_USER_ID) == "fix this"
 
-    def test_preserves_slack_url_formatting(self):
+    def test_preserves_slack_url_formatting(self) -> None:
         text = "<@U0BOT123> check <https://sentry.io/issues/123/|ISSUE-123>"
         assert (
             extract_prompt(text, BOT_USER_ID) == "check <https://sentry.io/issues/123/|ISSUE-123>"
@@ -48,22 +48,22 @@ class ExtractPromptTest(TestCase):
 
 
 class ExtractIssueLinksTest(TestCase):
-    def test_standard_issue_url(self):
+    def test_standard_issue_url(self) -> None:
         text = "check <https://sentry.io/organizations/test-org/issues/456/|ISSUE-456>"
         result = extract_issue_links(text)
         assert result == [IssueLink(group_id=456)]
 
-    def test_issue_url_with_event(self):
+    def test_issue_url_with_event(self) -> None:
         text = "see <https://sentry.io/organizations/test-org/issues/789/events/abc123/|link>"
         result = extract_issue_links(text)
         assert result == [IssueLink(group_id=789, event_id="abc123")]
 
-    def test_customer_domain_issue_url(self):
+    def test_customer_domain_issue_url(self) -> None:
         text = "look at <https://test-org.sentry.io/issues/321/|issue>"
         result = extract_issue_links(text)
         assert result == [IssueLink(group_id=321)]
 
-    def test_multiple_issue_urls(self):
+    def test_multiple_issue_urls(self) -> None:
         text = (
             "<https://sentry.io/organizations/test-org/issues/111/|one> "
             "and <https://sentry.io/organizations/test-org/issues/222/|two>"
@@ -71,7 +71,7 @@ class ExtractIssueLinksTest(TestCase):
         result = extract_issue_links(text)
         assert result == [IssueLink(group_id=111), IssueLink(group_id=222)]
 
-    def test_deduplicates_same_issue(self):
+    def test_deduplicates_same_issue(self) -> None:
         text = (
             "<https://sentry.io/organizations/test-org/issues/111/|first> "
             "<https://sentry.io/organizations/test-org/issues/111/|second>"
@@ -79,32 +79,32 @@ class ExtractIssueLinksTest(TestCase):
         result = extract_issue_links(text)
         assert result == [IssueLink(group_id=111)]
 
-    def test_no_issue_urls(self):
+    def test_no_issue_urls(self) -> None:
         text = "no links here, just text"
         assert extract_issue_links(text) == []
 
-    def test_ignores_non_issue_urls(self):
+    def test_ignores_non_issue_urls(self) -> None:
         text = "<https://google.com|Google> and <https://sentry.io/organizations/test-org/issues/999/|issue>"
         result = extract_issue_links(text)
         assert result == [IssueLink(group_id=999)]
 
-    def test_plain_url_without_label(self):
+    def test_plain_url_without_label(self) -> None:
         text = "<https://sentry.io/organizations/test-org/issues/555/>"
         result = extract_issue_links(text)
         assert result == [IssueLink(group_id=555)]
 
-    def test_ignores_metric_alert_urls(self):
+    def test_ignores_metric_alert_urls(self) -> None:
         text = "<https://sentry.io/organizations/test-org/alerts/rules/details/42/|alert>"
         assert extract_issue_links(text) == []
 
 
 class BuildThreadContextTest(TestCase):
-    def test_single_message(self):
+    def test_single_message(self) -> None:
         messages = [{"user": "U123", "text": "hello world", "ts": "1234567890.000001"}]
         result = build_thread_context(messages)
         assert result == "<@U123>: hello world"
 
-    def test_multiple_messages(self):
+    def test_multiple_messages(self) -> None:
         messages = [
             {"user": "U123", "text": "first message", "ts": "1234567890.000001"},
             {"user": "U456", "text": "second message", "ts": "1234567890.000002"},
@@ -112,10 +112,10 @@ class BuildThreadContextTest(TestCase):
         result = build_thread_context(messages)
         assert result == "<@U123>: first message\n<@U456>: second message"
 
-    def test_empty_messages(self):
+    def test_empty_messages(self) -> None:
         assert build_thread_context([]) == ""
 
-    def test_skips_empty_text(self):
+    def test_skips_empty_text(self) -> None:
         messages = [
             {"user": "U123", "text": "hello", "ts": "1234567890.000001"},
             {"user": "U456", "text": "", "ts": "1234567890.000002"},
@@ -124,12 +124,12 @@ class BuildThreadContextTest(TestCase):
         result = build_thread_context(messages)
         assert result == "<@U123>: hello\n<@U789>: world"
 
-    def test_missing_user_defaults_to_unknown(self):
+    def test_missing_user_defaults_to_unknown(self) -> None:
         messages = [{"text": "orphan message", "ts": "1234567890.000001"}]
         result = build_thread_context(messages)
         assert result == "<@unknown>: orphan message"
 
-    def test_preserves_urls_in_text(self):
+    def test_preserves_urls_in_text(self) -> None:
         messages = [
             {
                 "user": "U123",

--- a/tests/sentry/seer/entrypoints/slack/test_slack.py
+++ b/tests/sentry/seer/entrypoints/slack/test_slack.py
@@ -27,7 +27,7 @@ from sentry.testutils.cases import TestCase
 
 
 class SlackAutofixEntrypointTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.slack_user_id = "UXXXXXXXXX1"
         self.channel_id = "CXXXXXXXXX1"
         self.thread_ts = "1712345678.987654"
@@ -70,7 +70,7 @@ class SlackAutofixEntrypointTest(TestCase):
             action=self.action,
         )
 
-    def test_has_access(self):
+    def test_has_access(self) -> None:
         with self.feature({"organizations:seer-slack-workflows": False}):
             assert not SlackAutofixEntrypoint.has_access(self.organization)
         with self.feature("organizations:seer-slack-workflows"):
@@ -104,7 +104,7 @@ class SlackAutofixEntrypointTest(TestCase):
         ep.on_trigger_autofix_success(run_id=MOCK_RUN_ID)
         mock_update_message.assert_called_once()
 
-    def test_create_autofix_cache_payload(self):
+    def test_create_autofix_cache_payload(self) -> None:
         ep = self._get_entrypoint()
         cache_payload = ep.create_autofix_cache_payload()
         SlackAutofixCachePayload(**cache_payload)
@@ -240,7 +240,7 @@ class SlackAutofixEntrypointTest(TestCase):
 
         mock_update_message.assert_called_once()
 
-    def test_get_autofix_lock_key(self):
+    def test_get_autofix_lock_key(self) -> None:
         lock_key = SlackAutofixEntrypoint.get_autofix_lock_key(
             group_id=self.group.id,
             stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
@@ -452,7 +452,7 @@ class SlackAutofixEntrypointTest(TestCase):
         )
         assert result == expected
 
-    def test_get_autofix_stopping_point_from_action(self):
+    def test_get_autofix_stopping_point_from_action(self) -> None:
         # Empty, None, and invalid values default to ROOT_CAUSE
         self._assert_stopping_point_from_action("", AutofixStoppingPoint.ROOT_CAUSE)
         self._assert_stopping_point_from_action(None, AutofixStoppingPoint.ROOT_CAUSE)
@@ -462,7 +462,7 @@ class SlackAutofixEntrypointTest(TestCase):
             AutofixStoppingPoint.SOLUTION.value, AutofixStoppingPoint.SOLUTION
         )
 
-    def test_get_group_link_includes_seer_drawer(self):
+    def test_get_group_link_includes_seer_drawer(self) -> None:
         link = SlackAutofixEntrypoint.get_group_link(self.group)
         assert "seerDrawer=true" in link
 
@@ -486,7 +486,7 @@ class SlackAutofixEntrypointTest(TestCase):
 
 
 class SlackExplorerEntrypointTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.slack_user_id = "UXXXXXXXXX2"
         self.channel_id = "CXXXXXXXXX2"
         self.message_ts = "1712345678.111111"
@@ -507,7 +507,7 @@ class SlackExplorerEntrypointTest(TestCase):
             slack_user_id=self.slack_user_id,
         )
 
-    def test_init_success(self):
+    def test_init_success(self) -> None:
         ep = self._get_entrypoint()
         assert ep.channel_id == self.channel_id
         assert ep.message_ts == self.message_ts
@@ -517,7 +517,7 @@ class SlackExplorerEntrypointTest(TestCase):
         assert ep.install.model.id == self.integration.id
         assert ep.thread == SlackThreadDetails(thread_ts=self.thread_ts, channel_id=self.channel_id)
 
-    def test_init_defaults_thread_ts_to_message_ts_when_none(self):
+    def test_init_defaults_thread_ts_to_message_ts_when_none(self) -> None:
         ep = SlackExplorerEntrypoint(
             integration_id=self.integration.id,
             organization_id=self.organization.id,
@@ -529,7 +529,7 @@ class SlackExplorerEntrypointTest(TestCase):
         assert ep.thread_ts == self.message_ts
         assert ep.thread["thread_ts"] == self.message_ts
 
-    def test_init_raises_if_integration_not_found(self):
+    def test_init_raises_if_integration_not_found(self) -> None:
         with pytest.raises(ValueError):
             SlackExplorerEntrypoint(
                 integration_id=99999,
@@ -555,7 +555,7 @@ class SlackExplorerEntrypointTest(TestCase):
                 slack_user_id=self.slack_user_id,
             )
 
-    def test_has_access(self):
+    def test_has_access(self) -> None:
         explorer_flags = {
             "organizations:gen-ai-features": True,
             "organizations:seer-explorer": True,
@@ -581,11 +581,11 @@ class SlackExplorerEntrypointTest(TestCase):
             slack_user_id=self.slack_user_id,
         )
 
-    def test_on_trigger_explorer_success_is_noop(self):
+    def test_on_trigger_explorer_success_is_noop(self) -> None:
         ep = self._get_entrypoint()
         ep.on_trigger_explorer_success(run_id=12345)
 
-    def test_create_explorer_cache_payload(self):
+    def test_create_explorer_cache_payload(self) -> None:
         ep = self._get_entrypoint()
         payload = ep.create_explorer_cache_payload()
         SlackExplorerCachePayload(**payload)  # validates TypedDict structure
@@ -634,7 +634,7 @@ class SlackExplorerEntrypointTest(TestCase):
         assert isinstance(call_data, SeerExplorerError)
         assert call_data.error_message == "Seer was unable to generate a response."
 
-    def test_on_explorer_update_skips_clear_when_integration_not_found(self):
+    def test_on_explorer_update_skips_clear_when_integration_not_found(self) -> None:
         ep = self._get_entrypoint()
         cache_payload = ep.create_explorer_cache_payload()
 

--- a/tests/sentry/seer/entrypoints/test_cache.py
+++ b/tests/sentry/seer/entrypoints/test_cache.py
@@ -18,7 +18,7 @@ class MockCachePayload(TypedDict):
 
 
 class SeerOperatorAutofixCacheTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.entrypoint_key = str(SeerEntrypointKey.SLACK)
         self.pre_cache_key = SeerOperatorAutofixCache._get_pre_autofix_cache_key(
             entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
@@ -27,10 +27,10 @@ class SeerOperatorAutofixCacheTest(TestCase):
             entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
         )
 
-    def test_get_pre_autofix_cache_key(self):
+    def test_get_pre_autofix_cache_key(self) -> None:
         assert self.pre_cache_key == f"seer:pre_autofix:{self.entrypoint_key}:{MOCK_GROUP_ID}"
 
-    def test_get_post_autofix_cache_key(self):
+    def test_get_post_autofix_cache_key(self) -> None:
         assert self.post_cache_key == f"seer:post_autofix:{self.entrypoint_key}:{MOCK_RUN_ID}"
 
     @patch("sentry.seer.entrypoints.cache.cache.set")
@@ -164,7 +164,7 @@ class SeerOperatorAutofixCacheTest(TestCase):
 
 
 class SeerOperatorAutofixCacheMigrateTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.entrypoint_key = str(SeerEntrypointKey.SLACK)
         self.pre_cache_key = SeerOperatorAutofixCache._get_pre_autofix_cache_key(
             entrypoint_key=self.entrypoint_key, group_id=MOCK_GROUP_ID
@@ -228,13 +228,13 @@ class SeerOperatorAutofixCacheMigrateTest(TestCase):
 
 
 class SeerOperatorExplorerCacheTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.entrypoint_key = str(SeerEntrypointKey.SLACK)
         self.cache_key = SeerOperatorExplorerCache._get_cache_key(
             entrypoint_key=self.entrypoint_key, run_id=MOCK_RUN_ID
         )
 
-    def test_get_cache_key(self):
+    def test_get_cache_key(self) -> None:
         assert self.cache_key == f"seer:explorer:{self.entrypoint_key}:{MOCK_RUN_ID}"
 
     @patch("sentry.seer.entrypoints.cache.cache.set")

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -71,7 +71,7 @@ class MockAutofixEntrypoint(SeerAutofixEntrypoint[MockCachePayload]):
 
 
 class SeerOperatorTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.entrypoint = MockAutofixEntrypoint()
         self.operator = SeerAutofixOperator(self.entrypoint)
 
@@ -345,7 +345,7 @@ class SeerOperatorTest(TestCase):
             cache_payload=cache_payload,
         )
 
-    def test_process_autofix_updates_no_operator_access(self):
+    def test_process_autofix_updates_no_operator_access(self) -> None:
         mock_entrypoint_cls = Mock(spec=SeerAutofixEntrypoint)
         event_type = SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED
         event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
@@ -464,7 +464,7 @@ class SeerOperatorTest(TestCase):
         assert payload["type"] == "select_root_cause"
         assert payload["cause_id"] == 34
 
-    def test_can_trigger_autofix_returns_false_without_seer_access(self):
+    def test_can_trigger_autofix_returns_false_without_seer_access(self) -> None:
         assert SeerAutofixOperator.can_trigger_autofix(group=self.group) is False
 
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
@@ -521,11 +521,11 @@ class TestGetAutofixExplorerStatus(TestCase):
             repo_pr_states=repo_pr_states or {},
         )
 
-    def test_no_blocks_returns_none(self):
+    def test_no_blocks_returns_none(self) -> None:
         state = self._make_state(blocks=[])
         assert get_autofix_explorer_status(AutofixStoppingPoint.ROOT_CAUSE, state) is None
 
-    def test_blocks_with_no_metadata_returns_none(self):
+    def test_blocks_with_no_metadata_returns_none(self) -> None:
         block = MemoryBlock(
             id="1",
             message=Message(role="assistant", metadata=None),
@@ -534,7 +534,7 @@ class TestGetAutofixExplorerStatus(TestCase):
         state = self._make_state(blocks=[block])
         assert get_autofix_explorer_status(AutofixStoppingPoint.ROOT_CAUSE, state) is None
 
-    def test_blocks_with_metadata_but_no_step_key_returns_none(self):
+    def test_blocks_with_metadata_but_no_step_key_returns_none(self) -> None:
         block = MemoryBlock(
             id="1",
             message=Message(role="assistant", metadata={"other": "value"}),
@@ -543,7 +543,7 @@ class TestGetAutofixExplorerStatus(TestCase):
         state = self._make_state(blocks=[block])
         assert get_autofix_explorer_status(AutofixStoppingPoint.ROOT_CAUSE, state) is None
 
-    def test_block_with_invalid_step_value_returns_none(self):
+    def test_block_with_invalid_step_value_returns_none(self) -> None:
         block = MemoryBlock(
             id="1",
             message=Message(role="assistant", metadata={"step": "not_a_real_step"}),
@@ -552,34 +552,34 @@ class TestGetAutofixExplorerStatus(TestCase):
         state = self._make_state(blocks=[block])
         assert get_autofix_explorer_status(AutofixStoppingPoint.ROOT_CAUSE, state) is None
 
-    def test_matching_last_block_processing_returns_false(self):
+    def test_matching_last_block_processing_returns_false(self) -> None:
         block = self._make_block("root_cause")
         state = self._make_state(blocks=[block], status="processing")
         assert get_autofix_explorer_status(AutofixStoppingPoint.ROOT_CAUSE, state) is False
 
-    def test_matching_last_block_completed_returns_true(self):
+    def test_matching_last_block_completed_returns_true(self) -> None:
         block = self._make_block("root_cause")
         state = self._make_state(blocks=[block], status="completed")
         assert get_autofix_explorer_status(AutofixStoppingPoint.ROOT_CAUSE, state) is True
 
-    def test_matching_last_block_error_returns_true(self):
+    def test_matching_last_block_error_returns_true(self) -> None:
         block = self._make_block("root_cause")
         state = self._make_state(blocks=[block], status="error")
         assert get_autofix_explorer_status(AutofixStoppingPoint.ROOT_CAUSE, state) is True
 
-    def test_matching_block_not_last_returns_true(self):
+    def test_matching_block_not_last_returns_true(self) -> None:
         root_cause_block = self._make_block("root_cause", block_id="1")
         solution_block = self._make_block("solution", block_id="2")
         state = self._make_state(blocks=[root_cause_block, solution_block], status="processing")
         # root_cause is not the last block, so it's already completed
         assert get_autofix_explorer_status(AutofixStoppingPoint.ROOT_CAUSE, state) is True
 
-    def test_open_pr_no_repo_pr_states_returns_false(self):
+    def test_open_pr_no_repo_pr_states_returns_false(self) -> None:
         block = self._make_block("code_changes")
         state = self._make_state(blocks=[block], repo_pr_states={})
         assert get_autofix_explorer_status(AutofixStoppingPoint.OPEN_PR, state) is None
 
-    def test_open_pr_all_prs_completed_returns_true(self):
+    def test_open_pr_all_prs_completed_returns_true(self) -> None:
         block = self._make_block("code_changes")
         pr_states = {
             "repo1": RepoPRState(repo_name="repo1", pr_creation_status="completed"),
@@ -588,7 +588,7 @@ class TestGetAutofixExplorerStatus(TestCase):
         state = self._make_state(blocks=[block], repo_pr_states=pr_states)
         assert get_autofix_explorer_status(AutofixStoppingPoint.OPEN_PR, state) is True
 
-    def test_open_pr_some_prs_still_creating_returns_false(self):
+    def test_open_pr_some_prs_still_creating_returns_false(self) -> None:
         block = self._make_block("code_changes")
         pr_states = {
             "repo1": RepoPRState(repo_name="repo1", pr_creation_status="completed"),
@@ -597,7 +597,7 @@ class TestGetAutofixExplorerStatus(TestCase):
         state = self._make_state(blocks=[block], repo_pr_states=pr_states)
         assert get_autofix_explorer_status(AutofixStoppingPoint.OPEN_PR, state) is False
 
-    def test_multiple_stopping_points(self):
+    def test_multiple_stopping_points(self) -> None:
         """Verify from_autofix_stopping_point mapping works for various stopping points."""
         root_cause_block = self._make_block("root_cause", block_id="1")
         solution_block = self._make_block("solution", block_id="2")

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -9,42 +9,42 @@ from sentry.testutils.requests import make_request
 
 
 class TestHasSeerExplorerAccessWithDetail(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.org = self.create_organization(owner=self.user)
         self.org.flags.allow_joinleave = True
         self.org.save()
 
-    def test_gen_ai_features_disabled(self):
+    def test_gen_ai_features_disabled(self) -> None:
         result = has_seer_explorer_access_with_detail(self.org, self.user)
         assert result == (False, "Feature flag not enabled")
 
-    def test_hide_ai_features_option_set(self):
+    def test_hide_ai_features_option_set(self) -> None:
         self.org.update_option("sentry:hide_ai_features", True)
         with self.feature("organizations:gen-ai-features"):
             result = has_seer_explorer_access_with_detail(self.org, self.user)
         assert result == (False, "AI features are disabled for this organization.")
 
-    def test_no_explorer_flags_enabled(self):
+    def test_no_explorer_flags_enabled(self) -> None:
         with self.feature("organizations:gen-ai-features"):
             result = has_seer_explorer_access_with_detail(self.org, self.user)
         assert result == (False, "Feature flag not enabled")
 
-    def test_only_seer_explorer_flag(self):
+    def test_only_seer_explorer_flag(self) -> None:
         with self.feature(
             {"organizations:gen-ai-features": True, "organizations:seer-explorer": True}
         ):
             result = has_seer_explorer_access_with_detail(self.org, self.user)
         assert result == (True, None)
 
-    def test_only_autofix_on_explorer_flag(self):
+    def test_only_autofix_on_explorer_flag(self) -> None:
         with self.feature(
             {"organizations:gen-ai-features": True, "organizations:autofix-on-explorer": True}
         ):
             result = has_seer_explorer_access_with_detail(self.org, self.user)
         assert result == (True, None)
 
-    def test_all_explorer_flags_enabled(self):
+    def test_all_explorer_flags_enabled(self) -> None:
         with self.feature(
             {
                 "organizations:gen-ai-features": True,
@@ -55,7 +55,7 @@ class TestHasSeerExplorerAccessWithDetail(TestCase):
             result = has_seer_explorer_access_with_detail(self.org, self.user)
         assert result == (True, None)
 
-    def test_allow_joinleave_disabled(self):
+    def test_allow_joinleave_disabled(self) -> None:
         self.org.flags.allow_joinleave = False
         self.org.save()
         with self.feature(
@@ -88,7 +88,7 @@ class CollectUserOrgContextTest(TestCase):
             organization=self.organization, teams=[self.other_team], slug="other-project"
         )
 
-    def test_collect_context_with_member(self):
+    def test_collect_context_with_member(self) -> None:
         """Test context collection for a user who is an organization member"""
         context = collect_user_org_context(self.user, self.organization)
 
@@ -117,7 +117,7 @@ class CollectUserOrgContextTest(TestCase):
         all_project_ids = {p["id"] for p in context["all_org_projects"]}
         assert all_project_ids == {self.project1.id, self.project2.id, self.other_project.id}
 
-    def test_collect_context_with_multiple_teams(self):
+    def test_collect_context_with_multiple_teams(self) -> None:
         """Test context collection for a user in multiple teams"""
         team2 = self.create_team(organization=self.organization, slug="team-2")
         member = OrganizationMember.objects.get(
@@ -133,7 +133,7 @@ class CollectUserOrgContextTest(TestCase):
         team_slugs = {t["slug"] for t in context["user_teams"]}
         assert team_slugs == {self.team.slug, "team-2"}
 
-    def test_collect_context_with_no_teams(self):
+    def test_collect_context_with_no_teams(self) -> None:
         """Test context collection for a member with no team membership"""
         member = OrganizationMember.objects.get(
             organization=self.organization, user_id=self.user.id
@@ -152,7 +152,7 @@ class CollectUserOrgContextTest(TestCase):
         all_project_slugs = {p["slug"] for p in context["all_org_projects"]}
         assert all_project_slugs == {"project-1", "project-2", "other-project"}
 
-    def test_collect_context_with_non_member_returns_default(self):
+    def test_collect_context_with_non_member_returns_default(self) -> None:
         """Test context collection for a user who is not an organization member"""
         other_user = self.create_user()
         context = collect_user_org_context(other_user, self.organization)
@@ -164,7 +164,7 @@ class CollectUserOrgContextTest(TestCase):
         }
         assert all_project_slugs == {"project-1", "project-2", "other-project"}
 
-    def test_collect_context_with_timezone(self):
+    def test_collect_context_with_timezone(self) -> None:
         """Test context collection includes user's timezone setting"""
         from sentry.users.services.user_option import user_option_service
 
@@ -177,7 +177,7 @@ class CollectUserOrgContextTest(TestCase):
         assert context is not None
         assert context.get("user_timezone") == "America/Los_Angeles"
 
-    def test_collect_context_with_request(self):
+    def test_collect_context_with_request(self) -> None:
         """Test context collection includes request metadata like IP address"""
         request, _ = make_request()
         context = collect_user_org_context(self.user, self.organization, request=request)

--- a/tests/sentry/seer/explorer/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/explorer/test_coding_agent_handoff.py
@@ -23,7 +23,7 @@ def _repo(owner: str, name: str) -> SeerRepoDefinition:
 class TestLaunchCodingAgents(TestCase):
     """Tests for launch_coding_agents function."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.run_id = 12345
@@ -209,7 +209,7 @@ MOCK_HANDOFF_PATH = "sentry.seer.explorer.coding_agent_handoff"
 
 
 class TestResolveClient(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
 
@@ -281,6 +281,6 @@ class TestResolveClient(TestCase):
                 self.organization, integration_id=None, provider="github_copilot", user_id=None
             )
 
-    def test_raises_validation_error_when_no_integration_or_provider(self):
+    def test_raises_validation_error_when_no_integration_or_provider(self) -> None:
         with pytest.raises(ValidationError):
             _resolve_client(self.organization, integration_id=None, provider=None, user_id=None)

--- a/tests/sentry/seer/explorer/test_context_engine_utils.py
+++ b/tests/sentry/seer/explorer/test_context_engine_utils.py
@@ -14,14 +14,14 @@ from sentry.testutils.pytest.fixtures import django_db_all
 
 @django_db_all
 class TestGetInstrumentationTypes(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project()
 
-    def test_returns_empty_for_no_flags(self):
+    def test_returns_empty_for_no_flags(self) -> None:
         assert get_instrumentation_types(self.project) == []
 
-    def test_returns_correct_flags(self):
+    def test_returns_correct_flags(self) -> None:
         self.project.flags.has_transactions = True
         self.project.flags.has_profiles = True
         self.project.flags.has_replays = True
@@ -31,7 +31,7 @@ class TestGetInstrumentationTypes(TestCase):
         result = get_instrumentation_types(self.project)
         assert result == ["transactions", "spans", "profiles", "replays", "sessions"]
 
-    def test_returns_partial_flags(self):
+    def test_returns_partial_flags(self) -> None:
         self.project.flags.has_transactions = True
         self.project.flags.has_sessions = True
         self.project.save()
@@ -42,14 +42,14 @@ class TestGetInstrumentationTypes(TestCase):
 
 @django_db_all
 class TestGetEventCountsForOrgProjects(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.org = self.create_organization()
         self.project = self.create_project(organization=self.org)
         self.end = datetime.now(UTC)
         self.start = self.end - timedelta(days=7)
 
-    def test_returns_high_volume_projects_only(self):
+    def test_returns_high_volume_projects_only(self) -> None:
         raw_data = [
             {"project_id": self.project.id, "category": 1, "total": 800},  # error
             {"project_id": self.project.id, "category": 2, "total": 500},  # transaction
@@ -65,7 +65,7 @@ class TestGetEventCountsForOrgProjects(TestCase):
         # 800 + 500 = 1300 >= HIGH_VOLUME_THRESHOLD
         assert self.project.id in result
 
-    def test_excludes_low_volume_projects(self):
+    def test_excludes_low_volume_projects(self) -> None:
         raw_data = [
             {"project_id": self.project.id, "category": 1, "total": 100},
             {"project_id": self.project.id, "category": 2, "total": 200},
@@ -81,7 +81,7 @@ class TestGetEventCountsForOrgProjects(TestCase):
         # 100 + 200 = 300 < HIGH_VOLUME_THRESHOLD
         assert self.project.id not in result
 
-    def test_returns_empty_on_query_exception(self):
+    def test_returns_empty_on_query_exception(self) -> None:
         with mock.patch(
             "sentry.seer.explorer.context_engine_utils.raw_snql_query",
             side_effect=Exception("snuba error"),
@@ -95,18 +95,18 @@ class TestGetEventCountsForOrgProjects(TestCase):
 
 @django_db_all
 class TestGetTopTransactionsForOrgProjects(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.org = self.create_organization()
         self.project = self.create_project(organization=self.org)
         self.end = datetime.now(UTC)
         self.start = self.end - timedelta(days=7)
 
-    def test_returns_empty_for_no_projects(self):
+    def test_returns_empty_for_no_projects(self) -> None:
         result = get_top_transactions_for_org_projects([], self.start, self.end)
         assert result == {}
 
-    def test_returns_transaction_names_by_project(self):
+    def test_returns_transaction_names_by_project(self) -> None:
         span_data = [
             {
                 "project.id": self.project.id,
@@ -122,7 +122,7 @@ class TestGetTopTransactionsForOrgProjects(TestCase):
 
         assert result == {self.project.id: ["GET /api/0/projects/"]}
 
-    def test_returns_empty_on_query_exception(self):
+    def test_returns_empty_on_query_exception(self) -> None:
         with mock.patch(
             "sentry.seer.explorer.context_engine_utils.Spans.run_table_query",
             side_effect=Exception("eap error"),
@@ -131,7 +131,7 @@ class TestGetTopTransactionsForOrgProjects(TestCase):
 
         assert result == {}
 
-    def test_returns_empty_dict_when_no_transactions(self):
+    def test_returns_empty_dict_when_no_transactions(self) -> None:
         with mock.patch(
             "sentry.seer.explorer.context_engine_utils.Spans.run_table_query",
             return_value={"data": []},
@@ -143,18 +143,18 @@ class TestGetTopTransactionsForOrgProjects(TestCase):
 
 @django_db_all
 class TestGetTopSpanOpsForOrgProjects(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.org = self.create_organization()
         self.project = self.create_project(organization=self.org)
         self.end = datetime.now(UTC)
         self.start = self.end - timedelta(days=7)
 
-    def test_returns_empty_for_no_projects(self):
+    def test_returns_empty_for_no_projects(self) -> None:
         result = get_top_span_ops_for_org_projects([], self.start, self.end)
         assert result == {}
 
-    def test_returns_ops_by_project(self):
+    def test_returns_ops_by_project(self) -> None:
         span_data = [
             {
                 "project.id": self.project.id,
@@ -182,7 +182,7 @@ class TestGetTopSpanOpsForOrgProjects(TestCase):
             ]
         }
 
-    def test_returns_empty_on_query_exception(self):
+    def test_returns_empty_on_query_exception(self) -> None:
         with mock.patch(
             "sentry.seer.explorer.context_engine_utils.Spans.run_table_query",
             side_effect=Exception("eap error"),
@@ -197,14 +197,14 @@ MOCK_RUN_TABLE = "sentry.seer.explorer.context_engine_utils.Spans.run_table_quer
 
 @django_db_all
 class TestGetSdkNamesForOrgProjects(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.org = self.create_organization()
         self.project = self.create_project(organization=self.org)
         self.end = datetime.now(UTC)
         self.start = self.end - timedelta(days=7)
 
-    def test_returns_empty_for_no_projects(self):
+    def test_returns_empty_for_no_projects(self) -> None:
         assert get_sdk_names_for_org_projects([], self.start, self.end) == {}
 
     @mock.patch(MOCK_RUN_TABLE, return_value={"data": []})
@@ -215,13 +215,13 @@ class TestGetSdkNamesForOrgProjects(TestCase):
     def test_returns_empty_on_query_exception(self, _mock):
         assert get_sdk_names_for_org_projects([self.project], self.start, self.end) == {}
 
-    def test_returns_sdk_name_by_project(self):
+    def test_returns_sdk_name_by_project(self) -> None:
         data = [{"project.id": self.project.id, "sdk.name": "sentry.python", "count()": 500}]
         with mock.patch(MOCK_RUN_TABLE, return_value={"data": data}):
             result = get_sdk_names_for_org_projects([self.project], self.start, self.end)
         assert result == {self.project.id: "sentry.python"}
 
-    def test_keeps_first_sdk_name_per_project(self):
+    def test_keeps_first_sdk_name_per_project(self) -> None:
         data = [
             {"project.id": self.project.id, "sdk.name": "sentry.python", "count()": 500},
             {"project.id": self.project.id, "sdk.name": "sentry.javascript", "count()": 100},
@@ -230,7 +230,7 @@ class TestGetSdkNamesForOrgProjects(TestCase):
             result = get_sdk_names_for_org_projects([self.project], self.start, self.end)
         assert result == {self.project.id: "sentry.python"}
 
-    def test_skips_empty_sdk_name(self):
+    def test_skips_empty_sdk_name(self) -> None:
         data = [{"project.id": self.project.id, "sdk.name": "", "count()": 500}]
         with mock.patch(MOCK_RUN_TABLE, return_value={"data": data}):
             assert get_sdk_names_for_org_projects([self.project], self.start, self.end) == {}

--- a/tests/sentry/seer/explorer/test_custom_tool_utils.py
+++ b/tests/sentry/seer/explorer/test_custom_tool_utils.py
@@ -119,12 +119,12 @@ class ProcessItemsTool(ExplorerTool[ProcessItemsParams]):
 
 @cell_silo_test
 class CustomToolUtilsTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         create_test_cells()
         self.organization = self.create_organization()
 
-    def test_validate_tool_class_nested(self):
+    def test_validate_tool_class_nested(self) -> None:
         """Test validation fails for nested classes."""
 
         class OuterClass:
@@ -143,7 +143,7 @@ class CustomToolUtilsTest(TestCase):
             extract_tool_schema(OuterClass.NestedTool)
         assert "module-level class" in str(cm.value)
 
-    def test_extract_tool_schema_basic(self):
+    def test_extract_tool_schema_basic(self) -> None:
         """Test extracting schema from a basic tool class."""
         schema = extract_tool_schema(GetUserInfoTool)
 
@@ -154,7 +154,7 @@ class CustomToolUtilsTest(TestCase):
         assert "properties" in schema.param_schema
         assert "user_id" in schema.param_schema["properties"]
 
-    def test_extract_tool_schema_with_optional_params(self):
+    def test_extract_tool_schema_with_optional_params(self) -> None:
         """Test extracting schema with optional parameters."""
         schema = extract_tool_schema(SearchLogsTool)
 
@@ -168,7 +168,7 @@ class CustomToolUtilsTest(TestCase):
         # Only query is required
         assert schema.param_schema.get("required") == ["query"]
 
-    def test_extract_tool_schema_with_list_params(self):
+    def test_extract_tool_schema_with_list_params(self) -> None:
         """Test extracting schema with list parameters."""
         schema = extract_tool_schema(ProcessItemsTool)
 
@@ -179,7 +179,7 @@ class CustomToolUtilsTest(TestCase):
         assert properties["items"]["type"] == "array"
         assert properties["priorities"]["type"] == "array"
 
-    def test_call_custom_tool_success(self):
+    def test_call_custom_tool_success(self) -> None:
         """Test calling a custom tool successfully."""
         # Use test tool from this test module
         module_path = "tests.sentry.seer.explorer.test_custom_tool_utils.SampleCustomTool"
@@ -194,7 +194,7 @@ class CustomToolUtilsTest(TestCase):
         )
         assert result == "HiHiHi"
 
-    def test_call_custom_tool_with_optional_param(self):
+    def test_call_custom_tool_with_optional_param(self) -> None:
         """Test calling a custom tool with default parameter."""
         module_path = "tests.sentry.seer.explorer.test_custom_tool_utils.SampleToolWithDefault"
         result = call_custom_tool(
@@ -205,7 +205,7 @@ class CustomToolUtilsTest(TestCase):
         )
         assert result == "Hello!"
 
-    def test_call_custom_tool_security_restriction(self):
+    def test_call_custom_tool_security_restriction(self) -> None:
         """Test that only allowed prefixes module paths are allowed."""
         with pytest.raises(ValueError) as cm:
             call_custom_tool(
@@ -216,7 +216,7 @@ class CustomToolUtilsTest(TestCase):
         assert "must start with one of" in str(cm.value)
         assert "('sentry.',)" in str(cm.value)
 
-    def test_call_custom_tool_invalid_path(self):
+    def test_call_custom_tool_invalid_path(self) -> None:
         """Test calling with invalid module path."""
         with pytest.raises(ValueError) as cm:
             call_custom_tool(
@@ -225,7 +225,7 @@ class CustomToolUtilsTest(TestCase):
             )
         assert "Could not import" in str(cm.value)
 
-    def test_call_custom_tool_wrong_return_type(self):
+    def test_call_custom_tool_wrong_return_type(self) -> None:
         """Test error when tool returns non-string."""
         module_path = "tests.sentry.seer.explorer.test_custom_tool_utils.BadTool"
         with pytest.raises(RuntimeError) as cm:
@@ -236,7 +236,7 @@ class CustomToolUtilsTest(TestCase):
             )
         assert "must return str" in str(cm.value)
 
-    def test_tool_without_params_model_raises(self):
+    def test_tool_without_params_model_raises(self) -> None:
         """Test that a tool without params_model raises an error at class definition time."""
         with pytest.raises(TypeError) as cm:
             # This should raise when the class is defined, not when extract_tool_schema is called

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -18,7 +18,7 @@ from sentry.testutils.requests import make_request
 
 
 class TestSeerExplorerClient(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
@@ -388,7 +388,7 @@ class TestSeerExplorerClient(TestCase):
 class TestSeerExplorerClientArtifacts(TestCase):
     """Test artifact schema passing and retrieval"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
@@ -694,7 +694,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
 class TestSeerExplorerClientPushChanges(TestCase):
     """Test push_changes method"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
@@ -800,7 +800,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
 class TestSeerRunStateCodeChanges(TestCase):
     """Test SeerRunState helper methods for code changes"""
 
-    def test_has_code_changes_no_patches(self):
+    def test_has_code_changes_no_patches(self) -> None:
         """Test has_code_changes with no patches returns (False, True)"""
         state = SeerRunState(
             run_id=123,
@@ -819,7 +819,7 @@ class TestSeerRunStateCodeChanges(TestCase):
         assert has_changes is False
         assert is_synced is True
 
-    def test_has_code_changes_unsynced(self):
+    def test_has_code_changes_unsynced(self) -> None:
         """Test has_code_changes with patches but no PR"""
         state = SeerRunState(
             run_id=123,
@@ -844,7 +844,7 @@ class TestSeerRunStateCodeChanges(TestCase):
         assert has_changes is True
         assert is_synced is False
 
-    def test_has_code_changes_synced(self):
+    def test_has_code_changes_synced(self) -> None:
         """Test has_code_changes when changes are synced to PR"""
         state = SeerRunState(
             run_id=123,
@@ -877,7 +877,7 @@ class TestSeerRunStateCodeChanges(TestCase):
         assert has_changes is True
         assert is_synced is True
 
-    def test_get_diffs_by_repo(self):
+    def test_get_diffs_by_repo(self) -> None:
         """Test get_diffs_by_repo groups merged patches correctly"""
         state = SeerRunState(
             run_id=123,
@@ -911,7 +911,7 @@ class TestSeerRunStateCodeChanges(TestCase):
         assert len(result["owner/repo1"]) == 2
         assert len(result["owner/repo2"]) == 1
 
-    def test_get_diffs_by_repo_latest_patch_wins(self):
+    def test_get_diffs_by_repo_latest_patch_wins(self) -> None:
         """Test get_diffs_by_repo returns latest merged patch per file"""
         state = SeerRunState(
             run_id=123,

--- a/tests/sentry/seer/explorer/test_explorer_service_map_utils.py
+++ b/tests/sentry/seer/explorer/test_explorer_service_map_utils.py
@@ -34,7 +34,7 @@ def _make_snuba_params(organization, projects):
 
 @django_db_all
 class TestSendToSeer(TestCase):
-    def test_builds_correct_payload(self):
+    def test_builds_correct_payload(self) -> None:
         org = self.create_organization()
 
         nodes = [
@@ -78,7 +78,7 @@ class TestSendToSeer(TestCase):
         assert body["nodes"] == nodes
         assert body["edges"] == edges
 
-    def test_filters_nodes_with_missing_slugs(self):
+    def test_filters_nodes_with_missing_slugs(self) -> None:
         org = self.create_organization()
 
         nodes: list[dict[str, Any]] = [
@@ -124,7 +124,7 @@ class TestSendToSeer(TestCase):
 
 @django_db_all
 class TestBuildServiceMap(TestCase):
-    def test_handles_no_projects(self):
+    def test_handles_no_projects(self) -> None:
         org = self.create_organization()
 
         with override_options({"explorer.context_engine_indexing.enable": True}):
@@ -374,7 +374,7 @@ class TestQueryServiceDependenciesIntegration(SnubaTestCase, SpanTestCase):
 
         return projects, spans
 
-    def test_simple_cross_project_edge(self):
+    def test_simple_cross_project_edge(self) -> None:
         """Test basic A→B cross-project dependency"""
 
         # Setup projects
@@ -427,7 +427,7 @@ class TestQueryServiceDependenciesIntegration(SnubaTestCase, SpanTestCase):
         assert edge["target_project_slug"] == "api"
         assert edge["count"] == 1
 
-    def test_multi_hop_chain(self):
+    def test_multi_hop_chain(self) -> None:
         """Test A→B→C multi-hop chain"""
 
         # Setup projects
@@ -489,7 +489,7 @@ class TestQueryServiceDependenciesIntegration(SnubaTestCase, SpanTestCase):
         edge_pairs = {(e["source_project_slug"], e["target_project_slug"]) for e in edges}
         assert edge_pairs == {("frontend", "api"), ("api", "database")}
 
-    def test_filters_same_project_edges(self):
+    def test_filters_same_project_edges(self) -> None:
         """Test that same-project edges are filtered out"""
 
         # Setup single project
@@ -532,7 +532,7 @@ class TestQueryServiceDependenciesIntegration(SnubaTestCase, SpanTestCase):
         # Verify no edges (same-project filtered)
         assert len(edges) == 0
 
-    def test_aggregates_duplicate_edges(self):
+    def test_aggregates_duplicate_edges(self) -> None:
         """Test that duplicate A→B edges are aggregated with count"""
 
         # Setup projects
@@ -587,7 +587,7 @@ class TestQueryServiceDependenciesIntegration(SnubaTestCase, SpanTestCase):
         assert edge["target_project_slug"] == "api"
         assert edge["count"] == 3
 
-    def test_handles_missing_parent_spans(self):
+    def test_handles_missing_parent_spans(self) -> None:
         """Test graceful handling of orphaned spans with non-existent parents"""
 
         # Setup projects
@@ -614,7 +614,7 @@ class TestQueryServiceDependenciesIntegration(SnubaTestCase, SpanTestCase):
         # Verify no edges created for orphans
         assert len(edges) == 0
 
-    def test_multiple_services_calling_same_backend(self):
+    def test_multiple_services_calling_same_backend(self) -> None:
         """Test fan-in pattern: A→C and B→C"""
 
         # Setup projects
@@ -699,7 +699,7 @@ class TestQueryServiceDependenciesIntegration(SnubaTestCase, SpanTestCase):
         edge_pairs = {(e["source_project_slug"], e["target_project_slug"]) for e in edges}
         assert edge_pairs == {("frontend", "api"), ("mobile", "api")}
 
-    def test_circular_dependencies(self):
+    def test_circular_dependencies(self) -> None:
         """Test circular dependencies: A→B in trace1, B→A in trace2"""
 
         # Setup projects
@@ -799,7 +799,7 @@ class TestClassifyServiceRolesIntegration(SnubaTestCase, SpanTestCase):
         projects = list(self.organization.project_set.all())
         return _make_snuba_params(self.organization, projects)
 
-    def test_caller_classification(self):
+    def test_caller_classification(self) -> None:
         """Test classification of caller service (high out-degree, low in-degree)"""
 
         # Setup projects
@@ -857,7 +857,7 @@ class TestClassifyServiceRolesIntegration(SnubaTestCase, SpanTestCase):
         # Frontend should be classified as caller (only outgoing edges)
         assert roles[project_frontend.id] == "caller"
 
-    def test_hub_classification(self):
+    def test_hub_classification(self) -> None:
         """Test classification of hub service (high in-degree and out-degree)"""
 
         # Setup projects: frontend → api → database
@@ -944,7 +944,7 @@ class TestClassifyServiceRolesIntegration(SnubaTestCase, SpanTestCase):
         # API should be hub (both incoming and outgoing edges)
         assert roles[project_api.id] == "hub"
 
-    def test_peripheral_classification(self):
+    def test_peripheral_classification(self) -> None:
         """Test classification of peripheral service (low connectivity in both directions)
 
         To produce a peripheral node we need avg degree > 1, which requires more edges
@@ -1027,7 +1027,7 @@ class TestBuildServiceMapIntegration(SnubaTestCase, SpanTestCase):
         self.ten_mins_ago = before_now(minutes=10)
         yield
 
-    def test_complete_workflow_realistic_topology(self):
+    def test_complete_workflow_realistic_topology(self) -> None:
         """Test complete workflow with realistic multi-service topology"""
 
         # Setup realistic topology: frontend → api → [database, cache]

--- a/tests/sentry/seer/explorer/test_on_completion_hook.py
+++ b/tests/sentry/seer/explorer/test_on_completion_hook.py
@@ -19,14 +19,14 @@ class SampleCompletionHook(ExplorerOnCompletionHook):
 
 
 class OnCompletionHookTest(TestCase):
-    def test_extract_hook_definition(self):
+    def test_extract_hook_definition(self) -> None:
         """Test extracting hook definition from a hook class."""
         hook_def = extract_hook_definition(SampleCompletionHook)
 
         assert isinstance(hook_def, OnCompletionHookDefinition)
         assert hook_def.module_path.endswith("test_on_completion_hook.SampleCompletionHook")
 
-    def test_extract_hook_definition_nested_class_raises(self):
+    def test_extract_hook_definition_nested_class_raises(self) -> None:
         """Test that nested classes are rejected."""
 
         class OuterClass:
@@ -39,7 +39,7 @@ class OnCompletionHookTest(TestCase):
             extract_hook_definition(OuterClass.NestedHook)
         assert "module-level class" in str(cm.value)
 
-    def test_call_on_completion_hook_success(self):
+    def test_call_on_completion_hook_success(self) -> None:
         """Test calling a completion hook successfully."""
         module_path = "tests.sentry.seer.explorer.test_on_completion_hook.SampleCompletionHook"
 
@@ -53,7 +53,7 @@ class OnCompletionHookTest(TestCase):
         # Verify side effect: hook wrote run_id to organization options
         assert self.organization.get_option("test_hook_run_id") == 12345
 
-    def test_call_on_completion_hook_security_restriction(self):
+    def test_call_on_completion_hook_security_restriction(self) -> None:
         """Test that module path must start with allowed prefix."""
         with pytest.raises(ValueError) as cm:
             call_on_completion_hook(
@@ -64,7 +64,7 @@ class OnCompletionHookTest(TestCase):
             )
         assert "must start with one of" in str(cm.value)
 
-    def test_call_on_completion_hook_invalid_module(self):
+    def test_call_on_completion_hook_invalid_module(self) -> None:
         """Test calling a non-existent hook module."""
         with pytest.raises(ValueError) as cm:
             call_on_completion_hook(
@@ -74,7 +74,7 @@ class OnCompletionHookTest(TestCase):
             )
         assert "Could not import" in str(cm.value)
 
-    def test_call_on_completion_hook_not_a_hook_class(self):
+    def test_call_on_completion_hook_not_a_hook_class(self) -> None:
         """Test calling something that isn't an ExplorerOnCompletionHook."""
         # BaseModel is importable but not an ExplorerOnCompletionHook
         with pytest.raises(ValueError) as cm:

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -74,7 +74,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         "trace",
     ]
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.ten_mins_ago = before_now(minutes=10)
         self.two_mins_ago = before_now(minutes=2)
@@ -118,7 +118,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
 
         self.store_spans(spans)
 
-    def test_spans_timeseries_count_metric(self):
+    def test_spans_timeseries_count_metric(self) -> None:
         """Test timeseries query with count() metric using real data"""
         result = execute_timeseries_query(
             org_id=self.organization.id,
@@ -140,7 +140,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         total_count = sum(point[1][0]["count"] for point in data_points if point[1])
         assert total_count == 4
 
-    def test_spans_timeseries_count_metric_start_end_filter(self):
+    def test_spans_timeseries_count_metric_start_end_filter(self) -> None:
         """Test timeseries query with count() metric using real data, filtered by start and end"""
         # Since this is a small range, we need to specify the interval. The event endpoint's
         # get_rollup fx doesn't go below 15m when calculating from date range.
@@ -166,7 +166,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         total_count = sum(point[1][0]["count"] for point in data_points if point[1])
         assert total_count == 3  # Should exclude the span created at 1 minute ago
 
-    def test_spans_timeseries_multiple_metrics(self):
+    def test_spans_timeseries_multiple_metrics(self) -> None:
         """Test timeseries query with multiple metrics"""
         result = execute_timeseries_query(
             org_id=self.organization.id,
@@ -198,7 +198,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         ]
         assert len(duration_values) > 0
 
-    def test_spans_table_basic_query(self):
+    def test_spans_table_basic_query(self) -> None:
         """Test table query returns actual span data"""
         result = execute_table_query(
             org_id=self.organization.id,
@@ -226,7 +226,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         cache_rows = [row for row in rows if row.get("span.op") == "cache.get"]
         assert len(cache_rows) == 1  # One cache span
 
-    def test_spans_table_query_start_end_filter(self):
+    def test_spans_table_query_start_end_filter(self) -> None:
         result = execute_table_query(
             org_id=self.organization.id,
             dataset="spans",
@@ -251,7 +251,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         http_rows = [row for row in rows if row.get("span.op") == "http.client"]
         assert len(http_rows) == 1  # One HTTP span
 
-    def test_spans_table_specific_operation(self):
+    def test_spans_table_specific_operation(self) -> None:
         """Test table query filtering by specific operation"""
         result = execute_table_query(
             org_id=self.organization.id,
@@ -274,7 +274,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         descriptions = [row.get("span.description", "") for row in http_rows]
         assert any("api.external.com" in desc for desc in descriptions)
 
-    def test_spans_timeseries_empty_results(self):
+    def test_spans_timeseries_empty_results(self) -> None:
         """Test timeseries query with query that returns no results"""
         result = execute_timeseries_query(
             org_id=self.organization.id,
@@ -294,7 +294,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
             total_count = sum(point[1][0]["count"] for point in data_points if point[1])
             assert total_count == 0
 
-    def test_spans_table_empty_results(self):
+    def test_spans_table_empty_results(self) -> None:
         """Test table query with query that returns no results"""
         result = execute_table_query(
             org_id=self.organization.id,
@@ -310,7 +310,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         assert "data" in result
         assert len(result["data"]) == 0
 
-    def test_spans_timeseries_duration_filtering(self):
+    def test_spans_timeseries_duration_filtering(self) -> None:
         """Test timeseries query with duration filter"""
         result = execute_timeseries_query(
             org_id=self.organization.id,
@@ -330,7 +330,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         total_count = sum(point[1][0]["count"] for point in data_points if point[1])
         assert total_count == 3
 
-    def test_spans_table_duration_stats(self):
+    def test_spans_table_duration_stats(self) -> None:
         """Test table query with duration statistics"""
         result = execute_table_query(
             org_id=self.organization.id,
@@ -356,7 +356,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
             # Allow for some tolerance in duration matching
             assert any(abs(d - expected) < 10 for d in durations)
 
-    def test_spans_table_appends_sort(self):
+    def test_spans_table_appends_sort(self) -> None:
         """Test sort is automatically appended to selected fields if not provided."""
         for sort in ["timestamp", "-timestamp"]:
             result = execute_table_query(
@@ -373,7 +373,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
             assert "id" in rows[0]
             assert "timestamp" in rows[0]
 
-    def test_spans_query_nonexistent_organization(self):
+    def test_spans_query_nonexistent_organization(self) -> None:
         """Test queries handle nonexistent organization gracefully"""
         timeseries_result = execute_timeseries_query(
             org_id=99999,
@@ -452,7 +452,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
 
         assert exc_info.value.status_code == 500
 
-    def test_spans_timeseries_with_groupby(self):
+    def test_spans_timeseries_with_groupby(self) -> None:
         """Test timeseries query with group_by parameter for aggregates"""
         result = execute_timeseries_query(
             org_id=self.organization.id,
@@ -483,7 +483,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
             data_points = metrics["count()"]["data"]
             assert isinstance(data_points, list)
 
-    def test_spans_table_aggregates_groupby(self):
+    def test_spans_table_aggregates_groupby(self) -> None:
         """Test table query with group_by for aggregates mode"""
         result = execute_table_query(
             org_id=self.organization.id,
@@ -507,7 +507,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
             assert "span.op" in row
             assert "count()" in row
 
-    def test_spans_table_aggregates_basic(self):
+    def test_spans_table_aggregates_basic(self) -> None:
         """Test table query in aggregates mode without group_by"""
         result = execute_table_query(
             org_id=self.organization.id,
@@ -531,7 +531,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
             assert "count()" in row
             assert "avg(span.duration)" in row
 
-    def test_spans_table_aggregates_multiple_functions(self):
+    def test_spans_table_aggregates_multiple_functions(self) -> None:
         """Test table query in aggregates mode with multiple aggregate functions"""
         result = execute_table_query(
             org_id=self.organization.id,
@@ -556,7 +556,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
             assert "sum(span.duration)" in row
             assert "avg(span.duration)" in row
 
-    def test_get_organization_project_ids(self):
+    def test_get_organization_project_ids(self) -> None:
         """Test the get_organization_project_ids RPC method"""
         # Test with valid organization
         result = get_organization_project_ids(org_id=self.organization.id)
@@ -1318,12 +1318,12 @@ class TestGetIssueAndEventDetailsV2(
         _SentryEventData.parse_obj(event_dict)
         assert result["event_id"] == event_dict["id"]
 
-    def test_get_ie_details_from_event_id_with_issue(self):
+    def test_get_ie_details_from_event_id_with_issue(self) -> None:
         self._test_get_ie_details_from_event_id(
             include_issue=True,
         )
 
-    def test_get_ie_details_from_event_id_without_issue(self):
+    def test_get_ie_details_from_event_id_without_issue(self) -> None:
         self._test_get_ie_details_from_event_id(
             include_issue=False,
         )
@@ -1746,7 +1746,7 @@ class TestGetEventDetails(
 
     # --- both params / neither param ---
 
-    def test_raises_if_both_event_id_and_issue_id(self):
+    def test_raises_if_both_event_id_and_issue_id(self) -> None:
         with pytest.raises(BadRequest):
             get_event_details(
                 organization_id=self.organization.id,
@@ -1754,13 +1754,13 @@ class TestGetEventDetails(
                 issue_id="123",
             )
 
-    def test_raises_if_neither_event_id_nor_issue_id(self):
+    def test_raises_if_neither_event_id_nor_issue_id(self) -> None:
         with pytest.raises(BadRequest):
             get_event_details(organization_id=self.organization.id)
 
     # --- fetch by event_id ---
 
-    def test_by_event_id_single_project(self):
+    def test_by_event_id_single_project(self) -> None:
         """Fetching by event_id with project_slug hits the single-project code path."""
         event = self._make_error_event()
 
@@ -1772,7 +1772,7 @@ class TestGetEventDetails(
 
         self._assert_event_response_shape(result, expected_event_id=event.event_id)
 
-    def test_by_event_id_multi_project(self):
+    def test_by_event_id_multi_project(self) -> None:
         """Fetching by event_id without project_slug hits the multi-project code path."""
         self.create_project(organization=self.organization)  # second project → multi-project path
         event = self._make_error_event()
@@ -1784,7 +1784,7 @@ class TestGetEventDetails(
 
         self._assert_event_response_shape(result, expected_event_id=event.event_id)
 
-    def test_by_event_id_not_found_returns_none(self):
+    def test_by_event_id_not_found_returns_none(self) -> None:
         result = get_event_details(
             organization_id=self.organization.id,
             event_id=uuid.uuid4().hex,
@@ -1792,7 +1792,7 @@ class TestGetEventDetails(
         )
         assert result is None
 
-    def test_by_event_id_invalid_uuid_raises(self):
+    def test_by_event_id_invalid_uuid_raises(self) -> None:
         with pytest.raises(ValueError):
             get_event_details(
                 organization_id=self.organization.id,
@@ -1800,7 +1800,7 @@ class TestGetEventDetails(
                 project_slug=self.project.slug,
             )
 
-    def test_by_event_id_wrong_project_returns_none(self):
+    def test_by_event_id_wrong_project_returns_none(self) -> None:
         """Event in a different project should not be visible when project_slug is specified."""
         other_project = self.create_project(organization=self.organization)
         data = load_data("python", timestamp=before_now(minutes=5))
@@ -1814,7 +1814,7 @@ class TestGetEventDetails(
         )
         assert result is None
 
-    def test_by_event_id_occurrence(self):
+    def test_by_event_id_occurrence(self) -> None:
         """Occurrence data is included when fetching an issue-platform event by event_id."""
         occurrence, _ = self.process_occurrence(
             event_data={
@@ -1923,7 +1923,7 @@ class TestGetEventDetails(
         assert args[1].id == self.organization.id
         assert result is None
 
-    def test_no_projects_returns_none(self):
+    def test_no_projects_returns_none(self) -> None:
         """Returns None when the given project_slug doesn't exist."""
         event = self._make_error_event()
 
@@ -2141,7 +2141,7 @@ class TestGetIssueEventTimeseries(APITransactionTestCase, SnubaTestCase):
 
 
 class TestGetRecommendedEvent(APITransactionTestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.max_date_range = timedelta(days=14)
 
@@ -2163,7 +2163,7 @@ class TestGetRecommendedEvent(APITransactionTestCase, SnubaTestCase):
             }
         return self.store_event(data=data, project_id=project_id)
 
-    def test_get_recommended_event_start_clamped_to_retention(self):
+    def test_get_recommended_event_start_clamped_to_retention(self) -> None:
         """
         Start is clamped to retention boundary. Spans query should also be clamped.
         """
@@ -2206,7 +2206,7 @@ class TestGetRecommendedEvent(APITransactionTestCase, SnubaTestCase):
                 spans_start = datetime.fromisoformat(mock_execute_table_query.call_args[1]["start"])
                 assert abs(spans_start - retention_boundary) < timedelta(minutes=1)
 
-    def test_get_recommended_event_end_outside_retention(self):
+    def test_get_recommended_event_end_outside_retention(self) -> None:
         """
         Raises error if both start and end are outside retention.
         """
@@ -2230,7 +2230,7 @@ class TestGetRecommendedEvent(APITransactionTestCase, SnubaTestCase):
                     end=end,
                 )
 
-    def test_get_recommended_event_fallback_if_no_events_in_clamped_range(self):
+    def test_get_recommended_event_fallback_if_no_events_in_clamped_range(self) -> None:
         """Falls back to most recent event in full range if no events in clamped range."""
         project = self.create_project()
         now = datetime.now(UTC)
@@ -2259,7 +2259,7 @@ class TestGetRecommendedEvent(APITransactionTestCase, SnubaTestCase):
         assert isinstance(result, GroupEvent)
         assert result.event_id == event2.event_id
 
-    def test_get_recommended_event_fallback_if_no_events_with_spans_in_clamped_range(self):
+    def test_get_recommended_event_fallback_if_no_events_with_spans_in_clamped_range(self) -> None:
         """Falls back to most recent event if no events with spans in clamped range."""
         project = self.create_project()
         now = datetime.now(UTC)
@@ -2294,7 +2294,7 @@ class TestGetRecommendedEvent(APITransactionTestCase, SnubaTestCase):
 
 
 class TestGetRepositoryDefinition(APITransactionTestCase):
-    def test_get_repository_definition_success(self):
+    def test_get_repository_definition_success(self) -> None:
         """Test successful repository lookup"""
         Repository.objects.create(
             organization_id=self.organization.id,
@@ -2318,7 +2318,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         assert result["name"] == "seer"
         assert result["external_id"] == "12345678"
 
-    def test_get_repository_definition_invalid_format(self):
+    def test_get_repository_definition_invalid_format(self) -> None:
         """Test that invalid repo name format returns None"""
         result = get_repository_definition(
             organization_id=self.organization.id,
@@ -2327,7 +2327,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
 
         assert result is None
 
-    def test_get_repository_definition_not_found(self):
+    def test_get_repository_definition_not_found(self) -> None:
         """Test that nonexistent repository returns None"""
         result = get_repository_definition(
             organization_id=self.organization.id,
@@ -2336,7 +2336,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
 
         assert result is None
 
-    def test_get_repository_definition_wrong_org(self):
+    def test_get_repository_definition_wrong_org(self) -> None:
         """Test that repository from different org returns None"""
         other_org = self.create_organization()
         Repository.objects.create(
@@ -2355,7 +2355,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
 
         assert result is None
 
-    def test_get_repository_definition_inactive_repo(self):
+    def test_get_repository_definition_inactive_repo(self) -> None:
         """Test that inactive repository returns None"""
         Repository.objects.create(
             organization_id=self.organization.id,
@@ -2373,7 +2373,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
 
         assert result is None
 
-    def test_get_repository_definition_no_integration_id(self):
+    def test_get_repository_definition_no_integration_id(self) -> None:
         """Test repository without integration_id"""
         Repository.objects.create(
             organization_id=self.organization.id,
@@ -2392,7 +2392,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         assert result is not None
         assert result["integration_id"] is None
 
-    def test_get_repository_definition_unsupported_provider(self):
+    def test_get_repository_definition_unsupported_provider(self) -> None:
         """Test that repositories with unsupported providers are filtered out"""
         # Create a GitLab repo (unsupported provider)
         Repository.objects.create(
@@ -2412,7 +2412,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         # Should return None since GitLab is not a supported provider
         assert result is None
 
-    def test_get_repository_definition_github_enterprise(self):
+    def test_get_repository_definition_github_enterprise(self) -> None:
         """Test that GitHub Enterprise provider is supported"""
         Repository.objects.create(
             organization_id=self.organization.id,
@@ -2431,7 +2431,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         assert result is not None
         assert result["provider"] == "integrations:github_enterprise"
 
-    def test_get_repository_definition_multiple_providers(self):
+    def test_get_repository_definition_multiple_providers(self) -> None:
         """Test that when multiple repos with different supported providers exist, first one is returned"""
         # Create two repos with same name but different providers
         Repository.objects.create(
@@ -2466,7 +2466,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         assert result["owner"] == "getsentry"
         assert result["name"] == "seer"
 
-    def test_get_repository_definition_filters_unsupported_with_supported(self):
+    def test_get_repository_definition_filters_unsupported_with_supported(self) -> None:
         """Test that unsupported providers are ignored even when a supported one exists"""
         # Create unsupported provider repo
         Repository.objects.create(
@@ -2497,7 +2497,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         assert result["provider"] == "integrations:github"
         assert result["external_id"] == "12345678"
 
-    def test_get_repository_definition_multipart_name(self):
+    def test_get_repository_definition_multipart_name(self) -> None:
         """Test repository with multi-part name (e.g., owner/project/repo)"""
         Repository.objects.create(
             organization_id=self.organization.id,
@@ -2517,7 +2517,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         assert result["owner"] == "getsentry"
         assert result["name"] == "project/seer"
 
-    def test_get_repository_definition_by_external_id(self):
+    def test_get_repository_definition_by_external_id(self) -> None:
         """Test lookup by external_id when repo has been renamed."""
         Repository.objects.create(
             organization_id=self.organization.id,
@@ -2542,7 +2542,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
 
 
 class TestRpcGetProfileFlamegraph(APITestCase, SpanTestCase, SnubaTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.ten_mins_ago = before_now(minutes=10)
 
@@ -2712,7 +2712,7 @@ class TestRpcGetProfileFlamegraph(APITestCase, SpanTestCase, SnubaTestCase):
         assert "execution_tree" in result
         assert result["metadata"]["profile_id"] == full_profile_id
 
-    def test_rpc_get_profile_flamegraph_not_found_in_90_days(self):
+    def test_rpc_get_profile_flamegraph_not_found_in_90_days(self) -> None:
         """Test when profile ID doesn't match any spans in 90-day window"""
         # Create a span without the profile we're looking for
         span = self.create_span(

--- a/tests/sentry/seer/fetch_issues/test_by_function_name.py
+++ b/tests/sentry/seer/fetch_issues/test_by_function_name.py
@@ -20,22 +20,22 @@ from tests.sentry.seer.fetch_issues.test_by_text_query import CreateEventTestCas
 
 
 class TestLeftTruncatedPaths(CreateEventTestCase):
-    def test_simple_filename(self):
+    def test_simple_filename(self) -> None:
         assert _left_truncated_paths("foo.py") == []
 
-    def test_single_directory(self):
+    def test_single_directory(self) -> None:
         assert _left_truncated_paths("path/foo.py") == ["foo.py"]
 
-    def test_multiple_directories(self):
+    def test_multiple_directories(self) -> None:
         assert _left_truncated_paths("path/to/foo.py") == ["to/foo.py", "foo.py"]
 
-    def test_max_num_paths_limit(self):
+    def test_max_num_paths_limit(self) -> None:
         assert _left_truncated_paths("path/to/foo/bar.py", max_num_paths=2) == [
             "to/foo/bar.py",
             "foo/bar.py",
         ]
 
-    def test_max_num_paths_larger_than_available(self):
+    def test_max_num_paths_larger_than_available(self) -> None:
         assert _left_truncated_paths("path/to/foo/bar.py", max_num_paths=5) == [
             "to/foo/bar.py",
             "foo/bar.py",
@@ -46,7 +46,7 @@ class TestLeftTruncatedPaths(CreateEventTestCase):
 class TestGetProjectsAndFilenamesFromSourceFile(IntegrationTestCase, CreateEventTestCase):
     provider = GitHubIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.gh_repo: Repository = self.create_repo(
             name="getsentry/sentry",
@@ -63,7 +63,7 @@ class TestGetProjectsAndFilenamesFromSourceFile(IntegrationTestCase, CreateEvent
             stack_root="sentry/",
         )
 
-    def test_file_with_matching_code_mapping(self):
+    def test_file_with_matching_code_mapping(self) -> None:
         projects, filenames = _get_projects_and_filenames_from_source_file(
             self.organization.id, self.gh_repo.id, "src/sentry/models/user.py"
         )
@@ -72,7 +72,7 @@ class TestGetProjectsAndFilenamesFromSourceFile(IntegrationTestCase, CreateEvent
         assert "src/sentry/models/user.py" in filenames
         assert "models/user.py" in filenames
 
-    def test_file_without_matching_code_mapping(self):
+    def test_file_without_matching_code_mapping(self) -> None:
         _, filenames = _get_projects_and_filenames_from_source_file(
             self.organization.id, self.gh_repo.id, "other/path/file.py"
         )
@@ -83,12 +83,12 @@ class TestGetProjectsAndFilenamesFromSourceFile(IntegrationTestCase, CreateEvent
 
 
 class TestGetIssuesForFile(CreateEventTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.event_timestamp_start = datetime.now(UTC) - timedelta(days=NUM_DAYS_AGO)
         self.event_timestamp_end = datetime.now(UTC)
 
-    def test_empty_projects_list(self):
+    def test_empty_projects_list(self) -> None:
         result = _get_issues_for_file(
             projects=[],
             sentry_filenames=["foo.py"],
@@ -111,7 +111,7 @@ class TestGetIssuesForFile(CreateEventTestCase):
         )
         assert result == []
 
-    def test_basic_matching(self):
+    def test_basic_matching(self) -> None:
         # Create events that should match our search criteria
         group = self._create_event(
             function_names=["target_func", "other_func"],
@@ -132,7 +132,7 @@ class TestGetIssuesForFile(CreateEventTestCase):
         group_ids = [issue["group_id"] for issue in result]
         assert group.id in group_ids
 
-    def test_filename_mismatch(self):
+    def test_filename_mismatch(self) -> None:
         # Create event with different filename
         group = self._create_event(
             function_names=["target_func"],
@@ -152,7 +152,7 @@ class TestGetIssuesForFile(CreateEventTestCase):
         group_ids = [issue["group_id"] for issue in result]
         assert group.id not in group_ids
 
-    def test_function_name_mismatch(self):
+    def test_function_name_mismatch(self) -> None:
         # Create event with different function name
         group = self._create_event(
             function_names=["other_func"],
@@ -172,7 +172,7 @@ class TestGetIssuesForFile(CreateEventTestCase):
         group_ids = [issue["group_id"] for issue in result]
         assert group.id not in group_ids
 
-    def test_event_too_old(self):
+    def test_event_too_old(self) -> None:
         # Create old event - use a smaller offset to avoid timestamp validation errors
         group = self._create_event(
             function_names=["target_func"],
@@ -193,7 +193,7 @@ class TestGetIssuesForFile(CreateEventTestCase):
         group_ids = [issue["group_id"] for issue in result]
         assert group.id not in group_ids
 
-    def test_javascript_simple(self):
+    def test_javascript_simple(self) -> None:
         # Test with JavaScript files to ensure language-agnostic functionality
         group = self._create_event(
             function_names=["component.blue", "world"],
@@ -214,7 +214,7 @@ class TestGetIssuesForFile(CreateEventTestCase):
         group_ids = [issue["group_id"] for issue in result]
         assert group.id in group_ids
 
-    def test_stackframe_limit_edge_case(self):
+    def test_stackframe_limit_edge_case(self) -> None:
         # Create event with function name within the searchable stackframe range
         # The query searches the last STACKFRAME_COUNT frames (negative indices)
         # So put our target function in the last frame (which will be index -1)
@@ -239,7 +239,7 @@ class TestGetIssuesForFile(CreateEventTestCase):
         group_ids = [issue["group_id"] for issue in result]
         assert group.id in group_ids
 
-    def test_multiple_matching_issues(self):
+    def test_multiple_matching_issues(self) -> None:
         # Create multiple events that should match
         group1 = self._create_event(
             function_names=["target_func"], filenames=["test.py"], user_id="1", culprit="issue1"
@@ -266,7 +266,7 @@ class TestGetIssuesForFile(CreateEventTestCase):
 class TestFetchIssues(IntegrationTestCase, CreateEventTestCase):
     provider = GitHubIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.gh_repo: Repository = self.create_repo(
             name="getsentry/sentry",
@@ -281,7 +281,7 @@ class TestFetchIssues(IntegrationTestCase, CreateEventTestCase):
             repo=self.gh_repo,
         )
 
-    def test_successful_fetch(self):
+    def test_successful_fetch(self) -> None:
         # Create some test events
         group = self._create_event(
             filenames=["test.py", "other.py"],
@@ -318,7 +318,7 @@ class TestFetchIssues(IntegrationTestCase, CreateEventTestCase):
                 mock_fetch.assert_called_once()
                 mock_serialize.assert_called_once_with([group])
 
-    def test_custom_max_num_issues(self):
+    def test_custom_max_num_issues(self) -> None:
         group = self._create_event(
             filenames=["test.py"],
             function_names=["target_function"],
@@ -352,7 +352,7 @@ class TestFetchIssues(IntegrationTestCase, CreateEventTestCase):
                 call_args = mock_fetch.call_args
                 assert call_args[1]["max_num_issues_per_file"] == 10
 
-    def test_with_run_id(self):
+    def test_with_run_id(self) -> None:
         group = self._create_event().group
 
         with patch(
@@ -382,7 +382,7 @@ class TestFetchIssues(IntegrationTestCase, CreateEventTestCase):
                 call_args = mock_fetch.call_args
                 assert call_args[1]["run_id"] == 12345
 
-    def test_fetch_issues_end_to_end_with_metadata_and_message(self):
+    def test_fetch_issues_end_to_end_with_metadata_and_message(self) -> None:
         """Test end-to-end fetch_issues call to verify metadata and message fields are present."""
         # Create an event with specific data that will show up in metadata
         event = self._create_event(
@@ -434,7 +434,7 @@ class TestFetchIssues(IntegrationTestCase, CreateEventTestCase):
 class TestFetchIssuesFromRepoProjects(IntegrationTestCase, CreateEventTestCase):
     provider = GitHubIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.gh_repo: Repository = self.create_repo(
             name="getsentry/sentry",
@@ -505,7 +505,7 @@ class TestFetchIssuesFromRepoProjects(IntegrationTestCase, CreateEventTestCase):
         call_args = mock_get_issues.call_args[0]
         assert call_args[0] == [self.project]
 
-    def test_fetch_issues_from_repo_projects_returns_groups(self):
+    def test_fetch_issues_from_repo_projects_returns_groups(self) -> None:
         """Test that _fetch_issues_from_repo_projects returns a list of Group objects."""
         # Create a group that should match
         event = self._create_event(
@@ -539,7 +539,7 @@ class TestFetchIssuesFromRepoProjects(IntegrationTestCase, CreateEventTestCase):
 
         assert expected_group.id in [result.id for result in results]
 
-    def test_fetch_issues_from_repo_projects_empty_result(self):
+    def test_fetch_issues_from_repo_projects_empty_result(self) -> None:
         """Test that _fetch_issues_from_repo_projects returns empty list when no matches."""
         # Get repo projects but don't create any matching events
         assert self.gh_repo.external_id is not None

--- a/tests/sentry/seer/fetch_issues/test_by_text_query.py
+++ b/tests/sentry/seer/fetch_issues/test_by_text_query.py
@@ -61,7 +61,7 @@ class CreateEventTestCase(TestCase):
 class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
     provider = GitHubIntegrationProvider
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.gh_repo: Repository = self.create_repo(
             name="getsentry/sentry",
@@ -76,7 +76,7 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
             repo=self.gh_repo,
         )
 
-    def test_fetch_issues_message_substring_search(self):
+    def test_fetch_issues_message_substring_search(self) -> None:
         """Test that text queries do case-insensitive substring search in issue messages."""
         group = self._create_event(
             filenames=["auth.py", "utils.py"],
@@ -133,7 +133,7 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
         # Check that the group ID matches
         assert first_issue["id"] == str(group.id)
 
-    def test_fetch_issues_no_match(self):
+    def test_fetch_issues_no_match(self) -> None:
         """Test that non-matching queries return empty results."""
         self._create_event(
             filenames=["models/user.py"],
@@ -156,7 +156,7 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
         # Should return empty results
         assert seer_response == {"issues": [], "issues_full": []}
 
-    def test_fetch_issues_culprit_search(self):
+    def test_fetch_issues_culprit_search(self) -> None:
         """Test that queries match content in the culprit field."""
         group = self._create_event(
             filenames=["test.py"],
@@ -180,7 +180,7 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
         assert len(seer_response["issues"]) > 0
         assert group.id in seer_response["issues"]
 
-    def test_fetch_issues_limit_parameter(self):
+    def test_fetch_issues_limit_parameter(self) -> None:
         """Test that the limit parameter is respected."""
         # Create multiple matching events
         for i in range(5):
@@ -206,7 +206,7 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
         assert "error" not in seer_response
         assert len(seer_response["issues"]) <= limit
 
-    def test_fetch_issues_from_repo_projects_returns_groups(self):
+    def test_fetch_issues_from_repo_projects_returns_groups(self) -> None:
         """Test that _fetch_issues_from_repo_projects returns a list of Group objects."""
         # Create a group that should match the search query
         event = self._create_event(
@@ -240,7 +240,7 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
         result_ids = [result.id for result in results]
         assert expected_group.id in result_ids
 
-    def test_fetch_issues_from_repo_projects_empty_result(self):
+    def test_fetch_issues_from_repo_projects_empty_result(self) -> None:
         """Test that _fetch_issues_from_repo_projects returns empty list when no matches."""
         # Get repo projects but don't create any matching events
         assert self.gh_repo.external_id is not None

--- a/tests/sentry/seer/fetch_issues/test_utils.py
+++ b/tests/sentry/seer/fetch_issues/test_utils.py
@@ -16,7 +16,7 @@ from sentry.utils.samples import load_data
 
 
 class TestGetRepoAndProjects(TestCase):
-    def test_get_repo_and_projects_success(self):
+    def test_get_repo_and_projects_success(self) -> None:
         repo = self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -42,7 +42,7 @@ class TestGetRepoAndProjects(TestCase):
         assert len(result.projects) == 1
         assert result.projects[0] == self.project
 
-    def test_get_repo_and_projects_multiple_projects(self):
+    def test_get_repo_and_projects_multiple_projects(self) -> None:
         repo = self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -67,7 +67,7 @@ class TestGetRepoAndProjects(TestCase):
         project_ids = {proj.id for proj in result.projects}
         assert project_ids == {self.project.id, project2.id}
 
-    def test_get_repo_and_projects_no_configs(self):
+    def test_get_repo_and_projects_no_configs(self) -> None:
         self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -84,7 +84,7 @@ class TestGetRepoAndProjects(TestCase):
                 name="sentry",
             )
 
-    def test_get_repo_and_projects_unprefixed_provider(self):
+    def test_get_repo_and_projects_unprefixed_provider(self) -> None:
         repo = self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -104,7 +104,7 @@ class TestGetRepoAndProjects(TestCase):
         assert result.repo == repo
         assert len(result.projects) == 1
 
-    def test_get_repo_and_projects_with_wrong_owner_not_found(self):
+    def test_get_repo_and_projects_with_wrong_owner_not_found(self) -> None:
         from sentry.models.repository import Repository
 
         repo = self.create_repo(
@@ -124,7 +124,7 @@ class TestGetRepoAndProjects(TestCase):
                 name="sentry",
             )
 
-    def test_get_repo_and_projects_repo_not_found(self):
+    def test_get_repo_and_projects_repo_not_found(self) -> None:
         from sentry.models.repository import Repository
 
         with pytest.raises(Repository.DoesNotExist):
@@ -138,7 +138,7 @@ class TestGetRepoAndProjects(TestCase):
 
 
 class TestAsIssueDetails(TestCase):
-    def test_as_issue_details_success(self):
+    def test_as_issue_details_success(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(data=data, project_id=self.project.id)
         group = event.group
@@ -153,11 +153,11 @@ class TestAsIssueDetails(TestCase):
         assert result.transaction is None
         assert result.events == []
 
-    def test_as_issue_details_with_none_group(self):
+    def test_as_issue_details_with_none_group(self) -> None:
         result = as_issue_details(None)
         assert result is None
 
-    def test_as_issue_details_serialization_fails(self):
+    def test_as_issue_details_serialization_fails(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(data=data, project_id=self.project.id)
         group = event.group
@@ -166,7 +166,7 @@ class TestAsIssueDetails(TestCase):
             result = as_issue_details(group)
             assert result is None
 
-    def test_as_issue_details_includes_message(self):
+    def test_as_issue_details_includes_message(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(data=data, project_id=self.project.id)
         group = event.group
@@ -179,7 +179,7 @@ class TestAsIssueDetails(TestCase):
 
 
 class TestBulkSerializeForSeer(TestCase):
-    def test_bulk_serialize_for_seer_success(self):
+    def test_bulk_serialize_for_seer_success(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
         event1 = self.store_event(data=data, project_id=self.project.id)
         event2 = self.store_event(data=data, project_id=self.project.id)
@@ -201,7 +201,7 @@ class TestBulkSerializeForSeer(TestCase):
             assert item["transaction"] is None
             assert item["events"] == []
 
-    def test_bulk_serialize_for_seer_with_none_groups(self):
+    def test_bulk_serialize_for_seer_with_none_groups(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(data=data, project_id=self.project.id)
 
@@ -223,7 +223,7 @@ class TestBulkSerializeForSeer(TestCase):
             assert group_serialized["transaction"] is None
             assert group_serialized["events"] == []
 
-    def test_bulk_serialize_for_seer_serialization_fails(self):
+    def test_bulk_serialize_for_seer_serialization_fails(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(data=data, project_id=self.project.id)
 
@@ -237,7 +237,7 @@ class TestBulkSerializeForSeer(TestCase):
 
 
 class TestGetLatestIssueEvent(TestCase):
-    def test_get_latest_issue_event_success(self):
+    def test_get_latest_issue_event_success(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(data=data, project_id=self.project.id)
         group = event.group
@@ -252,12 +252,12 @@ class TestGetLatestIssueEvent(TestCase):
         assert len(result["events"]) == 1
         assert result["events"][0]["id"] == event.event_id
 
-    def test_get_latest_issue_event_not_found(self):
+    def test_get_latest_issue_event_not_found(self) -> None:
         nonexistent_group_id = 999999
         result = get_latest_issue_event(nonexistent_group_id, self.organization.id)
         assert result == {}
 
-    def test_get_latest_issue_event_with_short_id(self):
+    def test_get_latest_issue_event_with_short_id(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(data=data, project_id=self.project.id)
         group = event.group
@@ -272,24 +272,24 @@ class TestGetLatestIssueEvent(TestCase):
         assert len(result["events"]) == 1
         assert result["events"][0]["id"] == event.event_id
 
-    def test_get_latest_issue_event_with_short_id_not_found(self):
+    def test_get_latest_issue_event_with_short_id_not_found(self) -> None:
         result = get_latest_issue_event("INVALID-SHORT-ID", self.organization.id)
         assert result == {}
 
-    def test_get_latest_issue_event_no_events(self):
+    def test_get_latest_issue_event_no_events(self) -> None:
         # Create a group but don't store any events for it
         group = self.create_group(project=self.project)
         result = get_latest_issue_event(group.id, self.organization.id)
         assert result == {}
 
-    def test_get_latest_issue_event_wrong_organization(self):
+    def test_get_latest_issue_event_wrong_organization(self) -> None:
         event = self.store_event(data={}, project_id=self.project.id)
         group = event.group
         assert group is not None
         results = get_latest_issue_event(group.id, self.organization.id + 1)
         assert results == {}
 
-    def test_get_latest_issue_event_numeric_id_cross_org(self):
+    def test_get_latest_issue_event_numeric_id_cross_org(self) -> None:
         """Numeric group ID from another org must not be returned."""
         other_org = self.create_organization(owner=self.create_user())
         other_project = self.create_project(organization=other_org)
@@ -303,17 +303,17 @@ class TestGetLatestIssueEvent(TestCase):
 
 
 class TestHandleFetchIssuesExceptions(TestCase):
-    def test_handle_fetch_issues_exceptions_success(self):
+    def test_handle_fetch_issues_exceptions_success(self) -> None:
         @handle_fetch_issues_exceptions
-        def test_function():
+        def test_function() -> None:
             return {"success": True}
 
         result = test_function()
         assert result == {"success": True}
 
-    def test_handle_fetch_issues_exceptions_handles_exception(self):
+    def test_handle_fetch_issues_exceptions_handles_exception(self) -> None:
         @handle_fetch_issues_exceptions
-        def test_function():
+        def test_function() -> None:
             raise ValueError("test error")
 
         result = test_function()

--- a/tests/sentry/seer/fetch_issues/test_utils.py
+++ b/tests/sentry/seer/fetch_issues/test_utils.py
@@ -305,7 +305,7 @@ class TestGetLatestIssueEvent(TestCase):
 class TestHandleFetchIssuesExceptions(TestCase):
     def test_handle_fetch_issues_exceptions_success(self) -> None:
         @handle_fetch_issues_exceptions
-        def test_function() -> None:
+        def test_function() -> dict[str, bool]:
             return {"success": True}
 
         result = test_function()

--- a/tests/sentry/seer/similarity/test_config.py
+++ b/tests/sentry/seer/similarity/test_config.py
@@ -14,18 +14,18 @@ from sentry.testutils.cases import TestCase
 
 
 class GetGroupingModelVersionTest(TestCase):
-    def test_returns_stable_when_rollout_disabled(self):
+    def test_returns_stable_when_rollout_disabled(self) -> None:
         """When new model rollout is disabled, return stable version"""
         with patch("sentry.seer.similarity.config.SEER_GROUPING_NEW_VERSION", None):
             result = get_grouping_model_version(self.project)
             assert result == SEER_GROUPING_STABLE_VERSION
 
-    def test_returns_stable_when_feature_not_enabled(self):
+    def test_returns_stable_when_feature_not_enabled(self) -> None:
         """When feature flag is not enabled for project, return stable version"""
         result = get_grouping_model_version(self.project)
         assert result == SEER_GROUPING_STABLE_VERSION
 
-    def test_returns_new_when_feature_enabled(self):
+    def test_returns_new_when_feature_enabled(self) -> None:
         """When feature flag is enabled for project, return new version"""
         with self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE):
             result = get_grouping_model_version(self.project)
@@ -33,18 +33,18 @@ class GetGroupingModelVersionTest(TestCase):
 
 
 class IsNewModelRolledOutTest(TestCase):
-    def test_returns_false_when_no_new_version(self):
+    def test_returns_false_when_no_new_version(self) -> None:
         """When no new version is configured, rollout is not active"""
         with patch("sentry.seer.similarity.config.SEER_GROUPING_NEW_VERSION", None):
             result = is_new_model_rolled_out(self.project)
             assert result is False
 
-    def test_returns_false_when_feature_not_enabled(self):
+    def test_returns_false_when_feature_not_enabled(self) -> None:
         """When feature flag is not enabled, rollout is not active for project"""
         result = is_new_model_rolled_out(self.project)
         assert result is False
 
-    def test_returns_true_when_feature_enabled(self):
+    def test_returns_true_when_feature_enabled(self) -> None:
         """When feature flag is enabled, rollout is active for project"""
         with self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE):
             result = is_new_model_rolled_out(self.project)
@@ -52,12 +52,12 @@ class IsNewModelRolledOutTest(TestCase):
 
 
 class GetNewModelVersionTest(TestCase):
-    def test_returns_configured_version(self):
+    def test_returns_configured_version(self) -> None:
         """Returns the configured new model version"""
         result = get_new_model_version()
         assert result == GroupingVersion.V2
 
-    def test_returns_none_when_disabled(self):
+    def test_returns_none_when_disabled(self) -> None:
         """Returns None when rollout is disabled"""
         with patch("sentry.seer.similarity.config.SEER_GROUPING_NEW_VERSION", None):
             result = get_new_model_version()
@@ -65,7 +65,7 @@ class GetNewModelVersionTest(TestCase):
 
 
 class ShouldSendToSeerForTrainingTest(TestCase):
-    def test_returns_false_when_no_rollout(self):
+    def test_returns_false_when_no_rollout(self) -> None:
         """Returns False when no new version is being rolled out"""
         with patch("sentry.seer.similarity.config.SEER_GROUPING_NEW_VERSION", None):
             result = should_send_to_seer_for_training(
@@ -73,14 +73,14 @@ class ShouldSendToSeerForTrainingTest(TestCase):
             )
             assert result is False
 
-    def test_returns_false_when_feature_not_enabled(self):
+    def test_returns_false_when_feature_not_enabled(self) -> None:
         """Returns False when feature flag is not enabled for project"""
         result = should_send_to_seer_for_training(
             self.project, grouphash_seer_latest_training_model=None
         )
         assert result is False
 
-    def test_returns_true_when_never_sent(self):
+    def test_returns_true_when_never_sent(self) -> None:
         """Returns True when grouphash has never been sent to Seer"""
         with self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE):
             result = should_send_to_seer_for_training(
@@ -88,7 +88,7 @@ class ShouldSendToSeerForTrainingTest(TestCase):
             )
             assert result is True
 
-    def test_returns_true_when_sent_to_old_version(self):
+    def test_returns_true_when_sent_to_old_version(self) -> None:
         """Returns True when grouphash was sent to an older model version"""
         with self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE):
             result = should_send_to_seer_for_training(
@@ -96,7 +96,7 @@ class ShouldSendToSeerForTrainingTest(TestCase):
             )
             assert result is True
 
-    def test_returns_false_when_already_sent_to_new_version(self):
+    def test_returns_false_when_already_sent_to_new_version(self) -> None:
         """Returns False when grouphash was already sent to the new version"""
         with self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE):
             result = should_send_to_seer_for_training(

--- a/tests/sentry/seer/supergroups/test_lightweight_rca.py
+++ b/tests/sentry/seer/supergroups/test_lightweight_rca.py
@@ -5,14 +5,14 @@ from sentry.testutils.cases import TestCase
 
 
 class TestTriggerLightweightRca(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
         self.group = self.create_group(project=self.project)
 
-    def test_returns_none_when_feature_flag_off(self):
+    def test_returns_none_when_feature_flag_off(self) -> None:
         run_id = trigger_lightweight_rca(self.group)
 
         assert run_id is None

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -4,7 +4,7 @@ from sentry.testutils.cases import TestCase
 
 
 class TestFilterRepoByProvider(TestCase):
-    def test_matches_with_integrations_prefix(self):
+    def test_matches_with_integrations_prefix(self) -> None:
         repo = self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -14,7 +14,7 @@ class TestFilterRepoByProvider(TestCase):
         qs = filter_repo_by_provider(self.organization.id, "github", "123", "getsentry", "sentry")
         assert list(qs) == [repo]
 
-    def test_matches_with_exact_provider(self):
+    def test_matches_with_exact_provider(self) -> None:
         repo = self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -26,7 +26,7 @@ class TestFilterRepoByProvider(TestCase):
         )
         assert list(qs) == [repo]
 
-    def test_no_match_wrong_owner(self):
+    def test_no_match_wrong_owner(self) -> None:
         self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -36,7 +36,7 @@ class TestFilterRepoByProvider(TestCase):
         qs = filter_repo_by_provider(self.organization.id, "github", "123", "wrong-owner", "sentry")
         assert not qs.exists()
 
-    def test_no_match_wrong_name(self):
+    def test_no_match_wrong_name(self) -> None:
         self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -48,7 +48,7 @@ class TestFilterRepoByProvider(TestCase):
         )
         assert not qs.exists()
 
-    def test_no_match_wrong_external_id(self):
+    def test_no_match_wrong_external_id(self) -> None:
         self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -58,7 +58,7 @@ class TestFilterRepoByProvider(TestCase):
         qs = filter_repo_by_provider(self.organization.id, "github", "999", "getsentry", "sentry")
         assert not qs.exists()
 
-    def test_no_match_wrong_org(self):
+    def test_no_match_wrong_org(self) -> None:
         other_org = self.create_organization(owner=self.user)
         self.create_repo(
             project=self.project,
@@ -69,7 +69,7 @@ class TestFilterRepoByProvider(TestCase):
         qs = filter_repo_by_provider(other_org.id, "github", "123", "getsentry", "sentry")
         assert not qs.exists()
 
-    def test_excludes_inactive_repo(self):
+    def test_excludes_inactive_repo(self) -> None:
         repo = self.create_repo(
             project=self.project,
             name="getsentry/sentry",
@@ -82,7 +82,7 @@ class TestFilterRepoByProvider(TestCase):
         qs = filter_repo_by_provider(self.organization.id, "github", "123", "getsentry", "sentry")
         assert not qs.exists()
 
-    def test_github_enterprise_provider(self):
+    def test_github_enterprise_provider(self) -> None:
         repo = self.create_repo(
             project=self.project,
             name="mycompany/internal-repo",

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1801,7 +1801,7 @@ class TestBackfillServiceHooksEvents(TestCase):
             organization=self.organization, slug=self.sentry_app.slug
         )
 
-    def test_regenerate_service_hook_for_installation_success(self):
+    def test_regenerate_service_hook_for_installation_success(self) -> None:
         with assume_test_silo_mode(SiloMode.CELL):
             hook = ServiceHook.objects.get(installation_id=self.install.id)
             hook.events = ["issue.resolved", "error.created"]
@@ -1818,7 +1818,7 @@ class TestBackfillServiceHooksEvents(TestCase):
             hook.refresh_from_db()
             assert set(hook.events) == {"issue.created", "issue.resolved", "error.created"}
 
-    def test_regenerate_service_hook_for_installation_event_not_in_app_events(self):
+    def test_regenerate_service_hook_for_installation_event_not_in_app_events(self) -> None:
         with self.tasks(), assume_test_silo_mode(SiloMode.CONTROL):
             regenerate_service_hooks_for_installation(
                 installation_id=self.install.id,
@@ -1830,7 +1830,7 @@ class TestBackfillServiceHooksEvents(TestCase):
             hook = ServiceHook.objects.get(installation_id=self.install.id)
             assert set(hook.events) == {"issue.created", "issue.resolved", "error.created"}
 
-    def test_regenerate_service_hook_for_installation_with_empty_app_events(self):
+    def test_regenerate_service_hook_for_installation_with_empty_app_events(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.sentry_app.update(events=[])
             assert self.sentry_app.events == []

--- a/tests/sentry/sentry_apps/test_webhooks.py
+++ b/tests/sentry/sentry_apps/test_webhooks.py
@@ -169,7 +169,7 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
             self.installation_1.id, "issue.created", payload
         )
 
-    def test_valid_event_types_accepted(self):
+    def test_valid_event_types_accepted(self) -> None:
         """Test that all valid SentryAppEventType values are accepted."""
         valid_combinations = [
             ("error", "created"),
@@ -305,7 +305,7 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
         # Verify installations were fetched for the correct organization
         mock_installations.assert_called_once_with(organization_id=different_org.id)
 
-    def test_event_type_construction(self):
+    def test_event_type_construction(self) -> None:
         """Test that event types are constructed correctly."""
         test_cases = [
             ("issue", "created", "issue.created"),

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -440,7 +440,7 @@ def test_ops_breakdown_excludes_segment_span() -> None:
     assert result["span_ops.ops.http"]["value"] == 3600000.0  # 1 hour (child only)
 
 
-def test_write_tags_for_performance_issue_detection():
+def test_write_tags_for_performance_issue_detection() -> None:
     segment_span = _mock_performance_issue_span(
         is_segment=True,
         span_id="ffffffffffffffff",

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -261,7 +261,7 @@ class TestSpansTask(TestCase):
         signals = [args[0][1] for args in mock_track.call_args_list]
         assert signals == ["has_transactions", "has_insights_agent_monitoring"]
 
-    def test_segment_name_propagation(self):
+    def test_segment_name_propagation(self) -> None:
         child_span, segment_span = self.generate_basic_spans()
         segment_span["name"] = "my segment name"
 
@@ -280,7 +280,7 @@ class TestSpansTask(TestCase):
             "value": "my segment name",
         }
 
-    def test_segment_name_propagation_when_name_missing(self):
+    def test_segment_name_propagation_when_name_missing(self) -> None:
         child_span, segment_span = self.generate_basic_spans()
         del segment_span["name"]
 
@@ -321,7 +321,7 @@ class TestSpansTask(TestCase):
         )
         mock_record_segment_name.assert_not_called()
 
-    def test_segment_name_normalization_checks_source(self):
+    def test_segment_name_normalization_checks_source(self) -> None:
         _, segment_span = self.generate_basic_spans()
         segment_span["name"] = "/foo/2fd4e1c67a2d28fced849ee1bb76e7391b93eb12/user/123/0"
         segment_span["attributes"][ATTRIBUTE_NAMES.SENTRY_SPAN_SOURCE] = {
@@ -337,7 +337,7 @@ class TestSpansTask(TestCase):
         )
 
 
-def test_verify_compatibility():
+def test_verify_compatibility() -> None:
     spans: list[dict[str, Any]] = [
         # regular span:
         {"data": {"foo": 1}},

--- a/tests/sentry/spans/consumers/process_segments/test_shim.py
+++ b/tests/sentry/spans/consumers/process_segments/test_shim.py
@@ -7,7 +7,7 @@ from sentry.spans.consumers.process_segments.types import Attributes
 from tests.sentry.spans.consumers.process_segments.test_convert import SPAN_KAFKA_MESSAGE
 
 
-def test_make_compatible():
+def test_make_compatible() -> None:
     message = {**SPAN_KAFKA_MESSAGE}
     attributes: Attributes = {
         "sentry.exclusive_time_ms": {"type": "double", "value": 100.0},

--- a/tests/sentry/spans/log_analyzer/test_analyzer.py
+++ b/tests/sentry/spans/log_analyzer/test_analyzer.py
@@ -87,7 +87,7 @@ def test_get_summary_stats(sample_log_entries):
     assert stats["consumer_counts"]["process-spans-6"] == 2
 
 
-def test_trace_stats_duration_property():
+def test_trace_stats_duration_property() -> None:
     """Test duration calculation."""
     stats = TraceStats(
         project_id="123",

--- a/tests/sentry/spans/log_analyzer/test_fetchers.py
+++ b/tests/sentry/spans/log_analyzer/test_fetchers.py
@@ -16,7 +16,7 @@ from sentry.spans.log_analyzer.fetchers import (
 from sentry.utils import json
 
 
-def test_parse_top_traces_valid():
+def test_parse_top_traces_valid() -> None:
     """Test parsing valid trace entries."""
     operations = [
         "789789789:6a499a5de1f6e3b412adb0ef76009876:2303:26557",
@@ -37,7 +37,7 @@ def test_parse_top_traces_valid():
     assert result[1].cumulative_latency_ms == 6
 
 
-def test_parse_top_traces_empty_list():
+def test_parse_top_traces_empty_list() -> None:
     """Test parsing empty traces list."""
     result = parse_top_traces([])
     assert len(result) == 0
@@ -131,7 +131,7 @@ def test_fetch_logs_from_file_filter_by_consumer(sample_log_data):
     assert logs[0].consumer == "process-spans-6"
 
 
-def test_fetch_logs_from_gcp_with_filters():
+def test_fetch_logs_from_gcp_with_filters() -> None:
     """Test fetching logs with filters applied."""
     try:
         import google.cloud.logging as gcp_logging

--- a/tests/sentry/spans/test_gcp_log_analyzer.py
+++ b/tests/sentry/spans/test_gcp_log_analyzer.py
@@ -18,7 +18,7 @@ from sentry.spans.log_analyzer import (
 )
 
 
-def test_format_trace_table():
+def test_format_trace_table() -> None:
     """Test formatting trace table."""
     traces = [
         TraceStats(
@@ -49,14 +49,14 @@ def test_format_trace_table():
     assert "2,303" in result
 
 
-def test_format_empty_traces():
+def test_format_empty_traces() -> None:
     """Test formatting empty trace list."""
     result = format_trace_table([])
 
     assert "No traces found" in result
 
 
-def test_format_summary():
+def test_format_summary() -> None:
     """Test formatting summary statistics."""
     stats: SummaryStats = {
         "total_traces": 2,
@@ -74,7 +74,7 @@ def test_format_summary():
     assert "process-spans-6 (20)" in result
 
 
-def test_format_flusher_trace_table():
+def test_format_flusher_trace_table() -> None:
     """Test formatting flusher trace table."""
     traces = [
         FlusherTraceStats(
@@ -102,14 +102,14 @@ def test_format_flusher_trace_table():
     assert "Log Entries" not in result
 
 
-def test_format_flusher_empty_traces():
+def test_format_flusher_empty_traces() -> None:
     """Test formatting empty flusher trace list."""
     result = format_flusher_trace_table([])
 
     assert "No traces found" in result
 
 
-def test_format_flusher_summary():
+def test_format_flusher_summary() -> None:
     """Test formatting flusher summary statistics."""
     stats: FlusherSummaryStats = {
         "total_traces": 2,

--- a/tests/sentry/spans/test_log_analyzer.py
+++ b/tests/sentry/spans/test_log_analyzer.py
@@ -47,7 +47,7 @@ def _make_flusher_log_entry(
 
 
 class TestParseTopTraces:
-    def test_parses_valid_entries(self):
+    def test_parses_valid_entries(self) -> None:
         results = parse_top_traces(["123:aabb0011:100:5000", "456:ccdd0022:50:2000"])
 
         assert len(results) == 2
@@ -55,14 +55,14 @@ class TestParseTopTraces:
             project_id="123", trace_id="aabb0011", count=100, cumulative_latency_ms=5000
         )
 
-    def test_skips_malformed_entries(self):
+    def test_skips_malformed_entries(self) -> None:
         results = parse_top_traces(["bad_entry", "too:few", "123:aabb0011:100:5000"])
 
         assert len(results) == 1
 
 
 class TestParseTopFlushOperations:
-    def test_parses_valid_entries(self):
+    def test_parses_valid_entries(self) -> None:
         results = parse_top_flush_operations(
             ["123:aabb0011:5:200:50000", "456:ccdd0022:2:100:20000"]
         )
@@ -76,7 +76,7 @@ class TestParseTopFlushOperations:
             bytes_flushed=50000,
         )
 
-    def test_skips_malformed_entries(self):
+    def test_skips_malformed_entries(self) -> None:
         results = parse_top_flush_operations(
             ["bad_entry", "too:few:parts", "123:aabb0011:5:200:50000"]
         )
@@ -85,7 +85,7 @@ class TestParseTopFlushOperations:
 
 
 class TestLogAnalyzer:
-    def test_aggregates_across_entries(self):
+    def test_aggregates_across_entries(self) -> None:
         entries = [
             _make_buffer_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),
@@ -105,7 +105,7 @@ class TestLogAnalyzer:
         assert traces[0].log_entries == 2
         assert traces[0].duration == "0:01:00"
 
-    def test_filter_by_project(self):
+    def test_filter_by_project(self) -> None:
         entries = [
             _make_buffer_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),
@@ -118,7 +118,7 @@ class TestLogAnalyzer:
         assert len(traces) == 1
         assert traces[0].project_id == "123"
 
-    def test_filter_by_trace(self):
+    def test_filter_by_trace(self) -> None:
         entries = [
             _make_buffer_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),
@@ -131,7 +131,7 @@ class TestLogAnalyzer:
         assert len(traces) == 1
         assert traces[0].trace_id == "ccdd0022"
 
-    def test_summary_stats(self):
+    def test_summary_stats(self) -> None:
         entries = [
             _make_buffer_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),
@@ -154,7 +154,7 @@ class TestLogAnalyzer:
         assert stats["time_range_end"] == datetime(2026, 2, 3, 18, 55, 36, tzinfo=timezone.utc)
         assert stats["consumer_counts"] == {"process-spans-6": 1, "process-spans-7": 1}
 
-    def test_respects_limit(self):
+    def test_respects_limit(self) -> None:
         entries = [
             _make_buffer_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),
@@ -168,7 +168,7 @@ class TestLogAnalyzer:
 
 
 class TestFlusherLogAnalyzer:
-    def test_aggregates_across_entries(self):
+    def test_aggregates_across_entries(self) -> None:
         entries = [
             _make_flusher_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),
@@ -187,7 +187,7 @@ class TestFlusherLogAnalyzer:
         assert traces[0].total_span_count == 350
         assert traces[0].total_segment_count == 8
 
-    def test_sorts_by_bytes_flushed(self):
+    def test_sorts_by_bytes_flushed(self) -> None:
         entries = [
             _make_flusher_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),
@@ -201,7 +201,7 @@ class TestFlusherLogAnalyzer:
         assert traces[0].total_bytes_flushed == 50000
         assert traces[1].total_bytes_flushed == 20000
 
-    def test_filter_by_project(self):
+    def test_filter_by_project(self) -> None:
         entries = [
             _make_flusher_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),
@@ -214,7 +214,7 @@ class TestFlusherLogAnalyzer:
         assert len(traces) == 1
         assert traces[0].project_id == "456"
 
-    def test_filter_by_trace(self):
+    def test_filter_by_trace(self) -> None:
         entries = [
             _make_flusher_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),
@@ -227,7 +227,7 @@ class TestFlusherLogAnalyzer:
         assert len(traces) == 1
         assert traces[0].trace_id == "aabb0011"
 
-    def test_summary_stats_with_latencies(self):
+    def test_summary_stats_with_latencies(self) -> None:
         entries = [
             _make_flusher_log_entry(
                 datetime(2026, 2, 3, 18, 54, 36, tzinfo=timezone.utc),

--- a/tests/sentry/tasks/scim/test_privilege_sync.py
+++ b/tests/sentry/tasks/scim/test_privilege_sync.py
@@ -18,11 +18,11 @@ from sentry.users.services.user.service import user_service
 
 @cell_silo_test
 class UpdatePrivilegeGrantTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user(email="test@example.com")
 
-    def test_grant_staff(self):
+    def test_grant_staff(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert not User.objects.get(id=self.user.id).is_staff
 
@@ -33,7 +33,7 @@ class UpdatePrivilegeGrantTest(TestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert User.objects.get(id=self.user.id).is_staff
 
-    def test_grant_superuser(self):
+    def test_grant_superuser(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert not User.objects.get(id=self.user.id).is_superuser
 
@@ -44,7 +44,7 @@ class UpdatePrivilegeGrantTest(TestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert User.objects.get(id=self.user.id).is_superuser
 
-    def test_grant_superuser_write_sets_superuser_and_permission(self):
+    def test_grant_superuser_write_sets_superuser_and_permission(self) -> None:
         from sentry.users.models.userpermission import UserPermission
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -65,7 +65,7 @@ class UpdatePrivilegeGrantTest(TestCase):
                 user_id=self.user.id, permission="superuser.write"
             ).exists()
 
-    def test_grant_superuser_write_rolls_back_permission_on_failure(self):
+    def test_grant_superuser_write_rolls_back_permission_on_failure(self) -> None:
         from sentry.users.models.userpermission import UserPermission
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -89,7 +89,7 @@ class UpdatePrivilegeGrantTest(TestCase):
                 user_id=self.user.id, permission="superuser.write"
             ).exists()
 
-    def test_grant_superuser_write_integrity_error_removes_permission_without_raising(self):
+    def test_grant_superuser_write_integrity_error_removes_permission_without_raising(self) -> None:
         from sentry.users.models.userpermission import UserPermission
 
         with patch("sentry.tasks.scim.privilege_sync.user_service.update_user") as mock_update:
@@ -110,11 +110,11 @@ class UpdatePrivilegeGrantTest(TestCase):
 
 @cell_silo_test
 class UpdatePrivilegeRevokeTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user(email="test@example.com")
 
-    def test_revoke_staff(self):
+    def test_revoke_staff(self) -> None:
         user_service.update_user(user_id=self.user.id, attrs={"is_staff": True})
 
         update_privilege(
@@ -125,7 +125,7 @@ class UpdatePrivilegeRevokeTest(TestCase):
         assert user is not None
         assert not user.is_staff
 
-    def test_revoke_superuser(self):
+    def test_revoke_superuser(self) -> None:
         user_service.update_user(user_id=self.user.id, attrs={"is_superuser": True})
 
         update_privilege(
@@ -136,7 +136,7 @@ class UpdatePrivilegeRevokeTest(TestCase):
         assert user is not None
         assert not user.is_superuser
 
-    def test_revoke_superuser_write_removes_permission_and_superuser(self):
+    def test_revoke_superuser_write_removes_permission_and_superuser(self) -> None:
         from sentry.users.models.userpermission import UserPermission
 
         user_service.update_user(user_id=self.user.id, attrs={"is_superuser": True})
@@ -156,7 +156,7 @@ class UpdatePrivilegeRevokeTest(TestCase):
                 user_id=self.user.id, permission="superuser.write"
             ).exists()
 
-    def test_revoke_superuser_write_failure_keeps_permission_removed(self):
+    def test_revoke_superuser_write_failure_keeps_permission_removed(self) -> None:
         from sentry.users.models.userpermission import UserPermission
 
         user_service.update_user(
@@ -191,13 +191,13 @@ PRIVILEGE_SETTINGS = {
 
 @cell_silo_test
 class SyncScimTeamPrivilegesTaskTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.user_one = self.create_user(email="user1@example.com")
         self.user_two = self.create_user(email="user2@example.com")
         self.organization = self.create_organization(name="Test Org")
 
-    def test_non_saas_mode_is_noop(self):
+    def test_non_saas_mode_is_noop(self) -> None:
         with override_settings(
             SENTRY_MODE=SentryMode.SELF_HOSTED,
             SUPERUSER_ORG_ID=self.organization.id,
@@ -214,7 +214,7 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
             assert user is not None
             assert not user.is_staff
 
-    def test_wrong_org_is_noop(self):
+    def test_wrong_org_is_noop(self) -> None:
         other_org = self.create_organization(name="Other Org")
         with override_settings(
             SENTRY_MODE=SentryMode.SAAS,
@@ -232,7 +232,7 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
             assert user is not None
             assert not user.is_staff
 
-    def test_batch_grant_and_revoke(self):
+    def test_batch_grant_and_revoke(self) -> None:
         user_service.update_user(user_id=self.user_two.id, attrs={"is_staff": True})
 
         with override_settings(
@@ -255,7 +255,7 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
             assert user_two is not None
             assert not user_two.is_staff
 
-    def test_grant_failure_raises(self):
+    def test_grant_failure_raises(self) -> None:
         with override_settings(
             SENTRY_MODE=SentryMode.SAAS,
             SUPERUSER_ORG_ID=self.organization.id,
@@ -272,7 +272,7 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
                         user_ids_to_revoke=[],
                     )
 
-    def test_revoke_failure_raises(self):
+    def test_revoke_failure_raises(self) -> None:
         with override_settings(
             SENTRY_MODE=SentryMode.SAAS,
             SUPERUSER_ORG_ID=self.organization.id,
@@ -289,7 +289,7 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
                         user_ids_to_revoke=[self.user_one.id],
                     )
 
-    def test_unknown_team_slug_is_noop(self):
+    def test_unknown_team_slug_is_noop(self) -> None:
         with override_settings(
             SENTRY_MODE=SentryMode.SAAS,
             SUPERUSER_ORG_ID=self.organization.id,
@@ -307,7 +307,7 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
             assert not user.is_staff
             assert not user.is_superuser
 
-    def test_empty_lists_is_noop(self):
+    def test_empty_lists_is_noop(self) -> None:
         with override_settings(
             SENTRY_MODE=SentryMode.SAAS,
             SUPERUSER_ORG_ID=self.organization.id,

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -16,7 +16,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 
 @django_db_all
 class TestIndexOrgProjectKnowledge(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.org = self.create_organization()
         self.project = self.create_project(organization=self.org, platform="python")
@@ -24,7 +24,7 @@ class TestIndexOrgProjectKnowledge(TestCase):
         self.project.flags.has_profiles = True
         self.project.save()
 
-    def test_returns_early_when_no_projects_found(self):
+    def test_returns_early_when_no_projects_found(self) -> None:
         org_without_projects = self.create_organization()
         with override_options({"explorer.context_engine_indexing.enable": True}):
             with mock.patch(
@@ -33,7 +33,7 @@ class TestIndexOrgProjectKnowledge(TestCase):
                 index_org_project_knowledge(org_without_projects.id)
                 mock_counts.assert_not_called()
 
-    def test_returns_early_when_no_high_volume_projects(self):
+    def test_returns_early_when_no_high_volume_projects(self) -> None:
         with override_options({"explorer.context_engine_indexing.enable": True}):
             with mock.patch(
                 "sentry.tasks.seer.context_engine_index.get_event_counts_for_org_projects",
@@ -126,7 +126,7 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
         )
         return org
 
-    def test_returns_only_orgs_assigned_to_current_slot(self):
+    def test_returns_only_orgs_assigned_to_current_slot(self) -> None:
         from sentry.utils.hashlib import md5_text
 
         orgs = [self._create_org_with_github() for _ in range(50)]
@@ -152,7 +152,7 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
         for org_id in eligible:
             assert int(md5_text(str(org_id)).hexdigest(), 16) % TOTAL_SLOTS == target_slot
 
-    def test_excludes_orgs_without_feature_flag(self):
+    def test_excludes_orgs_without_feature_flag(self) -> None:
         from sentry.utils.hashlib import md5_text
 
         org_with_flag = self._create_org_with_github()
@@ -173,7 +173,7 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
 
         assert org_without_flag.id not in eligible
 
-    def test_returns_empty_when_no_orgs_have_feature_flag(self):
+    def test_returns_empty_when_no_orgs_have_feature_flag(self) -> None:
         with self.feature(
             {
                 "organizations:seer-explorer": False,
@@ -184,7 +184,7 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
 
         assert eligible == []
 
-    def test_excludes_orgs_without_github_integration(self):
+    def test_excludes_orgs_without_github_integration(self) -> None:
         from sentry.utils.hashlib import md5_text
 
         org_with_github = self._create_org_with_github()

--- a/tests/sentry/tasks/seer/test_explorer_index.py
+++ b/tests/sentry/tasks/seer/test_explorer_index.py
@@ -20,7 +20,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 @django_db_all
 class TestGetSeerExplorerEnabledProjects(TestCase):
     @freeze_time("2024-01-15 12:00:00")
-    def test_returns_projects_with_feature_flag(self):
+    def test_returns_projects_with_feature_flag(self) -> None:
         org1 = self.create_organization()
         org2 = self.create_organization()
         org3 = self.create_organization()
@@ -71,7 +71,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         assert project5.id not in project_ids
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_excludes_inactive_projects(self):
+    def test_excludes_inactive_projects(self) -> None:
         org = self.create_organization()
         active_project = self.create_project(organization=org)
         inactive_project = self.create_project(organization=org)
@@ -104,7 +104,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         assert inactive_project.id not in project_ids
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_returns_empty_without_feature_flag(self):
+    def test_returns_empty_without_feature_flag(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -131,7 +131,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
 
         assert len(result) == 0
 
-    def test_excludes_projects_with_hide_ai_features(self):
+    def test_excludes_projects_with_hide_ai_features(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -156,7 +156,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         assert project.id not in [p[0] for p in result]
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_excludes_projects_without_seer_acknowledgement(self):
+    def test_excludes_projects_without_seer_acknowledgement(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -175,7 +175,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         assert project.id not in [p[0] for p in result]
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_excludes_projects_without_transactions(self):
+    def test_excludes_projects_without_transactions(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -197,7 +197,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         assert len(result) == 0
         assert project.id not in [p[0] for p in result]
 
-    def test_includes_only_projects_matching_hour_shard(self):
+    def test_includes_only_projects_matching_hour_shard(self) -> None:
         org = self.create_organization()
 
         project1 = self.create_project(organization=org)
@@ -235,7 +235,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
             assert project2.id not in project_ids
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_excludes_projects_without_seer_billing_plan(self):
+    def test_excludes_projects_without_seer_billing_plan(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -260,7 +260,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
         assert project.id not in [p[0] for p in result]
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_includes_projects_with_legacy_seer_plan_via_rollout(self):
+    def test_includes_projects_with_legacy_seer_plan_via_rollout(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -288,7 +288,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
             assert project.id in project_ids
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_includes_projects_with_seat_based_plan_via_rollout(self):
+    def test_includes_projects_with_seat_based_plan_via_rollout(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -316,7 +316,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
             assert project.id in project_ids
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_excludes_projects_with_billing_plan_not_in_rollout(self):
+    def test_excludes_projects_with_billing_plan_not_in_rollout(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -347,7 +347,7 @@ class TestGetSeerExplorerEnabledProjects(TestCase):
 
 @django_db_all
 class TestScheduleExplorerIndex(TestCase):
-    def test_skips_when_option_disabled(self):
+    def test_skips_when_option_disabled(self) -> None:
         with self.options({"seer.explorer_index.enable": False}):
             with mock.patch(
                 "sentry.tasks.seer.explorer_index.get_seer_explorer_enabled_projects"
@@ -356,7 +356,7 @@ class TestScheduleExplorerIndex(TestCase):
                 mock_get_projects.assert_not_called()
 
     @freeze_time("2024-01-15 12:00:00")
-    def test_schedules_projects_with_option_enabled(self):
+    def test_schedules_projects_with_option_enabled(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -388,7 +388,7 @@ class TestScheduleExplorerIndex(TestCase):
 @django_db_all
 class TestDispatchExplorerIndexProjects(TestCase):
     @freeze_time("2024-01-15 12:00:00")
-    def test_batches_projects_with_delays(self):
+    def test_batches_projects_with_delays(self) -> None:
         timestamp = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         projects = [(i, 1) for i in range(150)]
 
@@ -440,7 +440,7 @@ class TestRunExplorerIndexForProjects(TestCase):
             with pytest.raises(Exception):
                 run_explorer_index_for_projects(projects, start)
 
-    def test_skips_when_option_disabled(self):
+    def test_skips_when_option_disabled(self) -> None:
         with self.options({"seer.explorer_index.enable": False}):
             with mock.patch(
                 "sentry.tasks.seer.explorer_index.make_explorer_index_request"

--- a/tests/sentry/tasks/test_organization_contributors.py
+++ b/tests/sentry/tasks/test_organization_contributors.py
@@ -14,7 +14,7 @@ from sentry.utils.outcomes import Outcome
 
 
 class ResetNumActionsForOrganizationContributorsTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -63,7 +63,7 @@ class ResetNumActionsForOrganizationContributorsTest(TestCase):
         assert contributor2.num_actions == 0
         assert contributor3.num_actions == 0
 
-    def test_skips_contributors_already_at_zero(self):
+    def test_skips_contributors_already_at_zero(self) -> None:
         contributor_zero = OrganizationContributors.objects.create(
             organization=self.organization,
             integration_id=self.integration.id,
@@ -92,7 +92,7 @@ class ResetNumActionsForOrganizationContributorsTest(TestCase):
         assert contributor_nonzero.num_actions == 0
         assert contributor_nonzero.date_updated > original_date_updated
 
-    def test_only_updates_specified_organization(self):
+    def test_only_updates_specified_organization(self) -> None:
         other_organization = self.create_organization()
 
         contributor_in_org = OrganizationContributors.objects.create(
@@ -121,7 +121,7 @@ class ResetNumActionsForOrganizationContributorsTest(TestCase):
 
 
 class AssignSeatToOrganizationContributorTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -753,7 +753,7 @@ class AssignmentTestMixin(BasePostProcessGroupMixin):
             (o.user_id, o.team_id) for o in owners
         }
 
-    def test_owner_assignment_existing_assignee_preserved(self):
+    def test_owner_assignment_existing_assignee_preserved(self) -> None:
         """
         Tests that if a group already has an assignee, post-processing won't reassign it
         even if ownership rules change in the interim.
@@ -4150,7 +4150,7 @@ class ProcessDataForwardingTest(BasePostProcessGroupMixin, SnubaTestCase):
 
         return data_forwarder, data_forwarder_project
 
-    def test_process_data_forwarding_no_forwarders(self):
+    def test_process_data_forwarding_no_forwarders(self) -> None:
         event = self.create_event(
             data={"message": "test message", "level": "error"},
             project_id=self.project.id,

--- a/tests/sentry/tasks/test_web_vitals_issue_detection.py
+++ b/tests/sentry/tasks/test_web_vitals_issue_detection.py
@@ -13,7 +13,7 @@ from sentry.testutils.helpers.task_runner import TaskRunner
 
 
 class WebVitalsIssueDetectionDataTest(TestCase, SnubaTestCase, SpanTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.ten_mins_ago = before_now(minutes=10)
 

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -1413,7 +1413,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             current_minute=5,
         )
 
-    def test_out_of_order_result_queued(self):
+    def test_out_of_order_result_queued(self) -> None:
         """Out-of-order results should be queued when feature flag is enabled."""
         cluster = get_cluster()
         base_time = datetime.now()
@@ -1446,7 +1446,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             assert call_kwargs["countdown"] == 10
             assert call_kwargs["kwargs"]["attempt"] == 1
 
-    def test_feature_flag_disabled_processes_normally(self):
+    def test_feature_flag_disabled_processes_normally(self) -> None:
         """When feature flag is disabled, results should process normally without queueing."""
         cluster = get_cluster()
         base_time = datetime.now()
@@ -1467,7 +1467,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         backlog_key = build_backlog_key(str(self.subscription.id))
         assert cluster.zcard(backlog_key) == 0
 
-    def test_task_scheduling_deduplication(self):
+    def test_task_scheduling_deduplication(self) -> None:
         """Multiple out-of-order results shouldn't schedule duplicate tasks."""
         cluster = get_cluster()
         base_time = datetime.now()

--- a/tests/sentry/uptime/consumers/test_tasks.py
+++ b/tests/sentry/uptime/consumers/test_tasks.py
@@ -16,14 +16,14 @@ from sentry.utils import json
 
 
 class TestProcessUptimeBacklog(UptimeTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.subscription = self.create_uptime_subscription(
             subscription_id=uuid4().hex, interval_seconds=300
         )
         self.detector = self.create_uptime_detector(uptime_subscription=self.subscription)
 
-    def test_empty_queue(self):
+    def test_empty_queue(self) -> None:
         """Task should exit gracefully when queue is empty."""
         cluster = get_cluster()
         task_scheduled_key = f"uptime:backlog_task_scheduled:{self.subscription.id}"
@@ -38,7 +38,7 @@ class TestProcessUptimeBacklog(UptimeTestCase):
 
         assert cluster.exists(task_scheduled_key) == 0
 
-    def test_subscription_not_found(self):
+    def test_subscription_not_found(self) -> None:
         """Task should handle missing subscription gracefully."""
         fake_id = "999999"
         cluster = get_cluster()
@@ -71,7 +71,7 @@ class TestProcessUptimeBacklog(UptimeTestCase):
         assert cluster.exists(backlog_key) == 0
         assert cluster.exists(task_scheduled_key) == 0
 
-    def test_processes_consecutive_results(self):
+    def test_processes_consecutive_results(self) -> None:
         """Task should process consecutive results from queue."""
         cluster = get_cluster()
         base_time = 1000000000000
@@ -122,7 +122,7 @@ class TestProcessUptimeBacklog(UptimeTestCase):
         assert int(cluster.get(last_update_key) or 0) == base_time + 600000
         assert cluster.exists(task_scheduled_key) == 0
 
-    def test_stops_at_gap(self):
+    def test_stops_at_gap(self) -> None:
         """Task should stop at gaps and reschedule."""
         cluster = get_cluster()
         base_time = 1000000000000

--- a/tests/sentry/uptime/endpoints/test_detector.py
+++ b/tests/sentry/uptime/endpoints/test_detector.py
@@ -297,11 +297,11 @@ class OrganizationDetectorIndexPostTest(APITestCase):
     endpoint = "sentry-api-0-organization-detector-index"
     method = "post"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
 
-    def test_create_detector_validation_error(self):
+    def test_create_detector_validation_error(self) -> None:
         invalid_data = _get_valid_data(
             self.project.id, self.environment.name, dataSources=[{"timeout_ms": 80000}]
         )
@@ -317,7 +317,7 @@ class OrganizationDetectorIndexPostTest(APITestCase):
             response.data["dataSources"]
         )
 
-    def test_create_detector(self):
+    def test_create_detector(self) -> None:
         valid_data = _get_valid_data(
             self.project.id,
             self.environment.name,
@@ -340,7 +340,7 @@ class OrganizationDetectorIndexPostTest(APITestCase):
         assert created_sub.url == "https://www.google.com"
         assert created_sub.interval_seconds == UptimeSubscription.IntervalSeconds.ONE_MINUTE
 
-    def test_create_detector_optional_fields(self):
+    def test_create_detector_optional_fields(self) -> None:
         valid_data = _get_valid_data(
             self.project.id,
             self.environment.name,
@@ -378,7 +378,7 @@ class OrganizationDetectorIndexPostTest(APITestCase):
         assert created_sub.body == "<html/>"
         assert created_sub.trace_sampling is True
 
-    def test_create_detector_non_superuser_cannot_set_auto_detected_mode(self):
+    def test_create_detector_non_superuser_cannot_set_auto_detected_mode(self) -> None:
         """Integration test: non-superuser cannot create with AUTO_DETECTED mode via API."""
         invalid_data = _get_valid_data(
             self.project.id,
@@ -407,7 +407,7 @@ class OrganizationDetectorIndexGetFilterTest(UptimeDetectorBaseTest):
 
     endpoint = "sentry-api-0-organization-detector-index"
 
-    def test_filters_onboarding_detectors_from_list(self):
+    def test_filters_onboarding_detectors_from_list(self) -> None:
         """Test that AUTO_DETECTED_ONBOARDING detectors are not returned in the list."""
         # Create a manual detector (should be visible)
         manual_detector = self.create_uptime_detector(
@@ -449,7 +449,7 @@ class OrganizationDetectorIndexGetFilterTest(UptimeDetectorBaseTest):
         # Verify the count is correct (5 = base detector + manual + active + default [issue stream + error])
         assert len(response.data) == 5
 
-    def test_filters_onboarding_detectors_with_query(self):
+    def test_filters_onboarding_detectors_with_query(self) -> None:
         """Test that AUTO_DETECTED_ONBOARDING detectors are filtered even when using query filters."""
         # Create an onboarding detector with a searchable name
         self.create_uptime_detector(
@@ -468,7 +468,7 @@ class OrganizationDetectorIndexGetFilterTest(UptimeDetectorBaseTest):
         # Should not find it because it's filtered out
         assert len(response.data) == 0
 
-    def test_filters_onboarding_detectors_by_id(self):
+    def test_filters_onboarding_detectors_by_id(self) -> None:
         """Test that AUTO_DETECTED_ONBOARDING detectors cannot be accessed via ID filtering."""
         # Create an onboarding detector
         onboarding_detector = self.create_uptime_detector(
@@ -504,7 +504,7 @@ class OrganizationDetectorDetailsGetFilterTest(UptimeDetectorBaseTest):
 
     endpoint = "sentry-api-0-organization-detector-details"
 
-    def test_onboarding_detector_returns_404(self):
+    def test_onboarding_detector_returns_404(self) -> None:
         """Test that accessing an AUTO_DETECTED_ONBOARDING detector by ID returns 404."""
         onboarding_detector = self.create_uptime_detector(
             project=self.project,
@@ -520,7 +520,7 @@ class OrganizationDetectorDetailsGetFilterTest(UptimeDetectorBaseTest):
             status_code=status.HTTP_404_NOT_FOUND,
         )
 
-    def test_active_auto_detected_is_accessible(self):
+    def test_active_auto_detected_is_accessible(self) -> None:
         """Test that AUTO_DETECTED_ACTIVE detectors are accessible via details endpoint."""
         active_detector = self.create_uptime_detector(
             project=self.project,

--- a/tests/sentry/uptime/endpoints/test_project_uptime_response_capture.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_response_capture.py
@@ -8,7 +8,7 @@ from sentry.uptime.models import UptimeResponseCapture
 class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
     endpoint = "sentry-api-0-project-uptime-response-capture"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
         self.uptime_subscription = self.create_uptime_subscription(url="https://example.com")
@@ -17,7 +17,7 @@ class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
             project=self.project,
         )
 
-    def test_get_response_capture(self):
+    def test_get_response_capture(self) -> None:
         response_content = b"Content-Type: text/html\r\nX-Custom: value\r\n\r\n---BODY---\r\n\r\n<html>Error</html>"
         file = File.objects.create(name="test-response", type="uptime.response")
         file.putfile(BytesIO(response_content))
@@ -43,7 +43,7 @@ class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
         assert response.data["body"] == "<html>Error</html>"
         assert response.data["bodySize"] == len(b"<html>Error</html>")
 
-    def test_get_response_capture_not_found(self):
+    def test_get_response_capture_not_found(self) -> None:
         self.get_error_response(
             self.organization.slug,
             self.project.slug,
@@ -52,7 +52,7 @@ class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
             status_code=404,
         )
 
-    def test_get_response_capture_wrong_detector(self):
+    def test_get_response_capture_wrong_detector(self) -> None:
         """Capture belongs to a different detector's subscription."""
         other_subscription = self.create_uptime_subscription(url="https://other.com")
         other_detector = self.create_uptime_detector(
@@ -86,7 +86,7 @@ class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
             capture.id,
         )
 
-    def test_get_response_capture_no_body(self):
+    def test_get_response_capture_no_body(self) -> None:
         response_content = b"Content-Type: text/html\r\nX-Custom: value"
         file = File.objects.create(name="test-response", type="uptime.response")
         file.putfile(BytesIO(response_content))
@@ -111,7 +111,7 @@ class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
         assert response.data["body"] == ""
         assert response.data["bodySize"] == 0
 
-    def test_delete_response_capture(self):
+    def test_delete_response_capture(self) -> None:
         file = File.objects.create(name="test-response", type="uptime.response")
         file.putfile(BytesIO(b"test content"))
         capture = UptimeResponseCapture.objects.create(
@@ -132,7 +132,7 @@ class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
         assert not UptimeResponseCapture.objects.filter(id=capture_id).exists()
         assert not File.objects.filter(id=file_id).exists()
 
-    def test_delete_response_capture_not_found(self):
+    def test_delete_response_capture_not_found(self) -> None:
         self.get_error_response(
             self.organization.slug,
             self.project.slug,
@@ -142,7 +142,7 @@ class ProjectUptimeResponseCaptureEndpointTest(APITestCase, UptimeTestCase):
             status_code=404,
         )
 
-    def test_delete_response_capture_wrong_detector(self):
+    def test_delete_response_capture_wrong_detector(self) -> None:
         """Cannot delete capture belonging to a different detector."""
         other_subscription = self.create_uptime_subscription(url="https://other.com")
         file = File.objects.create(name="test-response", type="uptime.response")

--- a/tests/sentry/uptime/endpoints/test_project_uptime_response_captures_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_response_captures_index.py
@@ -8,7 +8,7 @@ from sentry.uptime.models import UptimeResponseCapture
 class ProjectUptimeResponseCapturesIndexEndpointTest(APITestCase, UptimeTestCase):
     endpoint = "sentry-api-0-project-uptime-response-captures-index"
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
         self.uptime_subscription = self.create_uptime_subscription(url="https://example.com")
@@ -17,7 +17,7 @@ class ProjectUptimeResponseCapturesIndexEndpointTest(APITestCase, UptimeTestCase
             project=self.project,
         )
 
-    def test_delete_all_response_captures(self):
+    def test_delete_all_response_captures(self) -> None:
         files = [
             File.objects.create(name=f"test-response-{i}", type="uptime.response") for i in range(3)
         ]
@@ -50,7 +50,7 @@ class ProjectUptimeResponseCapturesIndexEndpointTest(APITestCase, UptimeTestCase
         assert UptimeResponseCapture.objects.filter(id__in=capture_ids).count() == 0
         assert File.objects.filter(id__in=file_ids).count() == 0
 
-    def test_delete_all_response_captures_empty(self):
+    def test_delete_all_response_captures_empty(self) -> None:
         """Deleting when there are no captures should succeed."""
         response = self.get_success_response(
             self.organization.slug,
@@ -61,7 +61,7 @@ class ProjectUptimeResponseCapturesIndexEndpointTest(APITestCase, UptimeTestCase
         )
         assert response.data["deletedCount"] == 0
 
-    def test_delete_only_affects_own_subscription(self):
+    def test_delete_only_affects_own_subscription(self) -> None:
         """Deleting captures should not affect other subscriptions."""
         file1 = File.objects.create(name="test-response-1", type="uptime.response")
         file1.putfile(BytesIO(b"test content 1"))

--- a/tests/sentry/uptime/endpoints/test_validators.py
+++ b/tests/sentry/uptime/endpoints/test_validators.py
@@ -72,31 +72,31 @@ class UptimeMonitorDataSourceValidatorTest(TestCase):
             "body": kwargs.get("body", None),
         }
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.context = {
             "organization": self.project.organization,
             "project": self.project,
             "request": self.make_request(),
         }
 
-    def test_simple(self):
+    def test_simple(self) -> None:
         validator = UptimeMonitorDataSourceValidator(
             data=self.get_valid_data(), context=self.context
         )
         assert validator.is_valid()
 
-    def test_bad_interval(self):
+    def test_bad_interval(self) -> None:
         data = self.get_valid_data(interval_seconds=3700)
         validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
         assert not validator.is_valid()
 
-    def test_bad_method(self):
+    def test_bad_method(self) -> None:
         data = self.get_valid_data(method="GOT")
         validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
         assert not validator.is_valid()
 
     @mock.patch("sentry.uptime.subscriptions.subscriptions.MAX_MONITORS_PER_DOMAIN", 1)
-    def test_too_many_urls(self):
+    def test_too_many_urls(self) -> None:
         self.create_uptime_subscription(
             url="https://www.google.com",
             interval_seconds=3600,
@@ -112,14 +112,14 @@ class UptimeMonitorDataSourceValidatorTest(TestCase):
             validator.errors["url"]
         )
 
-    def test_too_big_request(self):
+    def test_too_big_request(self) -> None:
         data = self.get_valid_data(body="0" * 1000)
         validator = UptimeMonitorDataSourceValidator(data=data, context=self.context)
         assert not validator.is_valid()
 
 
 class UptimeDomainCheckFailureValidatorTest(UptimeTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.context = {
             "organization": self.organization,
@@ -171,7 +171,7 @@ class UptimeDomainCheckFailureValidatorTest(UptimeTestCase):
         assert conditions[1].condition_result == DetectorPriorityLevel.OK
         assert conditions[1].type == Condition.EQUAL
 
-    def test_rejects_multiple_data_sources(self):
+    def test_rejects_multiple_data_sources(self) -> None:
         """Test that multiple data sources are rejected for uptime monitors."""
         data = self.get_valid_data(
             data_sources=[

--- a/tests/sentry/uptime/test_seer_assertions.py
+++ b/tests/sentry/uptime/test_seer_assertions.py
@@ -13,7 +13,7 @@ from sentry.uptime.seer_assertions import (
 
 
 class ParsePreviewResponseTest(TestCase):
-    def test_basic_json_body(self):
+    def test_basic_json_body(self) -> None:
         body_bytes = b'{"status": "ok", "count": 42}'
         encoded = base64.b64encode(body_bytes).decode()
 
@@ -37,7 +37,7 @@ class ParsePreviewResponseTest(TestCase):
         assert result["headers"] == {"content-type": "application/json"}
         assert result["body"] == {"status": "ok", "count": 42}
 
-    def test_non_json_body(self):
+    def test_non_json_body(self) -> None:
         body_bytes = b"<html>Hello</html>"
         encoded = base64.b64encode(body_bytes).decode()
 
@@ -56,7 +56,7 @@ class ParsePreviewResponseTest(TestCase):
 
         assert result["body"] == "<html>Hello</html>"
 
-    def test_empty_body(self):
+    def test_empty_body(self) -> None:
         preview_result = {
             "check_result": {
                 "duration_ms": 100,
@@ -73,7 +73,7 @@ class ParsePreviewResponseTest(TestCase):
         assert result["body"] is None
         assert result["status_code"] == 204
 
-    def test_empty_preview_result(self):
+    def test_empty_preview_result(self) -> None:
         result = parse_preview_response({})
 
         assert result["status_code"] is None
@@ -82,7 +82,7 @@ class ParsePreviewResponseTest(TestCase):
 
 
 class BuildAssertionPromptTest(TestCase):
-    def test_includes_response_data(self):
+    def test_includes_response_data(self) -> None:
         response_data = {
             "status_code": 200,
             "response_time_ms": 150,
@@ -99,7 +99,7 @@ class BuildAssertionPromptTest(TestCase):
 
 
 class SuggestionToAssertionJsonTest(TestCase):
-    def test_status_code(self):
+    def test_status_code(self) -> None:
         suggestion = SuggestedAssertion(
             assertion_type="status_code",
             comparison="equals",
@@ -116,7 +116,7 @@ class SuggestionToAssertionJsonTest(TestCase):
             "operator": {"cmp": "equals"},
         }
 
-    def test_json_path_equals(self):
+    def test_json_path_equals(self) -> None:
         suggestion = SuggestedAssertion(
             assertion_type="json_path",
             comparison="equals",
@@ -135,7 +135,7 @@ class SuggestionToAssertionJsonTest(TestCase):
             "operand": {"jsonpath_op": "literal", "value": "ok"},
         }
 
-    def test_json_path_always(self):
+    def test_json_path_always(self) -> None:
         suggestion = SuggestedAssertion(
             assertion_type="json_path",
             comparison="always",
@@ -154,7 +154,7 @@ class SuggestionToAssertionJsonTest(TestCase):
             "operand": {"jsonpath_op": "none"},
         }
 
-    def test_header_equals(self):
+    def test_header_equals(self) -> None:
         suggestion = SuggestedAssertion(
             assertion_type="header",
             comparison="equals",
@@ -174,7 +174,7 @@ class SuggestionToAssertionJsonTest(TestCase):
             "value_operand": {"header_op": "literal", "value": "application/json"},
         }
 
-    def test_header_always(self):
+    def test_header_always(self) -> None:
         suggestion = SuggestedAssertion(
             assertion_type="header",
             comparison="always",
@@ -194,7 +194,7 @@ class SuggestionToAssertionJsonTest(TestCase):
             "value_operand": {"header_op": "none"},
         }
 
-    def test_invalid_comparison_falls_back_to_equals(self):
+    def test_invalid_comparison_falls_back_to_equals(self) -> None:
         suggestion = SuggestedAssertion(
             assertion_type="status_code",
             comparison="invalid_op",
@@ -207,7 +207,7 @@ class SuggestionToAssertionJsonTest(TestCase):
 
         assert result["operator"]["cmp"] == "equals"
 
-    def test_unknown_type_falls_back_to_status_code(self):
+    def test_unknown_type_falls_back_to_status_code(self) -> None:
         suggestion = SuggestedAssertion(
             assertion_type="unknown",
             comparison="equals",
@@ -226,14 +226,14 @@ class SuggestionToAssertionJsonTest(TestCase):
 
 
 class SuggestionsToCombinedAssertionTest(TestCase):
-    def test_empty_suggestions(self):
+    def test_empty_suggestions(self) -> None:
         result = suggestions_to_combined_assertion([])
 
         assert result == {
             "root": {"op": "status_code_check", "value": 200, "operator": {"cmp": "equals"}}
         }
 
-    def test_single_suggestion(self):
+    def test_single_suggestion(self) -> None:
         suggestion = SuggestedAssertion(
             assertion_type="status_code",
             comparison="equals",
@@ -252,7 +252,7 @@ class SuggestionsToCombinedAssertionTest(TestCase):
             }
         }
 
-    def test_multiple_suggestions(self):
+    def test_multiple_suggestions(self) -> None:
         suggestions = [
             SuggestedAssertion(
                 assertion_type="status_code",
@@ -280,7 +280,7 @@ class SuggestionsToCombinedAssertionTest(TestCase):
 
 
 class GenerateAssertionSuggestionsTest(TestCase):
-    def test_no_status_code(self):
+    def test_no_status_code(self) -> None:
         suggestions, debug = generate_assertion_suggestions(
             {"check_result": {"request_info": {}}},
         )

--- a/tests/sentry/uptime/test_utils.py
+++ b/tests/sentry/uptime/test_utils.py
@@ -6,36 +6,36 @@ from sentry.uptime.utils import (
 
 
 class TestGenerateScheduledCheckTimesMs:
-    def test_forward_single(self):
+    def test_forward_single(self) -> None:
         assert generate_scheduled_check_times_ms(1000, 60000, 1) == [1000]
 
-    def test_forward_multiple(self):
+    def test_forward_multiple(self) -> None:
         assert generate_scheduled_check_times_ms(1000, 60000, 3) == [1000, 61000, 121000]
 
-    def test_backward_single(self):
+    def test_backward_single(self) -> None:
         assert generate_scheduled_check_times_ms(1000, 60000, 1, forward=False) == [1000]
 
-    def test_backward_multiple(self):
+    def test_backward_multiple(self) -> None:
         assert generate_scheduled_check_times_ms(121000, 60000, 3, forward=False) == [
             1000,
             61000,
             121000,
         ]
 
-    def test_forward_is_default(self):
+    def test_forward_is_default(self) -> None:
         assert generate_scheduled_check_times_ms(
             1000, 60000, 3
         ) == generate_scheduled_check_times_ms(1000, 60000, 3, forward=True)
 
 
 class TestBuildBacklogKey:
-    def test_formats_correctly(self):
+    def test_formats_correctly(self) -> None:
         assert build_backlog_key("123") == "uptime:backlog:123"
         assert build_backlog_key("abc-def") == "uptime:backlog:abc-def"
 
 
 class TestBuildBacklogTaskFlagKey:
-    def test_formats_correctly(self):
+    def test_formats_correctly(self) -> None:
         assert build_backlog_task_scheduled_key("123") == "uptime:backlog_task_scheduled:123"
         assert (
             build_backlog_task_scheduled_key("abc-def") == "uptime:backlog_task_scheduled:abc-def"

--- a/tests/sentry/utils/sentry_apps/test_webhook_timeout.py
+++ b/tests/sentry/utils/sentry_apps/test_webhook_timeout.py
@@ -17,7 +17,7 @@ from sentry.utils.sentry_apps.webhooks import WebhookTimeoutError, send_and_save
 
 @cell_silo_test
 class WebhookTimeoutTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.organization = self.create_organization()
         self.sentry_app = self.create_sentry_app(
             name="TestApp",

--- a/tests/sentry/utils/test_avatar.py
+++ b/tests/sentry/utils/test_avatar.py
@@ -17,30 +17,30 @@ def _make_image(pixels: list[tuple[int, int, int, int]], mode: str = "RGBA") -> 
 
 
 class TestIsBlackAlphaOnly:
-    def test_all_black_opaque(self):
+    def test_all_black_opaque(self) -> None:
         buf = _make_image([(0, 0, 0, 255), (0, 0, 0, 255)])
         assert is_black_alpha_only(buf) is True
 
-    def test_all_black_transparent(self):
+    def test_all_black_transparent(self) -> None:
         buf = _make_image([(0, 0, 0, 0), (0, 0, 0, 128)])
         assert is_black_alpha_only(buf) is True
 
-    def test_one_non_black_pixel(self):
+    def test_one_non_black_pixel(self) -> None:
         buf = _make_image([(0, 0, 0, 255), (1, 0, 0, 255)])
         assert is_black_alpha_only(buf) is False
 
-    def test_colored_pixel(self):
+    def test_colored_pixel(self) -> None:
         buf = _make_image([(255, 0, 0, 255)])
         assert is_black_alpha_only(buf) is False
 
-    def test_non_rgba_mode_returns_false(self):
+    def test_non_rgba_mode_returns_false(self) -> None:
         img = Image.new("RGB", (2, 1), color=(0, 0, 0))
         buf = io.BytesIO()
         img.save(buf, format="PNG")
         buf.seek(0)
         assert is_black_alpha_only(buf) is False
 
-    def test_resets_file_position(self):
+    def test_resets_file_position(self) -> None:
         buf = _make_image([(0, 0, 0, 255)])
         is_black_alpha_only(buf)
         assert buf.tell() == 0

--- a/tests/sentry/utils/test_eap.py
+++ b/tests/sentry/utils/test_eap.py
@@ -1,7 +1,7 @@
 from sentry.utils.eap import hex_to_item_id, item_id_to_hex
 
 
-def test_hex_to_item_id_basic():
+def test_hex_to_item_id_basic() -> None:
     hex_string = "0fe53e4887e143549dd0cc65c0370d38"
     item_id = hex_to_item_id(hex_string)
 
@@ -9,7 +9,7 @@ def test_hex_to_item_id_basic():
     assert isinstance(item_id, bytes)
 
 
-def test_item_id_to_hex_basic():
+def test_item_id_to_hex_basic() -> None:
     hex_string = "0fe53e4887e143549dd0cc65c0370d38"
     item_id = hex_to_item_id(hex_string)
 
@@ -19,7 +19,7 @@ def test_item_id_to_hex_basic():
     assert len(recovered) == 32
 
 
-def test_round_trip_conversion():
+def test_round_trip_conversion() -> None:
     test_ids = [
         "0fe53e4887e143549dd0cc65c0370d38",
         "b87e618e18dc428b9dbd9afc56c9e4cd",
@@ -39,7 +39,7 @@ def test_round_trip_conversion():
         )
 
 
-def test_hex_to_item_id_is_little_endian():
+def test_hex_to_item_id_is_little_endian() -> None:
     hex_string = "b402030405060708090a0b0c0d0e0f7a"
     item_id = hex_to_item_id(hex_string)
 

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -538,12 +538,12 @@ class ShouldDropS4STest(TestCase):
         envelope.headers = {"trace": {"trace_id": trace_id}}
         return envelope
 
-    def test_default_rate_sends_everything(self):
+    def test_default_rate_sends_everything(self) -> None:
         transport = self._get_transport()
         envelope = self._make_envelope()
         assert transport._should_drop_s4s("capture_envelope", envelope) is False
 
-    def test_zero_rate_drops_all_transactions(self):
+    def test_zero_rate_drops_all_transactions(self) -> None:
         transport = self._get_transport()
         with self.options({"store.s4s-transaction-sample-rate": 0.0}):
             envelope = self._make_envelope()
@@ -552,19 +552,19 @@ class ShouldDropS4STest(TestCase):
             event = {"type": "transaction", "contexts": {"trace": {"trace_id": "a" * 32}}}
             assert transport._should_drop_s4s("capture_event", event) is True
 
-    def test_never_drops_error_envelopes(self):
+    def test_never_drops_error_envelopes(self) -> None:
         transport = self._get_transport()
         with self.options({"store.s4s-transaction-sample-rate": 0.0}):
             envelope = self._make_envelope(is_transaction=False)
             assert transport._should_drop_s4s("capture_envelope", envelope) is False
 
-    def test_never_drops_error_events(self):
+    def test_never_drops_error_events(self) -> None:
         transport = self._get_transport()
         with self.options({"store.s4s-transaction-sample-rate": 0.0}):
             event = {"type": "error", "contexts": {"trace": {"trace_id": "a" * 32}}}
             assert transport._should_drop_s4s("capture_event", event) is False
 
-    def test_deterministic_by_trace_id(self):
+    def test_deterministic_by_trace_id(self) -> None:
         transport = self._get_transport()
         trace_id = "abcdef1234567890abcdef1234567890"
         with self.options({"store.s4s-transaction-sample-rate": 0.5}):
@@ -573,7 +573,7 @@ class ShouldDropS4STest(TestCase):
             for _ in range(10):
                 assert transport._should_drop_s4s("capture_envelope", envelope) == first
 
-    def test_no_trace_id_not_dropped(self):
+    def test_no_trace_id_not_dropped(self) -> None:
         transport = self._get_transport()
         with self.options({"store.s4s-transaction-sample-rate": 0.0}):
             envelope = MagicMock()
@@ -593,13 +593,13 @@ class ShouldDropS4STest(TestCase):
         envelope.items = [span_item]
         return envelope
 
-    def test_zero_rate_drops_span_envelopes(self):
+    def test_zero_rate_drops_span_envelopes(self) -> None:
         transport = self._get_transport()
         with self.options({"store.s4s-transaction-sample-rate": 0.0}):
             envelope = self._make_span_envelope()
             assert transport._should_drop_s4s("capture_envelope", envelope) is True
 
-    def test_never_drops_non_span_non_transaction_envelopes(self):
+    def test_never_drops_non_span_non_transaction_envelopes(self) -> None:
         transport = self._get_transport()
         with self.options({"store.s4s-transaction-sample-rate": 0.0}):
             envelope = MagicMock()

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -835,7 +835,7 @@ class OrganizationAuthSettingsScimTokenMaskingTest(AuthProviderTestCase):
             om.save()
         return om
 
-    def test_scim_token_visible_immediately_after_creation(self):
+    def test_scim_token_visible_immediately_after_creation(self) -> None:
         """SCIM token is fully visible within 5 minutes of creation."""
         organization, auth_provider = self.create_org_and_auth_provider()
         self.create_om_and_link_sso(organization)
@@ -867,7 +867,7 @@ class OrganizationAuthSettingsScimTokenMaskingTest(AuthProviderTestCase):
             assert scim_token_display.is_visible is True
             assert scim_token_display.token is not None
 
-    def test_scim_token_masked_after_visibility_window(self):
+    def test_scim_token_masked_after_visibility_window(self) -> None:
         """SCIM token is masked after 5 minutes."""
         from datetime import timedelta
 


### PR DESCRIPTION
Commands run:
```
# Add return types to test methods within classes
rg -ls 'def test.*\(self\):' tests/sentry | xargs sed -E -i '' -e 's/def test(.*)\(self\):/def test\1\(self\) -> None:/'

# Add return types to setup methods within classes
rg -l 'def setUp\(self\):' tests/sentry | xargs sed -i '' -E -e 's/def setUp\(self\):/def setUp(self) -> None:/'

# Add return types to toplevel test functions
rg -ls 'def test.*\(\):' tests/sentry | xargs sed -E -i '' -e 's/def test(.*)\(\):/def test\1\(\) -> None:/'

# Type check, only minor errors (addressed in separate commit)
mypy
```