### PR TITLE
feat(supergroups): Add feedback component and experimental badge to drawer

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -181,6 +181,11 @@ export type TeamInsightsEventParameters = {
   'releases_list.click_add_release_health': {
     project_id: number;
   };
+  'supergroup.feedback_submitted': {
+    choice_selected: boolean;
+    supergroup_id: number;
+    user_id: string;
+  };
   'suspect_commit.feedback_submitted': {
     choice_selected: boolean;
     group_owner_id: number;
@@ -259,5 +264,6 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'releases_list.click_add_release_health': 'Releases List: Click Add Release Health',
   trace_timeline_clicked: 'Trace Timeline Clicked',
   trace_timeline_more_events_clicked: 'Trace Timeline More Events Clicked',
+  'supergroup.feedback_submitted': 'Supergroup Feedback Submitted',
   'suspect_commit.feedback_submitted': 'Suspect Commit Feedback Submitted',
 };

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -45,10 +45,7 @@ export function SupergroupDetailDrawer({supergroup}: {supergroup: SupergroupDeta
         </Flex>
       </DrawerHeader>
       <DrawerContentBody>
-        <FeedbackContainer>
-          {t('Help us improve this feature. Is this grouping accurate?')}
-          <SupergroupFeedback supergroupId={supergroup.id} />
-        </FeedbackContainer>
+        <SupergroupFeedback supergroupId={supergroup.id} />
         <Container padding="2xl" borderBottom="muted">
           <Stack gap="lg">
             <Heading as="h2" size="lg">
@@ -115,13 +112,4 @@ export function SupergroupDetailDrawer({supergroup}: {supergroup: SupergroupDeta
 
 const DrawerContentBody = styled(DrawerBody)`
   padding: 0;
-`;
-
-const FeedbackContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.md};
-  padding: ${p => p.theme.space.md} ${p => p.theme.space['2xl']};
-  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-  background: ${p => p.theme.tokens.background.transparent.promotion.muted};
 `;

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -1,8 +1,8 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Badge} from '@sentry/scraps/badge';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {
@@ -15,12 +15,11 @@ import {GroupList} from 'sentry/components/issues/groupList';
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {IconFocus} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {StyledMarkedText} from 'sentry/views/issueList/pages/supergroups';
+import {SupergroupFeedback} from 'sentry/views/issueList/supergroups/supergroupFeedback';
 import type {SupergroupDetail} from 'sentry/views/issueList/supergroups/types';
 
 export function SupergroupDetailDrawer({supergroup}: {supergroup: SupergroupDetail}) {
-  const organization = useOrganization();
   const placeholderRows = Math.min(supergroup.group_ids.length, 10);
   const issueIdQuery = `issue.id:[${supergroup.group_ids.join(',')}]`;
 
@@ -28,29 +27,28 @@ export function SupergroupDetailDrawer({supergroup}: {supergroup: SupergroupDeta
     <Fragment>
       <DrawerHeader hideBar>
         <Flex justify="between" align="center" gap="md" flexGrow={1}>
-          <NavigationCrumbs
-            crumbs={[
-              {label: t('Supergroups')},
-              {
-                label: (
-                  <CrumbContainer>
-                    <ShortId>{`SG-${supergroup.id}`}</ShortId>
-                  </CrumbContainer>
-                ),
-              },
-            ]}
-          />
-          <Link
-            to={{
-              pathname: `/organizations/${organization.slug}/issues/`,
-              query: {query: issueIdQuery, project: ALL_ACCESS_PROJECTS},
-            }}
-          >
-            {t('View All Issues')} ({supergroup.group_ids.length})
-          </Link>
+          <Flex align="center" gap="sm">
+            <NavigationCrumbs
+              crumbs={[
+                {label: t('Supergroups')},
+                {
+                  label: (
+                    <CrumbContainer>
+                      <ShortId>{`SG-${supergroup.id}`}</ShortId>
+                    </CrumbContainer>
+                  ),
+                },
+              ]}
+            />
+            <Badge variant="experimental">{t('Experimental')}</Badge>
+          </Flex>
         </Flex>
       </DrawerHeader>
       <DrawerContentBody>
+        <FeedbackContainer>
+          {t('Help us improve this feature. Is this grouping accurate?')}
+          <SupergroupFeedback supergroupId={supergroup.id} />
+        </FeedbackContainer>
         <Container padding="2xl" borderBottom="muted">
           <Stack gap="lg">
             <Heading as="h2" size="lg">
@@ -117,4 +115,13 @@ export function SupergroupDetailDrawer({supergroup}: {supergroup: SupergroupDeta
 
 const DrawerContentBody = styled(DrawerBody)`
   padding: 0;
+`;
+
+const FeedbackContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space['2xl']};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  background: ${p => p.theme.tokens.background.transparent.promotion.muted};
 `;

--- a/static/app/views/issueList/supergroups/supergroupFeedback.tsx
+++ b/static/app/views/issueList/supergroups/supergroupFeedback.tsx
@@ -1,0 +1,55 @@
+import {useCallback, useState} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
+import {IconThumb} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
+
+interface SupergroupFeedbackProps {
+  supergroupId: number;
+}
+
+export function SupergroupFeedback({supergroupId}: SupergroupFeedbackProps) {
+  const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
+  const organization = useOrganization();
+  const user = useUser();
+
+  const handleFeedback = useCallback(
+    (isAccurate: boolean) => {
+      trackAnalytics('supergroup.feedback_submitted', {
+        choice_selected: isAccurate,
+        supergroup_id: supergroupId,
+        user_id: user.id,
+        organization,
+      });
+
+      setFeedbackSubmitted(true);
+    },
+    [supergroupId, organization, user]
+  );
+
+  if (feedbackSubmitted) {
+    return <span>{t('Thanks!')}</span>;
+  }
+
+  return (
+    <Flex gap="sm">
+      <Button
+        size="zero"
+        icon={<IconThumb direction="up" size="xs" />}
+        onClick={() => handleFeedback(true)}
+        aria-label={t('Yes, this grouping is accurate')}
+      />
+      <Button
+        size="zero"
+        icon={<IconThumb direction="down" size="xs" />}
+        onClick={() => handleFeedback(false)}
+        aria-label={t('No, this grouping is not accurate')}
+      />
+    </Flex>
+  );
+}

--- a/static/app/views/issueList/supergroups/supergroupFeedback.tsx
+++ b/static/app/views/issueList/supergroups/supergroupFeedback.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useState} from 'react';
+import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
@@ -32,24 +33,38 @@ export function SupergroupFeedback({supergroupId}: SupergroupFeedbackProps) {
     [supergroupId, organization, user]
   );
 
-  if (feedbackSubmitted) {
-    return <span>{t('Thanks!')}</span>;
-  }
-
   return (
-    <Flex gap="sm">
-      <Button
-        size="zero"
-        icon={<IconThumb direction="up" size="xs" />}
-        onClick={() => handleFeedback(true)}
-        aria-label={t('Yes, this grouping is accurate')}
-      />
-      <Button
-        size="zero"
-        icon={<IconThumb direction="down" size="xs" />}
-        onClick={() => handleFeedback(false)}
-        aria-label={t('No, this grouping is not accurate')}
-      />
-    </Flex>
+    <FeedbackContainer>
+      {feedbackSubmitted ? (
+        t('Thanks!')
+      ) : (
+        <Flex align="center" gap="md">
+          {t('Help us improve this feature. Is this grouping accurate?')}
+          <Flex gap="sm">
+            <Button
+              size="zero"
+              icon={<IconThumb direction="up" size="xs" />}
+              onClick={() => handleFeedback(true)}
+              aria-label={t('Yes, this grouping is accurate')}
+            />
+            <Button
+              size="zero"
+              icon={<IconThumb direction="down" size="xs" />}
+              onClick={() => handleFeedback(false)}
+              aria-label={t('No, this grouping is not accurate')}
+            />
+          </Flex>
+        </Flex>
+      )}
+    </FeedbackContainer>
   );
 }
+
+const FeedbackContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space['2xl']};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  background: ${p => p.theme.tokens.background.transparent.promotion.muted};
+`;


### PR DESCRIPTION
Add a feedback banner at the top of the supergroup drawer asking users if the grouping is accurate, with thumbs up/down buttons that fire a new analytics event. Also add an experimental badge to the breadcrumbs.

<img width="735" height="208" alt="image" src="https://github.com/user-attachments/assets/9ecf7dde-2dd8-47d0-a661-438ac8f3b6e3" />
