### PR TITLE
feat(gitlab): Add API-driven GitLab integration setup

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -9,9 +9,12 @@ from django import forms
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.translation import gettext_lazy as _
+from rest_framework.fields import BooleanField, CharField, URLField
 
 from sentry import features
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.identity.gitlab.provider import GitlabIdentityProvider, get_oauth_data, get_user_info
+from sentry.identity.oauth2 import OAuth2ApiStep
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.base import (
     FeatureDescription,
@@ -37,7 +40,8 @@ from sentry.models.organization import Organization
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import organization_service
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.exceptions import (
     ApiError,
@@ -393,6 +397,78 @@ class GitlabPRCommentWorkflow(PRCommentWorkflow):
         }
 
 
+class InstallationConfigSerializer(CamelSnakeSerializer):
+    url = URLField(required=False, default="https://gitlab.com")
+    group = CharField(required=False, allow_blank=True, default="")
+    include_subgroups = BooleanField(required=False, default=False)
+    verify_ssl = BooleanField(required=False, default=True)
+    client_id = CharField(required=True)
+    client_secret = CharField(required=True)
+
+
+class InstallationConfigApiStep:
+    """
+    Collects GitLab instance configuration: URL, group path, OAuth
+    credentials, and SSL/subgroup preferences.
+
+    On POST, validates the form data, binds ``installation_data`` and
+    ``oauth_config_information`` to pipeline state, then advances.
+    """
+
+    step_name = "installation_config"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        return {
+            "defaults": {
+                "verifySsl": True,
+                "includeSubgroups": False,
+            },
+            "setupValues": [
+                {"label": "Name", "value": "Sentry"},
+                {
+                    "label": "Redirect URI",
+                    "value": absolute_uri("/extensions/gitlab/setup/"),
+                },
+                {"label": "Scopes", "value": "api"},
+            ],
+        }
+
+    def get_serializer_cls(self) -> type:
+        return InstallationConfigSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, Any],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        # Strip trailing slash from URL (same as InstallationForm.clean_url)
+        validated_data["url"] = validated_data["url"].rstrip("/")
+
+        pipeline.bind_state("installation_data", validated_data)
+
+        pipeline.bind_state(
+            "oauth_config_information",
+            {
+                "access_token_url": f"{validated_data['url']}/oauth/token",
+                "authorize_url": f"{validated_data['url']}/oauth/authorize",
+                "client_id": validated_data["client_id"],
+                "client_secret": validated_data["client_secret"],
+                "verify_ssl": validated_data["verify_ssl"],
+            },
+        )
+
+        pipeline.get_logger().info(
+            "gitlab.setup.installation-config-api-step.success",
+            extra={
+                "base_url": validated_data["url"],
+                "client_id": validated_data["client_id"],
+                "verify_ssl": validated_data["verify_ssl"],
+            },
+        )
+        return PipelineStepResult.advance()
+
+
 class InstallationForm(forms.Form):
     url = forms.CharField(
         label=_("GitLab URL"),
@@ -604,8 +680,35 @@ class GitlabIntegrationProvider(IntegrationProvider):
             lambda: self._make_identity_pipeline_view(),
         )
 
+    def _make_oauth_api_step(self) -> OAuth2ApiStep:
+        oauth_info = self.pipeline._fetch_state("oauth_config_information")
+        if oauth_info is None:
+            raise AssertionError("pipeline called out of order")
+        return OAuth2ApiStep(
+            authorize_url=oauth_info["authorize_url"],
+            client_id=oauth_info["client_id"],
+            client_secret=oauth_info["client_secret"],
+            access_token_url=oauth_info["access_token_url"],
+            scope=" ".join(sorted(GitlabIdentityProvider.oauth_scopes)),
+            redirect_url=absolute_uri("/extensions/gitlab/setup/"),
+            verify_ssl=oauth_info.get("verify_ssl", True),
+            bind_key="oauth_data",
+        )
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [
+            InstallationConfigApiStep(),
+            lambda: self._make_oauth_api_step(),
+        ]
+
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        data = state["identity"]["data"]
+        # TODO: legacy views write token data to state["identity"]["data"] via
+        # NestedPipelineView. API steps write directly to state["oauth_data"].
+        # Remove the legacy path once the old views are retired.
+        if "oauth_data" in state:
+            data = state["oauth_data"]
+        else:
+            data = state["identity"]["data"]
 
         # Gitlab requires the client_id and client_secret for refreshing the access tokens
         oauth_config = state.get("oauth_config_information", {})

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import asdict
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 
@@ -8,6 +11,7 @@ import pytest
 import responses
 from django.core.cache import cache
 from django.test import override_settings
+from django.urls import reverse
 
 from fixtures.gitlab import GET_COMMIT_RESPONSE, GitLabTestCase
 from sentry.integrations.gitlab.blame import GitLabCommitResponse, GitLabFileBlameResponseItem
@@ -16,6 +20,7 @@ from sentry.integrations.gitlab.constants import GITLAB_WEBHOOK_VERSION, GITLAB_
 from sentry.integrations.gitlab.integration import GitlabIntegration, GitlabIntegrationProvider
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
@@ -27,7 +32,7 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiForbiddenError, IntegrationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
-from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.cases import APITestCase, IntegrationTestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -1357,3 +1362,210 @@ class GitlabIssueSyncTest(GitLabTestCase):
         assert org_integration.config["existing_key"] == "existing_value"
         assert org_integration.config["sync_forward_assignment"] is True
         assert org_integration.config["sync_comments"] is True
