### PR TITLE
feat(snapshots): add deletion path for endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_admin_batch_delete.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_admin_batch_delete.py
@@ -88,17 +88,6 @@ class PreprodArtifactAdminBatchDeleteEndpoint(Endpoint):
 
         try:
             result = delete_artifacts_and_eap_data(artifacts_to_delete)
-            return Response(
-                {
-                    "success": True,
-                    "message": f"Successfully deleted {result.artifacts_deleted} artifacts.",
-                    "artifact_ids": [str(artifact.id) for artifact in artifacts_to_delete],
-                    "files_deleted": result.files_deleted,
-                    "size_metrics_deleted": result.size_metrics_deleted,
-                    "installable_artifacts_deleted": result.installable_artifacts_deleted,
-                }
-            )
-
         except Exception:
             logger.exception(
                 "preprod_artifact.admin_batch_delete.artifacts_delete_failed",
@@ -111,3 +100,14 @@ class PreprodArtifactAdminBatchDeleteEndpoint(Endpoint):
                 {"success": False, "detail": "Internal error deleting artifacts."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+        return Response(
+            {
+                "success": True,
+                "message": f"Successfully deleted {result.artifacts_deleted} artifacts.",
+                "artifact_ids": [str(artifact.id) for artifact in artifacts_to_delete],
+                "files_deleted": result.files_deleted,
+                "size_metrics_deleted": result.size_metrics_deleted,
+                "installable_artifacts_deleted": result.installable_artifacts_deleted,
+            }
+        )

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -23,7 +23,10 @@ from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.objectstore import get_preprod_session
-from sentry.preprod.analytics import PreprodArtifactApiGetSnapshotDetailsEvent
+from sentry.preprod.analytics import (
+    PreprodArtifactApiDeleteEvent,
+    PreprodArtifactApiGetSnapshotDetailsEvent,
+)
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     BuildDetailsVcsInfo,
 )
@@ -33,6 +36,7 @@ from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import 
     SnapshotImageResponse,
 )
 from sentry.preprod.api.schemas import VCS_ERROR_MESSAGES, VCS_SCHEMA_PROPERTIES
