### PR TITLE
fix(test): Fix flaky EventReplay inline onboarding test

### DIFF
--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -30,6 +30,13 @@ jest.mock(
       return <div data-test-id="replay-clip" />;
     }
 );
+// Mock the onboarding panel to avoid flaky lazy-load + async usePrompt chain
+jest.mock('sentry/components/events/eventReplay/replayInlineOnboardingPanel', () => ({
+  __esModule: true,
+  default: function MockReplayOnboardingPanel() {
+    return <div data-test-id="replay-inline-onboarding" />;
+  },
+}));
 
 const mockEventTimestamp = new Date('2022-09-22T16:59:41Z');
 const mockReplayId = '761104e184c64d439ee1014b72b4d83b';
@@ -136,15 +143,9 @@ describe('EventReplay', () => {
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({
       activateSidebar: jest.fn(),
     });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/prompts-activity/',
-      body: {data: {dismissed_ts: null}},
-    });
     render(<EventReplay {...defaultProps} />, {organization});
 
-    expect(
-      await screen.findByText('Watch the errors and latency issues your users face')
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId('replay-inline-onboarding')).toBeInTheDocument();
   });
 
   it('should render a replay when there is a replayId from tags', async () => {


### PR DESCRIPTION
## Summary

Fixes a flaky test in `static/app/components/events/eventReplay/index.spec.tsx`:
- **Test**: "should render the replay inline onboarding component when replays are enabled and the project supports replay"
- **Occurrences**: 6 in the last 30 days

### Root Cause

The `ReplayInlineOnboardingPanel` component is loaded via `React.lazy()`, creating an async code-splitting boundary. Inside that lazy-loaded component, `usePrompt` calls `useApiQuery` (React Query), adding another async data-fetching boundary. The combination of these two async layers occasionally exceeded the `findByText` default timeout in CI, causing the test to flake.

### Fix

Mock the `replayInlineOnboardingPanel` module (same pattern already used for `replayClipPreview`) and assert on a `data-test-id` instead of the rendered text. This eliminates both async boundaries — the lazy import and the prompt API call — making the test deterministic.

The test's purpose is to verify that `EventReplay` correctly decides to render the onboarding component when conditions are met, not to test the onboarding panel's internal rendering. Mocking the panel isolates the unit under test.

## Test plan

- [x] All 4 tests in the file pass locally
- [x] Pre-commit passes

Made with [Cursor](https://cursor.com)