### PR TITLE
chore(ACI): Update front end usage of detector create endpoint to project scoped one

### DIFF
--- a/static/app/views/detectors/hooks/index.ts
+++ b/static/app/views/detectors/hooks/index.ts
@@ -111,9 +111,12 @@ export function useCreateDetector<T extends Detector = Detector>() {
   return useMutation<T, void, BaseDetectorUpdatePayload>({
     mutationFn: data =>
       api.requestPromise(
-        getApiUrl('/organizations/$organizationIdOrSlug/detectors/', {
-          path: {organizationIdOrSlug: org.slug},
-        }),
+        getApiUrl(
+          '/organizations/$organizationIdOrSlug/projects/$projectIdOrSlug/detectors/',
+          {
+            path: {organizationIdOrSlug: org.slug, projectIdOrSlug: data.projectId},
+          }
+        ),
         {
           method: 'POST',
           data,

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -167,7 +167,7 @@ describe('DetectorEdit', () => {
 
     it('can submit a new metric detector', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: MetricDetectorFixture({id: '123'}),
       });
@@ -190,7 +190,7 @@ describe('DetectorEdit', () => {
 
       await waitFor(() => {
         expect(mockCreateDetector).toHaveBeenCalledWith(
-          `/organizations/${organization.slug}/detectors/`,
+          `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
           expect.objectContaining({
             data: expect.objectContaining({
               name: 'Foo',
@@ -242,7 +242,7 @@ describe('DetectorEdit', () => {
 
     it('prefills form when selecting a template', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: MetricDetectorFixture({id: '123'}),
       });
@@ -274,7 +274,7 @@ describe('DetectorEdit', () => {
 
       await waitFor(() => {
         expect(mockCreateDetector).toHaveBeenCalledWith(
-          `/organizations/${organization.slug}/detectors/`,
+          `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
           expect.objectContaining({
             data: expect.objectContaining({
               type: 'metric_issue',
@@ -297,7 +297,7 @@ describe('DetectorEdit', () => {
 
     it('prefills from URL query params and submits', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: MetricDetectorFixture({id: '123'}),
       });
@@ -331,7 +331,7 @@ describe('DetectorEdit', () => {
 
       await waitFor(() => {
         expect(mockCreateDetector).toHaveBeenCalledWith(
-          `/organizations/${organization.slug}/detectors/`,
+          `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
           expect.objectContaining({
             data: expect.objectContaining({
               name: 'Users experiencing errors above 100 over past 1 hour',
@@ -374,7 +374,7 @@ describe('DetectorEdit', () => {
 
     it('can submit a new metric detector with event.type:error', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: MetricDetectorFixture({id: '123'}),
       });
@@ -410,7 +410,7 @@ describe('DetectorEdit', () => {
 
       await waitFor(() => {
         expect(mockCreateDetector).toHaveBeenCalledWith(
-          `/organizations/${organization.slug}/detectors/`,
+          `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
           expect.objectContaining({
             data: expect.objectContaining({
               conditionGroup: {
@@ -447,7 +447,7 @@ describe('DetectorEdit', () => {
 
     it('submits manual resolution threshold when selected', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: MetricDetectorFixture({id: '321'}),
       });
@@ -477,7 +477,7 @@ describe('DetectorEdit', () => {
       });
 
       expect(mockCreateDetector).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/detectors/`,
+        `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         expect.objectContaining({
           data: expect.objectContaining({
             type: 'metric_issue',
@@ -505,7 +505,7 @@ describe('DetectorEdit', () => {
 
     it('uses medium threshold for default resolution when both high and medium are set', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: MetricDetectorFixture({id: '789'}),
       });
@@ -535,7 +535,7 @@ describe('DetectorEdit', () => {
       });
 
       expect(mockCreateDetector).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/detectors/`,
+        `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         expect.objectContaining({
           data: expect.objectContaining({
             type: 'metric_issue',
@@ -597,7 +597,7 @@ describe('DetectorEdit', () => {
 
     it('creates detector with dynamic detection and no resolution thresholds', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: MetricDetectorFixture({id: '456'}),
       });
@@ -630,7 +630,7 @@ describe('DetectorEdit', () => {
 
       await waitFor(() => {
         expect(mockCreateDetector).toHaveBeenCalledWith(
-          `/organizations/${organization.slug}/detectors/`,
+          `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
           expect.objectContaining({
             data: expect.objectContaining({
               name: 'Dynamic',
@@ -675,7 +675,7 @@ describe('DetectorEdit', () => {
 
     it('can submit a new metric detector with apdex aggregate', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: MetricDetectorFixture({id: '789'}),
       });
@@ -711,7 +711,7 @@ describe('DetectorEdit', () => {
 
       await waitFor(() => {
         expect(mockCreateDetector).toHaveBeenCalledWith(
-          `/organizations/${organization.slug}/detectors/`,
+          `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
           expect.objectContaining({
             data: expect.objectContaining({
               name: 'Apdex',
@@ -803,7 +803,7 @@ describe('DetectorEdit', () => {
       });
 
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${metricsOrganization.slug}/detectors/`,
+        url: `/organizations/${metricsOrganization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: MetricDetectorFixture({id: '999'}),
       });
@@ -836,7 +836,7 @@ describe('DetectorEdit', () => {
 
       await waitFor(() => {
         expect(mockCreateDetector).toHaveBeenCalledWith(
-          `/organizations/${metricsOrganization.slug}/detectors/`,
+          `/organizations/${metricsOrganization.slug}/projects/${project.id}/detectors/`,
           expect.objectContaining({
             data: expect.objectContaining({
               name: 'Metrics Alert',
@@ -894,7 +894,7 @@ describe('DetectorEdit', () => {
 
     it('shows detect and resolve fields and submits default thresholds', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: UptimeDetectorFixture(),
       });
@@ -943,7 +943,7 @@ describe('DetectorEdit', () => {
       });
 
       expect(mockCreateDetector).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/detectors/`,
+        `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         expect.objectContaining({
           data: expect.objectContaining({
             config: {
@@ -994,7 +994,7 @@ describe('DetectorEdit', () => {
 
     it('submits custom thresholds when changed', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: UptimeDetectorFixture(),
       });
@@ -1030,7 +1030,7 @@ describe('DetectorEdit', () => {
       });
 
       expect(mockCreateDetector).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/detectors/`,
+        `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         expect.objectContaining({
           data: expect.objectContaining({
             config: {
@@ -1134,7 +1134,7 @@ describe('DetectorEdit', () => {
 
     it('submits default cron config with no changes', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: CronDetectorFixture({id: '999'}),
       });
@@ -1151,7 +1151,7 @@ describe('DetectorEdit', () => {
       });
 
       expect(mockCreateDetector).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/detectors/`,
+        `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         expect.objectContaining({
           data: expect.objectContaining({
             type: 'monitor_check_in_failure',
@@ -1179,7 +1179,7 @@ describe('DetectorEdit', () => {
 
     it('submits crons config with changes', async () => {
       const mockCreateDetector = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/detectors/`,
+        url: `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         method: 'POST',
         body: CronDetectorFixture({id: '999'}),
       });
@@ -1199,7 +1199,7 @@ describe('DetectorEdit', () => {
       });
 
       expect(mockCreateDetector).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/detectors/`,
+        `/organizations/${organization.slug}/projects/${project.id}/detectors/`,
         expect.objectContaining({
           data: expect.objectContaining({
             type: 'monitor_check_in_failure',


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/110285 we created a project scoped version of the `OrganizationDetectorIndex` `POST` method and this PR updates the front end usage of it so we can move towards removing it.