### PR TITLE
fix(test): stabilize flaky EventReplay inline onboarding test

### DIFF
--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -21,7 +21,6 @@ import type {RawReplayError} from 'sentry/utils/replays/types';
 
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
 jest.mock('sentry/utils/replays/hooks/useLoadReplayReader');
-jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
 // Replay clip preview is very heavy, mock it out
 jest.mock(
   'sentry/components/events/eventReplay/replayClipPreview',
@@ -30,6 +29,12 @@ jest.mock(
       return <div data-test-id="replay-clip" />;
     }
 );
+jest.mock('sentry/components/events/eventReplay/replayInlineOnboardingPanel', () => ({
+  __esModule: true,
+  default: function MockReplayOnboardingPanel() {
+    return <div data-test-id="replay-inline-onboarding" />;
+  },
+}));
 
 const mockEventTimestamp = new Date('2022-09-22T16:59:41Z');
 const mockReplayId = '761104e184c64d439ee1014b72b4d83b';
@@ -136,15 +141,9 @@ describe('EventReplay', () => {
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({
       activateSidebar: jest.fn(),
     });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/prompts-activity/',
-      body: {data: {dismissed_ts: null}},
-    });
     render(<EventReplay {...defaultProps} />, {organization});
 
-    expect(
-      await screen.findByText('Watch the errors and latency issues your users face')
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId('replay-inline-onboarding')).toBeInTheDocument();
   });
 
   it('should render a replay when there is a replayId from tags', async () => {


### PR DESCRIPTION
The `ReplayInlineOnboardingPanel` component is loaded via `React.lazy()`, creating an async code-splitting boundary. Inside that lazy-loaded component, `usePrompt` calls `useApiQuery` (React Query), adding another async data-fetching boundary. The combination of these two async layers occasionally exceeded the `findByText` default timeout in CI, causing the test to flake.

This PR mocks the `replayInlineOnboardingPanel` module (a pattern already used for `replayClipPreview`) and asserts on a `data-test-id` instead of the rendered text.

Fixes REPLAY-879

~Note that CI Jest tests are failing because the https://github.com/getsentry/sentry/labels/Frontend%3A%20Rerun%20Flaky%20Tests label is causing _other_, still-flaky tests to be run.~ No longer applicable now that this is targeting `master` and #111860 is not yet merged.

Made with [Cursor](https://cursor.com)
