### PR TITLE
feat(autofix): Replace ghost with loading text

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useMemo, useRef, type ReactNode} from 'react';
+import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button, LinkButton} from '@sentry/scraps/button';
@@ -22,7 +23,7 @@ import {
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
-import {Placeholder} from 'sentry/components/placeholder';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconRefresh} from 'sentry/icons';
 import {IconBot} from 'sentry/icons/iconBot';
@@ -52,7 +53,10 @@ export function RootCauseCard({autofix, section}: AutofixCardProps) {
   return (
     <ArtifactCard icon={<IconBug />} title={t('Root Cause')}>
       {section.status === 'processing' ? (
-        <LoadingDetails messages={section.messages} />
+        <LoadingDetails
+          messages={section.messages}
+          loadingMessage={t('Finding the root cause\u2026')}
+        />
       ) : artifact?.data ? (
         <Fragment>
           <Text>{artifact.data.one_line_description}</Text>
@@ -117,7 +121,10 @@ export function SolutionCard({autofix, section}: AutofixCardProps) {
   return (
     <ArtifactCard icon={<IconList />} title={t('Plan')}>
       {section.status === 'processing' ? (
-        <LoadingDetails messages={section.messages} />
+        <LoadingDetails
+          messages={section.messages}
+          loadingMessage={t('Formulating a plan\u2026')}
+        />
       ) : artifact?.data ? (
         <Fragment>
           <Text>{artifact.data.one_line_summary}</Text>
@@ -197,7 +204,10 @@ export function CodeChangesCard({autofix, section}: AutofixCardProps) {
   return (
     <ArtifactCard icon={<IconCode />} title={t('Code Changes')}>
       {section.status === 'processing' ? (
-        <LoadingDetails messages={section.messages} />
+        <LoadingDetails
+          messages={section.messages}
+          loadingMessage={t('Implementing changes\u2026')}
+        />
       ) : (
         <Fragment>
           {patchesByRepo.size ? (
@@ -393,10 +403,11 @@ function ArtifactDetails({children, ...flexProps}: ArtifactDetailsProps) {
 }
 
 interface LoadingDetailsProps {
+  loadingMessage: string;
   messages: AutofixSection['messages'];
 }
 
-function LoadingDetails({messages}: LoadingDetailsProps) {
+function LoadingDetails({loadingMessage, messages}: LoadingDetailsProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -440,10 +451,15 @@ function LoadingDetails({messages}: LoadingDetailsProps) {
 
           return null;
         })}
-        <div ref={bottomRef}>
-          <Placeholder height="1.5rem" />
-        </div>
+        <Flex ref={bottomRef} direction="row" gap="md">
+          <StyledLoadingIndicator size={16} />
+          <Text variant="muted">{loadingMessage}</Text>
+        </Flex>
       </Flex>
     </ArtifactDetails>
   );
 }
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  margin: 0;
+`;

--- a/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
@@ -47,12 +47,12 @@ describe('RootCausePreview', () => {
     expect(screen.getByText('Null pointer in user handler')).toBeInTheDocument();
   });
 
-  it('renders placeholder when processing', () => {
+  it('renders loading text when processing', () => {
     render(
       <RootCausePreview section={makeSection('root_cause', [], {status: 'processing'})} />
     );
 
-    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+    expect(screen.getByText('Finding the root cause…')).toBeInTheDocument();
   });
 
   it('handles null data', () => {
@@ -90,12 +90,12 @@ describe('SolutionPreview', () => {
     expect(screen.getByText('Add null check before accessing user')).toBeInTheDocument();
   });
 
-  it('renders placeholder when processing', () => {
+  it('renders loading text when processing', () => {
     render(
       <SolutionPreview section={makeSection('solution', [], {status: 'processing'})} />
     );
 
-    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+    expect(screen.getByText('Formulating a plan…')).toBeInTheDocument();
   });
 
   it('handles null data', () => {
@@ -176,14 +176,14 @@ describe('CodeChangesPreview', () => {
     expect(screen.getByText('3 files changed in 2 repos')).toBeInTheDocument();
   });
 
-  it('renders placeholder when processing', () => {
+  it('renders loading text when processing', () => {
     render(
       <CodeChangesPreview
         section={makeSection('code_changes', [], {status: 'processing'})}
       />
     );
 
-    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+    expect(screen.getByText('Implementing changes…')).toBeInTheDocument();
   });
 
   it('renders empty array with error message', () => {

--- a/static/app/components/events/autofix/v3/autofixPreviews.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.tsx
@@ -1,4 +1,5 @@
 import {useMemo, type ReactNode} from 'react';
+import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
@@ -20,6 +21,7 @@ import {
   isSolutionArtifact,
   type AutofixSection,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconOpen} from 'sentry/icons';
 import {IconBot} from 'sentry/icons/iconBot';
@@ -42,7 +44,10 @@ export function RootCausePreview({section}: ArtifactPreviewProps) {
   return (
     <ArtifactCard icon={<IconBug />} title={t('Root Cause')}>
       {section.status === 'processing' ? (
-        <Placeholder height="3rem" />
+        <Flex direction="row" gap="md">
+          <StyledLoadingIndicator size={16} />
+          <Text>{t('Finding the root cause\u2026')}</Text>
+        </Flex>
       ) : artifact?.data ? (
         <Text>{artifact.data.one_line_description}</Text>
       ) : (
@@ -65,7 +70,10 @@ export function SolutionPreview({section}: ArtifactPreviewProps) {
   return (
     <ArtifactCard icon={<IconList />} title={t('Plan')}>
       {section.status === 'processing' ? (
-        <Placeholder height="3rem" />
+        <Flex direction="row" gap="md">
+          <StyledLoadingIndicator size={16} />
+          <Text>{t('Formulating a plan\u2026')}</Text>
+        </Flex>
       ) : artifact?.data ? (
         <Text>{artifact.data.one_line_summary}</Text>
       ) : (
@@ -125,7 +133,14 @@ export function CodeChangesPreview({section}: ArtifactPreviewProps) {
 
   return (
     <ArtifactCard icon={<IconCode />} title={t('Code Changes')}>
-      {section.status === 'processing' ? <Placeholder height="1.5rem" /> : summary}
+      {section.status === 'processing' ? (
+        <Flex direction="row" gap="md">
+          <StyledLoadingIndicator size={16} />
+          <Text>{t('Implementing changes\u2026')}</Text>
+        </Flex>
+      ) : (
+        summary
+      )}
     </ArtifactCard>
   );
 }
@@ -228,3 +243,7 @@ function ArtifactCard({children, icon, title}: ArtifactCardProps) {
     </Flex>
   );
 }
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  margin: 0;
+`;

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -292,7 +292,6 @@ function AutofixEmptyState({
         size="md"
         icon={<IconBug />}
         aria-label={t('Start Analysis')}
-        tooltipProps={{title: t('Start Analysis')}}
         priority="primary"
         onClick={handleStartRootCause}
         analyticsEventKey="autofix.start_fix_clicked"


### PR DESCRIPTION
Improve the loading state by using loading text instead of the ghost to make it more obvious we're still in a loading state.

# Screenshots

## Drawer

| Root Cause | Plan | Code Changes |
| ----------- | ----- | -------------- |
|  <img width="1130" height="590" alt="image" src="https://github.com/user-attachments/assets/aecf3536-4a0b-4c31-9cb1-c79ea78124e9" /> | <img width="1130" height="402" alt="image" src="https://github.com/user-attachments/assets/4e462a27-ebf2-47e7-85b9-c40c5735cbff" /> | <img width="1130" height="402" alt="image" src="https://github.com/user-attachments/assets/e5d177d9-0ff5-43ae-bf56-99bf2937601f" /> |

## Sidebar

| Root Cause | Plan | Code Changes |
| ----------- | ----- | -------------- |
| <img width="554" height="132" alt="image" src="https://github.com/user-attachments/assets/82d074d7-763d-44ea-be8f-310cc4f2ef78" /> | <img width="554" height="130" alt="image" src="https://github.com/user-attachments/assets/7a8eed65-f9f8-4ae2-bb9a-1f32f0461055" /> | <img width="554" height="130" alt="image" src="https://github.com/user-attachments/assets/f5c92318-7c45-49a7-9cd6-8b21d7ee587e" /> |