### PR TITLE
fix(test): stabilize flaky useReplaysFromIssue assertion test

### DIFF
--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
@@ -41,13 +41,6 @@ describe('useReplaysFromIssue', () => {
       initialRouterConfig,
     });
 
-    expect(result.current).toEqual({
-      eventView: null,
-      fetchError: undefined,
-      isFetching: true,
-      pageLinks: null,
-    });
-
     await waitFor(() =>
       expect(result.current).toEqual({
         eventView: expect.objectContaining({
@@ -80,13 +73,6 @@ describe('useReplaysFromIssue', () => {
       initialRouterConfig,
     });
 
-    expect(result.current).toEqual({
-      eventView: null,
-      fetchError: undefined,
-      isFetching: true,
-      pageLinks: null,
-    });
-
     await waitFor(() =>
       expect(result.current).toEqual({
         eventView: expect.objectContaining({
@@ -115,13 +101,6 @@ describe('useReplaysFromIssue', () => {
         organization,
       },
       initialRouterConfig,
-    });
-
-    expect(result.current).toEqual({
-      eventView: null,
-      fetchError: undefined,
-      isFetching: true,
-      pageLinks: null,
     });
 
     await waitFor(() =>


### PR DESCRIPTION
Removes synchronous initial-state assertions (`isFetching: true`) from `useReplaysFromIssue` hook tests. These assertions are flaky because `renderHookWithProviders` uses `act()` internally, which flushes effects. Since `MockApiClient` resolves synchronously, the hook's `useEffect` → `fetchReplayIds()` → `setReplayIds()` chain can complete within the same `act()` boundary, leaving the hook already resolved by the time the synchronous assertion runs.

The `waitFor` assertions that check the final resolved state remain. I think they're enough to verify the hook's behavior.
_(I actually think and wrote that, not Cursor)_

Fixes ENG-7207

Made with [Cursor](https://cursor.com)
