### PR TITLE
fix(preprod): Speed up error page on snapshots and improve error UI

### DIFF
--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -60,7 +60,7 @@ export default function SnapshotsPage() {
       staleTime: 0,
       enabled: !!snapshotId,
       // Skip retries on 4xx so error pages render instantly
-      retry: (_, err) => !err?.status || err.status >= 500,
+      retry: (count, err) => count < 3 && (!err?.status || err.status >= 500),
       refetchInterval: query => {
         const state = query.state.data?.[0]?.comparison_run_info?.state;
         return state === ComparisonState.PENDING || state === ComparisonState.PROCESSING

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -3,7 +3,6 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -17,6 +16,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
+import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {BuildProcessing} from 'sentry/views/preprod/components/buildProcessing';
 import {ComparisonState, getImageGroup} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
@@ -59,6 +59,8 @@ export default function SnapshotsPage() {
     {
       staleTime: 0,
       enabled: !!snapshotId,
+      // Skip retries on 4xx so error pages render instantly
+      retry: (_, err) => !err?.status || err.status >= 500,
       refetchInterval: query => {
         const state = query.state.data?.[0]?.comparison_run_info?.state;
         return state === ComparisonState.PENDING || state === ComparisonState.PROCESSING
@@ -381,9 +383,12 @@ export default function SnapshotsPage() {
     return (
       <SentryDocumentTitle title={t('Snapshot')}>
         <Stack flex={1}>
-          <Flex align="center" justify="center" padding="3xl">
-            <Text variant="muted">{t('Unable to load snapshot data.')}</Text>
-          </Flex>
+          <BuildError
+            title={t('Snapshot unavailable')}
+            message={t(
+              'This snapshot may have been deleted or you may not have access to it.'
+            )}
+          />
         </Stack>
       </SentryDocumentTitle>
     );


### PR DESCRIPTION
React Query defaults to 3 retries with exponential backoff (~1s, ~2s, ~4s) on failed queries. When accessing a non-existent or inaccessible snapshot, the backend returns 404 almost instantly, but the frontend waited ~8 seconds retrying before showing the error page.

This skips retries on 4xx responses (which won't resolve on retry) while preserving retries for 5xx/network errors. Also replaces the plain text error message with the `BuildError` component used elsewhere in preprod for a more polished, consistent error experience.

Closes EME-918

also improved the UI
<img width="3312" height="2634" alt="CleanShot 2026-04-01 at 17 10 50@2x" src="https://github.com/user-attachments/assets/da818d4a-76e1-4069-843c-cbe7fff965a2" />
