### PR TITLE
fix(seer): don't read from org defaults when creating default project preference

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -389,13 +389,12 @@ class SeerAutofixSettingsSerializer(serializers.Serializer):
 
 
 def default_seer_project_preference(project: Project) -> SeerProjectPreference:
-    stopping_point, handoff = get_org_default_seer_automation_handoff(project.organization)
     return SeerProjectPreference(
         organization_id=project.organization.id,
         project_id=project.id,
         repositories=[],
-        automated_run_stopping_point=stopping_point,
-        automation_handoff=handoff,
+        automated_run_stopping_point=AutofixStoppingPoint.ROOT_CAUSE.value,
+        automation_handoff=None,
     )
 
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -393,7 +393,7 @@ def default_seer_project_preference(project: Project) -> SeerProjectPreference:
         organization_id=project.organization.id,
         project_id=project.id,
         repositories=[],
-        automated_run_stopping_point=AutofixStoppingPoint.ROOT_CAUSE.value,
+        automated_run_stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
         automation_handoff=None,
     )
 


### PR DESCRIPTION
I made [this change](https://github.com/getsentry/sentry/pull/111697/changes#diff-204df1d50b6d80eb112a1bafcdc4bb853e274f0e56ae3e082897b201aa0de550L391-L392) in my previous PR which I now realize is incorrect. This needs to read from project preferences and can be updated once the settings migration is complete. For now we can just use CODE_CHANGES.

Functionally there is not much difference between the two except the change in my previous PR allows the autoOpenPrs org option to override the stopping point. The project preference should always have the correct stopping point. Let's change it back.