### PR TITLE
feat(experiments): Add useExperiment hook for flagpole experiments

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -12,6 +12,8 @@ const productionEntryPoints = [
   'static/app/gettingStartedDocs/**/*.{js,ts,tsx}',
   // this is imported with require.context
   'static/app/data/forms/*.tsx',
+  // frontend experiemnt framework may be unused when we have no experiemnets
+  'static/app/utils/useExperiment.tsx',
   // --- we should be able to get rid of those: ---
   // Only used in stories (so far)
   'static/app/components/core/quote/*.tsx',

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -11,6 +11,7 @@ import type {DataCategory} from 'sentry/types/core';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import type {UseExperimentOptions, UseExperimentResult} from 'sentry/utils/useExperiment';
 import type {
   useDefaultMaxPickableDays,
   useMaxPickableDays,
@@ -350,6 +351,7 @@ type ReactHooks = {
     dataset: WidgetType;
   }) => number;
   'react-hook:use-default-max-pickable-days': typeof useDefaultMaxPickableDays;
+  'react-hook:use-experiment': (options: UseExperimentOptions) => UseExperimentResult;
   'react-hook:use-get-max-retention-days': () => number | undefined;
   'react-hook:use-max-pickable-days': typeof useMaxPickableDays;
   'react-hook:use-metric-detector-limit': () => {

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -115,6 +115,7 @@ export interface Organization extends OrganizationSummary {
   enableSeerCoding?: boolean;
   enableSeerEnhancedAlerts?: boolean;
   enabledConsolePlatforms?: string[];
+  experiments?: Record<string, string>;
   extraOptions?: {
     traces: {
       checkSpanExtractionDate: boolean;

--- a/static/app/utils/useExperiment.spec.tsx
+++ b/static/app/utils/useExperiment.spec.tsx
@@ -1,0 +1,21 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {useExperiment} from 'sentry/utils/useExperiment';
+
+function TestComponent({feature}: {feature: string}) {
+  const {inExperiment, experimentAssignment} = useExperiment({feature});
+  return (
+    <div>
+      <span data-test-id="in-experiment">{String(inExperiment)}</span>
+      <span data-test-id="assignment">{experimentAssignment}</span>
+    </div>
+  );
+}
+
+describe('useExperiment (open-source fallback)', () => {
+  it('returns control group when no gsApp hook is registered', () => {
+    render(<TestComponent feature="test-experiment" />);
+    expect(screen.getByTestId('in-experiment')).toHaveTextContent('false');
+    expect(screen.getByTestId('assignment')).toHaveTextContent('control');
+  });
+});

--- a/static/app/utils/useExperiment.tsx
+++ b/static/app/utils/useExperiment.tsx
@@ -1,0 +1,82 @@
+import {HookStore} from 'sentry/stores/hookStore';
+
+export interface UseExperimentResult {
+  /**
+   * The raw assignment string from the backend (e.g. "active" or "control").
+   * Useful for future multi-variant experiments where a simple boolean
+   * isn't sufficient.
+   */
+  experimentAssignment: string;
+  /**
+   * Whether the current organization is in the experiment's active group.
+   * True when the assignment is "active", false otherwise.
+   */
+  inExperiment: boolean;
+}
+
+export interface UseExperimentOptions {
+  /**
+   * The experiment key, matching the flagpole flag name without the
+   * "organizations:" prefix (e.g. "my-experiment").
+   */
+  feature: string;
+  /**
+   * Whether to report that the user has been exposed to this experiment.
+   * When true (the default), the hook will fire an exposure event on mount,
+   * recording that the user has "seen" the experiment. Set to false when you
+   * need to check the assignment without triggering exposure — for example,
+   * to conditionally render a feature only if other criteria are also met.
+   *
+   * This option is reactive: changing it from false to true will report
+   * exposure at that point.
+   */
+  reportExposure?: boolean;
+}
+
+/**
+ * Open-source fallback: always returns control group with no exposure logging.
+ */
+function noopUseExperiment(_options: UseExperimentOptions): UseExperimentResult {
+  return {inExperiment: false, experimentAssignment: 'control'};
+}
+
+/**
+ * Check whether the current organization is enrolled in an experiment and
+ * optionally report that the user has been exposed to it.
+ *
+ * Experiments are backed by flagpole feature flags with `experiment_mode`
+ * set. The assignment ("active" or "control") is returned by the organization
+ * details API in the `experiments` field.
+ *
+ * @param options.feature - The experiment key, matching the flagpole flag name
+ *   without the "organizations:" prefix (e.g. "my-experiment").
+ * @param options.reportExposure - Whether to log an exposure event. Defaults
+ *   to true. Set to false to check the assignment without exposing the user.
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const {inExperiment} = useExperiment({feature: 'my-experiment'});
+ *   if (!inExperiment) return null;
+ *   return <NewFeature />;
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Defer exposure until the user actually interacts
+ * function MyComponent() {
+ *   const [opened, setOpened] = useState(false);
+ *   const {inExperiment} = useExperiment({
+ *     feature: 'my-experiment',
+ *     reportExposure: opened,
+ *   });
+ *   // ...
+ * }
+ * ```
+ */
+export function useExperiment(options: UseExperimentOptions): UseExperimentResult {
+  const useExperimentHook =
+    HookStore.get('react-hook:use-experiment')[0] ?? noopUseExperiment;
+  return useExperimentHook(options);
+}

--- a/static/gsApp/hooks/useExperiment.spec.tsx
+++ b/static/gsApp/hooks/useExperiment.spec.tsx
@@ -1,0 +1,181 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {_resetExposureTracking, useExperiment} from 'getsentry/hooks/useExperiment';
+
+function TestComponent({
+  feature,
+  reportExposure,
+}: {
+  feature: string;
+  reportExposure?: boolean;
+}) {
+  const {inExperiment, experimentAssignment} = useExperiment({
+    feature,
+    reportExposure,
+  });
+  return (
+    <div>
+      <span data-test-id="in-experiment">{String(inExperiment)}</span>
+      <span data-test-id="assignment">{experimentAssignment}</span>
+    </div>
+  );
+}
+
+describe('useExperiment (gsApp)', () => {
+  beforeEach(() => {
+    _resetExposureTracking();
+  });
+
+  it('returns inExperiment: true when assignment is active', () => {
+    const org = OrganizationFixture({
+      experiments: {'test-experiment': 'active'},
+    });
+    render(<TestComponent feature="test-experiment" reportExposure={false} />, {
+      organization: org,
+    });
+    expect(screen.getByTestId('in-experiment')).toHaveTextContent('true');
+    expect(screen.getByTestId('assignment')).toHaveTextContent('active');
+  });
+
+  it('returns inExperiment: false when assignment is control', () => {
+    const org = OrganizationFixture({
+      experiments: {'test-experiment': 'control'},
+    });
+    render(<TestComponent feature="test-experiment" reportExposure={false} />, {
+      organization: org,
+    });
+    expect(screen.getByTestId('in-experiment')).toHaveTextContent('false');
+    expect(screen.getByTestId('assignment')).toHaveTextContent('control');
+  });
+
+  it('returns control when experiment is not present', () => {
+    const org = OrganizationFixture({experiments: {}});
+    render(<TestComponent feature="missing-experiment" reportExposure={false} />, {
+      organization: org,
+    });
+    expect(screen.getByTestId('in-experiment')).toHaveTextContent('false');
+    expect(screen.getByTestId('assignment')).toHaveTextContent('control');
+  });
+
+  it('posts exposure on mount when reportExposure is true', async () => {
+    const org = OrganizationFixture({
+      experiments: {'test-experiment': 'active'},
+    });
+    const mockExposure = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/experiment-exposure/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    render(<TestComponent feature="test-experiment" />, {organization: org});
+
+    await waitFor(() => {
+      expect(mockExposure).toHaveBeenCalledWith(
+        `/organizations/${org.slug}/experiment-exposure/`,
+        expect.objectContaining({
+          method: 'POST',
+          data: {experimentName: 'test-experiment', assignment: 'active'},
+        })
+      );
+    });
+  });
+
+  it('does not post exposure when reportExposure is false', () => {
+    const org = OrganizationFixture({
+      experiments: {'test-experiment': 'active'},
+    });
+    const mockExposure = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/experiment-exposure/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    render(<TestComponent feature="test-experiment" reportExposure={false} />, {
+      organization: org,
+    });
+
+    expect(mockExposure).not.toHaveBeenCalled();
+  });
+
+  it('reports exposure when reportExposure changes from false to true', async () => {
+    const org = OrganizationFixture({
+      experiments: {'test-experiment': 'active'},
+    });
+    const mockExposure = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/experiment-exposure/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    const {rerender} = render(
+      <TestComponent feature="test-experiment" reportExposure={false} />,
+      {organization: org}
+    );
+
+    expect(mockExposure).not.toHaveBeenCalled();
+
+    rerender(<TestComponent feature="test-experiment" reportExposure />);
+
+    await waitFor(() => expect(mockExposure).toHaveBeenCalledTimes(1));
+  });
+
+  it('deduplicates exposure reports across remounts', async () => {
+    const org = OrganizationFixture({
+      experiments: {'test-experiment': 'active'},
+    });
+    const mockExposure = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/experiment-exposure/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    const {unmount} = render(<TestComponent feature="test-experiment" />, {
+      organization: org,
+    });
+
+    await waitFor(() => {
+      expect(mockExposure).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+
+    render(<TestComponent feature="test-experiment" />, {organization: org});
+
+    expect(mockExposure).toHaveBeenCalledTimes(1);
+  });
+
+  // This verifies the dedupe key includes the assignment so a changed
+  // assignment is treated as a distinct exposure. This scenario is unlikely in
+  // practice since we don't typically reload the organization after the app
+  // boots.
+  it('re-reports exposure when assignment changes', async () => {
+    const org = OrganizationFixture({
+      experiments: {'test-experiment': 'control'},
+    });
+    const mockExposure = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/experiment-exposure/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    const {unmount} = render(<TestComponent feature="test-experiment" />, {
+      organization: org,
+    });
+
+    await waitFor(() => expect(mockExposure).toHaveBeenCalledTimes(1));
+
+    unmount();
+
+    const updatedOrg = OrganizationFixture({
+      experiments: {'test-experiment': 'active'},
+    });
+
+    render(<TestComponent feature="test-experiment" />, {
+      organization: updatedOrg,
+    });
+
+    await waitFor(() => expect(mockExposure).toHaveBeenCalledTimes(2));
+  });
+});

--- a/static/gsApp/hooks/useExperiment.tsx
+++ b/static/gsApp/hooks/useExperiment.tsx
@@ -1,0 +1,49 @@
+import {useEffect} from 'react';
+
+import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+import type {UseExperimentOptions, UseExperimentResult} from 'sentry/utils/useExperiment';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+const reportedExposures = new Set<string>();
+
+/**
+ * Used for testing, resets the exposure tracking set.
+ * @public
+ */
+export function _resetExposureTracking() {
+  reportedExposures.clear();
+}
+
+export function useExperiment(options: UseExperimentOptions): UseExperimentResult {
+  const {feature, reportExposure = true} = options;
+  const organization = useOrganization();
+
+  const assignment = organization.experiments?.[feature] ?? 'control';
+  const inExperiment = assignment === 'active';
+
+  const {mutate: logExposure} = useMutation({
+    mutationFn: () =>
+      fetchMutation({
+        method: 'POST',
+        url: `/organizations/${organization.slug}/experiment-exposure/`,
+        data: {experimentName: feature, assignment},
+      }),
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (!reportExposure) {
+      return;
+    }
+
+    const dedupKey = `${organization.slug}:${feature}:${assignment}`;
+    if (reportedExposures.has(dedupKey)) {
+      return;
+    }
+
+    reportedExposures.add(dedupKey);
+    logExposure();
+  }, [reportExposure, organization.slug, feature, assignment, logExposure]);
+
+  return {inExperiment, experimentAssignment: assignment};
+}

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -70,6 +70,7 @@ import {subscriptionSettingsRoutes} from 'getsentry/hooks/subscriptionSettingsRo
 import {SuperuserAccessCategory} from 'getsentry/hooks/superuserAccessCategory';
 import TargetedOnboardingHeader from 'getsentry/hooks/targetedOnboardingHeader';
 import {useDashboardDatasetRetentionLimit} from 'getsentry/hooks/useDashboardDatasetRetentionLimit';
+import {useExperiment} from 'getsentry/hooks/useExperiment';
 import {useMetricDetectorLimit} from 'getsentry/hooks/useMetricDetectorLimit';
 import {useProductBillingAccess} from 'getsentry/hooks/useProductBillingAccess';
 import {rawTrackAnalyticsEvent} from 'getsentry/utils/rawTrackAnalyticsEvent';
@@ -252,6 +253,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'react-hook:use-get-max-retention-days': useGetMaxRetentionDays,
   'react-hook:use-metric-detector-limit': useMetricDetectorLimit,
   'react-hook:use-dashboard-dataset-retention-limit': useDashboardDatasetRetentionLimit,
+  'react-hook:use-experiment': useExperiment,
   'react-hook:use-product-billing-access': useProductBillingAccess,
   'component:partnership-agreement': p => (
     <LazyLoad LazyComponent={PartnershipAgreement} {...p} />


### PR DESCRIPTION
Add a frontend hook that checks experiment assignments from the organization API and optionally reports exposure to the backend.

The hook reads from organization.experiments (populated by Dan's flagpole experiment_mode system) and POSTs to the getsentry experiment-exposure endpoint when reportExposure is true (default).

Architecture follows the HookStore pattern: sentry defines the interface with an open-source fallback (always control), and gsApp provides the real implementation with exposure logging via useMutation, module-level dedup, and reactive reportExposure support.