### PR TITLE
feat(autofix): Remove empty file patches from autofix

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -3,6 +3,7 @@ import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLib
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
 import {
+  collectPatches,
   isCodeChangesArtifact,
   isCodingAgentsArtifact,
   isPullRequestsArtifact,
@@ -12,7 +13,7 @@ import {
   type RootCauseArtifact,
   type SolutionArtifact,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
-import type {Artifact} from 'sentry/views/seerExplorer/types';
+import type {Artifact, ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
 jest.mock('sentry/actionCreators/indicator');
 
@@ -237,6 +238,156 @@ describe('isCodingAgentsArtifact', () => {
 
   it('returns false when array contains invalid items', () => {
     expect(isCodingAgentsArtifact([{not_an: 'agent'}])).toBe(false);
+  });
+});
+
+describe('collectPatches', () => {
+  function makePatch(
+    overrides: Partial<ExplorerFilePatch> & {repo_name: string}
+  ): ExplorerFilePatch {
+    return {
+      diff: 'diff content',
+      patch: {
+        added: 1,
+        removed: 0,
+        path: 'file.py',
+        source_file: 'file.py',
+        target_file: 'file.py',
+        type: DiffFileType.MODIFIED,
+        hunks: [],
+      },
+      ...overrides,
+    };
+  }
+
+  it('returns an empty map for empty input', () => {
+    expect(collectPatches([])).toEqual(new Map());
+  });
+
+  it('returns a single patch grouped by repo', () => {
+    const patch = makePatch({repo_name: 'owner/repo'});
+    const result = collectPatches([patch]);
+
+    expect(result.size).toBe(1);
+    expect(result.get('owner/repo')).toEqual([patch]);
+  });
+
+  it('groups multiple patches in the same repo', () => {
+    const patch1 = makePatch({
+      repo_name: 'owner/repo',
+      patch: {
+        added: 1,
+        removed: 0,
+        path: 'a.py',
+        source_file: 'a.py',
+        target_file: 'a.py',
+        type: DiffFileType.MODIFIED,
+        hunks: [],
+      },
+    });
+    const patch2 = makePatch({
+      repo_name: 'owner/repo',
+      patch: {
+        added: 2,
+        removed: 1,
+        path: 'b.py',
+        source_file: 'b.py',
+        target_file: 'b.py',
+        type: DiffFileType.MODIFIED,
+        hunks: [],
+      },
+    });
+
+    const result = collectPatches([patch1, patch2]);
+
+    expect(result.size).toBe(1);
+    expect(result.get('owner/repo')).toEqual([patch1, patch2]);
+  });
+
+  it('separates patches into different repos', () => {
+    const patch1 = makePatch({repo_name: 'owner/repo-a'});
+    const patch2 = makePatch({repo_name: 'owner/repo-b'});
+
+    const result = collectPatches([patch1, patch2]);
+
+    expect(result.size).toBe(2);
+    expect(result.get('owner/repo-a')).toEqual([patch1]);
+    expect(result.get('owner/repo-b')).toEqual([patch2]);
+  });
+
+  it('deduplicates by file path keeping the last occurrence', () => {
+    const patchOld = makePatch({
+      repo_name: 'owner/repo',
+      diff: 'old diff',
+      patch: {
+        added: 1,
+        removed: 0,
+        path: 'file.py',
+        source_file: 'file.py',
+        target_file: 'file.py',
+        type: DiffFileType.MODIFIED,
+        hunks: [],
+      },
+    });
+    const patchNew = makePatch({
+      repo_name: 'owner/repo',
+      diff: 'new diff',
+      patch: {
+        added: 3,
+        removed: 2,
+        path: 'file.py',
+        source_file: 'file.py',
+        target_file: 'file.py',
+        type: DiffFileType.MODIFIED,
+        hunks: [],
+      },
+    });
+
+    const result = collectPatches([patchOld, patchNew]);
+
+    expect(result.get('owner/repo')).toHaveLength(1);
+    expect(result.get('owner/repo')![0]!.diff).toBe('new diff');
+  });
+
+  it('filters out no-op patches with zero added and removed', () => {
+    const noOpPatch = makePatch({
+      repo_name: 'owner/repo',
+      patch: {
+        added: 0,
+        removed: 0,
+        path: 'file.py',
+        source_file: 'file.py',
+        target_file: 'file.py',
+        type: DiffFileType.MODIFIED,
+        hunks: [],
+      },
+    });
+
+    const result = collectPatches([noOpPatch]);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('removes repos that have only no-op patches', () => {
+    const noOp = makePatch({
+      repo_name: 'owner/empty-repo',
+      patch: {
+        added: 0,
+        removed: 0,
+        path: 'file.py',
+        source_file: 'file.py',
+        target_file: 'file.py',
+        type: DiffFileType.MODIFIED,
+        hunks: [],
+      },
+    });
+    const real = makePatch({repo_name: 'owner/real-repo'});
+
+    const result = collectPatches([noOp, real]);
+
+    expect(result.size).toBe(1);
+    expect(result.has('owner/empty-repo')).toBe(false);
+    expect(result.get('owner/real-repo')).toEqual([real]);
   });
 });
 

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -795,3 +795,44 @@ export function useExplorerAutofix(
     triggerCodingAgentHandoff,
   };
 }
+
+export function collectPatches(
+  patches: ExplorerFilePatch[]
+): Map<string, ExplorerFilePatch[]> {
+  const patchesByRepo = new Map<string, ExplorerFilePatch[]>();
+
+  for (const patch of patches) {
+    const existing = patchesByRepo.get(patch.repo_name) || [];
+    existing.push(patch);
+    patchesByRepo.set(patch.repo_name, existing);
+  }
+
+  for (const [repoName, repoPatches] of patchesByRepo) {
+    const cleanedPatches = cleanPatches(repoPatches);
+    if (cleanedPatches.length) {
+      patchesByRepo.set(repoName, cleanedPatches);
+    } else {
+      patchesByRepo.delete(repoName);
+    }
+  }
+
+  return patchesByRepo;
+}
+
+function cleanPatches(patches: ExplorerFilePatch[]): ExplorerFilePatch[] {
+  const cleanedPatches: ExplorerFilePatch[] = [];
+
+  const patchedFiles = new Set<string>();
+
+  patches.toReversed().forEach(patch => {
+    if (patchedFiles.has(patch.patch.path)) {
+      return;
+    }
+    patchedFiles.add(patch.patch.path);
+    cleanedPatches.push(patch);
+  });
+
+  return cleanedPatches.reverse().filter(patch => {
+    return patch.patch.added > 0 || patch.patch.removed > 0;
+  });
+}

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -12,6 +12,7 @@ import {
   getResultButtonLabel,
 } from 'sentry/components/events/autofix/types';
 import {
+  collectPatches,
   getAutofixArtifactFromSection,
   isCodeChangesArtifact,
   isCodingAgentsArtifact,
@@ -33,7 +34,6 @@ import {IconPullRequest} from 'sentry/icons/iconPullRequest';
 import {t, tct, tn} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/fileDiffViewer';
-import {type ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
 interface AutofixCardProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
@@ -167,22 +167,14 @@ export function CodeChangesCard({autofix, section}: AutofixCardProps) {
     return isCodeChangesArtifact(sectionArtifact) ? sectionArtifact : null;
   }, [section]);
 
-  const patchesForRepos = useMemo(() => {
-    const patchesByRepo = new Map<string, ExplorerFilePatch[]>();
-    for (const patch of artifact ?? []) {
-      const existing = patchesByRepo.get(patch.repo_name) || [];
-      existing.push(patch);
-      patchesByRepo.set(patch.repo_name, existing);
-    }
-    return patchesByRepo;
-  }, [artifact]);
+  const patchesByRepo = useMemo(() => collectPatches(artifact ?? []), [artifact]);
 
   const summary = useMemo(() => {
-    const reposChanged = patchesForRepos.size;
+    const reposChanged = patchesByRepo.size;
 
     const filesChanged = new Set<string>();
 
-    for (const [repo, patchesForRepo] of patchesForRepos.entries()) {
+    for (const [repo, patchesForRepo] of patchesByRepo.entries()) {
       for (const patch of patchesForRepo) {
         filesChanged.add(`${repo}:${patch.patch.path}`);
       }
@@ -197,7 +189,7 @@ export function CodeChangesCard({autofix, section}: AutofixCardProps) {
     }
 
     return t('%s files changed in %s repos', filesChanged.size, reposChanged);
-  }, [patchesForRepos]);
+  }, [patchesByRepo]);
 
   const {runState, startStep} = autofix;
   const runId = runState?.run_id;
@@ -208,10 +200,10 @@ export function CodeChangesCard({autofix, section}: AutofixCardProps) {
         <LoadingDetails messages={section.messages} />
       ) : (
         <Fragment>
-          {patchesForRepos.size ? (
+          {patchesByRepo.size ? (
             <Fragment>
               <Text>{summary}</Text>
-              {[...patchesForRepos.entries()].map(([repo, patches]) => (
+              {[...patchesByRepo.entries()].map(([repo, patches]) => (
                 <ArtifactDetails key={repo}>
                   <Flex gap="lg">
                     <Text bold>{t('Repository:')}</Text>

--- a/static/app/components/events/autofix/v3/autofixPreviews.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.tsx
@@ -11,6 +11,7 @@ import {
   getCodingAgentName,
 } from 'sentry/components/events/autofix/types';
 import {
+  collectPatches,
   getAutofixArtifactFromSection,
   isCodeChangesArtifact,
   isCodingAgentsArtifact,
@@ -27,7 +28,6 @@ import {IconCode} from 'sentry/icons/iconCode';
 import {IconList} from 'sentry/icons/iconList';
 import {IconPullRequest} from 'sentry/icons/iconPullRequest';
 import {t, tn} from 'sentry/locale';
-import {type ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
 interface ArtifactPreviewProps {
   section: AutofixSection;
@@ -83,22 +83,14 @@ export function CodeChangesPreview({section}: ArtifactPreviewProps) {
     return isCodeChangesArtifact(sectionArtifact) ? sectionArtifact : [];
   }, [section]);
 
-  const patchesForRepos = useMemo(() => {
-    const patchesByRepo = new Map<string, ExplorerFilePatch[]>();
-    for (const patch of artifact) {
-      const existing = patchesByRepo.get(patch.repo_name) || [];
-      existing.push(patch);
-      patchesByRepo.set(patch.repo_name, existing);
-    }
-    return patchesByRepo;
-  }, [artifact]);
+  const patchesByRepo = useMemo(() => collectPatches(artifact ?? []), [artifact]);
 
   const summary = useMemo(() => {
-    const reposChanged = patchesForRepos.size;
+    const reposChanged = patchesByRepo.size;
 
     const filesChanged = new Set<string>();
 
-    for (const [repo, patchesForRepo] of patchesForRepos.entries()) {
+    for (const [repo, patchesForRepo] of patchesByRepo.entries()) {
       for (const patch of patchesForRepo) {
         filesChanged.add(`${repo}:${patch.patch.path}`);
       }
@@ -129,7 +121,7 @@ export function CodeChangesPreview({section}: ArtifactPreviewProps) {
     return (
       <Text>{t('%s files changed in %s repos', filesChanged.size, reposChanged)}</Text>
     );
-  }, [patchesForRepos]);
+  }, [patchesByRepo]);
 
   return (
     <ArtifactCard icon={<IconCode />} title={t('Code Changes')}>


### PR DESCRIPTION
Empty file patches are generated to overwrite previous file patches. These are rendered as empty changes. We only want to preserve the last file patch for a file and we need to ensure it is a non empty file patch.