### PR TITLE
ref(preprod): Set odiff threshold to 0.001

### DIFF
--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -13,7 +13,9 @@ from .types import DiffResult
 
 logger = logging.getLogger(__name__)
 
-DIFF_THRESHOLD = 0
+# NOTE: Must be >0. odiff's server mode treats threshold=0 as falsy and
+# silently falls back to its default of 0.1, which swallows small diffs.
+DIFF_THRESHOLD = 0.001
 
 
 def _as_image(source: bytes | Image.Image) -> Image.Image:


### PR DESCRIPTION
Set the odiff pixel-diff threshold from `0` to `0.001`.

odiff's server mode treats `threshold=0` as falsy and silently falls back to
its built-in default of `0.1`, which causes small visual diffs to be missed
entirely. Using `0.001` is effectively zero but avoids the falsy-value bug,
giving us the strictest comparison odiff actually honors.

Closes EME-998