### PR TITLE
feat(eslint): Add prefer-find-by rule for react-testing-library 

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -860,6 +860,7 @@ export default typescript.config([
       ...testingLibrary.configs['flat/react'].rules,
       'testing-library/no-unnecessary-act': 'off',
       'testing-library/render-result-naming-convention': 'off',
+      '@sentry/prefer-find-by': 'error',
     },
   },
   {

--- a/static/app/bootstrap/processInitQueue.spec.tsx
+++ b/static/app/bootstrap/processInitQueue.spec.tsx
@@ -140,12 +140,9 @@ describe('processInitQueue', () => {
       render(<div id="setup-wizard-container" />);
       processInitQueue();
 
-      await waitFor(
-        () => {
-          expect(screen.getByText('Select your Sentry project')).toBeInTheDocument();
-        },
-        {timeout: 5000}
-      );
+      expect(
+        await screen.findByText('Select your Sentry project', undefined, {timeout: 5000})
+      ).toBeInTheDocument();
     });
 
     it('renders WebAuthn Assert', async () => {

--- a/static/app/components/arithmeticBuilder/token/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/token/index.spec.tsx
@@ -126,9 +126,7 @@ describe('token', () => {
 
       expect(await screen.findByLabelText('avg(span.duration)')).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Select an attribute')).toHaveFocus();
-      });
+      expect(await screen.findByLabelText('Select an attribute')).toHaveFocus();
     });
 
     it('allow selecting function using keyboard', async () => {
@@ -152,9 +150,7 @@ describe('token', () => {
         })
       ).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Select an attribute')).toHaveFocus();
-      });
+      expect(await screen.findByLabelText('Select an attribute')).toHaveFocus();
     });
 
     it('allows selecting function with no arguments using mouse', async () => {
@@ -259,9 +255,7 @@ describe('token', () => {
         })
       ).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Select an attribute')).toHaveFocus();
-      });
+      expect(await screen.findByLabelText('Select an attribute')).toHaveFocus();
     });
 
     it('autocompletes function token when they reach the open parenthesis even if there is more text', async () => {
@@ -283,9 +277,7 @@ describe('token', () => {
 
       expect(input).toHaveValue('foo bar');
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Select an attribute')).toHaveFocus();
-      });
+      expect(await screen.findByLabelText('Select an attribute')).toHaveFocus();
     });
 
     it('autocompletes function token with no arguments when they reach the open parenthesis', async () => {
@@ -450,13 +442,11 @@ describe('token', () => {
       await waitFor(() => expect(getLastInput()).toHaveFocus());
       await userEvent.type(getLastInput(), '{Escape}');
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole('row', {
-            name: 'avg(span.self_time)',
-          })
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByRole('row', {
+          name: 'avg(span.self_time)',
+        })
+      ).toBeInTheDocument();
     });
 
     it('allows changing attribute using combo box', async () => {

--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -492,9 +492,7 @@ describe('AssigneeSelectorDropdown', () => {
     await userEvent.type(screen.getByRole('textbox'), 'Cert');
 
     // 1 total item
-    await waitFor(() => {
-      expect(screen.getAllByRole('option')).toHaveLength(1);
-    });
+    expect(await screen.findAllByRole('option')).toHaveLength(1);
 
     expect(await screen.findByText(USER_2.name)).toBeInTheDocument();
 
@@ -537,9 +535,7 @@ describe('AssigneeSelectorDropdown', () => {
     await userEvent.type(screen.getByRole('textbox'), 'github@example.com');
 
     // 1 total item
-    await waitFor(() => {
-      expect(screen.getAllByRole('option')).toHaveLength(1);
-    });
+    expect(await screen.findAllByRole('option')).toHaveLength(1);
 
     expect(await screen.findByText(USER_4.name)).toBeInTheDocument();
   });

--- a/static/app/components/backendJsonFormAdapter/choiceMapperAdapter.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/choiceMapperAdapter.spec.tsx
@@ -503,9 +503,7 @@ describe('ChoiceMapperAdapter', () => {
     resolveMutation();
 
     // Controls should be re-enabled
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Delete'})).toBeEnabled();
-    });
+    expect(await screen.findByRole('button', {name: 'Delete'})).toBeEnabled();
     expect(screen.getByRole('button', {name: /Add Repo/i})).toBeEnabled();
   });
 });

--- a/static/app/components/backendJsonFormAdapter/tableAdapter.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/tableAdapter.spec.tsx
@@ -286,8 +286,6 @@ describe('TableAdapter', () => {
     resolveMutation();
 
     // Controls should be re-enabled
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: /Add Service/})).toBeEnabled();
-    });
+    expect(await screen.findByRole('button', {name: /Add Service/})).toBeEnabled();
   });
 });

--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -213,9 +213,7 @@ describe('ChartWidgetLoader - unmocked imports', () => {
     // @ts-expect-error - fails type check because `invalid-widget` is not a valid chart id, but we want to test that it shows an error state
     render(<ChartWidgetLoader id="invalid-widget" />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Error loading widget')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Error loading widget')).toBeInTheDocument();
     expect(consoleSpy).toHaveBeenCalled();
     consoleSpy.mockRestore();
   });

