### PR TITLE
feat(aci): Update new alert UI copy to make it a bit easier to unders…

### DIFF
--- a/static/app/components/workflowEngine/ui/formSection.tsx
+++ b/static/app/components/workflowEngine/ui/formSection.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 type FormSectionProps = {
@@ -33,14 +33,14 @@ export function FormSection({
         <Heading as="h3">{title}</Heading>
       </Disclosure.Title>
       <Disclosure.Content>
-        <Flex direction="column" gap="md">
+        <Stack gap="lg">
           {description && (
             <FormSectionDescription as="p" variant="secondary">
               {description}
             </FormSectionDescription>
           )}
-          {children}
-        </Flex>
+          <Stack gap="md">{children}</Stack>
+        </Stack>
       </Disclosure.Content>
     </Disclosure>
   );

--- a/static/app/views/automations/components/automationBuilderDrawerForm.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.tsx
@@ -68,10 +68,7 @@ function FormBody({closeDrawer, model}: {closeDrawer: () => void; model: FormMod
           <Stack gap="md">
             <AutomationBuilder />
           </Stack>
-          <ActionThrottleSelectField
-            label={t('Action Interval')}
-            help={t('Perform the actions above this often for an issue.')}
-          />
+          <ActionThrottleSelectField />
         </Flex>
         <EmbeddedTextField
           required

--- a/static/app/views/automations/components/automationBuilderDrawerForm.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.tsx
@@ -27,7 +27,7 @@ import {
   getNewAutomationData,
   validateAutomationBuilderState,
 } from 'sentry/views/automations/components/automationFormData';
-import {ActionIntervalSelectField} from 'sentry/views/automations/components/forms/actionIntervalSelectField';
+import {ActionThrottleSelectField} from 'sentry/views/automations/components/forms/actionThrottleSelectField';
 import {getAutomationAnalyticsPayload} from 'sentry/views/automations/components/forms/common/getAutomationAnalyticsPayload';
 import {
   AutomationFormProvider,
@@ -41,7 +41,7 @@ import {resolveDetectorIdsForProjects} from 'sentry/views/automations/utils/reso
 const DEFAULT_INITIAL_DATA = {
   name: '',
   environment: null,
-  frequency: 1440,
+  frequency: 0,
   projectIds: [],
   detectorIds: [],
 };
@@ -68,7 +68,7 @@ function FormBody({closeDrawer, model}: {closeDrawer: () => void; model: FormMod
           <Stack gap="md">
             <AutomationBuilder />
           </Stack>
-          <ActionIntervalSelectField
+          <ActionThrottleSelectField
             label={t('Action Interval')}
             help={t('Perform the actions above this often for an issue.')}
           />

--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -11,7 +11,7 @@ import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {AutomationBuilder} from 'sentry/views/automations/components/automationBuilder';
 import {EditConnectedMonitors} from 'sentry/views/automations/components/editConnectedMonitors';
-import {ActionIntervalSelectField} from 'sentry/views/automations/components/forms/actionIntervalSelectField';
+import {ActionThrottleSelectField} from 'sentry/views/automations/components/forms/actionThrottleSelectField';
 import {useSetAutomaticAutomationName} from 'sentry/views/automations/components/forms/useSetAutomaticAutomationName';
 
 export function AutomationForm({model}: {model: FormModel}) {
@@ -33,10 +33,8 @@ export function AutomationForm({model}: {model: FormModel}) {
       />
       <Card>
         <FormSection
-          title={t('Choose Environment')}
-          description={t(
-            'If you select environments different than your monitors then the automation will not fire.'
-          )}
+          title={t('Filter Issues')}
+          description={t('Only get alerted on Issues from these environments.')}
         >
           <EnvironmentSelector />
         </FormSection>
@@ -48,10 +46,10 @@ export function AutomationForm({model}: {model: FormModel}) {
       </Card>
       <Card>
         <FormSection
-          title={t('Action Interval')}
-          description={t('Perform the actions above this often for an issue.')}
+          title={t('Throttling')}
+          description={t('Set how often this alert can be triggered for a given issue.')}
         >
-          <ActionIntervalSelectField />
+          <ActionThrottleSelectField />
         </FormSection>
       </Card>
     </Flex>

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -315,7 +315,12 @@ function EditConnectedMonitorsContent({
 
   return (
     <WorkflowEngineContainer>
-      <FormSection title={t('Source')}>
+      <FormSection
+        title={t('Source')}
+        description={t(
+          'Get alerted when new issues are detected or an issue changes state.'
+        )}
+      >
         <Stack gap="lg">
           <RadioGroup
             label={t('Connected monitors mode')}
@@ -369,7 +374,12 @@ export function EditConnectedMonitors({connectedIds, setConnectedIds}: Props) {
   if (isLoading && firstLoad) {
     return (
       <WorkflowEngineContainer>
-        <FormSection title={t('Source')}>
+        <FormSection
+          title={t('Source')}
+          description={t(
+            'Get alerted when new issues are detected or an issue changes state.'
+          )}
+        >
           <Placeholder width="100%" height="200px" />
         </FormSection>
       </WorkflowEngineContainer>

--- a/static/app/views/automations/components/forms/actionThrottleSelectField.tsx
+++ b/static/app/views/automations/components/forms/actionThrottleSelectField.tsx
@@ -4,7 +4,7 @@ import {SelectField} from 'sentry/components/forms/fields/selectField';
 import {t} from 'sentry/locale';
 
 const FREQUENCY_OPTIONS = [
-  {value: 0, label: t('0 minutes')},
+  {value: 0, label: t('Get notified on every trigger')},
   {value: 5, label: t('5 minutes')},
   {value: 10, label: t('10 minutes')},
   {value: 30, label: t('30 minutes')},
@@ -21,7 +21,7 @@ type ActionIntervalSelectFieldProps = {
   label?: string;
 };
 
-export function ActionIntervalSelectField(props: ActionIntervalSelectFieldProps) {
+export function ActionThrottleSelectField(props: ActionIntervalSelectFieldProps) {
   return (
     <EmbeddedSelectField
       required
@@ -29,7 +29,7 @@ export function ActionIntervalSelectField(props: ActionIntervalSelectFieldProps)
       inline={false}
       clearable={false}
       options={FREQUENCY_OPTIONS}
-      label={t('Action Interval')}
+      label={t('Action Throttle')}
       {...props}
     />
   );

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -76,7 +76,7 @@ describe('AutomationDetail', () => {
     // Check sidebar sections
     expect(screen.getByRole('heading', {name: 'Last Triggered'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Environment'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Action Interval'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Throttling'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Conditions'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Details'})).toBeInTheDocument();
   });

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -20,7 +20,7 @@ import {TimeSince} from 'sentry/components/timeSince';
 import {DetailLayout} from 'sentry/components/workflowEngine/layout/detail';
 import {DetailSection} from 'sentry/components/workflowEngine/ui/detailSection';
 import {IconEdit} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {defined} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
@@ -133,10 +133,10 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
             <DetailSection title={t('Environment')}>
               {automation.environment || t('All environments')}
             </DetailSection>
-            <DetailSection title={t('Action Interval')}>
-              {tct('Every [frequency]', {
-                frequency: getDuration((automation.config.frequency || 0) * 60),
-              })}
+            <DetailSection title={t('Throttling')}>
+              {automation.config.frequency
+                ? getDuration(automation.config.frequency * 60)
+                : t('Notify on every trigger')}
             </DetailSection>
             <DetailSection title={t('Conditions')}>
               <ErrorBoundary mini>

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -281,7 +281,7 @@ describe('AutomationNewSettings', () => {
                 ],
               },
             ],
-            config: {frequency: 1440},
+            config: {frequency: 0},
             detectorIds: [],
             enabled: true,
           },

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -70,7 +70,7 @@ function AutomationBreadcrumbs() {
 const initialData = {
   name: '',
   environment: null,
-  frequency: 1440,
+  frequency: 0,
   enabled: true,
   projectIds: [],
 };


### PR DESCRIPTION
[Figma designs](https://www.figma.com/design/99EtM4v3UYfGCN0QJU1QfI/Alerts-Create-Issues---ACI?node-id=10498-1698&t=fuBUvzt4uJkSDo6o-0)

- Updated copy for "action interval" -> "throttling"
- 0 action interval is now "notify on every trigger"
- "notify on every trigger" is now the default when creating a new alert
- modified the title/description of the environment section per the new designs

<img width="480" height="187" alt="CleanShot 2026-04-01 at 14 06 22" src="https://github.com/user-attachments/assets/853f2af6-ff5a-4673-ac88-be6c107ed400" />
<img width="562" height="400" alt="CleanShot 2026-04-01 at 14 06 10" src="https://github.com/user-attachments/assets/bc8716bd-4ac9-42fa-88f3-11d675d7ade7" />
