### PR TITLE
feat(attachments): Write date_expires when saving attachments

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2508,6 +2508,7 @@ def save_attachment(
         sha1=file.sha1,
         # storage:
         blob_path=file.blob_path,
+        date_expires=datetime.now(timezone.utc) + timedelta(days=attachment.retention_days),
     )
 
     track_outcome(

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -1,9 +1,11 @@
+from datetime import timedelta
 from io import BytesIO
 from unittest import mock
 from uuid import uuid4
 
 import pytest
 import requests
+from django.utils import timezone
 from sentry_relay.auth import SecretKey, generate_key_pair
 
 from sentry.models.eventattachment import EventAttachment
@@ -157,10 +159,17 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
 
     def test_standalone_attachment(self) -> None:
         event_id = uuid4().hex
+        retention_days = 66
 
-        # First, ingest the attachment and ensure it is saved
-        files = {"some_file": ("hello.txt", BytesIO(b"Hello World!"))}
-        self.post_and_retrieve_attachment(event_id, files)
+        with mock.patch(
+            "sentry.relay.config.quotas.backend.get_event_retention",
+            return_value=retention_days,
+        ):
+            now = timezone.now()
+
+            # First, ingest the attachment and ensure it is saved
+            files = {"some_file": ("hello.txt", BytesIO(b"Hello World!"))}
+            self.post_and_retrieve_attachment(event_id, files)
 
         # Next, ingest an error event
         event = self.post_and_retrieve_event({"event_id": event_id, "message": "my error"})
@@ -170,6 +179,8 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
         # Finally, fetch the updated attachment and compare the group id
         attachment = EventAttachment.objects.get(project_id=self.project.id, event_id=event_id)
         assert attachment.group_id == event.group_id
+        delta = attachment.date_expires - (now + timedelta(days=retention_days))
+        assert abs(delta.total_seconds()) < 3600
 
     def test_blob_only_attachment(self) -> None:
         event_id = uuid4().hex

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -269,6 +269,8 @@ def test_feedbacks_spawn_save_event_feedback(
 @django_db_all
 @pytest.mark.parametrize("missing_chunks", (True, False))
 def test_with_attachments(default_project, task_runner, missing_chunks, django_cache) -> None:
+    retention_days = 66
+
     with patch("sentry.features.has", return_value=True):
         payload = get_normalized_event({"message": "hello world"}, default_project)
         event_id = payload["event_id"]
@@ -296,6 +298,7 @@ def test_with_attachments(default_project, task_runner, missing_chunks, django_c
                 }
             )
 
+        now = datetime.datetime.now(datetime.timezone.utc)
         with task_runner():
             process_event(
                 ConsumerType.Events,
@@ -313,6 +316,7 @@ def test_with_attachments(default_project, task_runner, missing_chunks, django_c
                             "attachment_type": "custom.attachment",
                             "size": len(b"Hello World!"),
                             "chunks": 2,
+                            "retention_days": retention_days,
                         }
                     ],
                 },
@@ -329,6 +333,8 @@ def test_with_attachments(default_project, task_runner, missing_chunks, django_c
         assert attachment.name == "lol.txt"
         with attachment.getfile() as file:
             assert file.read() == b"Hello World!"
+        delta = attachment.date_expires - (now + datetime.timedelta(days=retention_days))
+        assert abs(delta.total_seconds()) < 3600
     else:
         assert not persisted_attachments
 
@@ -533,6 +539,8 @@ def test_process_stored_attachment(
 def test_individual_attachments(
     default_project, factories, feature_enabled, attachment, with_group, django_cache
 ):
+    retention_days = 66
+
     with patch("sentry.features.has", return_value=feature_enabled):
         event_id = uuid.uuid4().hex
         attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
@@ -554,6 +562,7 @@ def test_individual_attachments(
             "content_type": content_type,
             "attachment_type": attachment_type,
             "chunks": len(chunks),
+            "retention_days": retention_days,
         }
         if isinstance(chunks, bytes):
             attachment_meta["data"] = chunks
@@ -572,6 +581,7 @@ def test_individual_attachments(
             expected_content = b"".join(chunks)
         attachment_meta["size"] = len(expected_content)
 
+        now = datetime.datetime.now(datetime.timezone.utc)
         process_individual_attachment(
             {
                 "type": "attachment",
@@ -594,6 +604,9 @@ def test_individual_attachments(
 
         with attachment.getfile() as file_contents:
             assert file_contents.read() == expected_content
+
+        delta = attachment.date_expires - (now + datetime.timedelta(days=retention_days))
+        assert abs(delta.total_seconds()) < 3600
 
 
 @django_db_all


### PR DESCRIPTION
Set `date_expires` explicitly when creating `EventAttachment` records during event ingestion, using `retention_days` from the `CachedAttachment`. This ensures each new attachment row carries an accurate expiry derived from the project's configured retention rather than relying on the sentinel value added in #111881.

Ref FS-328