### PR TITLE
ci(frontend): Increase Node memory limit to 8GB

### DIFF
--- a/.github/workflows/frontend-optional.yml
+++ b/.github/workflows/frontend-optional.yml
@@ -12,7 +12,7 @@ concurrency:
 # hack for https://github.com/actions/cache/issues/810#issuecomment-1222550359
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
-  NODE_OPTIONS: '--max-old-space-size=4096'
+  NODE_OPTIONS: '--max-old-space-size=8192'
 
 jobs:
   files-changed:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,7 +15,7 @@ concurrency:
 # hack for https://github.com/actions/cache/issues/810#issuecomment-1222550359
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
-  NODE_OPTIONS: '--max-old-space-size=4096'
+  NODE_OPTIONS: '--max-old-space-size=8192'
 
 jobs:
   files-changed:


### PR DESCRIPTION
Bump max-old-space-size from 4096 to 8192 in frontend CI workflows to give the TypeScript checker more headroom.