### PR TITLE
ref(navigation): Hide page-level FeedbackButtons when page-frame is enabled

### DIFF
--- a/static/app/components/events/autofix/autofixFeedback.tsx
+++ b/static/app/components/events/autofix/autofixFeedback.tsx
@@ -2,6 +2,7 @@ import {type ComponentProps} from 'react';
 
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {t} from 'sentry/locale';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 interface AutofixFeedbackProps extends ComponentProps<typeof FeedbackButton> {
   iconOnly?: boolean;
@@ -12,6 +13,8 @@ export function AutofixFeedback({
   iconOnly = false,
   ...buttonProps
 }: AutofixFeedbackProps) {
+  const hasPageFrame = useHasPageFrameFeature();
+  if (hasPageFrame) return null;
   return (
     <FeedbackButton
       size="xs"

--- a/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
@@ -38,6 +38,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export function EventFeatureFlagSection(props: EventFeatureFlagSectionProps) {
   return (
@@ -57,20 +58,22 @@ function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagSecti
   const organization = useOrganization();
   const theme = useTheme();
   const isXsScreen = useMedia(`(max-width: ${theme.breakpoints.xs})`);
+  const hasPageFrame = useHasPageFrameFeature();
 
-  const feedbackButton = isXsScreen ? null : (
-    <FeedbackButton
-      aria-label={t('Give feedback on the feature flag section')}
-      size="xs"
-      feedbackOptions={{
-        messagePlaceholder: t('How can we make feature flags work better for you?'),
-        tags: {
-          ['feedback.source']: 'issue_details_feature_flags',
-          ['feedback.owner']: 'replay',
-        },
-      }}
-    />
-  );
+  const feedbackButton =
+    isXsScreen || hasPageFrame ? null : (
+      <FeedbackButton
+        aria-label={t('Give feedback on the feature flag section')}
+        size="xs"
+        feedbackOptions={{
+          messagePlaceholder: t('How can we make feature flags work better for you?'),
+          tags: {
+            ['feedback.source']: 'issue_details_feature_flags',
+            ['feedback.owner']: 'replay',
+          },
+        }}
+      />
+    );
 
   const [orderBy, setOrderBy] = useState<OrderBy>(OrderBy.NEWEST);
   const {closeDrawer, isDrawerOpen, openDrawer} = useDrawer();

--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -11,9 +11,11 @@ import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export function FeedbackSummaryCategories() {
   const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
+  const hasPageFrame = useHasPageFrameFeature();
 
   const [isExpanded, setIsExpanded] = useSyncedLocalStorageState(
     'user-feedback-ai-summary-categories-expanded',
@@ -61,8 +63,8 @@ export function FeedbackSummaryCategories() {
         <Disclosure.Title
           trailingItems={
             <Flex gap="xs">
-              {feedbackButton({type: 'positive'})}
-              {feedbackButton({type: 'negative'})}
+              {!hasPageFrame && feedbackButton({type: 'positive'})}
+              {!hasPageFrame && feedbackButton({type: 'negative'})}
             </Flex>
           }
         >

--- a/static/app/components/profiling/continuousProfileHeader.tsx
+++ b/static/app/components/profiling/continuousProfileHeader.tsx
@@ -13,6 +13,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 interface ContinuousProfileHeader {
   transaction: Event | null;
@@ -21,6 +22,7 @@ interface ContinuousProfileHeader {
 export function ContinuousProfileHeader({transaction}: ContinuousProfileHeader) {
   const location = useLocation();
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
 
   // @TODO add breadcrumbs when other views are implemented
   const breadCrumbs = useMemo((): ProfilingBreadcrumbsProps['trails'] => {
@@ -51,7 +53,7 @@ export function ContinuousProfileHeader({transaction}: ContinuousProfileHeader) 
         </SmallerProfilingBreadcrumbsWrapper>
       </SmallerHeaderContent>
       <StyledHeaderActions>
-        <FeedbackButton />
+        {!hasPageFrame && <FeedbackButton />}
         {transactionTarget && (
           <LinkButton size="sm" onClick={handleGoToTransaction} to={transactionTarget}>
             {t('Go to Trace')}

--- a/static/app/components/profiling/profileHeader.tsx
+++ b/static/app/components/profiling/profileHeader.tsx
@@ -13,6 +13,7 @@ import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {isSchema, isSentrySampledProfile} from 'sentry/utils/profiling/guards/profile';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {useProfiles} from 'sentry/views/profiling/profilesProvider';
 
 function getTransactionName(input: Profiling.ProfileInput): string {
@@ -35,6 +36,7 @@ interface ProfileHeaderProps {
 function ProfileHeader({transaction, projectId, eventId}: ProfileHeaderProps) {
   const location = useLocation();
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const profiles = useProfiles();
 
   const transactionName =
@@ -89,7 +91,7 @@ function ProfileHeader({transaction, projectId, eventId}: ProfileHeaderProps) {
         </SmallerProfilingBreadcrumbsWrapper>
       </SmallerHeaderContent>
       <StyledHeaderActions>
-        <FeedbackButton />
+        {!hasPageFrame && <FeedbackButton />}
         {transactionTarget && (
           <LinkButton size="sm" onClick={handleGoToTransaction} to={transactionTarget}>
             {t('Go to Trace')}

--- a/static/app/views/alerts/list/header.tsx
+++ b/static/app/views/alerts/list/header.tsx
@@ -15,6 +15,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 type Props = {
   activeTab: 'stream' | 'rules';
@@ -24,6 +25,7 @@ export function AlertHeader({activeTab}: Props) {
   const navigate = useNavigate();
   const location = useLocation();
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const {selection} = usePageFilters();
   /**
    * Incidents list is currently at the organization level, but the link needs to
@@ -79,7 +81,7 @@ export function AlertHeader({activeTab}: Props) {
           >
             {t('Create Alert')}
           </CreateAlertButton>
-          <FeedbackButton />
+          {!hasPageFrame && <FeedbackButton />}
           <LinkButton
             size="sm"
             onClick={handleNavigateToSettings}

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -28,6 +28,7 @@ import {
 import {IncidentStatus} from 'sentry/views/alerts/types';
 import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 interface MetricDetailsSidebarProps {
   rule: MetricRule;
@@ -143,6 +144,7 @@ export function MetricDetailsSidebar({
   rule,
   showOnDemandMetricAlertUI,
 }: MetricDetailsSidebarProps) {
+  const hasPageFrame = useHasPageFrameFeature();
   // get current status
   const latestIncident = rule.latestIncident;
 
@@ -160,7 +162,7 @@ export function MetricDetailsSidebar({
   const ownerId = rule.owner?.split(':')[1];
   const teamActor = ownerId && {type: 'team' as Actor['type'], id: ownerId, name: ''};
 
-  const feedbackButton = (
+  const feedbackButton = !hasPageFrame && (
     <FeedbackButton
       feedbackOptions={{
         formTitle: t('Anomaly Detection Feedback'),

--- a/static/app/views/alerts/rules/metric/triggers/dynamicAlertsFeedbackButton.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/dynamicAlertsFeedbackButton.tsx
@@ -3,11 +3,13 @@ import styled from '@emotion/styled';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {useFeedbackSDKIntegration} from 'sentry/components/feedbackButton/useFeedbackSDKIntegration';
 import {t} from 'sentry/locale';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export function DynamicAlertsFeedbackButton() {
+  const hasPageFrame = useHasPageFrameFeature();
   const {feedback} = useFeedbackSDKIntegration();
 
-  if (!feedback) {
+  if (hasPageFrame || !feedback) {
     return null;
   }
 

--- a/static/app/views/automations/components/automationFeedbackButton.tsx
+++ b/static/app/views/automations/components/automationFeedbackButton.tsx
@@ -1,7 +1,10 @@
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {t} from 'sentry/locale';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export function AutomationFeedbackButton() {
+  const hasPageFrame = useHasPageFrameFeature();
+  if (hasPageFrame) return null;
   return (
     <FeedbackButton
       size="sm"

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -59,6 +59,7 @@ import type {DashboardsLayout} from 'sentry/views/dashboards/manage/types';
 import {DashboardFilter, PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 import type {DashboardDetails, DashboardListItem} from 'sentry/views/dashboards/types';
 import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import RouteError from 'sentry/views/routeError';
 
 import DashboardGrid from './dashboardGrid';
@@ -162,6 +163,7 @@ function ManageDashboards() {
   const navigate = useNavigate();
   const location = useLocation();
   const api = useApi();
+  const hasPageFrame = useHasPageFrameFeature();
   const dashboardGridRef = useRef<HTMLDivElement>(null);
   const hasPrebuiltDashboards = organization.features.includes(
     'dashboards-prebuilt-insights-dashboards'
@@ -659,7 +661,7 @@ function ManageDashboards() {
                         </TemplateSwitch>
                       )}
 
-                      <FeedbackButton />
+                      {!hasPageFrame && <FeedbackButton />}
                       <Feature features={['dashboards-ai-generate']}>
                         {({hasFeature: hasAiGenerate}) =>
                           hasAiGenerate && areAiFeaturesAllowed ? (

--- a/static/app/views/detectors/components/monitorFeedbackButton.tsx
+++ b/static/app/views/detectors/components/monitorFeedbackButton.tsx
@@ -1,7 +1,10 @@
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {t} from 'sentry/locale';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export function MonitorFeedbackButton() {
+  const hasPageFrame = useHasPageFrameFeature();
+  if (hasPageFrame) return null;
   return (
     <FeedbackButton
       size="sm"

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -30,6 +30,7 @@ import {
 } from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export default function LogsContent() {
   const organization = useOrganization();
@@ -87,6 +88,7 @@ function LogsHeader() {
   const organization = useOrganization();
   const {data: savedQuery} = useGetSavedQuery(pageId);
   const onboardingProject = useOnboardingProject({property: 'hasLogs'});
+  const hasPageFrame = useHasPageFrameFeature();
 
   const hasSavedQueryTitle =
     defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
@@ -108,15 +110,17 @@ function LogsHeader() {
       </Layout.HeaderContent>
       <Layout.HeaderActions>
         <Grid flow="column" align="center" gap="md">
-          <FeedbackButton
-            feedbackOptions={{
-              messagePlaceholder: t('How can we make logs work better for you?'),
-              tags: {
-                ['feedback.source']: 'logs-listing',
-                ['feedback.owner']: 'performance',
-              },
-            }}
-          />
+          {!hasPageFrame && (
+            <FeedbackButton
+              feedbackOptions={{
+                messagePlaceholder: t('How can we make logs work better for you?'),
+                tags: {
+                  ['feedback.source']: 'logs-listing',
+                  ['feedback.owner']: 'performance',
+                },
+              }}
+            />
+          )}
           {defined(onboardingProject) && <SetupLogsButton />}
         </Grid>
       </Layout.HeaderActions>

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -23,6 +23,7 @@ import {
 } from 'sentry/views/explore/queryParams/savedQuery';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export default function MetricsContent() {
   const organization = useOrganization();
@@ -71,6 +72,7 @@ function MetricsHeader() {
   const title = getTitleFromLocation(location, TITLE_KEY);
   const organization = useOrganization();
   const {data: savedQuery} = useGetSavedQuery(pageId);
+  const hasPageFrame = useHasPageFrameFeature();
 
   const hasSavedQueryTitle =
     defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
@@ -93,15 +95,17 @@ function MetricsHeader() {
         </Layout.Title>
       </Layout.HeaderContent>
       <Layout.HeaderActions>
-        <FeedbackButton
-          feedbackOptions={{
-            messagePlaceholder: t('How can we make metrics work better for you?'),
-            tags: {
-              ['feedback.source']: 'metrics-listing',
-              ['feedback.owner']: 'performance',
-            },
-          }}
-        />
+        {!hasPageFrame && (
+          <FeedbackButton
+            feedbackOptions={{
+              messagePlaceholder: t('How can we make metrics work better for you?'),
+              tags: {
+                ['feedback.source']: 'metrics-listing',
+                ['feedback.owner']: 'performance',
+              },
+            }}
+          />
+        )}
       </Layout.HeaderActions>
     </Layout.Header>
   );

--- a/static/app/views/explore/multiQueryMode/index.tsx
+++ b/static/app/views/explore/multiQueryMode/index.tsx
@@ -16,6 +16,7 @@ import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {MultiQueryModeContent} from 'sentry/views/explore/multiQueryMode/content';
 import {SavedQueryEditMenu} from 'sentry/views/explore/savedQueryEditMenu';
 import {StarSavedQueryButton} from 'sentry/views/explore/starSavedQueryButton';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {makeTracesPathname} from 'sentry/views/traces/pathnames';
 
 export default function MultiQueryMode() {
@@ -25,6 +26,7 @@ export default function MultiQueryMode() {
 
   const id = getIdFromLocation(location);
   const {data: savedQuery} = useGetSavedQuery(id);
+  const hasPageFrame = useHasPageFrameFeature();
 
   return (
     <Feature
@@ -58,7 +60,7 @@ export default function MultiQueryMode() {
             <Grid flow="column" align="center" gap="md">
               <StarSavedQueryButton />
               {defined(id) && savedQuery?.isPrebuilt === false && <SavedQueryEditMenu />}
-              <FeedbackButton />
+              {!hasPageFrame && <FeedbackButton />}
             </Grid>
           </Layout.HeaderActions>
         </Layout.Header>

--- a/static/app/views/explore/savedQueries/index.tsx
+++ b/static/app/views/explore/savedQueries/index.tsx
@@ -14,11 +14,13 @@ import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
 import {getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {SavedQueriesLandingContent} from 'sentry/views/explore/savedQueries/savedQueriesLandingContent';
 import {getExploreUrl} from 'sentry/views/explore/utils';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export default function SavedQueriesView() {
   const organization = useOrganization();
   const hasLogsFeature = isLogsEnabled(organization);
   const navigate = useNavigate();
+  const hasPageFrame = useHasPageFrameFeature();
 
   const items = [
     {
@@ -48,7 +50,7 @@ export default function SavedQueriesView() {
           </Layout.HeaderContent>
           <Layout.HeaderActions>
             <Grid flow="column" align="center" gap="md">
-              <FeedbackButton />
+              {!hasPageFrame && <FeedbackButton />}
               {hasLogsFeature ? (
                 <DropdownMenu
                   items={items}

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -44,6 +44,7 @@ import {
 import {StarSavedQueryButton} from 'sentry/views/explore/starSavedQueryButton';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 const CROSS_EVENTS_DATE_OVERRIDE: MaxPickableDaysOptions = {
   defaultPeriod: MAX_PERIOD_FOR_CROSS_EVENTS,
@@ -148,6 +149,7 @@ function SpansTabHeader() {
   const title = useQueryParamsTitle();
   const organization = useOrganization();
   const {data: savedQuery} = useGetSavedQuery(id);
+  const hasPageFrame = useHasPageFrameFeature();
 
   const hasSavedQueryTitle =
     defined(id) && defined(savedQuery) && savedQuery.name.length > 0;
@@ -179,7 +181,7 @@ function SpansTabHeader() {
         <Grid flow="column" align="center" gap="md">
           <StarSavedQueryButton />
           {defined(id) && savedQuery?.isPrebuilt === false && <SavedQueryEditMenu />}
-          <FeedbackButton />
+          {!hasPageFrame && <FeedbackButton />}
         </Grid>
       </Layout.HeaderActions>
     </Layout.Header>

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -31,9 +31,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useMedia} from 'sentry/utils/useMedia';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export default function FeedbackListPage() {
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const {hasSetupOneFeedback} = useHaveSelectedProjectsSetupFeedback();
   const pageFilters = usePageFilters();
 
@@ -153,17 +155,19 @@ export default function FeedbackListPage() {
             </Layout.HeaderContent>
             <Layout.HeaderActions>
               <Flex gap="lg">
-                <FeedbackButton
-                  size="sm"
-                  feedbackOptions={{
-                    messagePlaceholder: t(
-                      'How can we improve the User Feedback experience?'
-                    ),
-                    tags: {
-                      ['feedback.source']: 'feedback-list',
-                    },
-                  }}
-                />
+                {!hasPageFrame && (
+                  <FeedbackButton
+                    size="sm"
+                    feedbackOptions={{
+                      messagePlaceholder: t(
+                        'How can we improve the User Feedback experience?'
+                      ),
+                      tags: {
+                        ['feedback.source']: 'feedback-list',
+                      },
+                    }}
+                  />
+                )}
                 <LinkButton
                   size="sm"
                   icon={<IconSiren />}

--- a/static/app/views/insights/crons/components/monitorHeaderActions.tsx
+++ b/static/app/views/insights/crons/components/monitorHeaderActions.tsx
@@ -15,6 +15,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import type {Monitor} from 'sentry/views/insights/crons/types';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import {StatusToggleButton} from './statusToggleButton';
 
@@ -28,6 +29,7 @@ export function MonitorHeaderActions({monitor, orgSlug, onUpdate}: Props) {
   const api = useApi();
   const navigate = useNavigate();
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const {selection} = usePageFilters();
 
   const endpointOptions = {
@@ -84,7 +86,7 @@ export function MonitorHeaderActions({monitor, orgSlug, onUpdate}: Props) {
 
   return (
     <Flex direction="row" align="center" gap="md" wrap="wrap">
-      <FeedbackButton />
+      {!hasPageFrame && <FeedbackButton />}
       <Button
         size="sm"
         icon={monitor.isMuted ? <IconSubscribed /> : <IconUnsubscribed />}

--- a/static/app/views/insights/crons/views/overview.tsx
+++ b/static/app/views/insights/crons/views/overview.tsx
@@ -45,6 +45,7 @@ import {useCronsUpsertGuideState} from 'sentry/views/insights/crons/components/u
 import {MODULE_DESCRIPTION, MODULE_DOC_LINK} from 'sentry/views/insights/crons/settings';
 import type {Monitor} from 'sentry/views/insights/crons/types';
 import {makeMonitorListQueryKey} from 'sentry/views/insights/crons/utils';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 const CronsListPageHeader = HookOrDefault({
   hookName: 'component:crons-list-page-header',
@@ -52,6 +53,7 @@ const CronsListPageHeader = HookOrDefault({
 
 function CronsOverview() {
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const navigate = useNavigate();
   const location = useLocation();
   const {guideVisible} = useCronsUpsertGuideState();
@@ -96,7 +98,7 @@ function CronsOverview() {
         </Layout.HeaderContent>
         <Layout.HeaderActions>
           <Grid flow="column" align="center" gap="md">
-            <FeedbackButton />
+            {!hasPageFrame && <FeedbackButton />}
             <Button
               icon={<IconList />}
               size="sm"

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -29,6 +29,7 @@ import {
   isModuleVisible,
 } from 'sentry/views/insights/pages/utils';
 import {ModuleName} from 'sentry/views/insights/types';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export type Props = {
   domainBaseUrl: string;
@@ -59,6 +60,7 @@ export function DomainViewHeader({
   unified,
 }: Props) {
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const location = useLocation();
   const moduleURLBuilder = useModuleURLBuilder();
   const isLaravelInsightsAvailable = useIsLaravelInsightsAvailable();
@@ -135,7 +137,7 @@ export function DomainViewHeader({
         </Layout.HeaderContent>
         <Layout.HeaderActions>
           <Grid flow="column" align="center" gap="md">
-            <FeedbackButton feedbackOptions={feedbackOptions} />
+            {!hasPageFrame && <FeedbackButton feedbackOptions={feedbackOptions} />}
             {additonalHeaderActions}
           </Grid>
         </Layout.HeaderActions>

--- a/static/app/views/insights/uptime/views/overview.tsx
+++ b/static/app/views/insights/uptime/views/overview.tsx
@@ -37,9 +37,11 @@ import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
 import {makeMonitorTypePathname} from 'sentry/views/detectors/pathnames';
 import {OverviewTimeline} from 'sentry/views/insights/uptime/components/overviewTimeline';
 import {MODULE_DESCRIPTION, MODULE_DOC_LINK} from 'sentry/views/insights/uptime/settings';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export default function UptimeOverview() {
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const navigate = useNavigate();
   const location = useLocation();
   const project = decodeList(location.query?.project);
@@ -82,7 +84,7 @@ export default function UptimeOverview() {
         </Layout.HeaderContent>
         <Layout.HeaderActions>
           <Grid flow="column" align="center" gap="md">
-            <FeedbackButton />
+            {!hasPageFrame && <FeedbackButton />}
             <LinkButton
               size="sm"
               priority="primary"

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -52,6 +52,7 @@ import {
   getGroupReprocessingStatus,
   ReprocessingStatus,
 } from 'sentry/views/issueDetails/utils';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 interface GroupHeaderProps {
   event: Event | null;
@@ -94,6 +95,7 @@ export function StreamlinedGroupHeader({event, group, project}: GroupHeaderProps
   const statusProps = getBadgeProperties(group.status, group.substatus);
   const issueTypeConfig = getConfigForIssueType(group, project);
 
+  const hasPageFrame = useHasPageFrameFeature();
   const hasOnlyOneUIOption = defined(organization.streamlineOnly);
   const [showLearnMore, setShowLearnMore] = useLocalStorageState(
     'issue-details-learn-more',
@@ -147,18 +149,20 @@ export function StreamlinedGroupHeader({event, group, project}: GroupHeaderProps
               </LinkButton>
             )}
             {hasFeedbackForm && feedback ? (
-              <FeedbackButton
-                aria-label={t('Give feedback on the issue Sentry detected')}
-                size="xs"
-                feedbackOptions={{
-                  messagePlaceholder: t(
-                    'Please provide feedback on the issue Sentry detected.'
-                  ),
-                  tags: {
-                    ['feedback.source']: feedbackSource,
-                  },
-                }}
-              />
+              !hasPageFrame && (
+                <FeedbackButton
+                  aria-label={t('Give feedback on the issue Sentry detected')}
+                  size="xs"
+                  feedbackOptions={{
+                    messagePlaceholder: t(
+                      'Please provide feedback on the issue Sentry detected.'
+                    ),
+                    tags: {
+                      ['feedback.source']: feedbackSource,
+                    },
+                  }}
+                />
+              )
             ) : (
               <NewIssueExperienceButton />
             )}

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -48,6 +48,7 @@ import {useEventOpenPeriod} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import {AttributeComparisonSection} from './attributeComparisonSection';
 import {OpenPeriodTimelineSection} from './openPeriodTimelineSection';
@@ -360,6 +361,7 @@ function TriggeredConditionDetails({
   groupId: string;
   projectId: string | number;
 }) {
+  const hasPageFrame = useHasPageFrameFeature();
   const {conditions, dataSources, value} = evidenceData;
   const dataSource = dataSources[0];
   const snubaQuery = dataSource?.queryObj?.snubaQuery;
@@ -405,17 +407,21 @@ function TriggeredConditionDetails({
         type="triggered_condition"
         actions={
           <Flex gap="xs">
-            <FeedbackButton
-              aria-label={t('Give feedback on metric issues')}
-              size="xs"
-              feedbackOptions={{
-                messagePlaceholder: t('Tell us what you think about this metric issue.'),
-                tags: {
-                  ['feedback.source']: 'metric_issue_details',
-                  ['feedback.owner']: 'aci',
-                },
-              }}
-            />
+            {!hasPageFrame && (
+              <FeedbackButton
+                aria-label={t('Give feedback on metric issues')}
+                size="xs"
+                feedbackOptions={{
+                  messagePlaceholder: t(
+                    'Tell us what you think about this metric issue.'
+                  ),
+                  tags: {
+                    ['feedback.source']: 'metric_issue_details',
+                    ['feedback.owner']: 'aci',
+                  },
+                }}
+              />
+            )}
             {!isOpenPeriodLoading && (
               <OpenInDestinationButton
                 snubaQuery={snubaQuery}

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -44,6 +44,7 @@ import {
   type GroupSearchView,
 } from 'sentry/views/issueList/types';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 type IssueViewSectionProps = {
   createdBy: GroupSearchViewCreatedBy;
@@ -326,6 +327,7 @@ export default function IssueViewsList() {
   const navigate = useNavigate();
   const location = useLocation();
   const query = typeof location.query.query === 'string' ? location.query.query : '';
+  const hasPageFrame = useHasPageFrameFeature();
   const {mutate: createGroupSearchView, isPending: isCreatingView} =
     useCreateGroupSearchView();
 
@@ -365,17 +367,19 @@ export default function IssueViewsList() {
           </Layout.HeaderContent>
           <Layout.HeaderActions>
             <Grid flow="column" align="center" gap="md">
-              <FeedbackButton
-                size="sm"
-                feedbackOptions={{
-                  formTitle: t('Give Feedback'),
-                  messagePlaceholder: t('How can we make issue views better for you?'),
-                  tags: {
-                    ['feedback.source']: 'custom_views',
-                    ['feedback.owner']: 'issues',
-                  },
-                }}
-              />
+              {!hasPageFrame && (
+                <FeedbackButton
+                  size="sm"
+                  feedbackOptions={{
+                    formTitle: t('Give Feedback'),
+                    messagePlaceholder: t('How can we make issue views better for you?'),
+                    tags: {
+                      ['feedback.source']: 'custom_views',
+                      ['feedback.owner']: 'issues',
+                    },
+                  }}
+                />
+              )}
               <Feature
                 features="organizations:issue-views"
                 hookName="feature-disabled:issue-views"

--- a/static/app/views/issueList/pages/supergroups.tsx
+++ b/static/app/views/issueList/pages/supergroups.tsx
@@ -19,6 +19,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SupergroupDetailDrawer} from 'sentry/views/issueList/supergroups/supergroupDrawer';
 import type {SupergroupDetail} from 'sentry/views/issueList/supergroups/types';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 interface ListSupergroupsResponse {
   data: SupergroupDetail[];
@@ -86,6 +87,7 @@ function SupergroupCard({
 
 function Supergroups() {
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const hasTopIssuesUI = organization.features.includes('top-issues-ui');
   const {openDrawer} = useDrawer();
 
@@ -129,16 +131,18 @@ function Supergroups() {
           </Flex>
         </Layout.HeaderContent>
         <Layout.HeaderActions>
-          <FeedbackButton
-            size="sm"
-            feedbackOptions={{
-              messagePlaceholder: t('What do you think about Supergroups?'),
-              tags: {
-                ['feedback.source']: 'supergroups',
-                ['feedback.owner']: 'issues',
-              },
-            }}
-          />
+          {!hasPageFrame && (
+            <FeedbackButton
+              size="sm"
+              feedbackOptions={{
+                messagePlaceholder: t('What do you think about Supergroups?'),
+                tags: {
+                  ['feedback.source']: 'supergroups',
+                  ['feedback.owner']: 'issues',
+                },
+              }}
+            />
+          )}
         </Layout.HeaderActions>
       </Layout.Header>
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'sentry/views/explore/logs/types';
 import {useModuleURLBuilder} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import type {TraceMetaQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {Highlights} from 'sentry/views/performance/newTraceDetails/traceHeader/highlights';
@@ -42,6 +43,7 @@ export interface TraceMetadataHeaderProps {
 export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
   const location = useLocation();
   const {view} = useDomainViewFilters();
+  const hasPageFrame = useHasPageFrameFeature();
   const moduleURLBuilder = useModuleURLBuilder(true);
   const {projects} = useProjects();
   const {hasLogs, hasMetrics} = useTraceContextSections({
@@ -89,16 +91,18 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
             })}
           />
           <Grid flow="column" align="center" gap="md">
-            <FeedbackButton
-              size="xs"
-              feedbackOptions={{
-                messagePlaceholder: t('How can we make the trace view better for you?'),
-                tags: {
-                  ['feedback.source']: 'trace-view',
-                  ['feedback.owner']: 'performance',
-                },
-              }}
-            />
+            {!hasPageFrame && (
+              <FeedbackButton
+                size="xs"
+                feedbackOptions={{
+                  messagePlaceholder: t('How can we make the trace view better for you?'),
+                  tags: {
+                    ['feedback.source']: 'trace-view',
+                    ['feedback.owner']: 'performance',
+                  },
+                }}
+              />
+            )}
           </Grid>
         </TraceHeaderComponents.HeaderRow>
         <TraceHeaderComponents.HeaderRow>

--- a/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
@@ -8,6 +8,7 @@ import type {Project} from 'sentry/types/project';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useModuleURLBuilder} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import {getTraceViewBreadcrumbs} from './breadcrumbs';
 import {TraceHeaderComponents} from './styles';
@@ -24,6 +25,7 @@ export function PlaceHolder({
   const {view} = useDomainViewFilters();
   const moduleURLBuilder = useModuleURLBuilder(true);
   const location = useLocation();
+  const hasPageFrame = useHasPageFrameFeature();
 
   return (
     <TraceHeaderComponents.HeaderLayout>
@@ -40,16 +42,18 @@ export function PlaceHolder({
             })}
           />
           <Grid flow="column" align="center" gap="md">
-            <FeedbackButton
-              size="xs"
-              feedbackOptions={{
-                messagePlaceholder: t('How can we make the trace view better for you?'),
-                tags: {
-                  ['feedback.source']: 'trace-view',
-                  ['feedback.owner']: 'performance',
-                },
-              }}
-            />
+            {!hasPageFrame && (
+              <FeedbackButton
+                size="xs"
+                feedbackOptions={{
+                  messagePlaceholder: t('How can we make the trace view better for you?'),
+                  tags: {
+                    ['feedback.source']: 'trace-view',
+                    ['feedback.owner']: 'performance',
+                  },
+                }}
+              />
+            )}
           </Grid>
         </TraceHeaderComponents.HeaderRow>
         <TraceHeaderComponents.HeaderRow>

--- a/static/app/views/performance/newTraceDetails/traceSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSummary.tsx
@@ -17,6 +17,7 @@ import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
 interface SpanInsight {
@@ -78,6 +79,7 @@ export function TraceSummarySection({traceSlug}: {traceSlug: string}) {
   const {feedback} = useFeedbackSDKIntegration();
   const organization = useOrganization();
   const location = useLocation();
+  const hasPageFrame = useHasPageFrameFeature();
 
   if (traceContent.isPending) {
     return <LoadingIndicator />;
@@ -87,16 +89,18 @@ export function TraceSummarySection({traceSlug}: {traceSlug: string}) {
     return (
       <Flex align="center" padding="xl" gap="md">
         <div>{t('Error loading Trace Summary')}</div>
-        <FeedbackButton
-          size="xs"
-          feedbackOptions={{
-            messagePlaceholder: t('How can we make the trace summary better for you?'),
-            tags: {
-              ['feedback.source']: 'trace-summary',
-              ['feedback.owner']: 'ml-ai',
-            },
-          }}
-        />
+        {!hasPageFrame && (
+          <FeedbackButton
+            size="xs"
+            feedbackOptions={{
+              messagePlaceholder: t('How can we make the trace summary better for you?'),
+              tags: {
+                ['feedback.source']: 'trace-summary',
+                ['feedback.owner']: 'ml-ai',
+              },
+            }}
+          />
+        )}
       </Flex>
     );
   }
@@ -159,7 +163,7 @@ export function TraceSummarySection({traceSlug}: {traceSlug: string}) {
         <SectionContent text="" />
       )}
 
-      {feedback && (
+      {feedback && !hasPageFrame && (
         <Flex justify="end" marginTop="xl">
           <FeedbackButton
             size="xs"

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -32,6 +32,7 @@ import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/se
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {Breadcrumb, getTabCrumbs} from 'sentry/views/performance/breadcrumb';
 import {useTransactionSummaryEAP} from 'sentry/views/performance/eap/useTransactionSummaryEAP';
 import {TAB_ANALYTICS} from 'sentry/views/performance/transactionSummary/pageLayout';
@@ -72,6 +73,7 @@ export function TransactionHeader({
 }: Props) {
   const {isInDomainView, view} = useDomainViewFilters();
   const navigate = useNavigate();
+  const hasPageFrame = useHasPageFrameFeature();
 
   const getNewRoute = useCallback(
     (newTab: Tab) => {
@@ -314,7 +316,7 @@ export function TransactionHeader({
               onChangeThreshold={onChangeThreshold}
             />
           </GuideAnchor>
-          <FeedbackButton />
+          {!hasPageFrame && <FeedbackButton />}
         </Grid>
       </Layout.HeaderActions>
       <TabList

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -21,6 +21,7 @@ import {
 import {t} from 'sentry/locale';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {AppIcon} from 'sentry/views/preprod/components/appIcon';
 import {
   isSizeInfoCompleted,
@@ -47,6 +48,7 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
     props;
   const organization = useOrganization();
   const isSentryEmployee = useIsSentryEmployee();
+  const hasPageFrame = useHasPageFrameFeature();
   const labels = getLabels(buildDetails.app_info?.platform ?? undefined);
   const breadcrumbs: Crumb[] = [
     {
@@ -141,13 +143,15 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
         </Flex>
       </Stack>
       <Flex align="center" gap="sm">
-        <FeedbackButton
-          feedbackOptions={{
-            tags: {
-              'feedback.source': 'preprod.buildDetails',
-            },
-          }}
-        />
+        {!hasPageFrame && (
+          <FeedbackButton
+            feedbackOptions={{
+              tags: {
+                'feedback.source': 'preprod.buildDetails',
+              },
+            }}
+          />
+        )}
         {isSentryEmployee &&
           headArtifactId &&
           baseArtifactId &&

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -31,6 +31,7 @@ import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
   isSizeInfoCompleted,
@@ -52,6 +53,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
   const organization = useOrganization();
   const navigate = useNavigate();
   const isSentryEmployee = useIsSentryEmployee();
+  const hasPageFrame = useHasPageFrameFeature();
   const {buildDetailsQuery, projectSlug, artifactId, projectType} = props;
   const {
     isDeletingArtifact,
@@ -175,13 +177,15 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
       <Layout.HeaderActions>
         <Flex align="center" gap="sm" flexShrink={0}>
-          <FeedbackButton
-            feedbackOptions={{
-              tags: {
-                'feedback.source': 'preprod.buildDetails',
-              },
-            }}
-          />
+          {!hasPageFrame && (
+            <FeedbackButton
+              feedbackOptions={{
+                tags: {
+                  'feedback.source': 'preprod.buildDetails',
+                },
+              }}
+            />
+          )}
           <Button
             size="sm"
             priority="default"

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -40,6 +40,7 @@ import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {LandingAggregateFlamegraph} from 'sentry/views/profiling/landingAggregateFlamegraph';
 import {Onboarding} from 'sentry/views/profiling/onboarding';
 
@@ -375,6 +376,7 @@ function shouldShowProfilingOnboardingPanel(selection: PageFilters, projects: Pr
 }
 
 function ProfilingContentPageHeader() {
+  const hasPageFrame = useHasPageFrameFeature();
   return (
     <StyledLayoutHeader unified>
       <StyledHeaderContent unified>
@@ -387,7 +389,7 @@ function ProfilingContentPageHeader() {
             )}
           />
         </Layout.Title>
-        <FeedbackButton />
+        {!hasPageFrame && <FeedbackButton />}
       </StyledHeaderContent>
     </StyledLayoutHeader>
   );

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -61,6 +61,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {
   FlamegraphProvider,
@@ -108,6 +109,7 @@ interface ProfileSummaryHeaderProps {
 function ProfileSummaryHeader(props: ProfileSummaryHeaderProps) {
   const location = useLocation();
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
 
   const breadcrumbTrails: ProfilingBreadcrumbsProps['trails'] = useMemo(() => {
     return [
@@ -158,7 +160,7 @@ function ProfileSummaryHeader(props: ProfileSummaryHeaderProps) {
       </ProfilingHeaderContent>
       {transactionSummaryTarget && (
         <StyledHeaderActions>
-          <FeedbackButton />
+          {!hasPageFrame && <FeedbackButton />}
           <LinkButton to={transactionSummaryTarget} size="sm">
             {t('View Summary')}
           </LinkButton>

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -35,6 +35,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 import {ERRORS_BASIC_CHART_PERIODS} from './charts/projectErrorsBasicChart';
@@ -49,6 +50,7 @@ import {ProjectTeamAccess} from './projectTeamAccess';
 
 export function ProjectDetail() {
   const api = useApi();
+  const hasPageFrame = useHasPageFrameFeature();
   const params = useParams<{orgId: string; projectId: string}>();
   const location = useLocation();
   const navigate = useNavigate();
@@ -205,7 +207,7 @@ export function ProjectDetail() {
 
               <Layout.HeaderActions>
                 <Grid flow="column" align="center" gap="md">
-                  <FeedbackButton />
+                  {!hasPageFrame && <FeedbackButton />}
                   <LinkButton
                     size="sm"
                     to={

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -41,6 +41,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {ReleaseArchivedNotice} from 'sentry/views/releases/detail/overview/releaseArchivedNotice';
 import {MobileBuilds} from 'sentry/views/releases/list/mobileBuilds';
 import {ReleaseHealthCTA} from 'sentry/views/releases/list/releaseHealthCTA';
@@ -109,6 +110,7 @@ function makeReleaseListQueryKey({
 export default function ReleasesList() {
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const {projects} = useProjects();
   const {selection} = usePageFilters();
   const location = useLocation();
@@ -425,16 +427,18 @@ export default function ReleasesList() {
                   </Layout.Title>
                 </Layout.HeaderContent>
                 <Layout.HeaderActions>
-                  <FeedbackButton
-                    feedbackOptions={{
-                      messagePlaceholder: t(
-                        'How can we improve the Releases experience?'
-                      ),
-                      tags: {
-                        ['feedback.source']: 'releases-list-header',
-                      },
-                    }}
-                  />
+                  {!hasPageFrame && (
+                    <FeedbackButton
+                      feedbackOptions={{
+                        messagePlaceholder: t(
+                          'How can we improve the Releases experience?'
+                        ),
+                        tags: {
+                          ['feedback.source']: 'releases-list-header',
+                        },
+                      }}
+                    />
+                  )}
                 </Layout.HeaderActions>
               </Flex>
 

--- a/static/app/views/replays/detail/ai/ai.tsx
+++ b/static/app/views/replays/detail/ai/ai.tsx
@@ -18,6 +18,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {ChapterList} from 'sentry/views/replays/detail/ai/chapterList';
 import {useReplaySummaryContext} from 'sentry/views/replays/detail/ai/replaySummaryContext';
 import {ReplaySummaryLoading} from 'sentry/views/replays/detail/ai/replaySummaryLoading';
@@ -262,7 +263,8 @@ function ThumbsUpDownButton({
   type: 'positive' | 'negative';
   disabled?: boolean;
 }) {
-  return (
+  const hasPageFrame = useHasPageFrameFeature();
+  return hasPageFrame ? null : (
     <FeedbackButton
       aria-label={t('Give feedback on the replay summary section')}
       icon={<IconThumb direction={type === 'positive' ? 'up' : 'down'} />}

--- a/static/app/views/replays/detail/header/replayDetailsHeaderActions.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsHeaderActions.tsx
@@ -6,6 +6,7 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {ConfigureReplayCard} from 'sentry/components/replays/header/configureReplayCard';
 import {ReplayLoadingState} from 'sentry/components/replays/player/replayLoadingState';
 import type {useLoadReplayReader} from 'sentry/utils/replays/hooks/useLoadReplayReader';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {ReplayItemDropdown} from 'sentry/views/replays/detail/header/replayItemDropdown';
 
 interface Props {
@@ -13,6 +14,7 @@ interface Props {
 }
 
 export function ReplayDetailsHeaderActions({readerResult}: Props) {
+  const hasPageFrame = useHasPageFrameFeature();
   return (
     <ReplayLoadingState
       readerResult={readerResult}
@@ -23,7 +25,7 @@ export function ReplayDetailsHeaderActions({readerResult}: Props) {
       renderMissing={() => null}
       renderProcessingError={({replayRecord, projectSlug}) => (
         <ButtonActionsWrapper>
-          <FeedbackButton size="xs" />
+          {!hasPageFrame && <FeedbackButton size="xs" />}
           <ConfigureReplayCard isMobile={false} replayRecord={replayRecord} />
           <ReplayItemDropdown
             projectSlug={projectSlug}
@@ -35,7 +37,7 @@ export function ReplayDetailsHeaderActions({readerResult}: Props) {
     >
       {({replay}) => (
         <ButtonActionsWrapper>
-          <FeedbackButton size="xs" />
+          {!hasPageFrame && <FeedbackButton size="xs" />}
           <ConfigureReplayCard
             isMobile={replay.isVideoReplay()}
             replayRecord={replay.getReplay()}

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -7,6 +7,7 @@ import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {PreprodQuotaAlert} from 'sentry/views/preprod/components/preprodQuotaAlert';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
@@ -27,6 +28,7 @@ const DISTRIBUTION_ENABLED_QUERY_READ_KEY = 'sentry:preprod_distribution_enabled
 const DISTRIBUTION_ENABLED_QUERY_WRITE_KEY = 'preprodDistributionEnabledQuery';
 
 export default function PreprodSettings() {
+  const hasPageFrame = useHasPageFrameFeature();
   return (
     <Fragment>
       <Feature features="organizations:preprod-frontend-routes" renderDisabled>
@@ -35,7 +37,7 @@ export default function PreprodSettings() {
           title={t('Mobile Builds')}
           action={
             <Grid flow="column" align="center" gap="lg">
-              <FeedbackButton />
+              {!hasPageFrame && <FeedbackButton />}
             </Grid>
           }
         />

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -16,6 +16,7 @@ import {useDismissAlert} from 'sentry/utils/useDismissAlert';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -33,6 +34,7 @@ const PS5_WARNING_DISMISS_KEY = 'tempest-ps5-warning-dismissed';
 
 export default function TempestSettings() {
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const {project} = useProjectSettingsOutlet();
   const location = useLocation();
   const navigate = useNavigate();
@@ -110,7 +112,7 @@ export default function TempestSettings() {
         title={getPageTitle()}
         action={
           <Grid flow="column" align="center" gap="lg">
-            <FeedbackButton />
+            {!hasPageFrame && <FeedbackButton />}
             <RequestSdkAccessButton
               gamingPlatform="playstation"
               organization={organization}


### PR DESCRIPTION
Hide per-page `FeedbackButton` instances when the `page-frame` feature flag is enabled.

The TopBar (`views/navigation/topBar.tsx`) now renders a global `FeedbackButton` for all pages under the page-frame feature. Having individual feedback buttons on every page header alongside the TopBar one results in duplicates.

This adds a `useHasPageFrameFeature()` check to all 39 page-level usages so they return/render nothing when the flag is on. Usages inside modals and overlays (command palette, replay comparison modal, search filter dropdown) are intentionally left unchanged since the TopBar is not visible in those contexts.

Wrapper components (`AutofixFeedback`, `AutomationFeedbackButton`, `MonitorFeedbackButton`, `DynamicAlertsFeedbackButton`) use an early `return null`. Direct page-level usages gate the JSX with `{!hasPageFrame && <FeedbackButton />}`.