### PR TITLE
fix(seer-explorer): Memoize repoNames to stabilize useMemo dependencies

### DIFF
--- a/static/app/views/seerExplorer/prWidget.spec.tsx
+++ b/static/app/views/seerExplorer/prWidget.spec.tsx
@@ -1,5 +1,6 @@
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
+import {DiffFileType} from 'sentry/components/events/autofix/types';
 import type {Block, RepoPRState} from 'sentry/views/seerExplorer/types';
 
 import {usePRWidgetData} from './prWidget';
@@ -14,7 +15,12 @@ describe('usePRWidgetData', () => {
         {
           repo_name: 'getsentry/sentry',
           diff: '+added line',
-          patch: {path: 'src/file.py', added: 3, removed: 1, type: 'M'},
+          patch: {
+            path: 'src/file.py',
+            added: 3,
+            removed: 1,
+            type: DiffFileType.MODIFIED,
+          },
         },
       ],
     },

--- a/static/app/views/seerExplorer/prWidget.spec.tsx
+++ b/static/app/views/seerExplorer/prWidget.spec.tsx
@@ -1,0 +1,60 @@
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import type {Block, RepoPRState} from 'sentry/views/seerExplorer/types';
+
+import {usePRWidgetData} from './prWidget';
+
+describe('usePRWidgetData', () => {
+  const mockBlocks: Block[] = [
+    {
+      id: 'block-1',
+      message: {role: 'assistant', content: 'Made changes'},
+      timestamp: '2024-01-01T00:00:00Z',
+      merged_file_patches: [
+        {
+          repo_name: 'getsentry/sentry',
+          diff: '+added line',
+          patch: {path: 'src/file.py', added: 3, removed: 1, type: 'M'},
+        },
+      ],
+    },
+  ];
+
+  const mockRepoPRStates: Record<string, RepoPRState> = {
+    'getsentry/sentry': {
+      repo_name: 'getsentry/sentry',
+      branch_name: 'fix/test',
+      commit_sha: 'abc123',
+      pr_creation_error: null,
+      pr_creation_status: 'completed',
+      pr_id: 1,
+      pr_number: 100,
+      pr_url: 'https://github.com/getsentry/sentry/pull/100',
+      title: 'Test PR',
+    },
+  };
+
+  const mockOnCreatePR = jest.fn();
+
+  it('returns stable memoized values across rerenders with unchanged inputs', () => {
+    const {result, rerender} = renderHook(() =>
+      usePRWidgetData({
+        blocks: mockBlocks,
+        repoPRStates: mockRepoPRStates,
+        onCreatePR: mockOnCreatePR,
+      })
+    );
+
+    const firstRender = result.current;
+
+    rerender();
+
+    // All returned values should be referentially identical after a rerender
+    // with the same inputs — this verifies useMemo dependencies are stable
+    expect(result.current.menuItems).toBe(firstRender.menuItems);
+    expect(result.current.menuFooter).toBe(firstRender.menuFooter);
+    expect(result.current.allInSync).toBe(firstRender.allInSync);
+    expect(result.current.anyCreating).toBe(firstRender.anyCreating);
+    expect(result.current.hasPRs).toBe(firstRender.hasPRs);
+  });
+});

--- a/static/app/views/seerExplorer/prWidget.tsx
+++ b/static/app/views/seerExplorer/prWidget.tsx
@@ -132,7 +132,7 @@ export function usePRWidgetData({
     return status;
   }, [blocks, repoPRStates, repoStats]);
 
-  const repoNames = Object.keys(repoStats);
+  const repoNames = useMemo(() => Object.keys(repoStats), [repoStats]);
 
   // Compute overall sync status
   const {allInSync, anyCreating, hasPRs} = useMemo(() => {


### PR DESCRIPTION
`Object.keys(repoStats)` in `usePRWidgetData` was called at function body
level, producing a new array reference on every render. This defeated three
downstream `useMemo` hooks that listed `repoNames` in their dependency
arrays, causing them to recompute on every render regardless of whether the
underlying data changed.

Wraps the derivation in its own `useMemo` keyed on `repoStats` so the
reference stays stable across rerenders.

Adds a test that verifies memoized values remain referentially identical
across rerenders with unchanged inputs — the test fails without the fix.