--- a/static/app/components/charts/chartWidgetLoader.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader.spec.tsx
@@ -67,9 +67,7 @@ describe('ChartWidgetLoader', () => {
 
     render(<ChartWidgetLoader {...defaultProps} />, {wrapper});
 
-    await waitFor(() => {
-      expect(screen.getByText('Error loading widget')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Error loading widget')).toBeInTheDocument();
 
     expect(Sentry.captureException).toHaveBeenCalled();
     consoleSpy.mockRestore();
@@ -88,9 +86,7 @@ describe('ChartWidgetLoader', () => {
 
     render(<ChartWidgetLoader {...defaultProps} />, {wrapper});
 
-    await waitFor(() => {
-      expect(screen.getByText('Mock Widget')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Mock Widget')).toBeInTheDocument();
 
     // Verify the query was called with correct parameters
     expect(mockUseQuery).toHaveBeenCalledWith({

--- a/static/app/components/charts/intervalSelector.spec.tsx
+++ b/static/app/components/charts/intervalSelector.spec.tsx
@@ -30,9 +30,7 @@ describe('IntervalSelector', () => {
     );
     render(intervalSelector);
 
-    await waitFor(() => {
-      expect(screen.getByText('Interval')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Interval')).toBeInTheDocument();
 
     expect(interval).toBe('4h');
   });
@@ -48,9 +46,7 @@ describe('IntervalSelector', () => {
     );
     render(intervalSelector);
 
-    await waitFor(() => {
-      expect(screen.getByText('Interval')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Interval')).toBeInTheDocument();
 
     expect(eventView.interval).toBe('1m');
   });
@@ -67,9 +63,7 @@ describe('IntervalSelector', () => {
     );
     render(intervalSelector);
 
-    await waitFor(() => {
-      expect(screen.getByText('Interval')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Interval')).toBeInTheDocument();
 
     expect(interval).toBe('not called');
   });

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -127,12 +127,10 @@ describe('CommandPalette', () => {
     await userEvent.click(await screen.findByRole('option', {name: 'Parent action'}));
 
     // Textbox changes placeholder to parent action label
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Search commands'})).toHaveAttribute(
-        'placeholder',
-        'Search inside Parent action...'
-      );
-    });
+    expect(await screen.findByRole('textbox', {name: 'Search commands'})).toHaveAttribute(
+      'placeholder',
+      'Search inside Parent action...'
+    );
 
     // Child actions are visible, global actions are not
     expect(screen.getByRole('option', {name: 'Child action'})).toBeInTheDocument();

--- a/static/app/components/core/avatar/useAvatar.spec.tsx
+++ b/static/app/components/core/avatar/useAvatar.spec.tsx
@@ -105,9 +105,7 @@ describe('useAvatar', () => {
         img.dispatchEvent(new Event('error'));
       });
 
-      await waitFor(() => {
-        expect(screen.getByText('JB')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('JB')).toBeInTheDocument();
       expect(screen.queryByRole('img')).not.toBeInTheDocument();
     });
 

--- a/static/app/components/core/avatar/userAvatar.spec.tsx
+++ b/static/app/components/core/avatar/userAvatar.spec.tsx
@@ -53,9 +53,7 @@ describe('UserAvatar', () => {
         });
 
         // Should show letter avatar with initials from user.name, not email
-        await waitFor(() => {
-          expect(screen.getByText('JD')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('JD')).toBeInTheDocument();
         expect(screen.queryByRole('img')).not.toBeInTheDocument();
       }
     );

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -242,25 +242,17 @@ describe('CompactSelect', () => {
     await waitFor(() => {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Option One'})).toHaveFocus();
-    });
+    expect(await screen.findByRole('button', {name: 'Option One'})).toHaveFocus();
 
     // Can be dismissed by pressing Escape
     await userEvent.click(screen.getByRole('button', {name: 'Option One'}));
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
-    });
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus();
-    });
+    expect(await screen.findByRole('option', {name: 'Option One'})).toBeInTheDocument();
+    expect(await screen.findByRole('option', {name: 'Option One'})).toHaveFocus();
     await userEvent.keyboard('{Escape}');
     await waitFor(() => {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Option One'})).toHaveFocus();
-    });
+    expect(await screen.findByRole('button', {name: 'Option One'})).toHaveFocus();
 
     // When menu A is open, clicking once on menu B's trigger button closes menu A and
     // then opens menu B
@@ -503,9 +495,7 @@ describe('CompactSelect', () => {
 
       // reopen the menu — search input should be empty and all options visible
       await userEvent.click(screen.getByRole('button'));
-      await waitFor(() => {
-        expect(screen.getByPlaceholderText('Search here…')).toHaveValue('');
-      });
+      expect(await screen.findByPlaceholderText('Search here…')).toHaveValue('');
       expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
       expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
     });
@@ -877,18 +867,12 @@ describe('CompactSelect', () => {
         screen.queryByRole('option', {name: 'Option Three'})
       ).not.toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByPlaceholderText('Search…')).toHaveFocus();
-      });
+      expect(await screen.findByPlaceholderText('Search…')).toHaveFocus();
       // Option Three is not reachable via keyboard, focus wraps back to Option One
       await userEvent.keyboard(`{ArrowDown}`);
-      await waitFor(() => {
-        expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus();
-      });
+      expect(await screen.findByRole('option', {name: 'Option One'})).toHaveFocus();
       await userEvent.keyboard(`{ArrowDown>2}`);
-      await waitFor(() => {
-        expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus();
-      });
+      expect(await screen.findByRole('option', {name: 'Option One'})).toHaveFocus();
 
       // Option Three is still available via search
       await userEvent.type(screen.getByPlaceholderText('Search…'), 'three');
@@ -938,9 +922,7 @@ describe('CompactSelect', () => {
 
       // click on the trigger button
       await userEvent.click(screen.getByRole('button', {expanded: false}));
-      await waitFor(() =>
-        expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus()
-      );
+      expect(await screen.findByRole('option', {name: 'Option One'})).toHaveFocus();
 
       // move focus to Section 1's toggle button and press it to select all
       await userEvent.keyboard('{Tab}');
@@ -1254,9 +1236,7 @@ describe('CompactSelect', () => {
 
       // reopen the menu — search input should be empty and all options visible
       await userEvent.click(screen.getByRole('button'));
-      await waitFor(() => {
-        expect(screen.getByPlaceholderText('Search here…')).toHaveValue('');
-      });
+      expect(await screen.findByPlaceholderText('Search here…')).toHaveValue('');
       expect(screen.getByRole('row', {name: 'Option One'})).toBeInTheDocument();
       expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
     });
@@ -1314,9 +1294,7 @@ describe('CompactSelect', () => {
       expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('row', {name: 'Option Three'})).not.toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByPlaceholderText('Search…')).toHaveFocus();
-      });
+      expect(await screen.findByPlaceholderText('Search…')).toHaveFocus();
       // Option Three is not reachable via keyboard, focus wraps back to Option One
       await userEvent.keyboard(`{ArrowDown}`);
       expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus();
@@ -1372,9 +1350,7 @@ describe('CompactSelect', () => {
 
       // click on the trigger button
       await userEvent.click(screen.getByRole('button', {expanded: false}));
-      await waitFor(() =>
-        expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus()
-      );
+      expect(await screen.findByRole('row', {name: 'Option One'})).toHaveFocus();
 
       // move focus to Section 1's toggle button and press it to select all
       await userEvent.keyboard('{Tab}');
@@ -1510,9 +1486,7 @@ describe('CompactSelect', () => {
 
       // click on the trigger button
       await userEvent.click(screen.getByRole('button'));
-      await waitFor(() =>
-        expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus()
-      );
+      expect(await screen.findByRole('row', {name: 'Option One'})).toHaveFocus();
 
       // press Arrow Right, focus should be moved to the trailing button
       await userEvent.keyboard('{ArrowRight}');

--- a/static/app/components/core/compactSelect/composite.spec.tsx
+++ b/static/app/components/core/compactSelect/composite.spec.tsx
@@ -129,9 +129,7 @@ describe('CompositeSelect', () => {
     await userEvent.click(screen.getByRole('button'));
 
     // first option is focused
-    await waitFor(() =>
-      expect(screen.getByRole('option', {name: 'Choice One'})).toHaveFocus()
-    );
+    expect(await screen.findByRole('option', {name: 'Choice One'})).toHaveFocus();
 
     // press arrow down and second option gets focus
     await userEvent.keyboard('{ArrowDown}');
@@ -143,16 +141,12 @@ describe('CompositeSelect', () => {
 
     // press arrow up and second option in the first region gets focus
     await userEvent.keyboard('{ArrowUp}');
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'Choice Two'})).toHaveFocus();
-    });
+    expect(await screen.findByRole('option', {name: 'Choice Two'})).toHaveFocus();
 
     // press arrow down 3 times and focus moves to the third and fourth option, before
     // wrapping back to the first option
     await userEvent.keyboard('{ArrowDown>3}');
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'Choice One'})).toHaveFocus();
-    });
+    expect(await screen.findByRole('option', {name: 'Choice One'})).toHaveFocus();
   });
 
   it('has separate, async self-contained select regions', async () => {
@@ -337,9 +331,7 @@ describe('CompositeSelect', () => {
     // Region 1 is rendered & Choice One is selected
     expect(screen.getByRole('grid', {name: 'Region 1'})).toBeInTheDocument();
     expect(screen.getByRole('row', {name: 'Choice One'})).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByRole('row', {name: 'Choice One'})).toHaveFocus()
-    );
+    expect(await screen.findByRole('row', {name: 'Choice One'})).toHaveFocus();
     expect(screen.getByRole('row', {name: 'Choice One'})).toHaveAttribute(
       'aria-selected',
       'true'

--- a/static/app/components/core/compactSelect/listBox/index.spec.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.spec.tsx
@@ -212,18 +212,14 @@ describe('ListBox', () => {
 
     await userEvent.click(screen.getByRole('button'));
 
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus();
-    });
+    expect(await screen.findByRole('option', {name: 'Option One'})).toHaveFocus();
 
     expect(await screen.findByRole('tooltip')).toHaveTextContent(
       'Details for option one'
     );
 
     await userEvent.keyboard('{ArrowDown}');
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'Option Two'})).toHaveFocus();
-    });
+    expect(await screen.findByRole('option', {name: 'Option Two'})).toHaveFocus();
 
     expect(await screen.findByRole('tooltip')).toHaveTextContent(
       'Details for option two'

--- a/static/app/components/core/form/field/baseField.spec.tsx
+++ b/static/app/components/core/form/field/baseField.spec.tsx
@@ -215,9 +215,7 @@ describe('BaseField indicator', () => {
     await userEvent.click(input);
     await userEvent.tab(); // blur to trigger validation
 
-    await waitFor(() => {
-      expect(screen.getByRole('img')).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('img')).toBeInTheDocument();
   });
 
   it('shows error message in tooltip when field has validation errors', async () => {
@@ -231,9 +229,7 @@ describe('BaseField indicator', () => {
     await userEvent.click(input);
     await userEvent.tab(); // blur to trigger validation
 
-    await waitFor(() => {
-      expect(screen.getByText('Must be at least 3 characters')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Must be at least 3 characters')).toBeInTheDocument();
   });
 });
 

--- a/static/app/components/core/form/field/radioField.spec.tsx
+++ b/static/app/components/core/form/field/radioField.spec.tsx
@@ -153,9 +153,7 @@ describe('RadioField disabled', () => {
     // Hover on the lock icon to trigger tooltip
     await userEvent.hover(lockIcon);
 
-    await waitFor(() => {
-      expect(screen.getByText('Feature not available')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Feature not available')).toBeInTheDocument();
   });
 });
 

--- a/static/app/components/core/form/field/rangeField.spec.tsx
+++ b/static/app/components/core/form/field/rangeField.spec.tsx
@@ -125,9 +125,7 @@ describe('RangeField disabled', () => {
     // Hover on the lock icon to trigger tooltip
     await userEvent.hover(lockIcon);
 
-    await waitFor(() => {
-      expect(screen.getByText('Feature not available')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Feature not available')).toBeInTheDocument();
   });
 });
 

--- a/static/app/components/core/form/field/selectField.spec.tsx
+++ b/static/app/components/core/form/field/selectField.spec.tsx
@@ -423,9 +423,7 @@ describe('SelectField disabled', () => {
     // Hover on the lock icon to trigger tooltip
     await userEvent.hover(lockIcon);
 
-    await waitFor(() => {
-      expect(screen.getByText('Feature not available')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Feature not available')).toBeInTheDocument();
   });
 });
 
@@ -462,9 +460,7 @@ describe('SelectField auto-save', () => {
     await userEvent.click(screen.getByRole('textbox'));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Banana'}));
 
-    await waitFor(() => {
-      expect(screen.getByRole('textbox')).toBeDisabled();
-    });
+    expect(await screen.findByRole('textbox')).toBeDisabled();
   });
 
   it('does not trigger mutation when selecting the same value', async () => {
@@ -734,9 +730,7 @@ describe('SelectField multiple', () => {
     // Hover on the lock icon to trigger tooltip
     await userEvent.hover(lockIcon);
 
-    await waitFor(() => {
-      expect(screen.getByText('Feature not available')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Feature not available')).toBeInTheDocument();
   });
 });
 
@@ -892,8 +886,6 @@ describe('SelectField multiple auto-save', () => {
     const removeButtons = screen.getAllByLabelText('Remove item');
     await userEvent.click(removeButtons[0]!);
 
-    await waitFor(() => {
-      expect(screen.getByRole('textbox')).toBeDisabled();
-    });
+    expect(await screen.findByRole('textbox')).toBeDisabled();
   });
 });

--- a/static/app/components/core/form/field/switchField.spec.tsx
+++ b/static/app/components/core/form/field/switchField.spec.tsx
@@ -137,9 +137,7 @@ describe('SwitchField disabled', () => {
     // Hover on the lock icon to trigger tooltip
     await userEvent.hover(lockIcon);
 
-    await waitFor(() => {
-      expect(screen.getByText('Feature not available')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Feature not available')).toBeInTheDocument();
   });
 });
 

--- a/static/app/components/core/form/field/textAreaField.spec.tsx
+++ b/static/app/components/core/form/field/textAreaField.spec.tsx
@@ -123,9 +123,7 @@ describe('TextAreaField disabled', () => {
     // Hover on the lock icon to trigger tooltip
     await userEvent.hover(lockIcon);
 
-    await waitFor(() => {
-      expect(screen.getByText('Feature not available')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Feature not available')).toBeInTheDocument();
   });
 });
 
@@ -154,9 +152,7 @@ describe('TextAreaField auto-save', () => {
     // AutoSaveForm triggers mutation on blur for string fields
     await userEvent.tab();
 
-    await waitFor(() => {
-      expect(screen.getByTestId('icon-check-mark')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('icon-check-mark')).toBeInTheDocument();
     expect(mutationFn).toHaveBeenCalledWith({bio: 'test'});
   });
 

--- a/static/app/components/dataExport.spec.tsx
+++ b/static/app/components/dataExport.spec.tsx
@@ -95,9 +95,7 @@ describe('DataExport', () => {
       }
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('button')).toBeDisabled();
-    });
+    expect(await screen.findByRole('button')).toBeDisabled();
   });
 
   it('should reset the state when receiving a new payload', async () => {
@@ -112,17 +110,13 @@ describe('DataExport', () => {
     });
 
     await userEvent.click(screen.getByText(/Export All to CSV/));
-    await waitFor(() => {
-      expect(screen.getByRole('button')).toBeDisabled();
-    });
+    expect(await screen.findByRole('button')).toBeDisabled();
 
     rerender(
       <DataExport payload={{...mockPayload, queryType: ExportQueryType.DISCOVER}} />
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('button')).toBeEnabled();
-    });
+    expect(await screen.findByRole('button')).toBeEnabled();
   });
 
   it('should display default error message if non provided', async () => {
@@ -144,9 +138,7 @@ describe('DataExport', () => {
       );
     });
 
-    await waitFor(() => {
-      expect(screen.getByRole('button')).toBeEnabled();
-    });
+    expect(await screen.findByRole('button')).toBeEnabled();
   });
 
   it('should display provided error message', async () => {

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -48,9 +48,7 @@ describe('AutofixInsightCards', () => {
     const contextButton = screen.getByText('Sample insight 1');
 
     await userEvent.click(contextButton);
-    await waitFor(() => {
-      expect(screen.getByText('Sample justification 1')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Sample justification 1')).toBeInTheDocument();
 
     await userEvent.click(contextButton);
     await waitFor(() => {

--- a/static/app/components/events/autofix/autofixOutputStream.spec.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.spec.tsx
@@ -31,9 +31,7 @@ describe('AutofixOutputStream', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Hello World')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Hello World')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Add context...')).toBeInTheDocument();
   });
 
@@ -48,9 +46,7 @@ describe('AutofixOutputStream', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Active log message')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Active log message')).toBeInTheDocument();
   });
 
   it('shows required input placeholder when responseRequired is true', () => {
@@ -75,18 +71,14 @@ describe('AutofixOutputStream', () => {
       <AutofixOutputStream stream="Initial" groupId="123" runId="456" />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Initial')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Initial')).toBeInTheDocument();
 
     rerender(
       <AutofixOutputStream stream="Initial content updated" groupId="123" runId="456" />
     );
 
     // Wait for animation to complete
-    await waitFor(() => {
-      expect(screen.getByText('Initial content updated')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Initial content updated')).toBeInTheDocument();
   });
 
   it('handles user interruption', async () => {

--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -95,11 +95,9 @@ describe('HighlightsDataSection', () => {
         const highlightTagDropdown = within(row).getByLabelText('Tag Actions Menu');
         expect(highlightTagDropdown).toBeInTheDocument();
         await userEvent.click(highlightTagDropdown);
-        await waitFor(() => {
-          expect(
-            screen.getByLabelText('Search issues with this tag value')
-          ).toBeInTheDocument();
-        });
+        expect(
+          await screen.findByLabelText('Search issues with this tag value')
+        ).toBeInTheDocument();
         expect(
           screen.queryByLabelText('Add to event highlights')
         ).not.toBeInTheDocument();

--- a/static/app/components/events/metrics/metricsSection.spec.tsx
+++ b/static/app/components/events/metrics/metricsSection.spec.tsx
@@ -186,9 +186,7 @@ describe('MetricsSection', () => {
 
     expect(mockRequest).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => {
-      expect(screen.getByText(/Metrics/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/Metrics/)).toBeInTheDocument();
 
     expect(screen.getByTestId('metrics')).toBeInTheDocument();
   });
@@ -224,9 +222,7 @@ describe('MetricsSection', () => {
 
     expect(mockRequestWithManyMetrics).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => {
-      expect(screen.getByText(/Metrics/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/Metrics/)).toBeInTheDocument();
 
     expect(screen.getByRole('button', {name: 'View more'})).toBeInTheDocument();
   });
@@ -270,9 +266,7 @@ describe('MetricsSection', () => {
 
     expect(mockRequestWithManyMetrics).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => {
-      expect(screen.getByText(/Metrics/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/Metrics/)).toBeInTheDocument();
 
     expect(
       screen.queryByRole('complementary', {name: 'metrics drawer'})
@@ -321,9 +315,7 @@ describe('MetricsSection', () => {
 
     expect(mockRequestWithFewMetrics).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => {
-      expect(screen.getByText(/Metrics/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/Metrics/)).toBeInTheDocument();
 
     expect(screen.queryByRole('button', {name: 'View more'})).not.toBeInTheDocument();
   });

--- a/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
@@ -224,9 +224,7 @@ describe('OurlogsSection', () => {
     });
     expect(mockRequest).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => {
-      expect(screen.getByText(/i am a log/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/i am a log/)).toBeInTheDocument();
 
     expect(
       screen.queryByRole('complementary', {name: 'logs drawer'})
@@ -241,9 +239,7 @@ describe('OurlogsSection', () => {
       expect(mockRowDetailsRequest).toHaveBeenCalledTimes(1);
     });
 
-    await waitFor(() => {
-      expect(within(aside).getByText(/special value/)).toBeInTheDocument();
-    });
+    expect(await within(aside).findByText(/special value/)).toBeInTheDocument();
 
     expect(within(aside).getByTestId('tree-key-severity')).toBeInTheDocument();
     expect(within(aside).getByTestId('tree-key-severity')).toHaveTextContent('severity');
@@ -264,9 +260,7 @@ describe('OurlogsSection', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(screen.getByText(/i am a log/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/i am a log/)).toBeInTheDocument();
 
     await userEvent.click(screen.getByText(/i am a log/));
 

--- a/static/app/components/forms/fields/booleanField.spec.tsx
+++ b/static/app/components/forms/fields/booleanField.spec.tsx
@@ -60,9 +60,7 @@ describe('BooleanField', () => {
     expect(checkbox).toBeDisabled();
 
     await userEvent.hover(checkbox);
-    await waitFor(() => {
-      expect(screen.getByText('Not allowed')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Not allowed')).toBeInTheDocument();
   });
 
   describe('with confirm prop', () => {

--- a/static/app/components/forms/fields/choiceMapperField.spec.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.spec.tsx
@@ -181,9 +181,7 @@ describe('ChoiceMapperField', () => {
       const searchInput = screen.getByRole('textbox');
       await userEvent.type(searchInput, 'repo');
 
-      await waitFor(() => {
-        expect(screen.getByText('my-org/my-repo')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('my-org/my-repo')).toBeInTheDocument();
 
       await userEvent.click(screen.getByText('my-org/my-repo'));
 
@@ -230,9 +228,7 @@ describe('ChoiceMapperField', () => {
       const searchInput = screen.getByRole('textbox');
       await userEvent.type(searchInput, 'nonexistent');
 
-      await waitFor(() => {
-        expect(screen.getByText('No repos found')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('No repos found')).toBeInTheDocument();
     });
 
     it('filters out already added items from async results', async () => {
@@ -262,9 +258,7 @@ describe('ChoiceMapperField', () => {
       const searchInput = screen.getByPlaceholderText('Search…');
       await userEvent.type(searchInput, 'repo');
 
-      await waitFor(() => {
-        expect(screen.getByText('other-org/other-repo')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('other-org/other-repo')).toBeInTheDocument();
 
       const menuItems = screen.getAllByText('my-org/my-repo');
 
@@ -288,12 +282,9 @@ describe('ChoiceMapperField', () => {
       await userEvent.type(searchInput, 'test', {delay: 10});
 
       // Wait for the debounced request and result to appear
-      await waitFor(
-        () => {
-          expect(screen.getByText('Test Item')).toBeInTheDocument();
-        },
-        {timeout: 1000}
-      );
+      expect(
+        await screen.findByText('Test Item', undefined, {timeout: 1000})
+      ).toBeInTheDocument();
 
       expect(mockRequest).toHaveBeenCalled();
     });

--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -72,9 +72,7 @@ describe('GroupSummary', () => {
       organization,
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('What Happened')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('What Happened')).toBeInTheDocument();
     expect(await screen.findByText('Test whats wrong')).toBeInTheDocument();
     expect(screen.getByText('In the Trace')).toBeInTheDocument();
     expect(screen.getByText('Test trace')).toBeInTheDocument();
@@ -93,9 +91,7 @@ describe('GroupSummary', () => {
       organization,
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('What Happened')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('What Happened')).toBeInTheDocument();
     expect(await screen.findByText('Test whats wrong')).toBeInTheDocument();
     expect(screen.getByText('In the Trace')).toBeInTheDocument();
     expect(screen.getByText('Test trace')).toBeInTheDocument();
@@ -130,9 +126,7 @@ describe('GroupSummary', () => {
       organization,
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('Error loading summary')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Error loading summary')).toBeInTheDocument();
   });
 
   it('hides cards with no content', async () => {
@@ -149,9 +143,7 @@ describe('GroupSummary', () => {
       organization,
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('What Happened')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('What Happened')).toBeInTheDocument();
     expect(await screen.findByText('Test whats wrong')).toBeInTheDocument();
     expect(screen.queryByText('In the Trace')).not.toBeInTheDocument();
     expect(screen.getByText('Initial Guess')).toBeInTheDocument();
@@ -170,9 +162,7 @@ describe('GroupSummary', () => {
       {organization}
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Initial Guess')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Initial Guess')).toBeInTheDocument();
     expect(await screen.findByText('Test possible cause')).toBeInTheDocument();
     expect(screen.queryByText('What Happened')).not.toBeInTheDocument();
     expect(screen.queryByText('Test whats wrong')).not.toBeInTheDocument();

--- a/static/app/components/lazyLoad.spec.tsx
+++ b/static/app/components/lazyLoad.spec.tsx
@@ -32,9 +32,7 @@ describe('LazyLoad', () => {
     const getComponent = () => importTest;
     render(<LazyLoad LazyComponent={lazy(getComponent)} />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
   });
 
   it('renders when given a promise of a "foo" component', async () => {
@@ -46,9 +44,7 @@ describe('LazyLoad', () => {
     render(<LazyLoad LazyComponent={lazy(() => importFoo)} />);
 
     // Should be loading
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
 
     // resolve with foo
     doResolve!({default: FooComponent});
@@ -79,9 +75,7 @@ describe('LazyLoad', () => {
 
     // First render Foo
     const {rerender} = render(<LazyLoad LazyComponent={lazy(() => importFoo)} />);
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
 
     // resolve with foo
     doResolve!({default: FooComponent});

--- a/static/app/components/modals/inviteMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.tsx
@@ -103,9 +103,7 @@ describe('InviteMembersModal', () => {
 
   it('renders', async () => {
     setupView();
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Send invite'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('button', {name: 'Send invite'})).toBeInTheDocument();
 
     // We have two roles loaded from the members/me endpoint, defaulting to the
     // 'member' role.
@@ -259,9 +257,7 @@ describe('InviteMembersModal', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(screen.getByText(initialEmail)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(initialEmail)).toBeInTheDocument();
 
     // Just immediately click send
     await userEvent.click(screen.getByRole('button', {name: 'Send invite'}));
@@ -294,9 +290,7 @@ describe('InviteMembersModal', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(screen.getByText(initialEmail)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(initialEmail)).toBeInTheDocument();
     // Just immediately click send
     await userEvent.click(screen.getByRole('button', {name: 'Send invite'}));
 
@@ -350,9 +344,7 @@ describe('InviteMembersModal', () => {
         },
       });
 
-      await waitFor(() => {
-        expect(screen.getByText(initialEmail)).toBeInTheDocument();
-      });
+      expect(await screen.findByText(initialEmail)).toBeInTheDocument();
       await userEvent.click(screen.getByRole('button', {name: 'Send invite request'}));
       const apiMock = mocks[1];
       expect(apiMock).toHaveBeenCalledTimes(1);

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -150,9 +150,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
     expect(screen.getByText('Test title')).toBeInTheDocument();
     expect(screen.getByText('Select Dashboard')).toBeInTheDocument();
@@ -180,9 +178,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
     expect(screen.getByRole('button', {name: 'Add + Stay on this Page'})).toBeDisabled();
     expect(screen.getByRole('button', {name: 'Open in Widget Builder'})).toBeDisabled();
@@ -208,9 +204,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
     await selectEvent.openMenu(screen.getByText('Select Dashboard'));
     expect(screen.getByText('+ Create New Dashboard')).toBeInTheDocument();
@@ -232,9 +226,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -284,9 +276,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -319,9 +309,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
     await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
 
     await userEvent.click(screen.getByText('Open in Widget Builder'));
@@ -360,9 +348,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
     await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
 
     await userEvent.click(screen.getByText('Open in Widget Builder'));
@@ -410,9 +396,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
     await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
 
     await userEvent.click(screen.getByText('Add + Stay on this Page'));
@@ -472,9 +456,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
     await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
 
     await userEvent.click(screen.getByText('Add + Stay on this Page'));
@@ -552,9 +534,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
     await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
 
     await userEvent.click(screen.getByText('Add + Stay on this Page'));
@@ -609,9 +589,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
     await selectEvent.select(
       screen.getByText('Select Dashboard'),
       '+ Create New Dashboard'
@@ -644,9 +622,7 @@ describe('add to dashboard modal', () => {
       }
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
     await userEvent.click(screen.getByText('Select Dashboard'));
     expect(screen.getByText('Other Dashboard')).toBeInTheDocument();
@@ -681,9 +657,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
     // Open the dropdown to see the options
     await selectEvent.openMenu(screen.getByText('Select Dashboard'));
@@ -737,9 +711,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
     await selectEvent.openMenu(screen.getByText('Select Dashboard'));
     expect(screen.queryByText('Prebuilt Dashboard')).not.toBeInTheDocument();
     expect(screen.getByText('Test Dashboard')).toBeInTheDocument();
@@ -773,9 +745,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
     await selectEvent.select(
       screen.getByText('Select Dashboard'),
       '+ Create New Dashboard'
@@ -831,9 +801,7 @@ describe('add to dashboard modal', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Dashboard')).toBeEnabled();
-    });
+    expect(await screen.findByText('Select Dashboard')).toBeEnabled();
     await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
 
     await userEvent.click(screen.getByText('Open in Widget Builder'));
@@ -887,9 +855,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
       expect(eventsStatsMock).not.toHaveBeenCalled();
     });
@@ -919,9 +885,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
       await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
       await userEvent.click(screen.getByText('Add + Stay on this Page'));
 
@@ -962,9 +926,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
       await selectEvent.select(
         screen.getByText('Select Dashboard'),
         '+ Create New Dashboard'
@@ -1003,9 +965,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
       await selectEvent.select(
         screen.getByText('Select Dashboard'),
         '+ Create New Dashboard'
@@ -1083,9 +1043,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
       // Widget name input should not be present
       expect(screen.queryByLabelText('Optional Widget Name')).not.toBeInTheDocument();
@@ -1106,9 +1064,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
       // Widget preview message should not be present
       expect(
@@ -1133,9 +1089,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
       // Should show message about adding multiple widgets with full text
       expect(
@@ -1161,9 +1115,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
 
       // Should show "Add + Open Dashboard" button
       expect(
@@ -1201,9 +1153,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
       await selectEvent.select(screen.getByText('Select Dashboard'), 'Test Dashboard');
 
       await userEvent.click(screen.getByText('Add + Open Dashboard'));
@@ -1253,9 +1203,7 @@ describe('add to dashboard modal', () => {
         />
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Select Dashboard')).toBeEnabled();
-      });
+      expect(await screen.findByText('Select Dashboard')).toBeEnabled();
       await selectEvent.select(
         screen.getByText('Select Dashboard'),
         '+ Create New Dashboard'

--- a/static/app/components/notificationActions/notificationActionManager.spec.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.spec.tsx
@@ -156,9 +156,7 @@ describe('Adds, deletes, and updates notification actions', () => {
         }),
       })
     );
-    await waitFor(() => {
-      expect(screen.getByTestId('sentry_notification-action')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('sentry_notification-action')).toBeInTheDocument();
   });
 
   it('Removes a Sentry notification action', async () => {
@@ -230,9 +228,7 @@ describe('Adds, deletes, and updates notification actions', () => {
         }),
       })
     );
-    await waitFor(() => {
-      expect(screen.getByTestId('slack-action')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('slack-action')).toBeInTheDocument();
   });
 
   it('Removes a Slack action', async () => {
@@ -366,9 +362,7 @@ describe('Adds, deletes, and updates notification actions', () => {
         }),
       })
     );
-    await waitFor(() => {
-      expect(screen.getByTestId('pagerduty-action')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('pagerduty-action')).toBeInTheDocument();
   });
 
   it('Edits a Pagerduty action', async () => {
@@ -471,9 +465,7 @@ describe('Adds, deletes, and updates notification actions', () => {
         }),
       })
     );
-    await waitFor(() => {
-      expect(screen.getByTestId('opsgenie-action')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('opsgenie-action')).toBeInTheDocument();
   });
 
   it('Edits an Opsgenie Action', async () => {

--- a/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
@@ -82,9 +82,7 @@ describe('ProjectPageFilter', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
 
     // Trigger button & router are updated
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'project-3'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('button', {name: 'project-3'})).toBeInTheDocument();
     expect(router.location.query).toEqual({project: '3'});
   });
 
@@ -103,9 +101,7 @@ describe('ProjectPageFilter', () => {
 
     // Open the menu, search input has focus
     await userEvent.click(screen.getByRole('button', {name: 'My Projects'}));
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Search…')).toHaveFocus();
-    });
+    expect(await screen.findByPlaceholderText('Search…')).toHaveFocus();
 
     // Move focus past the two special items ("All Projects", "My Projects") to project-1
     await userEvent.keyboard('{ArrowDown}');

--- a/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
@@ -469,21 +469,17 @@ describe('useStagedCompactSelect', () => {
 
     // Open the menu, focus is on search input
     await userEvent.click(screen.getByRole('button', {expanded: false}));
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Search…')).toHaveFocus();
-    });
+    expect(await screen.findByPlaceholderText('Search…')).toHaveFocus();
 
     // Press Arrow Down to move focus to Option One
     await userEvent.keyboard('{ArrowDown}');
-    await waitFor(() => {
-      expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus();
-    });
+    expect(await screen.findByRole('row', {name: 'Option One'})).toHaveFocus();
 
     // Press Arrow Right to move focus to the checkbox
     await userEvent.keyboard('{ArrowRight}');
-    await waitFor(() => {
-      expect(screen.getByRole('checkbox', {name: 'Select Option One'})).toHaveFocus();
-    });
+    expect(
+      await screen.findByRole('checkbox', {name: 'Select Option One'})
+    ).toHaveFocus();
 
     // Activate the checkbox by clicking it
     await userEvent.click(screen.getByRole('checkbox', {name: 'Select Option One'}));

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1505,21 +1505,16 @@ describe('SearchQueryBuilder', () => {
 
       // Shift+ArrowLeft should select assigned:me
       await userEvent.keyboard('{Shift>}{ArrowLeft}{/Shift}');
-      await waitFor(() => {
-        expect(screen.getByRole('row', {name: 'assigned:me'})).toHaveAttribute(
-          'aria-selected',
-          'true'
-        );
-      });
+      expect(await screen.findByRole('row', {name: 'assigned:me'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
 
       // Shift+ArrowLeft again should select browser.name
       await userEvent.keyboard('{Shift>}{ArrowLeft}{/Shift}');
-      await waitFor(() => {
-        expect(screen.getByRole('row', {name: 'browser.name:firefox'})).toHaveAttribute(
-          'aria-selected',
-          'true'
-        );
-      });
+      expect(
+        await screen.findByRole('row', {name: 'browser.name:firefox'})
+      ).toHaveAttribute('aria-selected', 'true');
       // assigned:me should still be selected
       expect(screen.getByRole('row', {name: 'assigned:me'})).toHaveAttribute(
         'aria-selected',
@@ -1528,11 +1523,9 @@ describe('SearchQueryBuilder', () => {
 
       // Shift+ArrowRight should unselect browser.name:firefox
       await userEvent.keyboard('{Shift>}{ArrowRight}{/Shift}');
-      await waitFor(() => {
-        expect(
-          screen.getByRole('row', {name: 'browser.name:firefox'})
-        ).not.toHaveAttribute('aria-selected', 'true');
-      });
+      expect(
+        await screen.findByRole('row', {name: 'browser.name:firefox'})
+      ).not.toHaveAttribute('aria-selected', 'true');
       // assigned:me should still be selected
       expect(screen.getByRole('row', {name: 'assigned:me'})).toHaveAttribute(
         'aria-selected',
@@ -1847,12 +1840,10 @@ describe('SearchQueryBuilder', () => {
 
       await userEvent.click(getLastInput());
       await userEvent.keyboard('{Shift>}{ArrowLeft}{/Shift}');
-      await waitFor(() => {
-        expect(screen.getByRole('row', {name: 'is:unresolved'})).toHaveAttribute(
-          'aria-selected',
-          'true'
-        );
-      });
+      expect(await screen.findByRole('row', {name: 'is:unresolved'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
       await userEvent.keyboard('(');
 
       expect(mockOnChange).toHaveBeenCalledWith('( is:unresolved )', expect.anything());
@@ -1880,12 +1871,9 @@ describe('SearchQueryBuilder', () => {
       await userEvent.click(getLastInput());
       // Select only the browser.name token (shift+left)
       await userEvent.keyboard('{Shift>}{ArrowLeft}{/Shift}');
-      await waitFor(() => {
-        expect(screen.getByRole('row', {name: 'browser.name:chrome'})).toHaveAttribute(
-          'aria-selected',
-          'true'
-        );
-      });
+      expect(
+        await screen.findByRole('row', {name: 'browser.name:chrome'})
+      ).toHaveAttribute('aria-selected', 'true');
       await userEvent.keyboard('(');
 
       // Should wrap only the selected token, preserving existing parens
@@ -2406,11 +2394,9 @@ describe('SearchQueryBuilder', () => {
           screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
         );
         // Should start with previous values and an appended ',' for the next value
-        await waitFor(() => {
-          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
-            'firefox,'
-          );
-        });
+        expect(
+          await screen.findByRole('combobox', {name: 'Edit filter value'})
+        ).toHaveValue('firefox,');
 
         // Clicking the "Chrome option should add it to the list and commit changes
         await userEvent.click(screen.getByRole('option', {name: 'Chrome'}));
@@ -2446,11 +2432,9 @@ describe('SearchQueryBuilder', () => {
         await userEvent.clear(combobox);
         await userEvent.click(screen.getByRole('option', {name: 'custom_tag_name'}));
 
-        await waitFor(() => {
-          expect(
-            screen.getByRole('row', {name: 'custom_tag_name:firefox'})
-          ).toBeInTheDocument();
-        });
+        expect(
+          await screen.findByRole('row', {name: 'custom_tag_name:firefox'})
+        ).toBeInTheDocument();
         expect(getLastInput()).toHaveFocus();
 
         await waitFor(() => {
@@ -2483,9 +2467,7 @@ describe('SearchQueryBuilder', () => {
         await userEvent.clear(combobox);
         await userEvent.click(screen.getByRole('option', {name: 'age'}));
 
-        await waitFor(() => {
-          expect(screen.getByRole('row', {name: 'age:-24h'})).toBeInTheDocument();
-        });
+        expect(await screen.findByRole('row', {name: 'age:-24h'})).toBeInTheDocument();
         // Filter value should have focus
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
 
@@ -2507,11 +2489,9 @@ describe('SearchQueryBuilder', () => {
           screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
         );
         // Input value should start with previous value and appended ','
-        await waitFor(() => {
-          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
-            'firefox,'
-          );
-        });
+        expect(
+          await screen.findByRole('combobox', {name: 'Edit filter value'})
+        ).toHaveValue('firefox,');
 
         // Toggling off the "firefox" option should:
         // - Commit an empty string as the filter value
@@ -2524,11 +2504,9 @@ describe('SearchQueryBuilder', () => {
         expect(
           await screen.findByRole('row', {name: 'browser.name:""'})
         ).toBeInTheDocument();
-        await waitFor(() => {
-          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
-            ''
-          );
-        });
+        expect(
+          await screen.findByRole('combobox', {name: 'Edit filter value'})
+        ).toHaveValue('');
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
         expect(mockOnChange).not.toHaveBeenCalled();
 
@@ -2543,11 +2521,9 @@ describe('SearchQueryBuilder', () => {
         expect(
           await screen.findByRole('row', {name: 'browser.name:Chrome'})
         ).toBeInTheDocument();
-        await waitFor(() => {
-          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
-            'Chrome,'
-          );
-        });
+        expect(
+          await screen.findByRole('combobox', {name: 'Edit filter value'})
+        ).toHaveValue('Chrome,');
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
         expect(mockOnChange).not.toHaveBeenCalled();
 
@@ -2582,11 +2558,9 @@ describe('SearchQueryBuilder', () => {
         expect(
           await screen.findByRole('row', {name: 'browser.name:[firefox,Chrome]'})
         ).toBeInTheDocument();
-        await waitFor(() => {
-          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
-            'firefox,Chrome,'
-          );
-        });
+        expect(
+          await screen.findByRole('combobox', {name: 'Edit filter value'})
+        ).toHaveValue('firefox,Chrome,');
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
 
         // onChange should not be called until exiting edit mode
@@ -2623,11 +2597,9 @@ describe('SearchQueryBuilder', () => {
         expect(
           await screen.findByRole('row', {name: 'browser.name:[firefox,Chrome]'})
         ).toBeInTheDocument();
-        await waitFor(() => {
-          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
-            'firefox,Chrome,'
-          );
-        });
+        expect(
+          await screen.findByRole('combobox', {name: 'Edit filter value'})
+        ).toHaveValue('firefox,Chrome,');
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
 
         // onChange should not be called until exiting edit mode
@@ -2942,11 +2914,9 @@ describe('SearchQueryBuilder', () => {
         await userEvent.click(
           screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
         );
-        await waitFor(() => {
-          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
-            '1,c,3,'
-          );
-        });
+        expect(
+          await screen.findByRole('combobox', {name: 'Edit filter value'})
+        ).toHaveValue('1,c,3,');
 
         // Arrow left three times to put cursor inside "c" value
         await userEvent.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}');
@@ -4189,11 +4159,9 @@ describe('SearchQueryBuilder', () => {
 
         // After moving to next parameter, should now highlight 'operator'
         await userEvent.keyboard('a,');
-        await waitFor(() => {
-          expect(
-            within(descriptionTooltip).getByTestId('focused-param')
-          ).toHaveTextContent('operator: string');
-        });
+        expect(
+          await within(descriptionTooltip).findByTestId('focused-param')
+        ).toHaveTextContent('operator: string');
       });
 
       it('focuses on the filter value when user selects an aggregate filter with no arguments', async () => {
@@ -5905,9 +5873,9 @@ describe('SearchQueryBuilder', () => {
       await userEvent.keyboard('brow');
 
       // browser.name should appear only once despite being in both static and async keys
-      await waitFor(() => {
-        expect(screen.getAllByRole('option', {name: 'browser.name'})).toHaveLength(1);
-      });
+      expect(await screen.findAllByRole('option', {name: 'browser.name'})).toHaveLength(
+        1
+      );
     });
 
     it('can select an async-only key to create a filter token', async () => {

--- a/static/app/components/timeSince.spec.tsx
+++ b/static/app/components/timeSince.spec.tsx
@@ -67,8 +67,6 @@ describe('TimeSince', () => {
     );
     const timeElement = screen.getByRole('time');
     await userEvent.hover(timeElement);
-    await waitFor(() => {
-      expect(screen.getByText(/EST/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/EST/)).toBeInTheDocument();
   });
 });

--- a/static/app/makeLazyloadComponent.spec.tsx
+++ b/static/app/makeLazyloadComponent.spec.tsx
@@ -42,9 +42,7 @@ describe('makeLazyloadComponent', () => {
 
       render(<LazyComponent title="Test Title" />);
 
-      await waitFor(() => {
-        expect(screen.getByTestId('mock-component')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('mock-component')).toBeInTheDocument();
 
       expect(screen.getByText('Test Title')).toBeInTheDocument();
     });
@@ -54,9 +52,7 @@ describe('makeLazyloadComponent', () => {
 
       render(<LazyComponent title="Test Title" count={42} />);
 
-      await waitFor(() => {
-        expect(screen.getByTestId('mock-component')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('mock-component')).toBeInTheDocument();
 
       expect(screen.getByText('Test Title')).toBeInTheDocument();
       expect(screen.getByText('Count: 42')).toBeInTheDocument();
@@ -74,9 +70,7 @@ describe('makeLazyloadComponent', () => {
       expect(screen.getByTestId('loading')).toBeInTheDocument();
 
       // Wait for component to load
-      await waitFor(() => {
-        expect(screen.getByTestId('mock-component')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('mock-component')).toBeInTheDocument();
 
       // Loading fallback should be gone
       expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
@@ -90,11 +84,9 @@ describe('makeLazyloadComponent', () => {
       // Should not throw when rendering
       render(<LazyComponent title="Test Title" />);
 
-      await waitFor(() => {
-        expect(
-          screen.getByText('There was an error loading a component.')
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByText('There was an error loading a component.')
+      ).toBeInTheDocument();
       expect(consoleSpy).toHaveBeenCalledWith(new Error('Load failed'));
     });
   });
@@ -158,9 +150,7 @@ describe('makeLazyloadComponent', () => {
       render(<LazyComponent title="Shared Promise Test" />);
 
       await act(() => preloadPromise);
-      await waitFor(() => {
-        expect(screen.getByTestId('mock-component')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('mock-component')).toBeInTheDocument();
 
       expect(callCount).toBe(1);
     });
@@ -187,9 +177,7 @@ describe('makeLazyloadComponent', () => {
       shouldError = false;
       render(<LazyComponent title="Error Recovery Test" />);
 
-      await waitFor(() => {
-        expect(screen.getByTestId('mock-component')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('mock-component')).toBeInTheDocument();
     });
 
     it('multiple preload calls return the same promise', async () => {
@@ -301,9 +289,7 @@ describe('makeLazyloadComponent', () => {
 
       // Component should render immediately since it was preloaded
       // (though we still need to wait for React to process the render)
-      await waitFor(() => {
-        expect(screen.getByTestId('mock-component')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('mock-component')).toBeInTheDocument();
 
       expect(screen.getByText('Test Component')).toBeInTheDocument();
 
@@ -385,12 +371,8 @@ describe('makeLazyloadComponent', () => {
       );
 
       // Components should render successfully
-      await waitFor(() => {
-        expect(screen.getByTestId('component-1')).toBeInTheDocument();
-      });
-      await waitFor(() => {
-        expect(screen.getByTestId('component-2')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('component-1')).toBeInTheDocument();
+      expect(await screen.findByTestId('component-2')).toBeInTheDocument();
 
       // Preload functions should still only have been called once each
       expect(spy1).toHaveBeenCalledTimes(1);
@@ -425,9 +407,7 @@ describe('makeLazyloadComponent', () => {
       await userEvent.hover(screen.getByTestId('no-preload-link'));
 
       // Component should still load normally when rendered
-      await waitFor(() => {
-        expect(screen.getByTestId('mock-component')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('mock-component')).toBeInTheDocument();
     });
 
     it('handles preload errors', async () => {

--- a/static/app/utils/discover/teamKeyTransactionField.spec.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.spec.tsx
@@ -49,9 +49,9 @@ describe('TeamKeyTransactionField', () => {
       </TeamKeyTransactionManager.Provider>
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     expect(getTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
 
@@ -91,9 +91,9 @@ describe('TeamKeyTransactionField', () => {
       </TeamKeyTransactionManager.Provider>
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     expect(getTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
 
@@ -130,9 +130,9 @@ describe('TeamKeyTransactionField', () => {
       </TeamKeyTransactionManager.Provider>
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     expect(getTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
 
@@ -179,9 +179,9 @@ describe('TeamKeyTransactionField', () => {
       </TeamKeyTransactionManager.Provider>
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     await userEvent.click(screen.getByRole('button', {name: 'Toggle star for team'}));
 
@@ -190,9 +190,9 @@ describe('TeamKeyTransactionField', () => {
 
     await userEvent.click(teamOneOption);
     expect(postTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     expect(teamOneOption).toHaveAttribute('aria-selected', 'true');
   });
@@ -233,9 +233,9 @@ describe('TeamKeyTransactionField', () => {
       </TeamKeyTransactionManager.Provider>
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     await userEvent.click(screen.getByRole('button', {name: 'Toggle star for team'}));
 
@@ -244,9 +244,9 @@ describe('TeamKeyTransactionField', () => {
 
     await userEvent.click(teamOneOption);
     expect(deleteTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     expect(teamOneOption).toHaveAttribute('aria-selected', 'false');
   });
@@ -290,18 +290,18 @@ describe('TeamKeyTransactionField', () => {
       </TeamKeyTransactionManager.Provider>
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     await userEvent.click(screen.getByRole('button', {name: 'Toggle star for team'}));
 
     await userEvent.click(screen.getByRole('button', {name: 'Select All in My Teams'}));
 
     expect(postTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     const [teamOneOption, teamTwoOption] = screen.getAllByRole('option');
     expect(teamOneOption).toHaveAttribute('aria-selected', 'true');
@@ -347,18 +347,18 @@ describe('TeamKeyTransactionField', () => {
       </TeamKeyTransactionManager.Provider>
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     await userEvent.click(screen.getByRole('button', {name: 'Toggle star for team'}));
 
     await userEvent.click(screen.getByRole('button', {name: 'Unselect All in My Teams'}));
 
     expect(deleteTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Toggle star for team'})).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Toggle star for team'})
+    ).toBeEnabled();
 
     const [teamOneOption, teamTwoOption] = screen.getAllByRole('option');
     expect(teamOneOption).toHaveAttribute('aria-selected', 'false');

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -806,9 +806,7 @@ describe('Incident Rules Form', () => {
       expect(screen.getByLabelText('Static: above or below {x}')).not.toBeChecked();
       await userEvent.click(screen.getByText('Static: above or below {x}'));
 
-      await waitFor(() =>
-        expect(screen.getByLabelText('Static: above or below {x}')).toBeChecked()
-      );
+      expect(await screen.findByLabelText('Static: above or below {x}')).toBeChecked();
 
       await userEvent.click(screen.getByLabelText('Save Rule'));
 

--- a/static/app/views/alerts/rules/uptime/assertionSuggestionsDrawerContent.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertionSuggestionsDrawerContent.spec.tsx
@@ -112,9 +112,7 @@ describe('AssertionSuggestionsDrawerContent', () => {
       {organization}
     );
 
-    await waitFor(() => {
-      expect(screen.getByText(/Status code/)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/Status code/)).toBeInTheDocument();
 
     expect(screen.getByText(/\$\.status/)).toBeInTheDocument();
     expect(screen.getByText(/95% confidence/)).toBeInTheDocument();

--- a/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
@@ -116,9 +116,7 @@ describe('UptimeAssertionsField', () => {
     );
 
     // Wait for component to settle (react-popper causes async updates)
-    await waitFor(() => {
-      expect(screen.getAllByRole('textbox')).toHaveLength(2);
-    });
+    expect(await screen.findAllByRole('textbox')).toHaveLength(2);
 
     // UI should show default 2xx assertions
     const textboxes = screen.getAllByRole('textbox');
@@ -177,9 +175,7 @@ describe('UptimeAssertionsField', () => {
     );
 
     // Wait for component to settle (react-popper causes async updates)
-    await waitFor(() => {
-      expect(screen.getByRole('textbox')).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('textbox')).toBeInTheDocument();
 
     // Raw field value should still have NaN
     const rawValue = model.fields.get('assertion') as unknown as UptimeAssertion;
@@ -224,9 +220,7 @@ describe('UptimeAssertionsField', () => {
     );
 
     // Wait for component to settle (react-popper causes async updates)
-    await waitFor(() => {
-      expect(screen.getByRole('textbox')).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('textbox')).toBeInTheDocument();
 
     // getTransformedData should clamp to valid range
     const transformedData = model.getTransformedData();
@@ -263,9 +257,7 @@ describe('UptimeAssertionsField', () => {
       </Form>
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('textbox')).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('textbox')).toBeInTheDocument();
 
     const transformedData = model.getTransformedData();
     const transformedAssertion = transformedData.assertion as UptimeAssertion;
@@ -328,9 +320,7 @@ describe('UptimeAssertionsField', () => {
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Status Code'}));
 
     // Should now have 1 assertion input
-    await waitFor(() => {
-      expect(screen.getAllByRole('textbox')).toHaveLength(1);
-    });
+    expect(await screen.findAllByRole('textbox')).toHaveLength(1);
 
     // getValue should return the new assertion (not null)
     const transformedData = model.getTransformedData();
@@ -350,18 +340,14 @@ describe('UptimeAssertionsField', () => {
     );
 
     // Wait for default assertions to render (2 status code checks)
-    await waitFor(() => {
-      expect(screen.getAllByRole('textbox')).toHaveLength(2);
-    });
+    expect(await screen.findAllByRole('textbox')).toHaveLength(2);
 
     // Delete both default assertions by clicking their remove buttons
     const removeButtons = screen.getAllByRole('button', {name: 'Remove assertion'});
     expect(removeButtons).toHaveLength(2);
 
     await userEvent.click(removeButtons[0]!);
-    await waitFor(() => {
-      expect(screen.getAllByRole('textbox')).toHaveLength(1);
-    });
+    expect(await screen.findAllByRole('textbox')).toHaveLength(1);
 
     const remainingRemoveButton = screen.getByRole('button', {name: 'Remove assertion'});
     await userEvent.click(remainingRemoveButton);

--- a/static/app/views/automations/components/editConnectedMonitors.spec.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.spec.tsx
@@ -186,11 +186,9 @@ describe('EditConnectedMonitors', () => {
     );
 
     // Wait for the initial mode to be determined
-    await waitFor(() => {
-      expect(
-        screen.getByRole('radio', {name: 'Alert on all issues in selected projects'})
-      ).toBeChecked();
-    });
+    expect(
+      await screen.findByRole('radio', {name: 'Alert on all issues in selected projects'})
+    ).toBeChecked();
   });
 
   it('switches between modes correctly', async () => {

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -755,9 +755,7 @@ describe('Dashboards > Dashboard', () => {
       await userEvent.click(await screen.findByLabelText('Duplicate Widget'));
       rerender();
 
-      await waitFor(() => {
-        expect(screen.getAllByText('Test Discover Widget')).toHaveLength(2);
-      });
+      expect(await screen.findAllByText('Test Discover Widget')).toHaveLength(2);
     });
 
     it('triggers the edit widget callback', async () => {

--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -160,11 +160,9 @@ describe('FiltersBar', () => {
     });
 
     // Wait for any effects to settle
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', {name: /browser\.name.*Chrome/i})
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('button', {name: /browser\.name.*Chrome/i})
+    ).toBeInTheDocument();
 
     expect(onDashboardFilterChange).not.toHaveBeenCalled();
   });
@@ -192,9 +190,7 @@ describe('FiltersBar', () => {
     });
 
     // Wait for component to fully render
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'All Releases'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('button', {name: 'All Releases'})).toBeInTheDocument();
 
     // Should NOT call onDashboardFilterChange — user cleared filters intentionally
     expect(onDashboardFilterChange).not.toHaveBeenCalled();

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1525,9 +1525,7 @@ describe('Visualize', () => {
         })
       ).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Select an attribute')).toHaveFocus();
-      });
+      expect(await screen.findByLabelText('Select an attribute')).toHaveFocus();
       await userEvent.type(input, '{ArrowDown}{Enter}');
 
       expect(mockNavigate).toHaveBeenCalledWith(
@@ -1576,9 +1574,7 @@ describe('Visualize', () => {
         })
       ).toBeInTheDocument();
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Select an attribute')).toHaveFocus();
-      });
+      expect(await screen.findByLabelText('Select an attribute')).toHaveFocus();
       await userEvent.type(input, '{ArrowDown}{Enter}');
 
       expect(mockNavigate).toHaveBeenCalledWith(

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -643,9 +643,7 @@ describe('WidgetBuilderSlideout', () => {
     expect(screen.queryByLabelText('Add a search term')).not.toBeInTheDocument();
 
     // Wait for any pending popper updates to complete
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Issues'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('button', {name: 'Issues'})).toBeInTheDocument();
   });
 
   it('should show the markdown content field for text widgets', async () => {
@@ -781,8 +779,6 @@ describe('WidgetBuilderSlideout', () => {
     expect(screen.queryByText('Group by')).not.toBeInTheDocument();
 
     // Wait for any pending popper updates to complete
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Issues'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('button', {name: 'Issues'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/detectors/components/forms/automateSection.spec.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.spec.tsx
@@ -156,11 +156,9 @@ describe('AutomateSection', () => {
 
     // Clicking connect should add the automation to the connected list
     await userEvent.click(within(drawer).getByRole('button', {name: 'Connect'}));
-    await waitFor(() => {
-      expect(
-        within(connectedAutomationsList).getByText(automation1.name)
-      ).toBeInTheDocument();
-    });
+    expect(
+      await within(connectedAutomationsList).findByText(automation1.name)
+    ).toBeInTheDocument();
   });
 
   it('can disconnect an existing automation', async () => {

--- a/static/app/views/detectors/components/forms/cron/instrumentationGuide.spec.tsx
+++ b/static/app/views/detectors/components/forms/cron/instrumentationGuide.spec.tsx
@@ -161,9 +161,7 @@ describe('InstrumentationGuide', () => {
       expect(router.location.query.guide).toBe('upsert');
 
       // Should show PHP guide, not auto-select Python based on project
-      await waitFor(() => {
-        expect(screen.getByText('Auto-Instrument with PHP')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Auto-Instrument with PHP')).toBeInTheDocument();
     });
 
     it('auto-selects platform based on selected project', async () => {

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -138,31 +138,25 @@ describe('DetectorEdit', () => {
       await userEvent.click(screen.getByRole('button', {name: 'count'}));
       await userEvent.click(await screen.findByRole('option', {name: 'p75'}));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('editable-text-label')).toHaveTextContent(
-          'p75(span.duration) above 100ms over past 1 hour'
-        );
-      });
+      expect(await screen.findByTestId('editable-text-label')).toHaveTextContent(
+        'p75(span.duration) above 100ms over past 1 hour'
+      );
 
       // Change dataset from Spans to Errors
       await userEvent.click(screen.getByText('Spans'));
       await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Errors'}));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('editable-text-label')).toHaveTextContent(
-          'Number of errors above 100 over past 1 hour'
-        );
-      });
+      expect(await screen.findByTestId('editable-text-label')).toHaveTextContent(
+        'Number of errors above 100 over past 1 hour'
+      );
 
       // Change interval from 1 hour to 4 hours
       await userEvent.click(screen.getByText('1 hour'));
       await userEvent.click(screen.getByRole('menuitemradio', {name: '4 hours'}));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('editable-text-label')).toHaveTextContent(
-          'Number of errors above 100 over past 4 hours'
-        );
-      });
+      expect(await screen.findByTestId('editable-text-label')).toHaveTextContent(
+        'Number of errors above 100 over past 4 hours'
+      );
     });
 
     it('can submit a new metric detector', async () => {
@@ -260,9 +254,7 @@ describe('DetectorEdit', () => {
       );
 
       // Verify form fields are pre-filled with template values
-      await waitFor(() => {
-        expect(screen.getByText('Errors')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Errors')).toBeInTheDocument();
 
       // Set threshold and submit
       await userEvent.type(

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -250,9 +250,7 @@ describe('Discover > Homepage', () => {
       organization,
     });
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: /set as default/i})).toBeDisabled();
-    });
+    expect(await screen.findByRole('button', {name: /set as default/i})).toBeDisabled();
 
     expect(measurementsMetaMock).toHaveBeenCalled();
   });
@@ -307,9 +305,7 @@ describe('Discover > Homepage', () => {
       organization,
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('title')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('title')).toBeInTheDocument();
 
     // Simulate navigation to update the query
     const queryParams = new URLSearchParams({
@@ -341,9 +337,7 @@ describe('Discover > Homepage', () => {
       organization,
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('title')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('title')).toBeInTheDocument();
 
     expect(screen.queryByText('environment')).not.toBeInTheDocument();
 
@@ -417,7 +411,7 @@ describe('Discover > Homepage', () => {
       organization,
     });
 
-    await waitFor(() => expect(screen.getByTestId('set-as-default')).toBeEnabled());
+    expect(await screen.findByTestId('set-as-default')).toBeEnabled();
   });
 
   it('shows Set as Default when dataset differs from saved homepage', async () => {

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -108,9 +108,7 @@ describe('Discover > QueryList', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByTestId(/card-.*/)).toHaveLength(5);
-    });
+    expect(await screen.findAllByTestId(/card-.*/)).toHaveLength(5);
 
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -146,9 +144,7 @@ describe('Discover > QueryList', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByTestId(/card-.*/)).toHaveLength(5);
-    });
+    expect(await screen.findAllByTestId(/card-.*/)).toHaveLength(5);
 
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -203,9 +199,7 @@ describe('Discover > QueryList', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByTestId(/card-.*/)).toHaveLength(5);
-    });
+    expect(await screen.findAllByTestId(/card-.*/)).toHaveLength(5);
 
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',

--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -903,9 +903,7 @@ describe('Results', () => {
         organization,
       });
 
-      await waitFor(() => {
-        expect(screen.getByText('this is a tip')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('this is a tip')).toBeInTheDocument();
     });
 
     it('renders metric fallback alert', async () => {
@@ -986,9 +984,7 @@ describe('Results', () => {
         organization,
       });
 
-      await waitFor(() =>
-        expect(screen.getByRole('button', {name: /set as default/i})).toBeEnabled()
-      );
+      expect(await screen.findByRole('button', {name: /set as default/i})).toBeEnabled();
       await userEvent.click(screen.getByText('Set as Default'));
 
       expect(mockHomepageUpdate).toHaveBeenCalledWith(
@@ -1045,9 +1041,7 @@ describe('Results', () => {
         organization,
       });
 
-      await waitFor(() =>
-        expect(screen.getByRole('button', {name: /set as default/i})).toBeEnabled()
-      );
+      expect(await screen.findByRole('button', {name: /set as default/i})).toBeEnabled();
       await userEvent.click(screen.getByText('Set as Default'));
       expect(await screen.findByText('Remove Default')).toBeInTheDocument();
 

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -163,9 +163,7 @@ describe('LogsPage', () => {
     expect(projectSlugMock).toHaveBeenCalled();
     expect(sdkMock).toHaveBeenCalled();
 
-    await waitFor(() => {
-      expect(screen.getByText('Your Source for Log-ical Data')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Your Source for Log-ical Data')).toBeInTheDocument();
   });
 
   it('should call aggregates APIs as expected', async () => {
@@ -273,9 +271,7 @@ describe('LogsPage', () => {
         initialRouterConfig,
       });
 
-      await waitFor(() => {
-        expect(screen.getByTestId('logs-table')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('logs-table')).toBeInTheDocument();
 
       const switchInput = screen.getByRole('checkbox', {name: /auto-refresh/i});
       expect(switchInput).not.toBeChecked();
@@ -304,9 +300,7 @@ describe('LogsPage', () => {
       });
       expect(router.location.query[LOGS_AUTO_REFRESH_KEY]).toBe('enabled');
 
-      await waitFor(() => {
-        expect(screen.getByTestId('logs-table')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('logs-table')).toBeInTheDocument();
 
       const switchInput = screen.getByRole('checkbox', {name: /auto-refresh/i});
       expect(switchInput).toBeChecked();
@@ -337,9 +331,7 @@ describe('LogsPage', () => {
 
       expect(router.location.query[LOGS_AUTO_REFRESH_KEY]).toBe('enabled');
 
-      await waitFor(() => {
-        expect(screen.getByTestId('logs-table')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('logs-table')).toBeInTheDocument();
 
       expect(screen.getAllByTestId('log-table-row')).toHaveLength(5);
 

--- a/static/app/views/explore/logs/fieldRenderers.spec.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.spec.tsx
@@ -172,9 +172,9 @@ describe('Logs Field Renderers', () => {
 
       await userEvent.hover(timestampElement);
 
-      await waitFor(() => {
-        expect(screen.getByText(/Jan 15, 2024.*2:30:45\.123 PM UTC/)).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByText(/Jan 15, 2024.*2:30:45\.123 PM UTC/)
+      ).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
@@ -142,11 +142,9 @@ describe('LogsAutoRefresh Integration Tests', () => {
 
     await userEvent.hover(toggleSwitch);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Auto-refresh is only supported when sorting by time/i)
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(/Auto-refresh is only supported when sorting by time/i)
+    ).toBeInTheDocument();
   });
 
   it('disables toggle when using absolute date range', async () => {
@@ -170,13 +168,11 @@ describe('LogsAutoRefresh Integration Tests', () => {
 
     await userEvent.hover(toggleSwitch);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /Auto-refresh is only supported when using a relative time period/i
-        )
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(
+        /Auto-refresh is only supported when using a relative time period/i
+      )
+    ).toBeInTheDocument();
   });
 
   it('disables auto-refresh when on aggregates mode', async () => {
@@ -199,11 +195,9 @@ describe('LogsAutoRefresh Integration Tests', () => {
 
     await userEvent.hover(toggleSwitch);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Auto-refresh is not available in the aggregates view./i)
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(/Auto-refresh is not available in the aggregates view./i)
+    ).toBeInTheDocument();
   });
 
   it('disables auto-refresh when using not count(message)', async () => {
@@ -227,13 +221,11 @@ describe('LogsAutoRefresh Integration Tests', () => {
 
     await userEvent.hover(toggleSwitch);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /Auto-refresh is only available when visualizing `count\(logs\)`./i
-        )
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(
+        /Auto-refresh is only available when visualizing `count\(logs\)`./i
+      )
+    ).toBeInTheDocument();
   });
 
   it('shows error state in URL when query fails', async () => {

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -209,9 +209,7 @@ describe('LogsInfiniteTable', () => {
   it('should render the table component', async () => {
     renderWithProviders(<LogsInfiniteTable />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('logs-table')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('logs-table')).toBeInTheDocument();
   });
 
   it('should render with loading state initially', async () => {
@@ -241,9 +239,7 @@ describe('LogsInfiniteTable', () => {
     }
     renderWithProviders(<LogsInfiniteTable />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('logs-table')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('logs-table')).toBeInTheDocument();
 
     const allTreeRows = await screen.findAllByTestId('log-table-row');
     expect(allTreeRows).toHaveLength(3);
@@ -273,9 +269,7 @@ describe('LogsInfiniteTable', () => {
   it('should not be interactable on embedded views', async () => {
     renderWithProviders(<LogsInfiniteTable embedded />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('logs-table')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('logs-table')).toBeInTheDocument();
 
     const allTreeRows = await screen.findAllByTestId('log-table-row');
     expect(allTreeRows).toHaveLength(3);

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
@@ -93,9 +93,7 @@ describe('AggregatesTab', () => {
     });
 
     // Wait for the table to render with header cells
-    await waitFor(() => {
-      expect(screen.getByRole('columnheader', {name: /avg/i})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('columnheader', {name: /avg/i})).toBeInTheDocument();
 
     // Both aggregate columns should be present
     expect(screen.getByRole('columnheader', {name: /sum/i})).toBeInTheDocument();
@@ -145,11 +143,9 @@ describe('AggregatesTab', () => {
     });
 
     // Wait for the table to render
-    await waitFor(() => {
-      expect(
-        screen.getByRole('columnheader', {name: /environment/i})
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('columnheader', {name: /environment/i})
+    ).toBeInTheDocument();
 
     // GroupBy columns
     expect(screen.getByRole('columnheader', {name: /service/i})).toBeInTheDocument();
@@ -200,9 +196,7 @@ describe('AggregatesTab', () => {
     });
 
     // Wait for the empty state
-    await waitFor(() => {
-      expect(screen.getByText('No aggregates found')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('No aggregates found')).toBeInTheDocument();
   });
 
   it('shows error state when request fails', async () => {
@@ -241,8 +235,6 @@ describe('AggregatesTab', () => {
     });
 
     // Wait for the error state
-    await waitFor(() => {
-      expect(screen.getByTestId('error-indicator')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('error-indicator')).toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -158,9 +158,7 @@ describe('MetricPanel', () => {
         additionalWrapper: createWrapper({queryParams, traceMetric}),
       });
 
-      await waitFor(() => {
-        expect(screen.getByTestId('metric-panel')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('metric-panel')).toBeInTheDocument();
 
       // The visualize label badge ("A") should NOT be present
       expect(screen.queryByText('A')).not.toBeInTheDocument();
@@ -248,9 +246,7 @@ describe('MetricPanel', () => {
         additionalWrapper: createWrapper({queryParams, traceMetric}),
       });
 
-      await waitFor(() => {
-        expect(screen.getByTestId('metric-panel')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('metric-panel')).toBeInTheDocument();
 
       // Orientation controls should NOT be present in the refreshed UI
       expect(

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -155,9 +155,7 @@ describe('AggregateDropdown', () => {
     const trigger = screen.getByRole('button', {name: /Agg/});
     await userEvent.click(trigger);
 
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'p75'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('option', {name: 'p75'})).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('option', {name: 'p75'}));
 
@@ -203,18 +201,14 @@ describe('AggregateDropdown', () => {
     const trigger = screen.getByRole('button', {name: /Agg/});
     await userEvent.click(trigger);
 
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'p50'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('option', {name: 'p50'})).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('option', {name: 'p50'}));
 
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'p50'})).toHaveAttribute(
-        'aria-selected',
-        'false'
-      );
-    });
+    expect(await screen.findByRole('option', {name: 'p50'})).toHaveAttribute(
+      'aria-selected',
+      'false'
+    );
 
     await userEvent.click(screen.getByRole('option', {name: 'p90'}));
 
@@ -292,17 +286,13 @@ describe('AggregateDropdown', () => {
     const trigger = screen.getByRole('button', {name: /Agg/});
     await userEvent.click(trigger);
 
-    await waitFor(() =>
-      expect(screen.getByRole('option', {name: 'p50'})).toHaveAttribute(
-        'aria-selected',
-        'true'
-      )
+    expect(await screen.findByRole('option', {name: 'p50'})).toHaveAttribute(
+      'aria-selected',
+      'true'
     );
-    await waitFor(() =>
-      expect(screen.getByRole('option', {name: 'p90'})).toHaveAttribute(
-        'aria-selected',
-        'true'
-      )
+    expect(await screen.findByRole('option', {name: 'p90'})).toHaveAttribute(
+      'aria-selected',
+      'true'
     );
 
     await userEvent.click(screen.getByRole('option', {name: 'sum'}));
@@ -345,12 +335,10 @@ describe('AggregateDropdown', () => {
     const trigger = screen.getByRole('button', {name: /Agg/});
     await userEvent.click(trigger);
 
-    await waitFor(() => {
-      expect(screen.getByRole('option', {name: 'p50'})).toHaveAttribute(
-        'aria-selected',
-        'true'
-      );
-    });
+    expect(await screen.findByRole('option', {name: 'p50'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
 
     await userEvent.click(screen.getByRole('option', {name: 'p90'}));
 
@@ -393,11 +381,9 @@ describe('AggregateDropdown', () => {
     const trigger = screen.getByRole('button', {name: /Agg/});
     await userEvent.click(trigger);
 
-    await waitFor(() =>
-      expect(screen.getByRole('option', {name: 'sum'})).toHaveAttribute(
-        'aria-selected',
-        'true'
-      )
+    expect(await screen.findByRole('option', {name: 'sum'})).toHaveAttribute(
+      'aria-selected',
+      'true'
     );
 
     await userEvent.click(screen.getByRole('option', {name: 'per_second'}));
@@ -501,8 +487,6 @@ describe('AggregateDropdown', () => {
     await userEvent.click(trigger);
     await userEvent.click(screen.getByRole('option', {name: 'p75'}));
 
-    await waitFor(() => {
-      expect(within(trigger).getByText('+1')).toBeInTheDocument();
-    });
+    expect(await within(trigger).findByText('+1')).toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -157,10 +157,9 @@ describe('MetricsTabContent', () => {
     let toolbars = screen.getAllByTestId('metric-toolbar');
     expect(toolbars).toHaveLength(1);
     // have to wait for the response to load
-    await waitFor(() => {
-      // selects the first metric available - sorted alphanumerically
-      expect(within(toolbars[0]!).getByRole('button', {name: 'bar'})).toBeInTheDocument();
-    });
+    expect(
+      await within(toolbars[0]!).findByRole('button', {name: 'bar'})
+    ).toBeInTheDocument();
     expect(screen.getAllByTestId('metric-panel')).toHaveLength(1);
 
     let addButton = screen.getByRole('button', {name: 'Add Metric'});
@@ -258,9 +257,7 @@ describe('MetricsTabContent', () => {
     const addButton = screen.getByRole('button', {name: 'Add Metric'});
     await userEvent.click(addButton);
 
-    await waitFor(() => {
-      expect(screen.getAllByTestId('metric-panel')).toHaveLength(2);
-    });
+    expect(await screen.findAllByTestId('metric-panel')).toHaveLength(2);
 
     expect(trackAnalyticsMock).toHaveBeenNthCalledWith(
       1,
@@ -403,9 +400,9 @@ describe('MetricsTabContent', () => {
     const toolbars = screen.getAllByTestId('metric-toolbar');
     expect(toolbars).toHaveLength(1);
 
-    await waitFor(() => {
-      expect(within(toolbars[0]!).getByRole('button', {name: 'bar'})).toBeInTheDocument();
-    });
+    expect(
+      await within(toolbars[0]!).findByRole('button', {name: 'bar'})
+    ).toBeInTheDocument();
 
     trackAnalyticsMock.mockClear();
 
@@ -489,11 +486,9 @@ describe('MetricsTabContent', () => {
     const toolbars = screen.getAllByTestId('metric-toolbar');
     expect(toolbars).toHaveLength(1);
 
-    await waitFor(() => {
-      expect(
-        within(toolbars[0]!).getByRole('button', {name: 'None'})
-      ).toBeInTheDocument();
-    });
+    expect(
+      await within(toolbars[0]!).findByRole('button', {name: 'None'})
+    ).toBeInTheDocument();
 
     expect(screen.getByTestId('metric-panel')).toBeInTheDocument();
 
@@ -554,9 +549,9 @@ describe('MetricsTabContent', () => {
     expect(toolbars).toHaveLength(1);
 
     // Wait for the toolbar to load
-    await waitFor(() => {
-      expect(within(toolbars[0]!).getByRole('button', {name: 'bar'})).toBeInTheDocument();
-    });
+    expect(
+      await within(toolbars[0]!).findByRole('button', {name: 'bar'})
+    ).toBeInTheDocument();
 
     // Verify initial state is samples mode
     const initialMetricQuery = JSON.parse(router.location.query.metric as string);
@@ -711,13 +706,11 @@ describe('MetricsTabContent (tracemetrics-ui-refresh)', () => {
       }
     );
 
-    await waitFor(() => {
-      expect(
-        within(screen.getAllByTestId('metric-toolbar')[0]!).getByRole('button', {
-          name: 'bar',
-        })
-      ).toBeInTheDocument();
-    });
+    expect(
+      await within(screen.getAllByTestId('metric-toolbar')[0]!).findByRole('button', {
+        name: 'bar',
+      })
+    ).toBeInTheDocument();
 
     expect(screen.getByRole('button', {name: 'Collapse sidebar'})).toBeInTheDocument();
 
@@ -728,8 +721,6 @@ describe('MetricsTabContent (tracemetrics-ui-refresh)', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Expand sidebar'}));
 
-    await waitFor(() => {
-      expect(screen.getAllByTestId('metric-toolbar')).toHaveLength(1);
-    });
+    expect(await screen.findAllByTestId('metric-toolbar')).toHaveLength(1);
   });
 });

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -690,12 +690,10 @@ describe('SpansTabContent', () => {
       await userEvent.click(screen.getByRole('menuitemradio', {name: 'Logs'}));
 
       // Should switch to Span tab
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'Span Samples'})).toHaveAttribute(
-          'aria-selected',
-          'true'
-        );
-      });
+      expect(await screen.findByRole('tab', {name: 'Span Samples'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
     });
   });
 });

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -879,9 +879,7 @@ describe('ExploreToolbar', () => {
     );
 
     // After navigation, the UI should update to show "Save" instead of "Save as…"
-    await waitFor(() => {
-      expect(screen.getByText('Save')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Save')).toBeInTheDocument();
   });
 
   it('disables save as and compare when cross events are present', async () => {

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -274,11 +274,9 @@ describe('CacheLandingPage', () => {
       initialRouterConfig,
     });
 
-    await waitFor(() => {
-      expect(
-        screen.getByText('Bringing you one less hard problem in computer science')
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText('Bringing you one less hard problem in computer science')
+    ).toBeInTheDocument();
   });
 });
 

--- a/static/app/views/integrationPipeline/pipelineView.spec.tsx
+++ b/static/app/views/integrationPipeline/pipelineView.spec.tsx
@@ -67,9 +67,7 @@ describe('PipelineView', () => {
   it('renders awsLambdaProjectSelect', async () => {
     render(<PipelineView pipelineName="awsLambdaProjectSelect" someField="someVal" />);
 
-    await waitFor(() => {
-      expect(screen.getByText('mock_AwsLambdaProjectSelect')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('mock_AwsLambdaProjectSelect')).toBeInTheDocument();
     expect(document.title).toBe('AWS Lambda Select Project');
   });
 

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.spec.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerContent.spec.tsx
@@ -74,9 +74,7 @@ describe('GroupFeatureFlagsDrawerContent', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-error')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('loading-error')).toBeInTheDocument();
   });
 
   it('renders empty state when no flags match the search', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -250,11 +250,9 @@ describe('MetricDetectorTriggeredSection', () => {
 
     render(<MetricDetectorTriggeredSection {...defaultProps} event={event} />);
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('region', {name: 'Contributing Issues'})
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('region', {name: 'Contributing Issues'})
+    ).toBeInTheDocument();
 
     expect(contributingIssuesMock).toHaveBeenCalledWith(
       expect.anything(),

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -464,11 +464,9 @@ describe('SeerDrawer', () => {
     expect(resetButton).toBeEnabled();
     await userEvent.click(resetButton);
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', {name: 'Start Root Cause Analysis'})
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('button', {name: 'Start Root Cause Analysis'})
+    ).toBeInTheDocument();
   });
 
   it('shows setup instructions when GitHub integration setup is needed', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -76,9 +76,7 @@ describe('SeerNotices', () => {
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization,
     });
-    await waitFor(() => {
-      expect(screen.getByText('Unleash Automation')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Unleash Automation')).toBeInTheDocument();
   });
 
   it('shows fixability view step if automation is allowed and view not starred', async () => {
@@ -100,9 +98,7 @@ describe('SeerNotices', () => {
         features: ['issue-views'],
       },
     });
-    await waitFor(() => {
-      expect(screen.getByText('Get Some Quick Wins')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Get Some Quick Wins')).toBeInTheDocument();
   });
 
   it('shows cursor integration step if integration is installed but handoff not configured', async () => {
@@ -152,9 +148,9 @@ describe('SeerNotices', () => {
         features: ['integrations-cursor'],
       },
     });
-    await waitFor(() => {
-      expect(screen.getByText('Hand Off to Cursor Cloud Agents')).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText('Hand Off to Cursor Cloud Agents')
+    ).toBeInTheDocument();
   });
 
   it('does not show cursor integration step if localStorage skip key is set', () => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -62,9 +62,7 @@ describe('SeerSection', () => {
       organization,
     });
 
-    await waitFor(() => {
-      expect(screen.getByText(mockCause)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(mockCause)).toBeInTheDocument();
     expect(screen.queryByText(mockWhatHappened)).not.toBeInTheDocument();
     expect(screen.queryByText(mockTrace)).not.toBeInTheDocument();
   });
@@ -180,9 +178,9 @@ describe('SeerSection', () => {
         organization,
       });
 
-      await waitFor(() => {
-        expect(screen.getByRole('button', {name: 'Find Root Cause'})).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByRole('button', {name: 'Find Root Cause'})
+      ).toBeInTheDocument();
     });
 
     it('shows resource link when available', () => {

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -308,9 +308,7 @@ describe('IssueList', () => {
         });
       });
 
-      await waitFor(() => {
-        expect(screen.getByRole('button', {name: 'Previous'})).toBeEnabled();
-      });
+      expect(await screen.findByRole('button', {name: 'Previous'})).toBeEnabled();
 
       // Click next again
       await userEvent.click(screen.getByRole('button', {name: 'Next'}));
@@ -590,9 +588,7 @@ describe('IssueList', () => {
       await userEvent.keyboard('void{enter}');
 
       // Wait for the empty state to appear (not loading skeleton)
-      await waitFor(() => {
-        expect(screen.getByText(/No issues match your search/i)).toBeInTheDocument();
-      });
+      expect(await screen.findByText(/No issues match your search/i)).toBeInTheDocument();
     });
   });
 
@@ -838,9 +834,9 @@ describe('IssueList', () => {
       }),
     });
 
-    await waitFor(() => {
-      expect(screen.getByText(textWithMarkupMatcher('1-25 of 500'))).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(textWithMarkupMatcher('1-25 of 500'))
+    ).toBeInTheDocument();
 
     parseLinkHeaderSpy.mockReturnValue({
       next: {
@@ -856,9 +852,9 @@ describe('IssueList', () => {
     });
     rerender(<IssueListOverview />);
 
-    await waitFor(() => {
-      expect(screen.getByText(textWithMarkupMatcher('26-50 of 500'))).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(textWithMarkupMatcher('26-50 of 500'))
+    ).toBeInTheDocument();
   }, 20_000);
 
   describe('project low trends queue alert', () => {

--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -419,21 +419,15 @@ describe('desktop navigation', () => {
         const secondaryNav = screen.getByRole('navigation', {
           name: 'Secondary Navigation',
         });
-        await waitFor(() => {
-          expect(
-            within(secondaryNav).getByRole('link', {name: 'Organizations'})
-          ).toBeInTheDocument();
-        });
-        await waitFor(() => {
-          expect(
-            within(secondaryNav).getByRole('link', {name: 'Projects'})
-          ).toBeInTheDocument();
-        });
-        await waitFor(() => {
-          expect(
-            within(secondaryNav).getByRole('link', {name: 'Users'})
-          ).toBeInTheDocument();
-        });
+        expect(
+          await within(secondaryNav).findByRole('link', {name: 'Organizations'})
+        ).toBeInTheDocument();
+        expect(
+          await within(secondaryNav).findByRole('link', {name: 'Projects'})
+        ).toBeInTheDocument();
+        expect(
+          await within(secondaryNav).findByRole('link', {name: 'Users'})
+        ).toBeInTheDocument();
       });
 
       it('customer domain', async () => {
@@ -708,12 +702,9 @@ describe('desktop navigation', () => {
           await userEvent.hover(
             screen.getByRole('navigation', {name: 'Primary Navigation'})
           );
-          await waitFor(() => {
-            expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
-              'data-visible',
-              'true'
-            );
-          });
+          expect(
+            await screen.findByTestId('collapsed-secondary-sidebar')
+          ).toHaveAttribute('data-visible', 'true');
 
           expect(
             localStorage.getItem(NAVIGATION_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY)
@@ -761,12 +752,9 @@ describe('desktop navigation', () => {
             screen.getByRole('navigation', {name: 'Primary Navigation'})
           );
 
-          await waitFor(() => {
-            expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
-              'data-visible',
-              'true'
-            );
-          });
+          expect(
+            await screen.findByTestId('collapsed-secondary-sidebar')
+          ).toHaveAttribute('data-visible', 'true');
         });
 
         it('hides the sidebar on mouse leave when collapsed', async () => {
@@ -784,22 +772,16 @@ describe('desktop navigation', () => {
           await userEvent.hover(
             screen.getByRole('navigation', {name: 'Primary Navigation'})
           );
-          await waitFor(() => {
-            expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
-              'data-visible',
-              'true'
-            );
-          });
+          expect(
+            await screen.findByTestId('collapsed-secondary-sidebar')
+          ).toHaveAttribute('data-visible', 'true');
 
           await userEvent.unhover(
             screen.getByRole('navigation', {name: 'Primary Navigation'})
           );
-          await waitFor(() => {
-            expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
-              'data-visible',
-              'false'
-            );
-          });
+          expect(
+            await screen.findByTestId('collapsed-secondary-sidebar')
+          ).toHaveAttribute('data-visible', 'false');
         });
 
         it('shows the sidebar when a nav element receives keyboard focus while collapsed', async () => {
@@ -822,12 +804,9 @@ describe('desktop navigation', () => {
           await userEvent.tab();
           await userEvent.tab();
 
-          await waitFor(() => {
-            expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
-              'data-visible',
-              'true'
-            );
-          });
+          expect(
+            await screen.findByTestId('collapsed-secondary-sidebar')
+          ).toHaveAttribute('data-visible', 'true');
         });
 
         it('shows hovered group content when sidebar is expanded', async () => {
@@ -874,12 +853,9 @@ describe('desktop navigation', () => {
 
           await userEvent.hover(screen.getByRole('link', {name: 'Explore'}));
 
-          await waitFor(() => {
-            expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
-              'data-visible',
-              'true'
-            );
-          });
+          expect(
+            await screen.findByTestId('collapsed-secondary-sidebar')
+          ).toHaveAttribute('data-visible', 'true');
 
           const secondaryNav = screen.getByRole('navigation', {
             name: 'Secondary Navigation',

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -265,9 +265,7 @@ describe('ScmPlatformFeatures', () => {
     );
 
     // Wait for auto-select of first detected platform
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
-    });
+    expect(await screen.findByRole('button', {name: 'Continue'})).toBeEnabled();
   });
 
   it('enabling profiling auto-enables tracing', async () => {

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -1257,9 +1257,7 @@ describe('trace view', () => {
       await waitFor(() => expect(rows[1]).toHaveFocus());
 
       await userEvent.keyboard('{arrowright}');
-      await waitFor(() => {
-        expect(screen.getByText('special-span')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('special-span')).toBeInTheDocument();
     });
 
     it('arrow left collapses row', async () => {
@@ -1511,11 +1509,9 @@ describe('trace view', () => {
       const searchInput = await screen.findByPlaceholderText('Search in trace');
       expect(searchInput).toHaveValue('dead');
 
-      await waitFor(() => {
-        expect(screen.getByTestId('trace-search-result-iterator')).toHaveTextContent(
-          'no results'
-        );
-      });
+      expect(await screen.findByTestId('trace-search-result-iterator')).toHaveTextContent(
+        'no results'
+      );
 
       await waitFor(() => {
         const rows = container.querySelectorAll(VISIBLE_TRACE_ROW_SELECTOR);
@@ -1580,11 +1576,9 @@ describe('trace view', () => {
       expect(searchInput).toHaveFocus();
       await userEvent.keyboard('{arrowdown}');
 
-      await waitFor(() => {
-        expect(screen.getByTestId('trace-drawer-title')).toHaveTextContent(
-          'TransactionID: 1'
-        );
-      });
+      expect(await screen.findByTestId('trace-drawer-title')).toHaveTextContent(
+        'TransactionID: 1'
+      );
     });
 
     it('highlighted node narrows down on the first result', async () => {
@@ -1843,11 +1837,9 @@ describe('trace view', () => {
       }
 
       // User clicks on an entry in the list, then proceeds to search
-      await waitFor(() => {
-        expect(screen.getByTestId('trace-search-result-iterator')).toHaveTextContent(
-          '6/11'
-        );
-      });
+      expect(await screen.findByTestId('trace-search-result-iterator')).toHaveTextContent(
+        '6/11'
+      );
       // And then continues the query - the highlighting is preserved as long as the
       // row is part of the search results
       await assertHighlightedRowAtIndex(container, 6);

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
@@ -12,9 +12,7 @@ import {MAX_TEAM_KEY_TRANSACTIONS} from 'sentry/utils/performance/constants';
 import TeamKeyTransactionButton from 'sentry/views/performance/transactionSummary/teamKeyTransactionButton';
 
 async function clickTeamKeyTransactionDropdown() {
-  await waitFor(() =>
-    expect(screen.getByRole('button', {expanded: false})).toBeEnabled()
-  );
+  expect(await screen.findByRole('button', {expanded: false})).toBeEnabled();
   await userEvent.click(screen.getByRole('button', {expanded: false}));
 }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.spec.tsx
@@ -22,9 +22,7 @@ describe('EAPChartsWidget', () => {
   it('shows default widget type when no query param is provided', async () => {
     render(<EAPChartsWidget transactionName={transactionName} query="" />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Duration Breakdown')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Duration Breakdown')).toBeInTheDocument();
   });
 
   it('shows default widget when invalid query param is provided', async () => {
@@ -40,8 +38,6 @@ describe('EAPChartsWidget', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('Duration Breakdown')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Duration Breakdown')).toBeInTheDocument();
   });
 });

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -613,9 +613,7 @@ describe('Performance > TransactionSummary', () => {
       // It renders the web vitals widget
       await screen.findByRole('heading', {name: 'Web Vitals'});
 
-      await waitFor(() => {
-        expect(screen.getAllByTestId('vital-status')).toHaveLength(3);
-      });
+      expect(await screen.findAllByTestId('vital-status')).toHaveLength(3);
 
       const vitalStatues = screen.getAllByTestId('vital-status');
       expect(vitalStatues[0]).toHaveTextContent('31%');

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -263,11 +263,9 @@ describe('TransactionReplays', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(
-        screen.getByText("You don't have access to this feature")
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText("You don't have access to this feature")
+    ).toBeInTheDocument();
   });
 
   it('should hide replay content when user does not have granular replay permissions', async () => {

--- a/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
@@ -204,10 +204,7 @@ describe('Performance > Transaction Tags', () => {
 
     renderWithLayout(data);
 
-    await waitFor(() => {
-      // Table is loaded.
-      expect(screen.getByRole('table')).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('table')).toBeInTheDocument();
 
     await waitFor(() => expect(histogramMock).toHaveBeenCalledTimes(1));
     expect(histogramMock).toHaveBeenNthCalledWith(
@@ -229,10 +226,7 @@ describe('Performance > Transaction Tags', () => {
 
     renderWithLayout(data);
 
-    await waitFor(() => {
-      // Table is loaded.
-      expect(screen.getByRole('table')).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('table')).toBeInTheDocument();
 
     await waitFor(() => expect(histogramMock).toHaveBeenCalledTimes(1));
     expect(histogramMock).toHaveBeenNthCalledWith(
@@ -252,10 +246,7 @@ describe('Performance > Transaction Tags', () => {
 
     renderWithLayout(initialData);
 
-    await waitFor(() => {
-      // Table is loaded.
-      expect(screen.getByRole('table')).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('table')).toBeInTheDocument();
 
     // Release link is properly setup
     expect(await screen.findByText(TEST_RELEASE_NAME)).toBeInTheDocument();
@@ -327,10 +318,7 @@ describe('Performance > Transaction Tags', () => {
 
     renderWithLayout(data);
 
-    await waitFor(() => {
-      // Table is loaded.
-      expect(screen.getByRole('table')).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('table')).toBeInTheDocument();
 
     await waitFor(() => expect(histogramMock).toHaveBeenCalledTimes(1));
 

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
@@ -94,9 +94,7 @@ describe('BuildDetailsSidebarContent', () => {
     });
 
     // App info should be visible
-    await waitFor(() => {
-      expect(screen.getByText('Test App')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Test App')).toBeInTheDocument();
 
     // Build Metadata should show VCS data
     expect(screen.getByText('Build Metadata')).toBeInTheDocument();
@@ -170,9 +168,7 @@ describe('BuildDetailsSidebarContent', () => {
         organization,
       });
 
-      await waitFor(() => {
-        expect(screen.getByText('Build Metadata')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Build Metadata')).toBeInTheDocument();
 
       // Base Build row should not be present
       expect(screen.queryByText('Base Build')).not.toBeInTheDocument();
@@ -192,9 +188,7 @@ describe('BuildDetailsSidebarContent', () => {
         organization,
       });
 
-      await waitFor(() => {
-        expect(screen.getByText('Build Metadata')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Build Metadata')).toBeInTheDocument();
 
       // Base Build row should be present with label
       const baseBuildLabel = screen.getByText('Base Build');
@@ -226,9 +220,7 @@ describe('BuildDetailsSidebarContent', () => {
         organization,
       });
 
-      await waitFor(() => {
-        expect(screen.getByText('Build Metadata')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Build Metadata')).toBeInTheDocument();
 
       // Base Build row should be present with label
       const baseBuildLabel = screen.getByText('Base Build');
@@ -275,9 +267,7 @@ describe('BuildDetailsSidebarContent', () => {
         }
       );
 
-      await waitFor(() => {
-        expect(screen.getByText('Build Metadata')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Build Metadata')).toBeInTheDocument();
 
       // Base Build row should be present with label and link
       const baseBuildLink = screen.getByRole('link', {name: 'v1.0 (2)'});

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -326,9 +326,9 @@ describe('CreateProject', () => {
     router.navigate('/projects/new/?referrer=getting-started&project=12345');
 
     // The slug field should be auto-filled with the stored name
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('project-slug')).toHaveValue('my-custom-name');
-    });
+    expect(await screen.findByPlaceholderText('project-slug')).toHaveValue(
+      'my-custom-name'
+    );
 
     // Step 3: Click a different platform
     await userEvent.click(screen.getByTestId('platform-apple-ios'));
@@ -381,11 +381,9 @@ describe('CreateProject', () => {
 
     router.navigate('/projects/new/?referrer=getting-started&project=12345');
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('project-slug')).toHaveValue(
-        'javascript-angular'
-      );
-    });
+    expect(await screen.findByPlaceholderText('project-slug')).toHaveValue(
+      'javascript-angular'
+    );
 
     // Click a different platform — slug should update since user didn't manually modify it
     await userEvent.click(screen.getByTestId('platform-apple-ios'));
@@ -517,9 +515,7 @@ describe('CreateProject', () => {
     await userEvent.type(screen.getByLabelText('Select a Team'), teamWithAccess.slug);
     await userEvent.click(screen.getByText(`#${teamWithAccess.slug}`));
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Create Project'})).toBeEnabled();
-    });
+    expect(await screen.findByRole('button', {name: 'Create Project'})).toBeEnabled();
 
     renderGlobalModal();
 
@@ -553,9 +549,7 @@ describe('CreateProject', () => {
     await userEvent.type(screen.getByLabelText('Select a Team'), teamWithAccess.slug);
     await userEvent.click(screen.getByText(`#${teamWithAccess.slug}`));
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Create Project'})).toBeEnabled();
-    });
+    expect(await screen.findByRole('button', {name: 'Create Project'})).toBeEnabled();
 
     renderGlobalModal();
 
@@ -819,9 +813,7 @@ describe('CreateProject', () => {
           name: /Notify via integration/,
         })
       );
-      await waitFor(() => {
-        expect(screen.getByRole('button', {name: 'Create Project'})).toBeEnabled();
-      });
+      expect(await screen.findByRole('button', {name: 'Create Project'})).toBeEnabled();
     });
 
     it('should show validating tooltip and disable button while validating channel', async () => {

--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -490,9 +490,7 @@ describe('ProjectsDashboard', () => {
       render(<ProjectsDashboard />);
 
       // check that all projects are displayed
-      await waitFor(() =>
-        expect(screen.getAllByTestId('badge-display-name')).toHaveLength(6)
-      );
+      expect(await screen.findAllByTestId('badge-display-name')).toHaveLength(6);
 
       const projectName = screen.getAllByTestId('badge-display-name');
       // check that projects are in the correct order - alphabetical with bookmarked projects in front
@@ -610,9 +608,9 @@ describe('ProjectsDashboard', () => {
       jest.useRealTimers();
 
       // All cards have loaded
-      await waitFor(() => {
-        expect(within(projectSummary[0]!).getByText('Errors: 3')).toBeInTheDocument();
-      });
+      expect(
+        await within(projectSummary[0]!).findByText('Errors: 3')
+      ).toBeInTheDocument();
       expect(within(projectSummary[1]!).getByText('Errors: 3')).toBeInTheDocument();
       expect(within(projectSummary[2]!).getByText('Errors: 3')).toBeInTheDocument();
       expect(within(projectSummary[3]!).getByText('Errors: 3')).toBeInTheDocument();

--- a/static/app/views/sentryAppExternalInstallation/index.spec.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.spec.tsx
@@ -247,7 +247,7 @@ describe('SentryAppExternalInstallation', () => {
       expect(getOrgMock).toHaveBeenCalled();
       expect(getInstallationsMock).toHaveBeenCalled();
       expect(screen.queryByText('Select an organization')).not.toBeInTheDocument();
-      await waitFor(() => expect(screen.getByTestId('install')).toBeEnabled());
+      expect(await screen.findByTestId('install')).toBeEnabled();
     });
 
     it('loads orgs from multiple regions', async () => {

--- a/static/app/views/settings/account/accountEmails.spec.tsx
+++ b/static/app/views/settings/account/accountEmails.spec.tsx
@@ -151,11 +151,9 @@ describe('AccountEmails', () => {
       );
     });
 
-    await waitFor(() => {
-      expect(screen.getAllByLabelText('Remove email')).toHaveLength(
-        mockGetResponseBody.filter(email => !email.isPrimary).length
-      );
-    });
+    expect(await screen.findAllByLabelText('Remove email')).toHaveLength(
+      mockGetResponseBody.filter(email => !email.isPrimary).length
+    );
 
     expect(mockGet).toHaveBeenCalledWith(
       ENDPOINT,

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
@@ -61,11 +61,9 @@ describe('AccountSecurityEnroll', () => {
         },
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole('status', {name: 'Authentication Method Inactive'})
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByRole('status', {name: 'Authentication Method Inactive'})
+      ).toBeInTheDocument();
     });
 
     it('has qrcode component', async () => {
@@ -78,9 +76,7 @@ describe('AccountSecurityEnroll', () => {
         },
       });
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Enrollment QR Code')).toBeInTheDocument();
-      });
+      expect(await screen.findByLabelText('Enrollment QR Code')).toBeInTheDocument();
     });
 
     it('can enroll from org subdomain', async () => {
@@ -112,11 +108,9 @@ describe('AccountSecurityEnroll', () => {
         },
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole('status', {name: 'Authentication Method Inactive'})
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByRole('status', {name: 'Authentication Method Inactive'})
+      ).toBeInTheDocument();
 
       await userEvent.type(screen.getByRole('textbox', {name: 'OTP Code'}), 'otp{enter}');
 
@@ -163,11 +157,9 @@ describe('AccountSecurityEnroll', () => {
         },
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole('status', {name: 'Authentication Method Inactive'})
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByRole('status', {name: 'Authentication Method Inactive'})
+      ).toBeInTheDocument();
 
       await userEvent.type(screen.getByRole('textbox', {name: 'OTP Code'}), 'otp{enter}');
 

--- a/static/app/views/settings/account/apiApplications/index.spec.tsx
+++ b/static/app/views/settings/account/apiApplications/index.spec.tsx
@@ -188,10 +188,8 @@ describe('ApiApplications', () => {
       expect.objectContaining({method: 'DELETE'})
     );
 
-    await waitFor(() => {
-      expect(
-        screen.getByText("You haven't created any applications yet.")
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText("You haven't created any applications yet.")
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/account/passwordForm.spec.tsx
+++ b/static/app/views/settings/account/passwordForm.spec.tsx
@@ -62,9 +62,7 @@ describe('PasswordForm', () => {
       })
     );
 
-    await waitFor(() =>
-      expect(screen.getByLabelText('Current Password')).toHaveValue('')
-    );
+    expect(await screen.findByLabelText('Current Password')).toHaveValue('');
   });
 
   it('validates mismatched passwords and remvoes validation on match', async () => {

--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.spec.tsx
@@ -86,9 +86,9 @@ describe('AttributeField', () => {
       {organization}
     );
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
   });
 
   it('displays suggestions when input is focused', async () => {
@@ -105,9 +105,9 @@ describe('AttributeField', () => {
       {organization}
     );
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
 
     await userEvent.click(screen.getByPlaceholderText('Select or type attribute'));
 
@@ -136,9 +136,9 @@ describe('AttributeField', () => {
 
     await userEvent.click(screen.getByPlaceholderText('Select or type attribute'));
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
 
     // Wait for suggestions to load
     await screen.findByText('user.email');
@@ -168,9 +168,9 @@ describe('AttributeField', () => {
 
     await userEvent.click(screen.getByPlaceholderText('Select or type attribute'));
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
 
     // Wait for suggestions to load
     await screen.findByText('message');
@@ -200,9 +200,9 @@ describe('AttributeField', () => {
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.click(input);
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
 
     // Wait for suggestions to load
     await screen.findByText('message');
@@ -230,9 +230,9 @@ describe('AttributeField', () => {
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.click(input);
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
 
     // Wait for suggestions to load
     await screen.findByText('message');
@@ -258,9 +258,9 @@ describe('AttributeField', () => {
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.click(input);
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
 
     // Wait for suggestions to load
     await screen.findByText('message');
@@ -287,9 +287,9 @@ describe('AttributeField', () => {
       {organization}
     );
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.click(input);
     await userEvent.tab();
@@ -312,9 +312,9 @@ describe('AttributeField', () => {
       {organization}
     );
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
     const input = screen.getByPlaceholderText('Select or type attribute');
     await userEvent.type(input, 'custom');
 
@@ -350,9 +350,9 @@ describe('AttributeField', () => {
       {organization}
     );
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
 
     await userEvent.click(screen.getByPlaceholderText('Select or type attribute'));
 
@@ -410,9 +410,9 @@ describe('AttributeField', () => {
       {organization}
     );
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or type attribute')).toHaveValue(value);
-    });
+    expect(await screen.findByPlaceholderText('Select or type attribute')).toHaveValue(
+      value
+    );
 
     await screen.findByPlaceholderText('Select or type attribute');
 

--- a/static/app/views/settings/dynamicSampling/organizationSampling.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/organizationSampling.spec.tsx
@@ -118,9 +118,7 @@ describe('OrganizationSampling', () => {
     await userEvent.type(screen.getByRole('spinbutton'), '30');
     await userEvent.click(screen.getByRole('button', {name: 'Apply Changes'}));
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Reset'})).toBeDisabled()
-    );
+    expect(await screen.findByRole('button', {name: 'Reset'})).toBeDisabled();
   });
 
   it('keeps form dirty after an API error', async () => {
@@ -137,9 +135,7 @@ describe('OrganizationSampling', () => {
     await userEvent.type(screen.getByRole('spinbutton'), '30');
     await userEvent.click(screen.getByRole('button', {name: 'Apply Changes'}));
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Reset'})).toBeEnabled()
-    );
+    expect(await screen.findByRole('button', {name: 'Reset'})).toBeEnabled();
   });
 
   it('disables Apply Changes and input for users without org:write access', () => {

--- a/static/app/views/settings/dynamicSampling/projectSampling.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.spec.tsx
@@ -145,9 +145,7 @@ describe('ProjectSampling', () => {
     await userEvent.type(input, '30');
     await userEvent.click(screen.getByRole('button', {name: 'Apply Changes'}));
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Reset'})).toBeDisabled()
-    );
+    expect(await screen.findByRole('button', {name: 'Reset'})).toBeDisabled();
   });
 
   it('keeps form dirty after an API error', async () => {
@@ -165,9 +163,7 @@ describe('ProjectSampling', () => {
     await userEvent.type(input, '30');
     await userEvent.click(screen.getByRole('button', {name: 'Apply Changes'}));
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Reset'})).toBeEnabled()
-    );
+    expect(await screen.findByRole('button', {name: 'Reset'})).toBeEnabled();
   });
 
   it('updates project rates atomically via bulk org rate edit', async () => {

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
@@ -51,9 +51,7 @@ describe('SamplingModeSwitchModal', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Deactivate'}));
 
       // Modal should remain open and API should not have been called
-      await waitFor(() => {
-        expect(screen.getByText('Deactivate Advanced Mode')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Deactivate Advanced Mode')).toBeInTheDocument();
       expect(putMock).not.toHaveBeenCalled();
     });
 
@@ -129,9 +127,7 @@ describe('SamplingModeSwitchModal', () => {
       await screen.findByText('Deactivate Advanced Mode');
       await userEvent.click(screen.getByRole('button', {name: 'Deactivate'}));
 
-      await waitFor(() => {
-        expect(screen.getByText('Deactivate Advanced Mode')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Deactivate Advanced Mode')).toBeInTheDocument();
     });
 
     it('closes the modal when Cancel is clicked without submitting', async () => {
@@ -226,9 +222,7 @@ describe('SamplingModeSwitchModal', () => {
       await screen.findByText('Activate Advanced Mode');
       await userEvent.click(screen.getByRole('button', {name: 'Activate'}));
 
-      await waitFor(() => {
-        expect(screen.getByText('Activate Advanced Mode')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Activate Advanced Mode')).toBeInTheDocument();
     });
 
     it('closes the modal when Cancel is clicked without submitting', async () => {

--- a/static/app/views/settings/organizationDeveloperSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.spec.tsx
@@ -38,11 +38,9 @@ describe('Organization Developer Settings', () => {
       render(<OrganizationDeveloperSettings />, {
         organization: org,
       });
-      await waitFor(() => {
-        expect(
-          screen.getByText('No internal integrations have been created yet.')
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByText('No internal integrations have been created yet.')
+      ).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -391,12 +391,8 @@ describe('Sentry Application Details', () => {
 
       await userEvent.click(screen.getByRole('button', {name: 'New Token'}));
 
-      await waitFor(() => {
-        expect(screen.getAllByLabelText('Token preview')).toHaveLength(1);
-      });
-      await waitFor(() => {
-        expect(screen.getAllByLabelText('Generated token')).toHaveLength(1);
-      });
+      expect(await screen.findAllByLabelText('Token preview')).toHaveLength(1);
+      expect(await screen.findAllByLabelText('Generated token')).toHaveLength(1);
     });
 
     it('removing token from list', async () => {

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.spec.tsx
@@ -213,9 +213,7 @@ describe('IntegrationCodeMappings', () => {
     expect(screen.getByRole('textbox', {name: 'Branch'})).toHaveValue('main');
 
     await selectEvent.select(screen.getByText('Choose repo'), repos[1]!.name);
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Branch'})).toHaveValue('main');
-    });
+    expect(await screen.findByRole('textbox', {name: 'Branch'})).toHaveValue('main');
   });
 
   it('deletes existing config and refreshes data', async () => {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -189,12 +189,10 @@ describe('IntegrationDetailedView', () => {
       initialRouterConfig: createRouterConfig('bitbucket', {tab: 'configurations'}),
       organization,
     });
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: 'Uninstall'})).toHaveAttribute(
-        'aria-disabled',
-        'true'
-      );
-    });
+    expect(await screen.findByRole('button', {name: 'Uninstall'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
   });
 
   it('allows members to configure github/gitlab', async () => {

--- a/static/app/views/settings/organizationIntegrations/integrationExternalTeamMappings.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalTeamMappings.spec.tsx
@@ -69,9 +69,7 @@ describe('IntegrationExternalTeamMappings', () => {
     });
     renderGlobalModal();
 
-    await waitFor(() => {
-      expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('add-mapping-button')).toBeInTheDocument();
 
     // Open modal to create new mapping
     await userEvent.click(screen.getByTestId('add-mapping-button'));

--- a/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
@@ -202,7 +202,7 @@ describe('IntegrationRepos', () => {
       });
 
       render(<IntegrationRepos integration={integration} />);
-      await waitFor(() => expect(screen.getByText('Add Repository')).toBeEnabled());
+      expect(await screen.findByText('Add Repository')).toBeEnabled();
     });
   });
 

--- a/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.spec.tsx
@@ -222,9 +222,7 @@ describe('RepositoryProjectPathConfigModal', () => {
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'org/repo-one'}));
 
     // Branch should be auto-filled
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Branch'})).toHaveValue('trunk');
-    });
+    expect(await screen.findByRole('textbox', {name: 'Branch'})).toHaveValue('trunk');
   });
 
   it('allows submitting with empty stream for Perforce (stream-based) integrations', async () => {
@@ -310,10 +308,8 @@ describe('RepositoryProjectPathConfigModal', () => {
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'org/repo-one'}));
 
     // Branch should keep the manually entered value
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Branch'})).toHaveValue(
-        'my-custom-branch'
-      );
-    });
+    expect(await screen.findByRole('textbox', {name: 'Branch'})).toHaveValue(
+      'my-custom-branch'
+    );
   });
 });

--- a/static/app/views/settings/organizationSecurityAndPrivacy/index.spec.tsx
+++ b/static/app/views/settings/organizationSecurityAndPrivacy/index.spec.tsx
@@ -71,13 +71,11 @@ describe('OrganizationSecurityAndPrivacy', () => {
 
     // AutoSaveForm calls onError and reverts the switch.
     // The checkbox should become enabled again after the mutation fails.
-    await waitFor(() => {
-      expect(
-        screen.getByRole('checkbox', {
-          name: 'Enable to require and enforce two-factor authentication for all members',
-        })
-      ).toBeEnabled();
-    });
+    expect(
+      await screen.findByRole('checkbox', {
+        name: 'Enable to require and enforce two-factor authentication for all members',
+      })
+    ).toBeEnabled();
   });
 
   it('renders join request switch', async () => {
@@ -155,13 +153,11 @@ describe('OrganizationSecurityAndPrivacy', () => {
 
     // After successful save, form.reset() syncs defaults so the form is pristine again
     // The changes alert should become hidden
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          'Changes to your scrubbing configuration will apply to all new events.'
-        )
-      ).not.toBeVisible();
-    });
+    expect(
+      await screen.findByText(
+        'Changes to your scrubbing configuration will apply to all new events.'
+      )
+    ).not.toBeVisible();
   });
 
   it('enables require2fa with confirm modal', async () => {

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.spec.tsx
@@ -59,9 +59,7 @@ describe('AddCodeOwnerModal', () => {
         project={project}
       />
     );
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Add File'})).toBeDisabled()
-    );
+    expect(await screen.findByRole('button', {name: 'Add File'})).toBeDisabled();
   });
 
   it('renders codeowner file', async () => {

--- a/static/app/views/settings/project/projectReleaseTracking.spec.tsx
+++ b/static/app/views/settings/project/projectReleaseTracking.spec.tsx
@@ -50,9 +50,7 @@ describe('ProjectReleaseTracking', () => {
       initialRouterConfig,
     });
 
-    await waitFor(() => {
-      expect(screen.getByRole('textbox')).toHaveValue('token token token');
-    });
+    expect(await screen.findByRole('textbox')).toHaveValue('token token token');
   });
 
   it('can regenerate token', async () => {
@@ -81,9 +79,7 @@ describe('ProjectReleaseTracking', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
 
-    await waitFor(() => {
-      expect(screen.getByRole('textbox')).toHaveValue('token2 token2 token2');
-    });
+    expect(await screen.findByRole('textbox')).toHaveValue('token2 token2 token2');
     expect(mock).toHaveBeenCalledWith(
       url,
       expect.objectContaining({
@@ -109,8 +105,6 @@ describe('ProjectReleaseTracking', () => {
       initialRouterConfig,
     });
 
-    await waitFor(() => {
-      expect(screen.getByRole('textbox')).toHaveValue('YOUR_TOKEN');
-    });
+    expect(await screen.findByRole('textbox')).toHaveValue('YOUR_TOKEN');
   });
 });

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -157,10 +157,8 @@ describe('projectGeneralSettings', () => {
       })
     );
 
-    await waitFor(() =>
-      expect(screen.getByRole('textbox', {name: 'Allowed Domains'})).toHaveValue(
-        'example.com,https://example.com'
-      )
+    expect(await screen.findByRole('textbox', {name: 'Allowed Domains'})).toHaveValue(
+      'example.com,https://example.com'
     );
   });
 

--- a/static/eslint/eslintPluginSentry/index.ts
+++ b/static/eslint/eslintPluginSentry/index.ts
@@ -1,9 +1,11 @@
 import {noDefaultExports} from './no-default-exports';
 import {noStaticTranslations} from './no-static-translations';
 import {noUnnecessaryTypeAnnotation} from './no-unnecessary-type-annotation';
+import {preferFindBy} from './prefer-find-by';
 
 export const rules = {
   'no-default-exports': noDefaultExports,
   'no-static-translations': noStaticTranslations,
   'no-unnecessary-type-annotation': noUnnecessaryTypeAnnotation,
+  'prefer-find-by': preferFindBy,
 };

--- a/static/eslint/eslintPluginSentry/prefer-find-by.spec.ts
+++ b/static/eslint/eslintPluginSentry/prefer-find-by.spec.ts
@@ -1,0 +1,259 @@
+import {RuleTester} from '@typescript-eslint/rule-tester';
+
+import {preferFindBy} from './prefer-find-by';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-find-by', preferFindBy, {
+  valid: [
+    {
+      name: 'already using findByText',
+      code: `expect(await screen.findByText('foo')).toBeInTheDocument();`,
+    },
+    {
+      name: 'mock assertion inside waitFor (no getBy)',
+      code: `await waitFor(() => { expect(mockFn).toHaveBeenCalled(); });`,
+    },
+    {
+      name: 'queryByText for absence check',
+      code: `await waitFor(() => { expect(screen.queryByText('foo')).not.toBeInTheDocument(); });`,
+    },
+    {
+      name: 'queryAllBy for absence check',
+      code: `await waitFor(() => { expect(screen.queryAllByText('foo')).toHaveLength(0); });`,
+    },
+    {
+      name: 'multiple expect statements',
+      code: `await waitFor(() => { expect(screen.getByText('a')).toBeInTheDocument(); expect(screen.getByText('b')).toBeInTheDocument(); });`,
+    },
+    {
+      name: 'multi-statement with variable assignment and sibling traversal',
+      code: `
+        await waitFor(() => {
+          const term = screen.getByText('Sample Rate:');
+          const definition = term.nextElementSibling;
+          expect(definition).toHaveTextContent('75%');
+        });
+      `,
+    },
+    {
+      name: 'function reference passed to waitFor',
+      code: `
+        const check = () => expect(screen.getByText('foo')).toBeInTheDocument();
+        await waitFor(check);
+      `,
+    },
+    {
+      name: 'custom function call inside waitFor',
+      code: `await waitFor(() => myCustomFunction());`,
+    },
+    {
+      name: 'async arrow callback (uses await internally)',
+      code: `await waitFor(async () => { expect(await screen.findByText('foo')).toBeInTheDocument(); });`,
+    },
+    {
+      name: 'chained access on getBy result (.closest)',
+      code: `await waitFor(() => { expect(screen.getByText('foo').closest('a')).toHaveAttribute('href', '/link'); });`,
+    },
+    {
+      name: 'indexed getAllBy with property access',
+      code: `await waitFor(() => { expect(screen.getAllByTestId('item')[0].textContent).toBeTruthy(); });`,
+    },
+    {
+      name: 'getBy result assigned then used with other operations',
+      code: `
+        await waitFor(() => {
+          const el = screen.getByText('foo');
+          doSomething(el);
+          expect(el).toBeInTheDocument();
+        });
+      `,
+    },
+    {
+      name: 'waitFor with return statement (not an ExpressionStatement)',
+      code: `await waitFor(() => { return screen.getByText('foo'); });`,
+    },
+    {
+      name: 'bare getBy inside waitFor without expect (handled by community rule)',
+      code: `await waitFor(() => screen.getByText('foo'));`,
+    },
+    {
+      name: 'expect wrapping a non-getBy call',
+      code: `await waitFor(() => { expect(container.querySelector('.foo')).toBeInTheDocument(); });`,
+    },
+    {
+      name: 'getBy on unknown receiver (not screen or within)',
+      code: `await waitFor(() => { expect(view.getByText('foo')).toBeInTheDocument(); });`,
+    },
+  ],
+
+  invalid: [
+    // --- Body style variants ---
+    {
+      name: 'block body with toBeInTheDocument',
+      code: `await waitFor(() => { expect(screen.getByText('foo')).toBeInTheDocument(); });`,
+      output: `expect(await screen.findByText('foo')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'expression body single line',
+      code: `await waitFor(() => expect(screen.getByRole('button')).toBeInTheDocument());`,
+      output: `expect(await screen.findByRole('button')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'expression body with newline',
+      code: `await waitFor(() =>
+  expect(screen.getByRole('button', {name: 'Reset'})).toBeDisabled()
+);`,
+      output: `expect(await screen.findByRole('button', {name: 'Reset'})).toBeDisabled();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+
+    // --- Assertion variants ---
+    {
+      name: 'toBeDisabled assertion',
+      code: `await waitFor(() => { expect(screen.getByRole('button', {name: /set as default/i})).toBeDisabled(); });`,
+      output: `expect(await screen.findByRole('button', {name: /set as default/i})).toBeDisabled();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'toBeEnabled assertion',
+      code: `await waitFor(() => { expect(screen.getByText('Select Dashboard')).toBeEnabled(); });`,
+      output: `expect(await screen.findByText('Select Dashboard')).toBeEnabled();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'toHaveFocus assertion',
+      code: `await waitFor(() => expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus());`,
+      output: `expect(await screen.findByRole('option', {name: 'Option One'})).toHaveFocus();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'toHaveTextContent assertion',
+      code: `await waitFor(() => { expect(screen.getByTestId('count')).toHaveTextContent('5'); });`,
+      output: `expect(await screen.findByTestId('count')).toHaveTextContent('5');`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'toHaveAttribute assertion',
+      code: `await waitFor(() => { expect(screen.getByRole('link')).toHaveAttribute('href', '/foo'); });`,
+      output: `expect(await screen.findByRole('link')).toHaveAttribute('href', '/foo');`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'negated matcher (.not.toBeDisabled)',
+      code: `await waitFor(() => { expect(screen.getByRole('button')).not.toBeDisabled(); });`,
+      output: `expect(await screen.findByRole('button')).not.toBeDisabled();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+
+    // --- Query type variants ---
+    {
+      name: 'getByTestId',
+      code: `await waitFor(() => { expect(screen.getByTestId('my-element')).toBeInTheDocument(); });`,
+      output: `expect(await screen.findByTestId('my-element')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'getByLabelText',
+      code: `await waitFor(() => { expect(screen.getByLabelText('Email')).toBeInTheDocument(); });`,
+      output: `expect(await screen.findByLabelText('Email')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'getByPlaceholderText',
+      code: `await waitFor(() => { expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument(); });`,
+      output: `expect(await screen.findByPlaceholderText('Search...')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'getByDisplayValue',
+      code: `await waitFor(() => { expect(screen.getByDisplayValue('hello')).toBeInTheDocument(); });`,
+      output: `expect(await screen.findByDisplayValue('hello')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'getByAltText',
+      code: `await waitFor(() => { expect(screen.getByAltText('logo')).toBeInTheDocument(); });`,
+      output: `expect(await screen.findByAltText('logo')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'getByTitle',
+      code: `await waitFor(() => { expect(screen.getByTitle('Close')).toBeInTheDocument(); });`,
+      output: `expect(await screen.findByTitle('Close')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+
+    // --- getAllBy variants ---
+    {
+      name: 'getAllByText with toHaveLength',
+      code: `await waitFor(() => { expect(screen.getAllByText('item')).toHaveLength(3); });`,
+      output: `expect(await screen.findAllByText('item')).toHaveLength(3);`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'getAllByRole',
+      code: `await waitFor(() => { expect(screen.getAllByRole('listitem')).toHaveLength(5); });`,
+      output: `expect(await screen.findAllByRole('listitem')).toHaveLength(5);`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'getAllByTestId',
+      code: `await waitFor(() => { expect(screen.getAllByTestId('row')).toHaveLength(2); });`,
+      output: `expect(await screen.findAllByTestId('row')).toHaveLength(2);`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+
+    // --- Scope variants ---
+    {
+      name: 'within() scope',
+      code: `await waitFor(() => { expect(within(container).getByText('foo')).toBeInTheDocument(); });`,
+      output: `expect(await within(container).findByText('foo')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'within() with complex container expression',
+      code: `await waitFor(() => { expect(within(rows[0]).getByRole('button', {name: 'Edit'})).toBeInTheDocument(); });`,
+      output: `expect(await within(rows[0]).findByRole('button', {name: 'Edit'})).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+
+    // --- waitFor options ---
+    {
+      name: 'waitFor with timeout option (getBy has no options)',
+      code: `await waitFor(() => { expect(screen.getByText('Test Item')).toBeInTheDocument(); }, {timeout: 1000});`,
+      output: `expect(await screen.findByText('Test Item', undefined, {timeout: 1000})).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'waitFor with timeout+interval options',
+      code: `await waitFor(() => { expect(screen.getByText('foo')).toBeInTheDocument(); }, {timeout: 2000, interval: 10});`,
+      output: `expect(await screen.findByText('foo', undefined, {timeout: 2000, interval: 10})).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+    {
+      name: 'waitFor with options AND getBy has existing options (2 args)',
+      code: `await waitFor(() => { expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument(); }, {timeout: 5000});`,
+      output: `expect(await screen.findByRole('button', {name: 'Save'}, {timeout: 5000})).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+
+    // --- Argument patterns ---
+    {
+      name: 'regex argument',
+      code: `await waitFor(() => { expect(screen.getByText(/loading complete/i)).toBeInTheDocument(); });`,
+      output: `expect(await screen.findByText(/loading complete/i)).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+
+    // --- Without outer await ---
+    {
+      name: 'waitFor without await (rare)',
+      code: `waitFor(() => { expect(screen.getByText('foo')).toBeInTheDocument(); });`,
+      output: `expect(await screen.findByText('foo')).toBeInTheDocument();`,
+      errors: [{messageId: 'preferFindBy'}],
+    },
+  ],
+});

--- a/static/eslint/eslintPluginSentry/prefer-find-by.ts
+++ b/static/eslint/eslintPluginSentry/prefer-find-by.ts
@@ -1,0 +1,291 @@
+import {AST_NODE_TYPES, ESLintUtils, type TSESTree} from '@typescript-eslint/utils';
+
+const GET_BY_QUERIES = [
+  'getByText',
+  'getByRole',
+  'getByTestId',
+  'getByLabelText',
+  'getByPlaceholderText',
+  'getByDisplayValue',
+  'getByAltText',
+  'getByTitle',
+] as const;
+
+const GET_ALL_BY_QUERIES = [
+  'getAllByText',
+  'getAllByRole',
+  'getAllByTestId',
+  'getAllByLabelText',
+  'getAllByPlaceholderText',
+  'getAllByDisplayValue',
+  'getAllByAltText',
+  'getAllByTitle',
+] as const;
+
+const ALL_GET_QUERIES = new Set<string>([...GET_BY_QUERIES, ...GET_ALL_BY_QUERIES]);
+
+function getReplacementName(name: string): string {
+  if (name.startsWith('getAllBy')) {
+    return name.replace('getAllBy', 'findAllBy');
+  }
+  return name.replace('getBy', 'findBy');
+}
+
+/**
+ * Checks if a node is a call to screen.getBy* / screen.getAllBy* / within(...).getBy* etc.
+ * Returns the method name node if it matches, null otherwise.
+ */
+function getQueryMethodNode(
+  node: TSESTree.Node
+): {methodNode: TSESTree.Identifier; queryName: string} | null {
+  if (node.type !== AST_NODE_TYPES.CallExpression) {
+    return null;
+  }
+
+  const callee = node.callee;
+  if (callee.type !== AST_NODE_TYPES.MemberExpression) {
+    return null;
+  }
+
+  const property = callee.property;
+  if (property.type !== AST_NODE_TYPES.Identifier) {
+    return null;
+  }
+
+  if (!ALL_GET_QUERIES.has(property.name)) {
+    return null;
+  }
+
+  // Must be called on `screen` or `within(...)` (a CallExpression)
+  const object = callee.object;
+  if (object.type === AST_NODE_TYPES.Identifier && object.name === 'screen') {
+    return {methodNode: property, queryName: property.name};
+  }
+
+  if (
+    object.type === AST_NODE_TYPES.CallExpression &&
+    object.callee.type === AST_NODE_TYPES.Identifier &&
+    object.callee.name === 'within'
+  ) {
+    return {methodNode: property, queryName: property.name};
+  }
+
+  return null;
+}
+
+/**
+ * Extracts the single expression from a waitFor callback body.
+ * Returns null if the body has multiple statements or isn't a simple expression.
+ */
+function getSingleExpression(
+  callback: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression
+): TSESTree.Expression | null {
+  const {body} = callback;
+
+  // Expression body: () => expr
+  if (body.type !== AST_NODE_TYPES.BlockStatement) {
+    return body;
+  }
+
+  // Block body with exactly one ExpressionStatement: () => { expr; }
+  if (
+    body.body.length === 1 &&
+    body.body[0]!.type === AST_NODE_TYPES.ExpressionStatement
+  ) {
+    return body.body[0].expression;
+  }
+
+  return null;
+}
+
+/**
+ * Checks if a node is `expect(<query>).matcher(...)` or `expect(<query>).not.matcher(...)`.
+ * Returns the query call node and the expect argument if it matches.
+ */
+function getExpectWithQuery(node: TSESTree.Expression): {
+  queryCall: TSESTree.CallExpression;
+  queryMethod: {methodNode: TSESTree.Identifier; queryName: string};
+} | null {
+  // The outer shape is: someMatcherCall(...)
+  if (node.type !== AST_NODE_TYPES.CallExpression) {
+    return null;
+  }
+
+  // callee is either expect(...).matcher or expect(...).not.matcher
+  let expectCall: TSESTree.CallExpression | null = null;
+
+  const callee = node.callee;
+  if (callee.type === AST_NODE_TYPES.MemberExpression) {
+    const obj = callee.object;
+
+    // expect(...).matcher(...)
+    if (
+      obj.type === AST_NODE_TYPES.CallExpression &&
+      obj.callee.type === AST_NODE_TYPES.Identifier &&
+      obj.callee.name === 'expect'
+    ) {
+      expectCall = obj;
+    }
+
+    // expect(...).not.matcher(...)
+    if (
+      obj.type === AST_NODE_TYPES.MemberExpression &&
+      obj.property.type === AST_NODE_TYPES.Identifier &&
+      obj.property.name === 'not' &&
+      obj.object.type === AST_NODE_TYPES.CallExpression &&
+      obj.object.callee.type === AST_NODE_TYPES.Identifier &&
+      obj.object.callee.name === 'expect'
+    ) {
+      expectCall = obj.object;
+    }
+  }
+
+  if (expectCall?.arguments.length !== 1) {
+    return null;
+  }
+
+  const expectArg = expectCall.arguments[0]!;
+  const queryMethod = getQueryMethodNode(expectArg);
+  if (!queryMethod) {
+    return null;
+  }
+
+  return {
+    queryCall: expectArg as TSESTree.CallExpression,
+    queryMethod,
+  };
+}
+
+export const preferFindBy = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer `findBy*` queries over `waitFor` + `getBy*` for waiting on elements.',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferFindBy:
+        'Prefer `{{findByName}}` over `waitFor` + `{{getByName}}`. Use `expect(await {{receiver}}.{{findByName}}(...))` instead.',
+    },
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        // Match waitFor(...)
+        if (
+          node.callee.type !== AST_NODE_TYPES.Identifier ||
+          node.callee.name !== 'waitFor'
+        ) {
+          return;
+        }
+
+        const callback = node.arguments[0];
+        if (!callback) {
+          return;
+        }
+
+        // Must be an inline arrow or function expression
+        if (
+          callback.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
+          callback.type !== AST_NODE_TYPES.FunctionExpression
+        ) {
+          return;
+        }
+
+        // Skip async callbacks — they use await internally
+        if (callback.async) {
+          return;
+        }
+
+        const singleExpr = getSingleExpression(callback);
+        if (!singleExpr) {
+          return;
+        }
+
+        const match = getExpectWithQuery(singleExpr);
+        if (!match) {
+          return;
+        }
+
+        const {queryCall, queryMethod} = match;
+        const findByName = getReplacementName(queryMethod.queryName);
+
+        // Build the receiver name for the message (screen or within(...))
+        const receiverNode = queryCall.callee as TSESTree.MemberExpression;
+        const receiver =
+          receiverNode.object.type === AST_NODE_TYPES.Identifier
+            ? receiverNode.object.name
+            : 'within(...)';
+
+        context.report({
+          node,
+          messageId: 'preferFindBy',
+          data: {
+            findByName,
+            getByName: queryMethod.queryName,
+            receiver,
+          },
+          fix(fixer) {
+            const sourceCode = context.sourceCode;
+            const waitForOptions = node.arguments[1];
+
+            // Rename getBy* to findBy*
+            const fixes: Array<ReturnType<typeof fixer.replaceText>> = [
+              fixer.replaceText(queryMethod.methodNode, findByName),
+            ];
+
+            // Add `await` before the query call (inside expect)
+            fixes.push(fixer.insertTextBefore(queryCall, 'await '));
+
+            // If waitFor has options, append them to the findBy call
+            if (waitForOptions) {
+              const optionsText = sourceCode.getText(waitForOptions);
+              const queryArgs = queryCall.arguments;
+
+              if (queryArgs.length === 0) {
+                // findByText() → findByText(undefined, optionsText)
+                // Insert before the closing paren of the query call
+                fixes.push(
+                  fixer.insertTextBeforeRange(
+                    [queryCall.range[1] - 1, queryCall.range[1] - 1],
+                    `undefined, ${optionsText}`
+                  )
+                );
+              } else if (queryArgs.length === 1) {
+                // findByText('foo') → findByText('foo', undefined, optionsText)
+                // or findByRole('button', {name: 'x'}) has 2 args
+                const lastArg = queryArgs[queryArgs.length - 1]!;
+                fixes.push(fixer.insertTextAfter(lastArg, `, undefined, ${optionsText}`));
+              } else {
+                // Already has 2+ args (e.g. getByRole('button', {name: 'x'}))
+                // findBy takes (matcher, queryOptions, waitForOptions)
+                const lastArg = queryArgs[queryArgs.length - 1]!;
+                fixes.push(fixer.insertTextAfter(lastArg, `, ${optionsText}`));
+              }
+            }
+
+            // Replace the outer waitFor wrapper with just the inner expression.
+            // We need to handle: `await waitFor(() => { expr; })` or `await waitFor(() => expr)`
+            // The target node might be wrapped in AwaitExpression
+            const outerNode =
+              node.parent?.type === AST_NODE_TYPES.AwaitExpression ? node.parent : node;
+
+            const innerText = sourceCode.getText(singleExpr);
+
+            // We can't use replaceText on the outer node and getText on the inner,
+            // because our other fixes modify the inner. Instead, replace only the
+            // "wrapper" portions: everything before the inner expression and
+            // everything after it.
+            fixes.push(fixer.removeRange([outerNode.range[0], singleExpr.range[0]]));
+            fixes.push(fixer.removeRange([singleExpr.range[1], outerNode.range[1]]));
+
+            return fixes;
+          },
+        });
+      },
+    };
+  },
+});

--- a/static/gsAdmin/components/addToStartupProgramAction.spec.tsx
+++ b/static/gsAdmin/components/addToStartupProgramAction.spec.tsx
@@ -263,12 +263,9 @@ describe('AddToStartupProgramAction', () => {
 
     await userEvent.click(submitButton, {pointerEventsCheck: 0});
 
-    await waitFor(
-      () => {
-        expect(screen.getByRole('spinbutton', {name: 'Credit Amount'})).toBeEnabled();
-      },
-      {timeout: 5_000}
-    );
+    expect(
+      await screen.findByRole('spinbutton', {name: 'Credit Amount'}, {timeout: 5_000})
+    ).toBeEnabled();
     expect(screen.getByRole('textbox', {name: 'Ticket URL'})).toBeEnabled();
     expect(screen.getByRole('button', {name: /submit/i})).toBeEnabled();
   }, 25_000);

--- a/static/gsAdmin/components/changeBalanceAction.spec.tsx
+++ b/static/gsAdmin/components/changeBalanceAction.spec.tsx
@@ -193,9 +193,7 @@ describe('BalanceChangeAction', () => {
     await userEvent.type(screen.getByLabelText('Credit Amount'), '10');
 
     expect(await screen.findByRole('button', {name: /submit/i})).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: /submit/i})).toBeEnabled()
-    );
+    expect(await screen.findByRole('button', {name: /submit/i})).toBeEnabled();
 
     // Disable pointer-events check to avoid false positive in CI
     // where modal overlay may still be settling during initialization
@@ -212,12 +210,9 @@ describe('BalanceChangeAction', () => {
       );
     });
 
-    await waitFor(
-      () => {
-        expect(screen.getByLabelText('Credit Amount')).toBeEnabled();
-      },
-      {timeout: 5_000}
-    );
+    expect(
+      await screen.findByLabelText('Credit Amount', undefined, {timeout: 5_000})
+    ).toBeEnabled();
     expect(screen.getByRole('textbox', {name: 'Ticket URL'})).toBeEnabled();
     expect(screen.getByRole('textbox', {name: 'Notes'})).toBeEnabled();
     expect(screen.getByRole('button', {name: /submit/i})).toBeEnabled();

--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -119,9 +119,7 @@ describe('ChangePlanAction', () => {
     openAndLoadModal();
 
     // Wait for async data to load
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
 
     // Verify the tabs are rendered
     expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
@@ -211,9 +209,7 @@ describe('ChangePlanAction', () => {
     openAndLoadModal();
 
     // Wait for component to load
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
 
     // Select a plan
     await userEvent.click(screen.getAllByRole('radio')[0] as HTMLElement);
@@ -258,9 +254,7 @@ describe('ChangePlanAction', () => {
 
     openAndLoadModal();
 
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
 
     await userEvent.click(screen.getAllByRole('radio')[0] as HTMLElement);
 
@@ -306,9 +300,7 @@ describe('ChangePlanAction', () => {
     openAndLoadModal();
 
     // Wait for component to load
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
 
     // Verify AM3 tier plans are displayed
     expect(screen.getByTestId('change-plan-label-am3_business')).toBeInTheDocument();
@@ -340,9 +332,7 @@ describe('ChangePlanAction', () => {
     openAndLoadModal();
 
     // First, click the TEST tier to activate it
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'TEST'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('tab', {name: 'TEST'})).toBeInTheDocument();
 
     const testTierTab = screen.getByRole('tab', {name: 'TEST'});
     await userEvent.click(testTierTab);
@@ -370,9 +360,7 @@ describe('ChangePlanAction', () => {
     openAndLoadModal();
 
     // Wait for component to load
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'TEST'})).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('tab', {name: 'TEST'})).toBeInTheDocument();
 
     // Click on the TEST tier tab (if not already active)
     const testTierTab = screen.getByRole('tab', {name: 'TEST'});
@@ -428,9 +416,7 @@ describe('ChangePlanAction', () => {
     it('shows Seer budget checkbox for AM tiers', async () => {
       openAndLoadModal();
 
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
+      expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
       await userEvent.click(screen.getAllByRole('radio')[0] as HTMLElement);
 
       expect(screen.getByText('Seer')).toBeInTheDocument();
@@ -451,9 +437,7 @@ describe('ChangePlanAction', () => {
     it('hides Seer budget checkbox for MM2 tier', async () => {
       openAndLoadModal();
 
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
+      expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
 
       const mm2Tab = screen.getByRole('tab', {name: 'MM2'});
       await userEvent.click(mm2Tab);
@@ -484,9 +468,7 @@ describe('ChangePlanAction', () => {
       await openAndLoadModal({subscription: subscriptionWithSeer});
 
       // Wait for component to load
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
+      expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
 
       // Select a plan to make the Available Products section visible
       await userEvent.click(screen.getAllByRole('radio')[0] as HTMLElement);
@@ -502,9 +484,7 @@ describe('ChangePlanAction', () => {
       openAndLoadModal({});
 
       // Wait for component to load
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
+      expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
 
       // Select a plan to make the Available Products section visible
       await userEvent.click(screen.getAllByRole('radio')[0] as HTMLElement);
@@ -527,9 +507,7 @@ describe('ChangePlanAction', () => {
       openAndLoadModal({});
 
       // Wait for component to load
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
+      expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
 
       // Select a plan
       await userEvent.click(screen.getAllByRole('radio')[0] as HTMLElement);
@@ -587,9 +565,7 @@ describe('ChangePlanAction', () => {
       openAndLoadModal({});
 
       // Wait for component to load
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
+      expect(await screen.findByRole('tab', {name: 'AM3'})).toBeInTheDocument();
 
       // Select a plan
       await userEvent.click(screen.getAllByRole('radio')[0] as HTMLElement);

--- a/static/gsAdmin/components/customers/customerInvoices.spec.tsx
+++ b/static/gsAdmin/components/customers/customerInvoices.spec.tsx
@@ -32,9 +32,7 @@ describe('CustomerInvoices', () => {
 
       render(<CustomerInvoices orgId={orgId} region={region} />);
 
-      await waitFor(() => {
-        expect(screen.getByText('Paid')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Paid')).toBeInTheDocument();
 
       // Verify that invoice status is paid
       expect(screen.getByText('Paid')).toBeInTheDocument();
@@ -57,9 +55,7 @@ describe('CustomerInvoices', () => {
 
       render(<CustomerInvoices orgId={orgId} region={region} />);
 
-      await waitFor(() => {
-        expect(screen.getByText('Closed')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Closed')).toBeInTheDocument();
 
       // Verify that invoice status is closed
       expect(screen.getByText('Closed')).toBeInTheDocument();
@@ -86,9 +82,7 @@ describe('CustomerInvoices', () => {
 
       render(<CustomerInvoices orgId={orgId} region={region} />);
 
-      await waitFor(() => {
-        expect(screen.getByText('Pending')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Pending')).toBeInTheDocument();
 
       // Verify that invoice status is pending
       expect(screen.getByText('Pending')).toBeInTheDocument();
@@ -132,9 +126,7 @@ describe('CustomerInvoices', () => {
 
       render(<CustomerInvoices orgId={orgId} region={region} />);
 
-      await waitFor(() => {
-        expect(screen.getByText('Paid')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Paid')).toBeInTheDocument();
       expect(screen.getByText('Closed')).toBeInTheDocument();
       expect(screen.getByText('Pending')).toBeInTheDocument();
     });
@@ -160,9 +152,7 @@ describe('CustomerInvoices', () => {
       render(<CustomerInvoices orgId={orgId} region={region} />);
 
       // Wait for date to be displayed (moment format 'll')
-      await waitFor(() => {
-        expect(screen.getByText(/Jan.*2024/i)).toBeInTheDocument();
-      });
+      expect(await screen.findByText(/Jan.*2024/i)).toBeInTheDocument();
 
       // Check Stripe ID is displayed
       expect(screen.getByText('in_test123456')).toBeInTheDocument();
@@ -189,9 +179,7 @@ describe('CustomerInvoices', () => {
 
       render(<CustomerInvoices orgId={orgId} region={region} />);
 
-      await waitFor(() => {
-        expect(screen.getByText('n/a')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('n/a')).toBeInTheDocument();
     });
 
     it('displays refund information for refunded invoices', async () => {
@@ -211,10 +199,7 @@ describe('CustomerInvoices', () => {
 
       render(<CustomerInvoices orgId={orgId} region={region} />);
 
-      await waitFor(() => {
-        // Check that refund information is displayed (text is split across elements)
-        expect(screen.getByText(/refunded/i)).toBeInTheDocument();
-      });
+      expect(await screen.findByText(/refunded/i)).toBeInTheDocument();
     });
   });
 
@@ -301,9 +286,7 @@ describe('CustomerInvoices', () => {
 
       render(<CustomerInvoices orgId={orgId} region={region} />);
 
-      await waitFor(() => {
-        expect(screen.getByText('$0')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('$0')).toBeInTheDocument();
     });
   });
 
@@ -317,9 +300,7 @@ describe('CustomerInvoices', () => {
       render(<CustomerInvoices orgId={orgId} region={region} />);
 
       // Verify table headers are rendered
-      await waitFor(() => {
-        expect(screen.getByText('Invoice')).toBeInTheDocument();
-      });
+      expect(await screen.findByText('Invoice')).toBeInTheDocument();
       expect(screen.getByText('Stripe ID')).toBeInTheDocument();
       expect(screen.getByText('Channel')).toBeInTheDocument();
       expect(screen.getByText('Status')).toBeInTheDocument();

--- a/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
@@ -87,11 +87,11 @@ describe('DeleteBillingMetricHistory', () => {
     });
 
     // Check for the description text
-    await waitFor(() => {
-      expect(
-        screen.getByText('Delete billing metric history for a specific data category.')
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(
+        'Delete billing metric history for a specific data category.'
+      )
+    ).toBeInTheDocument();
 
     // Check that the form elements are rendered
     expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
@@ -153,9 +153,9 @@ describe('DeleteBillingMetricHistory', () => {
     });
 
     // Wait for the form to be visible
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('textbox', {name: 'Data Category'})
+    ).toBeInTheDocument();
 
     // Select a data category
     await selectEvent.select(
@@ -232,9 +232,9 @@ describe('DeleteBillingMetricHistory', () => {
     });
 
     // Wait for the form to be visible
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('textbox', {name: 'Data Category'})
+    ).toBeInTheDocument();
 
     // Select a data category
     await selectEvent.select(
@@ -286,9 +286,9 @@ describe('DeleteBillingMetricHistory', () => {
     });
 
     // Wait for the form to be visible
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('textbox', {name: 'Data Category'})
+    ).toBeInTheDocument();
 
     // Check that the Delete button is disabled when no data category is selected
     expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
@@ -336,9 +336,9 @@ describe('DeleteBillingMetricHistory', () => {
     expect(screen.getByText('Delete Billing Metric History')).toBeInTheDocument();
 
     // Wait for the form to be visible
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('textbox', {name: 'Data Category'})
+    ).toBeInTheDocument();
 
     // Click the Cancel button
     await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));

--- a/static/gsAdmin/views/billingPlans.spec.tsx
+++ b/static/gsAdmin/views/billingPlans.spec.tsx
@@ -107,9 +107,7 @@ describe('BillingPlans Component', () => {
     render(<BillingPlans />);
 
     // Wait for the Table of Contents to be rendered
-    await waitFor(() => {
-      expect(screen.getByText('Table of Contents')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Table of Contents')).toBeInTheDocument();
 
     expect(await screen.findByRole('link', {name: /AM9000\s+Plans/})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: /Business/})).toBeInTheDocument();
@@ -121,9 +119,7 @@ describe('BillingPlans Component', () => {
     render(<BillingPlans />);
 
     // Wait for the pricing tables to be rendered
-    await waitFor(() => {
-      expect(screen.getByText('Pricing:')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Pricing:')).toBeInTheDocument();
 
     // Check that pricing information is displayed
     expect(
@@ -137,9 +133,7 @@ describe('BillingPlans Component', () => {
     render(<BillingPlans />);
 
     // Wait for the price tiers tables to be rendered
-    await waitFor(() => {
-      expect(screen.getByText('Errors for AM9000 Business')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Errors for AM9000 Business')).toBeInTheDocument();
 
     // Check that price tier information is displayed
     expect(await screen.findByText('Tier')).toBeInTheDocument();

--- a/static/gsAdmin/views/relocationDetails.spec.tsx
+++ b/static/gsAdmin/views/relocationDetails.spec.tsx
@@ -134,8 +134,8 @@ describe('Relocation Details', () => {
       },
     });
 
-    await waitFor(() => expect(screen.getAllByText('Working')).toHaveLength(1));
-    await waitFor(() => expect(screen.getAllByText('--')).toHaveLength(2));
+    expect(await screen.findAllByText('Working')).toHaveLength(1);
+    expect(await screen.findAllByText('--')).toHaveLength(2);
 
     const {waitForModalToHide} = renderGlobalModal();
 
@@ -243,8 +243,8 @@ describe('Relocation Details', () => {
       },
     });
 
-    await waitFor(() => expect(screen.getAllByText('Paused')).toHaveLength(1));
-    await waitFor(() => expect(screen.getAllByText('--')).toHaveLength(3));
+    expect(await screen.findAllByText('Paused')).toHaveLength(1);
+    expect(await screen.findAllByText('--')).toHaveLength(3);
 
     const {waitForModalToHide} = renderGlobalModal();
 
@@ -348,8 +348,8 @@ describe('Relocation Details', () => {
       },
     });
 
-    await waitFor(() => expect(screen.getAllByText('Working')).toHaveLength(1));
-    await waitFor(() => expect(screen.getAllByText('--')).toHaveLength(2));
+    expect(await screen.findAllByText('Working')).toHaveLength(1);
+    expect(await screen.findAllByText('--')).toHaveLength(2);
 
     const {waitForModalToHide} = renderGlobalModal();
 

--- a/static/gsApp/components/billingDetails/form.spec.tsx
+++ b/static/gsApp/components/billingDetails/form.spec.tsx
@@ -63,16 +63,13 @@ describe('BillingDetailsForm', () => {
 
     render(<BillingDetailsForm {...defaultProps} />);
 
-    await waitFor(
-      () => {
-        expect(
-          screen.getByText(
-            /To add or update your business address, you may need to disable any ad or tracker blocking extensions/
-          )
-        ).toBeInTheDocument();
-      },
-      {timeout: 11000} // the timeout in the code is 10 seconds so we need to wait longer
-    );
+    expect(
+      await screen.findByText(
+        /To add or update your business address, you may need to disable any ad or tracker blocking extensions/,
+        undefined,
+        {timeout: 11000}
+      )
+    ).toBeInTheDocument();
 
     jest.restoreAllMocks();
   }, 15000);

--- a/static/gsApp/views/amCheckout/components/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.spec.tsx
@@ -381,10 +381,8 @@ describe('Cart', () => {
     );
 
     // wait for preview to be loaded
-    await waitFor(() =>
-      expect(screen.getByTestId('summary-item-due-today')).toHaveTextContent(
-        'Due on Jun 7, 2023$89USD'
-      )
+    expect(await screen.findByTestId('summary-item-due-today')).toHaveTextContent(
+      'Due on Jun 7, 2023$89USD'
     );
     expect(screen.getByTestId('summary-item-plan-total')).toHaveTextContent('$89');
     expect(
@@ -425,11 +423,8 @@ describe('Cart', () => {
     );
 
     // wait for preview to be loaded
-    await waitFor(() =>
-      // shows original price and price after credits + additional fees
-      expect(screen.getByTestId('summary-item-due-today')).toHaveTextContent(
-        'Due today$89 $0USD'
-      )
+    expect(await screen.findByTestId('summary-item-due-today')).toHaveTextContent(
+      'Due today$89 $0USD'
     );
     expect(screen.getByRole('button', {name: 'Confirm'})).toBeInTheDocument();
     expect(
@@ -511,9 +506,7 @@ describe('Cart', () => {
     );
 
     // wait for preview to be loaded
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Confirm and pay'})).toBeEnabled()
-    );
+    expect(await screen.findByRole('button', {name: 'Confirm and pay'})).toBeEnabled();
     screen.getByText(/you will be billed by Partner/);
   });
 


### PR DESCRIPTION
Adds an internal `sentry/prefer-find-by` lint rule that acts as a stricter form of [`testing-library/prefer-find-by`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/prefer-find-by.md). We now additionally catch:

* Block-body arrows: `waitFor(() => { expect(screen.getByText(...)).toBeInTheDocument(); })` -- the community rule's docs say it only handles "an arrow function with only one statement (that is, without a block of statements)"
* Non-presence assertions: `waitFor(() => expect(screen.getByText('bar')).toBeDisabled())` is listed as "correct" in their docs

Made with [Cursor](https://cursor.com)