### PR TITLE
fix(test): Fix flaky SpanEvidencePreview error state test

### DIFF
--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
@@ -31,7 +31,6 @@ describe('SpanEvidencePreview', () => {
   it('shows error when request fails', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/group-id/events/recommended/`,
-      body: {},
       statusCode: 500,
     });
 
@@ -39,7 +38,7 @@ describe('SpanEvidencePreview', () => {
 
     await userEvent.hover(screen.getByText('Hover me'), {delay: null});
 
-    await screen.findByText('Failed to load preview');
+    expect(await screen.findByText('Failed to load preview')).toBeInTheDocument();
   });
 
   it('renders the span evidence correctly when request succeeds', async () => {


### PR DESCRIPTION
Remove unnecessary `body: {}` from the error mock response in the `SpanEvidencePreview` test for the "shows error when request fails" case.

The empty body object gets assigned as `responseJSON` on the error response object, which in edge timing cases under CI load may briefly cause the query to resolve with data before the error propagates — the component checks `if (data)` before `if (isError)`, so a truthy `{}` body can short-circuit the error rendering path.

This aligns the test with the identical pattern used in `evidencePreview.spec.tsx` and `stackTracePreview.spec.tsx`, which omit `body` from error mocks and don't exhibit this flake.

This test failed 2 times on master in the last 30 days.

Made with [Cursor](https://cursor.com)