### PR TITLE
feat(billing): Select single project usage CSV

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {BillingHistoryFixture} from 'getsentry-test/fixtures/billingHistory';
@@ -9,6 +10,7 @@ import {
 } from 'getsentry-test/fixtures/subscription';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {DataCategory} from 'sentry/types/core';
 
 import {PreviewDataFixture} from 'getsentry/__fixtures__/previewData';
@@ -849,6 +851,32 @@ describe('Subscription > UsageHistory', () => {
     expect(await screen.findByText(/UI Profile Hours/i)).toBeInTheDocument();
     expect(await screen.findByText('2%')).toBeInTheDocument();
     expect(screen.queryByText('>100%')).not.toBeInTheDocument();
+  });
+
+  it('opens the per-project CSV URL for the selected project', async () => {
+    window.open = jest.fn();
+    const project = ProjectFixture({slug: 'my-project'});
+    ProjectsStore.loadInitialData([project]);
+
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/history/`,
+      method: 'GET',
+      body: [BillingHistoryFixture()],
+    });
+    const subscription = SubscriptionFixture({organization});
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<UsageHistory />, {organization});
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: /Download Project Breakdown/i})
+    );
+    await userEvent.click(screen.getByRole('option', {name: 'my-project'}));
+
+    expect(window.open).toHaveBeenCalledWith(
+      'https://sentry.io/organizations/acme/billing/history/625529670/export/per-project/my-project/',
+      '_blank'
+    );
   });
 
   it('shows >100% for UI profile duration overage', async () => {

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -4,7 +4,9 @@ import moment from 'moment-timezone';
 
 import {Badge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
+import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingError} from 'sentry/components/loadingError';
@@ -20,6 +22,7 @@ import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
 import {withSubscription} from 'getsentry/components/withSubscription';
@@ -141,6 +144,7 @@ type RowProps = {
 function UsageHistoryRow({history}: RowProps) {
   const organization = useOrganization();
   const [expanded, setExpanded] = useState<boolean>(history.isCurrent);
+  const {projects} = useProjects();
 
   function renderOnDemandUsage({
     sortedCategories,
@@ -265,18 +269,27 @@ function UsageHistoryRow({history}: RowProps) {
           >
             {t('Download Summary')}
           </Button>
-          <Button
-            icon={<IconDownload />}
-            onClick={() => {
+          <CompactSelect
+            trigger={triggerProps => (
+              <OverlayTrigger.Button {...triggerProps} icon={<IconDownload />}>
+                {t('Download Project Breakdown')}
+              </OverlayTrigger.Button>
+            )}
+            search={{placeholder: t('Filter projects')}}
+            options={projects.map(project => ({
+              value: project.slug,
+              label: project.slug,
+              textValue: project.slug,
+            }))}
+            value={undefined}
+            onChange={(option: SelectOption<string>) => {
               trackGetsentryAnalytics('subscription_page.download_reports.clicked', {
                 organization,
                 reportType: 'project_breakdown',
               });
-              window.open(history.links.csvPerProject, '_blank');
+              window.open(`${history.links.csvPerProject}${option.value}/`, '_blank');
             }}
-          >
-            {t('Download Project Breakdown')}
-          </Button>
+          />
         </Grid>
       </Flex>
       {expanded && (

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -144,7 +144,7 @@ type RowProps = {
 function UsageHistoryRow({history}: RowProps) {
   const organization = useOrganization();
   const [expanded, setExpanded] = useState<boolean>(history.isCurrent);
-  const {projects} = useProjects();
+  const {projects, onSearch: onProjectSearch} = useProjects();
 
   function renderOnDemandUsage({
     sortedCategories,
@@ -275,7 +275,7 @@ function UsageHistoryRow({history}: RowProps) {
                 {t('Download Project Breakdown')}
               </OverlayTrigger.Button>
             )}
-            search={{placeholder: t('Filter projects')}}
+            search={{placeholder: t('Filter projects'), onChange: onProjectSearch}}
             options={projects.map(project => ({
               value: project.slug,
               label: project.slug,


### PR DESCRIPTION
depends on https://github.com/getsentry/getsentry/pull/19727

Replaces Download Project Breakdown button with dropdown to select single project

<img width="498" height="210" alt="Screenshot 2026-04-01 at 2 05 23 PM" src="https://github.com/user-attachments/assets/c7621522-b086-4560-a55e-0c1188df8306" />
