### PR TITLE
fix(dashboards): Stop passing list page query params to dashboard details

### DIFF
--- a/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
@@ -1,9 +1,7 @@
 import {DashboardListItemFixture} from 'sentry-fixture/dashboard';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -24,8 +22,6 @@ describe('Dashboards - DashboardGrid', () => {
   const organization = OrganizationFixture({
     features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
   });
-
-  const {router} = initializeOrg();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -106,7 +102,6 @@ describe('Dashboards - DashboardGrid', () => {
         onDashboardsChange={jest.fn()}
         organization={organization}
         dashboards={[]}
-        location={router.location}
         columnCount={3}
         rowCount={3}
       />
@@ -124,7 +119,6 @@ describe('Dashboards - DashboardGrid', () => {
         onDashboardsChange={jest.fn()}
         organization={organization}
         dashboards={dashboards}
-        location={router.location}
         columnCount={3}
         rowCount={3}
       />
@@ -140,7 +134,6 @@ describe('Dashboards - DashboardGrid', () => {
         onDashboardsChange={jest.fn()}
         organization={organization}
         dashboards={dashboards}
-        location={router.location}
         columnCount={3}
         rowCount={3}
       />
@@ -156,42 +149,28 @@ describe('Dashboards - DashboardGrid', () => {
     );
   });
 
-  it('persists global selection headers', () => {
+  it('does not forward query params from the list page to dashboard links', () => {
     render(
       <DashboardGrid
         onDashboardsChange={jest.fn()}
         organization={organization}
         dashboards={dashboards}
-        location={{...LocationFixture(), query: {statsPeriod: '7d'}}}
         columnCount={3}
         rowCount={3}
-      />
+      />,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/dashboards/',
+            query: {sort: 'title', query: 'agent'},
+          },
+        },
+      }
     );
 
     expect(screen.getByRole('link', {name: 'Dashboard 1'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/dashboard/1/?statsPeriod=7d'
-    );
-  });
-
-  it('does not forward search query parameter to dashboard links', () => {
-    render(
-      <DashboardGrid
-        onDashboardsChange={jest.fn()}
-        organization={organization}
-        dashboards={dashboards}
-        location={{
-          ...LocationFixture(),
-          query: {query: 'agent', statsPeriod: '7d'},
-        }}
-        columnCount={3}
-        rowCount={3}
-      />
-    );
-
-    expect(screen.getByRole('link', {name: 'Dashboard 1'})).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/dashboard/1/?statsPeriod=7d'
+      '/organizations/org-slug/dashboard/1/'
     );
   });
 
@@ -200,7 +179,6 @@ describe('Dashboards - DashboardGrid', () => {
       <DashboardGrid
         organization={organization}
         dashboards={dashboards}
-        location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
         columnCount={3}
         rowCount={3}
@@ -239,7 +217,6 @@ describe('Dashboards - DashboardGrid', () => {
       <DashboardGrid
         organization={organization}
         dashboards={singleDashboard}
-        location={LocationFixture()}
         onDashboardsChange={dashboardUpdateMock}
         columnCount={3}
         rowCount={3}
@@ -258,7 +235,6 @@ describe('Dashboards - DashboardGrid', () => {
       <DashboardGrid
         organization={organization}
         dashboards={dashboards}
-        location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
         columnCount={3}
         rowCount={3}
@@ -294,7 +270,6 @@ describe('Dashboards - DashboardGrid', () => {
       <DashboardGrid
         organization={organization}
         dashboards={dashboards}
-        location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
         columnCount={3}
         rowCount={3}
@@ -340,7 +315,6 @@ describe('Dashboards - DashboardGrid', () => {
         onDashboardsChange={jest.fn()}
         organization={organization}
         dashboards={dashboards}
-        location={router.location}
         columnCount={3}
         rowCount={3}
       />,
@@ -383,7 +357,6 @@ describe('Dashboards - DashboardGrid', () => {
         onDashboardsChange={jest.fn()}
         organization={organization}
         dashboards={dashboards}
-        location={router.location}
         columnCount={3}
         rowCount={3}
       />,

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
 import {Button} from '@sentry/scraps/button';
@@ -36,7 +35,6 @@ type Props = {
   api: Client;
   columnCount: number;
   dashboards: DashboardListItem[] | undefined;
-  location: Location;
   onDashboardsChange: () => void;
   organization: Organization;
   rowCount: number;
@@ -46,7 +44,6 @@ type Props = {
 function DashboardGrid({
   api,
   organization,
-  location,
   dashboards,
   onDashboardsChange,
   rowCount,
@@ -167,13 +164,6 @@ function DashboardGrid({
     return <GridPreview widgetPreview={dashboard.widgetPreview} />;
   }
 
-  // TODO(__SENTRY_USING_REACT_ROUTER_SIX): We can remove this later, react
-  // router 6 handles empty query objects without appending a trailing ?
-  const {query: _searchQuery, ...queryWithoutSearch} = location.query;
-  const queryLocation = {
-    ...(Object.keys(queryWithoutSearch).length > 0 ? {query: queryWithoutSearch} : {}),
-  };
-
   function renderMiniDashboards() {
     // on pagination, render no dashboards to show placeholders while loading
     if (
@@ -189,10 +179,7 @@ function DashboardGrid({
           {dashboardLimitData => (
             <DashboardCard
               title={dashboard.title}
-              to={{
-                pathname: `/organizations/${organization.slug}/dashboard/${dashboard.id}/`,
-                ...queryLocation,
-              }}
+              to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
               detail={tn('%s widget', '%s widgets', dashboard.widgetPreview.length)}
               dateStatus={
                 dashboard.dateCreated ? (

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -155,23 +155,7 @@ describe('Dashboards - DashboardTable', () => {
     );
   });
 
-  it('persists global selection headers', async () => {
-    render(
-      <DashboardTable
-        onDashboardsChange={jest.fn()}
-        organization={organization}
-        dashboards={dashboards}
-        location={{...LocationFixture(), query: {statsPeriod: '7d'}}}
-      />
-    );
-
-    expect(await screen.findByRole('link', {name: 'Dashboard 1'})).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/dashboard/1/?statsPeriod=7d'
-    );
-  });
-
-  it('does not forward search query parameter to dashboard links', async () => {
+  it('does not forward query params from the list page to dashboard links', async () => {
     render(
       <DashboardTable
         onDashboardsChange={jest.fn()}
@@ -179,14 +163,14 @@ describe('Dashboards - DashboardTable', () => {
         dashboards={dashboards}
         location={{
           ...LocationFixture(),
-          query: {query: 'agent', statsPeriod: '7d'},
+          query: {sort: 'title', query: 'agent', statsPeriod: '7d'},
         }}
       />
     );
 
     expect(await screen.findByRole('link', {name: 'Dashboard 1'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/dashboard/1/?statsPeriod=7d'
+      '/organizations/org-slug/dashboard/1/'
     );
   });
 

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -146,13 +146,6 @@ function DashboardTable({
     {key: ResponseKeys.CREATED, name: t('Created'), width: COL_WIDTH_UNDEFINED},
   ];
 
-  // TODO(__SENTRY_USING_REACT_ROUTER_SIX): We can remove this later, react
-  // router 6 handles empty query objects without appending a trailing ?
-  const {query: _searchQuery, ...queryWithoutSearch} = location.query;
-  const queryLocation = {
-    ...(Object.keys(queryWithoutSearch).length > 0 ? {query: queryWithoutSearch} : {}),
-  };
-
   function renderHeadCell(column: GridColumnOrder<string>) {
     if (column.key in SortKeys) {
       const urlSort = decodeScalar(location.query.sort, 'mydashboards');
@@ -212,12 +205,7 @@ function DashboardTable({
     if (column.key === ResponseKeys.NAME) {
       return (
         <Text ellipsis variant="accent">
-          <Link
-            to={{
-              pathname: `/organizations/${organization.slug}/dashboard/${dataRow.id}/`,
-              ...queryLocation,
-            }}
-          >
+          <Link to={`/organizations/${organization.slug}/dashboard/${dataRow.id}/`}>
             {dataRow[ResponseKeys.NAME]}
           </Link>
         </Text>

--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -123,10 +123,7 @@ describe('Dashboards > Detail', () => {
 
     await userEvent.click(await screen.findByTestId('dashboard-create'));
 
-    expect(mockNavigate).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/dashboards/new/',
-      query: {},
-    });
+    expect(mockNavigate).toHaveBeenCalledWith('/organizations/org-slug/dashboards/new/');
   });
 
   it('can sort', async () => {

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -494,7 +494,6 @@ function ManageDashboards() {
         api={api}
         dashboards={dashboards}
         organization={organization}
-        location={location}
         onDashboardsChange={() => refetchDashboards()}
         isLoading={isLoading}
         rowCount={rowCount}
@@ -543,19 +542,12 @@ function ManageDashboards() {
     );
   }
 
-  const {query: _query, ...queryWithoutSearch} = location.query;
-
   function onCreate() {
     trackAnalytics('dashboards_manage.create.start', {
       organization,
     });
 
-    navigate(
-      normalizeUrl({
-        pathname: `/organizations/${organization.slug}/dashboards/new/`,
-        query: queryWithoutSearch,
-      })
-    );
+    navigate(normalizeUrl(`/organizations/${organization.slug}/dashboards/new/`));
   }
 
   async function onAdd(dashboard: DashboardDetails) {
@@ -578,10 +570,7 @@ function ManageDashboards() {
 
   function loadDashboard(dashboardId: string) {
     navigate(
-      normalizeUrl({
-        pathname: `/organizations/${organization.slug}/dashboards/${dashboardId}/`,
-        query: queryWithoutSearch,
-      })
+      normalizeUrl(`/organizations/${organization.slug}/dashboards/${dashboardId}/`)
     );
   }
 
@@ -592,10 +581,7 @@ function ManageDashboards() {
     });
 
     navigate(
-      normalizeUrl({
-        pathname: `/organizations/${organization.slug}/dashboards/new/${dashboardId}/`,
-        query: queryWithoutSearch,
-      })
+      normalizeUrl(`/organizations/${organization.slug}/dashboards/new/${dashboardId}/`)
     );
   }
 


### PR DESCRIPTION
The dashboards list page was forwarding its query parameters (`sort`, `filter`, `query`) through to dashboard detail page links. When navigating from the list to a specific dashboard, these list-page-specific params would appear in the detail URL, which could interfere with the dashboard's own filter handling (e.g., saved global filters).

These query params aren't really used in dashboard details, and has potential to mess up the state of certain widgets that might confuse these params

Removes query param forwarding from:
- `DashboardGrid` card links
- `DashboardTable` name links
- `onCreate`, `loadDashboard`, and `onPreview` navigation in the manage index

Fixes DAIN-1432