### PR TITLE
fix(copilot): Update models for GitHub Copilot Tasks API field migrations

### DIFF
--- a/src/sentry/integrations/github_copilot/client.py
+++ b/src/sentry/integrations/github_copilot/client.py
@@ -8,7 +8,6 @@ from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.github_copilot.models import (
     GithubCopilotTask,
     GithubCopilotTaskRequest,
-    GithubCopilotTaskResponse,
     GithubPRFromGraphQL,
 )
 from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentState, CodingAgentStatus
@@ -98,11 +97,7 @@ class GithubCopilotAgentClient(CodingAgentClient):
             },
         )
 
-        response_json = api_response.json
-        if isinstance(response_json, dict) and "task" in response_json:
-            task = GithubCopilotTaskResponse.validate(response_json).task
-        else:
-            task = GithubCopilotTask.validate(response_json)
+        task = GithubCopilotTask.validate(api_response.json)
 
         agent_id = self.encode_agent_id(owner, repo, task.id)
 

--- a/src/sentry/integrations/github_copilot/models.py
+++ b/src/sentry/integrations/github_copilot/models.py
@@ -91,7 +91,6 @@ class GithubCopilotTask(BaseModel):
     user_collaborators: list[Any] | None = None
     agent_collaborators: list[GithubCopilotAgentCollaborator] | None = None
     repository: GithubCopilotRepository | None = None
-    status: str | None = None  # deprecated, use state
     state: str | None = None  # queued, in_progress, completed, failed, timed_out
     session_count: int | None = None
     artifacts: list[GithubCopilotArtifact] | None = None

--- a/src/sentry/integrations/github_copilot/models.py
+++ b/src/sentry/integrations/github_copilot/models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel
 
 
@@ -12,6 +14,18 @@ class GithubCopilotTaskRequest(BaseModel):
     create_pull_request: bool = True
     base_ref: str | None = None
     event_type: str = "sentry"
+
+
+class GithubCopilotUser(BaseModel):
+    """Lightweight user/owner reference returned by the GitHub Copilot API."""
+
+    id: int
+
+
+class GithubCopilotRepository(BaseModel):
+    """Repository reference returned by the GitHub Copilot API."""
+
+    id: int
 
 
 class GithubCopilotArtifactData(BaseModel):
@@ -39,13 +53,14 @@ class GithubCopilotSession(BaseModel):
     id: str
     name: str | None = None
     state: str | None = None  # queued, in_progress, completed, failed, timed_out
-    user_id: int | None = None
+    user: GithubCopilotUser | None = None
+    owner: GithubCopilotUser | None = None
     agent_id: int | None = None
     agent_type: str | None = None
     resource_type: str | None = None
     resource_id: int | None = None
     resource_global_id: str | None = None
-    last_updated_at: str | None = None
+    updated_at: str | None = None
     created_at: str | None = None
     completed_at: str | None = None
     event_type: str | None = None
@@ -60,6 +75,7 @@ class GithubCopilotAgentCollaborator(BaseModel):
     agent_type: str | None = None
     agent_id: int | None = None
     agent_task_id: str | None = None
+    slug: str | None = None
 
 
 class GithubCopilotTask(BaseModel):
@@ -67,25 +83,30 @@ class GithubCopilotTask(BaseModel):
 
     id: str
     name: str | None = None
-    creator_id: int | None = None
-    user_collaborators: list[int] | None = None
+    # creator/owner changed from int IDs to objects: {"id": int}
+    creator: GithubCopilotUser | None = None
+    owner: GithubCopilotUser | None = None
+    # user_collaborators is transitioning from list[int] to list[User objects].
+    # Use list[Any] to accept both during the migration.
+    user_collaborators: list[Any] | None = None
     agent_collaborators: list[GithubCopilotAgentCollaborator] | None = None
-    owner_id: int | None = None
-    repo_id: int | None = None
-    status: str | None = None
+    repository: GithubCopilotRepository | None = None
+    status: str | None = None  # deprecated, use state
     state: str | None = None  # queued, in_progress, completed, failed, timed_out
     session_count: int | None = None
     artifacts: list[GithubCopilotArtifact] | None = None
     archived_at: str | None = None
-    last_updated_at: str | None = None
+    updated_at: str | None = None
     created_at: str | None = None
     sessions: list[GithubCopilotSession] | None = None
+    html_url: str | None = None
+    url: str | None = None
 
 
 class GithubCopilotTaskResponse(BaseModel):
     """
     Response from GitHub Copilot Tasks API.
-    The API wraps the task object in a {"task": {...}} envelope.
+    The API may wrap the task object in a {"task": {...}} envelope.
     """
 
     task: GithubCopilotTask

