### PR TITLE
fix(ui): shift Seer floating button up on footer hover

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -431,6 +431,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 ## Frontend
 /static/app/components/analyticsArea.spec.tsx  @getsentry/app-frontend
 /static/app/components/analyticsArea.tsx       @getsentry/app-frontend
+/static/app/components/footer*                 @getsentry/app-frontend
 /static/app/components/events/interfaces/      @getsentry/app-frontend
 /static/app/components/forms/                  @getsentry/app-frontend
 /static/app/locale.tsx                         @getsentry/app-frontend

--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -6,6 +6,7 @@ import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 
+import {useFooterHover} from 'sentry/components/footerHoverContext';
 import {useFrontendVersion} from 'sentry/components/frontendVersionContext';
 import Hook from 'sentry/components/hook';
 import {IconSentry, IconSentryPrideLogo} from 'sentry/icons';
@@ -45,6 +46,7 @@ function BaseFooter({className}: Props) {
 
   const secondaryNavigation = useContext(SecondaryNavigationContext);
   const hasPageFrame = useHasPageFrameFeature();
+  const {setFooterHovered} = useFooterHover();
 
   if (hasPageFrame) {
     // @TODO(JonasBadalic): Remove ~ footer CSS rules once this flag is GA'd
@@ -56,6 +58,8 @@ function BaseFooter({className}: Props) {
       as="footer"
       background="primary"
       className={className}
+      onMouseEnter={() => setFooterHovered(true)}
+      onMouseLeave={() => setFooterHovered(false)}
       borderLeft={
         hasPageFrame && secondaryNavigation?.view === 'expanded' ? 'secondary' : undefined
       }

--- a/static/app/components/footerHoverContext.spec.tsx
+++ b/static/app/components/footerHoverContext.spec.tsx
@@ -1,0 +1,125 @@
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  COOLING_PERIOD_MS,
+  FooterHoverProvider,
+  useFooterHover,
+} from './footerHoverContext';
+
+function TestHarness() {
+  const {hoverState, setFooterHovered, setButtonAreaHovered} = useFooterHover();
+  return (
+    <div>
+      <span data-test-id="state">{hoverState}</span>
+      <button data-test-id="footer-enter" onClick={() => setFooterHovered(true)} />
+      <button data-test-id="footer-leave" onClick={() => setFooterHovered(false)} />
+      <button data-test-id="button-enter" onClick={() => setButtonAreaHovered(true)} />
+      <button data-test-id="button-leave" onClick={() => setButtonAreaHovered(false)} />
+    </div>
+  );
+}
+
+function renderHarness() {
+  const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+  render(
+    <FooterHoverProvider>
+      <TestHarness />
+    </FooterHoverProvider>
+  );
+  return {
+    state: () => screen.getByTestId('state').textContent,
+    footerEnter: () => user.click(screen.getByTestId('footer-enter')),
+    footerLeave: () => user.click(screen.getByTestId('footer-leave')),
+    buttonEnter: () => user.click(screen.getByTestId('button-enter')),
+    buttonLeave: () => user.click(screen.getByTestId('button-leave')),
+  };
+}
+
+describe('FooterHoverContext', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('starts in off state', () => {
+    const {state} = renderHarness();
+    expect(state()).toBe('off');
+  });
+
+  it('transitions to active when footer is entered', async () => {
+    const {state, footerEnter} = renderHarness();
+    await footerEnter();
+    expect(state()).toBe('active');
+  });
+
+  it('stays active during cooling period after footer leave', async () => {
+    const {state, footerEnter, footerLeave} = renderHarness();
+    await footerEnter();
+    await footerLeave();
+    expect(state()).toBe('active');
+  });
+
+  it('transitions to off after cooling period expires', async () => {
+    const {state, footerEnter, footerLeave} = renderHarness();
+    await footerEnter();
+    await footerLeave();
+    act(() => jest.advanceTimersByTime(COOLING_PERIOD_MS));
+    expect(state()).toBe('off');
+  });
+
+  it('locks when button area is entered during cooling period', async () => {
+    const {state, footerEnter, footerLeave, buttonEnter} = renderHarness();
+    await footerEnter();
+    await footerLeave();
+    await buttonEnter();
+    expect(state()).toBe('locked');
+
+    act(() => jest.advanceTimersByTime(COOLING_PERIOD_MS));
+    expect(state()).toBe('locked');
+  });
+
+  it('locks when button area is entered while footer is active', async () => {
+    const {state, footerEnter, buttonEnter} = renderHarness();
+    await footerEnter();
+    await buttonEnter();
+    expect(state()).toBe('locked');
+  });
+
+  it('stays locked when footer leaves while button area is hovered', async () => {
+    const {state, footerEnter, footerLeave, buttonEnter} = renderHarness();
+    await footerEnter();
+    await buttonEnter();
+    await footerLeave();
+    expect(state()).toBe('locked');
+  });
+
+  it('stays off when button area is entered without prior footer hover', async () => {
+    const {state, buttonEnter} = renderHarness();
+    await buttonEnter();
+    expect(state()).toBe('off');
+  });
+
+  it('transitions to off when button area leaves and footer is not hovered', async () => {
+    const {state, footerEnter, footerLeave, buttonEnter, buttonLeave} = renderHarness();
+    await footerEnter();
+    await buttonEnter();
+    await footerLeave();
+    await buttonLeave();
+    expect(state()).toBe('off');
+  });
+
+  it('transitions to active when button area leaves but footer is still hovered', async () => {
+    const {state, footerEnter, buttonEnter, buttonLeave} = renderHarness();
+    await footerEnter();
+    await buttonEnter();
+    await buttonLeave();
+    expect(state()).toBe('active');
+  });
+
+  it('cancels cooling when footer is re-entered', async () => {
+    const {state, footerEnter, footerLeave} = renderHarness();
+    await footerEnter();
+    await footerLeave();
+    await footerEnter();
+    act(() => jest.advanceTimersByTime(COOLING_PERIOD_MS));
+    expect(state()).toBe('active');
+  });
+});

--- a/static/app/components/footerHoverContext.tsx
+++ b/static/app/components/footerHoverContext.tsx
@@ -1,0 +1,96 @@
+import {createContext, useContext, useEffect, useMemo, useReducer} from 'react';
+
+type FooterHoverState = 'off' | 'active' | 'locked';
+
+export const COOLING_PERIOD_MS = 400;
+
+interface FooterHoverContextValue {
+  hoverState: FooterHoverState;
+  setButtonAreaHovered: (hovered: boolean) => void;
+  setFooterHovered: (hovered: boolean) => void;
+}
+
+const FooterHoverContext = createContext<FooterHoverContextValue>({
+  hoverState: 'off',
+  setButtonAreaHovered: () => {},
+  setFooterHovered: () => {},
+});
+
+export function useFooterHover(): FooterHoverContextValue {
+  return useContext(FooterHoverContext);
+}
+
+type InternalState = 'off' | 'active' | 'locked' | 'cooling';
+
+type HoverAction =
+  | 'button-enter'
+  | 'button-leave'
+  | 'cooling-expired'
+  | 'footer-enter'
+  | 'footer-leave';
+
+interface HoverInternalState {
+  footerHovered: boolean;
+  state: InternalState;
+}
+
+function hoverReducer(prev: HoverInternalState, action: HoverAction): HoverInternalState {
+  switch (action) {
+    case 'button-enter':
+      return {
+        ...prev,
+        state:
+          prev.state === 'active' || prev.state === 'cooling' ? 'locked' : prev.state,
+      };
+
+    case 'button-leave':
+      return prev.state === 'locked'
+        ? {...prev, state: prev.footerHovered ? 'active' : 'off'}
+        : prev;
+
+    case 'cooling-expired':
+      return prev.state === 'cooling' ? {...prev, state: 'off'} : prev;
+
+    case 'footer-enter':
+      return {
+        footerHovered: true,
+        state: prev.state === 'off' || prev.state === 'cooling' ? 'active' : prev.state,
+      };
+
+    case 'footer-leave':
+      return {
+        footerHovered: false,
+        state: prev.state === 'active' ? 'cooling' : prev.state,
+      };
+  }
+}
+
+export function FooterHoverProvider({children}: {children: React.ReactNode}) {
+  const [internal, dispatch] = useReducer(hoverReducer, {
+    footerHovered: false,
+    state: 'off',
+  });
+
+  useEffect(() => {
+    if (internal.state !== 'cooling') {
+      return undefined;
+    }
+    const timer = setTimeout(() => dispatch('cooling-expired'), COOLING_PERIOD_MS);
+    return () => clearTimeout(timer);
+  }, [internal.state]);
+
+  const value = useMemo(
+    () => ({
+      hoverState: internal.state === 'cooling' ? 'active' : internal.state,
+      setFooterHovered: (hovered: boolean) =>
+        dispatch(hovered ? 'footer-enter' : 'footer-leave'),
+      setButtonAreaHovered: (hovered: boolean) =>
+        dispatch(hovered ? 'button-enter' : 'button-leave'),
+    }),
+    [internal.state]
+  );
+
+  return (
+    <FooterHoverContext.Provider value={value}>{children}</FooterHoverContext.Provider>
+  );
+}

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -10,6 +10,7 @@ import {fetchGuides} from 'sentry/actionCreators/guides';
 import {fetchOrganizations} from 'sentry/actionCreators/organizations';
 import {initApiClientErrorHandling} from 'sentry/api';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import {FooterHoverProvider} from 'sentry/components/footerHoverContext';
 import {GlobalModal} from 'sentry/components/globalModal';
 import Hook from 'sentry/components/hook';
 import Indicators from 'sentry/components/indicators';
@@ -241,12 +242,14 @@ export function App() {
                 <GlobalFeedbackForm>
                   <MainContainer tabIndex={-1}>
                     <DemoToursProvider>
-                      <ExplorerPanelProvider>
-                        <GlobalModal />
-                        <ExplorerPanel />
-                        <Indicators className="indicators-container" />
-                        <ErrorBoundary>{renderBody()}</ErrorBoundary>
-                      </ExplorerPanelProvider>
+                      <FooterHoverProvider>
+                        <ExplorerPanelProvider>
+                          <GlobalModal />
+                          <ExplorerPanel />
+                          <Indicators className="indicators-container" />
+                          <ErrorBoundary>{renderBody()}</ErrorBoundary>
+                        </ExplorerPanelProvider>
+                      </FooterHoverProvider>
                     </DemoToursProvider>
                   </MainContainer>
                 </GlobalFeedbackForm>

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -827,7 +827,14 @@ function SeerFloatingActionButton(props: SeerFloatingActionButtonProps) {
           onMouseEnter={() => setButtonAreaHovered(true)}
           onMouseLeave={() => setButtonAreaHovered(false)}
         >
-          <ButtonHoverCatch />
+          <Container
+            position="absolute"
+            left={`-${theme.space.md}`}
+            right={`-${theme.space.xl}`}
+            top={`-${theme.space.xl}`}
+            bottom="0"
+            pointerEvents="auto"
+          />
           <SeerButton
             initial={{opacity: 0, scale: 0.9, y: 20}}
             animate={{opacity: 1, scale: 1, y: 0}}
@@ -847,20 +854,6 @@ function SeerFloatingActionButton(props: SeerFloatingActionButtonProps) {
     </AnimatePresence>
   );
 }
-
-/**
- * Invisible area above the button that blocks footer hover events when the
- * mouse approaches from above. Only extends upward so it doesn't overlap
- * the footer below and block clicks on footer links.
- */
-const ButtonHoverCatch = styled('div')`
-  position: absolute;
-  left: -${p => p.theme.space.md};
-  right: -${p => p.theme.space.xl};
-  top: -${p => p.theme.space.xl};
-  bottom: 0;
-  pointer-events: auto;
-`;
 
 const SeerButton = styled(MotionButton)`
   position: relative;

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -11,6 +11,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {useFooterHover} from 'sentry/components/footerHoverContext';
 import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {User} from 'sentry/types/user';
@@ -809,16 +810,24 @@ interface SeerFloatingActionButtonProps extends React.ComponentProps<
 function SeerFloatingActionButton(props: SeerFloatingActionButtonProps) {
   const {visible, ...rest} = props;
   const theme = useTheme();
+  const {hoverState, setButtonAreaHovered} = useFooterHover();
+  const isShifted = hoverState !== 'off';
 
   return (
     <AnimatePresence>
       {visible && (
         <Container
           position="fixed"
-          bottom={theme.space.lg}
+          bottom={isShifted ? '4rem' : theme.space.lg}
           right={theme.space.lg}
-          style={{zIndex: theme.zIndex.sidebarPanel}}
+          style={{
+            zIndex: theme.zIndex.sidebarPanel,
+            transition: 'bottom 0.2s ease-in-out',
+          }}
+          onMouseEnter={() => setButtonAreaHovered(true)}
+          onMouseLeave={() => setButtonAreaHovered(false)}
         >
+          <ButtonHoverCatch />
           <SeerButton
             initial={{opacity: 0, scale: 0.9, y: 20}}
             animate={{opacity: 1, scale: 1, y: 0}}
@@ -839,7 +848,22 @@ function SeerFloatingActionButton(props: SeerFloatingActionButtonProps) {
   );
 }
 
+/**
+ * Invisible area above the button that blocks footer hover events when the
+ * mouse approaches from above. Only extends upward so it doesn't overlap
+ * the footer below and block clicks on footer links.
+ */
+const ButtonHoverCatch = styled('div')`
+  position: absolute;
+  left: -${p => p.theme.space.md};
+  right: -${p => p.theme.space.xl};
+  top: -${p => p.theme.space.xl};
+  bottom: 0;
+  pointer-events: auto;
+`;
+
 const SeerButton = styled(MotionButton)`
+  position: relative;
   & > span:last-child {
     overflow: visible;
   }


### PR DESCRIPTION
Add a `FooterHoverContext` so the "Ask Seer" floating action button shifts upward when the user hovers over the page footer, preventing it from obscuring footer links. It also keeps track of whether the button (or area behind it) is being hovered already so that it doesn't snap back down when you try to hover it while it's raised.

The context follows the same pattern as `SecondaryNavigationContext` — a provider placed high in the React tree (in `app/index.tsx`), with the footer calling `setIsFooterHovered` on mouse enter/leave and the Seer button consuming `isFooterHovered` to adjust its `bottom` position with a smooth CSS transition.

https://github.com/user-attachments/assets/6c98dd7c-8ef1-42b7-a9cc-f7ea19e96be8

Fixes [EXP-862](https://linear.app/getsentry/issue/EXP-862/shift-seer-floating-button-up-on-footer-hover)