### PR TITLE
fix(web_vitals): Add z-index to `PerformanceScoreRingTooltip`

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -383,6 +383,7 @@ const ProgressRingDiffSubText = styled(ProgressRingSubText)<{value: number}>`
 // Hover element on mouse
 const PerformanceScoreRingTooltip = styled('div')<{x: number; y: number}>`
   position: absolute;
+  z-index: ${p => p.theme.zIndex.tooltip};
   background: ${p => p.theme.tokens.background.primary};
   border-radius: ${p => p.theme.radius.md};
   border: 1px solid ${p => p.theme.tokens.border.primary};


### PR DESCRIPTION
Give `PerformanceScoreRingTooltip` the standard tooltip z-index. Otherwise it floats under other elements.

<img width="309" height="108" alt="Screenshot 2026-04-02 at 12 08 20" src="https://github.com/user-attachments/assets/74ee8f1b-7c40-4434-86e1-7aae8252db5a" />
