### PR TITLE
fix(alerts): Incorporate EventsAnalyticsPlatform into our downgrade checking

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -53,6 +53,31 @@ class MetricIssueDetectorConfig(TypedDict):
     detection_type: Literal["static", "percent", "dynamic"]
 
 
+def has_downgraded(dataset: str, organization: Organization) -> bool:
+    """
+    Check if the organization has downgraded since the subscription was created.
+    """
+    supports_metrics_issues = features.has("organizations:incidents", organization)
+    if dataset == Dataset.Events.value and not supports_metrics_issues:
+        metrics.incr("incidents.alert_rules.ignore_update_missing_incidents")
+        return True
+
+    supports_performance_view = features.has("organizations:performance-view", organization)
+    if dataset in (Dataset.Transactions.value, Dataset.EventsAnalyticsPlatform.value) and not (
+        supports_metrics_issues and supports_performance_view
+    ):
+        metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_performance")
+        return True
+
+    if dataset == Dataset.PerformanceMetrics.value and not features.has(
+        "organizations:on-demand-metrics-extraction", organization
+    ):
+        metrics.incr("incidents.alert_rules.ignore_update_missing_on_demand")
+        return True
+
+    return False
+
+
 class SubscriptionProcessor:
     """
     Class for processing subscription updates for workflow engine.
@@ -220,30 +245,6 @@ class SubscriptionProcessor:
             )
         return results
 
-    def has_downgraded(self, dataset: str, organization: Organization) -> bool:
-        """
-        Check if the organization has downgraded since the subscription was created, return early if True
-        """
-        supports_metrics_issues = features.has("organizations:incidents", organization)
-        if dataset == Dataset.Events.value and not supports_metrics_issues:
-            metrics.incr("incidents.alert_rules.ignore_update_missing_incidents")
-            return True
-
-        supports_performance_view = features.has("organizations:performance-view", organization)
-        if dataset in (Dataset.Transactions.value, Dataset.EventsAnalyticsPlatform.value) and not (
-            supports_metrics_issues and supports_performance_view
-        ):
-            metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_performance")
-            return True
-
-        if dataset == Dataset.PerformanceMetrics.value and not features.has(
-            "organizations:on-demand-metrics-extraction", organization
-        ):
-            metrics.incr("incidents.alert_rules.ignore_update_missing_on_demand")
-            return True
-
-        return False
-
     def process_update(self, subscription_update: QuerySubscriptionUpdate) -> bool:
         """
         Core processing method. Assumes subscription has cached project/organization
@@ -252,7 +253,7 @@ class SubscriptionProcessor:
         dataset = self.subscription.snuba_query.dataset
         organization = self.subscription.project.organization
 
-        if self.has_downgraded(dataset, organization):
+        if has_downgraded(dataset, organization):
             return False
 
         if subscription_update["timestamp"] <= self.last_update:

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -63,10 +63,17 @@ def has_downgraded(dataset: str, organization: Organization) -> bool:
         return True
 
     supports_performance_view = features.has("organizations:performance-view", organization)
