### PR TITLE
feat(admin): Add gsAdmin action to adjust dashboard parallel query limit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -759,6 +759,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 
 ## gsAdmin
 # /static/gsAdmin/*                          unowned
+/static/gsAdmin/components/changeDashboardsParallelLimitModal.tsx  @getsentry/data-browsing
 /static/gsAdmin/components/forkCustomer.tsx  @getsentry/hybrid-cloud
 /static/gsAdmin/components/relocation*       @getsentry/hybrid-cloud
 /static/gsAdmin/views/relocation*            @getsentry/hybrid-cloud

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -99,6 +99,7 @@ export interface Organization extends OrganizationSummary {
   teamRoleList: TeamRole[];
   trustedRelays: Relay[];
   consoleSdkInviteQuota?: number;
+  dashboardsAsyncQueueParallelLimit?: number;
   defaultAutofixAutomationTuning?:
     | 'off'
     | 'super_low'

--- a/static/gsAdmin/components/changeDashboardsParallelLimitModal.tsx
+++ b/static/gsAdmin/components/changeDashboardsParallelLimitModal.tsx
@@ -1,0 +1,103 @@
+import {useState} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {openModal} from 'sentry/actionCreators/modal';
+import {InputField} from 'sentry/components/forms/fields/inputField';
+import type {Organization} from 'sentry/types/organization';
+import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+
+const DEFAULT_PARALLEL_LIMIT = 20;
+
+interface ChangeDashboardsParallelLimitModalProps extends ModalRenderProps {
+  onSuccess: () => void;
+  organization: Organization;
+}
+
+function ChangeDashboardsParallelLimitModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  organization,
+  onSuccess,
+}: ChangeDashboardsParallelLimitModalProps) {
+  const currentLimit =
+    organization.dashboardsAsyncQueueParallelLimit ?? DEFAULT_PARALLEL_LIMIT;
+  const [limit, setLimit] = useState<number>(currentLimit);
+
+  const {isPending, mutate} = useMutation({
+    mutationFn: (newLimit: number) =>
+      fetchMutation({
+        method: 'PUT',
+        url: `/organizations/${organization.slug}/`,
+        data: {dashboardsAsyncQueueParallelLimit: newLimit},
+      }),
+    onMutate: () => addLoadingMessage('Saving changes\u2026'),
+    onSuccess: () => {
+      addSuccessMessage('Dashboard parallel query limit updated.');
+      onSuccess();
+      closeModal();
+    },
+    onError: () => {
+      addErrorMessage('Failed to update dashboard parallel query limit.');
+    },
+  });
+
+  return (
+    <div>
+      <Header closeButton>
+        <h4>Change Dashboard Parallel Query Limit</h4>
+      </Header>
+      <Body>
+        <p>
+          Controls how many dashboard widget queries can run in parallel. Current value:{' '}
+          <strong>{currentLimit}</strong>.
+        </p>
+        <InputField
+          name="dashboardsAsyncQueueParallelLimit"
+          label="Parallel Limit"
+          type="number"
+          min={1}
+          inline={false}
+          stacked
+          flexibleControlStateSize
+          value={limit}
+          onChange={(val: any) => setLimit(Number(val))}
+        />
+      </Body>
+      <Footer>
+        <Button onClick={closeModal}>Cancel</Button>
+        <Button
+          priority="primary"
+          disabled={isPending || limit < 1}
+          onClick={() => mutate(limit)}
+        >
+          Save
+        </Button>
+      </Footer>
+    </div>
+  );
+}
+
+export function openChangeDashboardsParallelLimitModal({
+  organization,
+  onSuccess,
+}: {
+  onSuccess: () => void;
+  organization: Organization;
+}) {
+  openModal(modalProps => (
+    <ChangeDashboardsParallelLimitModal
+      {...modalProps}
+      organization={organization}
+      onSuccess={onSuccess}
+    />
+  ));
+}

--- a/static/gsAdmin/components/changeDashboardsParallelLimitModal.tsx
+++ b/static/gsAdmin/components/changeDashboardsParallelLimitModal.tsx
@@ -1,19 +1,24 @@
-import {useState} from 'react';
+import {Fragment} from 'react';
 
-import {Button} from '@sentry/scraps/button';
+import {Heading, Text} from '@sentry/scraps/text';
 
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  addSuccessMessage,
-} from 'sentry/actionCreators/indicator';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
-import {InputField} from 'sentry/components/forms/fields/inputField';
+import {NumberField} from 'sentry/components/forms/fields/numberField';
+import {Form, type FormProps} from 'sentry/components/forms/form';
 import type {Organization} from 'sentry/types/organization';
 import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+import type {RequestError} from 'sentry/utils/requestError/requestError';
 
 const DEFAULT_PARALLEL_LIMIT = 20;
