### PR TITLE
fix(test): Fix flaky EventGroupingInfo rendering test

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfoSection.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfoSection.spec.tsx
@@ -1,7 +1,7 @@
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {EventGroupVariantType} from 'sentry/types/event';
 import {IssueCategory} from 'sentry/types/group';
@@ -50,6 +50,8 @@ describe('EventGroupingInfo', () => {
     await userEvent.click(
       screen.getByRole('button', {name: 'View Event Grouping Information Section'})
     );
+    // Lazy-loaded component must resolve before the API query fires
+    await waitFor(() => expect(groupingInfoRequest).toHaveBeenCalled());
     expect(await screen.findByText('variant description')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Fix flaky test `EventGroupingInfo > fetches and renders grouping info for errors` (2 occurrences in last 30 days)
- The test clicks to expand a collapsed `FoldSection`, which triggers a chain of async operations: `React.lazy` module resolution, API fetch via `useApiQuery`, and React re-render. The `findByText` call must wait for all three to complete, which occasionally exceeded the polling window under CI load.
- Added `await waitFor(() => expect(groupingInfoRequest).toHaveBeenCalled())` after the expand click to explicitly wait for the lazy-loaded component to resolve and fire the API query before asserting on rendered text.

## Test plan
- [x] `CI=true pnpm test static/app/components/events/groupingInfo/groupingInfoSection.spec.tsx` passes (all 4 tests)


Made with [Cursor](https://cursor.com)