### PR TITLE
ref(issue-alerts): Add 'attribute' and 'tag' words to Issue Alerts UI

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -458,7 +458,7 @@ A list of filters that determine if a rule fires after the necessary conditions 
 }
 ```
 
-**The event's `attribute` value `match` `value`**
+**The event's `attribute` attribute `match` `value`**
 - `attribute` - Valid values are `message`, `platform`, `environment`, `type`, `error.handled`, `error.unhandled`, `error.main_thread`, `exception.type`, `exception.value`, `user.id`, `user.email`, `user.username`, `user.ip_address`, `http.method`, `http.url`, `http.status_code`, `sdk.name`, `stacktrace.code`, `stacktrace.module`, `stacktrace.filename`, `stacktrace.abs_path`, `stacktrace.package`, `unreal.crash_type`, `app.in_foreground`.
 - `match` - The comparison operator. Valid values are `eq` (equals), `ne` (does not equal), `sw` (starts with), `ew` (ends with), `co` (contains), `nc` (does not contain), `is` (is set), and `ns` (is not set).
 - `value` - A string. Not required when `match` is `is` or `ns`.
@@ -471,7 +471,7 @@ A list of filters that determine if a rule fires after the necessary conditions 
 }
 ```
 
-**The event's tags match `key` `match` `value`**
+**The event's `key` tag `match` `value`**
 - `key` - The tag
 - `match` - The comparison operator. Valid values are `eq` (equals), `ne` (does not equal), `sw` (starts with), `ew` (ends with), `co` (contains), `nc` (does not contain), `is` (is set), and `ns` (is not set).
 - `value` - A string. Not required when `match` is `is` or `ns`.

--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -94,7 +94,7 @@ class EventAttributeCondition(EventCondition):
     """
 
     id = "sentry.rules.conditions.event_attribute.EventAttributeCondition"
-    label = "The event's {attribute} value {match} {value}"
+    label = "The event's {attribute} attribute {match} {value}"
 
     form_fields = {
         "attribute": {

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -36,7 +36,7 @@ class TaggedEventForm(forms.Form):
 
 class TaggedEventCondition(EventCondition):
     id = "sentry.rules.conditions.tagged_event.TaggedEventCondition"
-    label = "The event's tags match {key} {match} {value}"
+    label = "The event's {key} tag {match} {value}"
 
     form_fields = {
         "key": {"type": "string", "placeholder": "key"},

--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -289,7 +289,7 @@ ACTION_FILTERS_HELP_TEXT = """The filters to run before the action will fire and
         ```
 
         **Event Attribute**
-        The event's `attribute` value `match` `value`
+        The event's `attribute` attribute `match` `value`
 
         - `attribute`: The event attribute to match on. Valid values are: `message`, `platform`, `environment`, `type`, `error.handled`, `error.unhandled`, `error.main_thread`, `exception.type`, `exception.value`, `user.id`, `user.email`, `user.username`, `user.ip_address`, `http.method`, `http.url`, `http.status_code`, `sdk.name`, `stacktrace.code`, `stacktrace.module`, `stacktrace.filename`, `stacktrace.abs_path`, `stacktrace.package`, `unreal.crash_type`, `app.in_foreground`.
         - `match`: The comparison operator
@@ -316,7 +316,7 @@ ACTION_FILTERS_HELP_TEXT = """The filters to run before the action will fire and
         ```
 
         **Tagged Event**
-        The event's tags `key` match `value`
+        The event's `key` tag `match` `value`
         - `key`: The tag value
         - `match`: The comparison operator
             - `co`: Contains

--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -15,7 +15,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class EventAttributeConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
-    label_template = "The event's {attribute} value {match} {value}"
+    label_template = "The event's {attribute} attribute {match} {value}"
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -15,7 +15,7 @@ logger = log_context.get_logger(__name__)
 class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
