### PR TITLE
fix(test): Fix flaky MetricsTabContent sidebar toggle test

### DIFF
--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -731,5 +731,8 @@ describe('MetricsTabContent (tracemetrics-ui-refresh)', () => {
     await waitFor(() => {
       expect(screen.getAllByTestId('metric-toolbar')).toHaveLength(1);
     });
+    expect(
+      await within(screen.getAllByTestId('metric-toolbar')[0]!).findByRole('combobox')
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Fixes a flaky test: `MetricsTabContent (tracemetrics-ui-refresh) › toggles the query builder sidebar with the expand control`

**Root cause**: When the sidebar is expanded, the `SearchQueryBuilderCombobox` inside the `MetricToolbar` mounts and begins async initialization (attribute key fetching via React Query). The test only waited for the toolbar's `data-test-id` to appear but not for the `SearchQueryBuilderCombobox` to finish mounting. When the test ended, pending async state updates completed outside of `act()`, triggering a `console.error` that `jest-fail-on-console` caught.

**Fix**: After expanding the sidebar and confirming the toolbar is present, add a `findByRole('combobox')` assertion to wait for the `SearchQueryBuilderCombobox` to fully initialize. This ensures all async state updates from the component's mount cycle are flushed within the test's `act()` boundary before cleanup runs.

## Test plan
- [x] Test passes consistently (verified 5 consecutive runs)
- [x] All other tests in the file continue to pass
- [x] Pre-commit hooks pass


Made with [Cursor](https://cursor.com)