### PR TITLE
fix(grouping): Fix git sha parameterization test

### DIFF
--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -161,7 +161,7 @@ standard_cases = [
     ("hex without prefix - no letters, < 8 digits, negative", "-1234567", "<int>"),
     ("hex without prefix - no letters, 8+ digits, positive", "12345678", "<hex>"),
     ("git sha", "commit a93c7d2", "commit <git_sha>"),
-    ("git sha - all letters", "commit deadbeef", "commit deadbeef"),
+    ("git sha - all letters", "commit cabcafe", "commit cabcafe"),
     ("git sha - all numbers", "commit 4150908", "commit <int>"),
     ("float", "0.23", "<float>"),
     ("int", "23", "<int>"),


### PR DESCRIPTION
We have a parameterization test case for our git sha parameterization which was meant to show that if the value doesn't include any numbers, it doesn't match our the pattern. But our git sha pattern only matches strings with exactly 7 characters, and the test case currently has 8, so of course it doesn't match! This fixes things so we're actually testing against a valid git sha.