-    label_template = "The event's tags match {key} {match} {value}"
+    label_template = "The event's {key} tag {match} {value}"
 
     comparison_json_schema = {
         "type": "object",

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -362,7 +362,7 @@ describe('ProjectAlertsCreate', () => {
 
         // Add another condition
         await selectEvent.select(screen.getByText('Add optional filter...'), [
-          "The event's tags match {key} {match} {value}",
+          "The event's {key} tag {match} {value}",
         ]);
         // Edit new Condition
         await userEvent.click(screen.getByPlaceholderText('key'));

--- a/static/app/views/automations/components/actionFilters/eventAttribute.tsx
+++ b/static/app/views/automations/components/actionFilters/eventAttribute.tsx
@@ -13,7 +13,7 @@ import type {ValidateDataConditionProps} from 'sentry/views/automations/componen
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
 export function EventAttributeDetails({condition}: {condition: DataCondition}) {
-  return tct("The event's [attribute] [match] [value]", {
+  return tct("The event's [attribute] attribute [match] [value]", {
     attribute: condition.comparison.attribute,
     match:
       MATCH_CHOICES.find(choice => choice.value === condition.comparison.match)?.label ||
@@ -23,7 +23,7 @@ export function EventAttributeDetails({condition}: {condition: DataCondition}) {
 }
 
 export function EventAttributeNode() {
-  return tct("The event's [attribute] [match] [value]", {
+  return tct("The event's [attribute] attribute [match] [value]", {
     attribute: <AttributeField />,
     match: <MatchField />,
     value: <ValueField />,

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -28,7 +28,7 @@ export function TaggedEventDetails({condition}: {condition: DataCondition}) {
 }
 
 export function TaggedEventNode() {
-  return tct("The event's [key] [match] [value]", {
+  return tct("The event's [key] tag [match] [value]", {
     key: <KeyField />,
     match: <MatchField />,
     value: <ValueField />,

--- a/tests/sentry/rules/conditions/test_tagged_event.py
+++ b/tests/sentry/rules/conditions/test_tagged_event.py
@@ -22,7 +22,7 @@ class TaggedEventConditionTest(RuleTestCase):
 
     def test_render_label(self) -> None:
         rule = self.get_rule(data={"match": MatchType.EQUAL, "key": "\xc3", "value": "\xc4"})
-        assert rule.render_label() == "The event's tags match \xc3 equals \xc4"
+        assert rule.render_label() == "The event's \xc3 tag equals \xc4"
 
     def test_equals(self) -> None:
         event = self.get_event()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR improves the clarity of the Issue Alerts UI by adding the words "attribute" and "tag" to the condition labels, making it clearer what type of condition is being configured.

### Changes

**Before:**
- Event attribute: "The event's {attribute} value {match} {value}"
- Tagged event: "The event's tags match {key} {match} {value}"

**After:**
- Event attribute: "The event's {attribute} **attribute** {match} {value}"
- Tagged event: "The event's {key} **tag** {match} {value}"

### Files Modified

**Backend:**
- `src/sentry/rules/conditions/event_attribute.py` - Updated label template
- `src/sentry/rules/conditions/tagged_event.py` - Updated label template
- `src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py` - Updated label template
- `src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py` - Updated label template
- `src/sentry/api/endpoints/project_rules.py` - Updated API documentation
- `src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py` - Updated API docs

**Frontend:**
- `static/app/views/automations/components/actionFilters/eventAttribute.tsx` - Updated UI labels
- `static/app/views/automations/components/actionFilters/taggedEvent.tsx` - Updated UI labels

**Tests:**
- `tests/sentry/rules/conditions/test_tagged_event.py` - Updated test assertion
- `static/app/views/alerts/create.spec.tsx` - Updated test selector

## Motivation

Based on user feedback from the #all-user-feedback Slack channel, the alert builder UI was confusing when configuring event attributes and tag-based conditions. Adding these clarifying words makes it immediately clear what type of condition is being configured.

## Testing

- All existing tests have been updated to match the new labels
- Pre-commit hooks passed successfully
- Tests will run in CI to verify functionality

## Screenshots

The changes affect both the classic Issue Alerts UI and the new Automations UI:

**Classic Issue Alerts:**
- Condition dropdown will now show "The event's {attribute} attribute {match} {value}"
- Filter dropdown will now show "The event's {key} tag {match} {value}"

**Automations UI:**
- Event attribute conditions will display "The event's [attribute] attribute [match] [value]"
- Tagged event conditions will display "The event's [key] tag [match] [value]"
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C07525G48Q1/p1774968644112159?thread_ts=1774968644.112159&cid=C07525G48Q1)

<div><a href="https://cursor.com/agents/bc-24ac4d95-369d-5cc7-a74d-dfbce65ad37c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24ac4d95-369d-5cc7-a74d-dfbce65ad37c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

