### PR TITLE
feat(seer): Improve the loading state of the Seer SCM overview area

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -433,6 +433,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 ## Frontend
 /static/app/components/analyticsArea.spec.tsx  @getsentry/app-frontend
 /static/app/components/analyticsArea.tsx       @getsentry/app-frontend
+/static/app/components/loading/                @getsentry/app-frontend
 /static/app/components/events/interfaces/      @getsentry/app-frontend
 /static/app/components/forms/                  @getsentry/app-frontend
 /static/app/locale.tsx                         @getsentry/app-frontend

--- a/static/app/components/loading/useCycleText.tsx
+++ b/static/app/components/loading/useCycleText.tsx
@@ -5,10 +5,10 @@ import {useTimeout} from 'sentry/utils/useTimeout';
 interface Props {
   delayMs: number;
   messages: string[];
-  enabled?: boolean;
+  disabled?: boolean;
 }
 
-export function useCycleText({messages, delayMs, enabled}: Props) {
+export function useCycleText({messages, delayMs, disabled = false}: Props) {
   const [messageIndex, setMessageIndex] = useState(0);
 
   const {start, cancel} = useTimeout({
@@ -20,12 +20,12 @@ export function useCycleText({messages, delayMs, enabled}: Props) {
   });
 
   useEffect(() => {
-    if (enabled ?? true) {
-      start();
-    } else {
+    if (disabled) {
       cancel();
+    } else {
+      start();
     }
-  }, [start, cancel, enabled]);
+  }, [start, cancel, disabled]);
 
   return messages[messageIndex];
 }

--- a/static/app/components/loading/useCycleText.tsx
+++ b/static/app/components/loading/useCycleText.tsx
@@ -11,10 +11,10 @@ interface Props {
 export function useCycleText({messages, delayMs, enabled}: Props) {
   const [messageIndex, setMessageIndex] = useState(0);
 
-  const {start} = useTimeout({
+  const {start, cancel} = useTimeout({
     timeMs: delayMs,
     onTimeout: () => {
-      setMessageIndex(prev => prev + 1);
+      setMessageIndex(prev => Math.min(prev + 1, messages.length - 1));
       start();
     },
   });
@@ -22,8 +22,10 @@ export function useCycleText({messages, delayMs, enabled}: Props) {
   useEffect(() => {
     if (enabled ?? true) {
       start();
+    } else {
+      cancel();
     }
-  }, [start, enabled]);
+  }, [start, cancel, enabled]);
 
   return messages[messageIndex];
 }

--- a/static/app/components/loading/useCycleText.tsx
+++ b/static/app/components/loading/useCycleText.tsx
@@ -1,0 +1,29 @@
+import {useEffect, useState} from 'react';
+
+import {useTimeout} from 'sentry/utils/useTimeout';
+
+interface Props {
+  delayMs: number;
+  messages: string[];
+  enabled?: boolean;
+}
+
+export function useCycleText({messages, delayMs, enabled}: Props) {
+  const [messageIndex, setMessageIndex] = useState(0);
+
+  const {start} = useTimeout({
+    timeMs: delayMs,
+    onTimeout: () => {
+      setMessageIndex(prev => prev + 1);
+      start();
+    },
+  });
+
+  useEffect(() => {
+    if (enabled ?? true) {
+      start();
+    }
+  }, [start, enabled]);
+
+  return messages[messageIndex];
+}

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState, type CSSProperties, type ReactNode} from 'react';
+import {Fragment, useState, type CSSProperties, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Badge, Tag} from '@sentry/scraps/badge';
@@ -10,6 +10,7 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
+import {useCycleText} from 'sentry/components/loading/useCycleText';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {ProviderConfigLink} from 'sentry/components/repositories/scmIntegrationTree/providerConfigLink';
@@ -24,7 +25,6 @@ import type {
 } from 'sentry/types/integrations';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useTimeout} from 'sentry/utils/useTimeout';
 import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
 
 // ---------------------------------------------------------------------------
@@ -458,30 +458,20 @@ function RemoveButton({
   );
 }
 
+const messages = [
+  t('Loading repos...'),
+  t('Loading a few repos...'),
+  t('Loading a lot more repos...'),
+  t('This is getting interesting...'),
+  t('Almost done...'),
+  t('Just kidding, still loading...'),
+];
 function LoadingReposMessage() {
-  const [messageIndex, setMessageIndex] = useState(0);
-  const {start} = useTimeout({
-    timeMs: 5000,
-    onTimeout: () => {
-      setMessageIndex(prev => prev + 1);
-      start();
-    },
-  });
-  useEffect(start, [start]);
-
-  const messages = [
-    t('Loading repos...'),
-    t('Loading a few repos...'),
-    t('Loading a lot more repos...'),
-    t('This is getting interesting...'),
-    t('Almost done...'),
-    t('Just kidding, still loading...'),
-  ];
-
+  const message = useCycleText({messages, delayMs: 5000});
   return (
     <Flex align="center" gap="sm">
       <Text size="sm" variant="muted">
-        {messages[Math.min(messageIndex, messages.length - 1)]}
+        {message}
       </Text>
       <LoadingIndicator size={16} />
     </Flex>

--- a/static/app/views/settings/seer/overview/scmOverviewSection.tsx
+++ b/static/app/views/settings/seer/overview/scmOverviewSection.tsx
@@ -263,7 +263,7 @@ function AddedRepos({
   seerRepos,
   unconnectedRepos,
 }: Props) {
-  const message = useCycleText({messages, delayMs: 5000, enabled: isReposPending});
+  const message = useCycleText({messages, delayMs: 5000, disabled: !isReposPending});
   return (
     <Flex align="center" gap="lg">
       <Stack width="50%" gap="xs">

--- a/static/app/views/settings/seer/overview/scmOverviewSection.tsx
+++ b/static/app/views/settings/seer/overview/scmOverviewSection.tsx
@@ -21,7 +21,9 @@ import {
   isSeerSupportedProvider,
   useSeerSupportedProviderIds,
 } from 'sentry/components/events/autofix/utils';
+import {useCycleText} from 'sentry/components/loading/useCycleText';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Placeholder} from 'sentry/components/placeholder';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {getProviderConfigUrl} from 'sentry/components/repositories/scmIntegrationTree/providerConfigLink';
 import {useScmIntegrationTreeData} from 'sentry/components/repositories/scmIntegrationTree/useScmIntegrationTreeData';
@@ -34,7 +36,6 @@ import type {
 import {defined} from 'sentry/utils';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation} from 'sentry/utils/queryClient';
-
 interface SCMOverviewSectionData {
   connectedRepos: IntegrationRepository[];
   isError: boolean;
@@ -119,6 +120,7 @@ export function SCMOverviewSection(props: Props) {
   const {
     isError,
     isPending,
+    isReposPending,
     organizationSlug,
     refetchIntegrations,
     seerRepos,
@@ -140,12 +142,10 @@ export function SCMOverviewSection(props: Props) {
       }
     >
       {isPending ? (
-        <Flex align="center" gap="md">
-          <LoadingIndicator size={16} style={{margin: '0'}} />
-          <Text size="sm" variant="muted">
-            {t('Loading source code providers and repositories...')}
-          </Text>
-        </Flex>
+        <Stack gap="md">
+          <Placeholder height="20px" width="200px" />
+          <Placeholder height="14px" width="375px" />
+        </Stack>
       ) : isError ? (
         <AlertRoundBottom
           system
@@ -159,6 +159,8 @@ export function SCMOverviewSection(props: Props) {
         >
           {t('Error loading repositories')}
         </AlertRoundBottom>
+      ) : isReposPending ? (
+        <AddedRepos {...props} />
       ) : supportedScmIntegrations.length === 0 ? (
         <NoIntegrations {...props} />
       ) : seerRepos.length === 0 ? (
@@ -245,6 +247,13 @@ function NoRepos({supportedScmIntegrations}: Props) {
   );
 }
 
+const messages = [
+  t('Loading source code providers and repositories...'),
+  t('Loading a lot of repositories...'),
+  t('This is getting interesting...'),
+  t('Almost done...'),
+  t('Just kidding, still loading...'),
+];
 function AddedRepos({
   canWrite,
   connectedRepos,
@@ -254,14 +263,23 @@ function AddedRepos({
   seerRepos,
   unconnectedRepos,
 }: Props) {
+  const message = useCycleText({messages, delayMs: 5000, enabled: isReposPending});
   return (
     <Flex align="center" gap="lg">
       <Stack width="50%" gap="xs">
         <Flex align="center" gap="sm">
-          {isReposPending ? <LoadingIndicator size={16} style={{margin: '0'}} /> : null}
-          {seerRepos.length === 1
-            ? t('1 Repository Added')
-            : t('%s of %s Repositories Added', connectedRepos.length, seerRepos.length)}
+          {isReposPending ? (
+            <Flex align="center" gap="md">
+              <LoadingIndicator size={16} style={{margin: '0'}} />
+              <Text size="sm" variant="muted">
+                {message}
+              </Text>
+            </Flex>
+          ) : seerRepos.length === 1 ? (
+            t('1 Repository Added')
+          ) : (
+            t('%s of %s Repositories Added', connectedRepos.length, seerRepos.length)
+          )}
         </Flex>
 
         <Text size="sm" variant="muted">


### PR DESCRIPTION
An iteration on the loading state. Before it would show a sort-of incremental count and still be spinning along. It looked like it was stuck or something because it wasn't ticking up consistently.

Now we hold back on showing the count and buttons until we're fully ready to go. For these >800 repos it takes ~20seconds to load up for me. 

https://github.com/user-attachments/assets/c865cb0c-014b-4239-a50e-e685c28e36c3

