### PR TITLE
feat(snapshots): Set nice UI for left side of header

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
@@ -85,7 +85,7 @@ export function SnapshotHeaderContent({
         </Flex>
       )}
 
-      {data.comparison_type === 'diff' && (
+      {data.comparison_type === 'diff' && data.base_artifact_id && (
         <Flex align="center" gap="sm" padding="sm 0">
           <Text size="sm" variant="muted" bold>
             {t('Comparing:')}

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
@@ -1,83 +1,129 @@
-import React from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
 
-import {FeatureBadge} from '@sentry/scraps/badge';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
-import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {IconBranch, IconCommit} from 'sentry/icons';
+import {IconCommit, IconPullRequest, IconShow, IconStack} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import type {Theme} from 'sentry/utils/theme';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import type {SnapshotDetailsApiResponse} from 'sentry/views/preprod/types/snapshotTypes';
-import {makeReleasesUrl} from 'sentry/views/preprod/utils/releasesUrl';
 import {getBranchUrl, getPrUrl, getShaUrl} from 'sentry/views/preprod/utils/vcsLinkUtils';
+
+interface VcsItemConfig {
+  icon: React.ComponentType<SVGIconProps>;
+  key: string;
+  label: string;
+  href?: string | null;
+  monospace?: boolean;
+  requiresHref?: boolean;
+}
 
 interface SnapshotHeaderContentProps {
   data: SnapshotDetailsApiResponse;
-  projectId: string;
+  isSoloView: boolean;
+  onToggleView: () => void;
 }
 
-export function SnapshotHeaderContent({projectId, data}: SnapshotHeaderContentProps) {
-  const organization = useOrganization();
+export function SnapshotHeaderContent({
+  data,
+  isSoloView,
+  onToggleView,
+}: SnapshotHeaderContentProps) {
   const {vcs_info} = data;
-  const shaUrl = getShaUrl(vcs_info, vcs_info.head_sha);
-  const prUrl = getPrUrl(vcs_info);
-  const branchUrl = getBranchUrl(vcs_info, vcs_info.head_ref);
   const shortSha = vcs_info.head_sha?.slice(0, 7);
 
-  const breadcrumbs: Crumb[] = [
+  const vcsItems: VcsItemConfig[] = [
     {
-      to: makeReleasesUrl(organization.slug, projectId, {tab: 'mobile-builds'}),
-      label: t('Releases'),
+      key: 'pr',
+      icon: IconPullRequest,
+      label: vcs_info.pr_number ? `#${vcs_info.pr_number}` : '',
+      href: getPrUrl(vcs_info),
+      requiresHref: true,
     },
-  ];
+    {
+      key: 'sha',
+      icon: IconCommit,
+      label: shortSha ?? '',
+      href: getShaUrl(vcs_info, vcs_info.head_sha),
+      monospace: true,
+      requiresHref: true,
+    },
+    {
+      key: 'branch',
+      icon: IconStack,
+      label: vcs_info.head_ref ?? '',
+      href: getBranchUrl(vcs_info, vcs_info.head_ref),
+    },
+  ].filter(item => item.label && (!item.requiresHref || item.href));
 
   return (
-    <React.Fragment>
-      <Layout.HeaderContent>
-        <Flex align="center" gap="sm">
-          <Breadcrumbs crumbs={breadcrumbs} />
-          <FeatureBadge type="new" />
-        </Flex>
-        <Layout.Title>
-          {/* TODO: Replace with app-id/version when available */}
-          {t('Snapshots')}
-          <Flex align="center" gap="md" wrap="wrap">
-            {prUrl && vcs_info.pr_number && (
-              <ExternalLink href={prUrl}>
-                <Flex align="center" gap="xs">
-                  <IconBranch size="xs" />
-                  <Text size="sm">#{vcs_info.pr_number}</Text>
-                </Flex>
-              </ExternalLink>
-            )}
-            {shaUrl && shortSha && (
-              <ExternalLink href={shaUrl}>
-                <Flex align="center" gap="xs">
-                  <IconCommit size="xs" />
-                  <Text size="sm" monospace>
-                    {shortSha}
+    <Layout.HeaderContent>
+      <Layout.Title>{t('Snapshot')}</Layout.Title>
+
+      {vcsItems.length > 0 && (
+        <Flex align="center" gap="lg" wrap="wrap">
+          {vcsItems.map(item => (
+            <Flex align="center" gap="xs" key={item.key}>
+              <item.icon size="xs" />
+              {item.href ? (
+                <ExternalLink href={item.href}>
+                  <Text size="sm" variant="accent" monospace={item.monospace}>
+                    {item.label}
                   </Text>
-                </Flex>
-              </ExternalLink>
-            )}
-            {vcs_info.head_ref && (
-              <Flex align="center" gap="xs">
-                <IconBranch size="xs" />
-                {branchUrl ? (
-                  <ExternalLink href={branchUrl}>
-                    <Text size="sm">{vcs_info.head_ref}</Text>
-                  </ExternalLink>
-                ) : (
-                  <Text size="sm">{vcs_info.head_ref}</Text>
-                )}
-              </Flex>
-            )}
-          </Flex>
-        </Layout.Title>
-      </Layout.HeaderContent>
-    </React.Fragment>
+                </ExternalLink>
+              ) : (
+                <Text size="sm">{item.label}</Text>
+              )}
+            </Flex>
+          ))}
+        </Flex>
+      )}
+
+      {data.comparison_type === 'diff' && (
+        <Flex align="center" gap="sm" padding="sm 0">
+          <Text size="sm" variant="muted" bold>
+            {t('Comparing:')}
+          </Text>
+          <PillButton
+            size="xs"
+            icon={<IconShow variant={isSoloView ? undefined : 'accent'} />}
+            priority={isSoloView ? 'primary' : 'default'}
+            onClick={onToggleView}
+            aria-pressed={isSoloView}
+          >
+            {t('Head')}
+          </PillButton>
+          <Text size="sm" variant="muted" bold>
+            {t('vs')}
+          </Text>
+          <PillLinkButton
+            size="xs"
+            icon={<IconShow variant="accent" />}
+            priority="default"
+            to={normalizeUrl(`/preprod/snapshots/${data.base_artifact_id}/`)}
+          >
+            {t('Base')}
+          </PillLinkButton>
+        </Flex>
+      )}
+    </Layout.HeaderContent>
   );
 }
+
+const pillStyle = (p: {theme: Theme}) => css`
+  border-radius: ${p.theme.radius.full};
+`;
+
+const PillButton = styled(Button)`
+  ${pillStyle}
+`;
+
+const PillLinkButton = styled(LinkButton)`
+  ${pillStyle}
+`;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -393,7 +393,11 @@ export default function SnapshotsPage() {
     <SentryDocumentTitle title={t('Snapshot')}>
       <Layout.Page>
         <Layout.Header>
-          <SnapshotHeaderContent projectId={data.project_id} data={data} />
+          <SnapshotHeaderContent
+            data={data}
+            isSoloView={isSoloView}
+            onToggleView={handleToggleView}
+          />
           <Layout.HeaderActions>
             <SnapshotDevTools
               organizationSlug={organization.slug}


### PR DESCRIPTION
before: 
<img width="1510" height="694" alt="CleanShot 2026-03-30 at 13 35 40@2x" src="https://github.com/user-attachments/assets/c8425aea-5d0c-42d2-8b98-40bab7ac3237" />

after:
<img width="1512" height="682" alt="CleanShot 2026-03-30 at 13 36 50@2x" src="https://github.com/user-attachments/assets/cc5ab558-01a8-4399-9eee-047254148bc1" />


## Summary

Redesigns the snapshot page header (top-left section) with a cleaner layout:

- **Title**: Changed from "Snapshots" to singular "Snapshot", removed breadcrumbs and feature badge
- **VCS metadata row**: PR number, commit SHA, and branch name now display with proper icons (`IconPullRequest`, `IconCommit`, `IconStack`) and purple linked text
- **Comparing row**: New "Comparing: **Head** vs **Base**" section for diff-mode snapshots
  - **Head** button toggles between diff and solo view (`?view=solo` query param)
  - **Base** button navigates to the base artifact's snapshot page
  - Both use pill-shaped buttons with accent-colored eye icons

Uses Sentry design system components (`Button`, `LinkButton`, `Text`, `Flex`, `ExternalLink`) throughout. VCS items are rendered from a declarative config array for cleaner code.

## Test plan

- [ ] Visit a snapshot page with diff comparison data (e.g. `/preprod/snapshots/169382/`)
- [ ] Verify header shows "Snapshot" title, VCS info row with correct icons and purple links
- [ ] Verify "Comparing" row appears with Head and Base pill buttons
- [ ] Click Head → URL gets `?view=solo`, button turns primary (purple), content switches to solo view
- [ ] Click Head again → returns to diff view
- [ ] Click Base → navigates to base artifact's snapshot page
- [ ] Verify VCS links (PR, commit, branch) open correct GitHub URLs
- [ ] Visit a solo-mode snapshot (no base) → "Comparing" row should not appear