### PR TITLE
fix(grouping): Fix and expand hex parameterization

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -233,6 +233,16 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
                 (?<!\w)-
             )
             (
+                # The patterns for hex strings 4-6 characters long each consist of three parts:
+                #   - Lookahead to guarantee at least one digit (any number of letters, followed by
+                #     a single digit - doesn't have to cover the entire match, so there can continue
+                #     to be letters and numbers after the digit is found)
+                #   - Lookahead to guarantee at least one letter (any number of numbers, followed by
+                #     a single letter - as above, doesn't have to cover the entire match)
+                #   - The matcher itself - between 4 and 6 hex characters (7-character strings
+                #     aren't included because those are classified as git SHAs)
+                (?=[a-f]*[0-9])(?=[0-9]*[a-f])[0-9a-f]{4,6} |
+                (?=[A-F]*[0-9])(?=[0-9]*[A-F])[0-9A-F]{4,6} |
                 ((?=[a-f]*[0-9])[0-9a-f]{8,128}) |
                 ((?=[A-F]*[0-9])[0-9A-F]{8,128})
             )

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -222,7 +222,16 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             #     (?=[a-f]*[0-9])     The lookahead - there must be a digit, which may or may not be
             #                         preceded by some number of hex letters
             #     [0-9a-f]{8,128}     The matcher itself - between 8 and 128 hex characters
