### PR TITLE
perf(vercel): Skip gzip pre-compression and cache hashed assets in deploy previews

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -846,15 +846,18 @@ if (IS_UI_DEV_ONLY || SENTRY_EXPERIMENTAL_SPA) {
 }
 
 if (IS_PRODUCTION) {
-  // This compression-webpack-plugin generates pre-compressed files
-  // ending in .gz, to be picked up and served by our internal static media
-  // server as well as nginx when paired with the gzip_static module.
-  appConfig.plugins?.push(
-    new CompressionPlugin({
-      algorithm: 'gzip',
-      test: /\.(js|map|css|svg|html|txt|ico|eot|ttf)$/,
-    })
-  );
+  if (!IS_DEPLOY_PREVIEW) {
+    // This compression-webpack-plugin generates pre-compressed files
+    // ending in .gz, to be picked up and served by our internal static media
+    // server as well as nginx when paired with the gzip_static module.
+    // Skipped for deploy previews since Vercel handles compression itself.
+    appConfig.plugins?.push(
+      new CompressionPlugin({
+        algorithm: 'gzip',
+        test: /\.(js|map|css|svg|html|txt|ico|eot|ttf)$/,
+      })
+    );
+  }
 
   // Enable sentry-webpack-plugin for production builds
   appConfig.plugins?.push(

--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,15 @@
     {
       "source": "/api/(.*)",
       "headers": [{"key": "Referer", "value": "https://sentry.io/"}]
+    },
+    {
+      "source": "/_assets/(chunks|assets)/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
     }
   ],
   "github": {"silent": true}


### PR DESCRIPTION
Skip `CompressionPlugin` for Vercel deploy previews. The `.gz` files are generated for nginx's `gzip_static` module which Vercel doesn't use — it compresses responses at the edge instead.

Also adds `Cache-Control: public, max-age=31536000, immutable` headers for content-hashed assets (`chunks/` and `assets/` directories) served from deploy previews.

saves maybe 10 seconds on build