### PR TITLE
feat(notifications): Run Metric Alerts for Slack through Notification Platform

### DIFF
--- a/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
+++ b/src/sentry/notifications/notification_action/group_type_notification_registry/handlers/metric_alert_registry_handler.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Sequence
 from typing import override
 
@@ -6,16 +5,11 @@ from sentry.incidents.grouptype import MetricIssue
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.notifications.models.notificationaction import ActionTarget
-from sentry.notifications.notification_action.registry import (
-    group_type_notification_registry,
-    metric_alert_handler_registry,
-)
+from sentry.notifications.notification_action.registry import group_type_notification_registry
 from sentry.notifications.notification_action.types import LegacyRegistryHandler
-from sentry.utils.registry import NoRegistrationExistsError
+from sentry.notifications.notification_action.utils import execute_via_metric_alert_handler
 from sentry.workflow_engine.models import Action, DataConditionGroupAction
 from sentry.workflow_engine.types import ActionInvocation
-
-logger = logging.getLogger(__name__)
 
 
 @group_type_notification_registry.register(MetricIssue.slug)
@@ -23,22 +17,7 @@ class MetricAlertRegistryHandler(LegacyRegistryHandler):
     @staticmethod
     @override
     def handle_workflow_action(invocation: ActionInvocation) -> None:
