### PR TITLE
fix(seer): Add dual-write when project preference doesn't exist, and pass full preference to autofix request

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -39,6 +39,7 @@ from sentry.seer.autofix.types import (
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     get_autofix_repos_from_project_code_mappings,
+    get_org_default_seer_automation_handoff,
     get_project_seer_preferences,
     make_autofix_start_request,
     make_autofix_update_request,
@@ -46,11 +47,7 @@ from sentry.seer.autofix.utils import (
     write_preference_to_sentry_db,
 )
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree, fetch_profile_data
-from sentry.seer.models import (
-    SeerApiError,
-    SeerApiResponseValidationError,
-    SeerProjectPreference,
-)
+from sentry.seer.models import SeerProjectPreference
 from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -703,52 +700,35 @@ def get_all_tags_overview(
 
 def _resolve_project_preference(
     organization: Organization, project: Project, fallback_repos: list[dict]
-) -> SeerProjectPreference | None:
+) -> SeerProjectPreference:
     """
     Resolve the Seer project preference for a project before triggering autofix.
 
     If an existing preference is found in Seer, returns it.
     If not, creates one from fallback_repos.
-
-    Returns None only if the preference cannot be resolved (e.g. API errors
-    and no fallback repos to bootstrap from).
     """
-    try:
-        preference_response = get_project_seer_preferences(project.id)
-        if preference_response.preference:
-            return preference_response.preference
-    except (SeerApiError, SeerApiResponseValidationError):
-        logger.exception(
-            "seer.write_preferences.resolve_project_preference.get_failed",
-            extra={"project_id": project.id, "organization_id": organization.id},
-        )
-        return None
+    preference_response = get_project_seer_preferences(project.id)
+    if preference_response.preference:
+        return preference_response.preference
 
-    if not fallback_repos:
-        return None
-
+    default_stopping_point, default_handoff = get_org_default_seer_automation_handoff(organization)
     preference = SeerProjectPreference(
         organization_id=organization.id,
         project_id=project.id,
         repositories=fallback_repos,
-        automated_run_stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
+        automated_run_stopping_point=default_stopping_point,
+        automation_handoff=default_handoff,
     )
 
-    try:
-        set_project_seer_preference(preference)
-    except SeerApiError:
-        logger.exception(
-            "seer.write_preferences.resolve_project_preference.set_failed",
-            extra={"project_id": project.id, "organization_id": organization.id},
-        )
-        return None
+    set_project_seer_preference(preference)
 
     try:
         write_preference_to_sentry_db(project, preference)
     except Exception:
         logger.exception(
-            "seer.write_preferences.resolve_project_preference.write_failed",
+            "seer.write_preferences.resolve_project_preference.sentry_db_write_failed",
             extra={"project_id": project.id, "organization_id": organization.id},
+            exc_info=True,
         )
 
     return preference
@@ -802,9 +782,17 @@ def trigger_autofix(
     code_mappings = get_sorted_code_mapping_configs(group.project)
     repos = get_autofix_repos_from_project_code_mappings(group.project, code_mappings=code_mappings)
 
-    preference = _resolve_project_preference(group.organization, group.project, repos)
-    if preference and preference.repositories:
-        repos = [repo.dict() for repo in preference.repositories]
+    preference: SeerProjectPreference | None = None
+    try:
+        preference = _resolve_project_preference(group.organization, group.project, repos)
+        if preference.repositories:
+            repos = [repo.dict() for repo in preference.repositories]
+    except Exception:
+        logger.exception(
+            "seer.write_preferences.resolve_project_preference.failed",
+            extra={"project_id": group.project.id, "organization_id": group.organization.id},
+            exc_info=True,
+        )
 
     # Pre-resolve stacktrace frame paths using code mappings so Seer can skip
     # expensive git tree fetches for large repos.

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -702,16 +702,16 @@ def get_all_tags_overview(
 
 
 def _resolve_project_preference(
-    organization: Organization, project: Project, code_mapping_repos: list[dict]
+    organization: Organization, project: Project, fallback_repos: list[dict]
 ) -> SeerProjectPreference | None:
     """
     Resolve the Seer project preference for a project before triggering autofix.
 
     If an existing preference is found in Seer, returns it.
-    If not, creates one from code mapping repos.
+    If not, creates one from fallback_repos.
 
     Returns None only if the preference cannot be resolved (e.g. API errors
-    and no code mapping repos to bootstrap from).
+    and no fallback repos to bootstrap from).
     """
     try:
         preference_response = get_project_seer_preferences(project.id)
@@ -724,14 +724,13 @@ def _resolve_project_preference(
         )
         return None
 
-    # No code mapping repos to bootstrap from.
-    if not code_mapping_repos:
+    if not fallback_repos:
         return None
 
     preference = SeerProjectPreference(
         organization_id=organization.id,
         project_id=project.id,
-        repositories=code_mapping_repos,
+        repositories=fallback_repos,
         automated_run_stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
     )
 

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -741,7 +741,7 @@ def _resolve_project_preference(
             "seer.write_preferences.resolve_project_preference.failed",
             extra={"project_id": project.id, "organization_id": organization.id},
         )
-        return
+        return None
 
     try:
         write_preference_to_sentry_db(project, preference)

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -715,7 +715,7 @@ def _resolve_project_preference(
     """
     try:
         preference_response = get_project_seer_preferences(project.id)
-        if preference_response.preference and preference_response.preference.repositories:
+        if preference_response.preference:
             return preference_response.preference
     except (SeerApiError, SeerApiResponseValidationError):
         logger.exception(

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -39,10 +39,18 @@ from sentry.seer.autofix.types import (
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     get_autofix_repos_from_project_code_mappings,
+    get_project_seer_preferences,
     make_autofix_start_request,
     make_autofix_update_request,
+    set_project_seer_preference,
+    write_preference_to_sentry_db,
 )
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree, fetch_profile_data
+from sentry.seer.models import (
+    SeerApiError,
+    SeerApiResponseValidationError,
+    SeerProjectPreference,
+)
 from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -530,6 +538,7 @@ def _call_autofix(
     auto_run_source: str | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
     github_username: str | None = None,
+    preference: SeerProjectPreference | None = None,
 ):
     body = orjson.dumps(
         {
@@ -568,6 +577,7 @@ def _call_autofix(
                 ),
                 "stopping_point": stopping_point.value if stopping_point else None,
             },
+            "preference": preference.dict() if preference else None,
         },
         option=orjson.OPT_NON_STR_KEYS,
     )
@@ -691,6 +701,59 @@ def get_all_tags_overview(
     }
 
 
+def _resolve_project_preference(
+    organization: Organization, project: Project, code_mapping_repos: list[dict]
+) -> SeerProjectPreference | None:
+    """
+    Resolve the Seer project preference for a project before triggering autofix.
+
+    If an existing preference is found in Seer, returns it.
+    If not, creates one from code mapping repos.
+
+    Returns None only if the preference cannot be resolved (e.g. API errors
+    and no code mapping repos to bootstrap from).
+    """
+    try:
+        preference_response = get_project_seer_preferences(project.id)
+        if preference_response.preference and preference_response.preference.repositories:
+            return SeerProjectPreference.validate(preference_response.preference)
+    except (SeerApiError, SeerApiResponseValidationError):
+        logger.exception(
+            "seer.write_preferences.resolve_project_preference.failed",
+            extra={"project_id": project.id, "organization_id": organization.id},
+        )
+
+    # No code mapping repos to bootstrap from.
+    if not code_mapping_repos:
+        return None
+
+    preference = SeerProjectPreference(
+        organization_id=organization.id,
+        project_id=project.id,
+        repositories=code_mapping_repos,
+        automated_run_stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
+    )
+
+    try:
+        set_project_seer_preference(preference)
+    except SeerApiError:
+        logger.exception(
+            "seer.write_preferences.resolve_project_preference.failed",
+            extra={"project_id": project.id, "organization_id": organization.id},
+        )
+        return
+
+    try:
+        write_preference_to_sentry_db(project, preference)
+    except Exception:
+        logger.exception(
+            "seer.write_preferences.resolve_project_preference.failed",
+            extra={"project_id": project.id, "organization_id": organization.id},
+        )
+
+    return preference
+
+
 def trigger_autofix(
     *,
     group: Group,
@@ -738,6 +801,10 @@ def trigger_autofix(
 
     code_mappings = get_sorted_code_mapping_configs(group.project)
     repos = get_autofix_repos_from_project_code_mappings(group.project, code_mappings=code_mappings)
+
+    preference = _resolve_project_preference(group.organization, group.project, repos)
+    if preference and preference.repositories:
+        repos = [repo.dict() for repo in preference.repositories]
 
     # Pre-resolve stacktrace frame paths using code mappings so Seer can skip
     # expensive git tree fetches for large repos.
@@ -796,6 +863,7 @@ def trigger_autofix(
             auto_run_source=auto_run_source,
             stopping_point=stopping_point,
             github_username=github_username,
+            preference=preference,
         )
     except Exception:
         logger.exception("Failed to send autofix to seer")

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -722,6 +722,7 @@ def _resolve_project_preference(
             "seer.write_preferences.resolve_project_preference.failed",
             extra={"project_id": project.id, "organization_id": organization.id},
         )
+        return None
 
     # No code mapping repos to bootstrap from.
     if not code_mapping_repos:

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -782,11 +782,14 @@ def trigger_autofix(
     code_mappings = get_sorted_code_mapping_configs(group.project)
     repos = get_autofix_repos_from_project_code_mappings(group.project, code_mappings=code_mappings)
 
+    # Resolve the project preference from Seer, or bootstrap one from code mapping repos.
+    # On success, preference.repositories becomes the source of truth for repos
+    # (even if empty — matching Seer's behavior of unconditionally using preference repos).
+    # On failure, we fall back to the original code mapping repos above.
     preference: SeerProjectPreference | None = None
     try:
         preference = _resolve_project_preference(group.organization, group.project, repos)
-        if preference.repositories:
-            repos = [repo.dict() for repo in preference.repositories]
+        repos = [repo.dict() for repo in preference.repositories]
     except Exception:
         logger.exception(
             "seer.write_preferences.resolve_project_preference.failed",

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -716,10 +716,10 @@ def _resolve_project_preference(
     try:
         preference_response = get_project_seer_preferences(project.id)
         if preference_response.preference and preference_response.preference.repositories:
-            return SeerProjectPreference.validate(preference_response.preference)
+            return preference_response.preference
     except (SeerApiError, SeerApiResponseValidationError):
         logger.exception(
-            "seer.write_preferences.resolve_project_preference.failed",
+            "seer.write_preferences.resolve_project_preference.get_failed",
             extra={"project_id": project.id, "organization_id": organization.id},
         )
         return None
@@ -738,7 +738,7 @@ def _resolve_project_preference(
         set_project_seer_preference(preference)
     except SeerApiError:
         logger.exception(
-            "seer.write_preferences.resolve_project_preference.failed",
+            "seer.write_preferences.resolve_project_preference.set_failed",
             extra={"project_id": project.id, "organization_id": organization.id},
         )
         return None
@@ -747,7 +747,7 @@ def _resolve_project_preference(
         write_preference_to_sentry_db(project, preference)
     except Exception:
         logger.exception(
-            "seer.write_preferences.resolve_project_preference.failed",
+            "seer.write_preferences.resolve_project_preference.write_failed",
             extra={"project_id": project.id, "organization_id": organization.id},
         )
 

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1137,10 +1137,12 @@ class TestResolveProjectPreference(TestCase):
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
     @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_creates_preference_from_code_mappings(
+    def test_creates_preference_from_code_mappings_and_org_defaults(
         self, mock_get_prefs, mock_set_pref, mock_write_sentry
     ):
         mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
+        self.organization.update_option("sentry:default_automated_run_stopping_point", "open_pr")
+        self.organization.update_option("sentry:auto_open_prs", True)
 
         code_mapping_repos = [self._mock_repo("sentry", "123")]
         result = _resolve_project_preference(self.organization, self.project, code_mapping_repos)
@@ -1151,7 +1153,7 @@ class TestResolveProjectPreference(TestCase):
         assert len(result.repositories) == 1
         assert result.repositories[0].name == "sentry"
         assert result.repositories[0].external_id == "123"
-        assert result.automated_run_stopping_point == "code_changes"
+        assert result.automated_run_stopping_point == "open_pr"
         mock_set_pref.assert_called_once()
         mock_write_sentry.assert_called_once()
 

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -17,6 +17,7 @@ from sentry.seer.autofix.autofix import (
     _get_profile_from_trace_tree,
     _get_trace_tree_for_event,
     _pre_resolve_stacktrace_frames,
+    _resolve_project_preference,
     _respond_with_error,
     get_all_tags_overview,
     trigger_autofix,
@@ -24,6 +25,7 @@ from sentry.seer.autofix.autofix import (
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.types import AutofixSelectRootCausePayload
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
+from sentry.seer.models import SeerApiError, SeerProjectPreference, SeerRawPreferenceResponse
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
@@ -829,8 +831,10 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
+    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_trigger_autofix_with_event_id(
         self,
+        mock_resolve_pref,
         mock_check_autofix_status,
         mock_call,
         mock_get_trace,
@@ -935,8 +939,10 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
+    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_trigger_autofix_with_web_vitals_issue(
         self,
+        mock_resolve_pref,
         mock_check_autofix_status,
         mock_call,
         mock_get_trace,
@@ -1025,6 +1031,140 @@ class TestTriggerAutofixWithHideAiFeatures(APITestCase, SnubaTestCase):
         assert "AI features are disabled for this organization" in response.data["detail"]
         # Verify _get_serialized_event was not called since AI features are disabled
         mock_get_serialized_event.assert_not_called()
+
+
+class TestResolveProjectPreference(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+
+    def _mock_repo(self, name: str = "sentry", external_id: str = "123") -> dict:
+        return {
+            "provider": "integrations:github",
+            "owner": "getsentry",
+            "name": name,
+            "external_id": external_id,
+        }
+
+    def _mock_preference(
+        self,
+        organization_id: int,
+        project_id: int,
+        repos: list[dict] | None = None,
+        stopping_point: str = "CODE_CHANGES",
+    ) -> SeerProjectPreference:
+        return SeerProjectPreference(
+            organization_id=organization_id,
+            project_id=project_id,
+            repositories=repos or [self._mock_repo()],
+            automated_run_stopping_point=stopping_point,
+        )
+
+    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
+    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
+    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
+    def test_returns_existing_preference(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
+        existing_repos = [self._mock_repo("seer", "999")]
+        mock_get_prefs.return_value = SeerRawPreferenceResponse(
+            preference=self._mock_preference(
+                self.organization.id,
+                self.project.id,
+                repos=existing_repos,
+                stopping_point="ROOT_CAUSE",
+            )
+        )
+
+        result = _resolve_project_preference(
+            self.organization, self.project, [self._mock_repo("sentry", "123")]
+        )
+
+        assert result is not None
+        assert result.repositories == existing_repos
+        assert result.automated_run_stopping_point == "ROOT_CAUSE"
+        mock_set_pref.assert_not_called()
+        mock_write_sentry.assert_not_called()
+
+    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
+    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
+    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
+    def test_creates_preference_from_code_mappings(
+        self, mock_get_prefs, mock_set_pref, mock_write_sentry
+    ):
+        mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
+
+        code_mapping_repos = [self._mock_repo("sentry", "123")]
+        result = _resolve_project_preference(self.organization, self.project, code_mapping_repos)
+
+        assert result is not None
+        assert result.project_id == self.project.id
+        assert result.organization_id == self.organization.id
+        assert result.repositories == code_mapping_repos
+        assert result.automated_run_stopping_point == "CODE_CHANGES"
+
+    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
+    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
+    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
+    def test_returns_none_when_no_repos(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
+        mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
+
+        result = _resolve_project_preference(self.organization, self.project, [])
+
+        assert result is None
+        mock_set_pref.assert_not_called()
+        mock_write_sentry.assert_not_called()
+
+    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
+    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
+    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
+    def test_returns_none_on_get_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
+        mock_get_prefs.side_effect = SeerApiError()
+
+        result = _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
+
+        assert result is None
+        mock_set_pref.assert_not_called()
+        mock_write_sentry.assert_not_called()
+
+    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
+    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
+    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
+    def test_returns_none_on_set_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
+        mock_get_prefs.return_value = SeerRawPreferenceResponse(
+            preference=self._mock_preference(
+                self.organization.id,
+                self.project.id,
+                repos=[self._mock_repo()],
+                stopping_point="ROOT_CAUSE",
+            )
+        )
+        mock_set_pref.side_effect = SeerApiError()
+
+        result = _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
+
+        assert result is None
+        mock_write_sentry.assert_not_called()
+
+    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
+    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
+    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
+    def test_returns_preference_on_sentry_db_write_error(
+        self, mock_get_prefs, mock_set_pref, mock_write_sentry
+    ):
+        mock_get_prefs.return_value = SeerRawPreferenceResponse(
+            preference=self._mock_preference(
+                self.organization.id,
+                self.project.id,
+                repos=[self._mock_repo()],
+                stopping_point="ROOT_CAUSE",
+            )
+        )
+        mock_write_sentry.side_effect = Exception()
+
+        result = _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
+
+        assert result is not None
+        assert result.project_id == self.project.id
 
 
 class TestCallAutofix(TestCase):

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -25,12 +25,7 @@ from sentry.seer.autofix.autofix import (
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.types import AutofixSelectRootCausePayload
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
-from sentry.seer.models import (
-    SeerApiError,
-    SeerProjectPreference,
-    SeerRawPreferenceResponse,
-    SeerRepoDefinition,
-)
+from sentry.seer.models import SeerApiError, SeerProjectPreference, SeerRawPreferenceResponse
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
@@ -1044,19 +1039,19 @@ class TestResolveProjectPreference(TestCase):
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
 
-    def _mock_repo(self, name: str = "sentry", external_id: str = "123") -> SeerRepoDefinition:
-        return SeerRepoDefinition(
-            provider="integrations:github",
-            owner="getsentry",
-            name=name,
-            external_id=external_id,
-        )
+    def _mock_repo(self, name: str = "sentry", external_id: str = "123") -> dict:
+        return {
+            "provider": "integrations:github",
+            "owner": "getsentry",
+            "name": name,
+            "external_id": external_id,
+        }
 
     def _mock_preference(
         self,
         organization_id: int,
         project_id: int,
-        repos: list[SeerRepoDefinition] | None = None,
+        repos: list[dict] | None = None,
         stopping_point: str = "CODE_CHANGES",
     ) -> SeerProjectPreference:
         return SeerProjectPreference(
@@ -1085,7 +1080,9 @@ class TestResolveProjectPreference(TestCase):
         )
 
         assert result is not None
-        assert result.repositories == existing_repos
+        assert len(result.repositories) == 1
+        assert result.repositories[0].name == "seer"
+        assert result.repositories[0].external_id == "999"
         assert result.automated_run_stopping_point == "ROOT_CAUSE"
         mock_set_pref.assert_not_called()
         mock_write_sentry.assert_not_called()
@@ -1104,7 +1101,9 @@ class TestResolveProjectPreference(TestCase):
         assert result is not None
         assert result.project_id == self.project.id
         assert result.organization_id == self.organization.id
-        assert result.repositories == code_mapping_repos
+        assert len(result.repositories) == 1
+        assert result.repositories[0].name == "sentry"
+        assert result.repositories[0].external_id == "123"
         assert result.automated_run_stopping_point == "CODE_CHANGES"
 
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1158,37 +1158,40 @@ class TestResolveProjectPreference(TestCase):
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
     @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_returns_none_when_no_repos(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
+    def test_creates_preference_with_empty_repos_when_no_fallback(
+        self, mock_get_prefs, mock_set_pref, mock_write_sentry
+    ):
         mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
 
         result = _resolve_project_preference(self.organization, self.project, [])
 
-        assert result is None
-        mock_set_pref.assert_not_called()
-        mock_write_sentry.assert_not_called()
+        assert result is not None
+        assert result.repositories == []
+        mock_set_pref.assert_called_once()
+        mock_write_sentry.assert_called_once()
 
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
     @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_returns_none_on_get_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
+    def test_raises_on_get_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
         mock_get_prefs.side_effect = SeerApiError("test error", 500)
 
-        result = _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
+        with pytest.raises(SeerApiError):
+            _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
 
-        assert result is None
         mock_set_pref.assert_not_called()
         mock_write_sentry.assert_not_called()
 
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
     @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_returns_none_on_set_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
+    def test_raises_on_set_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
         mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
         mock_set_pref.side_effect = SeerApiError("test error", 500)
 
-        result = _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
+        with pytest.raises(SeerApiError):
+            _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
 
-        assert result is None
         mock_write_sentry.assert_not_called()
 
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
@@ -1197,20 +1200,15 @@ class TestResolveProjectPreference(TestCase):
     def test_returns_preference_on_sentry_db_write_error(
         self, mock_get_prefs, mock_set_pref, mock_write_sentry
     ):
-        mock_get_prefs.return_value = SeerRawPreferenceResponse(
-            preference=SeerProjectPreference(
-                organization_id=self.organization.id,
-                project_id=self.project.id,
-                repositories=[self._mock_repo()],
-                automated_run_stopping_point="root_cause",
-            )
-        )
+        mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
         mock_write_sentry.side_effect = Exception()
 
         result = _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
 
         assert result is not None
         assert result.project_id == self.project.id
+        mock_set_pref.assert_called_once()
+        mock_write_sentry.assert_called_once()
 
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1215,7 +1215,7 @@ class TestResolveProjectPreference(TestCase):
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
     @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_falls_back_when_preference_has_empty_repos(
+    def test_returns_preference_with_empty_repos(
         self, mock_get_prefs, mock_set_pref, mock_write_sentry
     ):
         mock_get_prefs.return_value = SeerRawPreferenceResponse(
@@ -1231,11 +1231,10 @@ class TestResolveProjectPreference(TestCase):
         result = _resolve_project_preference(self.organization, self.project, fallback_repos)
 
         assert result is not None
-        assert len(result.repositories) == 1
-        assert result.repositories[0].name == "sentry"
-        assert result.automated_run_stopping_point == "code_changes"
-        mock_set_pref.assert_called_once()
-        mock_write_sentry.assert_called_once()
+        assert len(result.repositories) == 0
+        assert result.automated_run_stopping_point == "root_cause"
+        mock_set_pref.assert_not_called()
+        mock_write_sentry.assert_not_called()
 
 
 class TestCallAutofix(TestCase):

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -25,7 +25,12 @@ from sentry.seer.autofix.autofix import (
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.types import AutofixSelectRootCausePayload
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
-from sentry.seer.models import SeerApiError, SeerProjectPreference, SeerRawPreferenceResponse
+from sentry.seer.models import (
+    SeerApiError,
+    SeerProjectPreference,
+    SeerRawPreferenceResponse,
+    SeerRepoDefinition,
+)
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
@@ -1039,19 +1044,19 @@ class TestResolveProjectPreference(TestCase):
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
 
-    def _mock_repo(self, name: str = "sentry", external_id: str = "123") -> dict:
-        return {
-            "provider": "integrations:github",
-            "owner": "getsentry",
-            "name": name,
-            "external_id": external_id,
-        }
+    def _mock_repo(self, name: str = "sentry", external_id: str = "123") -> SeerRepoDefinition:
+        return SeerRepoDefinition(
+            provider="integrations:github",
+            owner="getsentry",
+            name=name,
+            external_id=external_id,
+        )
 
     def _mock_preference(
         self,
         organization_id: int,
         project_id: int,
-        repos: list[dict] | None = None,
+        repos: list[SeerRepoDefinition] | None = None,
         stopping_point: str = "CODE_CHANGES",
     ) -> SeerProjectPreference:
         return SeerProjectPreference(
@@ -1118,7 +1123,7 @@ class TestResolveProjectPreference(TestCase):
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
     @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
     def test_returns_none_on_get_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
-        mock_get_prefs.side_effect = SeerApiError()
+        mock_get_prefs.side_effect = SeerApiError("test error", 500)
 
         result = _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
 
@@ -1138,7 +1143,7 @@ class TestResolveProjectPreference(TestCase):
                 stopping_point="ROOT_CAUSE",
             )
         )
-        mock_set_pref.side_effect = SeerApiError()
+        mock_set_pref.side_effect = SeerApiError("test error", 500)
 
         result = _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
 

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -900,6 +900,67 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             args=[123, group.organization.id], countdown=timedelta(minutes=15).seconds
         )
 
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.seer.autofix.autofix.get_all_tags_overview")
+    @patch("sentry.seer.autofix.autofix._get_profile_from_trace_tree")
+    @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
+    @patch("sentry.seer.autofix.autofix._call_autofix")
+    @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
+    @patch("sentry.seer.autofix.autofix._resolve_project_preference")
+    def test_trigger_autofix_passes_resolved_preference(
+        self,
+        mock_resolve_pref,
+        mock_check_autofix_status,
+        mock_call,
+        mock_get_trace,
+        mock_get_profile,
+        mock_get_tags,
+        mock_record_seer_run,
+    ):
+        """Tests that a resolved preference's repos and preference object are passed to _call_autofix."""
+        mock_get_profile.return_value = None
+        mock_get_trace.return_value = None
+        mock_get_tags.return_value = None
+
+        mock_preference = SeerProjectPreference(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            repositories=[
+                {
+                    "provider": "integrations:github",
+                    "owner": "getsentry",
+                    "name": "seer",
+                    "external_id": "456",
+                }
+            ],
+            automated_run_stopping_point="code_changes",
+        )
+        mock_resolve_pref.return_value = mock_preference
+
+        data = load_data("python", timestamp=before_now(minutes=1))
+        data["exception"] = {"values": [{"type": "Exception", "value": "Test exception"}]}
+        event = self.store_event(data=data, project_id=self.project.id)
+        group = event.group
+
+        mock_call.return_value = 123
+        test_user = self.create_user()
+
+        response = trigger_autofix(
+            group=group,
+            event_id=event.event_id,
+            user=test_user,
+            referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_call.call_args.kwargs
+        assert call_kwargs["preference"] == mock_preference
+        # repos should be replaced by preference repos (dict form)
+        assert len(call_kwargs["repos"]) == 1
+        assert call_kwargs["repos"][0]["name"] == "seer"
+        assert call_kwargs["repos"][0]["external_id"] == "456"
+
     @patch("sentry.models.Group.get_recommended_event_for_environments")
     @patch("sentry.models.Group.get_latest_event")
     @patch("sentry.seer.autofix.autofix._get_serialized_event")
@@ -1047,31 +1108,17 @@ class TestResolveProjectPreference(TestCase):
             "external_id": external_id,
         }
 
-    def _mock_preference(
-        self,
-        organization_id: int,
-        project_id: int,
-        repos: list[dict] | None = None,
-        stopping_point: str = "CODE_CHANGES",
-    ) -> SeerProjectPreference:
-        return SeerProjectPreference(
-            organization_id=organization_id,
-            project_id=project_id,
-            repositories=repos or [self._mock_repo()],
-            automated_run_stopping_point=stopping_point,
-        )
-
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
     @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
     def test_returns_existing_preference(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
         existing_repos = [self._mock_repo("seer", "999")]
         mock_get_prefs.return_value = SeerRawPreferenceResponse(
-            preference=self._mock_preference(
-                self.organization.id,
-                self.project.id,
-                repos=existing_repos,
-                stopping_point="ROOT_CAUSE",
+            preference=SeerProjectPreference(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                repositories=existing_repos,
+                automated_run_stopping_point="root_cause",
             )
         )
 
@@ -1083,7 +1130,7 @@ class TestResolveProjectPreference(TestCase):
         assert len(result.repositories) == 1
         assert result.repositories[0].name == "seer"
         assert result.repositories[0].external_id == "999"
-        assert result.automated_run_stopping_point == "ROOT_CAUSE"
+        assert result.automated_run_stopping_point == "root_cause"
         mock_set_pref.assert_not_called()
         mock_write_sentry.assert_not_called()
 
@@ -1104,7 +1151,9 @@ class TestResolveProjectPreference(TestCase):
         assert len(result.repositories) == 1
         assert result.repositories[0].name == "sentry"
         assert result.repositories[0].external_id == "123"
-        assert result.automated_run_stopping_point == "CODE_CHANGES"
+        assert result.automated_run_stopping_point == "code_changes"
+        mock_set_pref.assert_called_once()
+        mock_write_sentry.assert_called_once()
 
     @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
@@ -1134,14 +1183,7 @@ class TestResolveProjectPreference(TestCase):
     @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
     @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
     def test_returns_none_on_set_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
-        mock_get_prefs.return_value = SeerRawPreferenceResponse(
-            preference=self._mock_preference(
-                self.organization.id,
-                self.project.id,
-                repos=[self._mock_repo()],
-                stopping_point="ROOT_CAUSE",
-            )
-        )
+        mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
         mock_set_pref.side_effect = SeerApiError("test error", 500)
 
         result = _resolve_project_preference(self.organization, self.project, [self._mock_repo()])
@@ -1156,11 +1198,11 @@ class TestResolveProjectPreference(TestCase):
         self, mock_get_prefs, mock_set_pref, mock_write_sentry
     ):
         mock_get_prefs.return_value = SeerRawPreferenceResponse(
-            preference=self._mock_preference(
-                self.organization.id,
-                self.project.id,
-                repos=[self._mock_repo()],
-                stopping_point="ROOT_CAUSE",
+            preference=SeerProjectPreference(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                repositories=[self._mock_repo()],
+                automated_run_stopping_point="root_cause",
             )
         )
         mock_write_sentry.side_effect = Exception()
@@ -1169,6 +1211,31 @@ class TestResolveProjectPreference(TestCase):
 
         assert result is not None
         assert result.project_id == self.project.id
+
+    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
+    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
+    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
+    def test_falls_back_when_preference_has_empty_repos(
+        self, mock_get_prefs, mock_set_pref, mock_write_sentry
+    ):
+        mock_get_prefs.return_value = SeerRawPreferenceResponse(
+            preference=SeerProjectPreference(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                repositories=[],
+                automated_run_stopping_point="root_cause",
+            )
+        )
+
+        fallback_repos = [self._mock_repo("sentry", "123")]
+        result = _resolve_project_preference(self.organization, self.project, fallback_repos)
+
+        assert result is not None
+        assert len(result.repositories) == 1
+        assert result.repositories[0].name == "sentry"
+        assert result.automated_run_stopping_point == "code_changes"
+        mock_set_pref.assert_called_once()
+        mock_write_sentry.assert_called_once()
 
 
 class TestCallAutofix(TestCase):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -315,8 +315,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
+    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_ai_autofix_post_endpoint(
         self,
+        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call,
@@ -401,8 +403,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
+    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_ai_autofix_post_without_code_mappings(
         self,
+        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call,
@@ -470,8 +474,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
+    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_ai_autofix_post_without_event_id(
         self,
+        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call,
@@ -554,8 +560,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
+    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_ai_autofix_post_without_event_id_no_recommended_event(
         self,
+        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call,
@@ -937,8 +945,10 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
+    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_post_routes_to_legacy_with_mode_param(
         self,
+        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call_autofix,


### PR DESCRIPTION
fixes CW-1130
relates to CW-1007

depends on https://github.com/getsentry/seer/pull/5583

As part of the [Seer settings migration to Sentry DB](https://www.notion.so/sentry/Tech-Spec-Migrate-Seer-Settings-to-Sentry-Database-3208b10e4b5d80f58ea0d7b77a301e2a), in this PR we replace Seer's preference existence check and preference creation from code mappings, and move it to Sentry. This enables us to dual-write to Sentry DB. Then we pass the created preference to the autofix request payload. 