### PR TITLE
fix(test): stabilize flaky ResultsSearchQueryBuilder spec

### DIFF
--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -51,12 +51,11 @@ describe('ResultsSearchQueryBuilder', () => {
 
     // Focus the input and type "has:p" to simulate a search for p50
     const input = await screen.findByRole('combobox');
-    await userEvent.type(input, 'has:p');
+    await userEvent.type(input, 'has:p', {delay: null});
 
     // Check that "p50" (a function tag) is NOT in the dropdown
-    expect(
-      within(await screen.findByRole('listbox')).queryByText('p50')
-    ).not.toBeInTheDocument();
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).queryByText('p50')).not.toBeInTheDocument();
   });
 
   it.isKnownFlake('shows normal tags, e.g. transaction, in the dropdown', async () => {
@@ -83,10 +82,11 @@ describe('ResultsSearchQueryBuilder', () => {
 
     // Check that a normal tag (e.g. "transaction") IS in the dropdown
     const input = await screen.findByRole('combobox');
-    await userEvent.type(input, 'transact');
+    await userEvent.type(input, 'transact', {delay: null});
 
+    const listbox = await screen.findByRole('listbox');
     expect(
-      await within(screen.getByRole('listbox')).findByRole('option', {
+      await within(listbox).findByRole('option', {
         name: 'transaction',
       })
     ).toBeInTheDocument();


### PR DESCRIPTION
Adds `{delay: null}` to `userEvent.type` calls to speed them up. By default, each character is typed  with a simulated delay between keystrokes, which can add up to a lot of waiting.

Also uses `findByRole` for the listbox to properly await its async appearance before making assertions.

Made with [Cursor](https://cursor.com)

Fixes ENG-7201