### PR TITLE
feat(github): Add frontend implementation for GitHub integration pipeline

### DIFF
--- a/static/app/components/pipeline/index.stories.tsx
+++ b/static/app/components/pipeline/index.stories.tsx
@@ -10,7 +10,11 @@ import * as Storybook from 'sentry/stories';
 
 import {openPipelineModal} from './modal';
 import {PIPELINE_REGISTRY} from './registry';
-import type {ProvidersByType, RegisteredPipelineType} from './registry';
+import type {
+  CompletionDataFor,
+  ProvidersByType,
+  RegisteredPipelineType,
+} from './registry';
 import {usePipeline} from './usePipeline';
 
 const pipelineMenuItems = PIPELINE_REGISTRY.map(p => ({
@@ -123,7 +127,7 @@ function PipelineRunner({
 }
 
 function PipelineModalDemo() {
-  const [result, setResult] = useState<Record<string, unknown> | null>(null);
+  const [result, setResult] = useState<CompletionDataFor<any, any> | null>(null);
 
   return (
     <Flex direction="column" gap="lg">

--- a/static/app/components/pipeline/pipelineIntegrationGitHub.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHub.tsx
@@ -1,0 +1,283 @@
+import {useCallback} from 'react';
+
+import {Avatar} from '@sentry/scraps/avatar';
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {HookOrDefault} from 'sentry/components/hookOrDefault';
+import {t, tn} from 'sentry/locale';
+import type {ScmGithubMultiOrgInstallProps} from 'sentry/types/hooks';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {OAuthCallbackData} from './shared/oauthLoginStep';
+import {OAuthLoginStep} from './shared/oauthLoginStep';
+import {useRedirectPopupStep} from './shared/useRedirectPopupStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+export interface InstallationInfo {
+  avatarUrl: string;
+  githubAccount: string;
+  installationId: string;
+  count?: number | null;
+}
+
+interface OrgSelectionStepData {
+  installAppUrl?: string;
+  installationInfo?: InstallationInfo[];
+}
+
+interface OrgSelectionAdvanceData {
+  chosenInstallationId?: string;
+  installationId?: string;
+}
+
+function GitHubOAuthLoginStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<
+  {oauthUrl?: string},
+  {code: string; state: string; installationId?: string}
+>) {
+  const handleOAuthCallback = useCallback(
+    (data: OAuthCallbackData) => {
+      advance({
+        code: data.code,
+        state: data.state,
+        installationId: data.rest.installation_id,
+      });
+    },
+    [advance]
+  );
+
+  return (
+    <OAuthLoginStep
+      oauthUrl={stepData.oauthUrl}
+      isLoading={isAdvancing}
+      serviceName="GitHub"
+      onOAuthCallback={handleOAuthCallback}
+    />
+  );
+}
+
+export const NEW_INSTALL_KEY = '_new_install';
+
+export function buildInstallationMenuItems(
+  installations: InstallationInfo[],
+  options?: {newInstallDisabled?: boolean}
+) {
+  return [
+    ...installations.map(inst => ({
+      key: inst.installationId,
+      leadingItems: (
+        <Avatar
+          size={24}
+          type="upload"
+          identifier={inst.installationId}
+          uploadUrl={inst.avatarUrl}
+          name={inst.githubAccount}
+        />
+      ),
+      label: `github.com/${inst.githubAccount}`,
+      details: inst.count
+        ? tn(
+            'Connected to %s other Sentry organization',
+            'Connected to %s other Sentry organizations',
+            inst.count
+          )
+        : undefined,
+    })),
+    {
+      key: NEW_INSTALL_KEY,
+      label: t('Install on a new GitHub organization'),
+      disabled: options?.newInstallDisabled,
+    },
+  ];
+}
+
+function DefaultGitHubMultiOrgInstall({
+  installations,
+  onSelectInstallation,
+  onNewInstall,
+  isDisabled,
+  newInstallDisabled,
+  popupBlockedNotice,
+}: ScmGithubMultiOrgInstallProps) {
+  const menuItems = buildInstallationMenuItems(installations, {newInstallDisabled});
+
+  return (
+    <Stack gap="lg" align="start">
+      {popupBlockedNotice}
+      <DropdownMenu
+        triggerLabel={t('Select GitHub organization')}
+        items={menuItems}
+        isDisabled={isDisabled}
+        onAction={key => {
+          if (key === NEW_INSTALL_KEY) {
+            onNewInstall();
+          } else {
+            onSelectInstallation(key as string);
+          }
+        }}
+      />
+    </Stack>
+  );
+}
+
+const GitHubMultiOrgInstall = HookOrDefault({
+  hookName: 'component:scm-github-multi-org-install',
+  defaultComponent: DefaultGitHubMultiOrgInstall,
+});
+
+function OrgSelectionStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<OrgSelectionStepData, OrgSelectionAdvanceData>) {
+  const installations = stepData.installationInfo ?? [];
+
+  const handleInstallCallback = useCallback(
+    (data: Record<string, unknown>) => {
+      advance({
+        installationId: data.installation_id as string,
+      });
+    },
+    [advance]
+  );
+
+  const {openPopup, isWaitingForCallback, popupStatus} = useRedirectPopupStep({
+    redirectUrl: stepData.installAppUrl,
+    onCallback: handleInstallCallback,
+  });
+
+  // TODO(epurkhiser): Once we remove the legacy django views the function that
+  // generates this sentinel "Integrate with a new github organization" can be
+  // changed to not add this and we can drop this value here also
+  const existingInstallations = installations.filter(
+    inst => inst.installationId !== '-1'
+  );
+
+  if (existingInstallations.length === 0) {
+    return (
+      <FreshInstallSteps
+        isAdvancing={isAdvancing}
+        isWaitingForCallback={isWaitingForCallback}
+        popupBlockedNotice={
+          popupStatus === 'failed-to-open' ? <PopupBlockedNotice /> : undefined
+        }
+        installDisabled={!stepData.installAppUrl}
+        onInstall={openPopup}
+      />
+    );
+  }
+
+  return (
+    <Stack gap="lg" align="start">
+      <Text>
+        {t(
+          "Select the GitHub organization you'd like to connect to Sentry, or install the Sentry GitHub App on a GitHub organization that does not already have the app installed."
+        )}
+      </Text>
+      <GitHubMultiOrgInstall
+        installations={existingInstallations}
+        onSelectInstallation={installationId =>
+          advance({chosenInstallationId: installationId})
+        }
+        onNewInstall={openPopup}
+        isDisabled={isAdvancing}
+        newInstallDisabled={!stepData.installAppUrl}
+        popupBlockedNotice={
+          popupStatus === 'failed-to-open' ? <PopupBlockedNotice /> : undefined
+        }
+      />
+    </Stack>
+  );
+}
+
+function FreshInstallSteps({
+  isAdvancing,
+  isWaitingForCallback,
+  popupBlockedNotice,
+  installDisabled,
+  onInstall,
+}: {
+  installDisabled: boolean;
+  isAdvancing: boolean;
+  isWaitingForCallback: boolean;
+  onInstall: () => void;
+  popupBlockedNotice?: React.ReactNode;
+}) {
+  if (isAdvancing) {
+    return (
+      <Stack gap="lg" align="start">
+        <Text>
+          {t(
+            'Complete the installation in the popup window. Once finished, this page will update automatically.'
+          )}
+        </Text>
+        <Button size="sm" disabled>
+          {t('Completing...')}
+        </Button>
+      </Stack>
+    );
+  }
+
+  if (isWaitingForCallback) {
+    return (
+      <Stack gap="lg" align="start">
+        <Text>
+          {t(
+            'Complete the installation in the popup window. Once finished, this page will update automatically.'
+          )}
+        </Text>
+        <Button size="sm" onClick={onInstall}>
+          {t('Reopen installation window')}
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="lg" align="start">
+      <Text>
+        {t('Install the Sentry GitHub App on a GitHub organization to get started.')}
+      </Text>
+      {popupBlockedNotice}
+      <Button size="sm" priority="primary" onClick={onInstall} disabled={installDisabled}>
+        {t('Install GitHub App')}
+      </Button>
+    </Stack>
+  );
+}
+
+function PopupBlockedNotice() {
+  return (
+    <Text variant="danger" size="sm">
+      {t(
+        'The installation popup was blocked by your browser. Please ensure popups are allowed and try again.'
+      )}
+    </Text>
+  );
+}
+
+export const githubIntegrationPipeline = {
+  type: 'integration',
+  provider: 'github',
+  actionTitle: t('Installing GitHub Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  steps: [
+    {
+      stepId: 'oauth_login',
+      shortDescription: t('Authorizing via GitHub OAuth flow'),
+      component: GitHubOAuthLoginStep,
+    },
+    {
+      stepId: 'org_selection',
+      shortDescription: t('Installing GitHub Application'),
+      component: OrgSelectionStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,9 +1,13 @@
 import {dummyIntegrationPipeline} from './pipelineDummyProvider';
+import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 
 /**
  * All registered pipeline definitions.
  */
-export const PIPELINE_REGISTRY = [dummyIntegrationPipeline] as const;
+export const PIPELINE_REGISTRY = [
+  dummyIntegrationPipeline,
+  githubIntegrationPipeline,
+] as const;
 
 type AllPipelines = (typeof PIPELINE_REGISTRY)[number];
 

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -3,6 +3,7 @@ import type {ButtonProps} from '@sentry/scraps/button';
 import type {ChildrenRenderFn} from 'sentry/components/acl/feature';
 import type {Guide} from 'sentry/components/assistant/types';
 import type {ProductSelectionProps} from 'sentry/components/onboarding/productSelection';
+import type {InstallationInfo} from 'sentry/components/pipeline/pipelineIntegrationGitHub';
 import type {DateRange} from 'sentry/components/timeRangeSelector/dateRange';
 import type {SelectorItems} from 'sentry/components/timeRangeSelector/selectorItems';
 import type {SentryRouteObject} from 'sentry/router/types';
@@ -136,6 +137,15 @@ type FirstPartyIntegrationAlertProps = {
   wrapWithContainer?: boolean;
 };
 
+export type ScmGithubMultiOrgInstallProps = {
+  installations: InstallationInfo[];
+  onNewInstall: () => void;
+  onSelectInstallation: (installationId: string) => void;
+  isDisabled?: boolean;
+  newInstallDisabled?: boolean;
+  popupBlockedNotice?: React.ReactNode;
+};
+
 type FirstPartyIntegrationAdditionalCTAProps = {
   integrations: Integration[];
 };
@@ -223,6 +233,7 @@ type ComponentHooks = {
   'component:replay-onboarding-alert': () => React.ComponentType<ReplayOnboardingAlertProps>;
   'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardingCTAProps>;
   'component:replay-settings-alert': () => React.ComponentType | null;
+  'component:scm-github-multi-org-install': () => React.ComponentType<ScmGithubMultiOrgInstallProps>;
   'component:seer-beta-closing-alert': () => React.ComponentType;
   'component:superuser-access-category': React.ComponentType<any>;
   'component:superuser-warning': React.ComponentType<any>;

--- a/static/gsApp/hooks/scmGithubMultiOrgInstall.spec.tsx
+++ b/static/gsApp/hooks/scmGithubMultiOrgInstall.spec.tsx
@@ -1,0 +1,156 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {ScmGithubMultiOrgInstall} from 'getsentry/hooks/scmGithubMultiOrgInstall';
+import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
+import {PlanTier} from 'getsentry/types';
+
+function makeInstallations(
+  overrides?: Array<Partial<Parameters<typeof makeInstallation>[0]>>
+) {
+  const defaults = [
+    {installationId: '100', githubAccount: 'my-org', count: 0},
+    {installationId: '200', githubAccount: 'other-org', count: 2},
+  ];
+  return (overrides ?? defaults).map(makeInstallation);
+}
+
+function makeInstallation(
+  partial: Partial<{
+    avatarUrl: string;
+    count: number;
+    githubAccount: string;
+    installationId: string;
+  }> = {}
+) {
+  return {
+    installationId: '100',
+    githubAccount: 'my-org',
+    avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+    count: 0,
+    ...partial,
+  };
+}
+
+describe('ScmGithubMultiOrgInstall', () => {
+  const onSelectInstallation = jest.fn();
+  const onNewInstall = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockApiClient.clearMockResponses();
+  });
+
+  function renderComponent({
+    hasFeature = false,
+    installations = makeInstallations(),
+    withSubscription = true,
+  }: {
+    hasFeature?: boolean;
+    installations?: ReturnType<typeof makeInstallations>;
+    withSubscription?: boolean;
+  } = {}) {
+    const organization = OrganizationFixture({
+      features: hasFeature ? ['integrations-scm-multi-org'] : [],
+    });
+
+    if (withSubscription) {
+      const subscription = SubscriptionFixture({organization});
+      SubscriptionStore.set(organization.slug, subscription);
+
+      MockApiClient.addMockResponse({
+        url: `/customers/${organization.slug}/billing-config/`,
+        query: {tier: 'am2'},
+        body: BillingConfigFixture(PlanTier.AM2),
+      });
+    }
+
+    return render(
+      <ScmGithubMultiOrgInstall
+        installations={installations}
+        onSelectInstallation={onSelectInstallation}
+        onNewInstall={onNewInstall}
+      />,
+      {organization}
+    );
+  }
+
+  it('renders dropdown without alert when org has scm-multi-org feature', () => {
+    renderComponent({hasFeature: true});
+
+    expect(
+      screen.getByRole('button', {name: 'Select GitHub organization'})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/already connected to other Sentry organizations/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders dropdown without alert when no installations have count > 0', () => {
+    renderComponent({
+      hasFeature: false,
+      installations: [
+        makeInstallation({installationId: '100', githubAccount: 'my-org', count: 0}),
+        makeInstallation({
+          installationId: '200',
+          githubAccount: 'other-org',
+          count: 0,
+        }),
+      ],
+    });
+
+    expect(
+      screen.getByRole('button', {name: 'Select GitHub organization'})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/already connected to other Sentry organizations/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows upgrade alert when org lacks feature and has multi-org installations', () => {
+    renderComponent({hasFeature: false});
+
+    expect(
+      screen.getByText(/already connected to other Sentry organizations/)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Upgrade')).toBeInTheDocument();
+  });
+
+  it('upgrade link points to billing page in new tab', () => {
+    renderComponent({hasFeature: false});
+
+    const link = screen.getByText('Upgrade').closest('a');
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringContaining('/billing/overview/?referrer=upgrade-github-multi-org')
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('calls onSelectInstallation when clicking a non-multi-org item', async () => {
+    renderComponent({hasFeature: true});
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Select GitHub organization'})
+    );
+    await userEvent.click(await screen.findByText('github.com/my-org'));
+
+    expect(onSelectInstallation).toHaveBeenCalledWith('100');
+  });
+
+  it('calls onNewInstall when clicking new install option', async () => {
+    renderComponent({hasFeature: true});
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Select GitHub organization'})
+    );
+    await userEvent.click(
+      await screen.findByText('Install on a new GitHub organization')
+    );
+
+    expect(onNewInstall).toHaveBeenCalled();
+  });
+});

--- a/static/gsApp/hooks/scmGithubMultiOrgInstall.tsx
+++ b/static/gsApp/hooks/scmGithubMultiOrgInstall.tsx
@@ -1,0 +1,149 @@
+import {Alert} from '@sentry/scraps/alert';
+import {LinkButton} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {
+  buildInstallationMenuItems,
+  NEW_INSTALL_KEY,
+} from 'sentry/components/pipeline/pipelineIntegrationGitHub';
+import {IconLightning} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import type {ScmGithubMultiOrgInstallProps} from 'sentry/types/hooks';
+import type {Organization} from 'sentry/types/organization';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {useBillingConfig} from 'getsentry/hooks/useBillingConfig';
+import {useSubscription} from 'getsentry/hooks/useSubscription';
+import type {BillingConfig, Subscription} from 'getsentry/types';
+import {displayPlanName} from 'getsentry/utils/billing';
+
+export function ScmGithubMultiOrgInstall({
+  installations,
+  onSelectInstallation,
+  onNewInstall,
+  isDisabled,
+  newInstallDisabled,
+  popupBlockedNotice,
+}: ScmGithubMultiOrgInstallProps) {
+  const organization = useOrganization();
+  const subscription = useSubscription();
+
+  const hasSCMMultiOrg = organization.features.includes('integrations-scm-multi-org');
+  const hasMultiOrgInstallations = installations.some(inst => (inst.count ?? 0) > 0);
+  const needsUpgrade = !hasSCMMultiOrg && hasMultiOrgInstallations;
+
+  const menuItems = buildInstallationMenuItems(installations, {newInstallDisabled}).map(
+    item => {
+      if (item.key === NEW_INSTALL_KEY) {
+        return item;
+      }
+      const inst = installations.find(i => i.installationId === item.key);
+      const isMultiOrg = (inst?.count ?? 0) > 0;
+      return {...item, disabled: needsUpgrade && isMultiOrg};
+    }
+  );
+
+  return (
+    <Stack gap="lg" align="start">
+      {needsUpgrade && (
+        <Alert
+          variant="warning"
+          trailingItems={
+            <LinkButton
+              size="xs"
+              priority="primary"
+              icon={<IconLightning />}
+              href={`/settings/${organization.slug}/billing/overview/?referrer=upgrade-github-multi-org`}
+              external
+              analyticsEventKey="github.multi_org.upsell"
+              analyticsEventName="Github Multi-Org Upsell Clicked"
+            >
+              {t('Upgrade')}
+            </LinkButton>
+          }
+        >
+          <UpgradeMessage subscription={subscription} />
+        </Alert>
+      )}
+      {popupBlockedNotice}
+      <DropdownMenu
+        triggerLabel={t('Select GitHub organization')}
+        items={menuItems}
+        isDisabled={isDisabled}
+        onAction={key => {
+          if (key === NEW_INSTALL_KEY) {
+            onNewInstall();
+          } else {
+            onSelectInstallation(key as string);
+          }
+        }}
+      />
+    </Stack>
+  );
+}
+
+function UpgradeMessage({subscription}: {subscription: Subscription | null}) {
+  const organization = useOrganization();
+
+  if (!subscription) {
+    return (
+      <span>
+        {t(
+          'Some GitHub organizations are already connected to other Sentry organizations. An upgraded plan is required to share GitHub installations across multiple Sentry organizations.'
+        )}
+      </span>
+    );
+  }
+
+  return (
+    <UpgradeMessageWithBilling organization={organization} subscription={subscription} />
+  );
+}
+
+function UpgradeMessageWithBilling({
+  organization,
+  subscription,
+}: {
+  organization: Organization;
+  subscription: Subscription;
+}) {
+  const {data: billingConfig} = useBillingConfig({organization, subscription});
+  const planName = getRequiredPlanName(billingConfig);
+
+  if (planName) {
+    return (
+      <span>
+        {tct(
+          'Some GitHub organizations are already connected to other Sentry organizations. A [planName] plan or above is required to share GitHub installations across multiple Sentry organizations.',
+          {planName: <strong>{planName}</strong>}
+        )}
+      </span>
+    );
+  }
+
+  return (
+    <span>
+      {t(
+        'Some GitHub organizations are already connected to other Sentry organizations. An upgraded plan is required to share GitHub installations across multiple Sentry organizations.'
+      )}
+    </span>
+  );
+}
+
+function getRequiredPlanName(billingConfig: BillingConfig | undefined): string | null {
+  if (!billingConfig) {
+    return null;
+  }
+
+  const plan = billingConfig.planList
+    .filter(p => p.userSelectable)
+    .sort((a, b) => a.price - b.price)
+    .find(p => p.features.includes('integrations-scm-multi-org'));
+
+  if (!plan) {
+    return null;
+  }
+
+  return displayPlanName(plan);
+}

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -62,6 +62,7 @@ import {getOrgRoles} from 'getsentry/hooks/organizationRoles';
 import OrgStatsBanner from 'getsentry/hooks/orgStatsBanner';
 import {OrgStatsProfilingBanner} from 'getsentry/hooks/orgStatsProfilingBanner';
 import {rootRoutes} from 'getsentry/hooks/rootRoutes';
+import {ScmGithubMultiOrgInstall} from 'getsentry/hooks/scmGithubMultiOrgInstall';
 import {seerSettingsRoutes} from 'getsentry/hooks/seerSettingsRoutes';
 import {ComponentWrapper as EnhancedOrganizationStats} from 'getsentry/hooks/spendVisibility/enhancedIndex';
 import {SpikeProtectionProjectSettings} from 'getsentry/hooks/spendVisibility/spikeProtectionProjectSettings';
@@ -233,6 +234,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:first-party-integration-alert': () => FirstPartyIntegrationAlertHook,
   'component:first-party-integration-additional-cta': () =>
     FirstPartyIntegrationAdditionalCTA,
+  'component:scm-github-multi-org-install': () => ScmGithubMultiOrgInstall,
   'component:replay-onboarding-alert': () => ReplayOnboardingAlert,
   'component:replay-onboarding-cta': () => ReplayOnboardingCTA,
   'component:replay-settings-alert': () => ReplaySettingsAlert,


### PR DESCRIPTION
Adds the GitHub-specific pipeline step components (OAuth login and organization selection) and registers the GitHub integration pipeline definition in the frontend registry.

Refs VDY-38

Typical install flow

https://github.com/user-attachments/assets/e05fe79c-aa7a-4d12-847b-e7b4aab96c8e

Installing for a org with an already integrated github app

https://github.com/user-attachments/assets/250e0982-1ba3-440d-af92-9e59cee76ecc