### PR TITLE
fix(test): stabilize flaky StackTrace URL link tooltip test

### DIFF
--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -903,10 +903,10 @@ describe('Core StackTrace', () => {
 
     await userEvent.hover(screen.getByText('app.js'), {delay: null});
     act(() => jest.advanceTimersByTime(2000));
+    jest.useRealTimers();
 
     expect(
       await screen.findByRole('link', {name: 'https://example.com/static/app.js'})
     ).toBeInTheDocument();
-    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
The last test in the file calls `jest.useRealTimers()` _before_ its final `expect(await ...)` assertion. Other tests in the file call that _after_ the final assertion. It looks like tooltip transitions can still be chugging along internally when the machine is slow, so swapping timers mid-way through them cause flake.

~Note that CI Jest tests are failing because the https://github.com/getsentry/sentry/labels/Frontend%3A%20Rerun%20Flaky%20Tests label is causing _other_, still-flaky tests to be run.~ No longer applicable now that this is targeting `master` and #111860 is not yet merged.

Fixes ENG-7192

Made with [Cursor](https://cursor.com)