### PR TITLE
feat(aci): Add types for DetectorInput and DataSourceInput

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/data_source.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_source.py
@@ -11,6 +11,10 @@ from sentry.workflow_engine.types import DataSourceTypeHandler
 T = TypeVar("T", bound=Model)
 
 
+# TODO - make this a typed dict
+DataSourceInput = dict[str, Any]
+
+
 class DataSourceCreator(Generic[T]):
     def __init__(self, create_fn: Callable[[], T]):
         self._create_fn = create_fn

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -1,6 +1,6 @@
 import builtins
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 from django.db import router, transaction
 from jsonschema import ValidationError as JSONSchemaValidationError
@@ -24,6 +24,10 @@ from sentry.workflow_engine.endpoints.validators.base import (
     BaseDataConditionGroupValidator,
     BaseDataConditionValidator,
 )
+from sentry.workflow_engine.endpoints.validators.base.data_condition_group import (
+    DataConditionGroupInput,
+)
+from sentry.workflow_engine.endpoints.validators.base.data_source import DataSourceInput
 from sentry.workflow_engine.endpoints.validators.utils import (
     connect_detectors_to_workflows,
     get_unknown_detector_type_error,
@@ -46,6 +50,17 @@ class DetectorQuota:
     has_exceeded: bool
     limit: int
     count: int
+
+
+class DetectorInput(TypedDict):
+    name: str
+    type: str
+    data_sources: NotRequired[list[DataSourceInput]]
+    config: NotRequired[dict[str, Any]]
+    condition_group: NotRequired[DataConditionGroupInput]
+    owner: NotRequired[str | int | None]
+    description: NotRequired[str]
+    enabled: NotRequired[bool]
 
 
 class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):


### PR DESCRIPTION
# Description
Add basic type for `DetectorInput` which matches the expected input on the validator. Created a space to define the `DataSourceInput`, right now I just want to make sure it's passed into the detector input as expected.