### PR TITLE
feat(occurrences on eap): Implement EAP query for tagstore groups user counts (errors)

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -58,7 +58,7 @@ from sentry.search.events.filter import _flip_field_sort
 from sentry.search.events.types import SnubaParams
 from sentry.services.eventstore.query_preprocessing import translate_environment_ids_to_names
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.occurrences_rpc import Occurrences
+from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 from sentry.snuba.referrer import Referrer
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT, TagKeyStatus, TagStorage
 from sentry.tagstore.exceptions import GroupTagKeyNotFound, TagKeyNotFound
@@ -1260,6 +1260,7 @@ class SnubaTagStorage(TagStorage):
                 limit=len(group_ids),
                 referrer=referrer,
                 config=SearchResolverConfig(),
+                occurrence_category=OccurrenceCategory.ERROR,
             )
 
             return defaultdict(

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import logging
 import os
 import re
 from collections import defaultdict
@@ -30,6 +31,7 @@ from sentry.api.paginator import SequencePaginator
 from sentry.api.utils import default_start_end_dates, handle_query_errors
 from sentry.eventstream.item_helpers import format_attr_key
 from sentry.issues.grouptype import GroupCategory
+from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -56,6 +58,7 @@ from sentry.search.events.filter import _flip_field_sort
 from sentry.search.events.types import SnubaParams
 from sentry.services.eventstore.query_preprocessing import translate_environment_ids_to_names
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.occurrences_rpc import Occurrences
 from sentry.snuba.referrer import Referrer
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT, TagKeyStatus, TagStorage
 from sentry.tagstore.exceptions import GroupTagKeyNotFound, TagKeyNotFound
@@ -69,6 +72,8 @@ from sentry.utils.snuba import (
     nest_groups,
     raw_snql_query,
 )
+
+logger = logging.getLogger(__name__)
 
 _max_unsampled_projects = 50
 if os.environ.get("SENTRY_SINGLE_TENANT"):
@@ -131,6 +136,12 @@ def _translate_filter_keys(
 
     forward, reverse = get_snuba_translators(filter_keys, is_grouprelease=False)
     return forward(filter_keys)
+
+
+def _reasonable_user_counts_match(control: dict[int, int], experimental: dict[int, int]) -> bool:
+    if not set(experimental.keys()).issubset(set(control.keys())):
+        return False
+    return all(experimental[group_id] <= control[group_id] for group_id in experimental)
 
 
 class _OptimizeKwargs(TypedDict, total=False):
@@ -1166,7 +1177,7 @@ class SnubaTagStorage(TagStorage):
         tenant_ids: dict[str, str | int] | None = None,
         referrer: str = "tagstore.get_groups_user_counts",
     ) -> dict[int, int]:
-        return self.__get_groups_user_counts(
+        snuba_result = self.__get_groups_user_counts(
             project_ids,
             group_ids,
             environment_ids,
@@ -1177,6 +1188,98 @@ class SnubaTagStorage(TagStorage):
             referrer,
             tenant_ids=tenant_ids,
         )
+        result = snuba_result
+
+        callsite = "SnubaTagStorage::get_groups_user_counts"
+        if EAPOccurrencesComparator.should_check_experiment(callsite):
+            eap_result = self._eap_get_groups_user_counts(
+                project_ids, group_ids, environment_ids, start, end, referrer
+            )
+            result = EAPOccurrencesComparator.check_and_choose(
+                control_data=snuba_result,
+                experimental_data=eap_result,
+                callsite=callsite,
+                is_experimental_data_a_null_result=len(eap_result) == 0,
+                reasonable_match_comparator=_reasonable_user_counts_match,
+                debug_context={
+                    "project_ids": list(project_ids),
+                    "group_ids": list(group_ids),
+                    "environment_ids": list(environment_ids) if environment_ids else None,
+                    "start": start.isoformat() if start else None,
+                    "end": end.isoformat() if end else None,
+                },
+            )
+
+        return result
+
+    def _eap_get_groups_user_counts(
+        self,
+        project_ids: Sequence[int],
+        group_ids: Sequence[int],
+        environment_ids: Sequence[int] | None,
+        start: datetime | None,
+        end: datetime | None,
+        referrer: str,
+    ) -> dict[int, int]:
+        organization_id = get_organization_id_from_project_ids(project_ids)
+
+        now = datetime.now(tz=timezone.utc)
+        resolved_start = start if start else now - timedelta(days=90)
+        resolved_end = end if end else now
+
+        try:
+            organization = Organization.objects.get_from_cache(id=organization_id)
+        except Organization.DoesNotExist:
+            return defaultdict(int)
+
+        projects = list(Project.objects.filter(id__in=project_ids))
+        if not projects:
+            return defaultdict(int)
+
+        environments = (
+            list(Environment.objects.filter(id__in=environment_ids)) if environment_ids else []
+        )
+
+        query_string = f"group_id:[{','.join(str(gid) for gid in group_ids)}]"
+
+        snuba_params = SnubaParams(
+            start=resolved_start,
+            end=resolved_end,
+            organization=organization,
+            projects=projects,
+            environments=environments,
+        )
+
+        try:
+            result = Occurrences.run_table_query(
+                params=snuba_params,
+                query_string=query_string,
+                selected_columns=["group_id", "count_unique(user)"],
+                orderby=["-count_unique(user)"],
+                offset=0,
+                limit=len(group_ids),
+                referrer=referrer,
+                config=SearchResolverConfig(),
+            )
+
+            return defaultdict(
+                int,
+                {
+                    int(row["group_id"]): int(row["count_unique(user)"])
+                    for row in result.get("data", [])
+                    if row.get("group_id") is not None and row.get("count_unique(user)") is not None
+                },
+            )
+        except Exception:
+            logger.exception(
+                "EAP get_groups_user_counts query failed",
+                extra={
+                    "organization_id": organization_id,
+                    "project_ids": list(project_ids),
+                    "group_ids": list(group_ids),
+                },
+            )
+            return defaultdict(int)
 
     def get_generic_groups_user_counts(
         self,

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -21,7 +21,7 @@ from sentry.tagstore.snuba.backend import SnubaTagStorage
 from sentry.tagstore.types import GroupTagValue, TagValue
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import PerformanceIssueTestCase, SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
@@ -1559,3 +1559,176 @@ class GetTagValuePaginatorForProjectsSemverBuildTest(BaseSemverTest):
         self.run_test("1", ["124"], self.environment)
         self.run_test("4", ["456", "457a"])
         self.run_test("4", ["456"], env_2)
+
+
+class TestEAPGetGroupsUserCounts(TestCase, SnubaTestCase):
+    FROZEN_TIME = before_now(hours=24).replace(hour=6, minute=0, second=0)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.ts = SnubaTagStorage()
+
+    def _store_event_with_user(
+        self, fingerprint: str, user_id: str, timestamp: float, environment: str | None = None
+    ):
+        extra: dict = {
+            "user": {"id": user_id},
+            "tags": {"sentry:user": f"id:{user_id}"},
+        }
+        if environment is not None:
+            extra["environment"] = environment
+        return self.store_events_to_snuba_and_eap(
+            fingerprint,
+            count=1,
+            timestamp=timestamp,
+            extra_event_data=extra,
+        )[0]
+
+    @freeze_time(FROZEN_TIME)
+    def test_eap_and_snuba_user_counts_match_multiple_groups(self) -> None:
+        ts = (self.FROZEN_TIME - timedelta(minutes=5)).timestamp()
+
+        # Group A: 3 events from 2 unique users (user1 appears twice)
+        self._store_event_with_user("group-a", "user1", ts)
+        self._store_event_with_user("group-a", "user1", ts)
+        event_a = self._store_event_with_user("group-a", "user2", ts)
+        group_a = event_a.group
+        assert group_a is not None
+
+        # Group B: 2 events from 2 unique users
+        self._store_event_with_user("group-b", "user3", ts)
+        event_b = self._store_event_with_user("group-b", "user4", ts)
+        group_b = event_b.group
+        assert group_b is not None
+
+        # Group C: 1 event from 1 unique user
+        event_c = self._store_event_with_user("group-c", "user5", ts)
+        group_c = event_c.group
+        assert group_c is not None
+
+        group_ids = [group_a.id, group_b.id, group_c.id]
+        start = self.FROZEN_TIME - timedelta(hours=1)
+        end = self.FROZEN_TIME + timedelta(hours=1)
+
+        snuba_result = self.ts.get_groups_user_counts(
+            project_ids=[self.project.id],
+            group_ids=group_ids,
+            environment_ids=None,
+            start=start,
+            end=end,
+            tenant_ids={"referrer": "r", "organization_id": self.project.organization_id},
+        )
+
+        eap_result = self.ts._eap_get_groups_user_counts(
+            project_ids=[self.project.id],
+            group_ids=group_ids,
+            environment_ids=None,
+            start=start,
+            end=end,
+            referrer="tagstore.get_groups_user_counts",
+        )
+
+        assert snuba_result == {group_a.id: 2, group_b.id: 2, group_c.id: 1}
+        assert eap_result == snuba_result
+
+    @freeze_time(FROZEN_TIME)
+    def test_eap_and_snuba_user_counts_match_with_environment_filter(self) -> None:
+        ts = (self.FROZEN_TIME - timedelta(minutes=5)).timestamp()
+        env = self.create_environment(project=self.project, name="production")
+
+        # 2 events in "production" env from 2 unique users
+        self._store_event_with_user("group-a", "user1", ts, environment=env.name)
+        self._store_event_with_user("group-a", "user2", ts, environment=env.name)
+
+        # 1 event in a different env (should be excluded by env filter)
+        event = self._store_event_with_user("group-a", "user3", ts, environment="staging")
+        group_a = event.group
+        assert group_a is not None
+
+        group_ids = [group_a.id]
+        start = self.FROZEN_TIME - timedelta(hours=1)
+        end = self.FROZEN_TIME + timedelta(hours=1)
+
+        # With environment filter: should only count user1, user2
+        snuba_with_env = self.ts.get_groups_user_counts(
+            project_ids=[self.project.id],
+            group_ids=group_ids,
+            environment_ids=[env.id],
+            start=start,
+            end=end,
+            tenant_ids={"referrer": "r", "organization_id": self.project.organization_id},
+        )
+
+        eap_with_env = self.ts._eap_get_groups_user_counts(
+            project_ids=[self.project.id],
+            group_ids=group_ids,
+            environment_ids=[env.id],
+            start=start,
+            end=end,
+            referrer="tagstore.get_groups_user_counts",
+        )
+
+        assert snuba_with_env == {group_a.id: 2}
+        assert eap_with_env == snuba_with_env
+
+        # Without environment filter: should count all 3 users
+        snuba_no_env = self.ts.get_groups_user_counts(
+            project_ids=[self.project.id],
+            group_ids=group_ids,
+            environment_ids=None,
+            start=start,
+            end=end,
+            tenant_ids={"referrer": "r", "organization_id": self.project.organization_id},
+        )
+
+        eap_no_env = self.ts._eap_get_groups_user_counts(
+            project_ids=[self.project.id],
+            group_ids=group_ids,
+            environment_ids=None,
+            start=start,
+            end=end,
+            referrer="tagstore.get_groups_user_counts",
+        )
+
+        assert snuba_no_env == {group_a.id: 3}
+        assert eap_no_env == snuba_no_env
+
+    @freeze_time(FROZEN_TIME)
+    def test_eap_and_snuba_user_counts_match_with_time_range_filter(self) -> None:
+        old_ts = (self.FROZEN_TIME - timedelta(hours=5)).timestamp()
+        recent_ts = (self.FROZEN_TIME - timedelta(minutes=5)).timestamp()
+
+        # Old events outside the query window
+        self._store_event_with_user("group-a", "user1", old_ts)
+        self._store_event_with_user("group-a", "user2", old_ts)
+
+        # Recent event inside the query window
+        event = self._store_event_with_user("group-a", "user3", recent_ts)
+        group_a = event.group
+        assert group_a is not None
+
+        group_ids = [group_a.id]
+        # Query window that only includes the recent event
+        start = self.FROZEN_TIME - timedelta(hours=1)
+        end = self.FROZEN_TIME + timedelta(hours=1)
+
+        snuba_result = self.ts.get_groups_user_counts(
+            project_ids=[self.project.id],
+            group_ids=group_ids,
+            environment_ids=None,
+            start=start,
+            end=end,
+            tenant_ids={"referrer": "r", "organization_id": self.project.organization_id},
+        )
+
+        eap_result = self.ts._eap_get_groups_user_counts(
+            project_ids=[self.project.id],
+            group_ids=group_ids,
+            environment_ids=None,
+            start=start,
+            end=end,
+            referrer="tagstore.get_groups_user_counts",
+        )
+
+        assert snuba_result == {group_a.id: 1}
+        assert eap_result == snuba_result


### PR DESCRIPTION
Implements double reads of occurrences from EAP for `get_groups_user_counts` in `src/sentry/tagstore/snuba/backend.py`.