### PR TITLE
fix(preprod): Use recompare endpoint and add user-facing status check rerun

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -86,12 +86,28 @@ export function SnapshotHeaderActions({
     );
   }, [organizationSlug, data.head_artifact_id, queryClient, apiUrl]);
 
-  const handleRerunComparison = useCallback(() => {
+  const handleRerunStatusChecks = useCallback(() => {
     clientRef.current.request(
       `/organizations/${organizationSlug}/preprod-artifact/rerun-status-checks/${data.head_artifact_id}/`,
       {
         method: 'POST',
         data: {check_types: ['snapshots']},
+        success: () => {
+          addSuccessMessage(t('Status checks rerun initiated'));
+          queryClient.invalidateQueries({queryKey: [apiUrl]});
+        },
+        error: (_resp: any) => {
+          addErrorMessage(t('Failed to rerun status checks'));
+        },
+      }
+    );
+  }, [organizationSlug, data.head_artifact_id, queryClient, apiUrl]);
+
+  const handleRerunComparison = useCallback(() => {
+    clientRef.current.request(
+      `/organizations/${organizationSlug}/preprodartifacts/snapshots/${data.head_artifact_id}/recompare/`,
+      {
+        method: 'POST',
         success: () => {
           addSuccessMessage(t('Re-run comparison initiated'));
           queryClient.invalidateQueries({queryKey: [apiUrl]});
@@ -165,6 +181,17 @@ export function SnapshotHeaderActions({
       >
         {({open: openDeleteModal}) => {
           const menuItems: MenuItemProps[] = [
+            {
+              key: 'rerun-status-checks',
+              label: (
+                <Flex align="center" gap="sm">
+                  <IconRefresh size="sm" />
+                  {t('Rerun Status Checks')}
+                </Flex>
+              ),
+              onAction: handleRerunStatusChecks,
+              textValue: t('Rerun Status Checks'),
+            },
             {
               key: 'delete',
               label: (


### PR DESCRIPTION
## Summary
Two changes to the snapshot header actions menu:

1. **Admin "Re-run comparison"** now calls the `recompare` endpoint instead of
   `rerun-status-checks`. This actually re-runs the full image diff pipeline
   (and automatically re-posts the GitHub status check when complete).

2. **New user-facing "Rerun Status Checks"** menu item lets regular users
   re-post the GitHub status check without needing admin access or re-running
   the full image diff.

## Test plan
- Verify "Rerun Status Checks" is visible to all users and calls `rerun-status-checks` with `check_types: ['snapshots']`
- Verify "Re-run comparison" is only visible to Sentry employees and calls the `recompare` endpoint
- Confirm the snapshot comparison is re-run with fresh image diffs when using the admin action