### PR TITLE
feat(attachments): Backfill EventAttachment.date_expires

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -31,7 +31,7 @@ replays: 0007_organizationmember_replay_access
 
 seer: 0005_delete_seerorganizationsettings
 
-sentry: 1061_eventattachment_date_expires_index
+sentry: 1062_backfill_eventattachment_date_expires
 
 social_auth: 0003_social_auth_json_field
 

--- a/src/sentry/migrations/1060_backfill_eventattachment_date_expires.py
+++ b/src/sentry/migrations/1060_backfill_eventattachment_date_expires.py
@@ -15,7 +15,7 @@ from sentry.new_migrations.migrations import CheckedMigration
 logger = logging.getLogger(__name__)
 
 BATCH_SIZE = 1000
-DATE_EXPIRES_SENTINEL = datetime(1970, 1, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
+SENTINEL = datetime(1970, 1, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
 DEFAULT_RETENTION_DAYS = 30
 
 
@@ -27,11 +27,8 @@ def backfill_eventattachment_date_expires(
     total_updated = 0
 
     while True:
-        updated = EventAttachment.objects.filter(
-            id__in=EventAttachment.objects.filter(date_expires=DATE_EXPIRES_SENTINEL).values("id")[
-                :BATCH_SIZE
-            ]
-        ).update(
+        batch = EventAttachment.objects.filter(date_expires=SENTINEL).values("id")[:BATCH_SIZE]
+        updated = EventAttachment.objects.filter(id__in=batch).update(
             date_expires=ExpressionWrapper(
                 F("date_added") + timedelta(days=DEFAULT_RETENTION_DAYS),
                 output_field=DateTimeField(),

--- a/src/sentry/migrations/1060_backfill_eventattachment_date_expires.py
+++ b/src/sentry/migrations/1060_backfill_eventattachment_date_expires.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 
+import click
 from django.db import migrations
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
@@ -11,8 +11,6 @@ from django.db.models import ExpressionWrapper, F
 from django.db.models.fields import DateTimeField
 
 from sentry.new_migrations.migrations import CheckedMigration
-
-logger = logging.getLogger(__name__)
 
 BATCH_SIZE = 1000
 SENTINEL = datetime(1970, 1, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
@@ -24,31 +22,18 @@ def backfill_eventattachment_date_expires(
 ) -> None:
     EventAttachment = apps.get_model("sentry", "EventAttachment")
 
-    total_updated = 0
-
-    while True:
-        batch = EventAttachment.objects.filter(date_expires=SENTINEL).values("id")[:BATCH_SIZE]
-        updated = EventAttachment.objects.filter(id__in=batch).update(
-            date_expires=ExpressionWrapper(
-                F("date_added") + timedelta(days=DEFAULT_RETENTION_DAYS),
-                output_field=DateTimeField(),
+    with click.progressbar(length=None, label="Backfilling EventAttachment.date_expires") as bar:
+        while True:
+            batch = EventAttachment.objects.filter(date_expires=SENTINEL).values("id")[:BATCH_SIZE]
+            updated = EventAttachment.objects.filter(id__in=batch).update(
+                date_expires=ExpressionWrapper(
+                    F("date_added") + timedelta(days=DEFAULT_RETENTION_DAYS),
+                    output_field=DateTimeField(),
+                )
             )
-        )
-
-        total_updated += updated
-        logger.info(
-            "backfill_eventattachment_date_expires: updated %d rows (total: %d)",
-            updated,
-            total_updated,
-        )
-
-        if not updated:
-            break
-
-    logger.info(
-        "backfill_eventattachment_date_expires: complete, updated %d total rows",
-        total_updated,
-    )
+            bar.update(updated)
+            if not updated:
+                break
 
 
 class Migration(CheckedMigration):

--- a/src/sentry/migrations/1060_backfill_eventattachment_date_expires.py
+++ b/src/sentry/migrations/1060_backfill_eventattachment_date_expires.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
+
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import ExpressionWrapper, F
+from django.db.models.fields import DateTimeField
+
+from sentry.new_migrations.migrations import CheckedMigration
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 1000
+DATE_EXPIRES_SENTINEL = datetime(1970, 1, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
+DEFAULT_RETENTION_DAYS = 30
+
+
+def backfill_eventattachment_date_expires(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    EventAttachment = apps.get_model("sentry", "EventAttachment")
+
+    total_updated = 0
+
+    while True:
+        updated = EventAttachment.objects.filter(
+            id__in=EventAttachment.objects.filter(date_expires=DATE_EXPIRES_SENTINEL).values("id")[
+                :BATCH_SIZE
+            ]
+        ).update(
+            date_expires=ExpressionWrapper(
+                F("date_added") + timedelta(days=DEFAULT_RETENTION_DAYS),
+                output_field=DateTimeField(),
+            )
+        )
+
+        total_updated += updated
+        logger.info(
+            "backfill_eventattachment_date_expires: updated %d rows (total: %d)",
+            updated,
+            total_updated,
+        )
+
+        if not updated:
+            break
+
+    logger.info(
+        "backfill_eventattachment_date_expires: complete, updated %d total rows",
+        total_updated,
+    )
+
+
+class Migration(CheckedMigration):
+    # This flag is used to mark that a migration shouldn't be automatically run in production.
+    # This should only be used for operations where it's safe to run the migration after your
+    # code has deployed. So this should not be used for most operations that alter the schema
+    # of a table.
+    # Here are some things that make sense to mark as post deployment:
+    # - Large data migrations. Typically we want these to be run manually so that they can be
+    #   monitored and not block the deploy for a long period of time while they run.
+    # - Adding indexes to large tables. Since this can take a long time, we'd generally prefer to
+    #   run this outside deployments so that we don't block them. Note that while adding an index
+    #   is a schema change, it's completely safe to run the operation after the code has deployed.
+    # Once deployed, run these manually via: https://develop.sentry.dev/database-migrations/#migration-deployment
+
+    is_post_deployment = True
+
+    dependencies = [
+        ("sentry", "1059_eventattattachment_date_expires"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_eventattachment_date_expires,
+            migrations.RunPython.noop,
+            hints={"tables": ["sentry_eventattachment"]},
+        ),
+    ]

--- a/src/sentry/migrations/1062_backfill_eventattachment_date_expires.py
+++ b/src/sentry/migrations/1062_backfill_eventattachment_date_expires.py
@@ -52,7 +52,7 @@ class Migration(CheckedMigration):
     is_post_deployment = True
 
     dependencies = [
-        ("sentry", "1059_eventattattachment_date_expires"),
+        ("sentry", "1061_eventattachment_date_expires_index"),
     ]
 
     operations = [

--- a/src/sentry/migrations/1062_backfill_eventattachment_date_expires.py
+++ b/src/sentry/migrations/1062_backfill_eventattachment_date_expires.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 
+import itertools
+
 import click
 from django.db import migrations
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
@@ -12,7 +14,7 @@ from django.db.models.fields import DateTimeField
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-BATCH_SIZE = 1000
+BATCH_SIZE = 10_000
 SENTINEL = datetime(1970, 1, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
 DEFAULT_RETENTION_DAYS = 30
 
@@ -22,18 +24,23 @@ def backfill_eventattachment_date_expires(
 ) -> None:
     EventAttachment = apps.get_model("sentry", "EventAttachment")
 
-    with click.progressbar(length=None, label="Backfilling EventAttachment.date_expires") as bar:
-        while True:
-            batch = EventAttachment.objects.filter(date_expires=SENTINEL).values("id")[:BATCH_SIZE]
-            updated = EventAttachment.objects.filter(id__in=batch).update(
-                date_expires=ExpressionWrapper(
-                    F("date_added") + timedelta(days=DEFAULT_RETENTION_DAYS),
-                    output_field=DateTimeField(),
-                )
+    total_updated = 0
+    for i in itertools.count():
+        batch = EventAttachment.objects.filter(date_expires=SENTINEL).values("id")[:BATCH_SIZE]
+        updated = EventAttachment.objects.filter(id__in=batch).update(
+            date_expires=ExpressionWrapper(
+                F("date_added") + timedelta(days=DEFAULT_RETENTION_DAYS),
+                output_field=DateTimeField(),
             )
-            bar.update(updated)
-            if not updated:
-                break
+        )
+        if not updated:
+            break
+
+        total_updated += updated
+        if i % 100 == 0:
+            click.echo(f"Backfilled {total_updated} rows so far...")
+
+    click.echo(f"Done. Backfilled {total_updated} rows total.")
 
 
 class Migration(CheckedMigration):


### PR DESCRIPTION
Follow-up to #111881. Backfills all existing rows with that sentinel to `date_added + 30 days`, aligning them with the default attachment retention period. New rows will be written with a date_expires.

Requires #111983 before running.
Ref FS-328