### PR TITLE
feat(seer): Send page_name in explorer chat requests

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -39,6 +39,13 @@ class SeerExplorerChatSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Optional context from the user's screen.",
     )
+    page_name = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        default=None,
+        help_text="The UI page name where the request originated (e.g., route string).",
+    )
     override_ce_enable = serializers.BooleanField(
         required=False,
         default=True,
@@ -143,6 +150,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
         query = validated_data["query"]
         insert_index = validated_data.get("insert_index")
         on_page_context = validated_data.get("on_page_context")
+        page_name = validated_data.get("page_name")
         override_ce_enable = validated_data["override_ce_enable"]
 
         try:
@@ -164,12 +172,14 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
                     prompt=query,
                     insert_index=insert_index,
                     on_page_context=on_page_context,
+                    page_name=page_name,
                 )
             else:
                 # Start new conversation
                 result_run_id = client.start_run(
                     prompt=query,
                     on_page_context=on_page_context,
+                    page_name=page_name,
                     override_ce_enable=override_ce_enable,
                 )
 

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -238,6 +238,7 @@ class SeerExplorerClient:
         prompt: str,
         prompt_metadata: dict[str, str] | None = None,
         on_page_context: str | None = None,
+        page_name: str | None = None,
         artifact_key: str | None = None,
         artifact_schema: type[BaseModel] | None = None,
         metadata: dict[str, Any] | None = None,
@@ -271,6 +272,7 @@ class SeerExplorerClient:
             run_id=None,
             insert_index=None,
             on_page_context=on_page_context,
+            page_name=page_name,
             user_org_context=collect_user_org_context(
                 self.user, self.organization, request=request
             ),
@@ -339,6 +341,7 @@ class SeerExplorerClient:
         prompt_metadata: dict[str, str] | None = None,
         insert_index: int | None = None,
         on_page_context: str | None = None,
+        page_name: str | None = None,
         artifact_key: str | None = None,
         artifact_schema: type[BaseModel] | None = None,
     ) -> int:
@@ -369,6 +372,7 @@ class SeerExplorerClient:
             run_id=run_id,
             insert_index=insert_index,
             on_page_context=on_page_context,
+            page_name=page_name,
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
         )

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -52,6 +52,7 @@ class ExplorerChatRequest(TypedDict):
     run_id: int | None
     insert_index: int | None
     on_page_context: str | None
+    page_name: NotRequired[str | None]
     user_org_context: NotRequired[dict[str, Any] | None]
     intelligence_level: NotRequired[str]
     is_interactive: NotRequired[bool]

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -73,6 +73,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         mock_client.start_run.assert_called_once_with(
             prompt="What is this error about?",
             on_page_context=None,
+            page_name=None,
             override_ce_enable=True,
         )
 
@@ -126,6 +127,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             prompt="Follow up question",
             insert_index=2,
             on_page_context=None,
+            page_name=None,
         )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")


### PR DESCRIPTION
+ Add page_name field to the explorer chat request payload so Seer can track which UI page the user was on when sending a message. The value is the normalized route string from React Router (e.g., /organizations/:orgSlug/issues/:groupId/).

+ This completes the Sentry side of the on_page_context token tracking work — Seer already accepts and processes this field.

+ Backend changes only. different PR for frontend changes
