### PR TITLE
chore(ACI): Combine issue alert rule flags into one

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -104,7 +104,7 @@ class ProjectRuleDetailsPutSerializer(serializers.Serializer):
 @cell_silo_endpoint
 class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-projectruledetailsendpoint-get",
+        "GET": "organizations:workflow-engine-issue-alert-endpoints-get",
     }
     publish_status = {
         "DELETE": ApiPublishStatus.PUBLIC,

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -864,7 +864,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         queryset: BaseQuerySet[Workflow, Workflow] | BaseQuerySet[Rule, Rule]
         serializer: WorkflowEngineRuleSerializer | RuleSerializer
         if features.has(
-            "organizations:workflow-engine-projectrulesendpoint-get", project.organization
+            "organizations:workflow-engine-issue-alert-endpoints-get", project.organization
         ) or features.has("organizations:workflow-engine-rule-serializers", project.organization):
             queryset = Workflow.objects.filter(
                 detectorworkflow__detector__project=project,

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -58,7 +58,7 @@ class RuleGroupHistorySerializer(Serializer):
 @cell_silo_endpoint
 class ProjectRuleGroupHistoryIndexEndpoint(WorkflowEngineRuleEndpoint):
     workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-projectrulegroupstats-get",
+        "GET": "organizations:workflow-engine-issue-alert-endpoints-get",
     }
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -41,7 +41,7 @@ class TimeSeriesValueSerializer(Serializer):
 @cell_silo_endpoint
 class ProjectRuleStatsIndexEndpoint(WorkflowEngineRuleEndpoint):
     workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-projectrulegroupstats-get",
+        "GET": "organizations:workflow-engine-issue-alert-endpoints-get",
     }
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/workflow_engine/docs/legacy_backport.md
+++ b/src/sentry/workflow_engine/docs/legacy_backport.md
@@ -64,7 +64,7 @@ All endpoints decorated with `@track_alert_endpoint_execution` are in scope for 
 
 ## Feature Flag Strategy
 
-`organizations:workflow-engine-rule-serializers` enables all backported paths at once (useful for testing). Per-endpoint flags (e.g. `organizations:workflow-engine-projectrulesendpoint-get`) allow independent prod rollout — each is OR'd with the broad flag. Naming convention: `organizations:workflow-engine-{lowercaseendpointclass}-{method}`.
+`organizations:workflow-engine-rule-serializers` enables all backported paths at once (useful for testing). Per-endpoint flags (e.g. `organizations:workflow-engine-combinedruleindex-get`) allow independent prod rollout — each is OR'd with the broad flag. Per-feature flags (e.g. `organizations:workflow-engine-issue-alert-endpoints-get`) allow a subset of endpoints scoped to a feature to be enabled to avoid a large number of individual flags. Naming convention: `organizations:workflow-engine-{lowercaseendpointclass}-{method}`.
 
 ## Unsupported legacy features
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -248,7 +248,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["conditions"][0]["name"]
         assert response.data["filters"][0]["name"]
 
-    @with_feature("organizations:workflow-engine-projectruledetailsendpoint-get")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-get")
     def test_workflow_engine_granular_flag_dual_written_rule(self) -> None:
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200
@@ -257,7 +257,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["environment"] is None
         assert response.data["conditions"][0]["name"]
 
-    @with_feature("organizations:workflow-engine-projectruledetailsendpoint-get")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-get")
     def test_workflow_engine_granular_flag_single_written_rule(self) -> None:
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=200

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -170,7 +170,7 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
             assert workflow_resp_2["id"] == str(get_fake_id_from_object_id(self.workflow.id))
             assert workflow_resp_1["id"] == str(self.rule.id)
 
-    @with_feature("organizations:workflow-engine-projectrulesendpoint-get")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-get")
     def test_workflow_engine_granular_flag(self) -> None:
         response = self.get_success_response(
             self.organization.slug,

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -197,7 +197,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest, BaseWorkf
         )
 
     @with_feature("organizations:workflow-engine-rule-serializers")
-    @with_feature("organizations:workflow-engine-projectrulegroupstats-get")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-get")
     def test_single_written_workflow_history(self) -> None:
         """Test using WorkflowFireHistory when feature flag is enabled"""
         workflow_triggers = self.create_data_condition_group()
@@ -277,7 +277,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest, BaseWorkf
         )
 
     @with_feature("organizations:workflow-engine-rule-serializers")
-    @with_feature("organizations:workflow-engine-projectrulegroupstats-get")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-get")
     def test_combined_rule_and_workflow_history(self) -> None:
         """Test combining RuleFireHistory and WorkflowFireHistory when both exist"""
         rule = self.create_project_rule(project=self.event.project)
@@ -418,7 +418,7 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         assert [r.count for r in results[-5:]] == [0, 0, 1, 1, 0]
 
     @with_feature("organizations:workflow-engine-rule-serializers")
-    @with_feature("organizations:workflow-engine-projectrulegroupstats-get")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-get")
     def test_single_written_workflow_history(self) -> None:
         """Test using WorkflowFireHistory when feature flag is enabled"""
         workflow_triggers = self.create_data_condition_group()
@@ -455,7 +455,7 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         assert [r.count for r in results[-5:]] == [0, 2, 0, 1, 0]
 
     @with_feature("organizations:workflow-engine-rule-serializers")
-    @with_feature("organizations:workflow-engine-projectrulegroupstats-get")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-get")
     def test_combined_rule_and_workflow_history(self) -> None:
         """Test combining RuleFireHistory and WorkflowFireHistory when both exist"""
         rule = self.create_project_rule(project=self.event.project)


### PR DESCRIPTION
Replace usage of multiple issue alert rule backwards compatible endpoint flags with a single one. 

Don't merge until https://github.com/getsentry/sentry-options-automator/pull/7070 is merged.