### PR TITLE
perf(workflows): Avoid excessive querying in WorkflowEngineRuleSerializer

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -400,17 +400,11 @@ class WorkflowEngineRuleSerializer(Serializer):
 
     def _fetch_workflow_projects(self, item_list: Sequence[Workflow]) -> dict[int, set[Project]]:
         workflow_to_projects: dict[int, set[Project]] = defaultdict(set)
-        workflows_to_project_ids = list(
-            DetectorWorkflow.objects.filter(
-                workflow_id__in=[item.id for item in item_list]
-            ).values_list("workflow_id", "detector__project_id")
-        )
-        projects = Project.objects.get_many_from_cache(
-            {project_id for _, project_id in workflows_to_project_ids}
-        )
-        projects_by_id = {project.id: project for project in projects}
-        for workflow_id, project_id in workflows_to_project_ids:
-            workflow_to_projects[workflow_id].add(projects_by_id[project_id])
+        detector_workflows = DetectorWorkflow.objects.filter(
+            workflow_id__in=[item.id for item in item_list]
+        ).select_related("detector__project")
+        for dw in detector_workflows:
+            workflow_to_projects[dw.workflow_id].add(dw.detector.project)
 
         return workflow_to_projects
 

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -398,15 +398,19 @@ class WorkflowEngineRuleSerializer(Serializer):
             )
         }
 
-    def _fetch_workflow_projects(
-        self, item_list: Sequence[Workflow]
-    ) -> dict[Workflow, set[Project]]:
-        workflow_to_projects: dict[Workflow, set[Project]] = defaultdict(set)
-        detector_workflows = DetectorWorkflow.objects.filter(
-            workflow_id__in=[item.id for item in item_list]
-        ).prefetch_related("detector__project")
-        for detector_workflow in detector_workflows:
-            workflow_to_projects[detector_workflow.workflow].add(detector_workflow.detector.project)
+    def _fetch_workflow_projects(self, item_list: Sequence[Workflow]) -> dict[int, set[Project]]:
+        workflow_to_projects: dict[int, set[Project]] = defaultdict(set)
+        workflows_to_project_ids = list(
+            DetectorWorkflow.objects.filter(
+                workflow_id__in=[item.id for item in item_list]
+            ).values_list("workflow_id", "detector__project_id")
+        )
+        projects = Project.objects.get_many_from_cache(
+            {project_id for _, project_id in workflows_to_project_ids}
+        )
+        projects_by_id = {project.id: project for project in projects}
+        for workflow_id, project_id in workflows_to_project_ids:
+            workflow_to_projects[workflow_id].add(projects_by_id[project_id])
 
         return workflow_to_projects
 
@@ -583,7 +587,7 @@ class WorkflowEngineRuleSerializer(Serializer):
                 result[workflow]["owner"] = owner
 
             result[workflow]["environment"] = workflow.environment
-            result[workflow]["projects"] = list(workflow_to_projects[workflow])
+            result[workflow]["projects"] = list(workflow_to_projects[workflow.id])
             result[workflow]["rule_id"] = workflow_rule_ids.get(
                 workflow.id, get_fake_id_from_object_id(workflow.id)
             )

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -205,8 +205,8 @@ class WorkflowRuleSerializerTest(TestCase):
             [workflow, workflow_2, workflow_3]
         )
         assert workflow_projects == {
-            workflow_2: {self.project},
-            workflow_3: {self.project, project_2},
+            workflow_2.id: {self.project},
+            workflow_3.id: {self.project, project_2},
         }
 
     def test_fetch_workflows__prefetch(self) -> None:


### PR DESCRIPTION
The previous logic had us potentially sending 100+ workflow queries, which can add 300ms+ to the request.
By only fetching ids, we avoid considerable unnecessary work.
