### PR TITLE
chore(autofix): Remove redundant tooltip on autofix buttons

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -382,7 +382,6 @@ function AutofixPreviews({
         size="md"
         icon={<IconSeer />}
         aria-label={t('Open Seer')}
-        tooltipProps={{title: t('Open Seer')}}
         priority="primary"
         onClick={openSeerDrawer}
         analyticsEventKey="issue_details.seer_opened"


### PR DESCRIPTION
The tooltips say the same thing as the button.