### PR TITLE
ref(preprod): Remove snapshots from retention endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_retention.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_retention.py
@@ -72,6 +72,5 @@ class OrganizationPreprodRetentionEndpoint(OrganizationEndpoint):
             {
                 "size": size_retention,
                 "buildDistribution": build_distribution_retention,
-                "snapshots": 30,  # Hardcoded for now, check with Objectstore before increasing
             }
         )

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_retention.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_retention.py
@@ -25,7 +25,6 @@ class OrganizationPreprodRetentionEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["size"] == 90
         assert response.data["buildDistribution"] == 90
-        assert response.data["snapshots"] == 30
 
     @patch("sentry.quotas.backend.get_event_retention")
     def test_get_custom_retention(self, mock_get_retention) -> None:
@@ -39,7 +38,6 @@ class OrganizationPreprodRetentionEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["size"] == 30
         assert response.data["buildDistribution"] == 60
-        assert response.data["snapshots"] == 30
 
     def test_get_requires_authentication(self) -> None:
         client = APIClient()


### PR DESCRIPTION
Remove the hardcoded `snapshots` field from the preprod retention endpoint response.

We don't use snapshots from launchpad so there's no need to expose retention for them from this endpoint.


Agent transcript: https://claudescope.sentry.dev/share/G4IesPU-uYwagotQ6onn2g5xtr8VOAkKk4do_ZRFGJg