### PR TITLE
ref(assisted-query): cleanup redundant flag checks for polling variant

### DIFF
--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useMemo} from 'react';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import type {AskSeerSearchQuery} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
@@ -81,10 +80,6 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
     initialSeerQuery =
       initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
   }
-
-  const usePollingEndpoint = organization.features.includes(
-    'gen-ai-search-agent-translate'
-  );
 
   // Get selected project IDs for the polling variant
   const selectedProjectIds = useMemo(() => {
@@ -299,28 +294,16 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
     return null;
   }
 
-  if (usePollingEndpoint) {
-    return (
-      <AskSeerPollingComboBox<AskSeerSearchQuery>
-        initialQuery={initialSeerQuery}
-        projectIds={selectedProjectIds}
-        strategy="Errors"
-        applySeerSearchQuery={applySeerSearchQuery}
-        transformResponse={transformResponse}
-        analyticsSource="errors"
-        feedbackSource="errors_ai_query"
-        fallbackMutationOptions={issueListAskSeerMutationOptions}
-      />
-    );
-  }
-
   return (
-    <AskSeerComboBox
+    <AskSeerPollingComboBox<AskSeerSearchQuery>
       initialQuery={initialSeerQuery}
-      askSeerMutationOptions={issueListAskSeerMutationOptions}
+      projectIds={selectedProjectIds}
+      strategy="Errors"
       applySeerSearchQuery={applySeerSearchQuery}
+      transformResponse={transformResponse}
       analyticsSource="errors"
       feedbackSource="errors_ai_query"
+      fallbackMutationOptions={issueListAskSeerMutationOptions}
     />
   );
 }

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useMemo} from 'react';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
@@ -259,10 +258,6 @@ export function LogsTabSeerComboBox() {
     ]
   );
 
-  const usePollingEndpoint = organization.features.includes(
-    'gen-ai-search-agent-translate'
-  );
-
   // Get selected project IDs for the polling variant
   const selectedProjectIds = useMemo(() => {
     if (
@@ -310,28 +305,16 @@ export function LogsTabSeerComboBox() {
     return null;
   }
 
-  if (usePollingEndpoint) {
-    return (
-      <AskSeerPollingComboBox<AskSeerSearchQuery>
-        initialQuery={initialSeerQuery}
-        projectIds={selectedProjectIds}
-        strategy="Logs"
-        applySeerSearchQuery={applySeerSearchQuery}
-        transformResponse={transformResponse}
-        analyticsSource="logs"
-        feedbackSource="logs_ai_query"
-        fallbackMutationOptions={logsTabAskSeerMutationOptions}
-      />
-    );
-  }
-
   return (
-    <AskSeerComboBox
+    <AskSeerPollingComboBox<AskSeerSearchQuery>
       initialQuery={initialSeerQuery}
-      askSeerMutationOptions={logsTabAskSeerMutationOptions}
+      projectIds={selectedProjectIds}
+      strategy="Logs"
       applySeerSearchQuery={applySeerSearchQuery}
+      transformResponse={transformResponse}
       analyticsSource="logs"
       feedbackSource="logs_ai_query"
+      fallbackMutationOptions={logsTabAskSeerMutationOptions}
     />
   );
 }

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -2,7 +2,6 @@ import {useCallback, useMemo} from 'react';
 import omit from 'lodash/omit';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {Token} from 'sentry/components/searchSyntax/parser';
@@ -87,10 +86,6 @@ export function IssueListSeerComboBox() {
     initialSeerQuery =
       initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
   }
-
-  const usePollingEndpoint = organization.features.includes(
-    'gen-ai-search-agent-translate'
-  );
 
   // Get selected project IDs for the polling variant
   const selectedProjectIds = useMemo(() => {
@@ -238,28 +233,16 @@ export function IssueListSeerComboBox() {
     return null;
   }
 
-  if (usePollingEndpoint) {
-    return (
-      <AskSeerPollingComboBox<IssueAskSeerSearchQuery>
-        initialQuery={initialSeerQuery}
-        projectIds={selectedProjectIds}
-        strategy="Issues"
-        applySeerSearchQuery={applySeerSearchQuery}
-        transformResponse={transformResponse}
-        analyticsSource="issue.list"
-        feedbackSource="issue_list_ai_query"
-        fallbackMutationOptions={issueListAskSeerMutationOptions}
-      />
-    );
-  }
-
   return (
-    <AskSeerComboBox
+    <AskSeerPollingComboBox<IssueAskSeerSearchQuery>
       initialQuery={initialSeerQuery}
-      askSeerMutationOptions={issueListAskSeerMutationOptions}
+      projectIds={selectedProjectIds}
+      strategy="Issues"
       applySeerSearchQuery={applySeerSearchQuery}
+      transformResponse={transformResponse}
       analyticsSource="issue.list"
       feedbackSource="issue_list_ai_query"
+      fallbackMutationOptions={issueListAskSeerMutationOptions}
     />
   );
 }


### PR DESCRIPTION
For logs/discover/issues, `enableAiSearch` is = this flag being on. The combobox components are never shown unless enableAiSearch (condition right above usePollingEndpoint), so the !usePollingEndpoint is a dead branch. In general this FF is a killswitch for the whole ai search feature, not a polling variant. The polling toggle only works for spans, the only dataset that has a sync implementation