### PR TITLE
fix(dashboards): Render star icon header for is_starred_transaction column

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -24,6 +24,7 @@ import {
 } from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
 import {STARFISH_FIELDS} from 'sentry/views/insights/common/utils/constants';
 import {STARFISH_AGGREGATION_FIELDS} from 'sentry/views/insights/constants';
+import {SpanFields} from 'sentry/views/insights/types';
 
 import {CONDITIONS_ARGUMENTS, DiscoverDatasets, WEB_VITALS_QUALITY} from './types';
 
@@ -1404,6 +1405,10 @@ export function fieldAlignment(
   columnType?: ColumnValueType,
   metadata?: Record<string, ColumnValueType>
 ): Alignments {
+  if (columnName === SpanFields.IS_STARRED_TRANSACTION) {
+    return 'right';
+  }
+
   let align: Alignments = 'left';
 
   if (columnType) {

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -96,6 +96,7 @@ import {Thresholds as ThresholdsPlottable} from 'sentry/views/dashboards/widgets
 import {WheelWidgetVisualization} from 'sentry/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
+import {SpanFields} from 'sentry/views/insights/types';
 import type {SpanResponse} from 'sentry/views/insights/types';
 
 import {WidgetCardConfidenceFooter} from './confidenceFooter';
@@ -614,7 +615,9 @@ function TableComponent({
       tableResults[i]?.meta
     ).map((column, index) => {
       let sortable = false;
-      if (widget.widgetType === WidgetType.RELEASE) {
+      if (column.key === SpanFields.IS_STARRED_TRANSACTION) {
+        sortable = false;
+      } else if (widget.widgetType === WidgetType.RELEASE) {
         sortable = isAggregateField(column.key);
       } else if (widget.widgetType !== WidgetType.ISSUE) {
         sortable = true;

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -63,6 +63,43 @@ describe('TableWidgetVisualization', () => {
       expect($headers[1]).toHaveTextContent(columns[1]!.key!);
     });
 
+    it('Renders star icon for is_starred_transaction column without alias', () => {
+      const starredTableData: TabularData = {
+        data: [{is_starred_transaction: true, transaction: '/api/foo'}],
+        meta: {
+          fields: {is_starred_transaction: 'boolean', transaction: 'string'},
+          units: {is_starred_transaction: null, transaction: null},
+        },
+      };
+
+      render(<TableWidgetVisualization tableData={starredTableData} />);
+
+      const $headers = screen.getAllByRole('columnheader');
+      expect($headers[0]).not.toHaveTextContent('is_starred_transaction');
+      expect($headers[0]!.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('Renders alias text instead of star icon when alias is provided', () => {
+      const starredTableData: TabularData = {
+        data: [{is_starred_transaction: true, transaction: '/api/foo'}],
+        meta: {
+          fields: {is_starred_transaction: 'boolean', transaction: 'string'},
+          units: {is_starred_transaction: null, transaction: null},
+        },
+      };
+
+      render(
+        <TableWidgetVisualization
+          tableData={starredTableData}
+          aliases={{is_starred_transaction: 'Starred'}}
+        />
+      );
+
+      const $headers = screen.getAllByRole('columnheader');
+      expect($headers[0]).toHaveTextContent('Starred');
+      expect($headers[0]!.querySelector('svg')).not.toBeInTheDocument();
+    });
+
     it('Renders unique number fields correctly', async () => {
       const tableData: TabularData = {
         data: [{'span.duration': 123, failure_rate: 0.1, epm: 6}],

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -5,6 +5,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {COL_WIDTH_UNDEFINED, GridEditable} from 'sentry/components/tables/gridEditable';
 import {SortLink} from 'sentry/components/tables/gridEditable/sortLink';
+import {IconStar} from 'sentry/icons';
 import {defined} from 'sentry/utils';
 import {getSortField} from 'sentry/utils/dashboards/issueFieldRenderers';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
@@ -35,6 +36,7 @@ import {
   CellAction,
   copyToClipboard,
 } from 'sentry/views/discover/table/cellAction';
+import {SpanFields} from 'sentry/views/insights/types';
 
 export type FieldRendererGetter = (
   field: string,
@@ -233,9 +235,16 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
       grid={{
         renderHeadCell: (_tableColumn, columnIndex) => {
           const column = columnOrder[columnIndex]!;
+          const isStarredColumn = column.key === SpanFields.IS_STARRED_TRANSACTION;
+          const hasAlias = !!aliases?.[column.key];
           const align = fieldAlignment(column.key, column.type as ColumnValueType);
-          let name = aliases?.[column.key] || column.key;
-          if (isEquation(column.key)) name = stripEquationPrefix(name);
+          let name: React.ReactNode = aliases?.[column.key] || column.key;
+          if (isStarredColumn && !hasAlias) {
+            name = <IconStar isSolid size="md" variant="warning" />;
+          } else if (isEquation(column.key)) {
+            name = stripEquationPrefix(name as string);
+          }
+          const tooltipTitle = isStarredColumn && !hasAlias ? column.key : name;
           const sortColumn = getSortField(column.key) ?? column.key;
 
           let direction = undefined;
@@ -249,7 +258,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
             <SortLink
               align={align}
               canSort={column.sortable ?? false}
-              title={<StyledTooltip title={name}>{name}</StyledTooltip>}
+              title={<StyledTooltip title={tooltipTitle}>{name}</StyledTooltip>}
               onClick={e => {
                 if (!onChangeSort) return;
                 e.preventDefault();
@@ -376,14 +385,22 @@ TableWidgetVisualization.LoadingPlaceholder = function ({
         renderHeadCell: (_tableColumn, columnIndex) => {
           if (!columns) return null;
           const column = columns[columnIndex]!;
+          const isStarredColumn = column.key === SpanFields.IS_STARRED_TRANSACTION;
+          const hasAlias = !!aliases?.[column.key];
           const align = fieldAlignment(column.key, column.type as ColumnValueType);
-          const name = aliases?.[column.key] || column.key;
+          const displayAsIcon = isStarredColumn && !hasAlias;
+          const name: React.ReactNode = displayAsIcon ? (
+            <IconStar isSolid size="md" variant="warning" />
+          ) : (
+            aliases?.[column.key] || column.key
+          );
+          const tooltipTitle = displayAsIcon ? column.key : name;
 
           return (
             <SortLink
               canSort={false}
               align={align}
-              title={<StyledTooltip title={name}>{name}</StyledTooltip>}
+              title={<StyledTooltip title={tooltipTitle}>{name}</StyledTooltip>}
               direction={undefined}
               generateSortLink={() => undefined}
             />


### PR DESCRIPTION
Show a yellow star icon as the column header for `is_starred_transaction`
in dashboard widget tables instead of the raw field name. The icon matches
the star used in the insights overview tables.

- Render `<IconStar>` in the table widget header when `is_starred_transaction`
  is present and no field alias overrides it
- Right-align the column via `fieldAlignment`
- Disable sorting on the column since it's always a forced primary sort

Refs LINEAR-DAIN-1437

<img width="496" height="316" alt="image" src="https://github.com/user-attachments/assets/6c058d91-41a2-489c-97dd-1691515979c9" />
