### PR TITLE
chore(flags): Migrate projects:first-event-severity-calculation to flagpole

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -517,7 +517,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable error upsampling
     manager.add("projects:error-upsampling", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable calculating a severity score for events which create a new group
-    manager.add("projects:first-event-severity-calculation", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    manager.add("projects:first-event-severity-calculation", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable similarity embeddings API call
     # This feature is only available on the frontend using project details since the handler gets
     # project options and this is slow in the project index endpoint feature flag serialization


### PR DESCRIPTION
We want to keep this feature around for the moment even though it has been in EA for a long time. Migrating it to flagpole so that we can remove a deprecated handler.

Automator PR here: https://github.com/getsentry/sentry-options-automator/pull/7071