### PR TITLE
feat(preprod): Optimistic check run update on approval

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -240,6 +240,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod snapshots product feature
     manager.add("organizations:preprod-snapshots", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable optimistic immediate PATCH of GitHub check run on approval
+    manager.add("organizations:preprod-optimistic-check-run-update", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables PR page
     manager.add("organizations:pr-page", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the playstation ingestion in relay

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -856,6 +856,15 @@ class GitHubBaseClient(
         endpoint = f"/repos/{repo}/check-runs"
         return self.post(endpoint, data=data)
 
+    def update_check_run(self, repo: str, check_run_id: int, data: dict[str, Any]) -> Any:
+        """
+        https://docs.github.com/en/rest/checks/runs#update-a-check-run
+
+        The repo must be in the format of "owner/repo".
+        """
+        endpoint = f"/repos/{repo}/check-runs/{check_run_id}"
+        return self.patch(endpoint, data=data)
+
     def get_check_run(self, repo: str, check_run_id: int) -> Any:
         """
         https://docs.github.com/en/rest/checks/runs#get-a-check-run

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -9,7 +9,8 @@ from typing import Any, Literal
 from django.db.models import F, Window
 from django.db.models.functions import RowNumber
 
-from sentry import analytics
+from sentry import analytics, features
+from sentry.integrations.github.status_check import GitHubCheckConclusion, GitHubCheckStatus
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.organization import Organization
@@ -37,6 +38,9 @@ class Log(StrEnum):
     APPROVAL_ALREADY_EXISTS = "preprod.webhook.check_run.approval_already_exists"
     APPROVALS_CREATED = "preprod.webhook.check_run.approvals_created"
     UNKNOWN_IDENTIFIER = "preprod.webhook.check_run.unknown_identifier"
+    OPTIMISTIC_UPDATE_SUCCESS = "preprod.webhook.check_run.optimistic_update_success"
+    OPTIMISTIC_UPDATE_FAILED = "preprod.webhook.check_run.optimistic_update_failed"
+    OPTIMISTIC_UPDATE_SKIPPED = "preprod.webhook.check_run.optimistic_update_skipped"
 
 
 class GitHubCheckRunAction(StrEnum):
@@ -207,6 +211,14 @@ def handle_preprod_check_run_event(
             )
         )
 
+    if approvals_created > 0:
+        _optimistic_update_check_run(
+            event=event,
+            organization=organization,
+            integration=integration,
+            identifier=identifier,
+        )
+
     if identifier == APPROVE_SIZE_ACTION_IDENTIFIER:
         create_preprod_status_check_task.apply_async(
             kwargs={
@@ -223,3 +235,66 @@ def handle_preprod_check_run_event(
         )
     else:
         raise ValueError(f"Unknown identifier: {identifier}")
+
+
+def _optimistic_update_check_run(
+    *,
+    event: Mapping[str, Any],
+    organization: Organization,
+    integration: RpcIntegration | None,
+    identifier: str,
+) -> None:
+    if not features.has("organizations:preprod-optimistic-check-run-update", organization):
+        return
+
+    if not integration:
+        logger.info(Log.OPTIMISTIC_UPDATE_SKIPPED, extra={"reason": "no_integration"})
+        return
+
+    check_run = event.get("check_run", {})
+    check_run_id = check_run.get("id")
+    repo_full_name = event.get("repository", {}).get("full_name")
+
+    if not check_run_id or not repo_full_name:
+        logger.info(
+            Log.OPTIMISTIC_UPDATE_SKIPPED,
+            extra={"reason": "missing_check_run_id_or_repo"},
+        )
+        return
+
+    try:
+        installation = integration.get_installation(organization_id=organization.id)
+        client = installation.get_client()
+        client.update_check_run(
+            repo=repo_full_name,
+            check_run_id=check_run_id,
+            data={
+                "status": GitHubCheckStatus.COMPLETED.value,
+                "conclusion": GitHubCheckConclusion.SUCCESS.value,
+                "completed_at": datetime.now(timezone.utc).isoformat(),
+                "output": {
+                    "title": "Approved",
+                    "summary": "Changes approved. Full status update in progress...",
+                },
+                "actions": [],
+            },
+        )
+        logger.info(
+            Log.OPTIMISTIC_UPDATE_SUCCESS,
+            extra={
+                "organization_id": organization.id,
+                "check_run_id": check_run_id,
+                "identifier": identifier,
+            },
+        )
+        metrics.incr(Log.OPTIMISTIC_UPDATE_SUCCESS)
+    except Exception:
+        logger.exception(
+            Log.OPTIMISTIC_UPDATE_FAILED,
+            extra={
+                "organization_id": organization.id,
+                "check_run_id": check_run_id,
+                "identifier": identifier,
+            },
+        )
+        metrics.incr(Log.OPTIMISTIC_UPDATE_FAILED)

--- a/tests/sentry/preprod/vcs/webhooks/test_github_check_run.py
+++ b/tests/sentry/preprod/vcs/webhooks/test_github_check_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import unittest.mock
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -9,6 +10,7 @@ from sentry.models.commitcomparison import CommitComparison
 from sentry.models.repository import Repository
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.vcs.status_checks.size.tasks import APPROVE_SIZE_ACTION_IDENTIFIER
+from sentry.preprod.vcs.status_checks.snapshots.tasks import APPROVE_SNAPSHOT_ACTION_IDENTIFIER
 from sentry.preprod.vcs.webhooks.github_check_run import handle_preprod_check_run_event
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
@@ -457,3 +459,149 @@ class HandlePreprodCheckRunEventTest(TestCase):
 
         # Should be 3 approvals now (A, B, then A again)
         assert PreprodComparisonApproval.objects.filter(preprod_artifact=artifact).count() == 3
+
+    @patch("sentry.preprod.vcs.webhooks.github_check_run.create_preprod_status_check_task")
+    def test_optimistic_update_patches_check_run_on_approval(self, mock_task) -> None:
+        artifact = self._create_preprod_artifact()
+        event = self._create_webhook_event(
+            action="requested_action",
+            identifier=APPROVE_SIZE_ACTION_IDENTIFIER,
+            external_id=str(artifact.id),
+        )
+
+        mock_client = unittest.mock.MagicMock()
+        mock_installation = unittest.mock.MagicMock()
+        mock_installation.get_client.return_value = mock_client
+        mock_integration = unittest.mock.MagicMock()
+        mock_integration.get_installation.return_value = mock_installation
+
+        with self.feature("organizations:preprod-optimistic-check-run-update"):
+            handle_preprod_check_run_event(
+                github_event=GithubWebhookType.CHECK_RUN,
+                event=event,
+                organization=self.organization,
+                repo=self.repo,
+                integration=mock_integration,
+            )
+
+        mock_client.update_check_run.assert_called_once()
+        call_kwargs = mock_client.update_check_run.call_args
+        assert call_kwargs.kwargs["repo"] == "owner/repo"
+        assert call_kwargs.kwargs["check_run_id"] == 987654321
+        data = call_kwargs.kwargs["data"]
+        assert data["status"] == "completed"
+        assert data["conclusion"] == "success"
+        assert data["actions"] == []
+        assert data["output"]["title"] == "Approved"
+
+        mock_task.apply_async.assert_called_once()
+
+    @patch("sentry.preprod.vcs.webhooks.github_check_run.create_preprod_status_check_task")
+    def test_optimistic_update_skipped_without_feature_flag(self, mock_task) -> None:
+        artifact = self._create_preprod_artifact()
+        event = self._create_webhook_event(
+            action="requested_action",
+            identifier=APPROVE_SIZE_ACTION_IDENTIFIER,
+            external_id=str(artifact.id),
+        )
+
+        mock_integration = unittest.mock.MagicMock()
+
+        handle_preprod_check_run_event(
+            github_event=GithubWebhookType.CHECK_RUN,
+            event=event,
+            organization=self.organization,
+            repo=self.repo,
+            integration=mock_integration,
+        )
+
+        mock_integration.get_installation.assert_not_called()
+        mock_task.apply_async.assert_called_once()
+
+    @patch("sentry.preprod.vcs.webhooks.github_check_run.create_preprod_status_check_task")
+    def test_optimistic_update_failure_does_not_block_async_task(self, mock_task) -> None:
+        artifact = self._create_preprod_artifact()
+        event = self._create_webhook_event(
+            action="requested_action",
+            identifier=APPROVE_SIZE_ACTION_IDENTIFIER,
+            external_id=str(artifact.id),
+        )
+
+        mock_client = unittest.mock.MagicMock()
+        mock_client.update_check_run.side_effect = Exception("GitHub API error")
+        mock_installation = unittest.mock.MagicMock()
+        mock_installation.get_client.return_value = mock_client
+        mock_integration = unittest.mock.MagicMock()
+        mock_integration.get_installation.return_value = mock_installation
+
+        with self.feature("organizations:preprod-optimistic-check-run-update"):
+            handle_preprod_check_run_event(
+                github_event=GithubWebhookType.CHECK_RUN,
+                event=event,
+                organization=self.organization,
+                repo=self.repo,
+                integration=mock_integration,
+            )
+
+        assert PreprodComparisonApproval.objects.filter(preprod_artifact=artifact).count() == 1
+        mock_task.apply_async.assert_called_once()
+
+    @patch("sentry.preprod.vcs.webhooks.github_check_run.create_preprod_status_check_task")
+    def test_optimistic_update_skipped_when_no_approvals_created(self, mock_task) -> None:
+        artifact = self._create_preprod_artifact()
+
+        PreprodComparisonApproval.objects.create(
+            preprod_artifact=artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SIZE,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+            approved_at=datetime.now(timezone.utc),
+            extras={"github": {"id": 12345, "login": "octocat"}},
+        )
+
+        event = self._create_webhook_event(
+            action="requested_action",
+            identifier=APPROVE_SIZE_ACTION_IDENTIFIER,
+            external_id=str(artifact.id),
+            sender_id=12345,
+            sender_login="octocat",
+        )
+
+        mock_integration = unittest.mock.MagicMock()
+
+        with self.feature("organizations:preprod-optimistic-check-run-update"):
+            handle_preprod_check_run_event(
+                github_event=GithubWebhookType.CHECK_RUN,
+                event=event,
+                organization=self.organization,
+                repo=self.repo,
+                integration=mock_integration,
+            )
+
+        mock_integration.get_installation.assert_not_called()
+
+    @patch("sentry.preprod.vcs.webhooks.github_check_run.create_preprod_snapshot_status_check_task")
+    def test_optimistic_update_works_for_snapshot_approval(self, mock_task) -> None:
+        artifact = self._create_preprod_artifact()
+        event = self._create_webhook_event(
+            action="requested_action",
+            identifier=APPROVE_SNAPSHOT_ACTION_IDENTIFIER,
+            external_id=str(artifact.id),
+        )
+
+        mock_client = unittest.mock.MagicMock()
+        mock_installation = unittest.mock.MagicMock()
+        mock_installation.get_client.return_value = mock_client
+        mock_integration = unittest.mock.MagicMock()
+        mock_integration.get_installation.return_value = mock_installation
+
+        with self.feature("organizations:preprod-optimistic-check-run-update"):
+            handle_preprod_check_run_event(
+                github_event=GithubWebhookType.CHECK_RUN,
+                event=event,
+                organization=self.organization,
+                repo=self.repo,
+                integration=mock_integration,
+            )
+
+        mock_client.update_check_run.assert_called_once()
+        mock_task.apply_async.assert_called_once()

--- a/tests/sentry/scm/test_fixtures.py
+++ b/tests/sentry/scm/test_fixtures.py
@@ -1548,7 +1548,7 @@ class FakeGitHubApiClient(GitHubApiClient):
         return make_github_check_run()
 
     def update_check_run(
-        self, repo: str, check_run_id: str, data: dict[str, Any]
+        self, repo: str, check_run_id: int, data: dict[str, Any]
     ) -> dict[str, Any]:
         self._record_call("update_check_run", repo, check_run_id, data)
         self._maybe_raise()


### PR DESCRIPTION
associated PR: https://github.com/getsentry/sentry-options-automator/pull/7066

When a user clicks "Approve" on a GitHub check run, the status takes ~30 seconds to update because the async task sits in the Taskbroker (Kafka) queue before a worker picks it up. This was reported in EME-953 and a previous attempt (#107132) to make the task synchronous was rejected due to webhook timeout and retry concerns.

This adds a best-effort immediate PATCH to the existing GitHub check run in the webhook handler, marking it as completed/success right away. The existing async task dispatch is unchanged and still runs as the definitive update with full status computation and retry logic. If the PATCH fails for any reason, it's silently caught and the async task handles everything as before.

Changes:
- Added `update_check_run()` PATCH method to `GitHubBaseClient` (matches existing `create_check_run`/`get_check_run` pattern)
- Added `_optimistic_update_check_run()` helper in the webhook handler, called after approval records are created
- Behind feature flag `organizations:preprod-optimistic-check-run-update`
- 5 new tests covering success path, feature flag gating, failure resilience, duplicate clicks, and snapshot approvals

Refs LINEAR-EME-953