### PR TITLE
fix(test): Fix flaky StackTrace URL link tooltip test

### DIFF
--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -903,10 +903,10 @@ describe('Core StackTrace', () => {
 
     await userEvent.hover(screen.getByText('app.js'), {delay: null});
     act(() => jest.advanceTimersByTime(2000));
+    jest.useRealTimers();
 
     expect(
       await screen.findByRole('link', {name: 'https://example.com/static/app.js'})
     ).toBeInTheDocument();
-    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

Fixes a flaky test in `stackTrace.spec.tsx` — the test `shows URL link in tooltip when absPath is an http URL` was failing intermittently (5 occurrences in 30 days).

**Root cause:** The test uses `jest.useFakeTimers()` to advance past the tooltip's 1000ms open delay. After `act(() => jest.advanceTimersByTime(2000))`, the tooltip content (including an `<a>` link) should be in the DOM. However, `findByRole('link', ...)` internally uses `waitFor` which polls via `setTimeout` — and with fake timers still active, these polling timeouts don't fire reliably, causing the query to intermittently time out.

**Fix:** Move `jest.useRealTimers()` *before* the `findByRole` assertion instead of after it. This ensures:
1. Fake timers advance past the tooltip delay, opening the tooltip
2. Real timers are restored so `findByRole`'s internal polling mechanism works correctly
3. The tooltip remains visible since no `pointerleave` event has been triggered

This matches the pattern used by similar passing tests in the same file that use `findByText` (which succeeds on its first synchronous check, avoiding the polling issue).

## Test plan

- [x] Verified all 29 tests in `stackTrace.spec.tsx` pass
- [x] Pre-commit hooks pass on changed file

Made with [Cursor](https://cursor.com)