-    if dataset in (Dataset.Transactions.value, Dataset.EventsAnalyticsPlatform.value) and not (
+    if dataset == Dataset.Transactions.value and not (
         supports_metrics_issues and supports_performance_view
     ):
         metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_performance")
+        return True
+        
+    supports_explore_view = features.has("organizations:visibility-explore-view", organization)
+    if dataset == Dataset.EventsAnalyticsPlatform.value and not (
+        supports_metrics_issues and supports_explore_view
+    ):
+        metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_eap")
         return True
 
     if dataset == Dataset.PerformanceMetrics.value and not features.has(

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -68,7 +68,7 @@ def has_downgraded(dataset: str, organization: Organization) -> bool:
     ):
         metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_performance")
         return True
-        
+
     supports_explore_view = features.has("organizations:visibility-explore-view", organization)
     if dataset == Dataset.EventsAnalyticsPlatform.value and not (
         supports_metrics_issues and supports_explore_view

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -82,6 +82,14 @@ def has_downgraded(dataset: str, organization: Organization) -> bool:
         metrics.incr("incidents.alert_rules.ignore_update_missing_on_demand")
         return True
 
+    if not supports_metrics_issues:
+        # These should probably be downgraded, but we should know the impact first.
+        metrics.incr(
+            "incidents.alert_rules.no_incidents_not_downgraded",
+            sample_rate=1.0,
+            tags={"dataset": dataset},
+        )
+
     return False
 
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -224,17 +224,19 @@ class SubscriptionProcessor:
         """
         Check if the organization has downgraded since the subscription was created, return early if True
         """
-        if dataset == "events" and not features.has("organizations:incidents", organization):
+        supports_metrics_issues = features.has("organizations:incidents", organization)
+        if dataset == Dataset.Events.value and not supports_metrics_issues:
             metrics.incr("incidents.alert_rules.ignore_update_missing_incidents")
             return True
 
-        elif dataset == "transactions" and not features.has(
-            "organizations:performance-view", organization
+        supports_performance_view = features.has("organizations:performance-view", organization)
+        if dataset in (Dataset.Transactions.value, Dataset.EventsAnalyticsPlatform.value) and not (
+            supports_metrics_issues and supports_performance_view
         ):
             metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_performance")
             return True
 
-        elif dataset == "generic_metrics" and not features.has(
+        if dataset == Dataset.PerformanceMetrics.value and not features.has(
             "organizations:on-demand-metrics-extraction", organization
         ):
             metrics.incr("incidents.alert_rules.ignore_update_missing_on_demand")

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -1,5 +1,6 @@
 import copy
 import math
+from contextlib import contextmanager
 from datetime import timedelta
 from functools import cached_property
 from unittest.mock import MagicMock, call, patch
@@ -11,8 +12,9 @@ from django.utils import timezone
 from urllib3.response import HTTPResponse
 
 from sentry.constants import ObjectStatus
-from sentry.incidents.subscription_processor import SubscriptionProcessor
+from sentry.incidents.subscription_processor import SubscriptionProcessor, has_downgraded
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
+from sentry.models.organization import Organization
 from sentry.seer.anomaly_detection.types import (
     AnomalyDetectionSeasonality,
     AnomalyDetectionSensitivity,
@@ -63,33 +65,17 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.sub.project.delete()
         assert self.send_update(self.critical_threshold + 1) is False
 
-    @patch("sentry.incidents.subscription_processor.metrics")
-    def test_has_downgraded_incidents(self, mock_metrics: MagicMock) -> None:
+    @patch("sentry.incidents.subscription_processor.has_downgraded", return_value=True)
+    def test_process_update_returns_false_when_downgraded(
+        self, mock_has_downgraded: MagicMock
+    ) -> None:
         message = self.build_subscription_update(
             self.sub, value=self.critical_threshold + 1, time_delta=timedelta()
         )
 
         with self.capture_on_commit_callbacks(execute=True):
             assert SubscriptionProcessor.process(self.sub, message) is False
-            mock_metrics.incr.assert_has_calls(
-                [call("incidents.alert_rules.ignore_update_missing_incidents")]
-            )
-
-    @patch("sentry.incidents.subscription_processor.metrics")
-    def test_has_downgraded_incidents_performance(self, mock_metrics: MagicMock) -> None:
-        snuba_query = self.get_snuba_query(self.detector)
-        snuba_query.update(time_window=15 * 60, dataset=Dataset.Transactions.value)
-        snuba_query.save()
-
-        message = self.build_subscription_update(
-            self.sub, value=self.critical_threshold + 1, time_delta=timedelta()
-        )
-
-        with self.capture_on_commit_callbacks(execute=True):
-            assert SubscriptionProcessor.process(self.sub, message) is False
-            mock_metrics.incr.assert_has_calls(
-                [call("incidents.alert_rules.ignore_update_missing_incidents_performance")]
-            )
+        mock_has_downgraded.assert_called_once()
 
     @patch("sentry.incidents.subscription_processor.metrics")
     def test_invalid_aggregation_value(self, mock_metrics: MagicMock) -> None:
@@ -100,22 +86,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
             ]
         )
-
-    @patch("sentry.incidents.subscription_processor.metrics")
-    def test_has_downgraded_on_demand(self, mock_metrics: MagicMock) -> None:
-        snuba_query = self.get_snuba_query(self.detector)
-        snuba_query.update(time_window=15 * 60, dataset=Dataset.PerformanceMetrics.value)
-        snuba_query.save()
-
-        message = self.build_subscription_update(
-            self.sub, value=self.critical_threshold + 1, time_delta=timedelta()
-        )
-
-        with self.capture_on_commit_callbacks(execute=True):
-            assert SubscriptionProcessor.process(self.sub, message) is False
-            mock_metrics.incr.assert_has_calls(
-                [call("incidents.alert_rules.ignore_update_missing_on_demand")]
-            )
 
     @patch("sentry.incidents.subscription_processor.metrics")
     def test_skip_already_processed_update(self, mock_metrics: MagicMock) -> None:
@@ -1042,3 +1012,69 @@ class MetricsCrashRateDetectorProcessUpdateTest(ProcessUpdateBaseClass, BaseMetr
                 call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
             ]
         )
+
+
+@patch("sentry.incidents.subscription_processor.metrics")
+class TestHasDowngraded:
+    org = MagicMock(spec=Organization)
+
+    @contextmanager
+    def fake_features(self, enabled: set[str]):
+        with patch("sentry.incidents.subscription_processor.features") as mock_features:
+            mock_features.has.side_effect = lambda name, *a, **kw: name in enabled
+            yield
+
+    def test_events_without_incidents_feature(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features(set()):
+            assert has_downgraded(Dataset.Events.value, self.org) is True
+        mock_metrics.incr.assert_called_with(
+            "incidents.alert_rules.ignore_update_missing_incidents"
+        )
+
+    def test_events_with_incidents_feature(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features({"organizations:incidents"}):
+            assert has_downgraded(Dataset.Events.value, self.org) is False
+
+    def test_transactions_without_any_features(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features(set()):
+            assert has_downgraded(Dataset.Transactions.value, self.org) is True
+        mock_metrics.incr.assert_called_with(
+            "incidents.alert_rules.ignore_update_missing_incidents_performance"
+        )
+
+    def test_transactions_with_only_performance_view(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features({"organizations:performance-view"}):
+            assert has_downgraded(Dataset.Transactions.value, self.org) is True
+        mock_metrics.incr.assert_called_with(
+            "incidents.alert_rules.ignore_update_missing_incidents_performance"
+        )
+
+    def test_transactions_with_both_features(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features({"organizations:incidents", "organizations:performance-view"}):
+            assert has_downgraded(Dataset.Transactions.value, self.org) is False
+
+    def test_eap_without_features(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features(set()):
+            assert has_downgraded(Dataset.EventsAnalyticsPlatform.value, self.org) is True
+        mock_metrics.incr.assert_called_with(
+            "incidents.alert_rules.ignore_update_missing_incidents_performance"
+        )
+
+    def test_eap_with_both_features(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features({"organizations:incidents", "organizations:performance-view"}):
+            assert has_downgraded(Dataset.EventsAnalyticsPlatform.value, self.org) is False
+
+    def test_performance_metrics_without_on_demand_feature(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features(set()):
+            assert has_downgraded(Dataset.PerformanceMetrics.value, self.org) is True
+        mock_metrics.incr.assert_called_with(
+            "incidents.alert_rules.ignore_update_missing_on_demand"
+        )
+
+    def test_performance_metrics_with_on_demand_feature(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features({"organizations:on-demand-metrics-extraction"}):
+            assert has_downgraded(Dataset.PerformanceMetrics.value, self.org) is False
+
+    def test_unknown_dataset_not_downgraded(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features(set()):
+            assert has_downgraded("unknown_dataset", self.org) is False

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_aci.py
@@ -1057,11 +1057,20 @@ class TestHasDowngraded:
         with self.fake_features(set()):
             assert has_downgraded(Dataset.EventsAnalyticsPlatform.value, self.org) is True
         mock_metrics.incr.assert_called_with(
-            "incidents.alert_rules.ignore_update_missing_incidents_performance"
+            "incidents.alert_rules.ignore_update_missing_incidents_eap"
+        )
+
+    def test_eap_with_only_explore_view(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features({"organizations:visibility-explore-view"}):
+            assert has_downgraded(Dataset.EventsAnalyticsPlatform.value, self.org) is True
+        mock_metrics.incr.assert_called_with(
+            "incidents.alert_rules.ignore_update_missing_incidents_eap"
         )
 
     def test_eap_with_both_features(self, mock_metrics: MagicMock) -> None:
-        with self.fake_features({"organizations:incidents", "organizations:performance-view"}):
+        with self.fake_features(
+            {"organizations:incidents", "organizations:visibility-explore-view"}
+        ):
             assert has_downgraded(Dataset.EventsAnalyticsPlatform.value, self.org) is False
 
     def test_performance_metrics_without_on_demand_feature(self, mock_metrics: MagicMock) -> None:
@@ -1078,3 +1087,17 @@ class TestHasDowngraded:
     def test_unknown_dataset_not_downgraded(self, mock_metrics: MagicMock) -> None:
         with self.fake_features(set()):
             assert has_downgraded("unknown_dataset", self.org) is False
+        mock_metrics.incr.assert_called_with(
+            "incidents.alert_rules.no_incidents_not_downgraded",
+            sample_rate=1.0,
+            tags={"dataset": "unknown_dataset"},
+        )
+
+    def test_no_incidents_not_downgraded_emits_metric(self, mock_metrics: MagicMock) -> None:
+        with self.fake_features({"organizations:on-demand-metrics-extraction"}):
+            assert has_downgraded(Dataset.PerformanceMetrics.value, self.org) is False
+        mock_metrics.incr.assert_called_with(
+            "incidents.alert_rules.no_incidents_not_downgraded",
+            sample_rate=1.0,
+            tags={"dataset": Dataset.PerformanceMetrics.value},
+        )

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
@@ -200,7 +200,13 @@ class ProcessUpdateBaseClass(TestCase, SpanTestCase, SnubaTestCase):
             subscription = self.sub
         message = self.build_subscription_update(subscription, value=value, time_delta=time_delta)
         with (
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature(
+                [
+                    "organizations:incidents",
+                    "organizations:performance-view",
+                    "organizations:visibility-explore-view",
+                ]
+            ),
             self.capture_on_commit_callbacks(execute=True),
         ):
             return SubscriptionProcessor.process(subscription, message)
@@ -220,7 +226,13 @@ class TestSubscriptionProcessorLastUpdate(ProcessUpdateBaseClass):
         )
 
         with (
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature(
+                [
+                    "organizations:incidents",
+                    "organizations:performance-view",
+                    "organizations:visibility-explore-view",
+                ]
+            ),
             self.capture_on_commit_callbacks(execute=True),
         ):
             result = SubscriptionProcessor.process(self.sub, old_update_message)
@@ -250,7 +262,13 @@ class TestSubscriptionProcessorLastUpdate(ProcessUpdateBaseClass):
 
         message = self.build_subscription_update(subscription_without_detector, value=100)
         with (
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature(
+                [
+                    "organizations:incidents",
+                    "organizations:performance-view",
+                    "organizations:visibility-explore-view",
+                ]
+            ),
             self.capture_on_commit_callbacks(execute=True),
         ):
             result = SubscriptionProcessor.process(subscription_without_detector, message)


### PR DESCRIPTION
As I understand it, 'incidents' feature is required for alerts,  'performance-view' is required in _addition_ for performance-related alerts, and (importantly) a portion of the alerts that previously used the 'transactions' dataset now use 'events_analytics_platform', and we need to include them in this logic also.

Fixes ISWF-2366.