### PR TITLE
ref(assisted-query): change all labels to beta

### DIFF
--- a/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
@@ -185,7 +185,7 @@ export function ResultsSearchQueryBuilder(props: Props) {
       <SearchQueryBuilderProvider
         initialQuery={props.query ?? ''}
         enableAISearch={hasTranslateEndpoint}
-        aiSearchBadgeType="alpha"
+        aiSearchBadgeType="beta"
         disabled={disabled}
         fieldDefinitionGetter={undefined}
         filterKeys={getFilterKeys()}

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -177,7 +177,7 @@ const LogsSearchSection = memo(function LogsSearchSection({
   return (
     <SearchQueryBuilderProvider
       enableAISearch={hasTranslateEndpoint}
-      aiSearchBadgeType="alpha"
+      aiSearchBadgeType="beta"
       {...searchQueryBuilderProviderProps}
     >
       <ExploreBodySearch>

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -447,7 +447,11 @@ export function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSection
 
   return (
     <Layout.Main width="full">
-      <SearchQueryBuilderProvider enableAISearch {...spanSearchQueryBuilderProviderProps}>
+      <SearchQueryBuilderProvider
+        enableAISearch
+        aiSearchBadgeType="beta"
+        {...spanSearchQueryBuilderProviderProps}
+      >
         <TourElement<ExploreSpansTour>
           tourContext={ExploreSpansTourContext}
           id={ExploreSpansTour.SEARCH_BAR}

--- a/static/app/views/issueList/issueSearch.tsx
+++ b/static/app/views/issueList/issueSearch.tsx
@@ -54,7 +54,7 @@ export function IssueSearch({query, onSearch, className}: IssueSearchProps) {
       getTagValues={getTagValues}
       searchSource="main_search"
       enableAISearch={hasTranslateEndpoint}
-      aiSearchBadgeType="alpha"
+      aiSearchBadgeType="beta"
       onSearch={onSearch}
       recentSearches={SavedSearchType.ISSUE}
       disallowLogicalOperators


### PR DESCRIPTION
With https://github.com/getsentry/sentry-options-automator/pull/7061 we're starting to roll the Ask Seer feature out to EA for logs/issues/discover, and it's now considered beta