### PR TITLE
feat(seer): Add RPC interface for retrieving the installation_id

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -712,7 +712,10 @@ def get_repo_installation_id(
     if not installation_id:
         return {"error": "installation_id_not_found"}
 
-    return {"installation_id": installation_id}
+    return {
+        "installation_id": installation_id,
+        "permissions": integration.metadata.get("permissions"),
+    }
 
 
 def check_repository_integrations_status(*, repository_integrations: list[dict[str, Any]]) -> dict:

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -707,7 +707,7 @@ def get_repo_installation_id(
     elif integration.provider == IntegrationProviderSlug.GITHUB.value:
         installation_id = integration.external_id
     else:
-        raise NotImplementedError(f"{integration.provider} is not supported.")
+        return {"error": "unsupported_provider"}
 
     if not installation_id:
         return {"error": "installation_id_not_found"}

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -663,6 +663,58 @@ def validate_repo(
     return {"valid": True, "integration_id": repo.integration_id}
 
 
+def get_repo_installation_id(
+    *,
+    organization_id: int,
+    provider: str,
+    external_id: str,
+    owner: str,
+    name: str,
+) -> dict[str, Any]:
+    """
+    Look up a repository and return the external_id of its associated integration (the installation ID).
+
+    Args:
+        organization_id: The Sentry organization ID
+        provider: The SCM provider (e.g., "github", "github_enterprise")
+        external_id: The repository's external ID in the provider's system
+        owner: The repository owner (e.g., "getsentry")
+        name: The repository name (e.g., "sentry")
+
+    Returns:
+        {"installation_id": <str>} if found
+        {"error": <str>} if not found or unsupported
+    """
+    repo = filter_repo_by_provider(organization_id, provider, external_id, owner, name).first()
+
+    if not repo:
+        return {"error": "repository_not_found"}
+
+    if repo.provider not in SEER_SUPPORTED_SCM_PROVIDERS:
+        return {"error": "unsupported_provider"}
+
+    if repo.integration_id is None:
+        return {"error": "no_integration"}
+
+    integration = integration_service.get_integration(integration_id=repo.integration_id)
+    if integration is None:
+        return {"error": "integration_not_found"}
+
+    # GitHub stores the installation ID as the integration's external_id,
+    # while GitHub Enterprise stores it in metadata["installation_id"].
+    if integration.provider == IntegrationProviderSlug.GITHUB_ENTERPRISE.value:
+        installation_id = integration.metadata.get("installation_id")
+    elif integration.provider == IntegrationProviderSlug.GITHUB.value:
+        installation_id = integration.external_id
+    else:
+        raise NotImplementedError(f"{integration.provider} is not supported.")
+
+    if not installation_id:
+        return {"error": "installation_id_not_found"}
+
+    return {"installation_id": installation_id}
+
+
 def check_repository_integrations_status(*, repository_integrations: list[dict[str, Any]]) -> dict:
     """
     Check whether repository integrations exist and are active.
@@ -760,6 +812,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "get_organization_project_ids": get_organization_project_ids,
     "check_repository_integrations_status": check_repository_integrations_status,
     "validate_repo": validate_repo,
+    "get_repo_installation_id": get_repo_installation_id,
     #
     # Autofix
     "get_organization_slug": get_organization_slug,

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1342,7 +1342,36 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"installation_id": "12345"}
+        assert result == {"installation_id": "12345", "permissions": None}
+
+    def test_get_repo_installation_id_github_with_permissions(self) -> None:
+        """Test returns permissions from integration metadata"""
+        permissions = {"contents": "read", "issues": "write", "pull_requests": "read"}
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="12345",
+            metadata={"permissions": permissions},
+        )
+
+        Repository.objects.create(
+            name="getsentry/sentry",
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            external_id="123456",
+            status=ObjectStatus.ACTIVE,
+            integration_id=integration.id,
+        )
+
+        result = get_repo_installation_id(
+            organization_id=self.organization.id,
+            provider="github",
+            external_id="123456",
+            owner="getsentry",
+            name="sentry",
+        )
+
+        assert result == {"installation_id": "12345", "permissions": permissions}
 
     def test_get_repo_installation_id_github_enterprise(self) -> None:
         """Test returns metadata installation_id for GitHub Enterprise repos"""
@@ -1370,7 +1399,7 @@ class TestSeerRpcMethods(APITestCase):
             name="internal-repo",
         )
 
-        assert result == {"installation_id": "99999"}
+        assert result == {"installation_id": "99999", "permissions": None}
 
     def test_get_repo_installation_id_not_found(self) -> None:
         """Test returns error when repository does not exist"""

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -20,6 +20,7 @@ from sentry.seer.endpoints.seer_rpc import (
     generate_request_signature,
     get_attributes_for_span,
     get_github_enterprise_integration_config,
+    get_repo_installation_id,
     has_repo_code_mappings,
     validate_repo,
 )
@@ -1317,3 +1318,135 @@ class TestSeerRpcMethods(APITestCase):
         )
 
         assert result == {"valid": True, "integration_id": integration.id}
+
+    def test_get_repo_installation_id_github(self) -> None:
+        """Test returns external_id as installation_id for GitHub repos"""
+        integration = self.create_integration(
+            organization=self.organization, provider="github", external_id="12345"
+        )
+
+        Repository.objects.create(
+            name="getsentry/sentry",
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            external_id="123456",
+            status=ObjectStatus.ACTIVE,
+            integration_id=integration.id,
+        )
+
+        result = get_repo_installation_id(
+            organization_id=self.organization.id,
+            provider="github",
+            external_id="123456",
+            owner="getsentry",
+            name="sentry",
+        )
+
+        assert result == {"installation_id": "12345"}
+
+    def test_get_repo_installation_id_github_enterprise(self) -> None:
+        """Test returns metadata installation_id for GitHub Enterprise repos"""
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github_enterprise",
+            external_id="ghe:1",
+            metadata={"installation_id": "99999"},
+        )
+
+        Repository.objects.create(
+            name="mycompany/internal-repo",
+            organization_id=self.organization.id,
+            provider="integrations:github_enterprise",
+            external_id="789",
+            status=ObjectStatus.ACTIVE,
+            integration_id=integration.id,
+        )
+
+        result = get_repo_installation_id(
+            organization_id=self.organization.id,
+            provider="github_enterprise",
+            external_id="789",
+            owner="mycompany",
+            name="internal-repo",
+        )
+
+        assert result == {"installation_id": "99999"}
+
+    def test_get_repo_installation_id_not_found(self) -> None:
+        """Test returns error when repository does not exist"""
+        result = get_repo_installation_id(
+            organization_id=self.organization.id,
+            provider="github",
+            external_id="nonexistent",
+            owner="getsentry",
+            name="sentry",
+        )
+
+        assert result == {"error": "repository_not_found"}
+
+    def test_get_repo_installation_id_unsupported_provider(self) -> None:
+        """Test returns error for unsupported provider"""
+        integration = self.create_integration(
+            organization=self.organization, provider="gitlab", external_id="gitlab:1"
+        )
+
+        Repository.objects.create(
+            name="getsentry/sentry",
+            organization_id=self.organization.id,
+            provider="gitlab",
+            external_id="123456",
+            status=ObjectStatus.ACTIVE,
+            integration_id=integration.id,
+        )
+
+        result = get_repo_installation_id(
+            organization_id=self.organization.id,
+            provider="gitlab",
+            external_id="123456",
+            owner="getsentry",
+            name="sentry",
+        )
+
+        assert result == {"error": "unsupported_provider"}
+
+    def test_get_repo_installation_id_no_integration(self) -> None:
+        """Test returns error when repo has no integration_id"""
+        Repository.objects.create(
+            name="getsentry/sentry",
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            external_id="123456",
+            status=ObjectStatus.ACTIVE,
+            integration_id=None,
+        )
+
+        result = get_repo_installation_id(
+            organization_id=self.organization.id,
+            provider="github",
+            external_id="123456",
+            owner="getsentry",
+            name="sentry",
+        )
+
+        assert result == {"error": "no_integration"}
+
+    def test_get_repo_installation_id_integration_not_found(self) -> None:
+        """Test returns error when integration record doesn't exist"""
+        Repository.objects.create(
+            name="getsentry/sentry",
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            external_id="123456",
+            status=ObjectStatus.ACTIVE,
+            integration_id=999999,
+        )
+
+        result = get_repo_installation_id(
+            organization_id=self.organization.id,
+            provider="github",
+            external_id="123456",
+            owner="getsentry",
+            name="sentry",
+        )
+
+        assert result == {"error": "integration_not_found"}


### PR DESCRIPTION
Adds an RPC interface for fetching a GitHub integration's installation_id.

- Adds a new get_repo_installation_id function to the Seer RPC interface that resolves a repository to its GitHub App installation ID
- GitHub stores the installation ID as integration.external_id, while GitHub Enterprise stores it in integration.metadata["installation_id"]
- Registered in seer_method_registry so Seer can call it via RPC
- Only supports GitHub and GitHub Enterprise providers; returns an error for unsupported providers