### PR TITLE
fix(test): stabilize flaky MetricsTabContent sidebar toggle test

### DIFF
--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -730,8 +730,14 @@ describe('MetricsTabContent (tracemetrics-ui-refresh)', () => {
 
       await userEvent.click(screen.getByRole('button', {name: 'Expand sidebar'}));
 
+      const metricToolbar = await waitFor(() => {
+        return screen.getByTestId('metric-toolbar');
+      });
+
+      // Wait for the SearchQueryBuilderCombobox inside the re-expanded sidebar to
+      // finish initialising, otherwise its async state updates fire after test end
       await waitFor(() => {
-        expect(screen.getAllByTestId('metric-toolbar')).toHaveLength(1);
+        expect(within(metricToolbar).getByRole('combobox')).toBeInTheDocument();
       });
     }
   );

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -730,9 +730,7 @@ describe('MetricsTabContent (tracemetrics-ui-refresh)', () => {
 
       await userEvent.click(screen.getByRole('button', {name: 'Expand sidebar'}));
 
-      const metricToolbar = await waitFor(() => {
-        return screen.getByTestId('metric-toolbar');
-      });
+      const metricToolbar = await screen.findByTestId('metric-toolbar');
 
       // Wait for the SearchQueryBuilderCombobox inside the re-expanded sidebar to
       // finish initialising, otherwise its async state updates fire after test end


### PR DESCRIPTION
The test `toggles the query builder sidebar with the expand control` collapses and re-expands the sidebar, but only waited for the toolbar `testId` to reappear. The `SearchQueryBuilderCombobox` inside the toolbar was still running async initialization, so its state updates leaked past the test boundary. This adds an explicit wait afterwards to let that initialization finish. 

Fixes ENG-7202

Made with [Cursor](https://cursor.com)