-        try:
-            handler = metric_alert_handler_registry.get(invocation.action.type)
-            handler.invoke_legacy_registry(invocation)
-        except NoRegistrationExistsError:
-            logger.exception(
-                "No metric alert handler found for action type: %s",
-                invocation.action.type,
-                extra={"action_id": invocation.action.id},
-            )
-            raise
-        except Exception:
-            logger.exception(
-                "Error invoking metric alert handler",
-                extra={"action_id": invocation.action.id},
-            )
-            raise
+        execute_via_metric_alert_handler(invocation)
 
     @staticmethod
     def target(action: Action) -> OrganizationMember | Team | str | None:

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -194,7 +194,12 @@ def execute_via_metric_alert_handler(invocation: ActionInvocation) -> None:
     """
     if invocation.action.type == Action.Type.SLACK:
         organization = invocation.detector.project.organization
-        if NotificationService.has_access(organization, NotificationSource.METRIC_ALERT):
+        source = (
+            NotificationSource.ACTIVITY_METRIC_ALERT
+            if isinstance(invocation.event_data.event, Activity)
+            else NotificationSource.METRIC_ALERT
+        )
+        if NotificationService.has_access(organization, source):
             send_metric_alert_via_notification_platform(invocation)
             return
 

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -1,5 +1,6 @@
 import logging
 
+from sentry.eventstore.models import GroupEvent
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
@@ -9,11 +10,25 @@ from sentry.notifications.notification_action.registry import (
     metric_alert_handler_registry,
 )
 from sentry.notifications.notification_action.types import BaseMetricAlertHandler
+from sentry.notifications.platform.service import NotificationService
+from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.templates.issue import (
     IssueNotificationData,
     SerializableRuleProxy,
 )
+from sentry.notifications.platform.templates.metric_alert import (
+    ActivityMetricAlertNotificationData,
+    MetricAlertNotificationData,
+    SerializableAlertContext,
+)
+from sentry.notifications.platform.threading import ThreadingOptions, ThreadKey
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationSource,
+    NotificationTargetResourceType,
+)
 from sentry.utils.registry import NoRegistrationExistsError
+from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import ActionInvocation
 
 logger = logging.getLogger(__name__)
@@ -90,10 +105,99 @@ def execute_via_issue_alert_handler(invocation: ActionInvocation) -> None:
         raise
 
 
+def send_metric_alert_via_notification_platform(invocation: ActionInvocation) -> None:
+    notification_context = BaseMetricAlertHandler.build_notification_context(invocation.action)
+
+    if (
+        notification_context.integration_id is None
+        or notification_context.target_identifier is None
+    ):
+        logger.warning(
+            "notification_action.metric_alert.notification_platform.missing_integration_or_target",
+            extra={"action_id": invocation.action.id, "detector_id": invocation.detector.id},
+        )
+        return
+
+    event = invocation.event_data.event
+    organization = invocation.detector.project.organization
+
+    if isinstance(event, GroupEvent):
+        evidence_data, priority = BaseMetricAlertHandler._extract_from_group_event(event)
+    elif isinstance(event, Activity):
+        evidence_data, priority = BaseMetricAlertHandler._extract_from_activity(event)
+    else:
+        raise ValueError(
+            "WorkflowEventData.event must be a GroupEvent or Activity to invoke metric alert notification platform"
+        )
+
+    alert_context = BaseMetricAlertHandler.build_alert_context(
+        invocation.detector, evidence_data, invocation.event_data.group.status, priority
+    )
+    open_period_context = BaseMetricAlertHandler.build_open_period_context(
+        invocation.event_data.group
+    )
+    serializable_alert_context = SerializableAlertContext.from_alert_context(alert_context)
+
+    data: ActivityMetricAlertNotificationData | MetricAlertNotificationData
+    if isinstance(event, Activity):
+        data = ActivityMetricAlertNotificationData(
+            activity_id=event.id,
+            group_id=invocation.event_data.group.id,
+            organization_id=organization.id,
+            detector_id=invocation.detector.id,
+            alert_context=serializable_alert_context,
+            open_period_context=open_period_context,
+            notification_uuid=invocation.notification_uuid,
+        )
+    else:
+        data = MetricAlertNotificationData(
+            event_id=event.event_id,
+            project_id=invocation.detector.project.id,
+            group_id=invocation.event_data.group.id,
+            organization_id=organization.id,
+            detector_id=invocation.detector.id,
+            alert_context=serializable_alert_context,
+            open_period_context=open_period_context,
+            notification_uuid=invocation.notification_uuid,
+        )
+
+    target = IntegrationNotificationTarget(
+        provider_key=NotificationProviderKey.SLACK,
+        resource_type=NotificationTargetResourceType.CHANNEL,
+        resource_id=notification_context.target_identifier,
+        integration_id=notification_context.integration_id,
+        organization_id=organization.id,
+    )
+
+    thread_key = ThreadKey(
+        key_type=NotificationSource.METRIC_ALERT,
+        key_data={
+            "action_id": invocation.action.id,
+            "group_id": invocation.event_data.group.id,
+            "open_period_id": open_period_context.id,
+        },
+    )
+    # Resolutions reply into the original alert thread and broadcast to the channel.
+    threading_options = ThreadingOptions(
+        thread_key=thread_key,
+        reply_broadcast=isinstance(event, Activity),
+    )
+
+    NotificationService(data=data).notify_sync(
+        targets=[target], threading_options=threading_options
+    )
+
+
 def execute_via_metric_alert_handler(invocation: ActionInvocation) -> None:
     """
     This exists so that all metric alert resolution actions can use the same handler as metric alerts
     """
+    if invocation.action.type == Action.Type.SLACK:
+        organization = invocation.detector.project.organization
+        if NotificationService.has_access(organization, NotificationSource.METRIC_ALERT):
+            send_metric_alert_via_notification_platform(invocation)
+            return
+
     try:
         handler = metric_alert_handler_registry.get(invocation.action.type)
         handler.invoke_legacy_registry(invocation)

--- a/tests/sentry/notifications/notification_action/test_utils.py
+++ b/tests/sentry/notifications/notification_action/test_utils.py
@@ -1,0 +1,220 @@
+import uuid
+from dataclasses import asdict
+from unittest.mock import Mock, patch
+
+from slack_sdk.web import SlackResponse
+
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.activity import Activity
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.models.notificationthread import NotificationThread
+from sentry.notifications.notification_action.utils import (
+    send_metric_alert_via_notification_platform,
+)
+from sentry.notifications.platform.types import NotificationSource
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.skips import requires_snuba
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
+    MetricAlertHandlerBase,
+)
+
+pytestmark = [requires_snuba]
+
+SLACK_CLIENT_PATH = "sentry.integrations.slack.integration.SlackSdkClient"
+EVENTSTORE_PATH = (
+    "sentry.notifications.platform.slack.renderers.metric_alert.eventstore.backend.get_event_by_id"
+)
+CHART_PATH = "sentry.notifications.platform.slack.renderers.metric_alert.build_metric_alert_chart"
+INTERNAL_TESTING_OPTION = "notifications.platform-rollout.internal-testing"
+INTERNAL_TESTING_FLAG = "organizations:notification-platform.internal-testing"
+METRIC_ALERT_ROLLOUT = {
+    INTERNAL_TESTING_OPTION: {"metric-alert": 1.0, "activity-metric-alert": 1.0}
+}
+
+
+class TestSendMetricAlertViaNotificationPlatform(MetricAlertHandlerBase):
+    """
+    Tests for send_metric_alert_via_notification_platform.
+    Verifies the function correctly routes through the notification platform to the Slack client,
+    and stores threading objects.
+    """
+
+    def setUp(self) -> None:
+        self.create_models()
+        self.integration, _ = self.create_provider_integration_for(
+            provider=IntegrationProviderSlug.SLACK,
+            organization=self.organization,
+            user=self.user,
+            name="test-slack",
+            metadata={"domain_name": "test-workspace.slack.com"},
+        )
+        self.action = self.create_action(
+            type=Action.Type.SLACK,
+            integration_id=self.integration.id,
+            config={
+                "target_identifier": "C1234567890",
+                "target_display": "#alerts",
+                "target_type": ActionTarget.SPECIFIC,
+            },
+        )
+
+    def _make_invocation(self, event_data: WorkflowEventData | None = None) -> ActionInvocation:
+        return ActionInvocation(
+            event_data=event_data or self.event_data,
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+
+    def _make_slack_response(self, ts: str) -> SlackResponse:
+        mock_client = Mock()
+        return SlackResponse(
+            client=mock_client,
+            http_verb="POST",
+            api_url="https://slack.com/api/chat.postMessage",
+            req_args={},
+            data={"ok": True, "ts": ts},
+            headers={},
+            status_code=200,
+        )
+
+    def _make_activity_event_data(self) -> WorkflowEventData:
+        activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data=asdict(self.evidence_data),
+        )
+        activity.save()
+        return WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+    @with_feature(INTERNAL_TESTING_FLAG)
+    @override_options(METRIC_ALERT_ROLLOUT)
+    @patch(CHART_PATH, return_value=None)
+    @patch(EVENTSTORE_PATH)
+    @patch(SLACK_CLIENT_PATH)
+    def test_group_event_sends_to_slack(
+        self, mock_slack_client: Mock, mock_get_event: Mock, _mock_chart: Mock
+    ) -> None:
+        """GroupEvent (firing) path sends to the correct channel with a metric alert payload."""
+        mock_get_event.return_value = self.group_event
+        mock_client_instance = mock_slack_client.return_value
+        mock_client_instance.chat_postMessage.return_value = self._make_slack_response(
+            "1111.111111"
+        )
+
+        send_metric_alert_via_notification_platform(self._make_invocation())
+
+        mock_client_instance.chat_postMessage.assert_called_once()
+        call_kwargs = mock_client_instance.chat_postMessage.call_args[1]
+        assert call_kwargs["channel"] == "C1234567890"
+        assert call_kwargs["blocks"]
+        assert call_kwargs["blocks"][0]["type"] == "section"
+        assert self.detector.name in call_kwargs["text"]
+
+    @with_feature(INTERNAL_TESTING_FLAG)
+    @override_options(METRIC_ALERT_ROLLOUT)
+    @patch(CHART_PATH, return_value=None)
+    @patch(SLACK_CLIENT_PATH)
+    def test_activity_sends_to_slack(self, mock_slack_client: Mock, _mock_chart: Mock) -> None:
+        """Activity (resolution) path sends to the correct channel with a metric alert payload."""
+        mock_client_instance = mock_slack_client.return_value
+        mock_client_instance.chat_postMessage.return_value = self._make_slack_response(
+            "1111.111111"
+        )
+
+        invocation = self._make_invocation(event_data=self._make_activity_event_data())
+        send_metric_alert_via_notification_platform(invocation)
+
+        mock_client_instance.chat_postMessage.assert_called_once()
+        call_kwargs = mock_client_instance.chat_postMessage.call_args[1]
+        assert call_kwargs["channel"] == "C1234567890"
+        assert call_kwargs["blocks"]
+        assert call_kwargs["blocks"][0]["type"] == "section"
+        assert self.detector.name in call_kwargs["text"]
+
+    def test_missing_integration_or_target_logs_warning(self) -> None:
+        """When the action has no integration_id, logs a warning and returns early without sending."""
+        action_no_integration = self.create_action(
+            type=Action.Type.SLACK,
+            integration_id=None,
+            config={
+                "target_identifier": "C1234567890",
+                "target_display": "#alerts",
+                "target_type": ActionTarget.SPECIFIC,
+            },
+        )
+        invocation = ActionInvocation(
+            event_data=self.event_data,
+            action=action_no_integration,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+
+        with self.assertLogs("sentry", level="WARNING") as captured:
+            send_metric_alert_via_notification_platform(invocation)
+
+        assert any("missing_integration_or_target" in line for line in captured.output)
+
+    @with_feature(INTERNAL_TESTING_FLAG)
+    @override_options(METRIC_ALERT_ROLLOUT)
+    @patch(CHART_PATH, return_value=None)
+    @patch(EVENTSTORE_PATH)
+    @patch(SLACK_CLIENT_PATH)
+    def test_firing_creates_notification_thread(
+        self, mock_slack_client: Mock, mock_get_event: Mock, _mock_chart: Mock
+    ) -> None:
+        """Firing a metric alert stores a NotificationThread for subsequent replies."""
+        mock_get_event.return_value = self.group_event
+        mock_client_instance = mock_slack_client.return_value
+        mock_client_instance.chat_postMessage.return_value = self._make_slack_response(
+            "1111.111111"
+        )
+
+        assert NotificationThread.objects.count() == 0
+
+        send_metric_alert_via_notification_platform(self._make_invocation())
+
+        assert NotificationThread.objects.count() == 1
+        thread = NotificationThread.objects.get()
+        assert thread.thread_identifier == "1111.111111"
+        assert thread.target_id == "C1234567890"
+        assert thread.key_type == NotificationSource.METRIC_ALERT
+
+    @with_feature(INTERNAL_TESTING_FLAG)
+    @override_options(METRIC_ALERT_ROLLOUT)
+    @patch(CHART_PATH, return_value=None)
+    @patch(EVENTSTORE_PATH)
+    @patch(SLACK_CLIENT_PATH)
+    def test_resolution_replies_in_thread(
+        self, mock_slack_client: Mock, mock_get_event: Mock, _mock_chart: Mock
+    ) -> None:
+        """Resolution uses the same thread key as the firing notification and replies in-thread."""
+        mock_get_event.return_value = self.group_event
+        mock_client_instance = mock_slack_client.return_value
+        mock_client_instance.chat_postMessage.return_value = self._make_slack_response(
+            "1111.111111"
+        )
+
+        # Fire the alert — creates the thread
+        send_metric_alert_via_notification_platform(self._make_invocation())
+
+        # Send the resolution — should reply into the same thread
+        mock_client_instance.chat_postMessage.return_value = self._make_slack_response(
+            "2222.222222"
+        )
+        resolution_invocation = self._make_invocation(event_data=self._make_activity_event_data())
+        send_metric_alert_via_notification_platform(resolution_invocation)
+
+        assert mock_client_instance.chat_postMessage.call_count == 2
+        resolution_kwargs = mock_client_instance.chat_postMessage.call_args_list[1][1]
+        assert resolution_kwargs["thread_ts"] == "1111.111111"
+        assert resolution_kwargs["reply_broadcast"] is True


### PR DESCRIPTION
  Routes Slack metric alert notifications through the Notification Platform (NP).                                                                     
                                                                                                    
  What changed:                                                                                                                                                   
                                                                                                    
  - execute_via_metric_alert_handler (notification_action/utils.py) — added a feature-flag gate that checks access to `NotificationSource.METRIC_ALERT` or `NotificationSource.ACTIVITY_METRIC_ALERT   `                                                                                               
  - send_metric_alert_via_notification_platform (new function) — builds `MetricAlertNotificationData` or `ActivityMetricAlertNotificationData` from the `ActionInvocation`, constructs an `IntegrationNotificationTarget` for the Slack channel. Includes threading: firing creates  a new `NotificationThread` keyed on (`action_id`, `group_id`, `open_period_id`);
  - MetricAlertRegistryHandler.handle_workflow_action — simplified to call execute_via_metric_alert_handler directly, since the logic is the same.                                                                                             
                                           