### PR TITLE
fix(autofix): Github webhook analytics for explorer autofix

### DIFF
--- a/src/sentry/analytics/events/ai_autofix_pr_events.py
+++ b/src/sentry/analytics/events/ai_autofix_pr_events.py
@@ -9,6 +9,7 @@ class AiAutofixPrEvent(analytics.Event):
     run_id: int
     integration: str
     github_app: str
+    referrer: str | None = None
 
 
 @analytics.eventclass("ai.autofix.pr.closed")

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -71,7 +71,7 @@ def record_pr_action_analytic(
             )
         )
 
-        metrics.incr(f"ai.autofix.pr.{analytic_action}", tags={"mode": "legacy"})
+        metrics.incr(f"ai.autofix.pr.{analytic_action}")
         return
 
     explorer_state = get_explorer_state_from_pr_id(
@@ -94,6 +94,9 @@ def record_pr_action_analytic(
                 group_id=group.id,
                 run_id=explorer_state.run_id,
                 github_app=github_app,
+                referrer=explorer_state.metadata.get("referrer")
+                if explorer_state.metadata
+                else None,
             )
         )
 

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -80,11 +80,8 @@ def record_pr_action_analytic(
     if explorer_state:
         group_id = explorer_state.metadata.get("group_id") if explorer_state.metadata else None
         if group_id is None:
-            return
-        try:
-            group = Group.objects.get(id=group_id, project__organization_id=org.id)
-        except Group.DoesNotExist:
-            return
+            raise ValueError(f"Missing group id in explorer run {explorer_state.run_id}")
+        group = Group.objects.get(id=group_id, project__organization_id=org.id)
 
         analytics.record(
             ACTION_TO_EVENTS[analytic_action](

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -11,8 +11,10 @@ from sentry.analytics.events.ai_autofix_pr_events import (
     AiAutofixPrOpenedEvent,
 )
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.seer.autofix.utils import get_autofix_state_from_pr_id
+from sentry.seer.explorer.client_utils import get_explorer_state_from_pr_id
 from sentry.utils import metrics
 
 AnalyticAction = Literal["opened", "closed", "merged"]
@@ -43,24 +45,57 @@ def handle_github_pr_webhook_for_autofix(
     if action not in ["opened", "closed"]:
         return None
 
+    try:
+        record_pr_action_analytic(org, action, pull_request, github_app)
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+
+
+def record_pr_action_analytic(
+    org: Organization, action: str, pull_request: dict[str, Any], github_app: str
+) -> None:
+    analytic_action: AnalyticAction = "opened" if action == "opened" else "closed"
+    if pull_request["merged"]:
+        analytic_action = "merged"
+
     autofix_state = get_autofix_state_from_pr_id("integrations:github", pull_request["id"])
     if autofix_state:
-        analytic_action: AnalyticAction = "opened" if action == "opened" else "closed"
-        if pull_request["merged"]:
-            analytic_action = "merged"
-
-        try:
-            analytics.record(
-                ACTION_TO_EVENTS[analytic_action](
-                    organization_id=org.id,
-                    integration=IntegrationProviderSlug.GITHUB.value,
-                    project_id=autofix_state.request.project_id,
-                    group_id=autofix_state.request.issue["id"],
-                    run_id=autofix_state.run_id,
-                    github_app=github_app,
-                )
+        analytics.record(
+            ACTION_TO_EVENTS[analytic_action](
+                organization_id=org.id,
+                integration=IntegrationProviderSlug.GITHUB.value,
+                project_id=autofix_state.request.project_id,
+                group_id=autofix_state.request.issue["id"],
+                run_id=autofix_state.run_id,
+                github_app=github_app,
             )
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
+        )
 
-        metrics.incr(f"ai.autofix.pr.{analytic_action}")
+        metrics.incr(f"ai.autofix.pr.{analytic_action}", tags={"mode": "legacy"})
+        return
+
+    explorer_state = get_explorer_state_from_pr_id(
+        org.id, "integrations:github", pull_request["id"]
+    )
+    if explorer_state:
+        group_id = explorer_state.metadata.get("group_id") if explorer_state.metadata else None
+        if group_id is None:
+            return
+        try:
+            group = Group.objects.get(id=group_id, project__organization_id=org.id)
+        except Group.DoesNotExist:
+            return
+
+        analytics.record(
+            ACTION_TO_EVENTS[analytic_action](
+                organization_id=org.id,
+                integration=IntegrationProviderSlug.GITHUB.value,
+                project_id=group.project.id,
+                group_id=group.id,
+                run_id=explorer_state.run_id,
+                github_app=github_app,
+            )
+        )
+
+        metrics.incr(f"ai.autofix.pr.{analytic_action}", tags={"mode": "explorer"})
+        return

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -88,6 +88,12 @@ class ExplorerUpdateRequest(TypedDict):
     payload: NotRequired[dict[str, Any]]
 
 
+class ExplorerPrStateRequest(TypedDict):
+    organization_id: int
+    provider: str
+    pr_id: int
+
+
 def make_explorer_state_request(
     body: ExplorerStateRequest,
     connection_pool: HTTPConnectionPool | None = None,
@@ -138,6 +144,39 @@ def make_explorer_update_request(
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         viewer_context=viewer_context,
     )
+
+
+def make_explorer_state_pr_request(
+    body: ExplorerPrStateRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or explorer_connection_pool,
+        "/v1/automation/explorer/state/pr",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        viewer_context=viewer_context,
+    )
+
+
+def get_explorer_state_from_pr_id(
+    organization_id: int, provider: str, pr_id: int
+) -> SeerRunState | None:
+    body = ExplorerPrStateRequest(organization_id=organization_id, provider=provider, pr_id=pr_id)
+    response = make_explorer_state_pr_request(body)
+
+    if response.status >= 400:
+        raise SeerApiError("Seer request failed", response.status)
+
+    result = response.json()
+    if not result:
+        return None
+
+    session = result.get("session")
+    if session is None:
+        return None
+
+    return SeerRunState(**session)
 
 
 def has_seer_explorer_access_with_detail(


### PR DESCRIPTION
It's possible that the hook is for an explorer autofix run so if no autofix state is found, try to look for an explorer state and record any analytics.