### PR TITLE
Remove experimental from logs

### DIFF
--- a/static/app/gettingStartedDocs/apple-ios/logs.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/logs.tsx
@@ -79,7 +79,7 @@ pod update`,
 SentrySDK.start { options in
     options.dsn = "${params.dsn.public}"
     // Enable logs to be sent to Sentry
-    options.experimental.enableLogs = true
+    options.enableLogs = true
 }`,
             },
             {
@@ -90,7 +90,7 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"${params.dsn.public}";
     // Enable logs to be sent to Sentry
-    options.experimental.enableLogs = YES;
+    options.enableLogs = YES;
 }];`,
             },
           ],

--- a/static/app/gettingStartedDocs/apple-macos/logs.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/logs.tsx
@@ -79,7 +79,7 @@ pod update`,
 SentrySDK.start { options in
     options.dsn = "${params.dsn.public}"
     // Enable logs to be sent to Sentry
-    options.experimental.enableLogs = true
+    options.enableLogs = true
 }`,
             },
             {
@@ -90,7 +90,7 @@ SentrySDK.start { options in
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"${params.dsn.public}";
     // Enable logs to be sent to Sentry
-    options.experimental.enableLogs = YES;
+    options.enableLogs = YES;
 }];`,
             },
           ],


### PR DESCRIPTION
enableLogs is no longer an experimental feature in v9.x of the SDK.

