### PR TITLE
fix(test): Fix flaky SpanEvidencePreview error state test

### DIFF
--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
@@ -18,7 +18,6 @@ describe('SpanEvidencePreview', () => {
   it('does not fetch before hover', async () => {
     const mock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/group-id/events/recommended/`,
-      body: {},
     });
 
     render(<SpanEvidencePreview groupId="group-id">Hover me</SpanEvidencePreview>);
@@ -31,7 +30,6 @@ describe('SpanEvidencePreview', () => {
   it('shows error when request fails', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/group-id/events/recommended/`,
-      body: {},
       statusCode: 500,
     });
 
@@ -39,7 +37,7 @@ describe('SpanEvidencePreview', () => {
 
     await userEvent.hover(screen.getByText('Hover me'), {delay: null});
 
-    await screen.findByText('Failed to load preview');
+    expect(await screen.findByText('Failed to load preview')).toBeInTheDocument();
   });
 
   it('renders the span evidence correctly when request succeeds', async () => {


### PR DESCRIPTION
## Summary
- Fix flaky test `SpanEvidencePreview > shows error when request fails` by removing unnecessary `body: {}` from the error mock response and aligning the test pattern with the non-flaky `evidencePreview.spec.tsx` test
- The unnecessary `body: {}` on the 500 error mock could interfere with how the mock client processes the error response, since error responses should not include a response body
- Also added explicit `toBeInTheDocument()` assertion for consistency with other preview test files

## Test plan
- [x] `CI=true pnpm test static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx` passes (all 3 tests)
- [x] Pre-commit hooks pass on the changed file

Made with [Cursor](https://cursor.com)