### PR TITLE
feat(repos): Add framework for scheduling tasks from a queryset on a recurring basis

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 ## tell the contributor to move the files to someplace with better ownership.
 /src/sentry/api/                                        @getsentry/app-backend
 /src/sentry/utils/                                      @getsentry/app-backend
+/tests/sentry/utils/                                    @getsentry/app-backend
 /src/sentry/testutils/                                  @getsentry/app-backend
 /src/sentry/users/                                      @getsentry/app-backend
 /tests/sentry/api/                                      @getsentry/app-backend

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -1,0 +1,252 @@
+"""
+A general-purpose framework for processing large querysets in batches,
+spread over time via a scheduled task.
+
+The framework takes a queryset, a task, a cycle duration, and a schedule key.
+It reads the tick interval from the schedule config, then automatically
+calculates the batch size needed to complete one full cycle within the target
+duration. Each invocation, it fetches the next batch of PKs and dispatches
+the task for each one. The cursor is stored in cache (Redis) so progress
+persists across invocations. A distributed lock prevents overlapping ticks.
+
+Usage:
+
+    from datetime import timedelta
+    from sentry.utils.cursored_scheduler import CursoredScheduler
+
+    # my_module/tasks.py
+    scheduler = CursoredScheduler(
+        name="my_sync",
+        schedule_key="my-sync-beat",
+        queryset=MyModel.objects.filter(status=ACTIVE),
+        task=process_item,
+        cycle_duration=timedelta(hours=6),
+    )
+
+    @instrumented_task(name="sentry.my_module.tasks.my_sync_beat", ...)
+    def my_sync_beat():
+        scheduler.tick()
+
+    # server.py — TASKWORKER_SCHEDULES
+    "my-sync-beat": {
+        "task": "namespace:sentry.my_module.tasks.my_sync_beat",
+        "schedule": timedelta(minutes=1),  # must be timedelta, not crontab
+    },
+
+The task will be called with the PK as a positional argument:
+    process_item.delay(item_pk)
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.cache import cache
+from django.db.models import Model, QuerySet
+from taskbroker_client.task import Task
+
+from sentry.locks import locks
+from sentry.utils import metrics
+from sentry.utils.locking import UnableToAcquireLock
+
+logger = logging.getLogger(__name__)
+
+CURSOR_CACHE_KEY_PREFIX = "cursored_scheduler"
+BATCH_SIZE_CACHE_KEY_PREFIX = "cursored_scheduler_batch_size"
+CYCLE_START_CACHE_KEY_PREFIX = "cursored_scheduler_cycle_start"
+LOCK_PREFIX = "cursored_scheduler_lock"
+# How long to hold the lock during a tick
+DEFAULT_LOCK_DURATION_SECONDS = 120
+# Minimum batch size
+MIN_BATCH_SIZE = 1
+
+
+def _get_tick_interval(schedule_key: str) -> timedelta:
+    """
+    Read the tick interval from TASKWORKER_SCHEDULES for the given key.
+    Requires the schedule to be a timedelta, not a crontab.
+    """
+    schedules = getattr(settings, "TASKWORKER_SCHEDULES", {})
+    if schedule_key not in schedules:
+        raise ValueError(
+            f"Schedule key '{schedule_key}' not found in TASKWORKER_SCHEDULES. "
+            f"Register it in server.py before creating a CursoredScheduler."
+        )
+
+    schedule = schedules[schedule_key].get("schedule")
+    if not isinstance(schedule, timedelta):
+        raise TypeError(
+            f"CursoredScheduler requires a timedelta schedule, "
+            f"but '{schedule_key}' uses {type(schedule).__name__}. "
+            f"Change the schedule in server.py to use timedelta instead of crontab."
+        )
+
+    return schedule
+
+
+class CursoredScheduler[M: Model]:
+    """
+    Processes a queryset in batches over multiple scheduled task invocations.
+
+    Each call to tick() acquires a lock, fetches the next batch of rows by PK,
+    dispatches the configured task for each row's PK, and advances the cursor.
+    When all rows have been processed, the cursor resets and a new cycle
+    begins on the next tick().
+
+    Batch size is auto-calculated at the start of each cycle based on the total
+    row count, cycle_duration, and the tick interval from the schedule config,
+    so that one full pass through the queryset completes within approximately
+    cycle_duration.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        schedule_key: str,
+        queryset: QuerySet[M],
+        task: Task[[int], None],
+        cycle_duration: timedelta,
+        lock_duration: int = DEFAULT_LOCK_DURATION_SECONDS,
+    ):
+        self.name = name
+        self.schedule_key = schedule_key
+        self.cache_key = f"{CURSOR_CACHE_KEY_PREFIX}:{name}"
+        self.batch_size_cache_key = f"{BATCH_SIZE_CACHE_KEY_PREFIX}:{name}"
+        self.cycle_start_cache_key = f"{CYCLE_START_CACHE_KEY_PREFIX}:{name}"
+        self.lock_key = f"{LOCK_PREFIX}:{name}"
+        self.queryset = queryset
+        self.task = task
+        self.cycle_duration = cycle_duration
+        self.cache_ttl = int(cycle_duration.total_seconds() * 2)
+        self.lock_duration = lock_duration
+        self._metric_tags = {"scheduler": name}
+
+    @property
+    def tick_interval(self) -> timedelta:
+        return _get_tick_interval(self.schedule_key)
+
+    def tick(self) -> bool:
+        """
+        Process the next batch. Call this from your beat task.
+
+        Acquires a lock to prevent overlapping ticks, fetches the next batch
+        of PKs from the queryset, dispatches the task for each one, and
+        advances the cursor.
+
+        Returns True if there are more items to process, False if the cycle
+        is complete. Returns False without processing if the lock cannot be
+        acquired.
+        """
+        lock = locks.get(
+            key=self.lock_key,
+            duration=self.lock_duration,
+            name=self.name,
+        )
+
+        try:
+            with lock.acquire():
+                return self._process_batch()
+        except UnableToAcquireLock:
+            metrics.incr("cursored_scheduler.lock_contention", tags=self._metric_tags)
+            logger.info(
+                "cursored_scheduler.lock_contention",
+                extra={"scheduler": self.name},
+            )
+            return False
+
+    def _process_batch(self) -> bool:
+        tick_start = time.time()
+
+        cursor = self._get_cursor()
+        queryset = self.queryset
+
+        if cursor == 0:
+            batch_size = self._initialize_batch(queryset)
+        else:
+            batch_size = self._get_batch_size()
+
+        items = list(
+            queryset.filter(pk__gt=cursor).order_by("pk").values_list("pk", flat=True)[:batch_size]
+        )
+
+        if not items:
+            self._finalize_batch()
+            metrics.timing(
+                "cursored_scheduler.tick_duration", time.time() - tick_start, tags=self._metric_tags
+            )
+            return False
+
+        for pk in items:
+            self.task.delay(pk)
+
+        dispatched = len(items)
+        metrics.gauge("cursored_scheduler.batch_size", dispatched, tags=self._metric_tags)
+
+        self._set_cursor(items[-1])
+
+        metrics.timing(
+            "cursored_scheduler.tick_duration", time.time() - tick_start, tags=self._metric_tags
+        )
+
+        if dispatched < batch_size:
+            self._finalize_batch()
+            return False
+
+        return True
+
+    def _initialize_batch(self, queryset: QuerySet[M]) -> int:
+        batch_size = self._calculate_batch_size(queryset)
+        cache.set(self.batch_size_cache_key, batch_size, self.cache_ttl)
+        cache.set(self.cycle_start_cache_key, time.time(), self.cache_ttl)
+        return batch_size
+
+    def _finalize_batch(self):
+        """Reset cursor and batch size to 0, starting a new cycle on the next tick."""
+        self._emit_cycle_duration()
+        cache.set(self.cache_key, 0, self.cache_ttl)
+        cache.set(self.batch_size_cache_key, 0, self.cache_ttl)
+        cache.delete(self.cycle_start_cache_key)
+        metrics.incr("cursored_scheduler.cycle_complete", tags=self._metric_tags)
+
+    def _calculate_batch_size(self, queryset: QuerySet[M]) -> int:
+        """
+        Calculate batch size based on total rows, cycle duration, and tick interval.
+
+        batch_size = ceil(total_rows / ticks_per_cycle)
+        """
+        total_rows = queryset.count()
+        ticks_per_cycle = self.cycle_duration / self.tick_interval
+        batch_size = math.ceil(total_rows / ticks_per_cycle)
+        return max(batch_size, MIN_BATCH_SIZE)
+
+    def _emit_cycle_duration(self) -> None:
+        """Emit timing metrics for the completed cycle."""
+        cycle_start = cache.get(self.cycle_start_cache_key)
+        if cycle_start is None:
+            return
+
+        elapsed_seconds = time.time() - float(cycle_start)
+        target_seconds = self.cycle_duration.total_seconds()
+        drift_seconds = elapsed_seconds - target_seconds
+
+        metrics.timing("cursored_scheduler.cycle_duration", elapsed_seconds, tags=self._metric_tags)
+        metrics.timing("cursored_scheduler.cycle_drift", drift_seconds, tags=self._metric_tags)
+
+    def _get_cursor(self) -> int:
+        value = cache.get(self.cache_key)
+        if value is None:
+            return 0
+        return int(value)
+
+    def _set_cursor(self, cursor: int) -> None:
+        cache.set(self.cache_key, cursor, self.cache_ttl)
+
+    def _get_batch_size(self) -> int:
+        value = cache.get(self.batch_size_cache_key)
+        if value is None:
+            return 0
+        return int(value)

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -100,6 +100,8 @@ class CursoredSchedulerTest(TestCase):
         scheduler = self._make_scheduler()
 
         scheduler.tick()
