### PR TITLE
feat(preprod): Filter settings page builds by display type

### DIFF
--- a/static/app/views/settings/project/preprod/featureFilter.tsx
+++ b/static/app/views/settings/project/preprod/featureFilter.tsx
@@ -88,6 +88,7 @@ export function FeatureFilter({
   const queryParams: Record<string, string | number> = {
     per_page: EXAMPLE_BUILDS_COUNT,
     project: project.id,
+    display: display ?? PreprodBuildsDisplay.SIZE,
   };
 
   if (localQuery) {


### PR DESCRIPTION
Closes EME-991

## Summary
- Pass the `display` query parameter to the builds API from the Mobile Builds settings page
- The Size Analysis section sends `display=size` and the Build Distribution section sends `display=distribution`
- This filters out snapshot-only builds from both lists, matching the filtering already used on the explore/releases page

Previously both sections fetched all builds without any display filtering, so snapshot builds would appear in the size and distribution lists.