### PR TITLE
feat(deletions): Add CLI command to list and run scheduled deletions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -494,9 +494,10 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 
 /src/sentry/runner/commands/createproject.py                         @getsentry/ecosystem
 /src/sentry/runner/commands/createorg.py                             @getsentry/ecosystem
+/src/sentry/runner/commands/deletions.py                             @getsentry/ecosystem
 /tests/sentry/runner/commands/test_createproject.py                  @getsentry/ecosystem
 /tests/sentry/runner/commands/test_createorg.py                      @getsentry/ecosystem
-
+/tests/sentry/runner/commands/test_deletions.py                      @getsentry/ecosystem
 ## End of Integrations
 
 

--- a/src/sentry/runner/commands/deletions.py
+++ b/src/sentry/runner/commands/deletions.py
@@ -106,6 +106,7 @@ def run_deletions(
         )
         from sentry.silo.base import SiloLimit
 
+        model_cls: type[BaseScheduledDeletion]
         if cell_deletion_id:
             model_cls, target_id = CellScheduledDeletion, cell_deletion_id
         else:
@@ -114,7 +115,11 @@ def run_deletions(
 
         try:
             deletion = model_cls.objects.get(id=target_id)
-        except (model_cls.DoesNotExist, SiloLimit.AvailabilityError):
+        except (
+            ScheduledDeletion.DoesNotExist,
+            CellScheduledDeletion.DoesNotExist,
+            SiloLimit.AvailabilityError,
+        ):
             click.echo(f"Deletion with ID {target_id} not found in {model_cls.__name__}.")
             return
         _run_one(deletion=deletion, verbose=verbose)

--- a/src/sentry/runner/commands/deletions.py
+++ b/src/sentry/runner/commands/deletions.py
@@ -65,6 +65,8 @@ def run_deletions(deletion_id: int | None, model: str | None, run_all: bool, ver
     """
     Run pending scheduled deletions synchronously.
     """
+    from django.utils import timezone
+
     from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 
     if not any([deletion_id, model, run_all]):
@@ -82,7 +84,9 @@ def run_deletions(deletion_id: int | None, model: str | None, run_all: bool, ver
         _run_one(deletion=deletion, verbose=verbose)
         return
 
-    queryset = ScheduledDeletion.objects.all()
+    queryset = ScheduledDeletion.objects.filter(
+        in_progress=False, date_scheduled__lte=timezone.now()
+    )
     if model:
         queryset = queryset.filter(model_name=model)
 

--- a/src/sentry/runner/commands/deletions.py
+++ b/src/sentry/runner/commands/deletions.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
 from sentry.runner.decorators import configuration
+
+if TYPE_CHECKING:
+    from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 
 
 @click.group()
@@ -52,8 +59,9 @@ def list_deletions(model: str | None) -> None:
     default=None,
 )
 @click.option("--all", "run_all", is_flag=True, help="Run all pending deletions")
+@click.option("-v", "--verbose", is_flag=True, help="Show full tracebacks on failure")
 @configuration
-def run_deletions(deletion_id: int | None, model: str | None, run_all: bool) -> None:
+def run_deletions(deletion_id: int | None, model: str | None, run_all: bool, verbose: bool) -> None:
     """
     Run pending scheduled deletions synchronously.
     """
@@ -71,7 +79,7 @@ def run_deletions(deletion_id: int | None, model: str | None, run_all: bool) -> 
         except ScheduledDeletion.DoesNotExist:
             click.echo(f"Deletion with ID {deletion_id} not found.")
             return
-        _run_one(deletion)
+        _run_one(deletion=deletion, verbose=verbose)
         return
 
     queryset = ScheduledDeletion.objects.all()
@@ -85,10 +93,10 @@ def run_deletions(deletion_id: int | None, model: str | None, run_all: bool) -> 
 
     click.echo(f"Running {len(deletions_list)} deletion(s)...")
     for d in deletions_list:
-        _run_one(d)
+        _run_one(deletion=d, verbose=verbose)
 
 
-def _run_one(deletion) -> None:  # type: ignore[no-untyped-def]
+def _run_one(*, deletion: ScheduledDeletion, verbose: bool = False) -> None:
     from django.core.exceptions import ObjectDoesNotExist
 
     from sentry import deletions as deletions_module
@@ -124,4 +132,10 @@ def _run_one(deletion) -> None:  # type: ignore[no-untyped-def]
         deletion.delete()
         click.echo("  Done.")
     except Exception as e:
-        click.echo(f"  Failed: {e}")
+        if verbose:
+            import traceback
+
+            click.echo(f"  Failed:\n{traceback.format_exc()}", err=True)
+        else:
+            click.echo(f"  Failed: {e}", err=True)
+        click.echo("  Deletion record preserved for retry. Re-run to continue.")

--- a/src/sentry/runner/commands/deletions.py
+++ b/src/sentry/runner/commands/deletions.py
@@ -1,13 +1,44 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 
 from sentry.runner.decorators import configuration
 
 if TYPE_CHECKING:
-    from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
+    from sentry.deletions.models.scheduleddeletion import BaseScheduledDeletion
+
+
+def _get_deletion_models() -> list[type[BaseScheduledDeletion]]:
+    from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion, ScheduledDeletion
+
+    return [ScheduledDeletion, CellScheduledDeletion]
+
+
+def _query_all(**filters: Any) -> list[BaseScheduledDeletion]:
+    from sentry.silo.base import SiloLimit
+
+    results: list[BaseScheduledDeletion] = []
+    for model_cls in _get_deletion_models():
+        try:
+            results.extend(model_cls.objects.filter(**filters))
+        except SiloLimit.AvailabilityError:
+            continue
+    return results
+
+
+def _find_by_id(deletion_id: int) -> BaseScheduledDeletion | None:
+    from sentry.silo.base import SiloLimit
+
+    for model_cls in _get_deletion_models():
+        try:
+            return model_cls.objects.get(id=deletion_id)
+        except model_cls.DoesNotExist:
+            continue
+        except SiloLimit.AvailabilityError:
+            continue
+    return None
 
 
 @click.group()
@@ -29,13 +60,11 @@ def list_deletions(model: str | None) -> None:
     """
     List pending scheduled deletions.
     """
-    from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
-
-    queryset = ScheduledDeletion.objects.all()
+    filters: dict[str, Any] = {}
     if model:
-        queryset = queryset.filter(model_name=model)
+        filters["model_name"] = model
 
-    deletions_list = list(queryset)
+    deletions_list = _query_all(**filters)
     if not deletions_list:
         click.echo("No pending deletions found.")
         return
@@ -67,8 +96,6 @@ def run_deletions(deletion_id: int | None, model: str | None, run_all: bool, ver
     """
     from django.utils import timezone
 
-    from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
-
     if not any([deletion_id, model, run_all]):
         raise click.UsageError(
             "Provide one of: --id, --model, or --all. "
@@ -76,21 +103,21 @@ def run_deletions(deletion_id: int | None, model: str | None, run_all: bool, ver
         )
 
     if deletion_id:
-        try:
-            deletion = ScheduledDeletion.objects.get(id=deletion_id)
-        except ScheduledDeletion.DoesNotExist:
+        deletion = _find_by_id(deletion_id)
+        if not deletion:
             click.echo(f"Deletion with ID {deletion_id} not found.")
             return
         _run_one(deletion=deletion, verbose=verbose)
         return
 
-    queryset = ScheduledDeletion.objects.filter(
-        in_progress=False, date_scheduled__lte=timezone.now()
-    )
+    filters: dict[str, Any] = {
+        "in_progress": False,
+        "date_scheduled__lte": timezone.now(),
+    }
     if model:
-        queryset = queryset.filter(model_name=model)
+        filters["model_name"] = model
 
-    deletions_list = list(queryset)
+    deletions_list = _query_all(**filters)
     if not deletions_list:
         click.echo("No pending deletions found.")
         return
@@ -100,7 +127,7 @@ def run_deletions(deletion_id: int | None, model: str | None, run_all: bool, ver
         _run_one(deletion=d, verbose=verbose)
 
 
-def _run_one(*, deletion: ScheduledDeletion, verbose: bool = False) -> None:
+def _run_one(*, deletion: BaseScheduledDeletion, verbose: bool = False) -> None:
     from django.core.exceptions import ObjectDoesNotExist
 
     from sentry import deletions as deletions_module

--- a/src/sentry/runner/commands/deletions.py
+++ b/src/sentry/runner/commands/deletions.py
@@ -1,0 +1,127 @@
+import click
+
+from sentry.runner.decorators import configuration
+
+
+@click.group()
+def deletions() -> None:
+    """
+    Utilities to manage scheduled deletions locally.
+    """
+
+
+@deletions.command("list")
+@click.option(
+    "-m",
+    "--model",
+    help="Filter by model name (e.g. OrganizationIntegration)",
+    default=None,
+)
+@configuration
+def list_deletions(model: str | None) -> None:
+    """
+    List pending scheduled deletions.
+    """
+    from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
+
+    queryset = ScheduledDeletion.objects.all()
+    if model:
+        queryset = queryset.filter(model_name=model)
+
+    deletions_list = list(queryset)
+    if not deletions_list:
+        click.echo("No pending deletions found.")
+        return
+
+    click.echo(f"\n{'ID':<8} {'Model':<30} {'Object ID':<12} {'In Progress':<14} {'Scheduled'}")
+    click.echo("-" * 90)
+    for d in deletions_list:
+        click.echo(
+            f"{d.id:<8} {d.model_name:<30} {d.object_id:<12} {str(d.in_progress):<14} {d.date_scheduled}"
+        )
+
+
+@deletions.command("run")
+@click.option(
+    "-i", "--id", "deletion_id", type=int, help="Specific deletion ID to run", default=None
+)
+@click.option(
+    "-m",
+    "--model",
+    help="Run all pending deletions for a model name (e.g. OrganizationIntegration)",
+    default=None,
+)
+@click.option("--all", "run_all", is_flag=True, help="Run all pending deletions")
+@configuration
+def run_deletions(deletion_id: int | None, model: str | None, run_all: bool) -> None:
+    """
+    Run pending scheduled deletions synchronously.
+    """
+    from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
+
+    if not any([deletion_id, model, run_all]):
+        raise click.UsageError(
+            "Provide one of: --id, --model, or --all. "
+            "Use `sentry deletions list` to see pending deletions."
+        )
+
+    if deletion_id:
+        try:
+            deletion = ScheduledDeletion.objects.get(id=deletion_id)
+        except ScheduledDeletion.DoesNotExist:
+            click.echo(f"Deletion with ID {deletion_id} not found.")
+            return
+        _run_one(deletion)
+        return
+
+    queryset = ScheduledDeletion.objects.all()
+    if model:
+        queryset = queryset.filter(model_name=model)
+
+    deletions_list = list(queryset)
+    if not deletions_list:
+        click.echo("No pending deletions found.")
+        return
+
+    click.echo(f"Running {len(deletions_list)} deletion(s)...")
+    for d in deletions_list:
+        _run_one(d)
+
+
+def _run_one(deletion) -> None:  # type: ignore[no-untyped-def]
+    from django.core.exceptions import ObjectDoesNotExist
+
+    from sentry import deletions as deletions_module
+    from sentry.signals import pending_delete
+
+    click.echo(f"Running deletion {deletion.id} ({deletion.model_name} #{deletion.object_id})...")
+    try:
+        instance = deletion.get_instance()
+    except ObjectDoesNotExist:
+        click.echo("  Object already deleted, cleaning up scheduled deletion.")
+        deletion.delete()
+        return
+
+    task = deletions_module.get(
+        model=deletion.get_model(),
+        query={"id": deletion.object_id},
+        transaction_id=deletion.guid,
+        actor_id=deletion.actor_id,
+    )
+
+    if not task.should_proceed(instance):
+        click.echo("  Deletion aborted (should_proceed returned False).")
+        deletion.delete()
+        return
+
+    actor = deletion.get_actor()
+    pending_delete.send(sender=type(instance), instance=instance, actor=actor)
+
+    try:
+        has_more = True
+        while has_more:
+            has_more = task.chunk()
+        deletion.delete()
+        click.echo("  Done.")
+    except Exception as e:
+        click.echo(f"  Failed: {e}")

--- a/src/sentry/runner/commands/deletions.py
+++ b/src/sentry/runner/commands/deletions.py
@@ -10,35 +10,17 @@ if TYPE_CHECKING:
     from sentry.deletions.models.scheduleddeletion import BaseScheduledDeletion
 
 
-def _get_deletion_models() -> list[type[BaseScheduledDeletion]]:
-    from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion, ScheduledDeletion
-
-    return [ScheduledDeletion, CellScheduledDeletion]
-
-
 def _query_all(**filters: Any) -> list[BaseScheduledDeletion]:
+    from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion, ScheduledDeletion
     from sentry.silo.base import SiloLimit
 
     results: list[BaseScheduledDeletion] = []
-    for model_cls in _get_deletion_models():
+    for model_cls in [ScheduledDeletion, CellScheduledDeletion]:
         try:
             results.extend(model_cls.objects.filter(**filters))
         except SiloLimit.AvailabilityError:
             continue
     return results
-
-
-def _find_by_id(deletion_id: int) -> BaseScheduledDeletion | None:
-    from sentry.silo.base import SiloLimit
-
-    for model_cls in _get_deletion_models():
-        try:
-            return model_cls.objects.get(id=deletion_id)
-        except model_cls.DoesNotExist:
-            continue
-        except SiloLimit.AvailabilityError:
-            continue
-    return None
 
 
 @click.group()
@@ -69,17 +51,26 @@ def list_deletions(model: str | None) -> None:
         click.echo("No pending deletions found.")
         return
 
-    click.echo(f"\n{'ID':<8} {'Model':<30} {'Object ID':<12} {'In Progress':<14} {'Scheduled'}")
-    click.echo("-" * 90)
+    click.echo(
+        f"\n{'Table':<26} {'ID':<8} {'Model':<30} {'Object ID':<12} {'In Progress':<14} {'Scheduled'}"
+    )
+    click.echo("-" * 116)
     for d in deletions_list:
         click.echo(
-            f"{d.id:<8} {d.model_name:<30} {d.object_id:<12} {str(d.in_progress):<14} {d.date_scheduled}"
+            f"{type(d).__name__:<26} {d.id:<8} {d.model_name:<30} {d.object_id:<12} {str(d.in_progress):<14} {d.date_scheduled}"
         )
 
 
 @deletions.command("run")
 @click.option(
-    "-i", "--id", "deletion_id", type=int, help="Specific deletion ID to run", default=None
+    "-i", "--id", "deletion_id", type=int, help="ScheduledDeletion object ID to run", default=None
+)
+@click.option(
+    "--cid",
+    "cell_deletion_id",
+    type=int,
+    help="CellScheduledDeletion object ID to run",
+    default=None,
 )
 @click.option(
     "-m",
@@ -90,22 +81,41 @@ def list_deletions(model: str | None) -> None:
 @click.option("--all", "run_all", is_flag=True, help="Run all pending deletions")
 @click.option("-v", "--verbose", is_flag=True, help="Show full tracebacks on failure")
 @configuration
-def run_deletions(deletion_id: int | None, model: str | None, run_all: bool, verbose: bool) -> None:
+def run_deletions(
+    deletion_id: int | None,
+    cell_deletion_id: int | None,
+    model: str | None,
+    run_all: bool,
+    verbose: bool,
+) -> None:
     """
     Run pending scheduled deletions synchronously.
     """
     from django.utils import timezone
 
-    if not any([deletion_id, model, run_all]):
+    if not any([deletion_id, cell_deletion_id, model, run_all]):
         raise click.UsageError(
-            "Provide one of: --id, --model, or --all. "
+            "Provide one of: --id, --cid, --model, or --all. "
             "Use `sentry deletions list` to see pending deletions."
         )
 
-    if deletion_id:
-        deletion = _find_by_id(deletion_id)
-        if not deletion:
-            click.echo(f"Deletion with ID {deletion_id} not found.")
+    if deletion_id or cell_deletion_id:
+        from sentry.deletions.models.scheduleddeletion import (
+            CellScheduledDeletion,
+            ScheduledDeletion,
+        )
+        from sentry.silo.base import SiloLimit
+
+        if cell_deletion_id:
+            model_cls, target_id = CellScheduledDeletion, cell_deletion_id
+        else:
+            assert deletion_id is not None
+            model_cls, target_id = ScheduledDeletion, deletion_id
+
+        try:
+            deletion = model_cls.objects.get(id=target_id)
+        except (model_cls.DoesNotExist, SiloLimit.AvailabilityError):
+            click.echo(f"Deletion with ID {target_id} not found in {model_cls.__name__}.")
             return
         _run_one(deletion=deletion, verbose=verbose)
         return

--- a/src/sentry/runner/main.py
+++ b/src/sentry/runner/main.py
@@ -70,6 +70,7 @@ for cmd in map(
         "sentry.runner.commands.spans.spans",
         "sentry.runner.commands.spans.write_hashes",
         "sentry.runner.commands.notifications.notifications",
+        "sentry.runner.commands.deletions.deletions",
     ),
 ):
     cli.add_command(cmd)

--- a/tests/sentry/runner/commands/test_deletions.py
+++ b/tests/sentry/runner/commands/test_deletions.py
@@ -1,0 +1,100 @@
+from sentry.constants import ObjectStatus
+from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.runner.commands.deletions import deletions
+from sentry.testutils.cases import CliTestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.users.models.identity import Identity
+
+
+def _schedule_org_integration_deletion(test_case):
+    """Create an OrganizationIntegration and schedule it for deletion."""
+    integration = test_case.create_provider_integration(
+        provider="slack", name="Slack", external_id="slack:1"
+    )
+    identity = Identity.objects.create(
+        idp=test_case.create_identity_provider(type="slack", config={}, external_id="slack:1"),
+        user=test_case.user,
+        external_id="base_id",
+        data={},
+    )
+    integration.add_organization(
+        test_case.organization, test_case.user, default_auth_id=identity.id
+    )
+    org_integration = OrganizationIntegration.objects.get(
+        integration=integration, organization_id=test_case.organization.id
+    )
+    org_integration.update(status=ObjectStatus.PENDING_DELETION)
+    deletion = ScheduledDeletion.schedule(org_integration, days=0, actor=test_case.user)
+    return deletion, org_integration.id
+
+
+@control_silo_test
+class DeletionsListTest(CliTestCase):
+    command = deletions
+
+    def test_list_empty(self) -> None:
+        rv = self.invoke("list")
+        assert rv.exit_code == 0
+        assert "No pending deletions found" in rv.output
+
+    def test_list_shows_pending(self) -> None:
+        deletion, _ = _schedule_org_integration_deletion(self)
+        rv = self.invoke("list")
+        assert rv.exit_code == 0
+        assert "OrganizationIntegration" in rv.output
+        assert str(deletion.id) in rv.output
+
+    def test_list_filter_by_model(self) -> None:
+        _schedule_org_integration_deletion(self)
+        rv = self.invoke("list", "-m", "OrganizationIntegration")
+        assert rv.exit_code == 0
+        assert "OrganizationIntegration" in rv.output
+
+    def test_list_filter_by_model_no_match(self) -> None:
+        _schedule_org_integration_deletion(self)
+        rv = self.invoke("list", "-m", "Project")
+        assert rv.exit_code == 0
+        assert "No pending deletions found" in rv.output
+
+
+@control_silo_test
+class DeletionsRunTest(CliTestCase):
+    command = deletions
+
+    def test_run_requires_option(self) -> None:
+        rv = self.invoke("run")
+        assert rv.exit_code != 0
+        assert "Provide one of" in rv.output
+
+    def test_run_by_id(self) -> None:
+        deletion, oi_id = _schedule_org_integration_deletion(self)
+        rv = self.invoke("run", "-i", str(deletion.id))
+        assert rv.exit_code == 0, rv.output
+        assert "Done" in rv.output
+        assert not OrganizationIntegration.objects.filter(id=oi_id).exists()
+        assert not ScheduledDeletion.objects.filter(id=deletion.id).exists()
+
+    def test_run_by_model(self) -> None:
+        deletion, oi_id = _schedule_org_integration_deletion(self)
+        rv = self.invoke("run", "-m", "OrganizationIntegration")
+        assert rv.exit_code == 0, rv.output
+        assert "Done" in rv.output
+        assert not OrganizationIntegration.objects.filter(id=oi_id).exists()
+
+    def test_run_all(self) -> None:
+        deletion, oi_id = _schedule_org_integration_deletion(self)
+        rv = self.invoke("run", "--all")
+        assert rv.exit_code == 0, rv.output
+        assert "Done" in rv.output
+        assert not OrganizationIntegration.objects.filter(id=oi_id).exists()
+
+    def test_run_nonexistent_id(self) -> None:
+        rv = self.invoke("run", "-i", "99999")
+        assert rv.exit_code == 0
+        assert "not found" in rv.output
+
+    def test_run_no_pending(self) -> None:
+        rv = self.invoke("run", "--all")
+        assert rv.exit_code == 0
+        assert "No pending deletions found" in rv.output

--- a/tests/sentry/runner/commands/test_deletions.py
+++ b/tests/sentry/runner/commands/test_deletions.py
@@ -7,30 +7,29 @@ from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity
 
 
-def _schedule_org_integration_deletion(test_case):
-    """Create an OrganizationIntegration and schedule it for deletion."""
-    integration = test_case.create_provider_integration(
-        provider="slack", name="Slack", external_id="slack:1"
-    )
-    identity = Identity.objects.create(
-        idp=test_case.create_identity_provider(type="slack", config={}, external_id="slack:1"),
-        user=test_case.user,
-        external_id="base_id",
-        data={},
-    )
-    integration.add_organization(
-        test_case.organization, test_case.user, default_auth_id=identity.id
-    )
-    org_integration = OrganizationIntegration.objects.get(
-        integration=integration, organization_id=test_case.organization.id
-    )
-    org_integration.update(status=ObjectStatus.PENDING_DELETION)
-    deletion = ScheduledDeletion.schedule(org_integration, days=0, actor=test_case.user)
-    return deletion, org_integration.id
+class DeletionsTestMixin:
+    def _schedule_org_integration_deletion(self) -> tuple[ScheduledDeletion, int]:
+        """Create an OrganizationIntegration and schedule it for deletion."""
+        integration = self.create_provider_integration(
+            provider="slack", name="Slack", external_id="slack:1"
+        )
+        identity = Identity.objects.create(
+            idp=self.create_identity_provider(type="slack", config={}, external_id="slack:1"),
+            user=self.user,
+            external_id="base_id",
+            data={},
+        )
+        integration.add_organization(self.organization, self.user, default_auth_id=identity.id)
+        org_integration = OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        )
+        org_integration.update(status=ObjectStatus.PENDING_DELETION)
+        deletion = ScheduledDeletion.schedule(org_integration, days=0, actor=self.user)
+        return deletion, org_integration.id
 
 
 @control_silo_test
-class DeletionsListTest(CliTestCase):
+class DeletionsListTest(CliTestCase, DeletionsTestMixin):
     command = deletions
 
     def test_list_empty(self) -> None:
@@ -39,27 +38,27 @@ class DeletionsListTest(CliTestCase):
         assert "No pending deletions found" in rv.output
 
     def test_list_shows_pending(self) -> None:
-        deletion, _ = _schedule_org_integration_deletion(self)
+        deletion, _ = self._schedule_org_integration_deletion()
         rv = self.invoke("list")
         assert rv.exit_code == 0
         assert "OrganizationIntegration" in rv.output
         assert str(deletion.id) in rv.output
 
     def test_list_filter_by_model(self) -> None:
-        _schedule_org_integration_deletion(self)
+        self._schedule_org_integration_deletion()
         rv = self.invoke("list", "-m", "OrganizationIntegration")
         assert rv.exit_code == 0
         assert "OrganizationIntegration" in rv.output
 
     def test_list_filter_by_model_no_match(self) -> None:
-        _schedule_org_integration_deletion(self)
+        self._schedule_org_integration_deletion()
         rv = self.invoke("list", "-m", "Project")
         assert rv.exit_code == 0
         assert "No pending deletions found" in rv.output
 
 
 @control_silo_test
-class DeletionsRunTest(CliTestCase):
+class DeletionsRunTest(CliTestCase, DeletionsTestMixin):
     command = deletions
 
     def test_run_requires_option(self) -> None:
@@ -68,7 +67,7 @@ class DeletionsRunTest(CliTestCase):
         assert "Provide one of" in rv.output
 
     def test_run_by_id(self) -> None:
-        deletion, oi_id = _schedule_org_integration_deletion(self)
+        deletion, oi_id = self._schedule_org_integration_deletion()
         rv = self.invoke("run", "-i", str(deletion.id))
         assert rv.exit_code == 0, rv.output
         assert "Done" in rv.output
@@ -76,14 +75,14 @@ class DeletionsRunTest(CliTestCase):
         assert not ScheduledDeletion.objects.filter(id=deletion.id).exists()
 
     def test_run_by_model(self) -> None:
-        deletion, oi_id = _schedule_org_integration_deletion(self)
+        deletion, oi_id = self._schedule_org_integration_deletion()
         rv = self.invoke("run", "-m", "OrganizationIntegration")
         assert rv.exit_code == 0, rv.output
         assert "Done" in rv.output
         assert not OrganizationIntegration.objects.filter(id=oi_id).exists()
 
     def test_run_all(self) -> None:
-        deletion, oi_id = _schedule_org_integration_deletion(self)
+        deletion, oi_id = self._schedule_org_integration_deletion()
         rv = self.invoke("run", "--all")
         assert rv.exit_code == 0, rv.output
         assert "Done" in rv.output

--- a/tests/sentry/runner/commands/test_deletions.py
+++ b/tests/sentry/runner/commands/test_deletions.py
@@ -39,6 +39,7 @@ class DeletionsCliTest(CliTestCase):
         deletion, _ = self._schedule_org_integration_deletion()
         rv = self.invoke("list")
         assert rv.exit_code == 0
+        assert "ScheduledDeletion" in rv.output
         assert "OrganizationIntegration" in rv.output
         assert str(deletion.id) in rv.output
 
@@ -85,6 +86,13 @@ class DeletionsCliTest(CliTestCase):
         rv = self.invoke("run", "-i", "99999")
         assert rv.exit_code == 0
         assert "not found" in rv.output
+        assert "ScheduledDeletion" in rv.output
+
+    def test_run_nonexistent_cell_id(self) -> None:
+        rv = self.invoke("run", "--cid", "99999")
+        assert rv.exit_code == 0
+        assert "not found" in rv.output
+        assert "CellScheduledDeletion" in rv.output
 
     def test_run_no_pending(self) -> None:
         rv = self.invoke("run", "--all")

--- a/tests/sentry/runner/commands/test_deletions.py
+++ b/tests/sentry/runner/commands/test_deletions.py
@@ -7,7 +7,10 @@ from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity
 
 
-class DeletionsTestMixin:
+@control_silo_test
+class DeletionsCliTest(CliTestCase):
+    command = deletions
+
     def _schedule_org_integration_deletion(self) -> tuple[ScheduledDeletion, int]:
         """Create an OrganizationIntegration and schedule it for deletion."""
         integration = self.create_provider_integration(
@@ -26,11 +29,6 @@ class DeletionsTestMixin:
         org_integration.update(status=ObjectStatus.PENDING_DELETION)
         deletion = ScheduledDeletion.schedule(org_integration, days=0, actor=self.user)
         return deletion, org_integration.id
-
-
-@control_silo_test
-class DeletionsListTest(CliTestCase, DeletionsTestMixin):
-    command = deletions
 
     def test_list_empty(self) -> None:
         rv = self.invoke("list")
@@ -55,11 +53,6 @@ class DeletionsListTest(CliTestCase, DeletionsTestMixin):
         rv = self.invoke("list", "-m", "Project")
         assert rv.exit_code == 0
         assert "No pending deletions found" in rv.output
-
-
-@control_silo_test
-class DeletionsRunTest(CliTestCase, DeletionsTestMixin):
-    command = deletions
 
     def test_run_requires_option(self) -> None:
         rv = self.invoke("run")


### PR DESCRIPTION
adds `sentry deletions list` and `sentry deletions run` commands so you can manage and execute scheduled deletions synchronously in local dev instead of waiting for the task to run. 

includes tests for both subcommands covering listing, filtering, and running deletions by id/model/all.

wanted this for uninstalling integrations


<img width="758" height="167" alt="image" src="https://github.com/user-attachments/assets/90e325b1-639f-407c-806b-caf52cbeb809" />


<img width="496" height="198" alt="image" src="https://github.com/user-attachments/assets/7db99d8e-6b7d-4f02-be1d-9a8a3bedec55" />
