### PR TITLE
fix(txn_summary): Implement Web Vitals chart & sidebar for EAP

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -59,6 +59,7 @@ import {EAPChartsWidget} from 'sentry/views/performance/transactionSummary/trans
 import {EAPSidebarCharts} from 'sentry/views/performance/transactionSummary/transactionOverview/eapSidebarCharts';
 import {canUseTransactionMetricsData} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {
+  EAP_WEB_VITALS,
   makeVitalGroups,
   PERCENTILE as VITAL_PERCENTILE,
 } from 'sentry/views/performance/transactionSummary/transactionVitals/constants';
@@ -110,7 +111,6 @@ function EAPSummaryContentInner({
   projectId,
   transactionName,
 }: Props) {
-  const theme = useTheme();
   const navigate = useNavigate();
   const spanCategory = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
 
@@ -154,13 +154,10 @@ function EAPSummaryContentInner({
   const hasWebVitals =
     isSummaryViewFrontendPageLoad(eventView, projects) ||
     (totalValues !== null &&
-      makeVitalGroups(theme).some(group =>
-        group.vitals.some(vital => {
-          const functionName = `percentile(${vital},${VITAL_PERCENTILE})`;
-          const field = functionName;
-          return Number.isFinite(totalValues[field]) && totalValues[field] !== 0;
-        })
-      ));
+      EAP_WEB_VITALS.some(vital => {
+        const field = `percentile(${vital},${VITAL_PERCENTILE})`;
+        return Number.isFinite(totalValues[field]) && totalValues[field] !== 0;
+      }));
 
   const isFrontendView = isSummaryViewFrontend(eventView, projects);
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -54,7 +54,7 @@ const WIDGET_OPTIONS: Record<
     description: t(
       'Web Vitals Breakdown reflects the 75th percentile of web vitals over time.'
     ),
-    disabled: true,
+    disabled: false,
   },
 };
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.spec.tsx
@@ -1,0 +1,107 @@
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import {EAPSidebarCharts} from './eapSidebarCharts';
+
+describe('EAPSidebarCharts', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: []},
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [
+          {
+            yAxis: 'failure_rate()',
+            values: [{timestamp: 1000000, value: 0.05}],
+            meta: {interval: 3600, valueType: 'percentage', valueUnit: null},
+          },
+        ],
+      },
+    });
+  });
+
+  it('renders Web Vitals widget when hasWebVitals is true', async () => {
+    render(<EAPSidebarCharts transactionName="test-txn" hasWebVitals />);
+    expect(await screen.findByText('Web Vitals')).toBeInTheDocument();
+    expect(await screen.findByText('Failure Rate')).toBeInTheDocument();
+  });
+
+  it('does not render Web Vitals widget when hasWebVitals is false', async () => {
+    render(<EAPSidebarCharts transactionName="test-txn" hasWebVitals={false} />);
+    expect(await screen.findByText('Failure Rate')).toBeInTheDocument();
+    expect(screen.queryByText('Web Vitals')).not.toBeInTheDocument();
+  });
+
+  it('renders web vitals with correct values and state icons', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [
+          {
+            'p75(measurements.fcp)': 500, // Good: <= 1000
+            'p75(measurements.lcp)': 3000, // Meh: > 2500, <= 4000
+            'p75(measurements.cls)': 0.35, // Poor: > 0.25
+            'p75(measurements.inp)': null, // Missing
+            'p75(measurements.ttfb)': 700, // Good: <= 800
+          },
+        ],
+      },
+      match: [
+        (_url: string, options: Record<string, any>) =>
+          Array.isArray(options.query?.field) &&
+          options.query.field.includes('p75(measurements.fcp)'),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{'failure_rate()': 0.05}],
+      },
+      match: [
+        (_url: string, options: Record<string, any>) =>
+          Array.isArray(options.query?.field) &&
+          options.query.field.includes('failure_rate()'),
+      ],
+    });
+
+    render(<EAPSidebarCharts transactionName="test-txn" hasWebVitals />);
+
+    // FCP - Good: value shown with IconHappy
+    expect(await screen.findByText('500.00ms')).toBeInTheDocument();
+    const fcpRow = screen.getByText('500.00ms').parentElement!;
+    expect(within(fcpRow).getByText('FCP')).toBeInTheDocument();
+    expect(
+      within(fcpRow).getByRole('img').querySelector('path')?.getAttribute('d')
+    ).toContain('5 9H11');
+
+    // LCP - Meh: value shown with IconMeh
+    const lcpRow = screen.getByText('3.00s').parentElement!;
+    expect(within(lcpRow).getByText('LCP')).toBeInTheDocument();
+    expect(
+      within(lcpRow).getByRole('img').querySelector('path')?.getAttribute('d')
+    ).toContain('10.25 9.5');
+
+    // CLS - Poor: value shown with IconSad
+    const clsRow = screen.getByText('0.35').parentElement!;
+    expect(within(clsRow).getByText('CLS')).toBeInTheDocument();
+    expect(
+      within(clsRow).getByRole('img').querySelector('path')?.getAttribute('d')
+    ).toContain('10.34 11 12H5');
+
+    // INP - Missing: em-dash shown, no icon
+    const inpLabel = screen.getByText('INP');
+    const inpRow = inpLabel.parentElement!;
+    expect(within(inpRow).getByText('\u2014')).toBeInTheDocument();
+    expect(within(inpRow).queryByRole('img')).not.toBeInTheDocument();
+
+    // TTFB - value shown
+    expect(screen.getByText('TTFB')).toBeInTheDocument();
+    expect(screen.getByText('700.00ms')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {EAPSidebarCharts} from './eapSidebarCharts';
 
@@ -37,24 +37,31 @@ describe('EAPSidebarCharts', () => {
     expect(screen.queryByText('Web Vitals')).not.toBeInTheDocument();
   });
 
-  it('renders web vitals with correct values and state icons', async () => {
+  it('renders performance score wheel widget', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {
         data: [
           {
-            'p75(measurements.fcp)': 500, // Good: <= 1000
-            'p75(measurements.lcp)': 3000, // Meh: > 2500, <= 4000
-            'p75(measurements.cls)': 0.35, // Poor: > 0.25
-            'p75(measurements.inp)': null, // Missing
-            'p75(measurements.ttfb)': 700, // Good: <= 800
+            'performance_score(measurements.score.lcp)': 0.89,
+            'performance_score(measurements.score.fcp)': 0.92,
+            'performance_score(measurements.score.inp)': 0.75,
+            'performance_score(measurements.score.cls)': 0.95,
+            'performance_score(measurements.score.ttfb)': 0.88,
+            'performance_score(measurements.score.total)': 0.87,
+            'count_scores(measurements.score.total)': 100,
+            'count_scores(measurements.score.lcp)': 100,
+            'count_scores(measurements.score.fcp)': 100,
+            'count_scores(measurements.score.inp)': 100,
+            'count_scores(measurements.score.cls)': 100,
+            'count_scores(measurements.score.ttfb)': 100,
           },
         ],
       },
       match: [
         (_url: string, options: Record<string, any>) =>
           Array.isArray(options.query?.field) &&
-          options.query.field.includes('p75(measurements.fcp)'),
+          options.query.field.includes('performance_score(measurements.score.total)'),
       ],
     });
 
@@ -72,36 +79,7 @@ describe('EAPSidebarCharts', () => {
 
     render(<EAPSidebarCharts transactionName="test-txn" hasWebVitals />);
 
-    // FCP - Good: value shown with IconHappy
-    expect(await screen.findByText('500.00ms')).toBeInTheDocument();
-    const fcpRow = screen.getByText('500.00ms').parentElement!;
-    expect(within(fcpRow).getByText('FCP')).toBeInTheDocument();
-    expect(
-      within(fcpRow).getByRole('img').querySelector('path')?.getAttribute('d')
-    ).toContain('5 9H11');
-
-    // LCP - Meh: value shown with IconMeh
-    const lcpRow = screen.getByText('3.00s').parentElement!;
-    expect(within(lcpRow).getByText('LCP')).toBeInTheDocument();
-    expect(
-      within(lcpRow).getByRole('img').querySelector('path')?.getAttribute('d')
-    ).toContain('10.25 9.5');
-
-    // CLS - Poor: value shown with IconSad
-    const clsRow = screen.getByText('0.35').parentElement!;
-    expect(within(clsRow).getByText('CLS')).toBeInTheDocument();
-    expect(
-      within(clsRow).getByRole('img').querySelector('path')?.getAttribute('d')
-    ).toContain('10.34 11 12H5');
-
-    // INP - Missing: em-dash shown, no icon
-    const inpLabel = screen.getByText('INP');
-    const inpRow = inpLabel.parentElement!;
-    expect(within(inpRow).getByText('\u2014')).toBeInTheDocument();
-    expect(within(inpRow).queryByRole('img')).not.toBeInTheDocument();
-
-    // TTFB - value shown
-    expect(screen.getByText('TTFB')).toBeInTheDocument();
-    expect(screen.getByText('700.00ms')).toBeInTheDocument();
+    // The wheel widget renders with the total score (0.87 * 100 = 87)
+    expect(await screen.findByText('87')).toBeInTheDocument();
   });
 });

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.spec.tsx
@@ -25,16 +25,16 @@ describe('EAPSidebarCharts', () => {
     });
   });
 
