### PR TITLE
ci(lint): Disable ESLint concurrency to fix CI hangs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test-precommit": "node scripts/test.js --bail --findRelatedTests -u",
     "test-staged": "node scripts/test.js --findRelatedTests $(git diff --name-only --cached)",
     "lint": "pnpm run lint:format && pnpm run lint:js && pnpm run lint:css",
-    "lint:js": "eslint --concurrency=3",
+    "lint:js": "eslint",
     "lint:css": "stylelint '**/*.[jt]sx'",
     "lint:format": "oxfmt --check",
     "fix": "pnpm run fix:format && pnpm run fix:eslint",


### PR DESCRIPTION
Disable ESLint's `--concurrency=3` flag to fix intermittent hangs in the frontend CI workflow where the eslint job never completes and gets killed after 25 minutes.

The `--concurrency` flag was introduced in ESLint v9.34.0 (August 2025) — the exact version we're on. It spawns worker threads for parallel file linting, but one or more plugins (likely `eslint-plugin-boundaries` v6) appear to have thread-safety issues that cause intermittent deadlocks. This reverts to the default single-threaded mode (`--concurrency=off`).

Normal ESLint runtime is ~6 minutes. Single-threaded may be slightly slower but will not hang. We can re-evaluate concurrency once the upstream plugin ecosystem has better thread-safety support.