### PR TITLE
perf(feedback): Collapse stats on feedback group details request

### DIFF
--- a/static/app/components/feedback/getFeedbackItemQueryKey.tsx
+++ b/static/app/components/feedback/getFeedbackItemQueryKey.tsx
@@ -36,6 +36,11 @@ export function getFeedbackItemQueryKey({feedbackId, organization}: Props): {
               },
             }
           ),
+          {
+            query: {
+              collapse: ['fullRelease'],
+            },
+          },
         ]
       : undefined,
   };

--- a/static/app/components/feedback/getFeedbackItemQueryKey.tsx
+++ b/static/app/components/feedback/getFeedbackItemQueryKey.tsx
@@ -19,7 +19,7 @@ export function getFeedbackItemQueryKey({feedbackId, organization}: Props): {
           }),
           {
             query: {
-              collapse: ['release', 'tags'],
+              collapse: ['release', 'tags', 'stats'],
             },
           },
         ]


### PR DESCRIPTION
Adds `collapse=stats` to the feedback group details query key so the group details endpoint skips computing 24h/30d time-series stats. The feedback details page doesn't use the `stats` field from the group response.

Matches the pattern from #111156 which did the same for the issue details page.