### PR TITLE
chore(grouping): remove remaining similarity backfill option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1128,12 +1128,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "seer.similarity-backfill-killswitch.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "seer.similarity-embeddings-killswitch.enabled",
     default=False,
     type=Bool,


### PR DESCRIPTION
Missed this in my first cleanup, removed in the automator here: https://github.com/getsentry/sentry-options-automator/pull/7053/changes

https://claude.ai/code/session_01VFb2jPu1DRmqNM6D57krS4