### PR TITLE
fix(test): stabilize flaky VersionHoverCard renders test

### DIFF
--- a/static/app/components/versionHoverCard.spec.tsx
+++ b/static/app/components/versionHoverCard.spec.tsx
@@ -37,6 +37,7 @@ describe('VersionHoverCard', () => {
         organization={organization}
         projectSlug={project.slug}
         releaseVersion={release.version}
+        delay={0}
       >
         <div>{release.version}</div>
       </VersionHoverCard>


### PR DESCRIPTION
Stabilizes the `VersionHoverCard > renders` test by eliminating the overlay open delay as a source of flakiness.

The test hovers the rendered card and asserts on text contents appearing. The `useHoverOverlay` hook has a default 50ms `OPEN_DELAY` that, combined with React render time under CI load, seems to cause the assertion to fail intermittently.

This gets around the delay by passing an explicit `delay={0}`, making the overlay appear much more quickly.

Note that CI Jest tests are failing because the https://github.com/getsentry/sentry/labels/Frontend%3A%20Rerun%20Flaky%20Tests label is causing _other_, still-flaky tests to be run.

Fixes ENG-7212

Made with [Cursor](https://cursor.com)