### PR TITLE
fix(test): Fix flaky MetricsTabContent sidebar toggle test

### DIFF
--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -731,5 +731,14 @@ describe('MetricsTabContent (tracemetrics-ui-refresh)', () => {
     await waitFor(() => {
       expect(screen.getAllByTestId('metric-toolbar')).toHaveLength(1);
     });
+
+    // Wait for the SearchQueryBuilderCombobox inside the re-expanded sidebar to
+    // finish initialising, otherwise its async state updates fire after the test
+    // ends and trigger an act() warning that jest-fail-on-console catches.
+    await waitFor(() => {
+      expect(
+        within(screen.getAllByTestId('metric-toolbar')[0]!).getByRole('combobox')
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Wait for the SearchQueryBuilderCombobox inside the re-expanded sidebar to finish initialising. Without this, its async state updates fire after the test ends and trigger an act() warning that jest-fail-on-console catches, causing flaky failures.

The test `toggles the query builder sidebar with the expand control` collapses and re-expands the sidebar, but only waited for the toolbar `testId` to reappear. The `SearchQueryBuilderCombobox` inside the toolbar was still running async initialisation, so its state updates leaked past the test boundary. Adding a `waitFor` on the combobox role inside the toolbar ensures all updates have settled before the test completes.

This test failed 4 times on master in the last 30 days.

Made with [Cursor](https://cursor.com)