### PR TITLE
ref(nav) realign indicators

### DIFF
--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -10,7 +10,13 @@ import type {DistributedOmit} from 'type-fest';
 import {FeatureBadge, type FeatureBadgeProps} from '@sentry/scraps/badge';
 import type {ButtonBarProps, ButtonProps} from '@sentry/scraps/button';
 import {Button, ButtonBar} from '@sentry/scraps/button';
-import {Container, Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
+import {
+  Container,
+  Flex,
+  Stack,
+  type FlexProps,
+  type ContainerProps,
+} from '@sentry/scraps/layout';
 import {Link, type LinkProps} from '@sentry/scraps/link';
 import {SizeProvider, useSizeContext} from '@sentry/scraps/sizeContext';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
@@ -310,13 +316,20 @@ function PrimaryNavigationUnreadIndicator({
 }: PrimaryNavigationUnreadIndicatorProps) {
   const theme = useTheme();
   const {layout} = usePrimaryNavigation();
+  const hasPageFrame = useHasPageFrameFeature();
+  const indicatorPosition: Pick<
+    ContainerProps<'div'>,
+    'top' | 'right' | 'left'
+  > = hasPageFrame
+    ? layout === 'mobile'
+      ? {top: '0', right: '0'}
+      : {top: '0', right: '0'}
+    : layout === 'mobile'
+      ? {left: '11px', top: `-${theme.space['2xs']}`}
+      : {top: '0', right: '0'};
+
   return (
-    <Container
-      position="absolute"
-      top={layout === 'mobile' ? `-${theme.space.xs}` : '0'}
-      right={layout === 'mobile' ? 'auto' : '0px'}
-      left={layout === 'mobile' ? '11px' : 'auto'}
-    >
+    <Container position="absolute" {...indicatorPosition}>
       {p => (
         <StatusIndicator
           {...mergeProps(p, props)}
@@ -430,7 +443,7 @@ function NavigationButton(props: DistributedOmit<ButtonProps, 'size'>) {
       justify={layout === 'mobile' && !hasPageFrame ? 'start' : 'center'}
     >
       {p => (
-        <Button
+        <ButtonWithOverflowVisible
           {...p}
           {...props}
           {...(layout === 'mobile'
@@ -443,6 +456,18 @@ function NavigationButton(props: DistributedOmit<ButtonProps, 'size'>) {
     </Flex>
   );
 }
+
+/**
+ * @TODO(JonasBadalic) Scraps buttons have been setting overflow hidden onto the inner surface wrapper ever since
+ * we inherited that component, and we need to override that to ensure that the indicator is visible as it will
+ * otherwise clip the indicator and StatusIndicator animation. We need to unwind this and remove the overflow
+ * from buttons from ever being set.
+ */
+const ButtonWithOverflowVisible = styled(Button)`
+  > span:last-child {
+    overflow: initial;
+  }
+`;
 
 function PrimaryNavigationButtonBar(props: ButtonBarProps) {
   return <ButtonBar {...props} width="100%" />;


### PR DESCRIPTION
This broke with our change to the new indicators, so I'm updating each element's location and the button overflow accordingly 