+        first_batch_pks = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        assert first_batch_pks == [oi.pk for oi in ois[:10]]
         self.mock_task.reset_mock()
 
         scheduler.tick()

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -1,0 +1,332 @@
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from django.core.cache import cache
+from django.test import override_settings
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.utils.cursored_scheduler import (
+    BATCH_SIZE_CACHE_KEY_PREFIX,
+    CURSOR_CACHE_KEY_PREFIX,
+    CursoredScheduler,
+    _get_tick_interval,
+)
+
+TEST_SCHEDULES = {
+    "test-scheduler-beat": {
+        "task": "test:sentry.test_task",
+        "schedule": timedelta(minutes=1),
+    },
+    "test-scheduler-beat-5m": {
+        "task": "test:sentry.test_task_5m",
+        "schedule": timedelta(minutes=5),
+    },
+    "test-scheduler-beat-slow": {
+        "task": "test:sentry.test_task_slow",
+        "schedule": timedelta(minutes=1),
+    },
+}
+
+
+@control_silo_test
+@override_settings(TASKWORKER_SCHEDULES=TEST_SCHEDULES)
+class CursoredSchedulerTest(TestCase):
+    def setUp(self):
+        self.mock_task = MagicMock()
+        self.cache_key = f"{CURSOR_CACHE_KEY_PREFIX}:test_scheduler"
+        self.batch_size_key = f"{BATCH_SIZE_CACHE_KEY_PREFIX}:test_scheduler"
+        cache.delete(self.cache_key)
+        cache.delete(self.batch_size_key)
+
+    _oi_counter = 0
+
+    def _create_org_integrations(self, count):
+        """Create real OrganizationIntegration rows for testing."""
+        integrations = []
+        for _ in range(count):
+            CursoredSchedulerTest._oi_counter += 1
+            org = self.create_organization()
+            integration = self.create_integration(
+                organization=org,
+                external_id=str(CursoredSchedulerTest._oi_counter),
+                provider="github",
+            )
+            oi = OrganizationIntegration.objects.get(
+                organization_id=org.id, integration=integration
+            )
+            integrations.append(oi)
+        return integrations
+
+    def _make_scheduler(
+        self,
+        queryset=None,
+        cycle_duration=timedelta(minutes=3),
+        schedule_key="test-scheduler-beat",
+    ):
+        """
+        Default: 3-minute cycle with 1-minute tick interval (from schedule) = 3 ticks per cycle.
+        Batch size = ceil(total_rows / 3).
+        """
+        if queryset is None:
+            queryset = OrganizationIntegration.objects.filter(
+                integration__provider="github",
+                status=ObjectStatus.ACTIVE,
+            )
+        return CursoredScheduler(
+            name="test_scheduler",
+            schedule_key=schedule_key,
+            queryset=queryset,
+            task=self.mock_task,
+            cycle_duration=cycle_duration,
+        )
+
+    def test_calculates_batch_size(self):
+        """With 30 items, 3-min cycle, 1-min tick → batch_size=10."""
+        ois = self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+
+        assert self.mock_task.delay.call_count == 10
+        dispatched_pks = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        assert dispatched_pks == [oi.pk for oi in ois[:10]]
+
+    def test_advances_cursor_between_ticks(self):
+        ois = self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+        self.mock_task.reset_mock()
+
+        scheduler.tick()
+
+        dispatched_pks = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        assert dispatched_pks == [oi.pk for oi in ois[10:20]]
+
+    def test_completes_full_cycle(self):
+        ois = self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        assert scheduler.tick() is True  # batch 1: 10 items
+        assert scheduler.tick() is True  # batch 2: 10 items
+        assert scheduler.tick() is True  # batch 3: 10 items (exact batch_size)
+        assert scheduler.tick() is False  # batch 4: empty, cycle done
+
+        dispatched_pks = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        assert dispatched_pks == [oi.pk for oi in ois]
+
+    def test_resets_after_cycle_completes(self):
+        ois = self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        # Complete the cycle
+        scheduler.tick()
+        scheduler.tick()
+        scheduler.tick()
+        assert scheduler.tick() is False
+
+        self.mock_task.reset_mock()
+
+        # New cycle should start from beginning
+        scheduler.tick()
+        dispatched_pks = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        assert dispatched_pks == [oi.pk for oi in ois[:10]]
+
+    def test_empty_queryset(self):
+        scheduler = self._make_scheduler()
+
+        has_more = scheduler.tick()
+
+        assert has_more is False
+        self.mock_task.delay.assert_not_called()
+
+    def test_batch_size_cached_across_ticks(self):
+        """Batch size is calculated once at cycle start, not every tick."""
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+
+        cached_size = cache.get(self.batch_size_key)
+        assert cached_size is not None
+        assert int(cached_size) == 10
+
+    def test_batch_size_recalculated_on_new_cycle(self):
+        """After cycle completes and resets, batch size is recalculated."""
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        # Complete the cycle
+        scheduler.tick()
+        scheduler.tick()
+        scheduler.tick()
+        assert scheduler.tick() is False  # empty, cycle done
+
+        # Add more items — now 60 total, batch_size should be 20
+        self._create_org_integrations(30)
+
+        self.mock_task.reset_mock()
+
+        scheduler.tick()
+        assert self.mock_task.delay.call_count == 20
+
+    def test_reads_tick_interval_from_schedule(self):
+        """Tick interval is read from TASKWORKER_SCHEDULES, not passed directly."""
+        self._create_org_integrations(30)
+
+        # 5-min tick interval, 5-min cycle → 1 tick per cycle → batch_size=30
+        scheduler = self._make_scheduler(
+            cycle_duration=timedelta(minutes=5),
+            schedule_key="test-scheduler-beat-5m",
+        )
+
+        scheduler.tick()
+        assert self.mock_task.delay.call_count == 30
+
+    def test_cursor_survives_across_instances(self):
+        ois = self._create_org_integrations(30)
+        qs = OrganizationIntegration.objects.filter(
+            integration__provider="github",
+            status=ObjectStatus.ACTIVE,
+        )
+
+        scheduler1 = CursoredScheduler(
+            name="shared_key",
+            schedule_key="test-scheduler-beat",
+            queryset=qs,
+            task=self.mock_task,
+            cycle_duration=timedelta(minutes=3),
+        )
+        scheduler1.tick()
+        self.mock_task.reset_mock()
+
+        scheduler2 = CursoredScheduler(
+            name="shared_key",
+            schedule_key="test-scheduler-beat",
+            queryset=qs,
+            task=self.mock_task,
+            cycle_duration=timedelta(minutes=3),
+        )
+        scheduler2.tick()
+
+        dispatched_pks = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        assert dispatched_pks == [oi.pk for oi in ois[10:20]]
+
+    def test_different_names_are_independent(self):
+        self._create_org_integrations(30)
+        qs = OrganizationIntegration.objects.filter(
+            integration__provider="github",
+            status=ObjectStatus.ACTIVE,
+        )
+        task_a = MagicMock()
+        task_b = MagicMock()
+
+        # sched_a: 5-min tick, 5-min cycle → 1 tick → batch 30
+        scheduler_a = CursoredScheduler(
+            name="sched_a",
+            schedule_key="test-scheduler-beat-5m",
+            queryset=qs,
+            task=task_a,
+            cycle_duration=timedelta(minutes=5),
+        )
+        # sched_b: 1-min tick, 2-min cycle → 2 ticks → batch 15
+        scheduler_b = CursoredScheduler(
+            name="sched_b",
+            schedule_key="test-scheduler-beat",
+            queryset=qs,
+            task=task_b,
+            cycle_duration=timedelta(minutes=2),
+        )
+
+        scheduler_a.tick()
+        scheduler_b.tick()
+
+        assert task_a.delay.call_count == 30
+        assert task_b.delay.call_count == 15
+
+    def test_dispatches_pks_not_objects(self):
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+
+        for c in self.mock_task.delay.call_args_list:
+            assert isinstance(c.args[0], int)
+
+    def test_respects_queryset_filtering(self):
+        """Only items matching the queryset are processed."""
+        ois = self._create_org_integrations(30)
+
+        # Disable one
+        ois[5].update(status=ObjectStatus.DISABLED)
+
+        scheduler = self._make_scheduler()
+        scheduler.tick()
+
+        dispatched_pks = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        assert ois[5].pk not in dispatched_pks
+
+    def test_lock_contention_skips_tick(self):
+        """If lock is held by another tick, skip without processing."""
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        from sentry.locks import locks
+
+        lock = locks.get(
+            key=scheduler.lock_key,
+            duration=60,
+            name="test_contention",
+        )
+        with lock.acquire():
+            has_more = scheduler.tick()
+
+        assert has_more is False
+        self.mock_task.delay.assert_not_called()
+
+    def test_min_batch_size(self):
+        """Batch size is at least 1, even when math would produce < 1."""
+        self._create_org_integrations(3)
+        # 1-min tick, 100-min cycle, 3 items → ceil(3/100) = 1
+        scheduler = self._make_scheduler(
+            cycle_duration=timedelta(minutes=100),
+        )
+
+        # batch_size=1, so 3 ticks to process all 3 items
+        assert scheduler.tick() is True
+        assert self.mock_task.delay.call_count == 1
+
+        scheduler.tick()
+        scheduler.tick()
+        assert self.mock_task.delay.call_count == 3
+
+
+@override_settings(TASKWORKER_SCHEDULES=TEST_SCHEDULES)
+class GetTickIntervalTest(TestCase):
+    def test_reads_timedelta_schedule(self):
+        interval = _get_tick_interval("test-scheduler-beat")
+        assert interval == timedelta(minutes=1)
+
+    def test_reads_different_interval(self):
+        interval = _get_tick_interval("test-scheduler-beat-5m")
+        assert interval == timedelta(minutes=5)
+
+    def test_errors_on_missing_key(self):
+        with pytest.raises(ValueError, match="not found"):
+            _get_tick_interval("nonexistent-key")
+
+    @override_settings(
+        TASKWORKER_SCHEDULES={
+            "crontab-schedule": {
+                "task": "test:task",
+                "schedule": "not-a-timedelta",
+            },
+        }
+    )
+    def test_errors_on_non_timedelta_schedule(self):
+        with pytest.raises(TypeError, match="requires a timedelta"):
+            _get_tick_interval("crontab-schedule")


### PR DESCRIPTION
This adds in a framework that allows us to set up a beat task that schedules a task for all rows in a given queryset. It stripes the task over the schedule period to keep load evened out.

The initial usecase for this is to schedule a daily repo sync for all active integrations.

<!-- Describe your PR here. -->