### PR TITLE
feat(preprod): Add approval API endpoint and approval info in snapshot response

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import (
+    OrganizationEndpoint,
+    OrganizationReleasePermission,
+)
+from sentry.models.organization import Organization
+from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
+from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
+from sentry.preprod.vcs.status_checks.snapshots.tasks import (
+    create_preprod_snapshot_status_check_task,
+)
+
+logger = logging.getLogger(__name__)
+
+FEATURE_TYPE_MAP = {
+    "snapshots": PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+    "size": PreprodComparisonApproval.FeatureType.SIZE,
+}
+
+STATUS_CHECK_TASK_MAP = {
+    PreprodComparisonApproval.FeatureType.SNAPSHOTS: create_preprod_snapshot_status_check_task,
+    PreprodComparisonApproval.FeatureType.SIZE: create_preprod_status_check_task,
+}
+
+
+@cell_silo_endpoint
+class OrganizationPreprodArtifactApproveEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (OrganizationReleasePermission,)
+
+    def post(self, request: Request, organization: Organization, artifact_id: str) -> Response:
+        feature_type_str = request.data.get("feature_type")
+        if feature_type_str not in FEATURE_TYPE_MAP:
+            return Response(
+                {"detail": f"feature_type must be one of: {', '.join(FEATURE_TYPE_MAP.keys())}"},
+                status=400,
+            )
+
+        feature_type = FEATURE_TYPE_MAP[feature_type_str]
+
+        try:
+            artifact = PreprodArtifact.objects.get(
+                id=artifact_id,
+                project__organization_id=organization.id,
+            )
+        except (PreprodArtifact.DoesNotExist, ValueError):
+            return Response({"detail": "Artifact not found"}, status=404)
+
+        # TODO(hybrid-cloud): approved_by is a User FK (control silo). This cell silo
+        # endpoint stores the ID, and the snapshot GET resolves it via User.objects.filter().
+        # Both will need to use an RPC service when hybrid cloud enforcement is enabled.
+        # exists()+create() instead of get_or_create — no unique constraint on this model
+        # (see snapshots/tasks.py for rationale)
+        already_approved = PreprodComparisonApproval.objects.filter(
+            preprod_artifact=artifact,
+            preprod_feature_type=feature_type,
+            approved_by_id=request.user.id,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        ).exists()
+
+        if already_approved:
+            return Response({"detail": "Already approved"}, status=200)
+
+        PreprodComparisonApproval.objects.create(
+            preprod_artifact=artifact,
+            preprod_feature_type=feature_type,
+            approved_by_id=request.user.id,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+            approved_at=datetime.now(timezone.utc),
+        )
+
+        PreprodComparisonApproval.objects.filter(
+            preprod_artifact=artifact,
+            preprod_feature_type=feature_type,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+        ).delete()
+
+        task = STATUS_CHECK_TASK_MAP[feature_type]
+        task.apply_async(
+            kwargs={
+                "preprod_artifact_id": artifact.id,
+                "caller": "approval_endpoint",
+            }
+        )
+
+        return Response({"detail": "Approved"}, status=201)

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -348,12 +348,17 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         ]
 
         if approved:
-            sentry_user_ids = [a.approved_by_id for a in approved if a.approved_by_id]
+            sentry_user_ids = list({a.approved_by_id for a in approved if a.approved_by_id})
             users_by_id = {u.id: u for u in User.objects.filter(id__in=sentry_user_ids)}
 
             approver_list: list[SnapshotApprover] = []
+            seen_approver_keys: set[str] = set()
             for approval in approved:
                 if approval.approved_by_id:
