### PR TITLE
fix(test): stabilize flaky TimeSince timezone tooltip test

### DIFF
--- a/static/app/components/timeSince.spec.tsx
+++ b/static/app/components/timeSince.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {TimeSince} from 'sentry/components/timeSince';
 import {TimezoneProvider} from 'sentry/components/timezoneProvider';
@@ -62,13 +62,11 @@ describe('TimeSince', () => {
     const date = new Date('2024-01-15T12:00:00Z');
     render(
       <TimezoneProvider timezone="America/New_York">
-        <TimeSince date={date} />
+        <TimeSince date={date} tooltipProps={{delay: 0}} />
       </TimezoneProvider>
     );
     const timeElement = screen.getByRole('time');
     await userEvent.hover(timeElement);
-    await waitFor(() => {
-      expect(screen.getByText(/EST/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/EST/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Stabilizes the `TimeSince > respects timezone in tooltip` test by eliminating the tooltip open delay as a source of flakiness.

The test hovers a `<time>` element and asserts a tooltip containing "EST" appears. The `Tooltip` component has a default 50ms `OPEN_DELAY` that, combined with React render time under CI load, could cause the assertion to fail intermittently.

This gets around the delay by passing an explicit `tooltipProps={{delay: 0}}`, making the tooltip appear much more quickly.

Note that CI Jest tests are failing because the https://github.com/getsentry/sentry/labels/Frontend%3A%20Rerun%20Flaky%20Tests label is causing _other_, still-flaky tests to be run.

Fixes ENG-7211

Made with [Cursor](https://cursor.com)