### PR TITLE
fix(aci): Link from legacy alerts should go to /monitors/alerts

### DIFF
--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -23,6 +23,7 @@ import {AutomationSearch} from 'sentry/views/automations/components/automationLi
 import {AUTOMATION_LIST_PAGE_LIMIT} from 'sentry/views/automations/constants';
 import {useAutomationsQuery} from 'sentry/views/automations/hooks';
 import {makeAutomationCreatePathname} from 'sentry/views/automations/pathnames';
+import {AlertsRedirectNotice} from 'sentry/views/detectors/list/common/alertsRedirectNotice';
 
 export default function AutomationsList() {
   const location = useLocation();
@@ -85,6 +86,9 @@ export default function AutomationsList() {
         )}
         docsUrl="https://docs.sentry.io/product/new-monitors-and-alerts/alerts/"
       >
+        <AlertsRedirectNotice>
+          {t('Alert Rules have been moved to Monitors and Alerts.')}
+        </AlertsRedirectNotice>
         <TableHeader />
         <div>
           <VisuallyCompleteWithData

--- a/static/app/views/detectors/list/allMonitors.tsx
+++ b/static/app/views/detectors/list/allMonitors.tsx
@@ -1,7 +1,6 @@
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {WorkflowEngineListLayout} from 'sentry/components/workflowEngine/layout/list';
 import {t} from 'sentry/locale';
-import {AlertsRedirectNotice} from 'sentry/views/detectors/list/common/alertsRedirectNotice';
 import {DetectorListActions} from 'sentry/views/detectors/list/common/detectorListActions';
 import {DetectorListContent} from 'sentry/views/detectors/list/common/detectorListContent';
 import {DetectorListHeader} from 'sentry/views/detectors/list/common/detectorListHeader';
@@ -24,9 +23,6 @@ export default function AllMonitors() {
         description={DESCRIPTION}
         docsUrl={DOCS_URL}
       >
-        <AlertsRedirectNotice>
-          {t('Alert Rules have been moved to Monitors and Alerts.')}
-        </AlertsRedirectNotice>
         <DetectorListHeader />
         <DetectorListContent {...detectorListQuery} />
       </WorkflowEngineListLayout>

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
+import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
 import {usePrimaryNavigation} from 'sentry/views/navigation/primaryNavigationContext';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
@@ -127,7 +127,7 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
     !hasRedirectOptOut && organization.features.includes('workflow-engine-ui');
 
   const alertsLink = shouldRedirectToWorkflowEngineUI
-    ? `${makeMonitorBasePathname(organization.slug)}?alertsRedirect=true`
+    ? `${makeAutomationBasePathname(organization.slug)}?alertsRedirect=true`
     : `${baseUrl}/alerts/rules/`;
 
   return (


### PR DESCRIPTION
Quick fix: clicking the legacy "Alerts" nav under issues should take you to the `/monitors/alerts/` page instead of `/monitors/`