### PR TITLE
fix(onboarding): Wrap connected tag in Container to constrain width

### DIFF
--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -3,7 +3,7 @@ import {AnimatePresence, LayoutGroup, motion} from 'framer-motion';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -86,13 +86,15 @@ export function ScmConnect({onComplete}: StepProps) {
             width="100%"
             maxWidth={SCM_STEP_CONTENT_WIDTH}
           >
-            <Tag variant="success" icon={<IconCheckmark />}>
-              {t(
-                'Connected to %s org %s',
-                effectiveIntegration.provider.name,
-                effectiveIntegration.name
-              )}
-            </Tag>
+            <Container>
+              <Tag variant="success" icon={<IconCheckmark />}>
+                {t(
+                  'Connected to %s org %s',
+                  effectiveIntegration.provider.name,
+                  effectiveIntegration.name
+                )}
+              </Tag>
+            </Container>
             <ScmRepoSelector integration={effectiveIntegration} />
             <AnimatePresence>
               {selectedRepository ? (


### PR DESCRIPTION
The "Connected to {provider} org {name}" tag was expanding to 100% width of its parent flex container. Wrapping it in a Container constrains it to its natural content width.