### PR TITLE
fix(test): Pass delay={0} to SpanEvidencePreview in tests

### DIFF
--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
@@ -3,7 +3,7 @@ import {
   ProblemSpan,
   TransactionEventBuilder,
 } from 'sentry-test/performance/utils';
-import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {SpanEvidencePreview} from './spanEvidencePreview';
 
@@ -21,7 +21,11 @@ describe('SpanEvidencePreview', () => {
       body: {},
     });
 
-    render(<SpanEvidencePreview groupId="group-id">Hover me</SpanEvidencePreview>);
+    render(
+      <SpanEvidencePreview groupId="group-id" delay={0} displayTimeout={0}>
+        Hover me
+      </SpanEvidencePreview>
+    );
 
     await act(tick);
 
@@ -35,16 +39,15 @@ describe('SpanEvidencePreview', () => {
       statusCode: 500,
     });
 
-    render(<SpanEvidencePreview groupId="group-id">Hover me</SpanEvidencePreview>);
+    render(
+      <SpanEvidencePreview groupId="group-id" delay={0} displayTimeout={0}>
+        Hover me
+      </SpanEvidencePreview>
+    );
 
     await userEvent.hover(screen.getByText('Hover me'), {delay: null});
 
-    await waitFor(
-      () => {
-        expect(screen.getByText('Failed to load preview')).toBeInTheDocument();
-      },
-      {timeout: 3000}
-    );
+    await screen.findByText('Failed to load preview');
   });
 
   it('renders the span evidence correctly when request succeeds', async () => {
@@ -106,7 +109,11 @@ describe('SpanEvidencePreview', () => {
       body: event,
     });
 
-    render(<SpanEvidencePreview groupId="group-id">Hover me</SpanEvidencePreview>);
+    render(
+      <SpanEvidencePreview groupId="group-id" delay={0} displayTimeout={0}>
+        Hover me
+      </SpanEvidencePreview>
+    );
 
     await userEvent.hover(screen.getByText('Hover me'), {delay: null});
 

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
@@ -3,7 +3,7 @@ import {
   ProblemSpan,
   TransactionEventBuilder,
 } from 'sentry-test/performance/utils';
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SpanEvidencePreview} from './spanEvidencePreview';
 
@@ -39,7 +39,12 @@ describe('SpanEvidencePreview', () => {
 
     await userEvent.hover(screen.getByText('Hover me'), {delay: null});
 
-    await screen.findByText('Failed to load preview');
+    await waitFor(
+      () => {
+        expect(screen.getByText('Failed to load preview')).toBeInTheDocument();
+      },
+      {timeout: 3000}
+    );
   });
 
   it('renders the span evidence correctly when request succeeds', async () => {

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
@@ -89,8 +89,8 @@ export function SpanEvidencePreview({
   return (
     <GroupPreviewHovercard
       hide={!shouldShowLoadingState}
-      delay={delay}
-      displayTimeout={displayTimeout}
+      {...(delay !== undefined && {delay})}
+      {...(displayTimeout !== undefined && {displayTimeout})}
       body={
         <SpanEvidencePreviewBody
           onRequestBegin={onRequestBegin}

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
@@ -14,6 +14,8 @@ import type {EventTransaction} from 'sentry/types/event';
 type SpanEvidencePreviewProps = {
   children: React.ReactNode;
   groupId: string;
+  delay?: number;
+  displayTimeout?: number;
   query?: string;
 };
 
@@ -78,6 +80,8 @@ export function SpanEvidencePreview({
   children,
   groupId,
   query,
+  delay,
+  displayTimeout,
 }: SpanEvidencePreviewProps) {
   const {shouldShowLoadingState, onRequestBegin, onRequestEnd, reset} =
     useDelayedLoadingState();
@@ -85,6 +89,8 @@ export function SpanEvidencePreview({
   return (
     <GroupPreviewHovercard
       hide={!shouldShowLoadingState}
+      delay={delay}
+      displayTimeout={displayTimeout}
       body={
         <SpanEvidencePreviewBody
           onRequestBegin={onRequestBegin}


### PR DESCRIPTION
`GroupPreviewHovercard` defaults to `delay={100}`, which schedules a real `setTimeout` in `useHoverOverlay` before the overlay opens and the body mounts. Under CI load this timer can stretch, making the error-state `findByText` assertion flaky. 

This fixes the situation by threading `delay` and `displayTimeout` props through `SpanEvidencePreview` to `GroupPreviewHovercard` -> passing `delay={0}` and `displayTimeout={0}` in all test renders. That changes `useHoverOverlay` to take its synchronous fast path (`setIsVisible(true)` immediately), eliminating the nondeterminism.

Fixes ENG-7208

Made with [Cursor](https://cursor.com)