### PR TITLE
chore(ACI): Add custom metric and other aggregate options to API docs for detector creation

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -611,6 +611,7 @@ DATA_SOURCES_HELP_TEXT = """
             The data sources for the monitor to use based on what you want to measure.
 
             **Number of Errors Metric Monitor**
+            - `eventTypes`: Any of `error` or `default`.
             ```json
                 [
                     {
@@ -626,6 +627,7 @@ DATA_SOURCES_HELP_TEXT = """
             ```
 
             **Users Experiencing Errors Metric Monitor**
+            - `eventTypes`: Any of `error` or `default`.
             ```json
                 [
                     {
@@ -690,6 +692,9 @@ DATA_SOURCES_HELP_TEXT = """
             ```
 
             **Largest Contentful Paint Metric Monitor**
+            - `dataset`: If a custom percentile is used, dataset is `transactions`. Otherwise, dataset is `generic_metrics`.
+            - `aggregate`: Valid values are `avg(measurements.lcp)`, `p50(measurements.lcp)`, `p75(measurements.lcp)`, `p95(measurements.lcp)`, `p99(measurements.lcp)`, `p100(measurements.lcp)`, and `percentile(measurements.lcp,x)`, where `x` is your custom percentile.
+
             ```json
                 [
                     {
@@ -704,6 +709,29 @@ DATA_SOURCES_HELP_TEXT = """
                     },
                 ],
             ```
+
+            **Custom Metric Monitor**
+            - `dataset`: If a custom percentile is used, dataset is `transactions`. Otherwise, dataset is `generic_metrics`.
+            - `aggregate`: Valid values are:
+            `avg(x)`, where `x` is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
+            `p50(x)`, where `x` is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
+            `p75(x)`, where x is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
+            `p95(x)`, where x is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
+            `p99(x)`, where x is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
+            `p100(x)`, where `x` is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
+            `percentile(x,y)`, where `x` is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`, and `y` is the custom percentile.
+            `failure_rate()`
+            `apdex(x)`, where `x` is the value of the Apdex score.
+            `count()`
+
+            ```json
+            [
+                {
+                    "aggregate": "p75(measurements.ttfb)"
+                    "dataset": "generic_metrics",
+                    "queryType": 1,
+                },
+            ],
 """
 
 DETECTOR_CONFIG_HELP_TEXT = """


### PR DESCRIPTION
Update the `data_sources` docs in https://docs.sentry.io/api/monitors/create-a-monitor-for-a-project/ to add more detail, mostly related to aggregates and custom metrics, based on the documentation in https://docs.sentry.io/api/alerts/create-a-metric-alert-rule-for-an-organization/