### PR TITLE
feat(replay): Add a button to toggle the replay-details layout between the default & video-only

### DIFF
--- a/static/app/components/replays/replaySidebarToggleButton.tsx
+++ b/static/app/components/replays/replaySidebarToggleButton.tsx
@@ -13,7 +13,7 @@ export function ReplaySidebarToggleButton({isOpen, setIsOpen}: Props) {
     <Button
       size="sm"
       onClick={() => setIsOpen(!isOpen)}
-      icon={<IconChevron direction={isOpen ? 'right' : 'left'} />}
+      icon={<IconChevron direction={isOpen ? 'right' : 'left'} isDouble />}
     >
       {isOpen ? t('Collapse Sidebar') : t('Open Sidebar')}
     </Button>

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -106,11 +106,10 @@ export function ReplayView({isLoading, layout, toggleFullscreen, toggleLayout}: 
               <Button
                 size="xs"
                 icon={
-                  layout === LayoutKey.VIDEO_ONLY ? (
-                    <IconChevron direction="left" size="xs" />
-                  ) : (
-                    <IconChevron direction="right" size="xs" />
-                  )
+                  <IconChevron
+                    direction={layout === LayoutKey.VIDEO_ONLY ? 'left' : 'right'}
+                    isDouble
+                  />
                 }
                 aria-label="Toggle layout"
                 onClick={toggleLayout}

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -21,8 +22,10 @@ import {SentryPlayerRoot as ReplayPlayer} from 'sentry/components/replays/replay
 import {ReplayProcessingError} from 'sentry/components/replays/replayProcessingError';
 import {ReplaySidebarToggleButton} from 'sentry/components/replays/replaySidebarToggleButton';
 import {TextCopyInput} from 'sentry/components/textCopyInput';
+import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconFatal} from 'sentry/icons/iconFatal';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
 import {useIsFullscreen} from 'sentry/utils/window/useIsFullscreen';
 import {Breadcrumbs} from 'sentry/views/replays/detail/breadcrumbs';
@@ -32,7 +35,9 @@ import {ReplayViewScale} from 'sentry/views/replays/detail/replayViewScale';
 
 type Props = {
   isLoading: boolean;
+  layout: LayoutKey;
   toggleFullscreen: () => void;
+  toggleLayout: () => void;
 };
 
 function FatalIconTooltip({error}: {error: Error | null}) {
@@ -43,7 +48,7 @@ function FatalIconTooltip({error}: {error: Error | null}) {
   );
 }
 
-export function ReplayView({toggleFullscreen, isLoading}: Props) {
+export function ReplayView({isLoading, layout, toggleFullscreen, toggleLayout}: Props) {
   const isFullscreen = useIsFullscreen();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const replay = useReplayReader();
@@ -97,7 +102,26 @@ export function ReplayView({toggleFullscreen, isLoading}: Props) {
                 isOpen={isSidebarOpen}
                 setIsOpen={setIsSidebarOpen}
               />
-            ) : null}
+            ) : (
+              <Button
+                size="xs"
+                icon={
+                  layout === LayoutKey.VIDEO_ONLY ? (
+                    <IconChevron direction="left" size="xs" />
+                  ) : (
+                    <IconChevron direction="right" size="xs" />
+                  )
+                }
+                aria-label="Toggle layout"
+                onClick={toggleLayout}
+                tooltipProps={{
+                  title:
+                    layout === LayoutKey.VIDEO_ONLY
+                      ? t('Open Sidebar')
+                      : t('Collapse Sidebar'),
+                }}
+              />
+            )}
           </ContextContainer>
           {isLoading ? (
             <FluidHeight>

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -111,7 +111,11 @@ export function ReplayView({isLoading, layout, toggleFullscreen, toggleLayout}: 
                     isDouble
                   />
                 }
-                aria-label="Toggle layout"
+                aria-label={
+                  layout === LayoutKey.VIDEO_ONLY
+                    ? t('Open Sidebar')
+                    : t('Collapse Sidebar')
+                }
                 onClick={toggleLayout}
                 tooltipProps={{
                   title:

--- a/static/app/utils/replays/hooks/useReplayLayout.tsx
+++ b/static/app/utils/replays/hooks/useReplayLayout.tsx
@@ -1,11 +1,10 @@
-import {useCallback} from 'react';
+import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import type {Theme} from '@emotion/react';
 import {parseAsStringLiteral, useQueryState} from 'nuqs';
 
-import {trackAnalytics} from 'sentry/utils/analytics';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
+import {useWindowSize} from 'sentry/utils/window/useWindowSize';
 import {
   NAVIGATION_SIDEBAR_SECONDARY_WIDTH_LOCAL_STORAGE_KEY,
   PRIMARY_SIDEBAR_WIDTH,
@@ -68,17 +67,15 @@ export enum LayoutKey {
   SIDEBAR_LEFT = 'sidebar_left',
 }
 
-function isLayout(val: string): val is LayoutKey {
-  return val in LayoutKey;
-}
-
 function getDefaultLayout(
   collapsed: boolean,
   theme: Theme,
-  secondarySidebarWidth: number
+  secondarySidebarWidth: number,
+  {innerWidth, innerHeight} = {
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
+  }
 ): LayoutKey {
-  const {innerWidth, innerHeight} = window;
-
   const sidebarWidth = collapsed
     ? PRIMARY_SIDEBAR_WIDTH
     : PRIMARY_SIDEBAR_WIDTH + secondarySidebarWidth;
@@ -95,42 +92,32 @@ function getDefaultLayout(
   return LayoutKey.SIDEBAR_LEFT;
 }
 
-export function useReplayLayout() {
+export function useDefaultReplayLayout(): LayoutKey {
   const theme = useTheme();
   const {view} = useSecondaryNavigation();
   const [secondarySidebarWidth] = useSyncedLocalStorageState(
     NAVIGATION_SIDEBAR_SECONDARY_WIDTH_LOCAL_STORAGE_KEY,
     SECONDARY_SIDEBAR_WIDTH
   );
-  const defaultLayout = getDefaultLayout(
-    view !== 'expanded',
-    theme,
-    secondarySidebarWidth
-  );
+  const windowSize = useWindowSize();
+  return getDefaultLayout(view !== 'expanded', theme, secondarySidebarWidth, windowSize);
+}
 
-  const organization = useOrganization();
+export function useReplayLayout() {
+  const defaultLayout = useDefaultReplayLayout();
 
-  const [layoutValue, setLayoutValue] = useQueryState(
-    'l_page',
-    parseAsStringLiteral(Object.values(LayoutKey))
+  const parser = useMemo(() => {
+    return parseAsStringLiteral(Object.values(LayoutKey))
       .withDefault(defaultLayout)
-      .withOptions({history: 'push', throttleMs: 0})
-  );
+      .withOptions({history: 'push', throttleMs: 0});
+  }, [defaultLayout]);
 
-  return {
-    getLayout: useCallback((): LayoutKey => layoutValue, [layoutValue]),
-    setLayout: useCallback(
-      (value: string) => {
-        const chosenLayout = isLayout(value) ? value : defaultLayout;
+  const [layout, setLayout] = useQueryState('l_page', parser);
 
-        setLayoutValue(chosenLayout);
-        trackAnalytics('replay.details-layout-changed', {
-          organization,
-          default_layout: defaultLayout,
-          chosen_layout: chosenLayout,
-        });
-      },
-      [organization, defaultLayout, setLayoutValue]
-    ),
-  };
+  // We need to override the layout if the window resizes, because nuqs will
+  // cache the value if we switched from video-only back to default.
+  if (layout !== defaultLayout && layout !== LayoutKey.VIDEO_ONLY) {
+    return [defaultLayout, setLayout] as const;
+  }
+  return [layout, setLayout] as const;
 }

--- a/static/app/utils/replays/hooks/useReplayLayout.tsx
+++ b/static/app/utils/replays/hooks/useReplayLayout.tsx
@@ -1,4 +1,3 @@
-import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import type {Theme} from '@emotion/react';
 import {parseAsStringLiteral, useQueryState} from 'nuqs';
@@ -103,21 +102,18 @@ export function useDefaultReplayLayout(): LayoutKey {
   return getDefaultLayout(view !== 'expanded', theme, secondarySidebarWidth, windowSize);
 }
 
+const parser = parseAsStringLiteral(Object.values(LayoutKey)).withOptions({
+  history: 'push',
+  throttleMs: 0,
+});
+
 export function useReplayLayout() {
   const defaultLayout = useDefaultReplayLayout();
 
-  const parser = useMemo(() => {
-    return parseAsStringLiteral(Object.values(LayoutKey))
-      .withDefault(defaultLayout)
-      .withOptions({history: 'push', throttleMs: 0});
-  }, [defaultLayout]);
-
   const [layout, setLayout] = useQueryState('l_page', parser);
 
-  // We need to override the layout if the window resizes, because nuqs will
-  // cache the value if we switched from video-only back to default.
-  if (layout !== defaultLayout && layout !== LayoutKey.VIDEO_ONLY) {
-    return [defaultLayout, setLayout] as const;
-  }
-  return [layout, setLayout] as const;
+  // If the value is not video-only, then we can just return the default.
+  // The value might be different from the default, but that's probably because
+  // the window size changed and the default is different now.
+  return [layout === LayoutKey.VIDEO_ONLY ? layout : defaultLayout, setLayout] as const;
 }

--- a/static/app/utils/replays/hooks/useSplitPanelTracking.tsx
+++ b/static/app/utils/replays/hooks/useSplitPanelTracking.tsx
@@ -1,19 +1,18 @@
 import {useCallback, useRef} from 'react';
 
-import {trackAnalytics} from 'sentry/utils/analytics';
-import {useReplayLayout} from 'sentry/utils/replays/hooks/useReplayLayout';
-import {useOrganization} from 'sentry/utils/useOrganization';
-
 type CSSValuePct = `${number}%`;
 type CSSValueFR = '1fr';
 
+type TrackingCallback = (params: {
+  slideMotion: 'toTop' | 'toBottom' | 'toLeft' | 'toRight';
+}) => void;
+
 type Options = {
   slideDirection: 'updown' | 'leftright';
+  track: TrackingCallback | undefined;
 };
 
-export function useSplitPanelTracking({slideDirection}: Options) {
-  const organization = useOrganization();
-  const {getLayout} = useReplayLayout();
+export function useSplitPanelTracking({slideDirection, track}: Options) {
   const startSizeCSSRef = useRef<number>(0);
 
   const setStartPosition = useCallback(
@@ -30,13 +29,9 @@ export function useSplitPanelTracking({slideDirection}: Options) {
       const endSizeCSS = Number(
         endPosition?.endsWith('fr') ? '50' : endPosition?.replace('%', '') || 0
       );
-      trackAnalytics('replay.details-resized-panel', {
-        organization,
-        layout: getLayout(),
-        slide_motion: endSizeCSS > startSizeCSSRef.current ? bigger : smaller,
-      });
+      track?.({slideMotion: endSizeCSS > startSizeCSSRef.current ? bigger : smaller});
     },
-    [getLayout, organization, slideDirection]
+    [slideDirection, track]
   );
 
   return {

--- a/static/app/utils/window/useWindowSize.ts
+++ b/static/app/utils/window/useWindowSize.ts
@@ -1,0 +1,37 @@
+import {useEffect, useState} from 'react';
+
+interface WindowSize {
+  innerHeight: number;
+  innerWidth: number;
+}
+
+export function useWindowSize(): WindowSize {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
+  });
+
+  useEffect(() => {
+    let rafId: number | undefined;
+
+    const handleResize = () => {
+      if (rafId !== undefined) {
+        return;
+      }
+      rafId = requestAnimationFrame(() => {
+        setWindowSize({innerWidth: window.innerWidth, innerHeight: window.innerHeight});
+        rafId = undefined;
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (rafId !== undefined) {
+        cancelAnimationFrame(rafId);
+      }
+    };
+  }, []);
+
+  return windowSize;
+}

--- a/static/app/views/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/replays/detail/layout/replayLayout.tsx
@@ -8,8 +8,14 @@ import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {Placeholder} from 'sentry/components/placeholder';
 import {ReplayController} from 'sentry/components/replays/replayController';
 import {ReplayView} from 'sentry/components/replays/replayView';
-import {LayoutKey, useReplayLayout} from 'sentry/utils/replays/hooks/useReplayLayout';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {
+  LayoutKey,
+  useDefaultReplayLayout,
+  useReplayLayout,
+} from 'sentry/utils/replays/hooks/useReplayLayout';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useFullscreen} from 'sentry/utils/window/useFullscreen';
 import {FocusArea} from 'sentry/views/replays/detail/layout/focusArea';
 import {FocusTabs} from 'sentry/views/replays/detail/layout/focusTabs';
@@ -32,8 +38,9 @@ export function ReplayLayout({
   replayRecord: ReplayRecord | undefined;
   isVideoReplay?: boolean;
 }) {
-  const {getLayout} = useReplayLayout();
-  const layout = getLayout() ?? LayoutKey.TOPBAR;
+  const organization = useOrganization();
+  const defaultLayout = useDefaultReplayLayout();
+  const [layout, setLayout] = useReplayLayout();
 
   const fullscreenRef = useRef(null);
   const {toggle: toggleFullscreen} = useFullscreen({
@@ -47,7 +54,21 @@ export function ReplayLayout({
     <VideoSection ref={fullscreenRef}>
       <TooltipContext value={{container: fullscreenRef.current}}>
         <ErrorBoundary mini>
-          <ReplayView toggleFullscreen={toggleFullscreen} isLoading={isLoading} />
+          <ReplayView
+            isLoading={isLoading}
+            layout={layout}
+            toggleFullscreen={toggleFullscreen}
+            toggleLayout={() => {
+              const chosenLayout =
+                layout === LayoutKey.VIDEO_ONLY ? defaultLayout : LayoutKey.VIDEO_ONLY;
+              trackAnalytics('replay.details-layout-changed', {
+                organization,
+                default_layout: defaultLayout,
+                chosen_layout: chosenLayout,
+              });
+              setLayout(chosenLayout);
+            }}
+          />
         </ErrorBoundary>
       </TooltipContext>
     </VideoSection>
@@ -66,8 +87,10 @@ export function ReplayLayout({
   if (layout === LayoutKey.VIDEO_ONLY) {
     return (
       <BodyGrid>
-        {video}
-        {controller}
+        <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
+          {video}
+          {controller}
+        </Stack>
       </BodyGrid>
     );
   }
@@ -103,6 +126,7 @@ export function ReplayLayout({
         <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
           {hasSize ? (
             <SplitPanel
+              layout={layout}
               key={layout}
               availableSize={width}
               left={{
@@ -126,6 +150,7 @@ export function ReplayLayout({
       <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
         {hasSize ? (
           <SplitPanel
+            layout={layout}
             key={layout}
             availableSize={height}
             top={{

--- a/static/app/views/replays/detail/layout/splitPanel.tsx
+++ b/static/app/views/replays/detail/layout/splitPanel.tsx
@@ -3,14 +3,27 @@ import debounce from 'lodash/debounce';
 
 import type {SplitPanelProps} from 'sentry/components/splitPanel';
 import {SplitPanel} from 'sentry/components/splitPanel';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import type {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
 import {useSplitPanelTracking} from 'sentry/utils/replays/hooks/useSplitPanelTracking';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
-export function ReplaySplitPanel(props: SplitPanelProps) {
+export function ReplaySplitPanel({
+  layout,
+  ...props
+}: SplitPanelProps & {layout: LayoutKey}) {
   const {availableSize} = props;
   const isLeftRight = 'left' in props;
-
+  const organization = useOrganization();
   const {setStartPosition, logEndPosition} = useSplitPanelTracking({
     slideDirection: isLeftRight ? 'leftright' : 'updown',
+    track: ({slideMotion}) => {
+      trackAnalytics('replay.details-resized-panel', {
+        organization,
+        layout,
+        slide_motion: slideMotion,
+      });
+    },
   });
 
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This updates the replay details page to have a new toggle to open/collapse the tabs sidebar!

We had one before when in fullscreen, this is the same kind of thing but when the page is in a normal browser window. It's a little smaller of a button because there's necessarily less width, so i didn't want to put the full labels in there.

I also took the chance to reduce the number of places that call `useReplayLayout()`, and instead just pass some props around. With that I tried to hoist up the tracking that we are doing, so it's not baked in at a lower level, but can be passed along.

While i was testing i noticed that nuqs likes to cache the default value once we explicitly set it. So i needed to add the window resize listener so that the default can be updated, then also override the cached nuqs value with the new default. Fun and ugly.

<img width="228" height="102" alt="SCR-20260401-nmnn" src="https://github.com/user-attachments/assets/8bc489d2-2f2f-4602-a16d-cb658a2097ea" />
<img width="241" height="115" alt="SCR-20260401-nmol" src="https://github.com/user-attachments/assets/d5d256a1-4dec-478e-ad3b-d8a95d4f8f89" />

Existing chevrons in full-screen mode are updated to match too:
<img width="346" height="130" alt="SCR-20260401-nmma" src="https://github.com/user-attachments/assets/2e21b209-a549-48b4-a809-debb579673a3" />
<img width="233" height="149" alt="SCR-20260401-nmms" src="https://github.com/user-attachments/assets/3649d7be-8d5a-44b9-ab40-c94e7fc10c31" />



Fixes https://linear.app/getsentry/issue/REPLAY-883/make-collapse-sidebar-accessible-in-non-full-screen-mode