### PR TITLE
chore(flags): Migrate organizations:sdk-crash-detection to flagpole

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -280,7 +280,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable revocation of org auth keys when a user renames an org slug
     manager.add("organizations:revoke-org-auth-on-slug-rename", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable detecting SDK crashes during event processing
-    manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the Seer Config Reminder in the primary nav
     manager.add("organizations:seer-config-reminder", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer panel for AI-powered data exploration

--- a/src/sentry/utils/sdk_crashes/README.rst
+++ b/src/sentry/utils/sdk_crashes/README.rst
@@ -30,5 +30,7 @@ SDK and system library frames. For grouping to work correctly, the event_strippe
 config will change it to in_app false for all Cocoa SDK frames. To not change the grouping logic, we add the following stacktrace rule
 ``stack.abs_path:Sentry.framework +app +group`` to the configured in project with the id configured in the option ``issues.sdk_crash_detection.cocoa.project_id``.
 
-You can turn the feature on or off in https://sentry.io/_admin/options. The option name is ``issues.sdk-crash-detection`` and the feature name is ``organizations:sdk-crash-detection``.
-Furthermore, you can change the project to store the crash events and the sample rate per SDK with the options ``issues.sdk_crash_detection.cocoa.project_id`` and ``issues.sdk_crash_detection.cocoa.sample_rate``.
+The feature flag ``organizations:sdk-crash-detection`` controls whether SDK crash detection runs for an organization. It is managed via
+flagpole in `sentry-options-automator <https://github.com/getsentry/sentry-options-automator>`_ and is currently enabled in the US and s4s2
+regions. The per-SDK project IDs and sample rates are still controlled via options (e.g. ``issues.sdk_crash_detection.cocoa.project_id``,
+``issues.sdk_crash_detection.cocoa.sample_rate``).


### PR DESCRIPTION
This flag is still in use, but using an old deprecated rollout handler that I'd like to remove. Setting this to flagpole allows us to still fall back to the old handler until we roll out the options in `sentry-options-automator` and remove the old handler.

Related to https://github.com/getsentry/sentry/pull/111267, which I'll likely close
