### PR TITLE
fix(grouping): Handle callback false positives in parameterization

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -353,6 +353,13 @@ class Parameterizer:
             r.name: r.replacement_callback for r in regexes if r.replacement_callback
         }
 
+        # Store the individual regexes in case we need to handle replacement function false
+        # positives by manually looping through the patterns. This uses an `OrderedDict` to
+        # guarantee we apply them in the same order as in the main/combined regex.
+        self.compiled_regexes_by_name = OrderedDict(
+            (name, re.compile(rf"(?x){pattern}")) for name, pattern in patterns_by_name.items()
+        )
+
     def parameterize(self, input_str: str) -> str:
         """
         Replace all regex matches in the input string with placeholder strings, using the regexes

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -369,8 +369,13 @@ class Parameterizer:
         """
 
         replacement_counts: defaultdict[str, int] = defaultdict(int)
+        # Track whether any regex matches don't lead to a replacement
+        found_false_positive = False
 
         def _handle_regex_match(match: re.Match[str]) -> str:
+            # Ensure we're dealing with the flag from the outer scope, rather than shadowing it
+            nonlocal found_false_positive
+
             # Since
             #   a) our regex consists of a bunch of named capturing groups separated by `|`,
             #   b) no other capturing groups in the regex are named, and
@@ -394,6 +399,8 @@ class Parameterizer:
             # something which should be replaced, and we don't want to count that
             if replacement_string != orig_value:
                 replacement_counts[matched_key] += 1
+            else:
+                found_false_positive = True
 
             return replacement_string
 

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -1,6 +1,6 @@
 import dataclasses
 import re
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from collections.abc import Sequence
 from typing import Callable
 
@@ -329,18 +329,23 @@ class Parameterizer:
         )
 
         if self.is_experimental:
-            pattern_strings = [
-                r.experimental_pattern if r.experimental_pattern else r.pattern for r in regexes
-            ]
+            # This uses an `OrderedDict` to guarantee we apply the patterns in the given order.
+            patterns_by_name = OrderedDict(
+                (
+                    r.name,
+                    r.experimental_pattern if r.experimental_pattern else r.pattern,
+                )
+                for r in regexes
+            )
         else:
-            pattern_strings = [r.pattern for r in regexes]
+            patterns_by_name = OrderedDict((r.name, r.pattern) for r in regexes)
 
         # Combine the individual patterns into one giant regex to check against. (This is faster
         # than checking each pattern individually because it entails less overhead.)
         self.combined_regex = re.compile(
             # The `(?x)` tells the regex compiler to ignore comments and unescaped whitespace, so we
             # can use newlines and indentation for better legibility when defining regexes
-            rf"(?x){'|'.join(pattern_strings)}"
+            rf"(?x){'|'.join(patterns_by_name.values())}"
         )
 
         # Collect replacement callbacks, if any

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -376,12 +376,15 @@ class Parameterizer:
             # Ensure we're dealing with the flag from the outer scope, rather than shadowing it
             nonlocal found_false_positive
 
-            # Since
-            #   a) our regex consists of a bunch of named capturing groups separated by `|`,
-            #   b) no other capturing groups in the regex are named, and
-            #   c) there's nothing else in the regex,
-            # there should be exactly one named matching group, making the last matching group also
-            # the only matching group.
+            # This handler gets called on two types of regexes:
+            #   - The main/combination regex, which consists of a bunch of named capturing groups
+            #     (with no nested named groups) separated by `|`.
+            #   - Individual regexes for each pattern type, each consisting of one of the
+            #     alternatives in the main regex.
+            # In the former case, only one alternative can have been matched, so its group name will
+            # be the only (and therefore last) matched group name. In the latter case, there is only
+            # one named group to match, so its name will automatically be the only/last matched
+            # group name. Thus `lastgroup` should give us the group name in either case.
             matched_key = match.lastgroup
             orig_value = match.groupdict().get(
                 matched_key or ""  # Empty string for mypy appeasment

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -408,6 +408,23 @@ class Parameterizer:
             "grouping.parameterize", tags={"experimental": self.is_experimental}
         ) as metric_tags:
             parameterized = self.combined_regex.sub(_handle_regex_match, input_str)
+
+            # Our big combo regex will short-circuit when it finds a match, which is great for
+            # performance but problematic in cases where a replacement callback declines to
+            # parameterize a value, because then the value never gets checked against later
+            # patterns. To protect against that, in those cases we cycle through all patterns
+            # individually, which is slower but ensures we check them all.
+            if found_false_positive:
+                metric_tags["false_positive"] = True
+
+                # Reset values before applying the patterns again
+                replacement_counts = defaultdict(int)
+                parameterized = input_str
+
+                # Apply patterns one by one, with no short-circuiting
+                for regex_key, regex in self.compiled_regexes_by_name.items():
+                    parameterized = regex.sub(_handle_regex_match, parameterized)
+
             metric_tags["changed"] = parameterized != input_str
 
         for regex_key, count in replacement_counts.items():


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/111352, we added the ability for a `ParameterizationRegex` to use a callback for its replacement value, rather than just always replacing the original value with `<regex type>`. One thing this will let us do is make the replacement conditional, by having the callback return the original value if it decides the replacement shouldn't be made. (This is how our improved IPv6 parameterization is going to work, so that we can let Python's built-in `ipaddress` functions have the final word on whether or not an ip-like string is a valid IPv6 address.)

That's all very well and good in cases where the callback agrees that the original value should be replaced. When it decides _not_ to replace the value, though, we've created a problem for ourselves. Continuing with the IP example, say we encounter a string like `11:21:99`, which looks vaguely IPv6-ish, but isn't in fact a valid IP.

Before the aforementioned PR, when we were strictly using a `named_pattern_1 | named_pattern_2 | named_pattern_3`-type regex for replacement, parameterization looked like this: 
- The regex engine tests the string against the `ip` pattern, sees that it doesn't actually match, and keeps trying alternatives. 
- The regex engine tests the string against the `int` pattern, finds three matches, and makes the replacements.
- Final result: `<int>:<int>:<int>` (Yay, the right answer!)

With that change in place, though, once the `ip` pattern uses regex to find  IP-like strings and then confirms the match using a callback, parameterization will look like this:
- The regex engine tests the string against the `ip-like` pattern, finds a match, and passes it to the callback.
- The callback tests the string, finds it's not actually a valid IPv6 address, and returns the original string as the "replacement" value.
- As far as the regex engine is concerned, a match has been found, so no other patterns are tried.
- Final result: `11:21:99` (Boo, the wrong answer.)

To be clear, even with that change in place, we're not actually running into this problem in prod (yet), because the IP regex hasn't yet had the callback added to it. But we will unless we fix the problem, which is what this PR does. In cases where detect such a false positive, we'll now fall back to checking each pattern individually. Essentially, we're just taking control of whether or not to continue checking patterns away from the regex engine, and always forcing every pattern to be checked. While this double-parameterization does take more time, a) we expect this to be a fairly uncommon edge case, b) we recently saved a bunch of time by caching parameterization results, so we have a little wiggle room, and c) we're talking an extra half-millisecond on average, so it'll still be quite fast.

Note: There's not yet a test for this behavior, because testing it requires having something to test. Rather than more or less recreating everything the upcoming IP change will include, I decided to just hold off adding a test until that PR (which is now up at https://github.com/getsentry/sentry/pull/111979). For now, since there are no live callbacks, all we really need to know is that this change doesn't crash the normal running of the parameterizer, which is amply demonstrated by the fact that every other parameterization test still works.

