### PR TITLE
feat(dashboards): track seer session errors on generating dashboards

### DIFF
--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -255,8 +255,13 @@ export default function CreateFromSeer() {
   useEffect(() => {
     if (sessionStatus === 'error' || isError) {
       addErrorMessage(t('Failed to generate dashboard'));
+      Sentry.metrics.count('dashboards.seer.generation.session.error', 1, {
+        attributes: {
+          organization_slug: organization.slug,
+        },
+      });
     }
-  }, [sessionStatus, isError]);
+  }, [sessionStatus, isError, organization.slug]);
 
   const sendMessage = useCallback(
     async (message: string) => {


### PR DESCRIPTION
Tracks when a seer session returns a failed status on generating dashboards, indicating upstream failure (not the same as invalid dashboard). 