### PR TITLE
feat(issues): Refactor SuspectCommits layout, clean up types

### DIFF
--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 
-import {CommitRow} from 'sentry/components/commitRow';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {StacktraceContext} from 'sentry/components/events/interfaces/stackTraceContext';
 import {SuspectCommits} from 'sentry/components/events/suspectCommits';
@@ -120,7 +119,6 @@ export function Exception({
                     projectSlug={projectSlug}
                     eventId={event.id}
                     group={group}
-                    commitRow={CommitRow}
                   />
                 </ErrorBoundary>
               </Fragment>

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {Button, ButtonBar} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
-import {CommitRow} from 'sentry/components/commitRow';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {
   StacktraceContext,
@@ -396,7 +395,6 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
               <SuspectCommits
                 projectSlug={projectSlug}
                 eventId={event.id}
-                commitRow={CommitRow}
                 group={group}
               />
             </ErrorBoundary>

--- a/static/app/components/events/styles.tsx
+++ b/static/app/components/events/styles.tsx
@@ -76,28 +76,3 @@ export const BannerSummary = styled('p')`
     align-self: flex-end;
   }
 `;
-
-export const SuspectCommitHeader = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: ${p => p.theme.space.md};
-
-  & button,
-  & h3 {
-    color: ${p => p.theme.tokens.content.secondary};
-    font-size: ${p => p.theme.font.size.md};
-    font-weight: ${p => p.theme.font.weight.sans.medium};
-  }
-
-  & h3 {
-    margin-bottom: 0;
-  }
-
-  & button {
-    background: none;
-    border: 0;
-    outline: none;
-    padding: 0;
-  }
-`;

--- a/static/app/components/events/suspectCommitFeedback.spec.tsx
+++ b/static/app/components/events/suspectCommitFeedback.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RepositoryFixture} from 'sentry-fixture/repository';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -13,15 +12,7 @@ jest.mock('sentry/utils/analytics');
 describe('SuspectCommitFeedback', () => {
   const organization = OrganizationFixture();
   const user = UserFixture();
-  const mockCommit = {
-    id: 'abc123',
-    message: 'fix: resolve test issue',
-    group_owner_id: 12345,
-    author: UserFixture({name: 'Test Author', id: 'author1'}),
-    dateCreated: '2023-01-01T00:00:00Z',
-    repository: RepositoryFixture({id: 'repo1', name: 'test-repo'}),
-    releases: [],
-  };
+  const groupOwnerId = 12345;
 
   beforeEach(() => {
     jest.mocked(trackAnalytics).mockClear();
@@ -32,7 +23,9 @@ describe('SuspectCommitFeedback', () => {
   });
 
   it('tracks analytics and shows thank you message when thumbs up is clicked', async () => {
-    render(<SuspectCommitFeedback commit={mockCommit} organization={organization} />);
+    render(
+      <SuspectCommitFeedback groupOwnerId={groupOwnerId} organization={organization} />
+    );
 
     expect(screen.getByText('Is this correct?')).toBeInTheDocument();
     expect(
@@ -66,7 +59,9 @@ describe('SuspectCommitFeedback', () => {
   });
 
   it('tracks analytics and shows thank you message when thumbs down is clicked', async () => {
-    render(<SuspectCommitFeedback commit={mockCommit} organization={organization} />);
+    render(
+      <SuspectCommitFeedback groupOwnerId={groupOwnerId} organization={organization} />
+    );
 
     expect(screen.getByText('Is this correct?')).toBeInTheDocument();
     expect(

--- a/static/app/components/events/suspectCommitFeedback.tsx
+++ b/static/app/components/events/suspectCommitFeedback.tsx
@@ -6,22 +6,17 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Commit} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useUser} from 'sentry/utils/useUser';
 
-interface CommitWithGroupOwner extends Commit {
-  group_owner_id: number;
-}
-
 interface SuspectCommitFeedbackProps {
-  commit: CommitWithGroupOwner;
+  groupOwnerId: number;
   organization: Organization;
 }
 
 export function SuspectCommitFeedback({
-  commit,
+  groupOwnerId,
   organization,
 }: SuspectCommitFeedbackProps) {
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
@@ -31,7 +26,7 @@ export function SuspectCommitFeedback({
     (isCorrect: boolean) => {
       const analyticsData = {
         choice_selected: isCorrect,
-        group_owner_id: commit.group_owner_id,
+        group_owner_id: groupOwnerId,
         user_id: user.id,
         organization,
       };
@@ -40,7 +35,7 @@ export function SuspectCommitFeedback({
 
       setFeedbackSubmitted(true);
     },
-    [commit, organization, user]
+    [groupOwnerId, organization, user]
   );
 
   if (feedbackSubmitted) {
@@ -56,14 +51,14 @@ export function SuspectCommitFeedback({
       <FeedbackText>{t('Is this correct?')}</FeedbackText>
       <Flex gap="2xs">
         <Button
-          size="xs"
-          icon={<IconThumb direction="up" size="sm" />}
+          size="zero"
+          icon={<IconThumb direction="up" size="xs" />}
           onClick={() => handleFeedback(true)}
           aria-label={t('Yes, this suspect commit is correct')}
         />
         <Button
-          size="xs"
-          icon={<IconThumb direction="down" size="sm" />}
+          size="zero"
+          icon={<IconThumb direction="down" size="xs" />}
           onClick={() => handleFeedback(false)}
           aria-label={t('No, this suspect commit is incorrect')}
         />
@@ -73,9 +68,6 @@ export function SuspectCommitFeedback({
 }
 
 const FeedbackContainer = styled('div')`
-  position: absolute;
-  top: ${p => p.theme.space.md};
-  right: ${p => p.theme.space.md};
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/static/app/components/events/suspectCommits.spec.tsx
+++ b/static/app/components/events/suspectCommits.spec.tsx
@@ -7,333 +7,127 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {CommitRow} from 'sentry/components/commitRow';
-import {QuickContextCommitRow} from 'sentry/components/discover/quickContextCommitRow';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import {SuspectCommits} from './suspectCommits';
-
-jest.mock('sentry/views/issueDetails/utils', () => ({
-  ...jest.requireActual('sentry/views/issueDetails/utils'),
-  useHasStreamlinedUI: jest.fn(),
-}));
 
 jest.mock('sentry/utils/analytics');
 
 describe('SuspectCommits', () => {
-  describe('SuspectCommits', () => {
-    const organization = OrganizationFixture();
-    const project = ProjectFixture();
-    const event = EventFixture();
-    const group = GroupFixture({firstRelease: {}} as any);
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+  const event = EventFixture();
+  const group = GroupFixture({firstRelease: {}} as any);
 
-    const committers = [
-      {
-        group_owner_id: 123,
-        author: {name: 'Max Bittker', id: '1'},
-        commits: [
-          {
-            message:
-              'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
-            score: 4,
-            id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-            repository: RepositoryFixture(),
-            dateCreated: '2018-03-02T18:30:26Z',
-          },
-        ],
+  const committers = [
+    {
+      group_owner_id: 789,
+      author: {name: 'Max Bittker', id: '1'},
+      commits: [
+        {
+          message:
+            'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
+          score: 4,
+          id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
+          repository: RepositoryFixture(),
+          dateCreated: '2018-03-02T18:30:26Z',
+        },
+      ],
+    },
+    {
+      group_owner_id: 456,
+      author: {name: 'Somebody else', id: '2'},
+      commits: [
+        {
+          message: 'fix: Make things less broken',
+          score: 2,
+          id: 'zzzzzz3d0c9000829084ac7b1c9221fb18437c',
+          repository: RepositoryFixture(),
+          dateCreated: '2018-03-02T16:30:26Z',
+        },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    jest.mocked(trackAnalytics).mockClear();
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
+      body: {
+        committers: [committers[0]],
       },
-      {
-        group_owner_id: 456,
-        author: {name: 'Somebody else', id: '2'},
-        commits: [
-          {
-            message: 'fix: Make things less broken',
-            score: 2,
-            id: 'zzzzzz3d0c9000829084ac7b1c9221fb18437c',
-            repository: RepositoryFixture(),
-            dateCreated: '2018-03-02T16:30:26Z',
-          },
-        ],
-      },
-    ];
-
-    beforeEach(() => {
-      jest.mocked(useHasStreamlinedUI).mockReturnValue(false);
-      jest.mocked(trackAnalytics).mockClear();
-      MockApiClient.addMockResponse({
-        method: 'GET',
-        url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-        body: {
-          committers,
-        },
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/projects/`,
-        body: [project],
-      });
     });
-
-    afterEach(() => {
-      MockApiClient.clearMockResponses();
-      jest.clearAllMocks();
-    });
-
-    it('Renders base commit row', async () => {
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={CommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-
-      expect(await screen.findByTestId('commit-row')).toBeInTheDocument();
-      expect(screen.queryByTestId('quick-context-commit-row')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('email-warning')).not.toBeInTheDocument();
-    });
-
-    it('Renders quick context commit row', async () => {
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={QuickContextCommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-
-      expect(await screen.findByTestId('quick-context-commit-row')).toBeInTheDocument();
-      expect(screen.queryByTestId('commit-row')).not.toBeInTheDocument();
-    });
-
-    it('renders correct heading for single commit', async () => {
-      // For this one test, undo the `beforeEach` so that we can respond with just a single commit
-      MockApiClient.clearMockResponses();
-      MockApiClient.addMockResponse({
-        method: 'GET',
-        url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-        body: {
-          committers: [committers[0]],
-        },
-      });
-
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={CommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-
-      expect(await screen.findByText(/Suspect Commit/i)).toBeInTheDocument();
-      expect(screen.queryByText(/Suspect Commits/i)).not.toBeInTheDocument();
-    });
-
-    it('expands', async () => {
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={CommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-
-      await userEvent.click(await screen.findByText('Show more'));
-      expect(screen.getAllByTestId('commit-row')).toHaveLength(2);
-
-      // and hides
-      await userEvent.click(screen.getByText('Show less'));
-      expect(await screen.findByTestId('commit-row')).toBeInTheDocument();
-    });
-
-    it('shows unassociated email warning', async () => {
-      MockApiClient.addMockResponse({
-        method: 'GET',
-        url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-        body: {
-          committers: [
-            {
-              group_owner_id: 999,
-              author: {name: 'Somebody else', email: 'somebodyelse@email.com'},
-              commits: [
-                {
-                  message: 'fix: Make things less broken',
-                  score: 2,
-                  id: 'zzzzzz3d0c9000829084ac7b1c9221fb18437c',
-                  repository: RepositoryFixture(),
-                  dateCreated: '2018-03-02T16:30:26Z',
-                },
-              ],
-            },
-          ],
-        },
-      });
-
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={CommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-
-      expect(await screen.findByTestId('commit-row')).toBeInTheDocument();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [project],
     });
   });
 
-  describe('StreamlinedSuspectCommits', () => {
-    const organization = OrganizationFixture();
-    const project = ProjectFixture();
-    const event = EventFixture();
-    const group = GroupFixture({firstRelease: {}} as any);
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
 
-    const committers = [
-      {
-        group_owner_id: 789,
-        author: {name: 'Max Bittker', id: '1'},
-        commits: [
-          {
-            message:
-              'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
-            score: 4,
-            id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-            repository: RepositoryFixture(),
-            dateCreated: '2018-03-02T18:30:26Z',
-          },
-        ],
+  it('Renders base commit row', async () => {
+    render(
+      <SuspectCommits projectSlug={project.slug} eventId={event.id} group={group} />
+    );
+
+    expect(await screen.findByTestId('commit-row')).toBeInTheDocument();
+    expect(screen.queryByTestId('email-warning')).not.toBeInTheDocument();
+  });
+
+  it('renders multiple suspect commits', async () => {
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
+      body: {
+        committers,
       },
-      {
-        group_owner_id: 456,
-        author: {name: 'Somebody else', id: '2'},
-        commits: [
-          {
-            message: 'fix: Make things less broken',
-            score: 2,
-            id: 'zzzzzz3d0c9000829084ac7b1c9221fb18437c',
-            repository: RepositoryFixture(),
-            dateCreated: '2018-03-02T16:30:26Z',
-          },
-        ],
-      },
-    ];
+    });
+    render(
+      <SuspectCommits projectSlug={project.slug} eventId={event.id} group={group} />
+    );
+    expect(
+      await screen.findByText('feat: Enhance suggested commits and add to alerts')
+    ).toBeInTheDocument();
+    expect(await screen.findByText('fix: Make things less broken')).toBeInTheDocument();
+    expect(await screen.findAllByTestId('commit-row')).toHaveLength(2);
+  });
 
-    beforeEach(() => {
-      (useHasStreamlinedUI as jest.Mock).mockReturnValue(true);
-      jest.mocked(trackAnalytics).mockClear();
-      MockApiClient.addMockResponse({
-        method: 'GET',
-        url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-        body: {
-          committers: [committers[0]],
-        },
-      });
+  it('shows feedback component for suspect commits', async () => {
+    render(
+      <SuspectCommits projectSlug={project.slug} eventId={event.id} group={group} />
+    );
+
+    expect(await screen.findByTestId('commit-row')).toBeInTheDocument();
+    expect(screen.getByText('Is this correct?')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Yes, this suspect commit is correct'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'No, this suspect commit is incorrect'})
+    ).toBeInTheDocument();
+  });
+
+  it('tracks analytics when feedback is submitted', async () => {
+    render(
+      <SuspectCommits projectSlug={project.slug} eventId={event.id} group={group} />
+    );
+
+    const thumbsUpButton = await screen.findByRole('button', {
+      name: 'Yes, this suspect commit is correct',
+    });
+    await userEvent.click(thumbsUpButton);
+
+    expect(trackAnalytics).toHaveBeenCalledWith('suspect_commit.feedback_submitted', {
+      choice_selected: true,
+      group_owner_id: 789,
+      user_id: UserFixture().id,
+      organization,
     });
 
-    afterEach(() => {
-      MockApiClient.clearMockResponses();
-      jest.clearAllMocks();
-    });
-
-    it('Renders base commit row', async () => {
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={CommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-
-      expect(await screen.findByTestId('commit-row')).toBeInTheDocument();
-      expect(screen.queryByTestId('quick-context-commit-row')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('email-warning')).not.toBeInTheDocument();
-    });
-
-    it('Renders quick context commit row', async () => {
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={QuickContextCommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-
-      expect(await screen.findByTestId('quick-context-commit-row')).toBeInTheDocument();
-      expect(screen.queryByTestId('commit-row')).not.toBeInTheDocument();
-    });
-
-    it('renders multiple suspect commits', async () => {
-      MockApiClient.addMockResponse({
-        method: 'GET',
-        url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-        body: {
-          committers,
-        },
-      });
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={CommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-      expect(
-        await screen.findByText('feat: Enhance suggested commits and add to alerts')
-      ).toBeInTheDocument();
-      expect(await screen.findByText('fix: Make things less broken')).toBeInTheDocument();
-      expect(await screen.findAllByTestId('commit-row')).toHaveLength(2);
-    });
-
-    it('shows feedback component for suspect commits', async () => {
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={CommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-
-      expect(await screen.findByTestId('commit-row')).toBeInTheDocument();
-      expect(screen.getByText('Is this correct?')).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', {name: 'Yes, this suspect commit is correct'})
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', {name: 'No, this suspect commit is incorrect'})
-      ).toBeInTheDocument();
-    });
-
-    it('tracks analytics when feedback is submitted', async () => {
-      render(
-        <SuspectCommits
-          projectSlug={project.slug}
-          commitRow={CommitRow}
-          eventId={event.id}
-          group={group}
-        />
-      );
-
-      const thumbsUpButton = await screen.findByRole('button', {
-        name: 'Yes, this suspect commit is correct',
-      });
-      await userEvent.click(thumbsUpButton);
-
-      expect(trackAnalytics).toHaveBeenCalledWith('suspect_commit.feedback_submitted', {
-        choice_selected: true,
-        group_owner_id: 789,
-        user_id: UserFixture().id,
-        organization,
-      });
-
-      expect(screen.getByText('Thanks!')).toBeInTheDocument();
-    });
+    expect(screen.getByText('Thanks!')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -9,6 +9,7 @@ import {SuspectCommitFeedback} from 'sentry/components/events/suspectCommitFeedb
 import {Panel} from 'sentry/components/panels/panel';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import {t} from 'sentry/locale';
+import {ConfigStore} from 'sentry/stores/configStore';
 import type {Group} from 'sentry/types/group';
 import type {Commit} from 'sentry/types/integrations';
 import type {Project} from 'sentry/types/project';
@@ -33,6 +34,7 @@ export function SuspectCommits({group, eventId, projectSlug}: Props) {
     projectSlug,
     group,
   });
+  const isSelfHosted = ConfigStore.get('isSelfHosted');
 
   const committers = useMemo(
     () => (data?.committers ?? []).slice(0, 100),
@@ -86,7 +88,7 @@ export function SuspectCommits({group, eventId, projectSlug}: Props) {
                 <Heading as="h4" size="lg">
                   {t('Suspect Commit')}
                 </Heading>
-                {committer.group_owner_id !== undefined && (
+                {!isSelfHosted && committer.group_owner_id !== undefined && (
                   <SuspectCommitFeedback
                     groupOwnerId={committer.group_owner_id}
                     organization={organization}

--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -1,13 +1,14 @@
-import {Fragment, useState} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import type {CommitRowProps} from 'sentry/components/commitRow';
-import {SuspectCommitHeader} from 'sentry/components/events/styles';
+import {Flex} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+
+import {CommitRow} from 'sentry/components/commitRow';
 import {SuspectCommitFeedback} from 'sentry/components/events/suspectCommitFeedback';
 import {Panel} from 'sentry/components/panels/panel';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
-import {IconAdd, IconSubtract} from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Commit} from 'sentry/types/integrations';
 import type {Project} from 'sentry/types/project';
@@ -17,51 +18,31 @@ import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnaly
 import {useCommitters} from 'sentry/utils/useCommitters';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromSlug} from 'sentry/utils/useProjectFromSlug';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
-
-interface CommitWithGroupOwner extends Commit {
-  group_owner_id: number;
-}
 
 interface Props {
-  commitRow: React.ComponentType<CommitRowProps>;
   eventId: string;
+  group: Group;
   projectSlug: Project['slug'];
-  group?: Group;
 }
 
-export function SuspectCommits({
-  group,
-  eventId,
-  projectSlug,
-  commitRow: CommitRow,
-}: Props) {
+export function SuspectCommits({group, eventId, projectSlug}: Props) {
   const organization = useOrganization();
-  const [isExpanded, setIsExpanded] = useState(false);
   const project = useProjectFromSlug({organization, projectSlug});
   const {data} = useCommitters({
     eventId,
     projectSlug,
     group,
   });
-  const committers = data?.committers ?? [];
 
-  const hasStreamlinedUI = useHasStreamlinedUI();
-
-  function getUniqueCommitsWithAuthors() {
-    // Get a list of suspect commits with author information attached
-    return committers.map((committer: any) => ({
-      ...committer.commits[0],
-      author: committer.author,
-      group_owner_id: committer.group_owner_id,
-    }));
-  }
-
-  const commits = getUniqueCommitsWithAuthors();
+  const committers = useMemo(
+    () => (data?.committers ?? []).slice(0, 100),
+    [data?.committers]
+  );
 
   useRouteAnalyticsParams({
-    num_suspect_commits: commits.length,
-    suspect_commit_calculation: commits[0]?.suspectCommitType ?? 'no suspect commit',
+    num_suspect_commits: committers.length,
+    suspect_commit_calculation:
+      committers[0]?.commits[0]?.suspectCommitType ?? 'no suspect commit',
   });
 
   if (!committers.length) {
@@ -89,9 +70,7 @@ export function SuspectCommits({
     });
   };
 
-  const commitHeading = tn('Suspect Commit', 'Suspect Commits (%s)', commits.length);
-
-  return hasStreamlinedUI ? (
+  return (
     <SuspectCommitWrapper>
       <ScrollCarousel
         gap="lg"
@@ -99,79 +78,38 @@ export function SuspectCommits({
         jumpItemCount={1}
         aria-label={t('Suspect commits')}
       >
-        {commits.slice(0, 100).map((commit, commitIndex) => (
-          <StreamlinedPanel key={commitIndex}>
-            <SuspectCommitFeedback
-              commit={commit as CommitWithGroupOwner}
-              organization={organization}
-            />
-            <Title>{t('Suspect Commit')}</Title>
-            <div>
-              <CommitRow
-                key={commit.id}
-                commit={commit}
-                onCommitClick={() => handleCommitClick(commit, commitIndex)}
-                onPullRequestClick={() => handlePullRequestClick(commit, commitIndex)}
-                project={project}
-              />
-            </div>
-          </StreamlinedPanel>
-        ))}
+        {committers.map((committer, index) => {
+          const commit: Commit = {...committer.commits[0]!, author: committer.author};
+          return (
+            <GradientPanel key={index}>
+              <Flex justify="between" align="end" padding="md md xs lg">
+                <Heading as="h4" size="lg">
+                  {t('Suspect Commit')}
+                </Heading>
+                {committer.group_owner_id !== undefined && (
+                  <SuspectCommitFeedback
+                    groupOwnerId={committer.group_owner_id}
+                    organization={organization}
+                  />
+                )}
+              </Flex>
+              <div>
+                <CommitRow
+                  commit={commit}
+                  onCommitClick={() => handleCommitClick(commit, index)}
+                  onPullRequestClick={() => handlePullRequestClick(commit, index)}
+                  project={project}
+                />
+              </div>
+            </GradientPanel>
+          );
+        })}
       </ScrollCarousel>
     </SuspectCommitWrapper>
-  ) : (
-    <div>
-      <SuspectCommitHeader>
-        <h3 data-test-id="suspect-commit">{commitHeading}</h3>
-        {commits.length > 1 && (
-          <ExpandButton
-            onClick={() => setIsExpanded(!isExpanded)}
-            data-test-id="expand-commit-list"
-          >
-            {isExpanded ? (
-              <Fragment>
-                {t('Show less')} <IconSubtract size="md" />
-              </Fragment>
-            ) : (
-              <Fragment>
-                {t('Show more')} <IconAdd size="md" />
-              </Fragment>
-            )}
-          </ExpandButton>
-        )}
-      </SuspectCommitHeader>
-      <StyledPanel>
-        {commits.slice(0, isExpanded ? 100 : 1).map((commit, commitIndex) => (
-          <CommitRow
-            key={commit.id}
-            commit={commit}
-            onCommitClick={() => handleCommitClick(commit, commitIndex)}
-            onPullRequestClick={() => handlePullRequestClick(commit, commitIndex)}
-          />
-        ))}
-      </StyledPanel>
-    </div>
   );
 }
 
-const StyledPanel = styled(Panel)`
-  margin: 0;
-`;
-
-const ExpandButton = styled('button')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-`;
-
-const Title = styled('div')`
-  font-size: ${p => p.theme.font.size.lg};
-  font-weight: bold;
-  padding: 10px 12px 0 12px;
-`;
-
-const StreamlinedPanel = styled(Panel)`
-  position: relative;
+const GradientPanel = styled(Panel)`
   background: ${p => p.theme.tokens.background.primary}
     linear-gradient(to right, rgba(245, 243, 247, 0), ${p => p.theme.colors.surface200});
   overflow: hidden;

--- a/static/app/components/stackTrace/issueStackTrace/index.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.tsx
@@ -5,7 +5,6 @@ import {Flex} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 
-import {CommitRow} from 'sentry/components/commitRow';
 import {CopyAsDropdown} from 'sentry/components/copyAsDropdown';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {StacktraceBanners} from 'sentry/components/events/interfaces/crashContent/exception/banners/stacktraceBanners';
@@ -378,12 +377,7 @@ function IssueStackTraceSuspectCommits({
 
   return (
     <ErrorBoundary mini message={t('There was an error loading suspect commits')}>
-      <SuspectCommits
-        projectSlug={projectSlug}
-        eventId={event.id}
-        group={group}
-        commitRow={CommitRow}
-      />
+      <SuspectCommits projectSlug={projectSlug} eventId={event.id} group={group} />
     </ErrorBoundary>
   );
 }

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -131,6 +131,11 @@ export type Commit = {
 export type Committer = {
   author: User;
   commits: Commit[];
+  /**
+   * Primary key of the GroupOwner record that linked this committer to the issue.
+   * Used for suspect commit feedback analytics.
+   */
+  group_owner_id?: number;
 };
 
 export type CommitAuthor = {

--- a/static/app/utils/useCommitters.tsx
+++ b/static/app/utils/useCommitters.tsx
@@ -9,8 +9,8 @@ import {useOrganization} from './useOrganization';
 
 interface UseCommittersProps {
   eventId: string;
+  group: Group;
   projectSlug: string;
-  group?: Group;
 }
 
 interface CommittersResponse {
@@ -39,7 +39,7 @@ export function useCommitters(
   options: Partial<UseApiQueryOptions<CommittersResponse>> = {}
 ) {
   const org = useOrganization();
-  const previousGroupId = usePrevious(group?.id);
+  const previousGroupId = usePrevious(group.id);
   return useApiQuery<CommittersResponse>(
     makeCommittersQueryKey(org.slug, projectSlug, eventId),
     {
@@ -47,7 +47,7 @@ export function useCommitters(
       retry: false,
       enabled: !!eventId,
       placeholderData: previousData => {
-        return group?.id === previousGroupId ? previousData : undefined;
+        return group.id === previousGroupId ? previousData : undefined;
       },
       ...options,
     }

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -7,7 +7,6 @@ import {Button} from '@sentry/scraps/button';
 import {usePrompt} from 'sentry/actionCreators/prompts';
 import Feature from 'sentry/components/acl/feature';
 import {GuideAnchor} from 'sentry/components/assistant/guideAnchor';
-import {CommitRow} from 'sentry/components/commitRow';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {BreadcrumbsDataSection} from 'sentry/components/events/breadcrumbs/breadcrumbsDataSection';
 import {EventContexts} from 'sentry/components/events/contexts';
@@ -178,12 +177,7 @@ export function EventDetailsContent({
       <StyledDataSection>
         {!hasStreamlinedUI && <TraceDataSection event={event} />}
         {!hasStreamlinedUI && (
-          <SuspectCommits
-            projectSlug={project.slug}
-            eventId={event.id}
-            group={group}
-            commitRow={CommitRow}
-          />
+          <SuspectCommits projectSlug={project.slug} eventId={event.id} group={group} />
         )}
       </StyledDataSection>
       {event.userReport && (


### PR DESCRIPTION
- the feedback buttons seem to have grown, re-align them
- remove check for hasStreamline since that feature is now always enabled
- Remove the `commitRow` render prop — every call site passed the same `CommitRow` component
- Reflect the actual API shape of committers w/ `group_owner_id`

before

<img width="735" height="122" alt="image" src="https://github.com/user-attachments/assets/ffb873b2-d599-44af-a5ac-3247f5700754" />

after - the feedback is slightly further from the next line of text

<img width="726" height="131" alt="image" src="https://github.com/user-attachments/assets/42cab07a-cec6-4ccc-8f7c-6ab8fcee403f" />

how they looked when they were added https://github.com/getsentry/sentry/pull/99056