+from sentry.preprod.helpers.deletion import delete_artifacts_and_eap_data
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.comparison_categorizer import (
     CategorizedComparison,
@@ -103,8 +107,64 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
+        "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
     permission_classes = (OrganizationReleasePermission,)
+
+    def delete(self, request: Request, organization: Organization, snapshot_id: str) -> Response:
+        if not settings.IS_DEV and not features.has(
+            "organizations:preprod-snapshots", organization, actor=request.user
+        ):
+            return Response({"detail": "Feature not enabled"}, status=403)
+
+        try:
+            artifact = PreprodArtifact.objects.get(
+                id=snapshot_id, project__organization_id=organization.id
+            )
+        except PreprodArtifact.DoesNotExist:
+            return Response({"detail": "Snapshot not found"}, status=404)
+
+        try:
+            artifact.preprodsnapshotmetrics
+        except PreprodSnapshotMetrics.DoesNotExist:
+            return Response({"detail": "Artifact is not a snapshot"}, status=400)
+
+        analytics.record(
+            PreprodArtifactApiDeleteEvent(
+                organization_id=organization.id,
+                project_id=artifact.project_id,
+                user_id=(
+                    request.user.id if request.user and request.user.is_authenticated else None
+                ),
+                artifact_id=str(artifact.id),
+            )
+        )
+
+        try:
+            result = delete_artifacts_and_eap_data([artifact])
+
+            logger.info(
+                "preprod_snapshot.deleted",
+                extra={
+                    "artifact_id": int(snapshot_id),
+                    "user_id": request.user.id if request.user else None,
+                    "files_deleted": result.files_deleted,
+                    "size_metrics_deleted": result.size_metrics_deleted,
+                    "artifacts_deleted": result.artifacts_deleted,
+                },
+            )
+
+            return Response(status=204)
+
+        except Exception:
+            logger.exception(
+                "preprod_snapshot.delete_failed",
+                extra={"artifact_id": int(snapshot_id)},
+            )
+            return Response(
+                {"detail": "Internal error deleting snapshot."},
+                status=500,
+            )
 
     def get(self, request: Request, organization: Organization, snapshot_id: str) -> Response:
         if not settings.IS_DEV and not features.has(

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -131,31 +131,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         try:
             result = delete_artifacts_and_eap_data([artifact])
-
-            analytics.record(
-                PreprodArtifactApiDeleteEvent(
-                    organization_id=organization.id,
-                    project_id=artifact.project_id,
-                    user_id=(
-                        request.user.id if request.user and request.user.is_authenticated else None
-                    ),
-                    artifact_id=str(artifact.id),
-                )
-            )
-
-            logger.info(
-                "preprod_snapshot.deleted",
-                extra={
-                    "artifact_id": int(snapshot_id),
-                    "user_id": request.user.id if request.user else None,
-                    "files_deleted": result.files_deleted,
-                    "size_metrics_deleted": result.size_metrics_deleted,
-                    "artifacts_deleted": result.artifacts_deleted,
-                },
-            )
-
-            return Response(status=204)
-
         except Exception:
             logger.exception(
                 "preprod_snapshot.delete_failed",
@@ -165,6 +140,30 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 {"detail": "Internal error deleting snapshot."},
                 status=500,
             )
+
+        analytics.record(
+            PreprodArtifactApiDeleteEvent(
+                organization_id=organization.id,
+                project_id=artifact.project_id,
+                user_id=(
+                    request.user.id if request.user and request.user.is_authenticated else None
+                ),
+                artifact_id=str(artifact.id),
+            )
+        )
+
+        logger.info(
+            "preprod_snapshot.deleted",
+            extra={
+                "artifact_id": int(snapshot_id),
+                "user_id": request.user.id if request.user else None,
+                "files_deleted": result.files_deleted,
+                "size_metrics_deleted": result.size_metrics_deleted,
+                "artifacts_deleted": result.artifacts_deleted,
+            },
+        )
+
+        return Response(status=204)
 
     def get(self, request: Request, organization: Organization, snapshot_id: str) -> Response:
         if not settings.IS_DEV and not features.has(

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -129,19 +129,19 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         except PreprodSnapshotMetrics.DoesNotExist:
             return Response({"detail": "Artifact is not a snapshot"}, status=400)
 
-        analytics.record(
-            PreprodArtifactApiDeleteEvent(
-                organization_id=organization.id,
-                project_id=artifact.project_id,
-                user_id=(
-                    request.user.id if request.user and request.user.is_authenticated else None
-                ),
-                artifact_id=str(artifact.id),
-            )
-        )
-
         try:
             result = delete_artifacts_and_eap_data([artifact])
+
+            analytics.record(
+                PreprodArtifactApiDeleteEvent(
+                    organization_id=organization.id,
+                    project_id=artifact.project_id,
+                    user_id=(
+                        request.user.id if request.user and request.user.is_authenticated else None
+                    ),
+                    artifact_id=str(artifact.id),
+                )
+            )
 
             logger.info(
                 "preprod_snapshot.deleted",

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -121,7 +121,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             artifact = PreprodArtifact.objects.get(
                 id=snapshot_id, project__organization_id=organization.id
             )
-        except PreprodArtifact.DoesNotExist:
+        except (PreprodArtifact.DoesNotExist, ValueError):
             return Response({"detail": "Snapshot not found"}, status=404)
 
         try:

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -118,7 +118,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             return Response({"detail": "Feature not enabled"}, status=403)
 
         try:
-            artifact = PreprodArtifact.objects.get(
+            artifact = PreprodArtifact.objects.select_related("project").get(
                 id=snapshot_id, project__organization_id=organization.id
             )
         except (PreprodArtifact.DoesNotExist, ValueError):

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_delete.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_delete.py
@@ -50,29 +50,6 @@ class ProjectPreprodArtifactDeleteEndpoint(PreprodArtifactEndpoint):
 
         try:
             result = delete_artifacts_and_eap_data([head_artifact])
-
-            logger.info(
-                "preprod_artifact.deleted",
-                extra={
-                    "artifact_id": int(head_artifact_id),
-                    "user_id": request.user.id,
-                    "files_deleted": result.files_deleted,
-                    "size_metrics_deleted": result.size_metrics_deleted,
-                    "installable_artifacts_deleted": result.installable_artifacts_deleted,
-                },
-            )
-
-            return Response(
-                {
-                    "success": True,
-                    "message": f"Artifact {head_artifact_id} deleted successfully.",
-                    "artifact_id": str(head_artifact_id),
-                    "files_deleted_count": result.files_deleted,
-                    "size_metrics_deleted": result.size_metrics_deleted,
-                    "installable_artifacts_deleted": result.installable_artifacts_deleted,
-                }
-            )
-
         except Exception:
             logger.exception(
                 "preprod_artifact.delete_failed",
@@ -85,3 +62,25 @@ class ProjectPreprodArtifactDeleteEndpoint(PreprodArtifactEndpoint):
                 },
                 status=500,
             )
+
+        logger.info(
+            "preprod_artifact.deleted",
+            extra={
+                "artifact_id": int(head_artifact_id),
+                "user_id": request.user.id,
+                "files_deleted": result.files_deleted,
+                "size_metrics_deleted": result.size_metrics_deleted,
+                "installable_artifacts_deleted": result.installable_artifacts_deleted,
+            },
+        )
+
+        return Response(
+            {
+                "success": True,
+                "message": f"Artifact {head_artifact_id} deleted successfully.",
+                "artifact_id": str(head_artifact_id),
+                "files_deleted_count": result.files_deleted,
+                "size_metrics_deleted": result.size_metrics_deleted,
+                "installable_artifacts_deleted": result.installable_artifacts_deleted,
+            }
+        )


### PR DESCRIPTION
Add a DELETE method to the `OrganizationPreprodSnapshotEndpoint` so snapshot artifacts can be deleted via the API.

The endpoint validates that the artifact exists, belongs to the organization, and is actually a snapshot (has `PreprodSnapshotMetrics`). It then uses the existing `delete_artifacts_and_eap_data` helper to clean up the artifact, associated files, size metrics, and EAP data in a single call. Analytics are recorded and structured logging captures the deletion details.

Feature-gated behind `organizations:preprod-snapshots`.