### PR TITLE
fix(dashboards): align sortable widget builder visualize ghost field to original field

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useMemo, useState, type ReactNode} from 'react';
-import {createPortal} from 'react-dom';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
 import {useTheme} from '@emotion/react';
@@ -29,6 +28,7 @@ import {
   type LinkedDashboard,
   type ValidateWidgetResponse,
 } from 'sentry/views/dashboards/types';
+import {correctDragOverlayOffset} from 'sentry/views/dashboards/widgetBuilder/components/common/draggableUtils';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {useDashboardWidgetSource} from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
@@ -240,27 +240,28 @@ export function GroupBySelector({
                 ))}
               </SortableQueryFields>
             </SortableContext>
-            {createPortal(
-              <DragOverlay dropAnimation={null} zIndex={theme.zIndex.modal}>
-                {activeId ? (
-                  <Ghost>
-                    <QueryField
-                      value={columns[Number(activeId)]!}
-                      fieldOptions={{
-                        ...filteredFieldOptions,
-                        ...columnsAsFieldOptions[Number(activeId)],
-                      }}
-                      onChange={value => handleSelect(value, Number(activeId))}
-                      canDrag={canDrag}
-                      canDelete={canDelete}
-                      disabled={disable}
-                      renderTagOverride={renderTagOverride}
-                    />
-                  </Ghost>
-                ) : null}
-              </DragOverlay>,
-              document.body
-            )}
+            <DragOverlay
+              dropAnimation={null}
+              zIndex={theme.zIndex.modal}
+              modifiers={[correctDragOverlayOffset]}
+            >
+              {activeId ? (
+                <Ghost>
+                  <QueryField
+                    value={columns[Number(activeId)]!}
+                    fieldOptions={{
+                      ...filteredFieldOptions,
+                      ...columnsAsFieldOptions[Number(activeId)],
+                    }}
+                    onChange={value => handleSelect(value, Number(activeId))}
+                    canDrag={canDrag}
+                    canDelete={canDelete}
+                    disabled={disable}
+                    renderTagOverride={renderTagOverride}
+                  />
+                </Ghost>
+              ) : null}
+            </DragOverlay>
           </DndContext>
         )}
       </StyledField>

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -1,6 +1,8 @@
 import {Fragment, useMemo, useState, type ReactNode} from 'react';
+import {createPortal} from 'react-dom';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -68,6 +70,7 @@ export function GroupBySelector({
   const organization = useOrganization();
   const source = useDashboardWidgetSource();
   const isEditing = useIsEditingWidget();
+  const theme = useTheme();
   const builderVersion = WidgetBuilderVersion.SLIDEOUT;
 
   function handleAdd() {
@@ -237,24 +240,27 @@ export function GroupBySelector({
                 ))}
               </SortableQueryFields>
             </SortableContext>
-            <DragOverlay dropAnimation={null}>
-              {activeId ? (
-                <Ghost>
-                  <QueryField
-                    value={columns[Number(activeId)]!}
-                    fieldOptions={{
-                      ...filteredFieldOptions,
-                      ...columnsAsFieldOptions[Number(activeId)],
-                    }}
-                    onChange={value => handleSelect(value, Number(activeId))}
-                    canDrag={canDrag}
-                    canDelete={canDelete}
-                    disabled={disable}
-                    renderTagOverride={renderTagOverride}
-                  />
-                </Ghost>
-              ) : null}
-            </DragOverlay>
+            {createPortal(
+              <DragOverlay dropAnimation={null} zIndex={theme.zIndex.modal}>
+                {activeId ? (
+                  <Ghost>
+                    <QueryField
+                      value={columns[Number(activeId)]!}
+                      fieldOptions={{
+                        ...filteredFieldOptions,
+                        ...columnsAsFieldOptions[Number(activeId)],
+                      }}
+                      onChange={value => handleSelect(value, Number(activeId))}
+                      canDrag={canDrag}
+                      canDelete={canDelete}
+                      disabled={disable}
+                      renderTagOverride={renderTagOverride}
+                    />
+                  </Ghost>
+                ) : null}
+              </DragOverlay>,
+              document.body
+            )}
           </DndContext>
         )}
       </StyledField>
@@ -351,14 +357,9 @@ const Ghost = styled('div')`
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.15);
   opacity: 0.8;
   cursor: grabbing;
-  padding-right: ${p => p.theme.space.xl};
   width: 100%;
 
   button {
     cursor: grabbing;
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    width: 710px;
   }
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/common/draggableUtils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/common/draggableUtils.tsx
@@ -1,4 +1,4 @@
-import type {Translate} from '@dnd-kit/core';
+import type {Modifier, Translate} from '@dnd-kit/core';
 
 export type WidgetDragPositioning = {
   initialTranslate: Translate;
@@ -53,3 +53,26 @@ export function snapPreviewToCorners(over: any | null): WidgetDragPositioning {
       : undefined,
   };
 }
+
+/**
+ * Corrects the DragOverlay ghost position when the DndContext is inside a CSS-transformed
+ * container (e.g. a SlideOverPanel animated with framer-motion). Without this, the ghost
+ * is offset by the container's distance from the viewport edge.
+ *
+ * Positions the ghost at the original element's viewport position, preserving the
+ * natural grab offset — the exact point clicked stays under the cursor.
+ */
+export const correctDragOverlayOffset: Modifier = ({
+  activeNodeRect,
+  draggingNodeRect,
+  transform,
+}) => {
+  if (!activeNodeRect || !draggingNodeRect) {
+    return transform;
+  }
+  return {
+    ...transform,
+    x: transform.x + activeNodeRect.left - draggingNodeRect.left,
+    y: transform.y + activeNodeRect.top - draggingNodeRect.top,
+  };
+};

--- a/static/app/views/dashboards/widgetBuilder/components/common/sortableFieldWrapper.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/common/sortableFieldWrapper.tsx
@@ -53,6 +53,7 @@ export function SortableVisualizeFieldWrapper({
 
 const StyledDragReorderButton = styled(DragReorderButton)<{isDragging: boolean}>`
   height: ${p => p.theme.form.md.height};
