### PR TITLE
feat(preprod): Create NEEDS_APPROVAL records in status check tasks

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -296,18 +296,6 @@ def create_preprod_status_check_task(
                 approvals_map=approvals_map,
             )
 
-            if triggered_rules:
-                triggered_artifact_ids = {tr.artifact_id for tr in triggered_rules}
-                for artifact_id in triggered_artifact_ids:
-                    if artifact_id not in approvals_map:
-                        PreprodComparisonApproval.objects.get_or_create(
-                            preprod_artifact_id=artifact_id,
-                            preprod_feature_type=PreprodComparisonApproval.FeatureType.SIZE,
-                            defaults={
-                                "approval_status": PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
-                            },
-                        )
-
             title, subtitle, summary = format_status_check_messages(
                 all_artifacts,
                 size_metrics_map,

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -296,6 +296,18 @@ def create_preprod_status_check_task(
                 approvals_map=approvals_map,
             )
 
+            if triggered_rules:
+                triggered_artifact_ids = {tr.artifact_id for tr in triggered_rules}
+                for artifact_id in triggered_artifact_ids:
+                    if artifact_id not in approvals_map:
+                        PreprodComparisonApproval.objects.get_or_create(
+                            preprod_artifact_id=artifact_id,
+                            preprod_feature_type=PreprodComparisonApproval.FeatureType.SIZE,
+                            defaults={
+                                "approval_status": PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+                            },
+                        )
+
             title, subtitle, summary = format_status_check_messages(
                 all_artifacts,
                 size_metrics_map,

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -215,13 +215,16 @@ def create_preprod_snapshot_status_check_task(
 
         for artifact in all_artifacts:
             if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:
-                PreprodComparisonApproval.objects.get_or_create(
+                if not PreprodComparisonApproval.objects.filter(
                     preprod_artifact=artifact,
                     preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
-                    defaults={
-                        "approval_status": PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
-                    },
-                )
+                    approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+                ).exists():
+                    PreprodComparisonApproval.objects.create(
+                        preprod_artifact=artifact,
+                        preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+                        approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+                    )
 
         title, subtitle, summary = format_snapshot_status_check_messages(
             all_artifacts,

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -109,24 +109,6 @@ def create_preprod_snapshot_status_check_task(
 
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
-    client, repository = get_status_check_client(preprod_artifact.project, commit_comparison)
-    if not client or not repository:
-        return
-
-    provider = get_status_check_provider(
-        client,
-        commit_comparison.provider,
-        preprod_artifact.project.organization_id,
-        preprod_artifact.project.organization.slug,
-        repository.integration_id,
-    )
-    if not provider:
-        logger.info(
-            "preprod.snapshot_status_checks.create.not_supported_provider",
-            extra={"provider": commit_comparison.provider},
-        )
-        return
-
     artifact_ids = [a.id for a in all_artifacts]
     snapshot_metrics_qs = PreprodSnapshotMetrics.objects.filter(
         preprod_artifact_id__in=artifact_ids,
@@ -163,6 +145,50 @@ def create_preprod_snapshot_status_check_task(
     base_artifact_map = PreprodArtifact.get_base_artifacts_for_commit(all_artifacts)
 
     is_solo = not base_artifact_map
+
+    if not is_solo:
+        changes_map = _build_changes_map(
+            all_artifacts,
+            snapshot_metrics_map,
+            comparisons_map,
+            fail_on_added=fail_on_added,
+            fail_on_removed=fail_on_removed,
+        )
+        for artifact in all_artifacts:
+            if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:
+                # exists()+create() instead of get_or_create: no unique constraint
+                # on this model, so duplicates from races are harmless (cleaned
+                # up by filter().delete()), while get_or_create would crash with
+                # MultipleObjectsReturned if duplicates already exist.
+                if not PreprodComparisonApproval.objects.filter(
+                    preprod_artifact=artifact,
+                    preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+                    approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+                ).exists():
+                    PreprodComparisonApproval.objects.create(
+                        preprod_artifact=artifact,
+                        preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+                        approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+                    )
+
+    client, repository = get_status_check_client(preprod_artifact.project, commit_comparison)
+    if not client or not repository:
+        return
+
+    provider = get_status_check_provider(
+        client,
+        commit_comparison.provider,
+        preprod_artifact.project.organization_id,
+        preprod_artifact.project.organization.slug,
+        repository.integration_id,
+    )
+    if not provider:
+        logger.info(
+            "preprod.snapshot_status_checks.create.not_supported_provider",
+            extra={"provider": commit_comparison.provider},
+        )
+        return
+
     approve_action_identifier: str | None = None
 
     if is_solo:
@@ -198,13 +224,6 @@ def create_preprod_snapshot_status_check_task(
                 snapshot_metrics_map,
             )
     else:
-        changes_map = _build_changes_map(
-            all_artifacts,
-            snapshot_metrics_map,
-            comparisons_map,
-            fail_on_added=fail_on_added,
-            fail_on_removed=fail_on_removed,
-        )
         status = _compute_snapshot_status(
             all_artifacts,
             snapshot_metrics_map,
@@ -212,23 +231,6 @@ def create_preprod_snapshot_status_check_task(
             approvals_map,
             changes_map,
         )
-
-        for artifact in all_artifacts:
-            if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:
-                # exists()+create() instead of get_or_create: no unique constraint
-                # on this model, so duplicates from races are harmless (cleaned
-                # up by filter().delete()), while get_or_create would crash with
-                # MultipleObjectsReturned if duplicates already exist.
-                if not PreprodComparisonApproval.objects.filter(
-                    preprod_artifact=artifact,
-                    preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
-                    approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
-                ).exists():
-                    PreprodComparisonApproval.objects.create(
-                        preprod_artifact=artifact,
-                        preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
-                        approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
-                    )
 
         title, subtitle, summary = format_snapshot_status_check_messages(
             all_artifacts,

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -212,6 +212,17 @@ def create_preprod_snapshot_status_check_task(
             approvals_map,
             changes_map,
         )
+
+        for artifact in all_artifacts:
+            if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:
+                PreprodComparisonApproval.objects.get_or_create(
+                    preprod_artifact=artifact,
+                    preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+                    defaults={
+                        "approval_status": PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+                    },
+                )
+
         title, subtitle, summary = format_snapshot_status_check_messages(
             all_artifacts,
             snapshot_metrics_map,

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -215,6 +215,10 @@ def create_preprod_snapshot_status_check_task(
 
         for artifact in all_artifacts:
             if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:
+                # exists()+create() instead of get_or_create: no unique constraint
+                # on this model, so duplicates from races are harmless (cleaned
+                # up by filter().delete()), while get_or_create would crash with
+                # MultipleObjectsReturned if duplicates already exist.
                 if not PreprodComparisonApproval.objects.filter(
                     preprod_artifact=artifact,
                     preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -184,7 +184,6 @@ def handle_preprod_check_run_event(
         approvals_created += 1
 
     if approvals_created > 0:
-        sibling_ids = [s.id for s in sibling_artifacts]
         PreprodComparisonApproval.objects.filter(
             preprod_artifact_id__in=sibling_ids,
             preprod_feature_type=feature_type,

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -183,6 +183,14 @@ def handle_preprod_check_run_event(
         )
         approvals_created += 1
 
+    if approvals_created > 0:
+        sibling_ids = [s.id for s in sibling_artifacts]
+        PreprodComparisonApproval.objects.filter(
+            preprod_artifact_id__in=sibling_ids,
+            preprod_feature_type=feature_type,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+        ).delete()
+
     logger.info(
         Log.APPROVALS_CREATED,
         extra={


### PR DESCRIPTION
Create `NEEDS_APPROVAL` records in the snapshot status check task when visual changes are detected, so artifacts requiring review are tracked before a user explicitly acts. Clean up these records when approvals arrive via the GitHub check run webhook.

ALSO: Reorders the task so approval/change-detection logic runs **before** the repository/client lookup — NEEDS_APPROVAL records are now persisted even when the VCS integration lookup fails.

Also removes NEEDS_APPROVAL creation from the size status check task — approvals only apply to snapshots.