### PR TITLE
ref(cells): Update callers to convert_to_async_discord_response and convert_to_async_slack_response

### DIFF
--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -64,7 +64,7 @@ class DiscordRequestParser(BaseRequestParser):
         if self.discord_request:
             convert_to_async_discord_response.apply_async(
                 kwargs={
-                    "region_names": [c.name for c in cells],
+                    "cell_names": [c.name for c in cells],
                     "payload": create_async_request_payload(self.request),
                     "response_url": self.discord_request.response_url,
                 }

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -180,7 +180,7 @@ class SlackRequestParser(BaseRequestParser):
 
         convert_to_async_slack_response.apply_async(
             kwargs={
-                "region_names": [r.name for r in cells],
+                "cell_names": [r.name for r in cells],
                 "payload": create_async_request_payload(self.request),
                 "response_url": self.response_url,
             }

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -141,13 +141,13 @@ class DiscordRequestParserTest(TestCase):
             responses.POST,
             "http://us.testserver/extensions/discord/interactions/",
             status=202,
-            body=b"region_response",
+            body=b"cell_response",
         )
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
         assert response.status_code == status.HTTP_202_ACCEPTED
-        assert response.content == b"region_response"
+        assert response.content == b"cell_response"
         assert len(responses.calls) == 1
         assert_no_webhook_payloads()
 
@@ -186,13 +186,13 @@ class DiscordRequestParserTest(TestCase):
             responses.POST,
             "http://us.testserver/extensions/discord/interactions/",
             status=201,
-            body=b"region_response",
+            body=b"cell_response",
         )
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.content == b"region_response"
+        assert response.content == b"cell_response"
         assert len(responses.calls) == 1
         assert_no_webhook_payloads()
 
@@ -239,7 +239,7 @@ class DiscordRequestParserTest(TestCase):
         payload = create_async_request_payload(self.request)
         mock_discord_task.apply_async.assert_called_once_with(
             kwargs={
-                "region_names": ["us"],
+                "cell_names": ["us"],
                 "payload": payload,
                 "response_url": response_url,
             }

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -129,7 +129,7 @@ class SlackRequestParserTest(TestCase):
         response = parser.get_response()
         mock_slack_task.apply_async.assert_called_once_with(
             kwargs={
-                "region_names": ["us"],
+                "cell_names": ["us"],
                 "payload": create_async_request_payload(request),
                 "response_url": response_url,
             }

--- a/tests/sentry/middleware/integrations/test_tasks.py
+++ b/tests/sentry/middleware/integrations/test_tasks.py
@@ -55,7 +55,7 @@ class AsyncSlackResponseTest(TestCase):
             status=200,
         )
         convert_to_async_slack_response(
-            region_names=["eu", "us"],
+            cell_names=["eu", "us"],
             payload=self.payload,
             response_url=self.response_url,
         )
@@ -84,7 +84,7 @@ class AsyncSlackResponseTest(TestCase):
             match=[matchers.json_params_matcher({"ok": True, "region": "eu"})],
         )
         convert_to_async_slack_response(
-            region_names=["us", "eu"],
+            cell_names=["us", "eu"],
             payload=self.payload,
             response_url=self.response_url,
         )
@@ -111,7 +111,7 @@ class AsyncSlackResponseTest(TestCase):
             status=200,
         )
         convert_to_async_slack_response(
-            region_names=["us", "eu"],
+            cell_names=["us", "eu"],
             payload=self.payload,
             response_url=self.response_url,
         )
@@ -137,7 +137,7 @@ class AsyncSlackResponseTest(TestCase):
             status=200,
         )
         convert_to_async_slack_response(
-            region_names=["us", "eu"],
+            cell_names=["us", "eu"],
             payload=self.payload,
             response_url=self.response_url,
         )
@@ -194,7 +194,7 @@ class AsyncDiscordResponseTest(TestCase):
             status=200,
         )
         convert_to_async_discord_response(
-            region_names=["eu", "us"],
+            cell_names=["eu", "us"],
             payload=self.payload,
             response_url=self.response_url,
         )
@@ -223,7 +223,7 @@ class AsyncDiscordResponseTest(TestCase):
             match=[matchers.json_params_matcher({"ok": True, "region": "eu"})],
         )
         convert_to_async_discord_response(
-            region_names=["eu", "us"],
+            cell_names=["eu", "us"],
             payload=self.payload,
             response_url=self.response_url,
         )
@@ -250,7 +250,7 @@ class AsyncDiscordResponseTest(TestCase):
             status=200,
         )
         convert_to_async_discord_response(
-            region_names=["eu", "us"],
+            cell_names=["eu", "us"],
             payload=self.payload,
             response_url=self.response_url,
         )


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/111858, now workers are fully updated it is now safe to update callers to pass the new parameter
