### PR TITLE
chore(ACI): Add example data to payload for GitHub action in workflow creation

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -601,7 +601,26 @@ ACTION_FILTERS_HELP_TEXT = """The filters to run before the action will fire and
                     "targetDisplay":""
                     },
                 "integrationId":"2345",
-                "data":{...},
+                "data":{
+                  "additional_fields": {
+                      "assignee": "",
+                      "integration": "2345",
+                      "labels": [],
+                      "repo": "example-repo",
+                  },
+                  "dynamic_form_fields": [
+                      {
+                        "choices": [["YourOrg/example-repo", "example-repo"]],
+                        "default": "YourOrg/example-repo",
+                        "label": "GitHub Repository",
+                        "name": "repo",
+                        "required": true
+                        "type": "select",
+                        "updatesForm": true,
+                        "url": "/extensions/github/search/example-repo/1234567/",
+                      },
+                  ],
+                },
                 "status":"active"
             }
         ```


### PR DESCRIPTION
When creating a workflow with a GH ticket creation action you must pass `data` to it but the docs don't have an example of what that might look like. This PR adds an example. 

Note that we still have a [bug](https://linear.app/getsentry/issue/ISWF-2265/create-gh-issue-action-api-accepts-empty-data-object-when-front-end) where we accept an empty `data` dict on the backend, but the front end prevents this from being submitted as it's not actually valid. 