### PR TITLE
fix(test): Fix flaky React Native metrics onboarding test

### DIFF
--- a/static/app/gettingStartedDocs/react-native/metrics.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/metrics.spec.tsx
@@ -57,5 +57,5 @@ describe('getting started with react-native', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
     expect(await screen.findByText(/Sentry\.metrics\.count/)).toBeInTheDocument();
     expect(screen.getByText(/Sentry\.metrics\.gauge/)).toBeInTheDocument();
-  });
+  }, 10_000);
 });


### PR DESCRIPTION
## Summary
- Increase the Jest test timeout from the default 5s to 10s for the React Native metrics onboarding spec
- The test renders `MetricsTabOnboarding` which triggers a dynamic `import()` of the docs module, two API calls (`/keys/` and `/sdks/`), and multiple `userEvent.click` interactions with `findBy` queries
- On slow CI machines these async operations can collectively exceed the default 5000ms Jest timeout, causing intermittent failures (2 occurrences in last 30 days)

## Test plan
- [x] Pre-commit hooks pass (ESLint, format, stylelint, etc.)
- [ ] CI passes on the changed test file

Made with [Cursor](https://cursor.com)