### PR TITLE
fix(test): Fix flaky SpansSearchBar onSearch test

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -134,10 +134,7 @@ describe('SpansSearchBar', () => {
     const searchInput = await screen.findByRole('combobox', {
       name: 'Add a search term',
     });
-    await userEvent.type(searchInput, 'span.op:');
-    await userEvent.keyboard('{enter}');
-    await userEvent.keyboard('function');
-    await userEvent.keyboard('{enter}');
+    await userEvent.type(searchInput, 'span.op:{enter}function{enter}');
 
     await waitFor(() => {
       expect(onSearch).toHaveBeenCalledWith(


### PR DESCRIPTION
Fix flaky `SpansSearchBar > calls onSearch with the correct query` test that intermittently exceeded the 5000ms Jest timeout.

The test split its search interaction into four separate `userEvent` calls (`type`, `keyboard`, `keyboard`, `keyboard`). Each convenience API call creates a new user-event session, which loses focus context between the filter key entry and value entry steps. On slower CI, this caused the component's internal state transitions to race with the next interaction, leading to timeouts.

Consolidate into a single `userEvent.type(searchInput, 'span.op:{enter}function{enter}')` call, matching the pattern used in the SearchQueryBuilder's own test suite. This keeps the entire interaction in one session with consistent focus management.

Made with [Cursor](https://cursor.com)