### PR TITLE
fix(tests): stabilize flaky React Native metrics onboarding test

### DIFF
--- a/static/app/gettingStartedDocs/react-native/metrics.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/metrics.spec.tsx
@@ -2,7 +2,12 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitForElementToBeRemoved,
+} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -41,6 +46,8 @@ describe('getting started with react-native', () => {
       />
     );
 
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
     expect(
       await screen.findByRole('heading', {name: /install sentry/i})
     ).toBeInTheDocument();
@@ -50,11 +57,11 @@ describe('getting started with react-native', () => {
     ).toBeInTheDocument();
 
     // Goes to the configure step
-    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Next'}));
     expect(await screen.findByText(/Metrics are enabled by default/)).toBeInTheDocument();
 
     // Goes to the verify step
-    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Next'}));
     expect(await screen.findByText(/Sentry\.metrics\.count/)).toBeInTheDocument();
     expect(screen.getByText(/Sentry\.metrics\.gauge/)).toBeInTheDocument();
   });


### PR DESCRIPTION
This test is slow because the component does asynchronous dynamic importing. That can take a long time under CI load, along with added cumulative time with two `userEvent.click` interactions.

This fix adds more asynchronous waiting assertions within the test:

* An explicit wait for any loading indicator to be done before asserting on text contents
* Switching the first lookup in each group from synchronous `getBy` to asynchronous `findBy`

Fixes ENG-7206

Made with [Cursor](https://cursor.com)
