### PR TITLE
feat(autofix): add root cause as valid stopping point under feature flag

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -601,6 +601,18 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
 
         return attrs
 
+    def _get_default_stopping_point(self, obj: Organization) -> str:
+        stopping_point = obj.get_option(
+            "sentry:default_automated_run_stopping_point",
+            SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
+        )
+        valid_stopping_points = {"code_changes", "open_pr"}
+        if features.has("organizations:seer-overview", obj):
+            valid_stopping_points.add("root_cause")
+        if stopping_point not in valid_stopping_points:
+            return SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
+        return stopping_point
+
     def serialize(  # type: ignore[override]
         self,
         obj: Organization,
@@ -741,10 +753,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             "defaultCodingAgentIntegrationId": obj.get_option(
                 "sentry:seer_default_coding_agent_integration_id", None
             ),
-            "defaultAutomatedRunStoppingPoint": obj.get_option(
-                "sentry:default_automated_run_stopping_point",
-                SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
-            ),
+            "defaultAutomatedRunStoppingPoint": self._get_default_stopping_point(obj),
             "autoOpenPrs": bool(
                 obj.get_option(
                     "sentry:auto_open_prs",

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -84,6 +84,7 @@ from sentry.models.team import Team, TeamStatus
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.replays.models import OrganizationMemberReplayAccess
+from sentry.seer.autofix.utils import get_valid_stopping_points
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -606,10 +607,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             "sentry:default_automated_run_stopping_point",
             SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
         )
-        valid_stopping_points = {"code_changes", "open_pr"}
-        if features.has("organizations:root-cause-stopping-point", obj):
-            valid_stopping_points.add("root_cause")
-        if stopping_point not in valid_stopping_points:
+        if stopping_point not in get_valid_stopping_points(obj):
             return SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
         return stopping_point
 

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -84,7 +84,7 @@ from sentry.models.team import Team, TeamStatus
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.replays.models import OrganizationMemberReplayAccess
-from sentry.seer.autofix.utils import get_valid_stopping_points
+from sentry.seer.autofix.utils import get_valid_automated_run_stopping_points
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -602,12 +602,12 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
 
         return attrs
 
-    def _get_default_stopping_point(self, obj: Organization) -> str:
+    def _get_default_automated_run_stopping_point(self, obj: Organization) -> str:
         stopping_point = obj.get_option(
             "sentry:default_automated_run_stopping_point",
             SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
         )
-        if stopping_point not in get_valid_stopping_points(obj):
+        if stopping_point not in get_valid_automated_run_stopping_points(obj):
             return SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
         return stopping_point
 
@@ -751,7 +751,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             "defaultCodingAgentIntegrationId": obj.get_option(
                 "sentry:seer_default_coding_agent_integration_id", None
             ),
-            "defaultAutomatedRunStoppingPoint": self._get_default_stopping_point(obj),
+            "defaultAutomatedRunStoppingPoint": self._get_default_automated_run_stopping_point(obj),
             "autoOpenPrs": bool(
                 obj.get_option(
                     "sentry:auto_open_prs",

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -607,7 +607,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
         )
         valid_stopping_points = {"code_changes", "open_pr"}
-        if features.has("organizations:seer-overview", obj):
+        if features.has("organizations:root-cause-stopping-point", obj):
             valid_stopping_points.add("root_cause")
         if stopping_point not in valid_stopping_points:
             return SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -384,9 +384,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         allow_null=True,
     )
     defaultCodingAgentIntegrationId = serializers.IntegerField(required=False, allow_null=True)
-    defaultAutomatedRunStoppingPoint = serializers.ChoiceField(
-        choices=["code_changes", "open_pr"], required=False
-    )
+    defaultAutomatedRunStoppingPoint = serializers.CharField(required=False)
     autoOpenPrs = serializers.BooleanField(required=False)
     autoEnableCodeReview = serializers.BooleanField(required=False)
     defaultCodeReviewTriggers = serializers.ListField(
@@ -432,6 +430,16 @@ class OrganizationSerializer(BaseOrganizationSerializer):
             integration_id=value, organization_id=organization.id
         ):
             raise serializers.ValidationError("Integration does not exist.")
+        return value
+
+    def validate_defaultAutomatedRunStoppingPoint(self, value):
+        organization = self.context["organization"]
+        valid_choices = ["code_changes", "open_pr"]
+        if features.has("organizations:seer-overview", organization):
+            valid_choices.append("root_cause")
+
+        if value not in valid_choices:
+            raise serializers.ValidationError(f'"{value}" is not a valid choice.')
         return value
 
     def validate_sensitiveFields(self, value):

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -433,7 +433,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
             raise serializers.ValidationError("Integration does not exist.")
         return value
 
-    def validate_defaultAutomatedRunStoppingPoint(self, value):
+    def validate_defaultAutomatedRunStoppingPoint(self, value: str) -> str:
         organization = self.context["organization"]
         if value not in get_valid_automated_run_stopping_points(organization):
             raise serializers.ValidationError(f'"{value}" is not a valid choice.')

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -110,7 +110,7 @@ from sentry.organizations.services.organization.model import (
 from sentry.relay.datascrubbing import validate_pii_config_update, validate_pii_selectors
 from sentry.replays.models import OrganizationMemberReplayAccess
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
-from sentry.seer.autofix.utils import get_valid_stopping_points
+from sentry.seer.autofix.utils import get_valid_automated_run_stopping_points
 from sentry.services.organization.provisioning import organization_provisioning_service
 from sentry.tasks.console_platform_cleanup import remove_inaccessible_console_platform_sources
 from sentry.users.services.user.serial import serialize_generic_user
@@ -435,7 +435,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
 
     def validate_defaultAutomatedRunStoppingPoint(self, value):
         organization = self.context["organization"]
-        if value not in get_valid_stopping_points(organization):
+        if value not in get_valid_automated_run_stopping_points(organization):
             raise serializers.ValidationError(f'"{value}" is not a valid choice.')
         return value
 

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -110,6 +110,7 @@ from sentry.organizations.services.organization.model import (
 from sentry.relay.datascrubbing import validate_pii_config_update, validate_pii_selectors
 from sentry.replays.models import OrganizationMemberReplayAccess
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.seer.autofix.utils import get_valid_stopping_points
 from sentry.services.organization.provisioning import organization_provisioning_service
 from sentry.tasks.console_platform_cleanup import remove_inaccessible_console_platform_sources
 from sentry.users.services.user.serial import serialize_generic_user
@@ -434,11 +435,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
 
     def validate_defaultAutomatedRunStoppingPoint(self, value):
         organization = self.context["organization"]
-        valid_choices = ["code_changes", "open_pr"]
-        if features.has("organizations:root-cause-stopping-point", organization):
-            valid_choices.append("root_cause")
-
-        if value not in valid_choices:
+        if value not in get_valid_stopping_points(organization):
             raise serializers.ValidationError(f'"{value}" is not a valid choice.')
         return value
 

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -435,7 +435,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     def validate_defaultAutomatedRunStoppingPoint(self, value):
         organization = self.context["organization"]
         valid_choices = ["code_changes", "open_pr"]
-        if features.has("organizations:seer-overview", organization):
+        if features.has("organizations:root-cause-stopping-point", organization):
             valid_choices.append("root_cause")
 
         if value not in valid_choices:

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -299,6 +299,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Seer Overview sections for Seat-Based users
     manager.add("organizations:seer-overview", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Allow root_cause as a valid automated run stopping point and org-level default
+    manager.add("organizations:root-cause-stopping-point", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the Seer Wizard and related prompts/links/banners
     manager.add("organizations:seer-wizard", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Seer issues view

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -406,6 +406,13 @@ def get_org_default_seer_automation_handoff(
         "sentry:default_automated_run_stopping_point", SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
     )
 
+    # Guard against stored values that are no longer valid.
+    valid_stopping_points = {"code_changes", "open_pr"}
+    if features.has("organizations:seer-overview", organization):
+        valid_stopping_points.add("root_cause")
+    if stopping_point not in valid_stopping_points:
+        stopping_point = SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
+
     auto_open_prs = organization.get_option("sentry:auto_open_prs", AUTO_OPEN_PRS_DEFAULT)
 
     automation_handoff: SeerAutomationHandoffConfiguration | None = None

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -69,9 +69,9 @@ class AutofixStoppingPoint(StrEnum):
 
 def get_valid_automated_run_stopping_points(organization: Organization) -> set[str]:
     """Return the set of stopping points valid for the given organization."""
-    valid = {"code_changes", "open_pr"}
+    valid = {AutofixStoppingPoint.CODE_CHANGES, AutofixStoppingPoint.OPEN_PR}
     if features.has("organizations:root-cause-stopping-point", organization):
-        valid.add("root_cause")
+        valid.add(AutofixStoppingPoint.ROOT_CAUSE)
     return valid
 
 
@@ -382,11 +382,16 @@ class SeerAutofixSettingsSerializer(serializers.Serializer):
         required=False,
         help_text="The tuning setting for the projects.",
     )
-    automatedRunStoppingPoint = serializers.ChoiceField(
-        choices=[opt.value for opt in AutofixStoppingPoint],
+    automatedRunStoppingPoint = serializers.CharField(
         required=False,
         help_text="The stopping point for the projects.",
     )
+
+    def validate_automatedRunStoppingPoint(self, value):
+        organization = self.context["organization"]
+        if value not in get_valid_automated_run_stopping_points(organization):
+            raise serializers.ValidationError(f'"{value}" is not a valid choice.')
+        return value
 
     def validate(self, data):
         if "autofixAutomationTuning" not in data and "automatedRunStoppingPoint" not in data:

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -67,7 +67,9 @@ class AutofixStoppingPoint(StrEnum):
     OPEN_PR = "open_pr"
 
 
-def get_valid_automated_run_stopping_points(organization: Organization) -> set[str]:
+def get_valid_automated_run_stopping_points(
+    organization: Organization,
+) -> set[AutofixStoppingPoint]:
     """Return the set of stopping points valid for the given organization."""
     valid = {AutofixStoppingPoint.CODE_CHANGES, AutofixStoppingPoint.OPEN_PR}
     if features.has("organizations:root-cause-stopping-point", organization):
@@ -387,7 +389,7 @@ class SeerAutofixSettingsSerializer(serializers.Serializer):
         help_text="The stopping point for the projects.",
     )
 
-    def validate_automatedRunStoppingPoint(self, value):
+    def validate_automatedRunStoppingPoint(self, value: str) -> str:
         organization = self.context["organization"]
         if value not in get_valid_automated_run_stopping_points(organization):
             raise serializers.ValidationError(f'"{value}" is not a valid choice.')

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -67,6 +67,14 @@ class AutofixStoppingPoint(StrEnum):
     OPEN_PR = "open_pr"
 
 
+def get_valid_stopping_points(organization: Organization) -> set[str]:
+    """Return the set of stopping points valid for the given organization."""
+    valid = {"code_changes", "open_pr"}
+    if features.has("organizations:root-cause-stopping-point", organization):
+        valid.add("root_cause")
+    return valid
+
+
 class AutofixRequest(BaseModel):
     organization_id: int
     project_id: int
@@ -405,12 +413,8 @@ def get_org_default_seer_automation_handoff(
     stopping_point = organization.get_option(
         "sentry:default_automated_run_stopping_point", SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
     )
-
-    # Guard against stored values that are no longer valid.
-    valid_stopping_points = {"code_changes", "open_pr"}
-    if features.has("organizations:root-cause-stopping-point", organization):
-        valid_stopping_points.add("root_cause")
-    if stopping_point not in valid_stopping_points:
+    # Guard against stored stopping points that are no longer valid.
+    if stopping_point not in get_valid_stopping_points(organization):
         stopping_point = SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
 
     auto_open_prs = organization.get_option("sentry:auto_open_prs", AUTO_OPEN_PRS_DEFAULT)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -408,7 +408,7 @@ def get_org_default_seer_automation_handoff(
 
     # Guard against stored values that are no longer valid.
     valid_stopping_points = {"code_changes", "open_pr"}
-    if features.has("organizations:seer-overview", organization):
+    if features.has("organizations:root-cause-stopping-point", organization):
         valid_stopping_points.add("root_cause")
     if stopping_point not in valid_stopping_points:
         stopping_point = SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -67,7 +67,7 @@ class AutofixStoppingPoint(StrEnum):
     OPEN_PR = "open_pr"
 
 
-def get_valid_stopping_points(organization: Organization) -> set[str]:
+def get_valid_automated_run_stopping_points(organization: Organization) -> set[str]:
     """Return the set of stopping points valid for the given organization."""
     valid = {"code_changes", "open_pr"}
     if features.has("organizations:root-cause-stopping-point", organization):
@@ -414,7 +414,7 @@ def get_org_default_seer_automation_handoff(
         "sentry:default_automated_run_stopping_point", SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
     )
     # Guard against stored stopping points that are no longer valid.
-    if stopping_point not in get_valid_stopping_points(organization):
+    if stopping_point not in get_valid_automated_run_stopping_points(organization):
         stopping_point = SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
 
     auto_open_prs = organization.get_option("sentry:auto_open_prs", AUTO_OPEN_PRS_DEFAULT)

--- a/src/sentry/seer/blueprints/api.md
+++ b/src/sentry/seer/blueprints/api.md
@@ -27,12 +27,12 @@ Retrieves a paginated list of projects with their autofix automation settings.
 
 **Attributes**
 
-| Column                    | Type   | Description                                                                                                                                             |
-| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| projectId                 | int    | The project ID                                                                                                                                          |
-| autofixAutomationTuning   | string | The tuning setting for automated autofix. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`)                            |
-| automatedRunStoppingPoint | string | The stopping point for automated runs. One of: `code_changes`, `open_pr`, `root_cause` (requires `seer-overview` flag), (deprecated values: `solution`) |
-| reposCount                | int    | Number of repositories configured for the project                                                                                                       |
+| Column                    | Type   | Description                                                                                                                                                         |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| projectId                 | int    | The project ID                                                                                                                                                      |
+| autofixAutomationTuning   | string | The tuning setting for automated autofix. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`)                                        |
+| automatedRunStoppingPoint | string | The stopping point for automated runs. One of: `code_changes`, `open_pr`, `root_cause` (requires `root-cause-stopping-point` flag), (deprecated values: `solution`) |
+| reposCount                | int    | Number of repositories configured for the project                                                                                                                   |
 
 - Response 200
 
@@ -61,11 +61,11 @@ Bulk create/update the autofix automation settings for multiple projects in a si
 
 **Attributes**
 
-| Column                    | Type      | Required | Description                                                                                                                          |
-| ------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| projectIds                | list[int] | Yes      | List of project IDs to update (min: 1, max: 1000)                                                                                    |
-| autofixAutomationTuning   | string    | No\*     | The tuning setting. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`)                               |
-| automatedRunStoppingPoint | string    | No\*     | The stopping point. One of: `code_changes`, `open_pr`, `root_cause` (requires `seer-overview` flag), (deprecated values: `solution`) |
+| Column                    | Type      | Required | Description                                                                                                                                      |
+| ------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| projectIds                | list[int] | Yes      | List of project IDs to update (min: 1, max: 1000)                                                                                                |
+| autofixAutomationTuning   | string    | No\*     | The tuning setting. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`)                                           |
+| automatedRunStoppingPoint | string    | No\*     | The stopping point. One of: `code_changes`, `open_pr`, `root_cause` (requires `root-cause-stopping-point` flag), (deprecated values: `solution`) |
 
 \* At least one of either `autofixAutomationTuning` or `automatedRunStoppingPoint` must be provided.
 

--- a/src/sentry/seer/blueprints/api.md
+++ b/src/sentry/seer/blueprints/api.md
@@ -27,12 +27,12 @@ Retrieves a paginated list of projects with their autofix automation settings.
 
 **Attributes**
 
-| Column                    | Type   | Description                                                                                                                  |
-| ------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| projectId                 | int    | The project ID                                                                                                               |
-| autofixAutomationTuning   | string | The tuning setting for automated autofix. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`) |
-| automatedRunStoppingPoint | string | The stopping point for automated runs. One of: `code_changes`, `open_pr`, (deprecated values: `root_cause`, `solution`)      |
-| reposCount                | int    | Number of repositories configured for the project                                                                            |
+| Column                    | Type   | Description                                                                                                                                             |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| projectId                 | int    | The project ID                                                                                                                                          |
+| autofixAutomationTuning   | string | The tuning setting for automated autofix. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`)                            |
+| automatedRunStoppingPoint | string | The stopping point for automated runs. One of: `code_changes`, `open_pr`, `root_cause` (requires `seer-overview` flag), (deprecated values: `solution`) |
+| reposCount                | int    | Number of repositories configured for the project                                                                                                       |
 
 - Response 200
 
@@ -61,11 +61,11 @@ Bulk create/update the autofix automation settings for multiple projects in a si
 
 **Attributes**
 
-| Column                    | Type      | Required | Description                                                                                            |
-| ------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| projectIds                | list[int] | Yes      | List of project IDs to update (min: 1, max: 1000)                                                      |
-| autofixAutomationTuning   | string    | No\*     | The tuning setting. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`) |
-| automatedRunStoppingPoint | string    | No\*     | The stopping point. One of: `code_changes`, `open_pr`, (deprecated values: `root_cause`, `solution`)   |
+| Column                    | Type      | Required | Description                                                                                                                          |
+| ------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| projectIds                | list[int] | Yes      | List of project IDs to update (min: 1, max: 1000)                                                                                    |
+| autofixAutomationTuning   | string    | No\*     | The tuning setting. One of: `off`, `medium`, (deprecated values: `super_low`, `low`, `high`, `always`)                               |
+| automatedRunStoppingPoint | string    | No\*     | The stopping point. One of: `code_changes`, `open_pr`, `root_cause` (requires `seer-overview` flag), (deprecated values: `solution`) |
 
 \* At least one of either `autofixAutomationTuning` or `automatedRunStoppingPoint` must be provided.
 

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -246,7 +246,9 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
         :pparam string organization_id_or_slug: the id or slug of the organization.
         :auth: required
         """
-        serializer = SeerAutofixSettingsPostSerializer(data=request.data)
+        serializer = SeerAutofixSettingsPostSerializer(
+            data=request.data, context={"organization": organization}
+        )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -28,7 +28,7 @@ from sentry.seer.autofix.utils import (
     get_autofix_state,
     get_org_default_seer_automation_handoff,
     get_seer_seat_based_tier_cache_key,
-    get_valid_stopping_points,
+    get_valid_automated_run_stopping_points,
     resolve_repository_ids,
 )
 from sentry.seer.models import SeerProjectPreference
@@ -244,7 +244,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
 
     default_stopping_point, default_handoff = get_org_default_seer_automation_handoff(organization)
     default_handoff_dict = default_handoff.dict() if default_handoff else None
-    valid_stopping_points = get_valid_stopping_points(organization)
+    valid_stopping_points = get_valid_automated_run_stopping_points(organization)
 
     preferences_by_id = bulk_get_project_preferences(organization_id, project_ids)
 

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -245,7 +245,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     default_handoff_dict = default_handoff.dict() if default_handoff else None
 
     valid_stopping_points = {"open_pr", "code_changes"}
-    if features.has("organizations:seer-overview", organization):
+    if features.has("organizations:root-cause-stopping-point", organization):
         valid_stopping_points.add("root_cause")
 
     preferences_by_id = bulk_get_project_preferences(organization_id, project_ids)

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -28,6 +28,7 @@ from sentry.seer.autofix.utils import (
     get_autofix_state,
     get_org_default_seer_automation_handoff,
     get_seer_seat_based_tier_cache_key,
+    get_valid_stopping_points,
     resolve_repository_ids,
 )
 from sentry.seer.models import SeerProjectPreference
@@ -243,10 +244,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
 
     default_stopping_point, default_handoff = get_org_default_seer_automation_handoff(organization)
     default_handoff_dict = default_handoff.dict() if default_handoff else None
-
-    valid_stopping_points = {"open_pr", "code_changes"}
-    if features.has("organizations:root-cause-stopping-point", organization):
-        valid_stopping_points.add("root_cause")
+    valid_stopping_points = get_valid_stopping_points(organization)
 
     preferences_by_id = bulk_get_project_preferences(organization_id, project_ids)
 

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -245,6 +245,8 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     default_handoff_dict = default_handoff.dict() if default_handoff else None
 
     valid_stopping_points = {"open_pr", "code_changes"}
+    if features.has("organizations:seer-overview", organization):
+        valid_stopping_points.add("root_cause")
 
     preferences_by_id = bulk_get_project_preferences(organization_id, project_ids)
 

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -677,6 +677,14 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase, BaseMetricsLayerTestC
             )
             assert "onboarding" not in response.data["features"]
 
+    def test_invalid_stored_stopping_point_falls_back_to_default(self) -> None:
+        self.organization.update_option("sentry:default_automated_run_stopping_point", "root_cause")
+        response = self.get_success_response(self.organization.slug)
+        assert (
+            response.data["defaultAutomatedRunStoppingPoint"]
+            == SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
+        )
+
 
 @cell_silo_test(cells=cells)
 class OrganizationUpdateTest(OrganizationDetailsTestBase):

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1690,7 +1690,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
                 self.get_error_response(self.organization.slug, status_code=400, **data)
 
     def test_default_automated_run_stopping_point_accepts_root_cause_with_flag(self) -> None:
-        with self.feature("organizations:seer-overview"):
+        with self.feature("organizations:root-cause-stopping-point"):
             data = {"defaultAutomatedRunStoppingPoint": "root_cause"}
             response = self.get_success_response(self.organization.slug, **data)
             assert response.data["defaultAutomatedRunStoppingPoint"] == "root_cause"

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1684,10 +1684,16 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
                 assert response.data["defaultAutomatedRunStoppingPoint"] == choice
 
     def test_default_automated_run_stopping_point_rejects_invalid(self) -> None:
-        for invalid in ("root_cause", "solution", "invalid_point"):
+        for invalid in ("solution", "invalid_point", "root_cause"):
             with self.subTest(value=invalid):
                 data = {"defaultAutomatedRunStoppingPoint": invalid}
                 self.get_error_response(self.organization.slug, status_code=400, **data)
+
+    def test_default_automated_run_stopping_point_accepts_root_cause_with_flag(self) -> None:
+        with self.feature("organizations:seer-overview"):
+            data = {"defaultAutomatedRunStoppingPoint": "root_cause"}
+            response = self.get_success_response(self.organization.slug, **data)
+            assert response.data["defaultAutomatedRunStoppingPoint"] == "root_cause"
 
     def test_default_coding_agent_integration_id_can_be_cleared(self) -> None:
         self.organization.update_option("sentry:seer_default_coding_agent_integration_id", 123)

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import orjson
 import pytest
 
-from sentry.constants import DataCategory
+from sentry.constants import SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT, DataCategory
 from sentry.seer.autofix.constants import AutofixStatus
 from sentry.seer.autofix.trigger import is_issue_eligible_for_seer_automation
 from sentry.seer.autofix.utils import (
@@ -1307,3 +1307,10 @@ class TestGetOrgDefaultSeerAutomationHandoff(TestCase):
         stopping_point, handoff = get_org_default_seer_automation_handoff(self.organization)
         assert stopping_point == "open_pr"
         assert handoff is None
+
+    def test_invalid_stopping_point_falls_back_to_default(self):
+        self.organization.update_option(
+            "sentry:default_automated_run_stopping_point", "invalid_point"
+        )
+        stopping_point, _ = get_org_default_seer_automation_handoff(self.organization)
+        assert stopping_point == SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -315,7 +315,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
                     "automatedRunStoppingPoint": "root_cause",
                 },
             )
-        assert response.status_code == 200
+        assert response.status_code == 204
 
     def test_post_rejects_projects_not_in_organization(self) -> None:
         project = self.create_project(organization=self.organization)

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -294,6 +294,29 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
 
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_get_project_preferences"
+    )
+    @patch(
+        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
+    )
+    def test_post_accepts_root_cause_with_flag(
+        self, mock_bulk_set_preferences, mock_bulk_get_preferences
+    ) -> None:
+        project = self.create_project(organization=self.organization)
+        mock_bulk_get_preferences.return_value = {}
+        mock_bulk_set_preferences.return_value = None
+
+        with self.feature("organizations:root-cause-stopping-point"):
+            response = self.client.post(
+                self.url,
+                {
+                    "projectIds": [project.id],
+                    "automatedRunStoppingPoint": "root_cause",
+                },
+            )
+        assert response.status_code == 200
+
     def test_post_rejects_projects_not_in_organization(self) -> None:
         project = self.create_project(organization=self.organization)
         other_org = self.create_organization()

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -300,7 +300,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
     @patch(
         "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
     )
-    def test_post_accepts_root_cause_with_flag(
+    def test_post_accepts_root_cause_stopping_point_with_flag(
         self, mock_bulk_set_preferences, mock_bulk_get_preferences
     ) -> None:
         project = self.create_project(organization=self.organization)

--- a/tests/sentry/tasks/seer/test_autofix.py
+++ b/tests/sentry/tasks/seer/test_autofix.py
@@ -358,6 +358,26 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
         )
         assert prefs_by_project[project.id]["automation_handoff"] == existing_handoff
 
+    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
+    @patch("sentry.tasks.seer.autofix.bulk_get_project_preferences")
+    def test_root_cause_stopping_point_preserved_with_seer_overview_flag(
+        self, mock_bulk_get: MagicMock, mock_bulk_set: MagicMock
+    ) -> None:
+        """Project with root_cause stopping point is preserved when seer-overview flag is enabled."""
+        project = self.create_project(organization=self.organization)
+
+        mock_bulk_get.return_value = {
+            str(project.id): {
+                "automated_run_stopping_point": "root_cause",
+                "automation_handoff": None,
+            },
+        }
+
+        with self.feature("organizations:seer-overview"):
+            configure_seer_for_existing_org(organization_id=self.organization.id)
+
+        mock_bulk_set.assert_not_called()
+
     @patch("sentry.tasks.seer.autofix.bulk_get_project_preferences")
     def test_raises_on_bulk_get_api_failure(self, mock_bulk_get: MagicMock) -> None:
         """Test that task raises on bulk GET API failure to trigger retry."""

--- a/tests/sentry/tasks/seer/test_autofix.py
+++ b/tests/sentry/tasks/seer/test_autofix.py
@@ -363,7 +363,7 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
     def test_root_cause_stopping_point_preserved_with_seer_overview_flag(
         self, mock_bulk_get: MagicMock, mock_bulk_set: MagicMock
     ) -> None:
-        """Project with root_cause stopping point is preserved when seer-overview flag is enabled."""
+        """Project with root_cause stopping point is preserved when root-cause-stopping-point flag is enabled."""
         project = self.create_project(organization=self.organization)
 
         mock_bulk_get.return_value = {
@@ -373,7 +373,7 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
             },
         }
 
-        with self.feature("organizations:seer-overview"):
+        with self.feature("organizations:root-cause-stopping-point"):
             configure_seer_for_existing_org(organization_id=self.organization.id)
 
         mock_bulk_set.assert_not_called()

--- a/tests/sentry/tasks/seer/test_autofix.py
+++ b/tests/sentry/tasks/seer/test_autofix.py
@@ -360,7 +360,7 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
 
     @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
     @patch("sentry.tasks.seer.autofix.bulk_get_project_preferences")
-    def test_root_cause_stopping_point_preserved_with_seer_overview_flag(
+    def test_root_cause_stopping_point_preserved_when_valid(
         self, mock_bulk_get: MagicMock, mock_bulk_set: MagicMock
     ) -> None:
         """Project with root_cause stopping point is preserved when root-cause-stopping-point flag is enabled."""


### PR DESCRIPTION
 Allows root_cause as a valid automated run stopping point and org-level default, gated behind `organizations:root-cause-stopping-point`. 

- Org details PUT: dynamically validate defaultAutomatedRunStoppingPoint based on feature flag
- Bulk settings POST: dynamically validate automatedRunStoppingPoint based on feature flag
- Sync task: treat root_cause as a valid project stopping point when flag is enabled
- Read paths (org serializer GET, get_org_default_seer_automation_handoff): sanitize stored values so root_cause falls back to the default if the flag is later turned off