+                    key = f"sentry:{approval.approved_by_id}"
+                    if key in seen_approver_keys:
+                        continue
+                    seen_approver_keys.add(key)
                     user = users_by_id.get(approval.approved_by_id)
                     if user:
                         approver_list.append(
@@ -371,6 +376,10 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 elif approval.extras and "github" in approval.extras:
                     gh = approval.extras["github"]
                     gh_id = gh.get("id")
+                    key = f"github:{gh_id or gh.get('login')}"
+                    if key in seen_approver_keys:
+                        continue
+                    seen_approver_keys.add(key)
                     approver_list.append(
                         SnapshotApprover(
                             id=str(gh_id) if gh_id is not None else None,

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -31,13 +31,15 @@ from sentry.preprod.api.models.project_preprod_build_details_models import (
     BuildDetailsVcsInfo,
 )
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
+    SnapshotApprovalInfo,
+    SnapshotApprover,
     SnapshotComparisonRunInfo,
     SnapshotDetailsApiResponse,
     SnapshotImageResponse,
 )
 from sentry.preprod.api.schemas import VCS_ERROR_MESSAGES, VCS_SCHEMA_PROPERTIES
 from sentry.preprod.helpers.deletion import delete_artifacts_and_eap_data
-from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.comparison_categorizer import (
     CategorizedComparison,
     categorize_comparison_images,
@@ -59,6 +61,7 @@ from sentry.preprod.vcs.status_checks.snapshots.tasks import (
 )
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.users.models.user import User
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -134,7 +137,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         except Exception:
             logger.exception(
                 "preprod_snapshot.delete_failed",
-                extra={"artifact_id": int(snapshot_id)},
+                extra={"artifact_id": artifact.id},
             )
             return Response(
                 {"detail": "Internal error deleting snapshot."},
@@ -155,7 +158,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         logger.info(
             "preprod_snapshot.deleted",
             extra={
-                "artifact_id": int(snapshot_id),
+                "artifact_id": artifact.id,
                 "user_id": request.user.id if request.user else None,
                 "files_deleted": result.files_deleted,
                 "size_metrics_deleted": result.size_metrics_deleted,
@@ -175,7 +178,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             artifact = PreprodArtifact.objects.select_related("commit_comparison").get(
                 id=snapshot_id, project__organization_id=organization.id
             )
-        except PreprodArtifact.DoesNotExist:
+        except (PreprodArtifact.DoesNotExist, ValueError):
             return Response({"detail": "Snapshot not found"}, status=404)
 
         try:
@@ -331,6 +334,68 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 duration_ms=int(duration.total_seconds() * 1000),
             )
 
+        approval_info: SnapshotApprovalInfo | None = None
+        all_approvals = list(
+            PreprodComparisonApproval.objects.filter(
+                preprod_artifact=artifact,
+                preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            )
+        )
+        approved = [
+            a
+            for a in all_approvals
+            if a.approval_status == PreprodComparisonApproval.ApprovalStatus.APPROVED
+        ]
+
+        if approved:
+            sentry_user_ids = [a.approved_by_id for a in approved if a.approved_by_id]
+            users_by_id = {u.id: u for u in User.objects.filter(id__in=sentry_user_ids)}
+
+            approver_list: list[SnapshotApprover] = []
+            for approval in approved:
+                if approval.approved_by_id:
+                    user = users_by_id.get(approval.approved_by_id)
+                    if user:
+                        approver_list.append(
+                            SnapshotApprover(
+                                id=str(user.id),
+                                name=user.get_display_name(),
+                                email=user.email,
+                                username=user.username,
+                                approved_at=approval.approved_at.isoformat()
+                                if approval.approved_at
+                                else None,
+                                source="sentry",
+                            )
+                        )
+                elif approval.extras and "github" in approval.extras:
+                    gh = approval.extras["github"]
+                    gh_id = gh.get("id")
+                    approver_list.append(
+                        SnapshotApprover(
+                            id=str(gh_id) if gh_id is not None else None,
+                            name=gh.get("login"),
+                            username=gh.get("login"),
+                            avatar_url=f"https://avatars.githubusercontent.com/u/{gh_id}"
+                            if gh_id is not None
+                            else None,
+                            approved_at=approval.approved_at.isoformat()
+                            if approval.approved_at
+                            else None,
+                            source="github",
+                        )
+                    )
+            approval_info = SnapshotApprovalInfo(
+                status="approved",
+                approvers=approver_list,
+            )
+        elif all_approvals:
+            # If records exist but none are APPROVED, they must be NEEDS_APPROVAL
+            approval_info = SnapshotApprovalInfo(
+                status="requires_approval",
+                approvers=[],
+            )
+
         return Response(
             SnapshotDetailsApiResponse(
                 head_artifact_id=str(artifact.id),
@@ -354,6 +419,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 errored=categorized.errored,
                 errored_count=len(categorized.errored),
                 comparison_run_info=run_info,
+                approval_info=approval_info,
             ).dict()
         )
 

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -21,6 +21,7 @@ from .organization_preprod_quota import OrganizationPreprodQuotaEndpoint
 from .organization_preprod_retention import OrganizationPreprodRetentionEndpoint
 from .preprod_artifact_admin_batch_delete import PreprodArtifactAdminBatchDeleteEndpoint
 from .preprod_artifact_admin_info import PreprodArtifactAdminInfoEndpoint
+from .preprod_artifact_approve import OrganizationPreprodArtifactApproveEndpoint
 from .preprod_artifact_rerun_analysis import (
     PreprodArtifactAdminRerunAnalysisEndpoint,
     PreprodArtifactRerunAnalysisEndpoint,
@@ -187,6 +188,12 @@ preprod_organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/(?P<artifact_id>[^/]+)/size-analysis/$",
         OrganizationPreprodPublicSizeAnalysisEndpoint.as_view(),
         name="sentry-api-0-organization-preprod-artifact-public-size-analysis",
+    ),
+    # Approvals
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/(?P<artifact_id>[^/]+)/approve/$",
+        OrganizationPreprodArtifactApproveEndpoint.as_view(),
+        name="sentry-api-0-organization-preprod-artifact-approve",
     ),
     # Snapshots
     re_path(

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -45,6 +46,21 @@ class SnapshotComparisonRunInfo(BaseModel):
     duration_ms: int | None = None
 
 
+class SnapshotApprover(BaseModel):
+    id: str | None = None
+    name: str | None = None
+    email: str | None = None
+    username: str | None = None
+    avatar_url: str | None = None
+    approved_at: str | None = None
+    source: Literal["sentry", "github"] = "sentry"
+
+
+class SnapshotApprovalInfo(BaseModel):
+    status: Literal["approved", "requires_approval"]
+    approvers: list[SnapshotApprover] = []
+
+
 class SnapshotDetailsApiResponse(BaseModel):
     head_artifact_id: str
     base_artifact_id: str | None = None
@@ -77,6 +93,8 @@ class SnapshotDetailsApiResponse(BaseModel):
     errored_count: int = 0
 
     comparison_run_info: SnapshotComparisonRunInfo | None = None
+
+    approval_info: SnapshotApprovalInfo | None = None
 
 
 # TODO: POST request in the future when we migrate away from current schemas

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -475,6 +475,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/preprod-artifact/rerun-status-checks/$headArtifactId/'
   | '/organizations/$organizationIdOrSlug/preprod/quota/'
   | '/organizations/$organizationIdOrSlug/preprod/retention/'
+  | '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/approve/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/install-details/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/size-analysis/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/$headArtifactId/build-details/'


### PR DESCRIPTION
Adds the ability for users to approve snapshot comparison results via a new API endpoint, and surfaces approval status in the snapshot details response.

**Approve endpoint** (`POST /preprodartifacts/{id}/approve/`):
- Accepts a `feature_type` (`snapshots` or `size`) and creates an `APPROVED` record for the requesting user
- Cleans up any existing `NEEDS_APPROVAL` records for that artifact/feature
- Re-triggers the relevant status check task so the VCS commit status updates immediately

**Snapshot response changes**:
- Adds `approval_info` to the snapshot details response containing the current approval status (`approved` or `requires_approval`) and a list of approvers
- Supports both Sentry users and GitHub users (via `extras` on the approval record) with avatar URLs

Stacked on #111803