### PR TITLE
chore(ACI): Add a single feature flag to control issue alert rule backwards compatible endpoint flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -444,6 +444,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for ProjectRuleGroupHistoryIndexEndpoint.get and ProjectRuleStatsIndexEndpoint.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-projectrulegroupstats-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use workflow engine exclusively for legacy issue alert rule.get results.
+    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
+    manager.add("organizations:workflow-engine-issue-alert-endpoints-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition


### PR DESCRIPTION
We are using several flags to control rollout of the issue alert rule backwards compatible endpoints so it'd be simpler to combine them to use one flag now that they are all GA'd. 

Step 1: This PR - add the new flag
Step 2: options automator PR - enable the new flag for GA
Step 3: replace usage of `organizations:workflow-engine-projectrulesendpoint-get`, `organizations:workflow-engine-projectruledetailsendpoint-get`, and `organizations:workflow-engine-projectrulegroupstats-get` with this new flag