### PR TITLE
ref(autofix): Seer -> Seer Autofix

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
@@ -74,7 +74,7 @@ describe('AutofixSection', () => {
       organization,
     });
 
-    expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.getByText('Seer Autofix')).toBeInTheDocument();
   });
 
   it('renders Resources section when AI features are disabled', () => {
@@ -381,7 +381,7 @@ describe('AutofixSection', () => {
     });
 
     // The Seer title should still render
-    expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.getByText('Seer Autofix')).toBeInTheDocument();
     expect(await screen.findByTestId('loading-placeholder')).toBeInTheDocument();
   });
 
@@ -397,7 +397,7 @@ describe('AutofixSection', () => {
     });
 
     // The Seer title should still render
-    expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.getByText('Seer Autofix')).toBeInTheDocument();
     expect(await screen.findByText('Have Seer...')).toBeInTheDocument();
   });
 

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -92,7 +92,7 @@ export function AutofixSection({group, project, event}: AutofixSectionProps) {
     <SidebarFoldSection
       title={
         <Flex align="center" gap="xs">
-          <Text size="md">{t('Seer')}</Text>
+          <Text size="md">{t('Seer Autofix')}</Text>
           <IconSeer />
         </Flex>
       }


### PR DESCRIPTION
Users are sometimes confused which Seer feature is which. This makes it hard to look up the feature in the docs / get the correct support etc. This changes the sidebar to label the section with 'Seer Autofix' to make it clearer which feature this is.

Before:
<img width="2884" height="2016" alt="CleanShot 2026-04-01 at 10 20 54@2x" src="https://github.com/user-attachments/assets/f3831eb7-f2cc-4920-9a4d-600d2a2b5d67" />

After:
<img width="2884" height="2016" alt="CleanShot 2026-04-01 at 10 21 16@2x" src="https://github.com/user-attachments/assets/8f6555c7-6898-41a3-aaae-839e1bc20dba" />

