### PR TITLE
feat(preprod): Add app identifier to size analysis alert notifications

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -82,9 +82,9 @@ def _get_measurement_label(measurement: str, platform: str) -> str:
 
 
 def _build_identifier_prefix(metadata: SizeAnalysisMetadata | None) -> str:
-    """Build an app identifier prefix like 'MyApp, android (com.example.app) — '.
+    """Build an app identifier prefix like 'MyApp android (com.example.app) — '.
 
-    Returns empty string if no metadata or no useful identifiers are available.
+    Returns empty string if no metadata is available.
     """
     if metadata is None:
         return ""
@@ -100,9 +100,6 @@ def _build_identifier_prefix(metadata: SizeAnalysisMetadata | None) -> str:
 
     if head_artifact.app_id:
         parts.append(f"({head_artifact.app_id})")
-
-    if not parts:
-        return ""
 
     return " ".join(parts) + " — "
 

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -81,19 +81,46 @@ def _get_measurement_label(measurement: str, platform: str) -> str:
     return measurement.replace("_", " ").title()
 
 
+def _build_identifier_prefix(metadata: SizeAnalysisMetadata | None) -> str:
+    """Build an app identifier prefix like 'MyApp, android (com.example.app) — '.
+
+    Returns empty string if no metadata or no useful identifiers are available.
+    """
+    if metadata is None:
+        return ""
+
+    head_artifact = metadata["head_artifact"]
+    parts: list[str] = []
+
+    mobile_app_info = head_artifact.get_mobile_app_info()
+    if mobile_app_info is not None and mobile_app_info.app_name:
+        parts.append(mobile_app_info.app_name)
+
+    parts.append(metadata["platform"])
+
+    if head_artifact.app_id:
+        parts.append(f"({head_artifact.app_id})")
+
+    if not parts:
+        return ""
+
+    return " ".join(parts) + " — "
+
+
 def _build_evidence_text(
     detector_config: dict[str, Any],
     evaluation_result: ProcessedDataConditionGroup,
     data_packet: SizeAnalysisDataPacket,
     platform: str,
 ) -> str:
-    """Build a single-line evidence string for Slack/Jira notifications.
+    """Build evidence string for Slack/Jira notifications.
 
-    Format: {measurement}, {threshold_type} > {threshold_value} ({actual_value})
-    Example: Install Size, Absolute Diff > 1.0 MB (+1.0 MB)
+    Format: {app_name}, {platform} ({bundle}) — {measurement}, {threshold_type} > {threshold} ({actual_value})
+    Example: MyApp, android (com.example.app) — Install Size, Absolute Diff > 1.0 MB (+1.0 MB)
     """
     from sentry.preprod.utils import format_bytes_base10
 
+    metadata = data_packet.packet.get("metadata")
     measurement = detector_config["measurement"]
     threshold_type = detector_config["threshold_type"]
     measurement_label = _get_measurement_label(measurement, platform)
@@ -134,7 +161,8 @@ def _build_evidence_text(
         sign = "+" if delta >= 0 else "-"
         actual_value = f"{sign}{delta_formatted}"
 
-    return f"{measurement_label}{threshold_part} ({actual_value})"
+    identifier = _build_identifier_prefix(metadata)
+    return f"{identifier}{measurement_label}{threshold_part} ({actual_value})"
 
 
 class SizeAnalysisMetadata(TypedDict):

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -954,16 +954,20 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
         evidence = occurrence.evidence_display[0]
         assert evidence.value == "Download Size, Relative Diff > 5% (+20.0%)"
 
-    def _make_metadata(self, platform: str, artifact_type: int) -> dict[str, Any]:
+    def _make_metadata(
+        self, platform: str, artifact_type: int, app_name: str = "MyApp"
+    ) -> dict[str, Any]:
         head_artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",
             artifact_type=artifact_type,
+            app_name=app_name,
         )
         base_artifact = self.create_preprod_artifact(
             project=self.project,
             app_id="com.example.app",
             artifact_type=artifact_type,
+            app_name=app_name,
         )
         head_artifact = PreprodArtifact.objects.select_related(
             "mobile_app_info", "commit_comparison"
@@ -992,7 +996,10 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
             metadata=metadata,
         )
         evidence = occurrence.evidence_display[0]
-        assert evidence.value == "Uncompressed Size, Absolute Size > 1.0 MB (5.0 MB)"
+        assert (
+            evidence.value
+            == "MyApp android (com.example.app) — Uncompressed Size, Absolute Size > 1.0 MB (5.0 MB)"
+        )
 
     def test_evidence_apple_shows_install_size(self) -> None:
         self._create_condition(Condition.GREATER, 1000000)
@@ -1005,4 +1012,7 @@ class PreprodSizeAnalysisEvidenceTextTest(TestCase):
             metadata=metadata,
         )
         evidence = occurrence.evidence_display[0]
-        assert evidence.value == "Install Size, Absolute Size > 1.0 MB (5.0 MB)"
+        assert (
+            evidence.value
+            == "MyApp apple (com.example.app) — Install Size, Absolute Size > 1.0 MB (5.0 MB)"
+        )


### PR DESCRIPTION
Adds app name, platform, and bundle ID as a prefix to the evidence display text in size analysis Slack/Jira notifications. This gives recipients immediate context about which app triggered the alert without clicking through.

**Before:** `Install Size, Absolute Diff > 1.0 MB (+1.0 MB)`
**After:** `MyApp android (com.example.app) — Install Size, Absolute Diff > 1.0 MB (+1.0 MB)`

When metadata is unavailable (e.g. no artifact info), the output is unchanged.

Builds on #111660.