### PR TITLE
fix(cross-events): Enable raw-search replacement

### DIFF
--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -128,6 +128,10 @@ const SpansTabCrossEventSearchBar = memo(
     const mode = useQueryParamsMode();
     const crossEvents = useQueryParamsCrossEvents();
     const setCrossEvents = useSetQueryParamsCrossEvents();
+    const organization = useOrganization();
+    const hasRawSearchReplacement = organization.features.includes(
+      'search-query-builder-raw-search-replacement'
+    );
 
     const traceItemType =
       type === 'logs' ? TraceItemDataset.LOGS : TraceItemDataset.SPANS;
@@ -178,11 +182,17 @@ const SpansTabCrossEventSearchBar = memo(
         booleanSecondaryAliases,
         numberSecondaryAliases,
         stringSecondaryAliases,
+        replaceRawSearchKeys: hasRawSearchReplacement
+          ? type === 'logs'
+            ? ['message']
+            : ['span.description']
+          : undefined,
       }),
       [
         booleanAttributes,
         booleanSecondaryAliases,
         crossEvents,
+        hasRawSearchReplacement,
         index,
         mode,
         numberSecondaryAliases,


### PR DESCRIPTION
This PR fixes up the issue where we don't have raw-search replacement working properly on the cross-event search bars, so users were getting a broken experience.

Ticket: EXP-854