### PR TITLE
feat(preprod): Register feature flag and project option for snapshot PR comments

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1201,6 +1201,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:preprod_distribution_pr_comments_enabled_by_customer": self.get_value_with_default(
                 attrs, "sentry:preprod_distribution_pr_comments_enabled_by_customer"
             ),
+            "sentry:preprod_snapshot_pr_comments_enabled": self.get_value_with_default(
+                attrs, "sentry:preprod_snapshot_pr_comments_enabled"
+            ),
         }
 
     def get_value_with_default(self, attrs, key):

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -119,6 +119,7 @@ class ProjectMemberSerializer(serializers.Serializer):
     preprodDistributionPrCommentsEnabledByCustomer = serializers.BooleanField(
         required=False, allow_null=True
     )
+    preprodSnapshotPrCommentsEnabled = serializers.BooleanField(required=False, allow_null=True)
     preprodSizeEnabledQuery = serializers.CharField(required=False, allow_null=True)
     preprodDistributionEnabledQuery = serializers.CharField(required=False, allow_null=True)
 
@@ -167,6 +168,7 @@ class ProjectMemberSerializer(serializers.Serializer):
         "preprodSnapshotStatusChecksFailOnAdded",
         "preprodSnapshotStatusChecksFailOnRemoved",
         "preprodDistributionPrCommentsEnabledByCustomer",
+        "preprodSnapshotPrCommentsEnabled",
     ]
 )
 class ProjectAdminSerializer(ProjectMemberSerializer):
@@ -889,6 +891,14 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 changed_proj_settings[
                     "sentry:preprod_distribution_pr_comments_enabled_by_customer"
                 ] = result["preprodDistributionPrCommentsEnabledByCustomer"]
+        if "preprodSnapshotPrCommentsEnabled" in result:
+            if project.update_option(
+                "sentry:preprod_snapshot_pr_comments_enabled",
+                result["preprodSnapshotPrCommentsEnabled"],
+            ):
+                changed_proj_settings["sentry:preprod_snapshot_pr_comments_enabled"] = result[
+                    "preprodSnapshotPrCommentsEnabled"
+                ]
         if "debugFilesRole" in result:
             if result["debugFilesRole"] is None:
                 project.delete_option("sentry:debug_files_role")

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -232,6 +232,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod PR comments for build distribution
     manager.add("organizations:preprod-build-distribution-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable preprod PR comments for snapshots
+    manager.add("organizations:preprod-snapshot-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -78,6 +78,7 @@ OPTION_KEYS = frozenset(
         "sentry:preprod_snapshot_status_checks_fail_on_added",
         "sentry:preprod_snapshot_status_checks_fail_on_removed",
         "sentry:preprod_distribution_pr_comments_enabled_by_customer",
+        "sentry:preprod_snapshot_pr_comments_enabled",
         "sentry:scm_source_context_enabled",
         "quotas:spike-protection-disabled",
         "feedback:branding",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -211,5 +211,8 @@ register(key="sentry:preprod_distribution_enabled_query", default="")
 # Boolean to enable/disable build distribution PR comments for this project.
 register(key="sentry:preprod_distribution_pr_comments_enabled_by_customer", default=True)
 
+# Boolean to enable/disable snapshot PR comments for this project.
+register(key="sentry:preprod_snapshot_pr_comments_enabled", default=True)
+
 # Whether to enable on-demand source context fetching from SCM integrations
 register(key="sentry:scm_source_context_enabled", default=False)

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -810,6 +810,13 @@ class ProjectUpdateTest(APITestCase):
             ],
         )
 
+    def test_preprod_snapshot_pr_comments_option(self) -> None:
+        self.get_success_response(
+            self.org_slug, self.proj_slug, preprodSnapshotPrCommentsEnabled=False
+        )
+        project = Project.objects.get(id=self.project.id)
+        assert project.get_option("sentry:preprod_snapshot_pr_comments_enabled") is False
+
     def test_bookmarks(self) -> None:
         self.get_success_response(self.org_slug, self.proj_slug, isBookmarked="false")
         assert not ProjectBookmark.objects.filter(


### PR DESCRIPTION
Register the infrastructure needed to gate snapshot PR comments:

- Feature flag: `organizations:preprod-snapshot-pr-comments` (FlagPole, api_expose=True)
- Project option: `sentry:preprod_snapshot_pr_comments_enabled` (default true)
- Serializer field and PUT handler in project details endpoint so the toggle is read/writable via the API

This is the first step toward EME-999 — adding PR comment support for snapshot comparisons. Follow-up PRs will add the task, template, frontend toggle, and trigger wiring.

Refs EME-999