### PR TITLE
fix(onboarding): Pass accessibleOnly to SCM repo search

### DIFF
--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -78,7 +78,9 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
       return t('Failed to search repositories. Please try again.');
     }
     if (debouncedSearch) {
-      return t('No repositories found.');
+      return t(
+        'No repositories found. Check your installation permissions to ensure your integration has access.'
+      );
     }
     return t('Type to search repositories');
   }

--- a/static/app/views/onboarding/components/useScmRepoSearch.ts
+++ b/static/app/views/onboarding/components/useScmRepoSearch.ts
@@ -26,7 +26,7 @@ export function useScmRepoSearch(integrationId: string, selectedRepo?: Repositor
           },
         }
       ),
-      {method: 'GET', query: {search: debouncedSearch}},
+      {method: 'GET', query: {search: debouncedSearch, accessibleOnly: true}},
     ] as const,
     queryFn: async context => {
       return fetchDataQuery<ScmRepoSearchResult>(context);

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -262,7 +262,6 @@ class OrganizationIntegrationReposTest(APITestCase):
             "searchable": True,
         }
 
-
     def test_no_repository_method(self) -> None:
         integration = self.create_integration(
             organization=self.org, provider="jira", name="Example", external_id="example:1"

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -262,6 +262,7 @@ class OrganizationIntegrationReposTest(APITestCase):
             "searchable": True,
         }
 
+
     def test_no_repository_method(self) -> None:
         integration = self.create_integration(
             organization=self.org, provider="jira", name="Example", external_id="example:1"


### PR DESCRIPTION
Pass `accessibleOnly: true` when searching repos during SCM onboarding so only repos the GitHub App installation has access to are returned. This prevents users from selecting repos they cannot actually use.

When the search returns no results, show a message prompting the user to check their installation permissions, since the most likely cause is the GitHub App not having access to the repository.

Depends on #111892 (backend).

Refs VDY-54