### PR TITLE
fix(test): Fix flaky useReplaysFromIssue assertion test

### DIFF
--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
@@ -41,13 +41,6 @@ describe('useReplaysFromIssue', () => {
       initialRouterConfig,
     });
 
-    expect(result.current).toEqual({
-      eventView: null,
-      fetchError: undefined,
-      isFetching: true,
-      pageLinks: null,
-    });
-
     await waitFor(() =>
       expect(result.current).toEqual({
         eventView: expect.objectContaining({
@@ -80,13 +73,6 @@ describe('useReplaysFromIssue', () => {
       initialRouterConfig,
     });
 
-    expect(result.current).toEqual({
-      eventView: null,
-      fetchError: undefined,
-      isFetching: true,
-      pageLinks: null,
-    });
-
     await waitFor(() =>
       expect(result.current).toEqual({
         eventView: expect.objectContaining({
@@ -115,13 +101,6 @@ describe('useReplaysFromIssue', () => {
         organization,
       },
       initialRouterConfig,
-    });
-
-    expect(result.current).toEqual({
-      eventView: null,
-      fetchError: undefined,
-      isFetching: true,
-      pageLinks: null,
     });
 
     await waitFor(() =>


### PR DESCRIPTION
## Summary
- Remove synchronous initial-state assertions (`isFetching: true`) from `useReplaysFromIssue` hook tests
- These assertions are flaky because `renderHookWithProviders` uses `act()` internally, which flushes effects. Since `MockApiClient` resolves synchronously, the hook's `useEffect` → `fetchReplayIds()` → `setReplayIds()` chain can complete within the same `act()` boundary, leaving the hook already resolved by the time the synchronous assertion runs
- The `waitFor` assertions that check the final resolved state remain and are sufficient to verify correct behavior

## Test plan
- [x] All 3 tests in `useReplaysFromIssue.spec.tsx` pass locally
- [x] Pre-commit hooks pass

Made with [Cursor](https://cursor.com)