### PR TITLE
fix(stories): avoid circular dependencies on `Button`

### DIFF
--- a/static/app/stories/index.tsx
+++ b/static/app/stories/index.tsx
@@ -1,4 +1,3 @@
-export {APIReference} from './apiReference';
 export {ColorReference} from './colorReference';
 export {Demo} from './demo';
 export {JSXNode, JSXProperty} from './jsx';
@@ -8,6 +7,5 @@ export {Section} from './layout';
 export {SideBySide} from './layout';
 export {SizingWindow, Grid} from './layout';
 export {story} from './storybook';
-export {ThemeSwitcher} from './theme';
 export {TokenReference} from './tokenReference';
 export {StoryTable as Table} from './table';

--- a/static/app/stories/storybook.tsx
+++ b/static/app/stories/storybook.tsx
@@ -1,13 +1,18 @@
 import type {ReactNode} from 'react';
-import {Children, Fragment, useEffect} from 'react';
+import {Children, Fragment, Suspense, lazy, useEffect} from 'react';
 
 import {Container} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
-import {StoryHeading} from 'sentry/stories/view/storyHeading';
-
-import {APIReference} from './apiReference';
 import {Section, SideBySide} from './layout';
+
+// Lazy-loaded to bypass circular dependencies on Button
+const StoryHeading = lazy(() =>
+  import('sentry/stories/view/storyHeading').then(m => ({default: m.StoryHeading}))
+);
+const APIReference = lazy(() =>
+  import('./apiReference').then(m => ({default: m.APIReference}))
+);
 
 function makeStorybookDocumentTitle(title: string | undefined): string {
   return title ? `${title} — Scraps` : 'Scraps';
@@ -51,7 +56,9 @@ export function story(title: string, setup: SetupFunction): StoryRenderFunction 
           <Story key={name + idx} name={name} render={render} />
         ))}
         {APIDocumentation.map((documentation, i) => (
-          <APIReference key={i} componentProps={documentation} />
+          <Suspense key={i} fallback={null}>
+            <APIReference componentProps={documentation} />
+          </Suspense>
         ))}
       </Fragment>
     );
@@ -65,9 +72,11 @@ function Story(props: {name: string; render: StoryRenderFunction}) {
   return (
     <Section>
       <Container borderBottom="primary">
-        <StoryHeading as="h2" size="2xl">
-          {props.name}
-        </StoryHeading>
+        <Suspense fallback={<Heading as="h2">{props.name}</Heading>}>
+          <StoryHeading as="h2" size="2xl">
+            {props.name}
+          </StoryHeading>
+        </Suspense>
       </Container>
       {isOneChild ? children : <SideBySide>{children}</SideBySide>}
     </Section>

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -13,6 +13,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 import * as Storybook from 'sentry/stories';
+import {APIReference} from 'sentry/stories/apiReference';
 import {useQuery} from 'sentry/utils/queryClient';
 
 import {StoryFooter} from './storyFooter';
@@ -250,7 +251,7 @@ function StoryAPI(props: {documentation: TypeLoader.TypeLoaderResult | undefined
   return (
     <Fragment>
       {Object.entries(props.documentation.props ?? {}).map(([key, value]) => {
-        return <Storybook.APIReference key={key} componentProps={value} />;
+        return <APIReference key={key} componentProps={value} />;
       })}
     </Fragment>
   );

--- a/static/app/stories/view/storyHeader.tsx
+++ b/static/app/stories/view/storyHeader.tsx
@@ -6,7 +6,7 @@ import {Link} from '@sentry/scraps/link';
 import {Heading} from '@sentry/scraps/text';
 
 import {IconGithub, IconLink} from 'sentry/icons';
-import * as Storybook from 'sentry/stories';
+import {ThemeSwitcher} from 'sentry/stories/theme';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -57,7 +57,7 @@ export function StoryHeader() {
           sentry.io
         </LinkButton>
         <span />
-        <Storybook.ThemeSwitcher />
+        <ThemeSwitcher />
       </Flex>
     </HeaderGrid>
   );


### PR DESCRIPTION
Currently we use `import * as Stories from 'sentry/stories'` in quite a few places.

When working on #111369, I discovered that this can cause circular imports in the `Button` component because `APIReference` and `ThemeSwitcher` imported `Button` internally.

This PR cleans up the `sentry/stories` barrel file to remove circular import opportunities