+
+
+@control_silo_test
+class GitLabIntegrationApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    gitlab_url = "https://gitlab.example.com"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.client_id = "app-id-abc123"
+        self.client_secret = "secret-xyz789"
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "gitlab"},
+            format="json",
+        )
+
+    def _get_step_info(self) -> Any:
+        return self.client.get(self._get_pipeline_url())
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _stub_gitlab_oauth(self) -> None:
+        responses.add(
+            responses.POST,
+            f"{self.gitlab_url}/oauth/token",
+            json={
+                "access_token": "test-access-token",
+                "token_type": "bearer",
+                "refresh_token": "test-refresh-token",
+                "created_at": 1536798907,
+                "scope": "api",
+            },
+        )
+
+    def _stub_gitlab_user(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.gitlab_url}/api/v4/user",
+            json={
+                "id": 42,
+                "username": "testuser",
+                "email": "test@example.com",
+                "name": "Test User",
+            },
+        )
+
+    def _stub_gitlab_group(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.gitlab_url}/api/v4/groups/my-group",
+            json={
+                "id": 1,
+                "full_name": "My Group",
+                "full_path": "my-group",
+                "avatar_url": "https://gitlab.example.com/avatar.png",
+                "web_url": "https://gitlab.example.com/my-group",
+            },
+        )
+
+    def _submit_config(self, **overrides: Any) -> Any:
+        data = {
+            "url": self.gitlab_url,
+            "group": "my-group",
+            "includeSubgroups": False,
+            "verifySsl": True,
+            "clientId": self.client_id,
+            "clientSecret": self.client_secret,
+        }
+        data.update(overrides)
+        return self._advance_step(data)
+
+    def _get_pipeline_signature(self, resp: Any) -> str:
+        return resp.data["data"]["oauthUrl"].split("state=")[1].split("&")[0]
+
+    @responses.activate
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "installation_config"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 2
+        assert resp.data["provider"] == "gitlab"
+
+    @responses.activate
+    def test_config_step_data(self) -> None:
+        resp = self._initialize_pipeline()
+        data = resp.data["data"]
+        defaults = data["defaults"]
+        assert defaults["verifySsl"] is True
+        assert defaults["includeSubgroups"] is False
+        setup_values = data["setupValues"]
+        labels = [v["label"] for v in setup_values]
+        assert "Name" in labels
+        assert "Redirect URI" in labels
+        assert "Scopes" in labels
+
+    @responses.activate
+    def test_config_step_validation_missing_required_fields(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({"url": self.gitlab_url})
+        assert resp.status_code == 400
+        assert resp.data["clientId"] == ["This field is required."]
+        assert resp.data["clientSecret"] == ["This field is required."]
+
+    @responses.activate
+    def test_config_step_advance_to_oauth(self) -> None:
+        self._initialize_pipeline()
+        resp = self._submit_config()
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "oauth_login"
+        assert resp.data["stepIndex"] == 1
+        assert "oauthUrl" in resp.data["data"]
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert self.gitlab_url in oauth_url
+        assert "client_id=" in oauth_url
+
+    @responses.activate
+    def test_oauth_step_invalid_state(self) -> None:
+        self._initialize_pipeline()
+        self._submit_config()
+        resp = self._advance_step({"code": "abc123", "state": "wrong-state"})
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+
+    @responses.activate
+    def test_oauth_step_missing_code(self) -> None:
+        self._initialize_pipeline()
+        self._submit_config()
+        resp = self._advance_step({})
+        assert resp.status_code == 400
+        assert resp.data["code"] == ["This field is required."]
+        assert resp.data["state"] == ["This field is required."]
+
+    @responses.activate
+    def test_full_pipeline_flow(self) -> None:
+        self._stub_gitlab_oauth()
+        self._stub_gitlab_user()
+        self._stub_gitlab_group()
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "installation_config"
+
+        resp = self._submit_config()
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "gitlab-auth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+        assert "data" in resp.data
+
+        integration = Integration.objects.get(provider="gitlab")
+        assert integration.metadata["base_url"] == self.gitlab_url
+        assert integration.metadata["group_id"] == 1
+
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
+
+    @responses.activate
+    def test_full_pipeline_flow_no_group(self) -> None:
+        self._stub_gitlab_oauth()
+        self._stub_gitlab_user()
+
+        self._initialize_pipeline()
+        resp = self._submit_config(group="")
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "gitlab-auth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="gitlab")
+        assert integration.metadata["group_id"] is None
+        assert integration.metadata["include_subgroups"] is False
+
+    @responses.activate
+    def test_config_strips_trailing_slash(self) -> None:
+        self._stub_gitlab_oauth()
+        self._stub_gitlab_user()
+        self._stub_gitlab_group()
+
+        self._initialize_pipeline()
+        resp = self._submit_config(url=f"{self.gitlab_url}///")
+        assert resp.data["status"] == "advance"
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert "gitlab.example.com/oauth/authorize" in oauth_url
+        assert "///" not in oauth_url


### PR DESCRIPTION
Add API pipeline steps for GitLab integration installation:
InstallationConfigApiStep collects instance URL, group path, OAuth
credentials, and SSL preferences. The OAuth step is late-bound via
OAuth2ApiStep using config from the previous step's state.

build_integration now reads token data from either the legacy
state["identity"]["data"] path or the new state["oauth_data"] path
so both flows work during migration.

Refs VDY-39