### PR TITLE
fix(explorer): use issue.id filter for event timeseries

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -34,6 +34,7 @@ from sentry.replays.query import query_replay_id_by_prefix, query_replay_instanc
 from sentry.search.eap.constants import BOOLEAN, DOUBLE, INT, STRING
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.constants import ISSUE_ID_ALIAS
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.seer.autofix.autofix import get_all_tags_overview
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
@@ -776,7 +777,7 @@ def _get_issue_event_timeseries(
         dataset=dataset,
         y_axes=["count()"],
         group_by=[],
-        query=f"issue:{group.qualified_short_id}",
+        query=f"{ISSUE_ID_ALIAS}:{group.id}",
         start=start.isoformat(),
         end=end.isoformat(),
         interval=interval,

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -2076,7 +2076,7 @@ class TestGetIssueEventTimeseries(APITransactionTestCase, SnubaTestCase):
             # Validate return value: (data, stats_period, interval).
             assert result is not None
             timeseries_data, returned_period, returned_interval = result
-            _validate_event_timeseries(timeseries_data)
+            _validate_event_timeseries(timeseries_data, expected_total=2)
             assert returned_period == stats_period
             assert returned_interval == interval
 
@@ -2107,6 +2107,11 @@ class TestGetIssueEventTimeseries(APITransactionTestCase, SnubaTestCase):
             data["exception"] = {"values": [{"type": "Exception", "value": "Test exception"}]}
             self.store_event(data=data, project_id=self.project.id)
 
+            # Out of range event
+            data = load_data("python", timestamp=start - timedelta(minutes=1))
+            data["exception"] = {"values": [{"type": "Exception", "value": "Test exception"}]}
+            self.store_event(data=data, project_id=self.project.id)
+
             group = event.group
             assert isinstance(group, Group)
 
@@ -2132,7 +2137,7 @@ class TestGetIssueEventTimeseries(APITransactionTestCase, SnubaTestCase):
             # Validate return value: (data, stats_period, interval).
             assert result is not None
             timeseries_data, returned_period, returned_interval = result
-            _validate_event_timeseries(timeseries_data)
+            _validate_event_timeseries(timeseries_data, expected_total=2)
             assert returned_period == stats_period
             assert returned_interval == interval
 


### PR DESCRIPTION
Fixes [SENTRY-5MPK](https://sentry.sentry.io/issues/7380499064/events/a0228ed0904f46d3902e8a8ab8deb137/). Use id filter instead of short id