### PR TITLE
fix(ci): use ephemeral ports for relay xdist to avoid port conflicts

### DIFF
--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -69,7 +69,7 @@ def relay_server_setup(live_server, tmpdir_factory):
     template_path = _get_template_dir()
     sources = ["config.yml", "credentials.json"]
 
-    relay_port = ephemeral_port_reserve.reserve(ip="127.0.0.1")
+    relay_port = ephemeral_port_reserve.reserve(ip="127.0.0.1", port=0)
 
     redis_db = xdist.get_redis_db()
 

--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -69,8 +69,7 @@ def relay_server_setup(live_server, tmpdir_factory):
     template_path = _get_template_dir()
     sources = ["config.yml", "credentials.json"]
 
-    worker_num = xdist._worker_num if xdist._worker_num is not None else 0
-    relay_port = ephemeral_port_reserve.reserve(ip="127.0.0.1", port=33331 + worker_num * 100)
+    relay_port = ephemeral_port_reserve.reserve(ip="127.0.0.1")
 
     redis_db = xdist.get_redis_db()
 


### PR DESCRIPTION
The relay test fixture (`relay_server_setup`) used a deterministic port per xdist worker (`33331 + worker_num * 100`). When multiple `relay_integration` test modules land on the same worker, the module-scoped fixture teardown releases the port but Docker's port proxy doesn't free it immediately. The next module reserves the same port but Docker fails to bind, causing persistent "address already in use" errors that survive all retries and reruns.
- Switch to a truly ephemeral port (`port=0`) so each module-scoped fixture invocation gets a unique random port from the OS, eliminating cross-module collisions entirely.

Failing runs:
- https://github.com/getsentry/sentry/actions/runs/23862938440/job/69574257795
- https://github.com/getsentry/sentry/actions/runs/23861106497/job/69567779568
