### PR TITLE
fix(organization) Fix an issue with deleting an older Organization

### DIFF
--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -47,6 +47,7 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
             AlertRule,
             Release,
             Project,
+            Workflow,
             Environment,
             Dashboard,
             TeamKeyTransaction,
@@ -64,7 +65,6 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
                 task=DiscoverSavedQueryDeletionTask,
             )
         )
-        relations.append(ModelRelation(Workflow, {"organization_id": instance.id}))
 
         return relations
 


### PR DESCRIPTION
When the task tries to delete sentry_environment rows, Django's cascade sees that workflow_engine_workflow rows still reference them. It tries to cascade-delete those workflows in Python — but those rows haven't gone through their own proper deletion task yet, and if Workflow has any child relations or outbox requirements, the inline cascade may fail or leave orphans.                                                                                                                                                                                

This is a deletion ordering bug introduced when Workflow was added to the org deletion task. Workflow should be appended before Environment in the relation list, not after. Since it has an FK pointing at Environment, it needs to be cleaned up first.

Fixed by moving the Workflow relation earlier in get_child_relations, before Environment. 

## Investigation

I ran a query for child rows of an organization that was failing to delete, and `Environment` was the top in the list that still had undeleted rows. This indicated a dependent table that was not getting rows related to this Organization removed. 

table_name | row_count 
-- | -- 
sentry_externalissue | 748   
sentry_promptsactivity | 183   
sentry_environment | 177 
workflow_engine_workflow | 9 
sentry_dashboard | 9 
sentry_discoversavedquery | 7




