### PR TITLE
feat(preprod): Add triggered condition section for size analysis issues

### DIFF
--- a/static/app/views/detectors/components/details/mobileBuild/detect.tsx
+++ b/static/app/views/detectors/components/details/mobileBuild/detect.tsx
@@ -38,7 +38,7 @@ function getConditionLabel({condition}: {condition: MetricCondition}) {
   }
 }
 
-export function formatComparisonValue(
+function formatComparisonValue(
   comparison: MetricCondition['comparison'],
   thresholdType: PreprodDetector['config']['thresholdType']
 ): string {
@@ -51,7 +51,7 @@ export function formatComparisonValue(
   return String(bytesToMB(comparison));
 }
 
-export function getConditionDescription({
+function getConditionDescription({
   condition,
   thresholdType,
 }: {
@@ -62,13 +62,13 @@ export function getConditionDescription({
   const unit = getDisplayUnit(thresholdType);
 
   if (condition.conditionResult === DetectorPriorityLevel.OK) {
-    return t('Below or equal to %(value)s %(unit)s', {
+    return t('Below or equal to %(value)s%(unit)s', {
       value: comparisonValue,
       unit,
     });
   }
 
-  return t('Above %(value)s %(unit)s', {
+  return t('Above %(value)s%(unit)s', {
     value: comparisonValue,
     unit,
   });

--- a/static/app/views/detectors/components/details/mobileBuild/detect.tsx
+++ b/static/app/views/detectors/components/details/mobileBuild/detect.tsx
@@ -38,7 +38,7 @@ function getConditionLabel({condition}: {condition: MetricCondition}) {
   }
 }
 
-function formatComparisonValue(
+export function formatComparisonValue(
   comparison: MetricCondition['comparison'],
   thresholdType: PreprodDetector['config']['thresholdType']
 ): string {
@@ -51,7 +51,7 @@ function formatComparisonValue(
   return String(bytesToMB(comparison));
 }
 
-function getConditionDescription({
+export function getConditionDescription({
   condition,
   thresholdType,
 }: {
@@ -62,13 +62,13 @@ function getConditionDescription({
   const unit = getDisplayUnit(thresholdType);
 
   if (condition.conditionResult === DetectorPriorityLevel.OK) {
-    return t('Below or equal to %(value)s%(unit)s', {
+    return t('Below or equal to %(value)s %(unit)s', {
       value: comparisonValue,
       unit,
     });
   }
 
-  return t('Above %(value)s%(unit)s', {
+  return t('Above %(value)s %(unit)s', {
     value: comparisonValue,
     unit,
   });

--- a/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
@@ -24,6 +24,7 @@ import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 import {
   getMetricLabelForPlatform,
   guessPlatformForProject,
+  isDiffThreshold,
   MEASUREMENT_OPTIONS,
   METRIC_OPTIONS,
 } from 'sentry/views/settings/project/preprod/types';
@@ -81,7 +82,7 @@ export function MobileBuildDetectSection() {
               flexibleControlStateSize
               preserveOnUnmount
             />
-            {(thresholdType === 'absolute_diff' || thresholdType === 'relative_diff') && (
+            {isDiffThreshold(thresholdType) && (
               <Flex align="center" gap="sm">
                 <IconInfo size="xs" />
                 <Text variant="muted" size="sm">

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -90,6 +90,7 @@ import {useCopyIssueDetails} from 'sentry/views/issueDetails/streamline/hooks/us
 import {InstrumentationFixSection} from 'sentry/views/issueDetails/streamline/instrumentationFixSection';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {MetricDetectorTriggeredSection} from 'sentry/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection';
+import {SizeAnalysisTriggeredSection} from 'sentry/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection';
 import {TraceDataSection} from 'sentry/views/issueDetails/traceDataSection';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
@@ -385,6 +386,9 @@ export function EventDetailsContent({
       )}
       <ErrorBoundary customComponent={() => null}>
         <MetricDetectorTriggeredSection group={group} event={event} />
+      </ErrorBoundary>
+      <ErrorBoundary customComponent={() => null}>
+        <SizeAnalysisTriggeredSection group={group} event={event} />
       </ErrorBoundary>
       <EventHydrationDiff event={event} group={group} />
       <EventReplay event={event} group={group} projectSlug={project.slug} />

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.spec.tsx
@@ -188,14 +188,14 @@ describe('SizeAnalysisTriggeredSection', () => {
 
     render(<SizeAnalysisTriggeredSection {...defaultProps} event={event} />);
 
-    expect(screen.getByRole('cell', {name: '15%'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '+15%'})).toBeInTheDocument();
   });
 
   it('renders absolute_diff values in MB', () => {
     render(<SizeAnalysisTriggeredSection {...defaultProps} />);
 
-    // 4292608 bytes = 4.29 MB (capped at 2 decimals)
-    expect(screen.getByRole('cell', {name: '4.29 MB'})).toBeInTheDocument();
+    // 4292608 bytes = +4.29 MB (capped at 2 decimals, + prefix for diff)
+    expect(screen.getByRole('cell', {name: '+4.29 MB'})).toBeInTheDocument();
   });
 
   it('renders query field when present in config', () => {

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.spec.tsx
@@ -102,6 +102,15 @@ describe('SizeAnalysisTriggeredSection', () => {
     expect(screen.getByRole('cell', {name: 'Evaluated Value'})).toBeInTheDocument();
   });
 
+  it('formats condition as "measurement Diff > value" for diff threshold', () => {
+    render(<SizeAnalysisTriggeredSection {...defaultProps} />);
+
+    // absolute_diff with no artifact tag: "Install/Uncompressed Size Diff > 1 MB"
+    expect(
+      screen.getByRole('cell', {name: 'Install/Uncompressed Size Diff > 1 MB'})
+    ).toBeInTheDocument();
+  });
+
   it('shows platform-specific measurement label from artifact type tag', () => {
     const event = EventFixture({
       ...defaultEvent,
@@ -111,6 +120,9 @@ describe('SizeAnalysisTriggeredSection', () => {
     render(<SizeAnalysisTriggeredSection {...defaultProps} event={event} />);
 
     expect(screen.getByRole('cell', {name: 'Install Size'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', {name: 'Install Size Diff > 1 MB'})
+    ).toBeInTheDocument();
   });
 
   it('shows Android measurement label for aab artifact type', () => {

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.spec.tsx
@@ -1,0 +1,217 @@
+import type {ComponentProps} from 'react';
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {IssueCategory, IssueType} from 'sentry/types/group';
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import type {MetricCondition} from 'sentry/types/workflowEngine/detectors';
+import {SizeAnalysisTriggeredSection} from 'sentry/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection';
+
+describe('SizeAnalysisTriggeredSection', () => {
+  const condition: MetricCondition = {
+    id: 'cond-1',
+    type: DataConditionType.GREATER,
+    comparison: 1000000,
+    conditionResult: 75,
+  };
+
+  const defaultGroup = GroupFixture({
+    issueType: IssueType.PREPROD_SIZE_ANALYSIS,
+    issueCategory: IssueCategory.PREPROD,
+  });
+
+  const defaultEvidenceData = {
+    detectorId: 8,
+    value: 4292608,
+    conditions: [condition],
+    config: {
+      measurement: 'install_size',
+      thresholdType: 'absolute_diff',
+    },
+    headArtifactId: 100,
+    baseArtifactId: 99,
+    headSizeMetricId: 200,
+    baseSizeMetricId: 199,
+  };
+
+  const defaultEvent = EventFixture({
+    id: 'event-1',
+    eventID: 'event-1',
+    occurrence: {
+      id: '1',
+      eventId: 'event-1',
+      fingerprint: ['fingerprint'],
+      issueTitle: 'Size regression',
+      subtitle: 'A preprod static analysis issue was detected',
+      resourceId: 'resource-1',
+      evidenceData: defaultEvidenceData,
+      evidenceDisplay: [],
+      type: 11003,
+      detectionTime: '2024-01-01T00:00:00Z',
+    },
+  });
+
+  const defaultProps: ComponentProps<typeof SizeAnalysisTriggeredSection> = {
+    group: defaultGroup,
+    event: defaultEvent,
+  };
+
+  it('renders nothing when event has no occurrence', () => {
+    const event = EventFixture({occurrence: null});
+    const {container} = render(
+      <SizeAnalysisTriggeredSection {...defaultProps} event={event} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when evidenceData has no config', () => {
+    const event = EventFixture({
+      occurrence: {
+        id: '1',
+        eventId: 'event-1',
+        fingerprint: ['fingerprint'],
+        issueTitle: 'Test',
+        subtitle: '',
+        resourceId: 'resource-1',
+        evidenceData: {},
+        evidenceDisplay: [],
+        type: 11003,
+        detectionTime: '2024-01-01T00:00:00Z',
+      },
+    });
+    const {container} = render(
+      <SizeAnalysisTriggeredSection {...defaultProps} event={event} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders triggered condition details for absolute_diff', () => {
+    render(<SizeAnalysisTriggeredSection {...defaultProps} />);
+
+    expect(screen.getByRole('region', {name: 'Triggered Condition'})).toBeInTheDocument();
+
+    expect(screen.getByRole('cell', {name: 'Threshold Type'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Absolute Diff'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Measurement'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', {name: 'Install/Uncompressed Size'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Condition'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Evaluated Value'})).toBeInTheDocument();
+  });
+
+  it('shows platform-specific measurement label from artifact type tag', () => {
+    const event = EventFixture({
+      ...defaultEvent,
+      tags: [{key: 'head.artifact_type', value: 'xcarchive'}],
+    });
+
+    render(<SizeAnalysisTriggeredSection {...defaultProps} event={event} />);
+
+    expect(screen.getByRole('cell', {name: 'Install Size'})).toBeInTheDocument();
+  });
+
+  it('shows Android measurement label for aab artifact type', () => {
+    const event = EventFixture({
+      ...defaultEvent,
+      tags: [{key: 'head.artifact_type', value: 'aab'}],
+    });
+
+    render(<SizeAnalysisTriggeredSection {...defaultProps} event={event} />);
+
+    expect(screen.getByRole('cell', {name: 'Uncompressed Size'})).toBeInTheDocument();
+  });
+
+  it('shows both Open Build and Open Comparison for diff threshold types', () => {
+    render(<SizeAnalysisTriggeredSection {...defaultProps} />);
+
+    expect(screen.getByRole('button', {name: 'Open Build'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Comparison'})).toBeInTheDocument();
+  });
+
+  it('shows comparison link with correct path', () => {
+    render(<SizeAnalysisTriggeredSection {...defaultProps} />);
+
+    expect(screen.getByRole('button', {name: 'Open Comparison'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/preprod/size/compare/100/99/'
+    );
+  });
+
+  it('does not show Open Comparison for absolute threshold type', () => {
+    const event = EventFixture({
+      ...defaultEvent,
+      occurrence: {
+        ...defaultEvent.occurrence!,
+        evidenceData: {
+          ...defaultEvidenceData,
+          config: {measurement: 'install_size', thresholdType: 'absolute'},
+          baseArtifactId: undefined,
+        },
+      },
+    });
+
+    render(<SizeAnalysisTriggeredSection {...defaultProps} event={event} />);
+
+    expect(screen.getByRole('button', {name: 'Open Build'})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Open Comparison'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders relative_diff values with percentage', () => {
+    const event = EventFixture({
+      ...defaultEvent,
+      occurrence: {
+        ...defaultEvent.occurrence!,
+        evidenceData: {
+          ...defaultEvidenceData,
+          value: 15,
+          config: {measurement: 'install_size', thresholdType: 'relative_diff'},
+        },
+      },
+    });
+
+    render(<SizeAnalysisTriggeredSection {...defaultProps} event={event} />);
+
+    expect(screen.getByRole('cell', {name: '15%'})).toBeInTheDocument();
+  });
+
+  it('renders absolute_diff values in MB', () => {
+    render(<SizeAnalysisTriggeredSection {...defaultProps} />);
+
+    // 4292608 bytes = 4.29 MB (capped at 2 decimals)
+    expect(screen.getByRole('cell', {name: '4.29 MB'})).toBeInTheDocument();
+  });
+
+  it('renders query field when present in config', () => {
+    const event = EventFixture({
+      ...defaultEvent,
+      occurrence: {
+        ...defaultEvent.occurrence!,
+        evidenceData: {
+          ...defaultEvidenceData,
+          config: {
+            ...defaultEvidenceData.config,
+            query: 'app_id:com.example.app',
+          },
+        },
+      },
+    });
+
+    render(<SizeAnalysisTriggeredSection {...defaultProps} event={event} />);
+
+    expect(screen.getByRole('cell', {name: 'Query'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', {name: 'app_id:com.example.app'})
+    ).toBeInTheDocument();
+  });
+
+  it('does not render query field when not present', () => {
+    render(<SizeAnalysisTriggeredSection {...defaultProps} />);
+
+    expect(screen.queryByRole('cell', {name: 'Query'})).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
@@ -1,0 +1,171 @@
+import {Fragment} from 'react';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
+import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
+import {t} from 'sentry/locale';
+import type {Event, EventOccurrence} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import type {MetricCondition} from 'sentry/types/workflowEngine/detectors';
+import {defined} from 'sentry/utils';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {getConditionDescription} from 'sentry/views/detectors/components/details/mobileBuild/detect';
+import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+import {
+  getCompareBuildPath,
+  getSizeBuildPath,
+} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {
+  bytesToMB,
+  getDisplayUnit,
+  getMeasurementLabel,
+  getMetricLabelForArtifactType,
+} from 'sentry/views/settings/project/preprod/types';
+import type {
+  MeasurementType,
+  MetricType,
+} from 'sentry/views/settings/project/preprod/types';
+
+interface SizeAnalysisEvidenceData {
+  conditions: MetricCondition[];
+  config: {
+    measurement: MetricType;
+    thresholdType: MeasurementType;
+    query?: string;
+  };
+  detectorId: number;
+  headArtifactId: number;
+  value: number;
+  baseArtifactId?: number;
+  baseSizeMetricId?: number;
+  headSizeMetricId?: number;
+}
+
+function isSizeAnalysisEvidenceData(
+  evidenceData?: EventOccurrence['evidenceData']
+): evidenceData is SizeAnalysisEvidenceData {
+  if (!defined(evidenceData) || !('config' in evidenceData)) {
+    return false;
+  }
+
+  const {config} = evidenceData;
+  return (
+    defined(config) &&
+    typeof config === 'object' &&
+    'thresholdType' in config &&
+    'measurement' in config &&
+    'headArtifactId' in evidenceData
+  );
+}
+
+function formatEvaluatedValue(value: number, thresholdType: MeasurementType): string {
+  if (thresholdType === 'relative_diff') {
+    return `${value}%`;
+  }
+  const mb = parseFloat(bytesToMB(value).toFixed(2));
+  return `${mb} ${getDisplayUnit(thresholdType)}`;
+}
+
+interface SizeAnalysisTriggeredSectionProps {
+  event: Event;
+  group: Group;
+}
+
+export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSectionProps) {
+  const organization = useOrganization();
+  const evidenceData = event.occurrence?.evidenceData;
+
+  if (!isSizeAnalysisEvidenceData(evidenceData)) {
+    return null;
+  }
+
+  const {conditions, config, value, headArtifactId, baseArtifactId} = evidenceData;
+  const triggeredCondition = conditions[0];
+  const artifactType = event.tags?.find(({key}) => key === 'head.artifact_type')?.value;
+  const isDiffThreshold =
+    config.thresholdType === 'absolute_diff' || config.thresholdType === 'relative_diff';
+
+  const headBuildPath = getSizeBuildPath({
+    organizationSlug: organization.slug,
+    baseArtifactId: String(headArtifactId),
+  });
+
+  const compareBuildPath =
+    isDiffThreshold && defined(baseArtifactId)
+      ? getCompareBuildPath({
+          organizationSlug: organization.slug,
+          headArtifactId: String(headArtifactId),
+          baseArtifactId: String(baseArtifactId),
+        })
+      : undefined;
+
+  return (
+    <Fragment>
+      <InterimSection
+        title={t('Triggered Condition')}
+        type="triggered_condition"
+        actions={
+          <Flex gap="xs">
+            {headBuildPath && (
+              <LinkButton size="xs" to={headBuildPath}>
+                {t('Open Build')}
+              </LinkButton>
+            )}
+            {compareBuildPath && (
+              <LinkButton size="xs" to={compareBuildPath}>
+                {t('Open Comparison')}
+              </LinkButton>
+            )}
+          </Flex>
+        }
+      >
+        <KeyValueList
+          shouldSort={false}
+          data={[
+            {
+              key: 'thresholdType',
+              value: getMeasurementLabel(config.thresholdType),
+              subject: t('Threshold Type'),
+            },
+            {
+              key: 'measurement',
+              value: getMetricLabelForArtifactType(config.measurement, artifactType),
+              subject: t('Measurement'),
+            },
+            ...(config.query
+              ? [
+                  {
+                    key: 'query',
+                    value: config.query,
+                    subject: t('Query'),
+                  },
+                ]
+              : []),
+            ...(triggeredCondition
+              ? [
+                  {
+                    key: 'condition',
+                    value: (
+                      <pre>
+                        {getConditionDescription({
+                          condition: triggeredCondition,
+                          thresholdType: config.thresholdType,
+                        })}
+                      </pre>
+                    ),
+                    subject: t('Condition'),
+                  },
+                ]
+              : []),
+            {
+              key: 'value',
+              value: formatEvaluatedValue(value, config.thresholdType),
+              subject: t('Evaluated Value'),
+            },
+          ]}
+        />
+      </InterimSection>
+    </Fragment>
+  );
+}

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
@@ -122,72 +120,68 @@ export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSecti
       : undefined;
 
   return (
-    <Fragment>
-      <InterimSection
-        title={t('Triggered Condition')}
-        type="triggered_condition"
-        actions={
-          <Flex gap="xs">
-            {headBuildPath && (
-              <LinkButton size="xs" to={headBuildPath}>
-                {t('Open Build')}
-              </LinkButton>
-            )}
-            {compareBuildPath && (
-              <LinkButton size="xs" to={compareBuildPath}>
-                {t('Open Comparison')}
-              </LinkButton>
-            )}
-          </Flex>
-        }
-      >
-        <KeyValueList
-          shouldSort={false}
-          data={[
-            {
-              key: 'thresholdType',
-              value: getMeasurementLabel(config.thresholdType),
-              subject: t('Threshold Type'),
-            },
-            {
-              key: 'measurement',
-              value: measurementLabel,
-              subject: t('Measurement'),
-            },
-            ...(config.query
-              ? [
-                  {
-                    key: 'query',
-                    value: config.query,
-                    subject: t('Query'),
-                  },
-                ]
-              : []),
-            ...(triggeredCondition
-              ? [
-                  {
-                    key: 'condition',
-                    value: (
-                      <pre>
-                        {formatCondition({
-                          condition: triggeredCondition,
-                          thresholdType: config.thresholdType,
-                          measurementLabel,
-                        })}
-                      </pre>
-                    ),
-                    subject: t('Condition'),
-                  },
-                ]
-              : []),
-            {
-              key: 'value',
-              value: formatValueWithUnit(value, config.thresholdType),
-              subject: t('Evaluated Value'),
-            },
-          ]}
-        />
-      </InterimSection>
-    </Fragment>
+    <InterimSection
+      title={t('Triggered Condition')}
+      type="triggered_condition"
+      actions={
+        <Flex gap="xs">
+          <LinkButton size="xs" to={headBuildPath}>
+            {t('Open Build')}
+          </LinkButton>
+          {compareBuildPath && (
+            <LinkButton size="xs" to={compareBuildPath}>
+              {t('Open Comparison')}
+            </LinkButton>
+          )}
+        </Flex>
+      }
+    >
+      <KeyValueList
+        shouldSort={false}
+        data={[
+          {
+            key: 'thresholdType',
+            value: getMeasurementLabel(config.thresholdType),
+            subject: t('Threshold Type'),
+          },
+          {
+            key: 'measurement',
+            value: measurementLabel,
+            subject: t('Measurement'),
+          },
+          ...(config.query
+            ? [
+                {
+                  key: 'query',
+                  value: config.query,
+                  subject: t('Query'),
+                },
+              ]
+            : []),
+          ...(triggeredCondition
+            ? [
+                {
+                  key: 'condition',
+                  value: (
+                    <pre>
+                      {formatCondition({
+                        condition: triggeredCondition,
+                        thresholdType: config.thresholdType,
+                        measurementLabel,
+                      })}
+                    </pre>
+                  ),
+                  subject: t('Condition'),
+                },
+              ]
+            : []),
+          {
+            key: 'value',
+            value: formatValueWithUnit(value, config.thresholdType),
+            subject: t('Evaluated Value'),
+          },
+        ]}
+      />
+    </InterimSection>
   );
 }

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
@@ -9,10 +9,7 @@ import type {MetricCondition} from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
-import {
-  getCompareBuildPath,
-  getSizeBuildPath,
-} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {getCompareBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   bytesToMB,
   getDisplayUnit,
@@ -56,12 +53,18 @@ function isSizeAnalysisEvidenceData(
   );
 }
 
-function formatValueWithUnit(value: number, thresholdType: MeasurementType): string {
+function formatRawValueWithUnit(value: number, thresholdType: MeasurementType): string {
   if (thresholdType === 'relative_diff') {
     return `${value}%`;
   }
   const mb = parseFloat(bytesToMB(value).toFixed(2));
   return `${mb} ${getDisplayUnit(thresholdType)}`;
+}
+
+function formatEvaluatedValue(value: number, thresholdType: MeasurementType): string {
+  const isDiff = thresholdType === 'absolute_diff' || thresholdType === 'relative_diff';
+  const prefix = isDiff ? '+' : '';
+  return `${prefix}${formatRawValueWithUnit(value, thresholdType)}`;
 }
 
 function formatCondition({
@@ -77,7 +80,7 @@ function formatCondition({
   const label = isDiff ? `${measurementLabel} Diff` : measurementLabel;
   const comparisonValue =
     typeof condition.comparison === 'number'
-      ? formatValueWithUnit(condition.comparison, thresholdType)
+      ? formatRawValueWithUnit(condition.comparison, thresholdType)
       : '';
   return `${label} > ${comparisonValue}`;
 }
@@ -105,10 +108,7 @@ export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSecti
   const isDiffThreshold =
     config.thresholdType === 'absolute_diff' || config.thresholdType === 'relative_diff';
 
-  const headBuildPath = getSizeBuildPath({
-    organizationSlug: organization.slug,
-    baseArtifactId: String(headArtifactId),
-  });
+  const headBuildPath = `/organizations/${organization.slug}/preprod/size/${headArtifactId}/`;
 
   const compareBuildPath =
     isDiffThreshold && defined(baseArtifactId)
@@ -117,7 +117,7 @@ export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSecti
           headArtifactId: String(headArtifactId),
           baseArtifactId: String(baseArtifactId),
         })
-      : undefined;
+      : null;
 
   return (
     <InterimSection
@@ -177,7 +177,7 @@ export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSecti
             : []),
           {
             key: 'value',
-            value: formatValueWithUnit(value, config.thresholdType),
+            value: formatEvaluatedValue(value, config.thresholdType),
             subject: t('Evaluated Value'),
           },
         ]}

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
@@ -15,6 +15,7 @@ import {
   getDisplayUnit,
   getMeasurementLabel,
   getMetricLabelForArtifactType,
+  isDiffThreshold,
 } from 'sentry/views/settings/project/preprod/types';
 import type {
   MeasurementType,
@@ -51,10 +52,6 @@ function isSizeAnalysisEvidenceData(
     'measurement' in config &&
     'headArtifactId' in evidenceData
   );
-}
-
-function isDiffThreshold(thresholdType: MeasurementType): boolean {
-  return thresholdType === 'absolute_diff' || thresholdType === 'relative_diff';
 }
 
 function formatRawValueWithUnit(value: number, thresholdType: MeasurementType): string {

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
@@ -53,6 +53,10 @@ function isSizeAnalysisEvidenceData(
   );
 }
 
+function isDiffThreshold(thresholdType: MeasurementType): boolean {
+  return thresholdType === 'absolute_diff' || thresholdType === 'relative_diff';
+}
+
 function formatRawValueWithUnit(value: number, thresholdType: MeasurementType): string {
   if (thresholdType === 'relative_diff') {
     return `${value}%`;
@@ -62,8 +66,7 @@ function formatRawValueWithUnit(value: number, thresholdType: MeasurementType): 
 }
 
 function formatEvaluatedValue(value: number, thresholdType: MeasurementType): string {
-  const isDiff = thresholdType === 'absolute_diff' || thresholdType === 'relative_diff';
-  const prefix = isDiff ? '+' : '';
+  const prefix = isDiffThreshold(thresholdType) ? '+' : '';
   return `${prefix}${formatRawValueWithUnit(value, thresholdType)}`;
 }
 
@@ -76,8 +79,9 @@ function formatCondition({
   measurementLabel: string;
   thresholdType: MeasurementType;
 }): string {
-  const isDiff = thresholdType === 'absolute_diff' || thresholdType === 'relative_diff';
-  const label = isDiff ? `${measurementLabel} Diff` : measurementLabel;
+  const label = isDiffThreshold(thresholdType)
+    ? `${measurementLabel} Diff`
+    : measurementLabel;
   const comparisonValue =
     typeof condition.comparison === 'number'
       ? formatRawValueWithUnit(condition.comparison, thresholdType)
@@ -105,13 +109,12 @@ export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSecti
     config.measurement,
     artifactType
   );
-  const isDiffThreshold =
-    config.thresholdType === 'absolute_diff' || config.thresholdType === 'relative_diff';
+  const hasDiffThreshold = isDiffThreshold(config.thresholdType);
 
   const headBuildPath = `/organizations/${organization.slug}/preprod/size/${headArtifactId}/`;
 
   const compareBuildPath =
-    isDiffThreshold && defined(baseArtifactId)
+    hasDiffThreshold && defined(baseArtifactId)
       ? getCompareBuildPath({
           organizationSlug: organization.slug,
           headArtifactId: String(headArtifactId),

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.tsx
@@ -10,7 +10,6 @@ import type {Group} from 'sentry/types/group';
 import type {MetricCondition} from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {getConditionDescription} from 'sentry/views/detectors/components/details/mobileBuild/detect';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {
   getCompareBuildPath,
@@ -59,12 +58,30 @@ function isSizeAnalysisEvidenceData(
   );
 }
 
-function formatEvaluatedValue(value: number, thresholdType: MeasurementType): string {
+function formatValueWithUnit(value: number, thresholdType: MeasurementType): string {
   if (thresholdType === 'relative_diff') {
     return `${value}%`;
   }
   const mb = parseFloat(bytesToMB(value).toFixed(2));
   return `${mb} ${getDisplayUnit(thresholdType)}`;
+}
+
+function formatCondition({
+  condition,
+  thresholdType,
+  measurementLabel,
+}: {
+  condition: MetricCondition;
+  measurementLabel: string;
+  thresholdType: MeasurementType;
+}): string {
+  const isDiff = thresholdType === 'absolute_diff' || thresholdType === 'relative_diff';
+  const label = isDiff ? `${measurementLabel} Diff` : measurementLabel;
+  const comparisonValue =
+    typeof condition.comparison === 'number'
+      ? formatValueWithUnit(condition.comparison, thresholdType)
+      : '';
+  return `${label} > ${comparisonValue}`;
 }
 
 interface SizeAnalysisTriggeredSectionProps {
@@ -83,6 +100,10 @@ export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSecti
   const {conditions, config, value, headArtifactId, baseArtifactId} = evidenceData;
   const triggeredCondition = conditions[0];
   const artifactType = event.tags?.find(({key}) => key === 'head.artifact_type')?.value;
+  const measurementLabel = getMetricLabelForArtifactType(
+    config.measurement,
+    artifactType
+  );
   const isDiffThreshold =
     config.thresholdType === 'absolute_diff' || config.thresholdType === 'relative_diff';
 
@@ -130,7 +151,7 @@ export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSecti
             },
             {
               key: 'measurement',
-              value: getMetricLabelForArtifactType(config.measurement, artifactType),
+              value: measurementLabel,
               subject: t('Measurement'),
             },
             ...(config.query
@@ -148,9 +169,10 @@ export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSecti
                     key: 'condition',
                     value: (
                       <pre>
-                        {getConditionDescription({
+                        {formatCondition({
                           condition: triggeredCondition,
                           thresholdType: config.thresholdType,
+                          measurementLabel,
                         })}
                       </pre>
                     ),
@@ -160,7 +182,7 @@ export function SizeAnalysisTriggeredSection({event}: SizeAnalysisTriggeredSecti
               : []),
             {
               key: 'value',
-              value: formatEvaluatedValue(value, config.thresholdType),
+              value: formatValueWithUnit(value, config.thresholdType),
               subject: t('Evaluated Value'),
             },
           ]}

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -132,6 +132,15 @@ export function getMetricLabelForPlatform(
   return getMetricLabel(metric);
 }
 
+export function getMetricLabelForArtifactType(
+  metric: MetricType,
+  artifactType: string | undefined
+): string {
+  const platform =
+    artifactType === 'xcarchive' ? 'apple' : artifactType ? 'android' : undefined;
+  return getMetricLabelForPlatform(metric, platform);
+}
+
 export function getMeasurementLabel(measurement: MeasurementType): string {
   return MEASUREMENT_LABELS[measurement];
 }

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -185,3 +185,7 @@ export function bytesToMB(bytes: number): number {
 export function mbToBytes(mb: number): number {
   return mb * 1000 * 1000;
 }
+
+export function isDiffThreshold(thresholdType: MeasurementType): boolean {
+  return thresholdType === 'absolute_diff' || thresholdType === 'relative_diff';
+}


### PR DESCRIPTION
Display the triggered condition details on the issue detail page for `preprod_size_analysis` issues. New self-gating `SizeAnalysisTriggeredSection` component renders an `InterimSection` with a `KeyValueList` showing:

- **Threshold Type** — absolute size, absolute diff, or relative diff
- **Measurement** — platform-aware label derived from `head.artifact_type` event tag (e.g., "Install Size" for Apple, "Uncompressed Size" for Android)
- **Query** — shown when a filter query is configured
- **Condition** — human-readable threshold description (e.g., "Above 1 MB")
- **Evaluated Value** — formatted with 2 decimal places and appropriate units

Action buttons:
- **Open Build** — always shown, links to the head build detail page
- **Open Comparison** — shown for `absolute_diff` / `relative_diff` threshold types when a base artifact exists

Also adds `getMetricLabelForArtifactType` to the preprod types utils, exports `formatComparisonValue` and `getConditionDescription` from mobileBuild/detect.tsx, and adds a space between values and units in condition descriptions.

Diff Example
<img width="2754" height="488" alt="CleanShot 2026-04-01 at 09 33 35@2x" src="https://github.com/user-attachments/assets/6502cbe9-a84d-466e-86e2-d157403759f7" />

absolute example
<img width="2730" height="490" alt="CleanShot 2026-04-01 at 09 34 23@2x" src="https://github.com/user-attachments/assets/59a79c73-47d2-46ca-9832-400e36b89fbb" />


Refs EME-981