### PR TITLE
ref(preprod): Decouple approval creation from status check client lookup

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -109,24 +109,6 @@ def create_preprod_snapshot_status_check_task(
 
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
-    client, repository = get_status_check_client(preprod_artifact.project, commit_comparison)
-    if not client or not repository:
-        return
-
-    provider = get_status_check_provider(
-        client,
-        commit_comparison.provider,
-        preprod_artifact.project.organization_id,
-        preprod_artifact.project.organization.slug,
-        repository.integration_id,
-    )
-    if not provider:
-        logger.info(
-            "preprod.snapshot_status_checks.create.not_supported_provider",
-            extra={"provider": commit_comparison.provider},
-        )
-        return
-
     artifact_ids = [a.id for a in all_artifacts]
     snapshot_metrics_qs = PreprodSnapshotMetrics.objects.filter(
         preprod_artifact_id__in=artifact_ids,
@@ -163,6 +145,50 @@ def create_preprod_snapshot_status_check_task(
     base_artifact_map = PreprodArtifact.get_base_artifacts_for_commit(all_artifacts)
 
     is_solo = not base_artifact_map
+
+    if not is_solo:
+        changes_map = _build_changes_map(
+            all_artifacts,
+            snapshot_metrics_map,
+            comparisons_map,
+            fail_on_added=fail_on_added,
+            fail_on_removed=fail_on_removed,
+        )
+        for artifact in all_artifacts:
+            if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:
+                # exists()+create() instead of get_or_create: no unique constraint
+                # on this model, so duplicates from races are harmless (cleaned
+                # up by filter().delete()), while get_or_create would crash with
+                # MultipleObjectsReturned if duplicates already exist.
+                if not PreprodComparisonApproval.objects.filter(
+                    preprod_artifact=artifact,
+                    preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+                    approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+                ).exists():
+                    PreprodComparisonApproval.objects.create(
+                        preprod_artifact=artifact,
+                        preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+                        approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+                    )
+
+    client, repository = get_status_check_client(preprod_artifact.project, commit_comparison)
+    if not client or not repository:
+        return
+
+    provider = get_status_check_provider(
+        client,
+        commit_comparison.provider,
+        preprod_artifact.project.organization_id,
+        preprod_artifact.project.organization.slug,
+        repository.integration_id,
+    )
+    if not provider:
+        logger.info(
+            "preprod.snapshot_status_checks.create.not_supported_provider",
+            extra={"provider": commit_comparison.provider},
+        )
+        return
+
     approve_action_identifier: str | None = None
 
     if is_solo:
@@ -198,13 +224,6 @@ def create_preprod_snapshot_status_check_task(
                 snapshot_metrics_map,
             )
     else:
-        changes_map = _build_changes_map(
-            all_artifacts,
-            snapshot_metrics_map,
-            comparisons_map,
-            fail_on_added=fail_on_added,
-            fail_on_removed=fail_on_removed,
-        )
         status = _compute_snapshot_status(
             all_artifacts,
             snapshot_metrics_map,
@@ -212,23 +231,6 @@ def create_preprod_snapshot_status_check_task(
             approvals_map,
             changes_map,
         )
-
-        for artifact in all_artifacts:
-            if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:
-                # exists()+create() instead of get_or_create: no unique constraint
-                # on this model, so duplicates from races are harmless (cleaned
-                # up by filter().delete()), while get_or_create would crash with
-                # MultipleObjectsReturned if duplicates already exist.
-                if not PreprodComparisonApproval.objects.filter(
-                    preprod_artifact=artifact,
-                    preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
-                    approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
-                ).exists():
-                    PreprodComparisonApproval.objects.create(
-                        preprod_artifact=artifact,
-                        preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
-                        approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
-                    )
 
         title, subtitle, summary = format_snapshot_status_check_messages(
             all_artifacts,


### PR DESCRIPTION
## Summary

Decouples `PreprodComparisonApproval` (NEEDS_APPROVAL) record creation from the status check client/repository lookup in the snapshot status check task.

Previously, `get_status_check_client()` was called early in the task and returned early if no repository or integration was configured. This meant the approval creation logic (further down) was never reached — so snapshots with changes would never enter the "pending approval" state unless a GitHub integration was set up.

Now the approval records are created **before** the status check client lookup, so the approval workflow functions independently of whether a VCS integration is configured.