### PR TITLE
fix(logs): port log detail buttons to Button priority=transparent

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -157,15 +157,12 @@ export const LogDetailTableActionsCell = styled(TableBodyCell)`
     padding: ${p => p.theme.space.xs} ${p => p.theme.space.xl};
   }
   &:last-child {
-    padding: ${p => p.theme.space.xs} ${p => p.theme.space.xl};
+    padding: ${p => p.theme.space.xs} 0;
   }
 `;
 export const LogDetailTableActionsButtonBar = styled('div')`
   display: flex;
   gap: ${p => p.theme.space.md};
-  & button {
-    font-weight: ${p => p.theme.font.weight.sans.regular};
-  }
 `;
 
 export const DetailsWrapper = styled('tr')`

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -612,13 +612,13 @@ function LogRowDetails({
 }
 
 function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowItem}) {
-  const theme = useTheme();
   const addSearchFilter = useAddSearchFilter();
   return (
     <LogDetailTableActionsButtonBar>
       <Button
-        priority="link"
+        priority="transparent"
         size="sm"
+        icon={<IconAdd />}
         onClick={() => {
           addSearchFilter({
             key: OurLogKnownFieldKey.MESSAGE,
@@ -626,12 +626,12 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
           });
         }}
       >
-        <IconAdd size="md" style={{paddingRight: theme.space.xs}} />
         {t('Add to filter')}
       </Button>
       <Button
-        priority="link"
+        priority="transparent"
         size="sm"
+        icon={<IconSubtract />}
         onClick={() => {
           addSearchFilter({
             key: OurLogKnownFieldKey.MESSAGE,
@@ -640,7 +640,6 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
           });
         }}
       >
-        <IconSubtract size="md" style={{paddingRight: theme.space.xs}} />
         {t('Exclude from filter')}
       </Button>
     </LogDetailTableActionsButtonBar>
@@ -654,7 +653,6 @@ function LogRowDetailsActions({
   fullLogDataResult: UseApiQueryResult<TraceItemDetailsResponse, RequestError>;
   tableDataRow: LogTableRowItem;
 }) {
-  const theme = useTheme();
   const {data, isPending, isError} = fullLogDataResult;
   const isFrozen = useLogsFrozenIsFrozen();
   const organization = useOrganization();
@@ -689,12 +687,12 @@ function LogRowDetailsActions({
       )}
       <LogDetailTableActionsButtonBar>
         <Button
-          priority="link"
+          priority="transparent"
           size="sm"
+          icon={<IconJson />}
           onClick={betterCopyToClipboard}
           disabled={isPending || isError || !json}
         >
-          <IconJson size="md" style={{paddingRight: theme.space.xs}} />
           {t('Copy as JSON')}
         </Button>
       </LogDetailTableActionsButtonBar>


### PR DESCRIPTION
Removes some of the old custom styles in favor of our [standard Scraps transparent Button](https://sentry.sentry.io/stories/core/button/#priorities).

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1514" height="314" src="https://github.com/user-attachments/assets/2ff4fcf2-a6ec-4791-8b47-8c2c692320ae" />
</td>
<td>
<img width="1514" height="314" src="https://github.com/user-attachments/assets/8499f706-1eff-4947-a76c-7b41b441733a" />
</td>
</tr>
</tbody>
</table>

Fixes EXP-860

Made with [Cursor](https://cursor.com)