### PR TITLE
fix(onboarding): Surface backend error message when repo selection fails

### DIFF
--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -107,7 +107,12 @@ export function useScmRepoSelection({
       onSelect({...optimistic, ...created});
     } catch (error) {
       Sentry.captureException(error);
-      addErrorMessage(t('Failed to select repository'));
+      // The POST to add a repo returns errors.__all__ with a specific message
+      // (e.g. "You must grant Sentry access to {repo}"). The GET lookup above
+      // won't return this shape, so the fallback message covers that case.
+      const errorData = error as any;
+      const text = errorData?.responseJSON?.errors?.__all__;
+      addErrorMessage(text ?? t('Failed to select repository'));
       onSelect(undefined);
     } finally {
       setBusy(false);


### PR DESCRIPTION
A more minimal solution to [VDY-54](https://linear.app/getsentry/issue/VDY-54/repo-search-in-scm-onboarding-shows-repos-the-github-app-doesnt-have) that aligns with current behavior on the GitHub integration settings page.

When a user installs the GitHub App with access to only select repositories, the repo search in SCM onboarding can still surface repos outside the installation's scope (public repos via the GitHub Search API). If the user selects one, the backend POST fails with a specific error: "You must grant Sentry access to {repo}".

Previously the onboarding flow showed a generic "Failed to select repository" message. This change surfaces the backend's error message so the user understands why it failed and what to do about it.

A more comprehensive backend fix (scoping search results to only installation-accessible repos) is explored in draft PRs #111892 and #111895.

Refs VDY-54