-  it('renders Web Vitals widget when hasWebVitals is true', async () => {
+  it('renders Performance Score widget when hasWebVitals is true', async () => {
     render(<EAPSidebarCharts transactionName="test-txn" hasWebVitals />);
-    expect(await screen.findByText('Web Vitals')).toBeInTheDocument();
+    expect(await screen.findByText('Performance Score')).toBeInTheDocument();
     expect(await screen.findByText('Failure Rate')).toBeInTheDocument();
   });
 
-  it('does not render Web Vitals widget when hasWebVitals is false', async () => {
+  it('does not render Performance Score widget when hasWebVitals is false', async () => {
     render(<EAPSidebarCharts transactionName="test-txn" hasWebVitals={false} />);
     expect(await screen.findByText('Failure Rate')).toBeInTheDocument();
-    expect(screen.queryByText('Web Vitals')).not.toBeInTheDocument();
+    expect(screen.queryByText('Performance Score')).not.toBeInTheDocument();
   });
 
   it('renders performance score wheel widget', async () => {

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -2,32 +2,213 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Stack} from '@sentry/scraps/layout';
+import {LinkButton} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
+import {getMeasurementSlug} from 'sentry/utils/discover/fields';
+import {getDuration} from 'sentry/utils/duration/getDuration';
+import {FieldKind, WebVital} from 'sentry/utils/fields';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {WidgetType} from 'sentry/views/dashboards/types';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {usePrebuiltDashboardUrl} from 'sentry/views/dashboards/utils/usePrebuiltDashboardUrl';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {SpanFields} from 'sentry/views/insights/types';
 import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
+import {
+  VitalState,
+  vitalStateIcons,
+  webVitalMeh,
+  webVitalPoor,
+} from 'sentry/views/performance/vitalDetail/utils';
+
+const REFERRER = 'eap-sidebar-charts';
 
 type Props = {
   hasWebVitals: boolean;
   transactionName: string;
 };
 
-const REFERRER = 'eap-sidebar-charts';
-
 export function EAPSidebarCharts({transactionName, hasWebVitals}: Props) {
   return (
     <Stack gap="md">
-      {hasWebVitals && <Widget Title={t('Web Vitals')} />}
+      {hasWebVitals && <WebVitalsWidget transactionName={transactionName} />}
       <FailureRateWidget transactionName={transactionName} />
+    </Stack>
+  );
+}
+
+function WebVitalsWidget({transactionName}: {transactionName: string}) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const hasPrebuiltDashboards = organization.features.includes(
+    'dashboards-prebuilt-insights-dashboards'
+  );
+
+  const search = new MutableSearch('');
+  search.addFilterValue(SpanFields.TRANSACTION, transactionName);
+  const filterValue = search.formatString();
+
+  const dashboardUrl = usePrebuiltDashboardUrl(PrebuiltDashboardId.WEB_VITALS_SUMMARY, {
+    filters: {
+      globalFilter: [
+        {
+          dataset: WidgetType.SPANS,
+          tag: {
+            key: SpanFields.TRANSACTION,
+            name: SpanFields.TRANSACTION,
+            kind: FieldKind.TAG,
+          },
+          value: filterValue,
+        },
+      ],
+    },
+  });
+
+  const transactionSearch = new MutableSearch('');
+  transactionSearch.addFilterValue('transaction', transactionName);
+  transactionSearch.addFilterValue('is_transaction', 'true');
+
+  const {
+    data: vitalsData,
+    isPending,
+    isError,
+  } = useSpans(
+    {
+      search: transactionSearch,
+      fields: WEB_VITALS.map(v => `p75(${v})` as const),
+      pageFilters: selection,
+    },
+    REFERRER
+  );
+
+  if (isPending || isError) {
+    return (
+      <Widget
+        Title={<SideBarWidgetTitle>{t('Web Vitals')}</SideBarWidgetTitle>}
+        Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
+        borderless
+      />
+    );
+  }
+
+  const row = vitalsData[0];
+
+  return (
+    <Widget
+      Title={<SideBarWidgetTitle>{t('Web Vitals')}</SideBarWidgetTitle>}
+      Actions={
+        <Widget.WidgetToolbar>
+          {hasPrebuiltDashboards && dashboardUrl && (
+            <LinkButton to={dashboardUrl} size="sm">
+              {t('View Details')}
+            </LinkButton>
+          )}
+        </Widget.WidgetToolbar>
+      }
+      Visualization={
+        <Stack gap="md" padding="md">
+          {WEB_VITALS.map(vital => {
+            const value = row?.[`p75(${vital})`];
+            const slug = getMeasurementSlug(vital);
+            const label = slug ? slug.toUpperCase() : vital;
+
+            if (value === null || value === undefined || !Number.isFinite(value)) {
+              return (
+                <Flex key={vital} justify="between" align="center">
+                  <Text variant="muted">{label}</Text>
+                  <Text variant="muted">{'\u2014'}</Text>
+                </Flex>
+              );
+            }
+
+            const state = getVitalState(vital, value);
+
+            return (
+              <Flex key={vital} justify="between" align="center">
+                <Flex align="center" gap="xs">
+                  <Tooltip title={getThresholdTooltip(vital)}>
+                    {vitalStateIcons[state]}
+                  </Tooltip>
+                  <Text>{label}</Text>
+                </Flex>
+                <Text>{formatVitalValue(vital, value)}</Text>
+              </Flex>
+            );
+          })}
+        </Stack>
+      }
+      borderless
+    />
+  );
+}
+
+const WEB_VITALS = [
+  WebVital.FCP,
+  WebVital.LCP,
+  WebVital.CLS,
+  WebVital.INP,
+  WebVital.TTFB,
+] as const;
+
+function getVitalState(vital: (typeof WEB_VITALS)[number], value: number): VitalState {
+  if (value > webVitalPoor[vital]) {
+    return VitalState.POOR;
+  }
+  if (value > webVitalMeh[vital]) {
+    return VitalState.MEH;
+  }
+  return VitalState.GOOD;
+}
+
+function formatVitalValue(
+  vital: (typeof WEB_VITALS)[number],
+  value: number,
+  decimalPlaces?: number
+): string {
+  decimalPlaces = decimalPlaces === undefined ? 2 : decimalPlaces;
+  if (vital === WebVital.CLS) {
+    return value.toFixed(2);
+  }
+  // Time-based vitals are in milliseconds, getDuration expects seconds
+  return getDuration(value / 1000, decimalPlaces, true);
+}
+
+function getThresholdTooltip(vital: (typeof WEB_VITALS)[number]): React.ReactNode {
+  const mehThreshold = webVitalMeh[vital];
+  const poorThreshold = webVitalPoor[vital];
+  const formatThreshold = (v: number) => formatVitalValue(vital, v, 0);
+
+  return (
+    <Stack gap="xs">
+      <Flex align="center" gap="xs">
+        {vitalStateIcons[VitalState.GOOD]}
+        <Text>{t('Good: ≤ %s', formatThreshold(mehThreshold))}</Text>
+      </Flex>
+      <Flex align="center" gap="xs">
+        {vitalStateIcons[VitalState.MEH]}
+        <Text>
+          {t(
+            'Meh: %s – %s',
+            formatThreshold(mehThreshold),
+            formatThreshold(poorThreshold)
+          )}
+        </Text>
+      </Flex>
+      <Flex align="center" gap="xs">
+        {vitalStateIcons[VitalState.POOR]}
+        <Text>{t('Poor: > %s', formatThreshold(poorThreshold))}</Text>
+      </Flex>
     </Stack>
   );
 }
@@ -85,9 +266,10 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
   if (isFailureRateSeriesPending || isFailureRateSeriesError) {
     return (
       <Widget
-        Title={t('Failure Rate')}
+        Title={<SideBarWidgetTitle>{t('Failure Rate')}</SideBarWidgetTitle>}
         TitleBadges={getFailureRateBadge()}
         Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
+        borderless
       />
     );
   }

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -4,7 +4,6 @@ import {useTheme} from '@emotion/react';
 import {Tag} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
 import {Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
@@ -89,7 +88,7 @@ function WebVitalsWidget({transactionName}: {transactionName: string}) {
 
   return (
     <Widget
-      Title={<Text bold>{t('Performance Score')}</Text>}
+      Title={<Widget.WidgetTitle title={t('Performance Score')} />}
       Actions={
         <Widget.WidgetToolbar>
           {hasPrebuiltDashboards && dashboardUrl && (
@@ -167,7 +166,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
   if (isFailureRateSeriesPending || isFailureRateSeriesError) {
     return (
       <Widget
-        Title={<Text bold>{t('Failure Rate')}</Text>}
+        Title={<Widget.WidgetTitle title={t('Failure Rate')} />}
         TitleBadges={getFailureRateBadge()}
         Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
         borderless
@@ -181,7 +180,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
 
   return (
     <Widget
-      Title={<Text bold>{t('Failure Rate')}</Text>}
+      Title={<Widget.WidgetTitle title={t('Failure Rate')} />}
       TitleBadges={getFailureRateBadge()}
       Actions={
         <Widget.WidgetToolbar>

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -1,10 +1,10 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
 import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
@@ -89,7 +89,7 @@ function WebVitalsWidget({transactionName}: {transactionName: string}) {
 
   return (
     <Widget
-      Title={<SideBarWidgetTitle>{t('Web Vitals')}</SideBarWidgetTitle>}
+      Title={<Text bold>{t('Performance Score')}</Text>}
       Actions={
         <Widget.WidgetToolbar>
           {hasPrebuiltDashboards && dashboardUrl && (
@@ -167,7 +167,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
   if (isFailureRateSeriesPending || isFailureRateSeriesError) {
     return (
       <Widget
-        Title={<SideBarWidgetTitle>{t('Failure Rate')}</SideBarWidgetTitle>}
+        Title={<Text bold>{t('Failure Rate')}</Text>}
         TitleBadges={getFailureRateBadge()}
         Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
         borderless
@@ -181,7 +181,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
 
   return (
     <Widget
-      Title={<SideBarWidgetTitle>{t('Failure Rate')}</SideBarWidgetTitle>}
+      Title={<Text bold>{t('Failure Rate')}</Text>}
       TitleBadges={getFailureRateBadge()}
       Actions={
         <Widget.WidgetToolbar>
@@ -197,7 +197,3 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
     />
   );
 }
-
-const SideBarWidgetTitle = styled('div')`
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-`;

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -49,9 +49,11 @@ function WebVitalsWidget({transactionName}: {transactionName: string}) {
     'dashboards-prebuilt-insights-dashboards'
   );
 
-  const search = new MutableSearch('');
-  search.addFilterValue(SpanFields.TRANSACTION, transactionName);
-  const filterValue = search.formatString();
+  const filterValue = useMemo(() => {
+    const search = new MutableSearch('');
+    search.addFilterValue(SpanFields.TRANSACTION, transactionName);
+    return search.formatString();
+  }, [transactionName]);
 
   const dashboardUrl = usePrebuiltDashboardUrl(PrebuiltDashboardId.WEB_VITALS_SUMMARY, {
     filters: {

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -1,17 +1,14 @@
+import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
+import {Stack} from '@sentry/scraps/layout';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
-import {getMeasurementSlug} from 'sentry/utils/discover/fields';
-import {getDuration} from 'sentry/utils/duration/getDuration';
-import {FieldKind, WebVital} from 'sentry/utils/fields';
+import {FieldKind} from 'sentry/utils/fields';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -19,18 +16,15 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {usePrebuiltDashboardUrl} from 'sentry/views/dashboards/utils/usePrebuiltDashboardUrl';
+import {WidgetCardDataLoader} from 'sentry/views/dashboards/widgetCard/widgetCardDataLoader';
+import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {WheelWidgetVisualization} from 'sentry/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanFields} from 'sentry/views/insights/types';
 import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
-import {
-  VitalState,
-  vitalStateIcons,
-  webVitalMeh,
-  webVitalPoor,
-} from 'sentry/views/performance/vitalDetail/utils';
 
 const REFERRER = 'eap-sidebar-charts';
 
@@ -75,34 +69,21 @@ function WebVitalsWidget({transactionName}: {transactionName: string}) {
     },
   });
 
-  const transactionSearch = new MutableSearch('');
-  transactionSearch.addFilterValue('transaction', transactionName);
-  transactionSearch.addFilterValue('is_transaction', 'true');
-
-  const {
-    data: vitalsData,
-    isPending,
-    isError,
-  } = useSpans(
-    {
-      search: transactionSearch,
-      fields: WEB_VITALS.map(v => `p75(${v})` as const),
-      pageFilters: selection,
-    },
-    REFERRER
-  );
-
-  if (isPending || isError) {
-    return (
-      <Widget
-        Title={<SideBarWidgetTitle>{t('Web Vitals')}</SideBarWidgetTitle>}
-        Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
-        borderless
-      />
+  const widget = useMemo(() => {
+    const conditions = new MutableSearch(
+      SCORE_BREAKDOWN_WHEEL_WIDGET.queries[0]!.conditions
     );
-  }
-
-  const row = vitalsData[0];
+    conditions.addFilterValue('transaction', transactionName);
+    return {
+      ...SCORE_BREAKDOWN_WHEEL_WIDGET,
+      queries: [
+        {
+          ...SCORE_BREAKDOWN_WHEEL_WIDGET.queries[0]!,
+          conditions: conditions.formatString(),
+        },
+      ],
+    };
+  }, [transactionName]);
 
   return (
     <Widget
@@ -117,99 +98,17 @@ function WebVitalsWidget({transactionName}: {transactionName: string}) {
         </Widget.WidgetToolbar>
       }
       Visualization={
-        <Stack gap="md" padding="md">
-          {WEB_VITALS.map(vital => {
-            const value = row?.[`p75(${vital})`];
-            const slug = getMeasurementSlug(vital);
-            const label = slug ? slug.toUpperCase() : vital;
-
-            if (value === null || value === undefined || !Number.isFinite(value)) {
-              return (
-                <Flex key={vital} justify="between" align="center">
-                  <Text variant="muted">{label}</Text>
-                  <Text variant="muted">{'\u2014'}</Text>
-                </Flex>
-              );
+        <WidgetCardDataLoader widget={widget} selection={selection}>
+          {({loading, tableResults, errorMessage}) => {
+            if (loading || errorMessage) {
+              return <TimeSeriesWidgetVisualization.LoadingPlaceholder />;
             }
-
-            const state = getVitalState(vital, value);
-
-            return (
-              <Flex key={vital} justify="between" align="center">
-                <Flex align="center" gap="xs">
-                  <Tooltip title={getThresholdTooltip(vital)}>
-                    {vitalStateIcons[state]}
-                  </Tooltip>
-                  <Text>{label}</Text>
-                </Flex>
-                <Text>{formatVitalValue(vital, value)}</Text>
-              </Flex>
-            );
-          })}
-        </Stack>
+            return <WheelWidgetVisualization tableResults={tableResults} />;
+          }}
+        </WidgetCardDataLoader>
       }
       borderless
     />
-  );
-}
-
-const WEB_VITALS = [
-  WebVital.FCP,
-  WebVital.LCP,
-  WebVital.CLS,
-  WebVital.INP,
-  WebVital.TTFB,
-] as const;
-
-function getVitalState(vital: (typeof WEB_VITALS)[number], value: number): VitalState {
-  if (value > webVitalPoor[vital]) {
-    return VitalState.POOR;
-  }
-  if (value > webVitalMeh[vital]) {
-    return VitalState.MEH;
-  }
-  return VitalState.GOOD;
-}
-
-function formatVitalValue(
-  vital: (typeof WEB_VITALS)[number],
-  value: number,
-  decimalPlaces?: number
-): string {
-  decimalPlaces = decimalPlaces === undefined ? 2 : decimalPlaces;
-  if (vital === WebVital.CLS) {
-    return value.toFixed(2);
-  }
-  // Time-based vitals are in milliseconds, getDuration expects seconds
-  return getDuration(value / 1000, decimalPlaces, true);
-}
-
-function getThresholdTooltip(vital: (typeof WEB_VITALS)[number]): React.ReactNode {
-  const mehThreshold = webVitalMeh[vital];
-  const poorThreshold = webVitalPoor[vital];
-  const formatThreshold = (v: number) => formatVitalValue(vital, v, 0);
-
-  return (
-    <Stack gap="xs">
-      <Flex align="center" gap="xs">
-        {vitalStateIcons[VitalState.GOOD]}
-        <Text>{t('Good: ≤ %s', formatThreshold(mehThreshold))}</Text>
-      </Flex>
-      <Flex align="center" gap="xs">
-        {vitalStateIcons[VitalState.MEH]}
-        <Text>
-          {t(
-            'Meh: %s – %s',
-            formatThreshold(mehThreshold),
-            formatThreshold(poorThreshold)
-          )}
-        </Text>
-      </Flex>
-      <Flex align="center" gap="xs">
-        {vitalStateIcons[VitalState.POOR]}
-        <Text>{t('Poor: > %s', formatThreshold(poorThreshold))}</Text>
-      </Flex>
-    </Stack>
   );
 }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -34,6 +34,7 @@ import {
 import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {useTransactionSummaryContext} from 'sentry/views/performance/transactionSummary/transactionSummaryContext';
 import {
+  EAP_WEB_VITALS,
   makeVitalGroups,
   PERCENTILE as VITAL_PERCENTILE,
 } from 'sentry/views/performance/transactionSummary/transactionVitals/constants';
@@ -370,7 +371,7 @@ function getEAPTotalsEventView(
   _organization: Organization,
   eventView: EventView
 ): EventView {
-  const vitals = [WebVital.FCP, WebVital.LCP, WebVital.CLS];
+  const vitals = EAP_WEB_VITALS;
 
   const totalsColumns: QueryFieldValue[] = [
     {

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -10,7 +10,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import {EventView} from 'sentry/utils/discover/eventView';
 import type {Column, QueryFieldValue} from 'sentry/utils/discover/fields';
-import type {WebVital} from 'sentry/utils/fields';
+import {WebVital} from 'sentry/utils/fields';
 import {useMetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {
   getIsMetricsDataFromResults,
@@ -370,6 +370,8 @@ function getEAPTotalsEventView(
   _organization: Organization,
   eventView: EventView
 ): EventView {
+  const vitals = [WebVital.FCP, WebVital.LCP, WebVital.CLS];
+
   const totalsColumns: QueryFieldValue[] = [
     {
       kind: 'function',
@@ -381,7 +383,16 @@ function getEAPTotalsEventView(
     },
   ];
 
-  return eventView.withColumns([...totalsColumns]);
+  return eventView.withColumns([
+    ...totalsColumns,
+    ...vitals.map(
+      vital =>
+        ({
+          kind: 'function',
+          function: ['percentile', vital, VITAL_PERCENTILE.toString(), undefined],
+        }) as Column
+    ),
+  ]);
 }
 
 export default TransactionOverview;

--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -2,7 +2,11 @@ import {useTheme} from '@emotion/react';
 
 import {getInterval, getSeriesSelection} from 'sentry/components/charts/utils';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {parseFunction} from 'sentry/utils/discover/fields';
+import {
+  getAggregateArg,
+  getMeasurementSlug,
+  parseFunction,
+} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -53,12 +57,22 @@ export function useWidgetChartVisualization({
     query,
   });
 
+  const webVitalsVisualization = useWebVitalsVisualization({
+    enabled: selectedWidget === EAPWidgetType.WEB_VITALS,
+    transactionName,
+    query,
+  });
+
   if (selectedWidget === EAPWidgetType.DURATION_BREAKDOWN) {
     return durationBreakdownVisualization;
   }
 
   if (selectedWidget === EAPWidgetType.DURATION_PERCENTILES) {
     return durationPercentilesVisualization;
+  }
+
+  if (selectedWidget === EAPWidgetType.WEB_VITALS) {
+    return webVitalsVisualization;
   }
 
   return <TimeSeriesWidgetVisualization.LoadingPlaceholder />;
@@ -208,6 +222,94 @@ function useDurationPercentilesVisualization({
     <DurationPercentileChart
       series={transformData(durationPercentilesData, false, /p(\d+)\(/)}
       colors={colors}
+    />
+  );
+}
+
+type WebVitalsVisualizationOptions = {
+  enabled: boolean;
+  query: string;
+  transactionName: string;
+};
+
+function useWebVitalsVisualization({
+  enabled,
+  transactionName,
+  query,
+}: WebVitalsVisualizationOptions) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const {selection} = usePageFilters();
+  const legendSelection = getSeriesSelection(location);
+
+  const {releases: releasesWithDate} = useReleaseStats(selection);
+  const releases =
+    releasesWithDate?.map(({date, version}) => ({
+      timestamp: date,
+      version,
+    })) ?? [];
+
+  const newQuery = new MutableSearch(query);
+  newQuery.addFilterValue('transaction', transactionName);
+  newQuery.addFilterValue('is_transaction', '1');
+
+  const {
+    data: spanSeriesData,
+    isPending: isSpanSeriesPending,
+    isError: isSpanSeriesError,
+  } = useFetchSpanTimeSeries(
+    {
+      yAxis: [
+        'p75(measurements.fcp)',
+        'p75(measurements.lcp)',
+        'p75(measurements.cls)',
+        'p75(measurements.ttfb)',
+        'p75(measurements.inp)',
+      ],
+      query: newQuery,
+      interval: getInterval(selection.datetime, 'high'),
+      enabled,
+    },
+    REFERRER
+  );
+
+  if (!enabled) {
+    return null;
+  }
+
+  if (isSpanSeriesPending || isSpanSeriesError) {
+    return <TimeSeriesWidgetVisualization.LoadingPlaceholder />;
+  }
+
+  const plottables =
+    spanSeriesData?.timeSeries.map(series => {
+      const arg = getAggregateArg(series.yAxis);
+      let name = series.yAxis;
+      if (arg) {
+        const slug = getMeasurementSlug(arg);
+        if (slug) {
+          name = slug.toUpperCase();
+        }
+      }
+      return new Line(series, {name, alias: name});
+    }) ?? [];
+
+  return (
+    <TimeSeriesWidgetVisualization
+      plottables={plottables}
+      releases={releases}
+      showReleaseAs="bubble"
+      legendSelection={legendSelection}
+      onLegendSelectionChange={selected => {
+        const unselected = Object.keys(selected).filter(key => !selected[key]);
+        navigate({
+          ...location,
+          query: {
+            ...location.query,
+            unselectedSeries: unselected,
+          },
+        });
+      }}
     />
   );
 }

--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -2,11 +2,7 @@ import {useTheme} from '@emotion/react';
 
 import {getInterval, getSeriesSelection} from 'sentry/components/charts/utils';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {
-  getAggregateArg,
-  getMeasurementSlug,
-  parseFunction,
-} from 'sentry/utils/discover/fields';
+import {parseFunction} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -16,6 +12,7 @@ import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import type {SpanProperty} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
 import {
   filterToColor,
@@ -23,6 +20,7 @@ import {
 } from 'sentry/views/performance/transactionSummary/filter';
 import {transformData} from 'sentry/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils';
 import {EAPWidgetType} from 'sentry/views/performance/transactionSummary/transactionOverview/eapChartsWidget';
+import {EAP_WEB_VITALS} from 'sentry/views/performance/transactionSummary/transactionVitals/constants';
 
 import {Chart as DurationPercentileChart} from './durationPercentileChart/chart';
 
@@ -259,13 +257,7 @@ function useWebVitalsVisualization({
     isError: isSpanSeriesError,
   } = useFetchSpanTimeSeries(
     {
-      yAxis: [
-        'p75(measurements.fcp)',
-        'p75(measurements.lcp)',
-        'p75(measurements.cls)',
-        'p75(measurements.ttfb)',
-        'p75(measurements.inp)',
-      ],
+      yAxis: EAP_WEB_VITALS.map(vital => `p75(${vital})` as SpanProperty),
       query: newQuery,
       interval: getInterval(selection.datetime, 'high'),
       enabled,
@@ -283,15 +275,7 @@ function useWebVitalsVisualization({
 
   const plottables =
     spanSeriesData?.timeSeries.map(series => {
-      const arg = getAggregateArg(series.yAxis);
-      let name = series.yAxis;
-      if (arg) {
-        const slug = getMeasurementSlug(arg);
-        if (slug) {
-          name = slug.toUpperCase();
-        }
-      }
-      return new Line(series, {name, alias: name});
+      return new Line(series);
     }) ?? [];
 
   return (

--- a/static/app/views/performance/transactionSummary/transactionVitals/constants.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/constants.tsx
@@ -5,6 +5,14 @@ import type {VitalGroup} from 'sentry/utils/performance/vitals/types';
 
 export const PERCENTILE = 0.75;
 
+export const EAP_WEB_VITALS = [
+  WebVital.FCP,
+  WebVital.LCP,
+  WebVital.CLS,
+  WebVital.TTFB,
+  WebVital.INP,
+];
+
 /**
  * This defines the grouping for histograms. Histograms that are in the same group
  * will be queried together on initial load for alignment. However, the zoom controls

--- a/static/app/views/performance/vitalDetail/utils.tsx
+++ b/static/app/views/performance/vitalDetail/utils.tsx
@@ -10,6 +10,8 @@ export const webVitalPoor = {
   [WebVital.LCP]: 4000,
   [WebVital.FID]: 300,
   [WebVital.CLS]: 0.25,
+  [WebVital.INP]: 500,
+  [WebVital.TTFB]: 1800,
 };
 
 export const webVitalMeh = {
@@ -18,6 +20,8 @@ export const webVitalMeh = {
   [WebVital.LCP]: 2500,
   [WebVital.FID]: 100,
   [WebVital.CLS]: 0.1,
+  [WebVital.INP]: 200,
+  [WebVital.TTFB]: 800,
 };
 
 export enum VitalState {

--- a/static/app/views/performance/vitalDetail/vitalPercents.tsx
+++ b/static/app/views/performance/vitalDetail/vitalPercents.tsx
@@ -25,17 +25,17 @@ function getVitalStateText(vital: WebVital | WebVital[], vitalState: any) {
     case VitalState.POOR:
       return Array.isArray(vital)
         ? t('Poor')
-        : // @ts-expect-error TS(2551): Property 'measurements.ttfb' does not exist on typ... Remove this comment to see the full error message
+        : // @ts-expect-error WebVital.REQUEST_TIME is not in the threshold maps
           tct('(>[threshold][unit])', {threshold: webVitalPoor[vital], unit});
     case VitalState.MEH:
       return Array.isArray(vital)
         ? t('Meh')
-        : // @ts-expect-error TS(2551): Property 'measurements.ttfb' does not exist on typ... Remove this comment to see the full error message
+        : // @ts-expect-error WebVital.REQUEST_TIME is not in the threshold maps
           tct('(>[threshold][unit])', {threshold: webVitalMeh[vital], unit});
     case VitalState.GOOD:
       return Array.isArray(vital)
         ? t('Good')
-        : // @ts-expect-error TS(2551): Property 'measurements.ttfb' does not exist on typ... Remove this comment to see the full error message
+        : // @ts-expect-error WebVital.REQUEST_TIME is not in the threshold maps
           tct('(<=[threshold][unit])', {threshold: webVitalMeh[vital], unit});
     default:
       return null;


### PR DESCRIPTION
Implements the Web Vitals option on the Transaction Summary page's main chart as well as restores the Web Vitals widget in the sidebar.

## Chart

<img width="1245" height="316" alt="Screenshot 2026-04-02 at 12 52 17" src="https://github.com/user-attachments/assets/9550933a-8c1d-433b-962b-6b8b1f1170d8" />

Straightforward. Compared to the old chart, removes FID (dead vital, no longer supported) but adds TTFB and INP.

## Widget

This is a different visualization than our old one because we don't have the same functionality in EAP for bucketing web vitals into good/meh/poor. Reuses the Performance Score Wheel from the Sentry-built web vitals page details dashboard.

Our **old widget**:

<img width="390" height="169" alt="Screenshot 2026-04-01 at 13 36 48" src="https://github.com/user-attachments/assets/fdec81f8-8559-4e7c-b46d-9845e6c167a1" />

(There was no hover state on the bars.)

The **new widget**:

<img width="644" height="404" alt="Screenshot 2026-04-02 at 12 38 09" src="https://github.com/user-attachments/assets/08f858ca-c6e4-49cd-bcd4-9778521adb9d" />

You can hover for a button that takes you to the web vitals page summary dashboard for this specific transaction.

<img width="328" height="305" alt="Screenshot 2026-04-02 at 12 38 56" src="https://github.com/user-attachments/assets/f938c4c8-0478-4995-801f-a09ef4a731bf" />

Fixes DAIN-1414.