### PR TITLE
ref(grouping): remove `useReranking` from similar issues UI

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
@@ -216,7 +216,7 @@ describe('Issues Similar Embeddings View', () => {
 
   beforeEach(() => {
     mock = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/similar-issues-embeddings/?k=10&threshold=0.01&useReranking=true`,
+      url: `/organizations/org-slug/issues/${group.id}/similar-issues-embeddings/?k=10&threshold=0.01`,
       body: mockData.similarEmbeddings,
     });
     MockApiClient.addMockResponse({
@@ -330,7 +330,7 @@ describe('Issues Similar Embeddings View', () => {
 
   it('shows empty message', async () => {
     mock = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/similar-issues-embeddings/?k=10&threshold=0.01&useReranking=true`,
+      url: `/organizations/org-slug/issues/${group.id}/similar-issues-embeddings/?k=10&threshold=0.01`,
       body: [],
     });
 

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -58,11 +58,6 @@ export function SimilarStackTrace({project}: Props) {
   const hasSimilarityEmbeddingsFeature =
     projectData?.features.includes('similarity-embeddings') ||
     location.query.similarityEmbeddings === '1';
-  // Use reranking by default (assuming the `seer.similarity.similar_issues.use_reranking`
-  // backend option is using its default value of `True`). This is just so we can turn it off
-  // on demand to see if/how that changes the results.
-  const useReranking = String(location.query.useReranking !== '0');
-
   const fetchData = useCallback(() => {
     if (isPending) {
       return;
@@ -77,7 +72,6 @@ export function SimilarStackTrace({project}: Props) {
           {
             k: 10,
             threshold: 0.01,
-            useReranking,
           }
         )}`,
         dataKey: 'similar',
@@ -101,7 +95,6 @@ export function SimilarStackTrace({project}: Props) {
     organization.slug,
     hasSimilarityFeature,
     hasSimilarityEmbeddingsFeature,
-    useReranking,
     isPending,
   ]);
 


### PR DESCRIPTION
Related: https://github.com/getsentry/sentry/pull/111866, https://github.com/getsentry/seer/pull/5554

Reranking has been on for ~2 years, we don't need to check it in the frontend.