### PR TITLE
feat(detectors): Add preprod_size_analysis to detector filter types

### DIFF
--- a/static/app/views/detectors/utils/useDetectorFilterKeys.tsx
+++ b/static/app/views/detectors/utils/useDetectorFilterKeys.tsx
@@ -27,7 +27,7 @@ const DETECTOR_FILTER_KEYS: Record<
       kind: FieldKind.FIELD,
       valueType: FieldValueType.STRING,
       allowWildcard: false,
-      values: ['error', 'metric', 'cron', 'uptime'],
+      values: ['error', 'metric', 'cron', 'uptime', 'preprod_size_analysis'],
     },
   },
   assignee: {


### PR DESCRIPTION
Add `preprod_size_analysis` to the list of allowed detector type filter
values in the detector search/filter UI, so users can filter by this
new detector type.


Agent transcript: https://claudescope.sentry.dev/share/hCp5-xaM-TOsxRNjX2_AIVFnl4YgbP3LQAcFkwUWCpk