### PR TITLE
feat(seer): Update default triggers for Code Review

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -727,7 +727,6 @@ AUTO_ENABLE_CODE_REVIEW = False
 # Seer Org level default for code review triggers
 DEFAULT_CODE_REVIEW_TRIGGERS: list[str] = [
     "on_ready_for_review",
-    "on_new_commit",
 ]
 SEER_DEFAULT_CODING_AGENT_DEFAULT = "seer"
 SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT = "code_changes"

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -99,10 +99,7 @@ export interface RepositoryWithSettings extends Repository {
   };
 }
 
-export const DEFAULT_CODE_REVIEW_TRIGGERS: CodeReviewTrigger[] = [
-  'on_ready_for_review',
-  'on_new_commit',
-];
+export const DEFAULT_CODE_REVIEW_TRIGGERS: CodeReviewTrigger[] = ['on_ready_for_review'];
 
 /**
  * Integration Repositories from OrganizationIntegrationReposEndpoint

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_details.py
@@ -90,7 +90,6 @@ class OrganizationRepositoryGetTest(APITestCase):
         assert response.data["settings"]["enabledCodeReview"] is False
         assert response.data["settings"]["codeReviewTriggers"] == [
             "on_ready_for_review",
-            "on_new_commit",
         ]
 
 


### PR DESCRIPTION
This is a repeat of https://github.com/getsentry/sentry/pull/111829 

That #111829 was reverted because of a failing test: the selective test runner didn't find the test so i missed it.