### PR TITLE
fix(test): stabilize flaky EventGroupingInfo rendering test

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -345,6 +345,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/views/performance/                                            @getsentry/data-browsing
 /static/app/components/performance/                                       @getsentry/data-browsing
 /static/app/utils/performance/                                            @getsentry/data-browsing
+/static/app/components/events/groupingInfo                                @getsentry/data-browsing
 /static/app/components/events/interfaces/spans/                           @getsentry/data-browsing
 /static/app/components/events/viewHierarchy/*                             @getsentry/data-browsing
 /static/app/components/searchQueryBuilder/                                @getsentry/data-browsing

--- a/static/app/components/events/groupingInfo/groupingInfo.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.spec.tsx
@@ -1,12 +1,12 @@
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {EventGroupVariantType} from 'sentry/types/event';
 import {IssueCategory} from 'sentry/types/group';
 
-import {EventGroupingInfoSection} from './groupingInfoSection';
+import GroupingInfo from './groupingInfo';
 
 describe('EventGroupingInfo', () => {
   const group = GroupFixture();
@@ -45,15 +45,6 @@ describe('EventGroupingInfo', () => {
     });
   });
 
-  it('fetches and renders grouping info for errors', async () => {
-    render(<EventGroupingInfoSection {...defaultProps} />);
-    await userEvent.click(
-      screen.getByRole('button', {name: 'View Event Grouping Information Section'})
-    );
-    expect(await screen.findByText('variant description')).toBeInTheDocument();
-    expect(screen.getByText('123')).toBeInTheDocument();
-  });
-
   it('gets performance grouping info from group/event data', async () => {
     const perfEvent = EventFixture({
       type: 'transaction',
@@ -61,9 +52,7 @@ describe('EventGroupingInfo', () => {
     });
     const perfGroup = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
 
-    render(
-      <EventGroupingInfoSection {...defaultProps} event={perfEvent} group={perfGroup} />
-    );
+    render(<GroupingInfo {...defaultProps} event={perfEvent} group={perfGroup} />);
 
     expect(await screen.findByText('performance problem')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();
@@ -88,7 +77,7 @@ describe('EventGroupingInfo', () => {
         },
       },
     });
-    render(<EventGroupingInfoSection {...defaultProps} />);
+    render(<GroupingInfo {...defaultProps} />);
 
     expect(await screen.findByText('variant description')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();
@@ -116,9 +105,7 @@ describe('EventGroupingInfo', () => {
     });
     const perfGroup = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
 
-    render(
-      <EventGroupingInfoSection {...defaultProps} event={perfEvent} group={perfGroup} />
-    );
+    render(<GroupingInfo {...defaultProps} event={perfEvent} group={perfGroup} />);
 
     expect(await screen.findByText('performance problem')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();


### PR DESCRIPTION
Previously, `groupingInfoSection.spec.tsx` was testing the `GroupingInfoSection` component: but all that component does is combine the `InterimSection` component with a lazy-loaded `GroupingInfo` component. That lazy-loading can take >=100-150ms locally, and might be the cause of flake in CI. 

This PR changes the test to:

* Directly test `GroupingInfo`, bypassing the lazy-load
* Delete the specific flaky test that was checking for the component being loaded after click (since that's covered by `FoldSection`'s unit tests, as rendered by `InterimSection`)

Fixes ENG-7209

~Note that CI Jest tests are failing because the https://github.com/getsentry/sentry/labels/Frontend%3A%20Rerun%20Flaky%20Tests label is causing _other_, still-flaky tests to be run.~ Rebased on `master` so the `it.isKnownFlake` (#111860) addition isn't here yet. 

Made with [Cursor](https://cursor.com)

Co-authored-by: @nikkikapadia 