+  cursor: grab;
 
   ${p => p.isDragging && p.theme.visuallyHidden}
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -1,7 +1,8 @@
 import {Fragment, useMemo, useState, type ReactNode} from 'react';
+import {createPortal} from 'react-dom';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
-import {css} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -279,6 +280,7 @@ interface VisualizeProps {
 export function Visualize({error, setError}: VisualizeProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const organization = useOrganization();
+  const theme = useTheme();
   const {state, dispatch} = useWidgetBuilderContext();
   const tags = useTags();
   const {customMeasurements} = useCustomMeasurements();
@@ -1063,18 +1065,21 @@ export function Visualize({error, setError}: VisualizeProps) {
               })}
             </Stack>
           </SortableContext>
-          <DragOverlay dropAnimation={null}>
-            {activeId && (
-              <VisualizeGhostField
-                activeId={Number(activeId)}
-                aggregates={aggregates}
-                fields={fields ?? []}
-                isBigNumberWidget={isBigNumberWidget}
-                isTimeSeriesWidget={isTimeSeriesWidget}
-                stringFields={stringFields ?? []}
-              />
-            )}
-          </DragOverlay>
+          {createPortal(
+            <DragOverlay dropAnimation={null} zIndex={theme.zIndex.modal}>
+              {activeId && (
+                <VisualizeGhostField
+                  activeId={Number(activeId)}
+                  aggregates={aggregates}
+                  fields={fields ?? []}
+                  isBigNumberWidget={isBigNumberWidget}
+                  isTimeSeriesWidget={isTimeSeriesWidget}
+                  stringFields={stringFields ?? []}
+                />
+              )}
+            </DragOverlay>,
+            document.body
+          )}
         </DndContext>
       </StyledFieldGroup>
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useMemo, useState, type ReactNode} from 'react';
-import {createPortal} from 'react-dom';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
 import {css, useTheme} from '@emotion/react';
@@ -46,6 +45,7 @@ import {
   type LinkedDashboard,
 } from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
+import {correctDragOverlayOffset} from 'sentry/views/dashboards/widgetBuilder/components/common/draggableUtils';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {SortableVisualizeFieldWrapper} from 'sentry/views/dashboards/widgetBuilder/components/common/sortableFieldWrapper';
 import {ExploreArithmeticBuilder} from 'sentry/views/dashboards/widgetBuilder/components/exploreArithmeticBuilder';
@@ -1065,21 +1065,22 @@ export function Visualize({error, setError}: VisualizeProps) {
               })}
             </Stack>
           </SortableContext>
-          {createPortal(
-            <DragOverlay dropAnimation={null} zIndex={theme.zIndex.modal}>
-              {activeId && (
-                <VisualizeGhostField
-                  activeId={Number(activeId)}
-                  aggregates={aggregates}
-                  fields={fields ?? []}
-                  isBigNumberWidget={isBigNumberWidget}
-                  isTimeSeriesWidget={isTimeSeriesWidget}
-                  stringFields={stringFields ?? []}
-                />
-              )}
-            </DragOverlay>,
-            document.body
-          )}
+          <DragOverlay
+            dropAnimation={null}
+            zIndex={theme.zIndex.modal}
+            modifiers={[correctDragOverlayOffset]}
+          >
+            {activeId && (
+              <VisualizeGhostField
+                activeId={Number(activeId)}
+                aggregates={aggregates}
+                fields={fields ?? []}
+                isBigNumberWidget={isBigNumberWidget}
+                isTimeSeriesWidget={isTimeSeriesWidget}
+                stringFields={stringFields ?? []}
+              />
+            )}
+          </DragOverlay>
         </DndContext>
       </StyledFieldGroup>
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/visualizeGhostField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/visualizeGhostField.tsx
@@ -221,18 +221,14 @@ const Ghost = styled('div')`
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.15);
   opacity: 0.8;
   cursor: grabbing;
-  padding-right: ${p => p.theme.space.xl};
   width: 100%;
 
   button {
     cursor: grabbing;
   }
-
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    width: 710px;
-  }
 `;
 
 const StyledDragReorderButton = styled(DragReorderButton)`
   height: ${p => p.theme.form.md.height};
+  cursor: grabbing;
 `;


### PR DESCRIPTION
Context in linear ticket: [DAIN-1417](https://linear.app/getsentry/issue/DAIN-1417/visualize-drag-and-drop-shows-wrong-cursor-and-ghost-position)

the drag and drop ghost field was always shifted a lot further to the right than the original field. This happened because the widget builder slideout has transitions applied to it already which then applies to all nested components. This means that the drag and drop context was applying the transformation calculations on top of the exisiting x/y values but we need it to apply to when x/y=0. I've added in a modifier function to adjust the x and y coordinates of the drag overlay so that the drag button aligns with the cursor. 

Here's working proof:

https://github.com/user-attachments/assets/b02d887c-cb0c-4ab5-a047-0aa4b32344e4

