### PR TITLE
fix(test): Fix flaky ResultsSearchQueryBuilder spec

### DIFF
--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -49,14 +49,11 @@ describe('ResultsSearchQueryBuilder', () => {
       }
     );
 
-    // Focus the input and type "has:p" to simulate a search for p50
     const input = await screen.findByRole('combobox');
-    await userEvent.type(input, 'has:p');
+    await userEvent.type(input, 'has:p', {delay: null});
 
-    // Check that "p50" (a function tag) is NOT in the dropdown
-    expect(
-      within(screen.getByRole('listbox')).queryByText('p50')
-    ).not.toBeInTheDocument();
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).queryByText('p50')).not.toBeInTheDocument();
   });
 
   it('shows normal tags, e.g. transaction, in the dropdown', async () => {
@@ -81,9 +78,8 @@ describe('ResultsSearchQueryBuilder', () => {
       }
     );
 
-    // Check that a normal tag (e.g. "transaction") IS in the dropdown
     const input = await screen.findByRole('combobox');
-    await userEvent.type(input, 'transact');
+    await userEvent.type(input, 'transact', {delay: null});
 
     expect(
       await within(screen.getByRole('listbox')).findByRole('option', {


### PR DESCRIPTION
Add {delay: null} to userEvent.type calls to prevent test timeouts.

Without this option, userEvent types each character with a simulated delay between keystrokes, which can push the total test duration past the 5000ms timeout under CI load. Also use findByRole for the listbox to properly await its async appearance before making assertions.

Two tests in this file were flaking on master (5 occurrences in the last 30 days):
1. 'does not show function tags in has: dropdown' - timeout
2. 'shows normal tags, e.g. transaction, in the dropdown' - act() warning from pending async updates

Made with [Cursor](https://cursor.com)