### PR TITLE
feat(dashboards): update /dashboard/generate endpoint to accept edit prompts

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -21,15 +22,29 @@ from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
+
+CREATE_ON_PAGE_CONTEXT = "The user is on the dashboard generation page. This session must ONLY generate a dashboard artifact. Do not perform code changes or any tasks unrelated to dashboard generation."
+
+EDIT_ON_PAGE_CONTEXT_TEMPLATE = """The user is editing an existing dashboard. The current dashboard state is:
+
+{current_dashboard_json}
+
+This session must ONLY modify the dashboard artifact. Produce a COMPLETE dashboard artifact that incorporates the requested changes while preserving widgets the user did not ask to change. Do not perform code changes or any tasks unrelated to dashboard editing."""
 
 
 class DashboardGenerateSerializer(serializers.Serializer[dict[str, Any]]):
     prompt = serializers.CharField(
         required=True,
         allow_blank=False,
-        help_text="Natural language description of the dashboard to generate.",
+        help_text="Natural language description of the dashboard to generate or edit.",
+    )
+    current_dashboard = serializers.JSONField(
+        required=False,
+        default=None,
+        help_text="Natural language description of the dashboard to generate or modifications to apply to an existing dashboard if provided.",
     )
 
 
@@ -71,7 +86,27 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        prompt = serializer.validated_data["prompt"]
+        validated_data = serializer.validated_data
+        prompt = validated_data["prompt"]
+        current_dashboard = validated_data.get("current_dashboard")
+
+        # If current_dashboard is provided, we're editing; otherwise creating
+        if current_dashboard is not None:
+            try:
+                GeneratedDashboard.parse_obj(current_dashboard)
+            except ValidationError:
+                return Response(
+                    {
+                        "detail": "current_dashboard does not match the expected schema.",
+                    },
+                    status=400,
+                )
+
+            on_page_context = EDIT_ON_PAGE_CONTEXT_TEMPLATE.format(
+                current_dashboard_json=json.dumps(current_dashboard)
+            )
+        else:
+            on_page_context = CREATE_ON_PAGE_CONTEXT
 
         try:
             client = SeerExplorerClient(
@@ -83,7 +118,7 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
             )
             run_id = client.start_run(
                 prompt=prompt,
-                on_page_context="The user is on the dashboard generation page. This session must ONLY generate a dashboard artifact. Do not perform code changes or any tasks unrelated to dashboard generation.",
+                on_page_context=on_page_context,
                 artifact_key="dashboard",
                 artifact_schema=GeneratedDashboard,
                 request=request,

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -14,6 +13,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.serializers.rest_framework import DashboardDetailsSerializer
 from sentry.dashboards.models.generate_dashboard_artifact import GeneratedDashboard
 from sentry.dashboards.on_completion_hook import DashboardOnCompletionHook
 from sentry.models.organization import Organization
@@ -44,7 +44,7 @@ class DashboardGenerateSerializer(serializers.Serializer[dict[str, Any]]):
     current_dashboard = serializers.JSONField(
         required=False,
         default=None,
-        help_text="Natural language description of the dashboard to generate or modifications to apply to an existing dashboard if provided.",
+        help_text="JSON representation of the current dashboard state to edit.",
     )
 
 
@@ -90,17 +90,18 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
         prompt = validated_data["prompt"]
         current_dashboard = validated_data.get("current_dashboard")
 
-        # If current_dashboard is provided, we're editing; otherwise creating
+        # If current_dashboard is provided, we're editing; otherwise generating a new dashboard.
         if current_dashboard is not None:
-            try:
-                GeneratedDashboard.parse_obj(current_dashboard)
-            except ValidationError:
-                return Response(
-                    {
-                        "detail": "current_dashboard does not match the expected schema.",
-                    },
-                    status=400,
-                )
+            dashboard_serializer = DashboardDetailsSerializer(
+                data=current_dashboard,
+                context={
+                    "organization": organization,
+                    "request": request,
+                    "projects": self.get_projects(request, organization),
+                },
+            )
+            if not dashboard_serializer.is_valid():
+                return Response(dashboard_serializer.errors, status=400)
 
             on_page_context = EDIT_ON_PAGE_CONTEXT_TEMPLATE.format(
                 current_dashboard_json=json.dumps(current_dashboard)

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -87,3 +87,62 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
     def test_get_not_allowed(self) -> None:
         response = self.client.get(self.url)
         assert response.status_code == 405
+
+    def test_post_with_invalid_current_dashboard_returns_400(self) -> None:
+        data = {
+            "prompt": "Add an error widget",
+            "current_dashboard": {"invalid": "schema"},
+        }
+        response = self.client.post(self.url, data, format="json")
+        assert response.status_code == 400
+
+    @patch("sentry.dashboards.endpoints.organization_dashboard_generate.SeerExplorerClient")
+    def test_post_with_current_dashboard_uses_edit_context(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = 123
+        mock_client_class.return_value = mock_client
+
+        data = {
+            "prompt": "Add a widget showing error rates by project",
+            "current_dashboard": {
+                "title": "My Dashboard",
+                "widgets": [
+                    {
+                        "title": "Error Count",
+                        "description": "Total errors",
+                        "display_type": "line",
+                        "widget_type": "error-events",
+                        "queries": [
+                            {
+                                "aggregates": ["count()"],
+                                "columns": [],
+                                "conditions": "",
+                                "orderby": "",
+                            }
+                        ],
+                        "layout": {"x": 0, "y": 0, "w": 3, "h": 2, "min_h": 2},
+                        "limit": 5,
+                        "interval": "1h",
+                    }
+                ],
+            },
+        }
+        response = self.client.post(self.url, data, format="json")
+
+        assert response.status_code == 200
+        assert response.data == {"run_id": 123}
+
+        mock_client_class.assert_called_once_with(
+            self.organization,
+            ANY,
+            on_completion_hook=DashboardOnCompletionHook,
+            category_key="dashboard_generate",
+            category_value=str(self.organization.id),
+        )
+
+        # Verify on_page_context includes the current dashboard JSON
+        call_kwargs = mock_client.start_run.call_args[1]
+        assert "My Dashboard" in call_kwargs["on_page_context"]
+        assert "Error Count" in call_kwargs["on_page_context"]

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -91,7 +91,14 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
     def test_post_with_invalid_current_dashboard_returns_400(self) -> None:
         data = {
             "prompt": "Add an error widget",
-            "current_dashboard": {"invalid": "schema"},
+            "current_dashboard": {
+                "title": "Bad Dashboard",
+                "widgets": [
+                    {
+                        "displayType": "not_a_real_type",
+                    }
+                ],
+            },
         }
         response = self.client.post(self.url, data, format="json")
         assert response.status_code == 400
@@ -112,17 +119,18 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
                     {
                         "title": "Error Count",
                         "description": "Total errors",
-                        "display_type": "line",
-                        "widget_type": "error-events",
+                        "displayType": "line",
+                        "widgetType": "error-events",
                         "queries": [
                             {
                                 "aggregates": ["count()"],
                                 "columns": [],
+                                "fields": ["count()"],
                                 "conditions": "",
                                 "orderby": "",
                             }
                         ],
-                        "layout": {"x": 0, "y": 0, "w": 3, "h": 2, "min_h": 2},
+                        "layout": {"x": 0, "y": 0, "w": 3, "h": 2, "minH": 2},
                         "limit": 5,
                         "interval": "1h",
                     }


### PR DESCRIPTION
Extends the `/dashboard/generate` endpoint to accept a current dashboard parameter as json. When a dashboard is provided, the seer run is prompted to edit the existing dashboard. 