### PR TITLE
fix(agents): Make negative cost tooltip hoverable for clickable link

### DIFF
--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -24,6 +24,7 @@ export function NegativeCostWarning({children}: {children: React.ReactNode}) {
         }
       )}
       skipWrapper
+      isHoverable
     >
       <Flex as="span" display="inline-flex" align="center" gap="xs">
         <IconWarning legacySize="1em" variant="warning" />


### PR DESCRIPTION
The negative cost warning tooltip contains a docs link but closes before users can click it. Add `isHoverable` to the Tooltip so it stays open while hovering over its content.

One-line fix in `NegativeCostWarning` — propagates to both `CurrencyCell` (tables) and the platformized dashboard widget footer (`visualizationWidget.tsx`).

Follows up on #111986.