--- a/src/sentry/integrations/github_copilot/models.py
+++ b/src/sentry/integrations/github_copilot/models.py
@@ -102,15 +102,6 @@ class GithubCopilotTask(BaseModel):
     url: str | None = None
 
 
-class GithubCopilotTaskResponse(BaseModel):
-    """
-    Response from GitHub Copilot Tasks API.
-    The API may wrap the task object in a {"task": {...}} envelope.
-    """
-
-    task: GithubCopilotTask
-
-
 class GithubPRFromGraphQL(BaseModel):
     """PR info fetched from GitHub GraphQL API"""
 

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -121,6 +121,7 @@ class GithubCopilotAgentClientTest(TestCase):
         mock_response = Mock()
         mock_response.json = {
             "id": "task-123",
+            "state": "in_progress",
             "status": "in_progress",
             "created_at": "2024-06-01T12:00:00Z",
         }
@@ -143,6 +144,7 @@ class GithubCopilotAgentClientTest(TestCase):
         mock_response = Mock()
         mock_response.json = {
             "id": "task-456",
+            "state": "in_progress",
             "status": "in_progress",
         }
         mock_response.status_code = 200
@@ -166,6 +168,7 @@ class GithubCopilotAgentClientTest(TestCase):
         mock_response.json = {
             "task": {
                 "id": "task-789",
+                "state": "in_progress",
                 "status": "in_progress",
                 "created_at": "2024-06-01T12:00:00Z",
             }

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -160,29 +160,6 @@ class GithubCopilotAgentClientTest(TestCase):
         assert before <= result.started_at <= after
 
     @patch.object(GithubCopilotAgentClient, "post")
-    def test_launch_with_legacy_task_envelope(self, mock_post: Mock) -> None:
-        """Test launch handles the legacy {"task": {...}} response envelope"""
-        mock_response = Mock()
-        mock_response.json = {
-            "task": {
-                "id": "task-789",
-                "state": "in_progress",
-                "status": "in_progress",
-                "created_at": "2024-06-01T12:00:00Z",
-            }
-        }
-        mock_response.status_code = 200
-        mock_post.return_value = mock_response
-
-        result = self.copilot_client.launch(
-            webhook_url="https://example.com/webhook",
-            request=self._make_launch_request(),
-        )
-
-        assert result.id == "getsentry:sentry:task-789"
-        assert result.status == CodingAgentStatus.RUNNING
-
-    @patch.object(GithubCopilotAgentClient, "post")
     def test_get_pr_from_graphql_success(self, mock_post: Mock) -> None:
         """Test that get_pr_from_graphql correctly fetches PR info"""
         mock_response = Mock()

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -122,7 +122,6 @@ class GithubCopilotAgentClientTest(TestCase):
         mock_response.json = {
             "id": "task-123",
             "state": "in_progress",
-            "status": "in_progress",
             "created_at": "2024-06-01T12:00:00Z",
         }
         mock_response.status_code = 200
@@ -145,7 +144,6 @@ class GithubCopilotAgentClientTest(TestCase):
         mock_response.json = {
             "id": "task-456",
             "state": "in_progress",
-            "status": "in_progress",
         }
         mock_response.status_code = 200
         mock_post.return_value = mock_response


### PR DESCRIPTION
## Summary
- Update `GithubCopilotTask`, `GithubCopilotSession`, and related models to match the current live GitHub Copilot Tasks API response shape
- `creator_id`/`owner_id` (int) → `creator`/`owner` (object with `id` field)
- `last_updated_at` → `updated_at`
- `user_collaborators` changed from `list[int]` to `list[Any]` to handle the upcoming migration from int IDs to User objects
- Added new fields: `repository`, `html_url`, `url`, `slug` on collaborators
- Removed deprecated `status` field from `GithubCopilotTask` — our code only reads `state`
- Removed legacy `{"task": {...}}` response envelope handling and `GithubCopilotTaskResponse` model — the API returns task objects directly now

**Context:** GitHub is rolling out breaking changes to their Copilot Tasks API. We verified the current API state by testing against a live repo — `last_updated_at`, `creator_id`, `owner_id`, and the `{"task": ...}` envelope are already gone. `status` is still present alongside `state` but deprecated. `user_collaborators` type change (int → object) is coming soon.

Our polling flow (`poll_github_copilot_agents`) only reads `task.state` and `task.artifacts`, so it's unaffected. These changes prevent Pydantic validation failures when parsing API responses with the new field shapes.

## Test plan
- [x] All existing tests pass (54 tests across `test_client.py` + `test_coding_agent.py`)
- [x] Verified against live GitHub Copilot API