### PR TITLE
feat(consumer): use `gen_ai.function_id` as a fallback for `gen_ai.agent.name`

### DIFF
--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -155,13 +155,13 @@ class TreeEnricher:
         self, span: SpanEvent, start_with_self: bool = False
     ) -> Iterator[SpanEvent]:
         """
-        Iterates over the ancestors of a span in order towards the root using the "parent_span_id" attribute.
+        Iterates over the ancestors of a span in order towards the root using the "parent_span_id" attribute. If start_with_self is True, the span itself is yielded first.
         """
         current: SpanEvent | None = span
         parent_span_id: str | None = None
 
         if start_with_self:
-            current = span
+            yield current
 
         while current is not None:
             parent_span_id = current.get("parent_span_id")

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -138,6 +138,11 @@ class TreeEnricher:
                         "type": "string",
                         "value": agent_name,
                     }
+                elif (function_id := self._find_function_id(span)) is not None:
+                    attributes[ATTRIBUTE_NAMES.GEN_AI_AGENT_NAME] = {
+                        "type": "string",
+                        "value": function_id,
+                    }
 
         attributes["sentry.exclusive_time_ms"] = {
             "type": "double",
@@ -146,12 +151,17 @@ class TreeEnricher:
 
         return attributes
 
-    def _iter_ancestors(self, span: SpanEvent) -> Iterator[SpanEvent]:
+    def _iter_ancestors(
+        self, span: SpanEvent, start_with_self: bool = False
+    ) -> Iterator[SpanEvent]:
         """
         Iterates over the ancestors of a span in order towards the root using the "parent_span_id" attribute.
         """
         current: SpanEvent | None = span
         parent_span_id: str | None = None
+
+        if start_with_self:
+            current = span
 
         while current is not None:
             parent_span_id = current.get("parent_span_id")
@@ -174,6 +184,18 @@ class TreeEnricher:
                 agent_name := attribute_value(ancestor, ATTRIBUTE_NAMES.GEN_AI_AGENT_NAME)
             ) is not None:
                 return agent_name
+        return None
+
+    def _find_function_id(self, span: SpanEvent) -> str | None:
+        """
+        Finds the nearest ancestor's function id within MAX_AGENT_NAME_ANCESTOR_HOPS, starting with the span itself.
+        Returns the first function id found, or None if no ancestor has one.
+        """
+        for ancestor in islice(
+            self._iter_ancestors(span, start_with_self=True), MAX_AGENT_NAME_ANCESTOR_HOPS
+        ):
+            if (function_id := attribute_value(ancestor, "gen_ai.function_id")) is not None:
+                return function_id
         return None
 
     def _exclusive_time(self, span: SpanEvent) -> float:

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -812,6 +812,164 @@ def test_enrich_gen_ai_agent_name_respects_max_depth() -> None:
     assert attribute_value(compatible_spans[-1], "gen_ai.agent.name") is None
 
 
+def test_enrich_gen_ai_agent_name_fallback_to_own_function_id() -> None:
+    """Test that gen_ai.agent.name falls back to the span's own gen_ai.function_id when no ancestor agent name exists."""
+    parent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="some.operation",
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        attributes={
+            "gen_ai.operation.name": {"type": "string", "value": "execute_tool"},
+            "gen_ai.function_id": {"type": "string", "value": "my_tool_function"},
+        },
+    )
+
+    spans = [parent_span, child_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+
+    child = enriched_spans[1]
+    assert attribute_value(child, "gen_ai.agent.name") == "my_tool_function"
+
+
+def test_enrich_gen_ai_agent_name_fallback_to_ancestor_function_id() -> None:
+    """Test that gen_ai.agent.name falls back to an ancestor's gen_ai.function_id when no agent name exists."""
+    parent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="some.operation",
+        attributes={
+            "gen_ai.function_id": {"type": "string", "value": "parent_function"},
+        },
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        attributes={
+            "gen_ai.operation.name": {"type": "string", "value": "execute_tool"},
+        },
+    )
+
+    spans = [parent_span, child_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+
+    child = enriched_spans[1]
+    assert attribute_value(child, "gen_ai.agent.name") == "parent_function"
+
+
+def test_enrich_gen_ai_agent_name_prefers_agent_name_over_function_id() -> None:
+    """Test that ancestor agent name takes priority over function_id."""
+    parent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="gen_ai.invoke_agent",
+        attributes={
+            "gen_ai.agent.name": {"type": "string", "value": "MyAgent"},
+            "gen_ai.function_id": {"type": "string", "value": "should_not_use"},
+        },
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        attributes={
+            "gen_ai.operation.name": {"type": "string", "value": "execute_tool"},
+            "gen_ai.function_id": {"type": "string", "value": "also_should_not_use"},
+        },
+    )
+
+    spans = [parent_span, child_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+
+    child = enriched_spans[1]
+    assert attribute_value(child, "gen_ai.agent.name") == "MyAgent"
+
+
+def test_enrich_gen_ai_agent_name_own_function_id_preferred_over_ancestor_function_id() -> None:
+    """Test that the span's own function_id is preferred over an ancestor's function_id."""
+    parent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="some.operation",
+        attributes={
+            "gen_ai.function_id": {"type": "string", "value": "parent_function"},
+        },
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        attributes={
+            "gen_ai.operation.name": {"type": "string", "value": "execute_tool"},
+            "gen_ai.function_id": {"type": "string", "value": "child_function"},
+        },
+    )
+
+    spans = [parent_span, child_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+
+    child = enriched_spans[1]
+    assert attribute_value(child, "gen_ai.agent.name") == "child_function"
+
+
+def test_enrich_gen_ai_no_agent_name_no_function_id() -> None:
+    """Test that gen_ai.agent.name is not set when neither agent name nor function_id exists."""
+    parent_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_op="some.operation",
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+        attributes={
+            "gen_ai.operation.name": {"type": "string", "value": "execute_tool"},
+        },
+    )
+
+    spans = [parent_span, child_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+
+    child = enriched_spans[1]
+    assert attribute_value(child, "gen_ai.agent.name") is None
+
+
 def test_enrich_gen_ai_agent_name_from_deep_ancestor() -> None:
     """Test that agent name is inherited from ancestor at exactly MAX_AGENT_NAME_ANCESTOR_HOPS."""
     spans = []


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-2148/map-vercels-function-id-to-gen-aiagentname