-            \b
+            (
+                # Regular word boundary (for positive values)
+                \b
+                |
+                # Alphanumeric negative lookbehind before the dash in negative values to ensure it's
+                # only considered a minus sign if it doesn't connect two alphanumeric strings. (No
+                # word boundary here because the dash serves as the word boundary, since it's not a
+                # word character.)
+                (?<!\w)-
+            )
             (
                 ((?=[a-f]*[0-9])[0-9a-f]{8,128}) |
                 ((?=[A-F]*[0-9])[0-9A-F]{8,128})

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -243,8 +243,14 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
                 #     aren't included because those are classified as git SHAs)
                 (?=[a-f]*[0-9])(?=[0-9]*[a-f])[0-9a-f]{4,6} |
                 (?=[A-F]*[0-9])(?=[0-9]*[A-F])[0-9A-F]{4,6} |
-                ((?=[a-f]*[0-9])[0-9a-f]{8,128}) |
-                ((?=[A-F]*[0-9])[0-9A-F]{8,128})
+                # The patterns for hex strings 8-128 characters long are less restrictive. We don't
+                # require a number because exceedingly few 8+-letter words consist of only the
+                # letters A-E - the string 'fabaceae' is much more likely to be hex than the Latin
+                # name for the plant family which includes legumes. And we don't require a letter
+                # because long strings of digits are probably more likely to be hex than to be giant
+                # integers.
+                [0-9a-f]{8,128} |
+                [0-9A-F]{8,128}
             )
             \b
         """,

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -207,21 +207,9 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             # the prefix pretty much guarantees it's hex).
             (\b0[xX][0-9a-fA-F]+\b) |
 
-            # Hex value without `0x/0X` prefix (between 8 and 128 digits, including a number, and
-            # either all uppercase or all lowercase - we're more conservative here on all three
-            # scores in order to reduce false positives).
-            #
-            # Note: We use a lookahead for `0-9` but don't need one for `a-f/A-F` since if
-            #   a) the value consists of nothing but potential hex digits, but
-            #   b) none of those potential hex digits is a letter
-            # then the <int> pattern would already have caught it. Given that we're here, it didn't,
-            # so the only thing we need the lookahead to guard against is it being all letters.
-            #
-            # Each regex consists of two parts, the lookahead and the hex characters themselves. For
-            # example, for the lowercase pattern we have:
-            #     (?=[a-f]*[0-9])     The lookahead - there must be a digit, which may or may not be
-            #                         preceded by some number of hex letters
-            #     [0-9a-f]{8,128}     The matcher itself - between 8 and 128 hex characters
+            # Hex value without `0x/0X` prefix (at least 4 characters long, containing both a letter
+            # and number if shorter than 8 characters, and either all uppercase or all lowercase -
+            # we're more conservative here in order to reduce false positives).
             (
                 # Regular word boundary (for positive values)
                 \b
@@ -274,10 +262,8 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
                 # Regular word boundary for positive ints
                 \b
                 |
-                # Alphanumeric negative lookbehind for negative ints to ensure a dash is only
-                # considered a minus sign if it doesn't connect two alphanumeric strings. (No word
-                # boundary here because the dash serves as the word boundary, since it's not a word
-                # character.)
+                # Alphanumeric negative lookbehind before the dash in negative ints (logic the same
+                # as in the hex pattern above)
                 (?<!\w)-
             )
             \d{1,7} # Anything 8 digits and up is considered hex

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -222,8 +222,12 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             #     (?=[a-f]*[0-9])     The lookahead - there must be a digit, which may or may not be
             #                         preceded by some number of hex letters
             #     [0-9a-f]{8,128}     The matcher itself - between 8 and 128 hex characters
-            (\b(?=[a-f]*[0-9])[0-9a-f]{8,128}\b) |
-            (\b(?=[A-F]*[0-9])[0-9A-F]{8,128}\b)
+            \b
+            (
+                ((?=[a-f]*[0-9])[0-9a-f]{8,128}) |
+                ((?=[A-F]*[0-9])[0-9A-F]{8,128})
+            )
+            \b
         """,
     ),
     ParameterizationRegex(

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -47,7 +47,7 @@ standard_cases = [
     (
         "traceparent - aws, but not word boundary",
         "abc1-67891233-abcdef012345678912345678",
-        "abc1-<hex>-<hex>",
+        "<hex>-<hex>-<hex>",
     ),
     ("uuid", "7c1811ed-e98f-4c9c-a9f9-58c757ff494f", "<uuid>"),
     (
@@ -141,8 +141,10 @@ standard_cases = [
     ("hex with prefix - uppercase, 24 digits", "0x9AF8C3BE3A1231FE1121ACB1", "<hex>"),
     ("hex with prefix - lowercase, no numbers", "0xdeadbeef", "<hex>"),
     ("hex with prefix - uppercase, no numbers", "0xDEADBEEF", "<hex>"),
-    ("hex without prefix - lowercase, 4 digits", "9af8", "9af8"),
-    ("hex without prefix - uppercase, 4 digits", "9AF8", "9AF8"),
+    ("hex without prefix - lowercase, < 4 digits", "9af", "9af"),
+    ("hex without prefix - uppercase, < 4 digits", "9AF", "9AF"),
+    ("hex without prefix - lowercase, 4 digits", "9af8", "<hex>"),
+    ("hex without prefix - uppercase, 4 digits", "9AF8", "<hex>"),
     ("hex without prefix - lowercase, 8 digits", "9af8c3be", "<hex>"),
     ("hex without prefix - uppercase, 8 digits", "9AF8C3BE", "<hex>"),
     ("hex without prefix - lowercase, 10 digits", "9af8c3be3a", "<hex>"),
@@ -153,13 +155,16 @@ standard_cases = [
     ("hex without prefix - uppercase, 24 digits", "9AF8C3BE3A1231FE1121ACB1", "<hex>"),
     ("hex without prefix - lowercase, 128 digits", "b0" * 64, "<hex>"),
     ("hex without prefix - uppercase, 128 digits", "B0" * 64, "<hex>"),
-    ("hex without prefix - lowercase, no numbers", "deadbeef", "deadbeef"),
-    ("hex without prefix - uppercase, no numbers", "DEADBEEF", "DEADBEEF"),
-    ("hex without prefix - lowercase, no numbers until later", "deadbeef 123", "deadbeef <int>"),
-    ("hex without prefix - uppercase, no numbers until later", "DEADBEEF 123", "DEADBEEF <int>"),
+    ("hex without prefix - lowercase, no numbers, < 8 digits", "deadbee", "deadbee"),
+    ("hex without prefix - uppercase, no numbers, < 8 digits", "DEADBEE", "DEADBEE"),
+    ("hex without prefix - lowercase, no numbers, 8 digits", "deadbeef", "<hex>"),
+    ("hex without prefix - uppercase, no numbers, 8 digits", "DEADBEEF", "<hex>"),
+    ("hex without prefix - lowercase, no numbers until later", "cafe 123", "cafe <int>"),
+    ("hex without prefix - uppercase, no numbers until later", "CAFE 123", "CAFE <int>"),
     ("hex without prefix - no letters, < 8 digits, positive", "1234567", "<int>"),
     ("hex without prefix - no letters, < 8 digits, negative", "-1234567", "<int>"),
     ("hex without prefix - no letters, 8+ digits, positive", "12345678", "<hex>"),
+    ("hex without prefix - no letters, 8+ digits, negative", "-12345678", "<hex>"),
     ("git sha", "commit a93c7d2", "commit <git_sha>"),
     ("git sha - all letters", "commit cabcafe", "commit cabcafe"),
     ("git sha - all numbers", "commit 4150908", "commit <int>"),
@@ -240,12 +245,6 @@ def test_experimental_parameterization(name: str, input: str, expected: str) -> 
 # parameterization. (Remember to remove the last item in each tuple for the cases you fix.)
 incorrect_cases = [
     # ("name", "input", "desired", "actual")
-    (
-        "hex without prefix - no letters, 8+ digits, negative",
-        "-12345678",
-        "<hex>",
-        "-<hex>",
-    ),
     (
         "int - number in word",
         "Encoding: utf-8",


### PR DESCRIPTION
This makes a few different changes to our hex parameterization:

- Include the negative sign as part of the hex number. Also make dashes only count as negative signs if they're not in the middle of something alphanumeric. (This matches our recent int parameterization fix.)

- Allow hex values to be as short as 4 characters as long as they include both a hex letter and a number. There's a small chance for false positives here, but right now we're missing a lot of parameterizations where longer hex values are broken up by dashes or dots into shorter ones, so it seems worth it to make this change. (There's also definitely a chance of false negatives - where values which should be `<hex>-<hex>-<hex>` instead end up as `<hex>-<hex>-<int>` or `<hex>-<hex>-face` - but unless we see examples in the wild, it's probably not worth it to try to be smarter about when `face`, etc. should count as a word and when it should count as hex.)

- Stop requiring a number in longer (8+-character) hex strings. The chance of false positives here is _extremely_ low (Claude could find literally exactly one 8+-letter word consisting of only hex letters in any common language using the roman alphabet, and it's the latin name for a plant family), and though _most_ hex strings have numbers in them, the chances of seeing some without still seems much higher than the chance of encountering the `fabaceae` family of legumes in an error message.