### PR TITLE
fix(st): add src/sentry/constants.py to full_suite_triggers

### DIFF
--- a/.github/workflows/scripts/compute-sentry-selected-tests.py
+++ b/.github/workflows/scripts/compute-sentry-selected-tests.py
@@ -43,6 +43,7 @@ TEST_DIRS = (
 
 FULL_SUITE_TRIGGERS: list[str | re.Pattern[str]] = [
     "src/sentry/testutils/pytest/sentry.py",
+    "src/sentry/constants.py",
     "pyproject.toml",
     "src/sentry/conf/server.py",
     "src/sentry/web/urls.py",


### PR DESCRIPTION
tests failed on master here: https://github.com/getsentry/sentry/actions/runs/23808567753/job/69388944325

https://github.com/getsentry/sentry/actions/runs/23767928687/job/69252070904

```
gh api "repos/getsentry/sentry/actions/workflows/backend.yml/runs?head
      _sha=b8bd5add647a14a7c80afae86cf5cafe1ec26ba5&per_page=10" --jq
      '.workflow_runs[] | {id, run_number, created_at, run_attempt, event,
      status}'
```

and the newer stuff (prints how many test contexts changed files are linked to): https://github.com/getsentry/sentry/actions/runs/23767928704/job/69252070278#step:7:32

src/sentry/constants.py has plenty of coverage apparently but not enough