### PR TITLE
feat(agents): Use CurrencyCell in Agent Monitoring dashboards and handle negative costs

### DIFF
--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -520,7 +520,7 @@ function NegativeCurrencyValue({
   return (
     <Tooltip
       title={tct(
-        'Negative costs can occur when cached token pricing differs from standard token pricing. [link:Learn more].',
+        'Cached tokens may cost less than estimated, resulting in a negative total. [link:Learn more about cost tracking].',
         {
           link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
         }

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -1,16 +1,12 @@
 import {Fragment} from 'react';
 import {Link} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import {Container, Flex, type ContainerProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {ExternalLink} from 'sentry/components/links/externalLink';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {IconWarning} from 'sentry/icons';
-import {tct} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {EChartDataZoomHandler, Series} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
@@ -52,6 +48,7 @@ import {Thresholds} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plott
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {getExploreUrl} from 'sentry/views/explore/utils';
+import {NegativeCostWarning} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
@@ -368,11 +365,9 @@ function VisualizationWidgetContent({
             </Tooltip>
             <TextAlignRight>
               {dataType === 'currency' && value !== null && value < 0 ? (
-                <NegativeCurrencyValue
-                  value={value}
-                  dataType={dataType}
-                  dataUnit={dataUnit}
-                />
+                <NegativeCostWarning>
+                  {formatBreakdownLegendValue(value, dataType, dataUnit)}
+                </NegativeCostWarning>
               ) : dataType === 'number' &&
                 value !== null &&
                 value > 0 &&
@@ -505,39 +500,3 @@ function renderBreakdownLabel(
 
   return fallbackLabel;
 }
-
-const NEGATIVE_COST_DOCS_URL =
-  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
-
-function NegativeCurrencyValue({
-  value,
-  dataType,
-  dataUnit,
-}: {
-  dataType: string;
-  value: number;
-  dataUnit?: string;
-}) {
-  return (
-    <Tooltip
-      title={tct(
-        'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
-        {
-          link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
-        }
-      )}
-      skipWrapper
-    >
-      <NegativeCostWrapper>
-        <IconWarning legacySize="1em" variant="warning" />
-        {formatBreakdownLegendValue(value, dataType, dataUnit)}
-      </NegativeCostWrapper>
-    </Tooltip>
-  );
-}
-
-const NegativeCostWrapper = styled('span')`
-  display: inline-flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-`;

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -529,7 +529,7 @@ function NegativeCurrencyValue({
       skipWrapper
     >
       <NegativeCostWrapper>
-        <IconWarning size="sm" variant="warning" />
+        <IconWarning legacySize="1em" variant="warning" />
         {formatBreakdownLegendValue(value, dataType, dataUnit)}
       </NegativeCostWrapper>
     </Tooltip>

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -506,7 +506,8 @@ function renderBreakdownLabel(
   return fallbackLabel;
 }
 
-const NEGATIVE_COST_DOCS_URL = 'https://docs.sentry.io/ai/monitoring/agents/costs/';
+const NEGATIVE_COST_DOCS_URL =
+  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
 
 function NegativeCurrencyValue({
   value,
@@ -520,7 +521,7 @@ function NegativeCurrencyValue({
   return (
     <Tooltip
       title={tct(
-        'Cached tokens may cost less than estimated, resulting in a negative total. [link:Learn more about cost tracking].',
+        'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
         {
           link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
         }

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -1,12 +1,16 @@
 import {Fragment} from 'react';
 import {Link} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import {Container, Flex, type ContainerProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {ExternalLink} from 'sentry/components/links/externalLink';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {IconWarning} from 'sentry/icons';
+import {tct} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {EChartDataZoomHandler, Series} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
@@ -363,10 +367,16 @@ function VisualizationWidgetContent({
               {labelContent}
             </Tooltip>
             <TextAlignRight>
-              {dataType === 'number' &&
-              value !== null &&
-              value > 0 &&
-              value < NUMBER_MIN_VALUE ? (
+              {dataType === 'currency' && value !== null && value < 0 ? (
+                <NegativeCurrencyValue
+                  value={value}
+                  dataType={dataType}
+                  dataUnit={dataUnit}
+                />
+              ) : dataType === 'number' &&
+                value !== null &&
+                value > 0 &&
+                value < NUMBER_MIN_VALUE ? (
                 <Tooltip title={value.toLocaleString()}>
                   <span>{formatBreakdownLegendValue(value, dataType, dataUnit)}</span>
                 </Tooltip>
@@ -495,3 +505,38 @@ function renderBreakdownLabel(
 
   return fallbackLabel;
 }
+
+const NEGATIVE_COST_DOCS_URL = 'https://docs.sentry.io/ai/monitoring/agents/costs/';
+
+function NegativeCurrencyValue({
+  value,
+  dataType,
+  dataUnit,
+}: {
+  dataType: string;
+  value: number;
+  dataUnit?: string;
+}) {
+  return (
+    <Tooltip
+      title={tct(
+        'Negative costs can occur when cached token pricing differs from standard token pricing. [link:Learn more].',
+        {
+          link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
+        }
+      )}
+      skipWrapper
+    >
+      <NegativeCostWrapper>
+        <IconWarning size="sm" variant="warning" />
+        {formatBreakdownLegendValue(value, dataType, dataUnit)}
+      </NegativeCostWrapper>
+    </Tooltip>
+  );
+}
+
+const NegativeCostWrapper = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+`;

--- a/static/app/views/insights/common/components/tableCells/currencyCell.spec.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.spec.tsx
@@ -33,9 +33,11 @@ describe('CurrencyCell', () => {
     const warningIcon = screen.getByRole('img', {hidden: true});
     expect(warningIcon).toBeInTheDocument();
 
-    // Hover over the warning icon to see tooltip
+    // Hover over the wrapper to see tooltip
     await userEvent.hover(warningIcon);
-    expect(await screen.findByText(/Negative costs can occur/)).toBeInTheDocument();
-    expect(screen.getByText('Learn more')).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Negative costs indicate an error/)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Follow this guide')).toBeInTheDocument();
   });
 });

--- a/static/app/views/insights/common/components/tableCells/currencyCell.spec.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.spec.tsx
@@ -1,0 +1,41 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {CurrencyCell} from './currencyCell';
+
+describe('CurrencyCell', () => {
+  it('renders em dash for null values', () => {
+    render(<CurrencyCell value={null} />);
+    expect(screen.getByText('\u2014')).toBeInTheDocument();
+  });
+
+  it('renders formatted dollar value', () => {
+    render(<CurrencyCell value={17.5} />);
+    expect(screen.getByText('$17.5')).toBeInTheDocument();
+  });
+
+  it('renders less than $0.01 for small positive values', () => {
+    render(<CurrencyCell value={0.005} />);
+    expect(screen.getByText(/^<\$/)).toBeInTheDocument();
+  });
+
+  it('renders $0 for zero value', () => {
+    render(<CurrencyCell value={0} />);
+    expect(screen.getByText('$0')).toBeInTheDocument();
+  });
+
+  it('renders negative value with warning icon', async () => {
+    render(<CurrencyCell value={-5.5} />);
+
+    // The negative value should be rendered
+    expect(screen.getByText('$-5.5')).toBeInTheDocument();
+
+    // Warning icon should be present
+    const warningIcon = screen.getByRole('img', {hidden: true});
+    expect(warningIcon).toBeInTheDocument();
+
+    // Hover over the warning icon to see tooltip
+    await userEvent.hover(warningIcon);
+    expect(await screen.findByText(/Negative costs can occur/)).toBeInTheDocument();
+    expect(screen.getByText('Learn more')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -1,5 +1,4 @@
-import styled from '@emotion/styled';
-
+import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ExternalLink} from 'sentry/components/links/externalLink';
@@ -15,6 +14,25 @@ type Props = {
 const NEGATIVE_COST_DOCS_URL =
   'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
 
+export function NegativeCostWarning({children}: {children: React.ReactNode}) {
+  return (
+    <Tooltip
+      title={tct(
+        'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
+        {
+          link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
+        }
+      )}
+      skipWrapper
+    >
+      <Flex as="span" display="inline-flex" align="center" gap="xs">
+        <IconWarning legacySize="1em" variant="warning" />
+        {children}
+      </Flex>
+    </Tooltip>
+  );
+}
+
 export function CurrencyCell({value}: Props) {
   if (value === null || value === undefined) {
     return <NumberContainer>{'\u2014'}</NumberContainer>;
@@ -23,20 +41,7 @@ export function CurrencyCell({value}: Props) {
   if (value < 0) {
     return (
       <NumberContainer>
-        <Tooltip
-          title={tct(
-            'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
-            {
-              link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
-            }
-          )}
-          skipWrapper
-        >
-          <NegativeCostWrapper>
-            <IconWarning legacySize="1em" variant="warning" />
-            {formatDollars(value)}
-          </NegativeCostWrapper>
-        </Tooltip>
+        <NegativeCostWarning>{formatDollars(value)}</NegativeCostWarning>
       </NumberContainer>
     );
   }
@@ -47,9 +52,3 @@ export function CurrencyCell({value}: Props) {
 
   return <NumberContainer>{formatDollars(value)}</NumberContainer>;
 }
-
-const NegativeCostWrapper = styled('span')`
-  display: inline-flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-`;

--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -1,10 +1,58 @@
+import styled from '@emotion/styled';
+
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {ExternalLink} from 'sentry/components/links/externalLink';
+import {IconWarning} from 'sentry/icons';
+import {tct} from 'sentry/locale';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatDollars} from 'sentry/utils/formatters';
 
 type Props = {
-  value: number;
+  value: number | null;
 };
 
+const NEGATIVE_COST_DOCS_URL =
+  'https://docs.sentry.io/product/insights/agents/#cost-tracking';
+
 export function CurrencyCell({value}: Props) {
+  if (value === null || value === undefined) {
+    return <NumberContainer>{'\u2014'}</NumberContainer>;
+  }
+
+  if (value < 0) {
+    return (
+      <NumberContainer>
+        <NegativeCostWrapper>
+          {formatDollars(value)}
+          <Tooltip
+            title={tct(
+              'Negative costs can occur when cached token pricing differs from standard token pricing. [link:Learn more].',
+              {
+                link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
+              }
+            )}
+          >
+            <StyledIconWarning size="sm" color="warning" />
+          </Tooltip>
+        </NegativeCostWrapper>
+      </NumberContainer>
+    );
+  }
+
+  if (value > 0 && value < 0.01) {
+    return <NumberContainer>{`<$${(0.01).toLocaleString()}`}</NumberContainer>;
+  }
+
   return <NumberContainer>{formatDollars(value)}</NumberContainer>;
 }
+
+const NegativeCostWrapper = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+`;
+
+const StyledIconWarning = styled(IconWarning)`
+  flex-shrink: 0;
+`;

--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -14,6 +14,21 @@ type Props = {
 
 const NEGATIVE_COST_DOCS_URL = 'https://docs.sentry.io/ai/monitoring/agents/costs/';
 
+export function NegativeCostWarning() {
+  return (
+    <Tooltip
+      title={tct(
+        'Negative costs can occur when cached token pricing differs from standard token pricing. [link:Learn more].',
+        {
+          link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
+        }
+      )}
+    >
+      <StyledIconWarning size="sm" variant="warning" />
+    </Tooltip>
+  );
+}
+
 export function CurrencyCell({value}: Props) {
   if (value === null || value === undefined) {
     return <NumberContainer>{'\u2014'}</NumberContainer>;
@@ -23,17 +38,8 @@ export function CurrencyCell({value}: Props) {
     return (
       <NumberContainer>
         <NegativeCostWrapper>
+          <NegativeCostWarning />
           {formatDollars(value)}
-          <Tooltip
-            title={tct(
-              'Negative costs can occur when cached token pricing differs from standard token pricing. [link:Learn more].',
-              {
-                link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
-              }
-            )}
-          >
-            <StyledIconWarning size="sm" color="warning" />
-          </Tooltip>
         </NegativeCostWrapper>
       </NumberContainer>
     );

--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -12,8 +12,7 @@ type Props = {
   value: number | null;
 };
 
-const NEGATIVE_COST_DOCS_URL =
-  'https://docs.sentry.io/product/insights/agents/#cost-tracking';
+const NEGATIVE_COST_DOCS_URL = 'https://docs.sentry.io/ai/monitoring/agents/costs/';
 
 export function CurrencyCell({value}: Props) {
   if (value === null || value === undefined) {

--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -24,7 +24,7 @@ export function CurrencyCell({value}: Props) {
       <NumberContainer>
         <Tooltip
           title={tct(
-            'Negative costs can occur when cached token pricing differs from standard token pricing. [link:Learn more].',
+            'Cached tokens may cost less than estimated, resulting in a negative total. [link:Learn more about cost tracking].',
             {
               link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
             }

--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -12,7 +12,8 @@ type Props = {
   value: number | null;
 };
 
-const NEGATIVE_COST_DOCS_URL = 'https://docs.sentry.io/ai/monitoring/agents/costs/';
+const NEGATIVE_COST_DOCS_URL =
+  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
 
 export function CurrencyCell({value}: Props) {
   if (value === null || value === undefined) {
@@ -24,7 +25,7 @@ export function CurrencyCell({value}: Props) {
       <NumberContainer>
         <Tooltip
           title={tct(
-            'Cached tokens may cost less than estimated, resulting in a negative total. [link:Learn more about cost tracking].',
+            'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
             {
               link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
             }

--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -14,21 +14,6 @@ type Props = {
 
 const NEGATIVE_COST_DOCS_URL = 'https://docs.sentry.io/ai/monitoring/agents/costs/';
 
-export function NegativeCostWarning() {
-  return (
-    <Tooltip
-      title={tct(
-        'Negative costs can occur when cached token pricing differs from standard token pricing. [link:Learn more].',
-        {
-          link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
-        }
-      )}
-    >
-      <StyledIconWarning size="sm" variant="warning" />
-    </Tooltip>
-  );
-}
-
 export function CurrencyCell({value}: Props) {
   if (value === null || value === undefined) {
     return <NumberContainer>{'\u2014'}</NumberContainer>;
@@ -37,10 +22,20 @@ export function CurrencyCell({value}: Props) {
   if (value < 0) {
     return (
       <NumberContainer>
-        <NegativeCostWrapper>
-          <NegativeCostWarning />
-          {formatDollars(value)}
-        </NegativeCostWrapper>
+        <Tooltip
+          title={tct(
+            'Negative costs can occur when cached token pricing differs from standard token pricing. [link:Learn more].',
+            {
+              link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
+            }
+          )}
+          skipWrapper
+        >
+          <NegativeCostWrapper>
+            <IconWarning size="sm" variant="warning" />
+            {formatDollars(value)}
+          </NegativeCostWrapper>
+        </Tooltip>
       </NumberContainer>
     );
   }
@@ -56,8 +51,4 @@ const NegativeCostWrapper = styled('span')`
   display: inline-flex;
   align-items: center;
   gap: ${p => p.theme.space.xs};
-`;
-
-const StyledIconWarning = styled(IconWarning)`
-  flex-shrink: 0;
 `;

--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -33,7 +33,7 @@ export function CurrencyCell({value}: Props) {
           skipWrapper
         >
           <NegativeCostWrapper>
-            <IconWarning size="sm" variant="warning" />
+            <IconWarning legacySize="1em" variant="warning" />
             {formatDollars(value)}
           </NegativeCostWrapper>
         </Tooltip>

--- a/static/app/views/insights/pages/agents/components/modelCostWidget.tsx
+++ b/static/app/views/insights/pages/agents/components/modelCostWidget.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import {ExternalLink} from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
+import {formatDollars} from 'sentry/utils/formatters';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
@@ -12,7 +13,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {CurrencyCell} from 'sentry/views/insights/common/components/tableCells/currencyCell';
+import {NegativeCostWarning} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
@@ -124,7 +125,7 @@ export function ModelCostWidget() {
             <ModelText>
               <ModelName modelId={modelId} />
             </ModelText>
-            <CurrencyCell value={Number(item['sum(gen_ai.cost.total_tokens)']) || null} />
+            <CostValue cost={Number(item['sum(gen_ai.cost.total_tokens)'])} />
           </Fragment>
         );
       })}
@@ -173,6 +174,27 @@ export function ModelCostWidget() {
     />
   );
 }
+
+function CostValue({cost}: {cost: number}) {
+  if (cost < 0) {
+    return (
+      <CostValueWrapper>
+        <NegativeCostWarning />
+        {formatDollars(cost)}
+      </CostValueWrapper>
+    );
+  }
+  if (cost > 0 && cost < 0.01) {
+    return <span>{`<$${(0.01).toLocaleString()}`}</span>;
+  }
+  return <span>{formatDollars(cost)}</span>;
+}
+
+const CostValueWrapper = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+`;
 
 const ModelText = styled('div')`
   color: ${p => p.theme.tokens.content.secondary};

--- a/static/app/views/insights/pages/agents/components/modelCostWidget.tsx
+++ b/static/app/views/insights/pages/agents/components/modelCostWidget.tsx
@@ -12,10 +12,10 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {CurrencyCell} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
+import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 import {getAIGenerationsFilter} from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -124,7 +124,7 @@ export function ModelCostWidget() {
             <ModelText>
               <ModelName modelId={modelId} />
             </ModelText>
-            <CurrencyCell value={Number(item['sum(gen_ai.cost.total_tokens)']) || null} />
+            <span>{formatLLMCosts(item['sum(gen_ai.cost.total_tokens)'] || 0)}</span>
           </Fragment>
         );
       })}

--- a/static/app/views/insights/pages/agents/components/modelCostWidget.tsx
+++ b/static/app/views/insights/pages/agents/components/modelCostWidget.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import {ExternalLink} from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
-import {formatDollars} from 'sentry/utils/formatters';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
@@ -13,7 +12,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {NegativeCostWarning} from 'sentry/views/insights/common/components/tableCells/currencyCell';
+import {CurrencyCell} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
@@ -125,7 +124,7 @@ export function ModelCostWidget() {
             <ModelText>
               <ModelName modelId={modelId} />
             </ModelText>
-            <CostValue cost={Number(item['sum(gen_ai.cost.total_tokens)'])} />
+            <CurrencyCell value={Number(item['sum(gen_ai.cost.total_tokens)']) || null} />
           </Fragment>
         );
       })}
@@ -174,27 +173,6 @@ export function ModelCostWidget() {
     />
   );
 }
-
-function CostValue({cost}: {cost: number}) {
-  if (cost < 0) {
-    return (
-      <CostValueWrapper>
-        <NegativeCostWarning />
-        {formatDollars(cost)}
-      </CostValueWrapper>
-    );
-  }
-  if (cost > 0 && cost < 0.01) {
-    return <span>{`<$${(0.01).toLocaleString()}`}</span>;
-  }
-  return <span>{formatDollars(cost)}</span>;
-}
-
-const CostValueWrapper = styled('span')`
-  display: inline-flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-`;
 
 const ModelText = styled('div')`
   color: ${p => p.theme.tokens.content.secondary};

--- a/static/app/views/insights/pages/agents/components/modelCostWidget.tsx
+++ b/static/app/views/insights/pages/agents/components/modelCostWidget.tsx
@@ -12,10 +12,10 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {CurrencyCell} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
-import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 import {getAIGenerationsFilter} from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -124,7 +124,7 @@ export function ModelCostWidget() {
             <ModelText>
               <ModelName modelId={modelId} />
             </ModelText>
-            <span>{formatLLMCosts(item['sum(gen_ai.cost.total_tokens)'] || 0)}</span>
+            <CurrencyCell value={Number(item['sum(gen_ai.cost.total_tokens)']) || null} />
           </Fragment>
         );
       })}

--- a/static/app/views/insights/pages/agents/components/modelsTable.tsx
+++ b/static/app/views/insights/pages/agents/components/modelsTable.tsx
@@ -19,7 +19,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
+import {CurrencyCell} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   CellLink,
@@ -34,7 +34,6 @@ import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 import {ErrorCell} from 'sentry/views/insights/pages/agents/utils/cells';
-import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 import {getAIGenerationsFilter} from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
@@ -263,7 +262,7 @@ const BodyCell = memo(function BodyCell({
     case 'p95(span.duration)':
       return <DurationCell milliseconds={dataRow.p95} />;
     case 'sum(gen_ai.cost.total_tokens)':
-      return <TextAlignRight>{formatLLMCosts(dataRow.cost)}</TextAlignRight>;
+      return <CurrencyCell value={dataRow.cost} />;
     case 'count_if(span.status,equals,internal_error)':
       return (
         <ErrorCell

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -32,10 +32,10 @@ import {FRAMELESS_STYLES} from 'sentry/views/dashboards/widgets/tableWidget/tabl
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTraces} from 'sentry/views/explore/hooks/useTraces';
 import {getExploreUrl} from 'sentry/views/explore/utils';
+import {CurrencyCell} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import type {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
-import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 import {resolveAgentName} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
@@ -421,11 +421,7 @@ const BodyCell = memo(function BodyCell({
       if (dataRow.isSpanDataLoading) {
         return <NumberPlaceholder />;
       }
-      return (
-        <TextAlignRight>
-          <LLMCosts cost={dataRow.totalCost} />
-        </TextAlignRight>
-      );
+      return <CurrencyCell value={dataRow.totalCost} />;
     case 'timestamp':
       return (
         <TextAlignRight>


### PR DESCRIPTION


Replace the custom `LLMCosts`/`formatLLMCosts` usage in the Agent Monitoring models table, traces table, and model cost widget with the shared `CurrencyCell` renderer.

Extend `CurrencyCell` to handle null values (em dash), small positive values (`<$0.01`), and negative costs — displaying the value alongside a warning icon with a tooltip explaining that negative costs can occur due to cached token pricing differences, linking to the cost tracking docs.


<img width="390" height="184" alt="CleanShot 2026-04-01 at 14 19 31" src="https://github.com/user-attachments/assets/ae91e4af-b416-471e-b587-6d2f1cc429c8" />

<img width="1398" height="1019" alt="CleanShot 2026-04-01 at 14 18 35" src="https://github.com/user-attachments/assets/3bb73838-0ff8-4261-bed6-d869eed7dff6" />

<img width="1398" height="1019" alt="CleanShot 2026-04-01 at 14 18 58" src="https://github.com/user-attachments/assets/05ac6fd0-9000-4bc0-953e-3a176bf62949" />

Refs TET-2175