### PR TITLE
fix(github): Add accessibleOnly param to scope repo search to installation repos

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_repos.py
@@ -71,18 +71,7 @@ class OrganizationIntegrationReposEndpoint(CellOrganizationIntegrationBaseEndpoi
             accessible_only = request.GET.get("accessibleOnly", "false").lower() == "true"
 
             try:
-                if accessible_only and search:
-                    # Fetch all installation-accessible repos and filter locally by
-                    # identifier only. Unlike the provider search API, this won't
-                    # match on name/description — but identifiers already contain the
-                    # repo name (e.g. "org/repo-name"), so this covers typical searches.
-                    repositories = install.get_repositories()
-                    search_lower = search.lower()
-                    repositories = [
-                        r for r in repositories if search_lower in str(r["identifier"]).lower()
-                    ]
-                else:
-                    repositories = install.get_repositories(search)
+                repositories = install.get_repositories(search, accessible_only=accessible_only)
             except (IntegrationError, IdentityNotValid) as e:
                 return self.respond({"detail": str(e)}, status=400)
 

--- a/src/sentry/integrations/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_repos.py
@@ -49,6 +49,10 @@ class OrganizationIntegrationReposEndpoint(CellOrganizationIntegrationBaseEndpoi
         :qparam string search: Name fragment to search repositories by.
         :qparam bool installableOnly: If true, return only repositories that can be installed.
                                       If false or not provided, return all repositories.
+        :qparam bool accessibleOnly: If true, only return repositories that the integration
+                                     installation has access to, filtering locally instead of
+                                     using the provider's search API which may return results
+                                     beyond the installation's scope.
         """
         integration = self.get_integration(organization.id, integration_id)
 
@@ -63,8 +67,18 @@ class OrganizationIntegrationReposEndpoint(CellOrganizationIntegrationBaseEndpoi
         install = integration.get_installation(organization_id=organization.id)
 
         if isinstance(install, RepositoryIntegration):
+            search = request.GET.get("search")
+            accessible_only = request.GET.get("accessibleOnly", "false").lower() == "true"
+
             try:
-                repositories = install.get_repositories(request.GET.get("search"))
+                if accessible_only and search:
+                    repositories = install.get_repositories()
+                    search_lower = search.lower()
+                    repositories = [
+                        r for r in repositories if search_lower in str(r["identifier"]).lower()
+                    ]
+                else:
+                    repositories = install.get_repositories(search)
             except (IntegrationError, IdentityNotValid) as e:
                 return self.respond({"detail": str(e)}, status=400)
 

--- a/src/sentry/integrations/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_repos.py
@@ -72,6 +72,10 @@ class OrganizationIntegrationReposEndpoint(CellOrganizationIntegrationBaseEndpoi
 
             try:
                 if accessible_only and search:
+                    # Fetch all installation-accessible repos and filter locally by
+                    # identifier only. Unlike the provider search API, this won't
+                    # match on name/description — but identifiers already contain the
+                    # repo name (e.g. "org/repo-name"), so this covers typical searches.
                     repositories = install.get_repositories()
                     search_lower = search.lower()
                     repositories = [

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -121,7 +121,10 @@ class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
     # RepositoryIntegration methods
 
     def get_repositories(
-        self, query: str | None = None, page_number_limit: int | None = None
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
     ) -> list[dict[str, Any]]:
         username = self.model.metadata.get("uuid", self.username)
         if not query:

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -281,7 +281,10 @@ class BitbucketServerIntegration(RepositoryIntegration):
     # RepositoryIntegration methods
 
     def get_repositories(
-        self, query: str | None = None, page_number_limit: int | None = None
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
     ) -> list[dict[str, Any]]:
         if not query:
             resp = self.get_client().get_repos()

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -147,7 +147,10 @@ class ExampleIntegration(RepositoryIntegration, SourceCodeIssueIntegration, Issu
         }
 
     def get_repositories(
-        self, query: str | None = None, page_number_limit: int | None = None
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
     ) -> list[dict[str, Any]]:
         return [{"name": "repo", "identifier": "user/repo"}]
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -310,18 +310,24 @@ class GitHubIntegration(
         return source_path
 
     def get_repositories(
-        self, query: str | None = None, page_number_limit: int | None = None
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
     ) -> list[dict[str, Any]]:
         """
         args:
         * query - a query to filter the repositories by
+        * accessible_only - when True with a query, fetch only installation-
+          accessible repos and filter locally instead of using the Search API
+          (which may return repos outside the installation's scope)
 
         This fetches all repositories accessible to the Github App
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
         """
-        if not query:
+        if not query or accessible_only:
             all_repos = self.get_client().get_repos(page_number_limit=page_number_limit)
-            return [
+            repos = [
                 {
                     "name": i["name"],
                     "identifier": i["full_name"],
@@ -330,6 +336,10 @@ class GitHubIntegration(
                 for i in all_repos
                 if not i.get("archived")
             ]
+            if query:
+                query_lower = query.lower()
+                repos = [r for r in repos if query_lower in r["identifier"].lower()]
+            return repos
 
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
         response = self.get_client().search_repositories(full_query)

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -216,7 +216,10 @@ class GitHubEnterpriseIntegration(
     # RepositoryIntegration methods
 
     def get_repositories(
-        self, query: str | None = None, page_number_limit: int | None = None
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
     ) -> list[dict[str, Any]]:
         if not query:
             all_repos = self.get_client().get_repos(page_number_limit=page_number_limit)

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -161,7 +161,10 @@ class GitlabIntegration(
         return False
 
     def get_repositories(
-        self, query: str | None = None, page_number_limit: int | None = None
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
     ) -> list[dict[str, Any]]:
         try:
             # Note: gitlab projects are the same things as repos everywhere else

--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -349,7 +349,10 @@ class PerforceIntegration(RepositoryIntegration, CommitContextIntegration):
         return url
 
     def get_repositories(
-        self, query: str | None = None, page_number_limit: int | None = None
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Get list of depots/streams from Perforce server.

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -32,7 +32,10 @@ from sentry.users.models.identity import Identity
 class BaseRepositoryIntegration(ABC):
     @abstractmethod
     def get_repositories(
-        self, query: str | None = None, page_number_limit: int | None = None
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Get a list of available repositories for an installation
@@ -50,6 +53,10 @@ class BaseRepositoryIntegration(ABC):
         IntegrationRepositoryProvider.repository_external_slug()
 
         You can use the `query` argument to filter repositories.
+        When `accessible_only` is True and a query is provided,
+        only repositories the installation has access to are
+        returned, filtering locally instead of using the provider's
+        search API.
         """
         raise NotImplementedError
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -308,7 +308,10 @@ class VstsIntegration(RepositoryIntegration, VstsIssuesSpec):
     # RepositoryIntegration methods
 
     def get_repositories(
-        self, query: str | None = None, page_number_limit: int | None = None
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
     ) -> list[dict[str, Any]]:
         try:
             repos = self.get_client().get_repos()

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -187,6 +187,90 @@ class OrganizationIntegrationReposTest(APITestCase):
             "searchable": True,
         }
 
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
+    )
+    def test_accessible_only_filters_locally(self, get_repositories: MagicMock) -> None:
+        """When accessibleOnly=true, fetches all repos without a query and filters locally."""
+        get_repositories.return_value = [
+            {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
+            {"name": "cool-repo", "identifier": "Example/cool-repo", "default_branch": "dev"},
+        ]
+        response = self.client.get(
+            self.path, format="json", data={"search": "rad", "accessibleOnly": "true"}
+        )
+
+        assert response.status_code == 200, response.content
+        # Called without a search query — filtering is done at the endpoint level
+        get_repositories.assert_called_once_with()
+        assert response.data == {
+            "repos": [
+                {
+                    "name": "rad-repo",
+                    "identifier": "Example/rad-repo",
+                    "defaultBranch": "main",
+                    "isInstalled": False,
+                },
+            ],
+            "searchable": True,
+        }
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
+    )
+    def test_accessible_only_with_integer_identifier(self, get_repositories: MagicMock) -> None:
+        """Handles non-string identifiers without crashing."""
+        get_repositories.return_value = [
+            {"name": "my-project", "identifier": 12345},
+            {"name": "other-project", "identifier": 67890},
+        ]
+        response = self.client.get(
+            self.path, format="json", data={"search": "123", "accessibleOnly": "true"}
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data == {
+            "repos": [
+                {
+                    "name": "my-project",
+                    "identifier": 12345,
+                    "defaultBranch": None,
+                    "isInstalled": False,
+                },
+            ],
+            "searchable": True,
+        }
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
+    )
+    def test_accessible_only_no_match(self, get_repositories: MagicMock) -> None:
+        """When accessibleOnly=true and the search matches nothing, returns empty list."""
+        get_repositories.return_value = [
+            {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
+            {"name": "cool-repo", "identifier": "Example/cool-repo", "default_branch": "dev"},
+        ]
+        response = self.client.get(
+            self.path, format="json", data={"search": "nonexistent", "accessibleOnly": "true"}
+        )
+
+        assert response.status_code == 200, response.content
+        get_repositories.assert_called_once_with()
+        assert response.data == {"repos": [], "searchable": True}
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
+    )
+    def test_accessible_only_without_search_passes_query(self, get_repositories: MagicMock) -> None:
+        """When accessibleOnly=true but no search, behaves normally."""
+        get_repositories.return_value = [
+            {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
+        ]
+        response = self.client.get(self.path, format="json", data={"accessibleOnly": "true"})
+
+        assert response.status_code == 200, response.content
+        get_repositories.assert_called_once_with(None)
+
     def test_no_repository_method(self) -> None:
         integration = self.create_integration(
             organization=self.org, provider="jira", name="Example", external_id="example:1"

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -190,19 +190,17 @@ class OrganizationIntegrationReposTest(APITestCase):
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
     )
-    def test_accessible_only_filters_locally(self, get_repositories: MagicMock) -> None:
-        """When accessibleOnly=true, fetches all repos without a query and filters locally."""
+    def test_accessible_only_passes_param(self, get_repositories: MagicMock) -> None:
+        """When accessibleOnly=true, passes accessible_only to get_repositories."""
         get_repositories.return_value = [
             {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
-            {"name": "cool-repo", "identifier": "Example/cool-repo", "default_branch": "dev"},
         ]
         response = self.client.get(
             self.path, format="json", data={"search": "rad", "accessibleOnly": "true"}
         )
 
         assert response.status_code == 200, response.content
-        # Called without a search query — filtering is done at the endpoint level
-        get_repositories.assert_called_once_with()
+        get_repositories.assert_called_once_with("rad", accessible_only=True)
         assert response.data == {
             "repos": [
                 {
@@ -218,58 +216,15 @@ class OrganizationIntegrationReposTest(APITestCase):
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
     )
-    def test_accessible_only_with_integer_identifier(self, get_repositories: MagicMock) -> None:
-        """Handles non-string identifiers without crashing."""
-        get_repositories.return_value = [
-            {"name": "my-project", "identifier": 12345},
-            {"name": "other-project", "identifier": 67890},
-        ]
-        response = self.client.get(
-            self.path, format="json", data={"search": "123", "accessibleOnly": "true"}
-        )
-
-        assert response.status_code == 200, response.content
-        assert response.data == {
-            "repos": [
-                {
-                    "name": "my-project",
-                    "identifier": 12345,
-                    "defaultBranch": None,
-                    "isInstalled": False,
-                },
-            ],
-            "searchable": True,
-        }
-
-    @patch(
-        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
-    )
-    def test_accessible_only_no_match(self, get_repositories: MagicMock) -> None:
-        """When accessibleOnly=true and the search matches nothing, returns empty list."""
-        get_repositories.return_value = [
-            {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
-            {"name": "cool-repo", "identifier": "Example/cool-repo", "default_branch": "dev"},
-        ]
-        response = self.client.get(
-            self.path, format="json", data={"search": "nonexistent", "accessibleOnly": "true"}
-        )
-
-        assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with()
-        assert response.data == {"repos": [], "searchable": True}
-
-    @patch(
-        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
-    )
-    def test_accessible_only_without_search_passes_query(self, get_repositories: MagicMock) -> None:
-        """When accessibleOnly=true but no search, behaves normally."""
+    def test_accessible_only_without_search(self, get_repositories: MagicMock) -> None:
+        """When accessibleOnly=true but no search, passes both params through."""
         get_repositories.return_value = [
             {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
         ]
         response = self.client.get(self.path, format="json", data={"accessibleOnly": "true"})
 
         assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with(None)
+        get_repositories.assert_called_once_with(None, accessible_only=True)
 
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
@@ -279,7 +234,6 @@ class OrganizationIntegrationReposTest(APITestCase):
         get_repositories.return_value = [
             {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
             {"name": "cool-repo", "identifier": "Example/cool-repo", "default_branch": "dev"},
-            {"name": "other-repo", "identifier": "Other/other-repo", "default_branch": "main"},
         ]
 
         self.create_repo(
@@ -295,7 +249,7 @@ class OrganizationIntegrationReposTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with()
+        get_repositories.assert_called_once_with("Example", accessible_only=True)
         assert response.data == {
             "repos": [
                 {

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -271,6 +271,43 @@ class OrganizationIntegrationReposTest(APITestCase):
         assert response.status_code == 200, response.content
         get_repositories.assert_called_once_with(None)
 
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
+    )
+    def test_accessible_only_with_installable_only(self, get_repositories: MagicMock) -> None:
+        """Both filters compose: accessible scopes the fetch, installable excludes installed repos."""
+        get_repositories.return_value = [
+            {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
+            {"name": "cool-repo", "identifier": "Example/cool-repo", "default_branch": "dev"},
+            {"name": "other-repo", "identifier": "Other/other-repo", "default_branch": "main"},
+        ]
+
+        self.create_repo(
+            project=self.project,
+            integration_id=self.integration.id,
+            name="Example/rad-repo",
+        )
+
+        response = self.client.get(
+            self.path,
+            format="json",
+            data={"search": "Example", "accessibleOnly": "true", "installableOnly": "true"},
+        )
+
+        assert response.status_code == 200, response.content
+        get_repositories.assert_called_once_with()
+        assert response.data == {
+            "repos": [
+                {
+                    "name": "cool-repo",
+                    "identifier": "Example/cool-repo",
+                    "defaultBranch": "dev",
+                    "isInstalled": False,
+                },
+            ],
+            "searchable": True,
+        }
+
     def test_no_repository_method(self) -> None:
         integration = self.create_integration(
             organization=self.org, provider="jira", name="Example", external_id="example:1"

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -652,6 +652,36 @@ class GitHubIntegrationTest(IntegrationTestCase):
         ]
 
     @responses.activate
+    def test_get_repositories_accessible_only(self) -> None:
+        """When accessible_only=True, fetches installation repos and filters locally."""
+        with self.tasks():
+            self.assert_setup_flow()
+
+        integration = Integration.objects.get(provider=self.provider.key)
+        installation = get_installation_of_type(
+            GitHubIntegration, integration, self.organization.id
+        )
+
+        result = installation.get_repositories("foo", accessible_only=True)
+        assert result == [
+            {"name": "foo", "identifier": "Test-Organization/foo", "default_branch": "master"},
+        ]
+
+    @responses.activate
+    def test_get_repositories_accessible_only_no_match(self) -> None:
+        """When accessible_only=True and nothing matches, returns empty list."""
+        with self.tasks():
+            self.assert_setup_flow()
+
+        integration = Integration.objects.get(provider=self.provider.key)
+        installation = get_installation_of_type(
+            GitHubIntegration, integration, self.organization.id
+        )
+
+        result = installation.get_repositories("nonexistent", accessible_only=True)
+        assert result == []
+
+    @responses.activate
     def test_get_repositories_all_and_pagination(self) -> None:
         """Fetch all repositories and test the pagination logic."""
         with self.tasks():


### PR DESCRIPTION
When a user installs the GitHub App and grants Sentry access to only select repositories, the repo search box can return repos beyond what the installation has access to. Selecting one of these inaccessible repos causes the backend POST to add it to fail.

The root cause is that `get_repositories()` uses two different GitHub API paths depending on whether a search query is present:

```mermaid
flowchart TD
    R["GET /integrations/{id}/repos/"] --> S{Has search query?}

    S -->|No| C["<b>Path C</b> (existing, safe)"]
    C --> C1["get_repositories(None)"]
    C1 --> C2["GitHub API: GET /installation/repositories"]
    C2 --> C3["_get_with_pagination fetches all pages"]
    C3 --> F["Apply installableOnly filter"]

    S -->|Yes| AO{accessibleOnly=true?}

    AO -->|Yes| A["<b>Path A</b> (new fix)"]
    A --> A1["get_repositories(search, accessible_only=True)"]
    A1 --> A2["GitHub API: GET /installation/repositories"]
    A2 --> A3["_get_with_pagination fetches all pages"]
    A3 --> A4["Filter locally by search string"]
    A4 --> F

    AO -->|No| B["<b>Path B</b> (existing problem)"]
    B --> B1["get_repositories(search)"]
    B1 --> B2["GitHub Search API: GET /search/repositories"]
    B2 --> B3["Returns all public repos matching query"]
    B3 --> F

    style A fill:#d4edda,stroke:#1a7a5c
    style B fill:#f8d7da,stroke:#b44030
    style C fill:#d6eaf8,stroke:#3b6fa0
    style B3 fill:#f8d7da,stroke:#b44030
```

Paths A and C hit `GET /installation/repositories` (GitHub API), which only returns repos the app has access to. Path B hits the Search API, which returns any public repo in the org regardless of installation scope.

### Why not use the existing `installableOnly` filter?

`installableOnly` and `accessibleOnly` solve different problems:

- **`installableOnly`** is a post-fetch filter on Sentry's database state. It removes repos that are already linked to this Sentry org. It doesn't change which GitHub API is called.
- **`accessibleOnly`** changes the fetch strategy itself. It forces `get_repositories()` to use the installation-scoped API (`/installation/repositories`) instead of the GitHub Search API, so repos the app can't access are never returned in the first place.

A repo can pass `installableOnly` (not yet linked in Sentry) but still be inaccessible to the GitHub App installation. That's exactly the bug: the Search API returns public repos the app has no permission to install.

### Behavior

The `accessible_only` parameter is added to the base `RepositoryIntegration.get_repositories()` interface. When `accessible_only=True` with a search query, `GitHubIntegration.get_repositories()` fetches installation-scoped repos and filters locally instead of calling the Search API. Without a search query, `get_repositories()` already uses the installation endpoint, which is inherently scoped. No race condition with the `link_all_repos` background task since we query GitHub directly, not Sentry's database records.

**Backend only** — a follow-up frontend PR will pass `accessibleOnly: true` from the SCM onboarding hook.

Refs VDY-54