+
+type OnSubmitArgs = Parameters<NonNullable<FormProps['onSubmit']>>;
+interface MutationVariables {
+  limit: number;
+  onSubmitError: OnSubmitArgs[2];
+  onSubmitSuccess: OnSubmitArgs[1];
+}
 
 interface ChangeDashboardsParallelLimitModalProps extends ModalRenderProps {
   onSuccess: () => void;
@@ -23,66 +28,81 @@ interface ChangeDashboardsParallelLimitModalProps extends ModalRenderProps {
 function ChangeDashboardsParallelLimitModal({
   Header,
   Body,
-  Footer,
   closeModal,
   organization,
   onSuccess,
 }: ChangeDashboardsParallelLimitModalProps) {
   const currentLimit =
     organization.dashboardsAsyncQueueParallelLimit ?? DEFAULT_PARALLEL_LIMIT;
-  const [limit, setLimit] = useState<number>(currentLimit);
 
-  const {isPending, mutate} = useMutation({
-    mutationFn: (newLimit: number) =>
+  const {mutate, isPending} = useMutation<
+    Record<string, any>,
+    RequestError,
+    MutationVariables
+  >({
+    mutationFn: ({limit}) =>
       fetchMutation({
         method: 'PUT',
         url: `/organizations/${organization.slug}/`,
-        data: {dashboardsAsyncQueueParallelLimit: newLimit},
+        data: {dashboardsAsyncQueueParallelLimit: limit},
       }),
-    onMutate: () => addLoadingMessage('Saving changes\u2026'),
-    onSuccess: () => {
+    onSuccess: (response, {onSubmitSuccess}) => {
+      onSubmitSuccess?.(response);
       addSuccessMessage('Dashboard parallel query limit updated.');
       onSuccess();
       closeModal();
     },
-    onError: () => {
+    onError: (error, {onSubmitError}) => {
+      onSubmitError?.({responseJSON: error?.responseJSON});
       addErrorMessage('Failed to update dashboard parallel query limit.');
     },
   });
 
+  const onSubmit: NonNullable<FormProps['onSubmit']> = (
+    data,
+    onSubmitSuccess,
+    onSubmitError
+  ) => {
+    const limit = Number(data.dashboardsAsyncQueueParallelLimit);
+
+    if (!limit || limit < 1 || isPending) {
+      return;
+    }
+
+    mutate({limit, onSubmitSuccess, onSubmitError});
+  };
+
   return (
-    <div>
-      <Header closeButton>
-        <h4>Change Dashboard Parallel Query Limit</h4>
+    <Fragment>
+      <Header>
+        <Heading as="h2">Change Dashboard Parallel Query Limit</Heading>
       </Header>
       <Body>
         <p>
-          Controls how many dashboard widget queries can run in parallel. Current value:{' '}
-          <strong>{currentLimit}</strong>.
+          <Text bold>Current value: </Text>
+          {currentLimit}
         </p>
-        <InputField
-          name="dashboardsAsyncQueueParallelLimit"
-          label="Parallel Limit"
-          type="number"
-          min={1}
-          inline={false}
-          stacked
-          flexibleControlStateSize
-          value={limit}
-          onChange={(val: any) => setLimit(Number(val))}
-        />
-      </Body>
-      <Footer>
-        <Button onClick={closeModal}>Cancel</Button>
-        <Button
-          priority="primary"
-          disabled={isPending || limit < 1}
-          onClick={() => mutate(limit)}
+        <Form
+          onSubmit={onSubmit}
+          onCancel={closeModal}
+          submitLabel={isPending ? 'Submitting...' : 'Save'}
+          submitDisabled={isPending}
+          cancelLabel="Cancel"
+          footerClass="modal-footer"
         >
-          Save
-        </Button>
-      </Footer>
-    </div>
+          <NumberField
+            label="Parallel Limit"
+            name="dashboardsAsyncQueueParallelLimit"
+            help="Controls how many dashboard widget queries can run in parallel."
+            defaultValue={currentLimit}
+            min={1}
+            disabled={isPending}
+            inline={false}
+            stacked
+          />
+        </Form>
+      </Body>
+    </Fragment>
   );
 }
 

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -40,6 +40,7 @@ import {AddGiftEventsAction} from 'admin/components/addGiftEventsAction';
 import {triggerAddToStartupProgramModal} from 'admin/components/addToStartupProgramAction';
 import {CancelSubscriptionAction} from 'admin/components/cancelSubscriptionAction';
 import {triggerChangeBalanceModal} from 'admin/components/changeBalanceAction';
+import {openChangeDashboardsParallelLimitModal} from 'admin/components/changeDashboardsParallelLimitModal';
 import {triggerChangeDatesModal} from 'admin/components/changeDatesAction';
 import {triggerGoogleDomainModal} from 'admin/components/changeGoogleDomainAction';
 import {triggerChangePlanAction} from 'admin/components/changePlanAction';
@@ -868,6 +869,18 @@ export function CustomerDetails() {
               openUpdateRetentionSettingsModal({
                 organization,
                 subscription,
+                onSuccess: reloadData,
+              });
+            },
+          },
+          {
+            key: 'changeDashboardsParallelLimit',
+            name: 'Change Dashboard Parallel Query Limit',
+            help: 'Adjust how many dashboard widget queries can run in parallel for this organization.',
+            skipConfirmModal: true,
+            onAction: () => {
+              openChangeDashboardsParallelLimitModal({
+                organization,
                 onSuccess: reloadData,
               });
             },


### PR DESCRIPTION
Add a modal in the `/_admin/` customer details page that allows staff to
change the `dashboardsAsyncQueueParallelLimit` org option, which controls
how many dashboard widget queries can run in parallel per org.

This option was previously only settable via the API directly
(`PUT /api/0/organizations/{org}/`). The new action appears in the admin
customer details actions dropdown alongside existing options like
"Toggle Console Platforms" and "Update Retentions".
<img width="363" height="585" alt="image" src="https://github.com/user-attachments/assets/fea7a42d-17d8-416e-bf96-48bf9f420525" />

<img width="854" height="607" alt="image" src="https://github.com/user-attachments/assets/3ce6e3b8-838d-4994-9a56-033350158218" />
