### PR TITLE
ref(cells): Update slack and discord tasks to accept cell_name

### DIFF
--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -121,11 +121,12 @@ class _AsyncSlackDispatcher(_AsyncCellDispatcher):
     silo_mode=SiloMode.CONTROL,
 )
 def convert_to_async_slack_response(
-    region_names: list[str],
     payload: dict[str, Any],
     response_url: str,
+    cell_names: list[str] | None = None,  # TODO(cells): make required once region_names is removed
+    region_names: list[str] | None = None,  # TODO(cells): remove after queue drains
 ) -> None:
-    _AsyncSlackDispatcher(payload, response_url).dispatch(region_names)
+    _AsyncSlackDispatcher(payload, response_url).dispatch(cell_names or region_names or [])
 
 
 class _AsyncDiscordDispatcher(_AsyncCellDispatcher):
@@ -148,9 +149,10 @@ class _AsyncDiscordDispatcher(_AsyncCellDispatcher):
     silo_mode=SiloMode.CONTROL,
 )
 def convert_to_async_discord_response(
-    region_names: list[str],
     payload: dict[str, Any],
     response_url: str,
+    cell_names: list[str] | None = None,  # TODO(cells): make required once region_names is removed
+    region_names: list[str] | None = None,  # TODO(cells): remove after queue drains
 ) -> None:
     """
     This task asks relevant cell silos for response data to send asynchronously to Discord. It
@@ -159,7 +161,9 @@ def convert_to_async_discord_response(
 
     In the event this task finishes prior to returning the above type, the outbound post will fail.
     """
-    response = _AsyncDiscordDispatcher(payload, response_url).dispatch(region_names)
+    response = _AsyncDiscordDispatcher(payload, response_url).dispatch(
+        cell_names or region_names or []
+    )
 
     if response is not None and response.status_code == status.HTTP_404_NOT_FOUND:
         raise Exception("Discord hook is not ready.")


### PR DESCRIPTION
Update the convert_to_async_slack_response and convert_to_async_discord_response tasks to also accept cell_name.

Once deployed everywhere, will update callers to pass cell_name
