### PR TITLE
fix(test): Fix flaky ResultsSearchQueryBuilder spec

### DIFF
--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -1,6 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {SavedSearchType} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
@@ -11,6 +17,8 @@ import {ResultsSearchQueryBuilder} from './resultsSearchQueryBuilder';
 describe('ResultsSearchQueryBuilder', () => {
   let organization: Organization;
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
     organization = OrganizationFixture();
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/recent-searches/`,
@@ -41,7 +49,6 @@ describe('ResultsSearchQueryBuilder', () => {
           user: {key: 'user', name: 'user', kind: FieldKind.FIELD},
         }}
         recentSearches={SavedSearchType.EVENT}
-        // This fields definition is what caused p50 to appear as a function tag
         fields={[{field: 'p50(transaction.duration)'}]}
       />,
       {
@@ -49,14 +56,17 @@ describe('ResultsSearchQueryBuilder', () => {
       }
     );
 
-    // Focus the input and type "has:p" to simulate a search for p50
     const input = await screen.findByRole('combobox');
-    await userEvent.type(input, 'has:p');
+    await userEvent.click(input);
+    await screen.findByRole('listbox');
+    await userEvent.keyboard('has:p');
 
-    // Check that "p50" (a function tag) is NOT in the dropdown
-    expect(
-      within(screen.getByRole('listbox')).queryByText('p50')
-    ).not.toBeInTheDocument();
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).queryByText('p50')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
   });
 
   it('shows normal tags, e.g. transaction, in the dropdown', async () => {
@@ -73,7 +83,6 @@ describe('ResultsSearchQueryBuilder', () => {
           user: {key: 'user', name: 'user', kind: FieldKind.FIELD},
         }}
         recentSearches={SavedSearchType.EVENT}
-        // This fields definition is what caused p50 to appear as a function tag
         fields={[{field: 'p50(transaction.duration)'}]}
       />,
       {
@@ -81,14 +90,19 @@ describe('ResultsSearchQueryBuilder', () => {
       }
     );
 
-    // Check that a normal tag (e.g. "transaction") IS in the dropdown
     const input = await screen.findByRole('combobox');
-    await userEvent.type(input, 'transact');
+    await userEvent.click(input);
+    await screen.findByRole('listbox');
+    await userEvent.keyboard('transact');
 
     expect(
       await within(screen.getByRole('listbox')).findByRole('option', {
         name: 'transaction',
       })
     ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fix two flaky tests in `resultsSearchQueryBuilder.spec.tsx` that failed 5 times on master in the last 30 days.

1. **"does not show function tags in has: dropdown"** timed out at 5000ms because `userEvent.type` started typing before async API responses (feature flags via `useFetchOrganizationFeatureFlags`, recent searches) had settled. Re-renders triggered by those responses mid-typing slowed each keystroke. Fixed by splitting into `userEvent.click` → `findByRole('listbox')` → `userEvent.keyboard` so initial renders complete before typing begins.

2. **"shows normal tags in the dropdown"** failed with act() warnings from `SearchQueryBuilderCombobox` because pending state updates from API responses fired after test assertions completed, triggering React's act() warning which `jest-fail-on-console` caught as a failure. Fixed by adding `await waitFor()` at the end to flush pending React state updates before teardown.

Also added `MockApiClient.clearMockResponses()` in `beforeEach` to prevent mock leakage between tests.

## Test plan

- [x] Tests pass locally (3 consecutive runs)
- [x] Pre-commit passes

Made with [Cursor](https://cursor.com)