### PR TITLE
ref(slack): Remove slack-compact-alerts flag usage

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -313,7 +313,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-on-explorer-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Workflows in Slack
     manager.add("organizations:seer-slack-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-
+    # Enable new compact issue alert UI in Slack
+    manager.add("organizations:slack-compact-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer in Slack via @mentions
     manager.add("organizations:seer-slack-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable search query attribute validation

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -313,8 +313,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-on-explorer-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Workflows in Slack
     manager.add("organizations:seer-slack-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable new compact issue alert UI in Slack
-    manager.add("organizations:slack-compact-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+
     # Enable Seer Explorer in Slack via @mentions
     manager.add("organizations:seer-slack-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable search query attribute validation

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from typing import Any, TypedDict
@@ -10,7 +9,7 @@ import orjson
 from django.core.exceptions import ObjectDoesNotExist
 from sentry_relay.processing import parse_release
 
-from sentry import features, tagstore
+from sentry import tagstore
 from sentry.constants import LOG_LEVELS
 from sentry.identity.services.identity import RpcIdentity, identity_service
 from sentry.integrations.messaging.message_builder import (
@@ -41,7 +40,7 @@ from sentry.integrations.slack.utils.escape import (
     escape_slack_text,
 )
 from sentry.integrations.time_utils import get_approx_start_time, time_since
-from sentry.integrations.types import ExternalProviders, IntegrationProviderSlug
+from sentry.integrations.types import ExternalProviders
 from sentry.integrations.utils.issue_summary_for_alerts import fetch_issue_summary
 from sentry.issues.endpoints.group_details import get_group_global_count
 from sentry.issues.grouptype import GroupCategory, NotificationContextField
@@ -49,9 +48,7 @@ from sentry.models.commit import Commit
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.projectownership import ProjectOwnership
-from sentry.models.pullrequest import PullRequest
 from sentry.models.release import Release
-from sentry.models.repository import Repository
 from sentry.models.rule import Rule
 from sentry.models.team import Team
 from sentry.notifications.notifications.base import ProjectNotification
@@ -72,19 +69,8 @@ from sentry.users.services.user.model import RpcUser
 from sentry.workflow_engine.models import Workflow
 
 STATUSES = {"resolved": "resolved", "ignored": "ignored", "unresolved": "re-opened"}
-SUPPORTED_COMMIT_PROVIDERS = (
-    IntegrationProviderSlug.GITHUB.value,
-    "integrations:github",
-    "integrations:github_enterprise",
-    "integrations:vsts",
-    "integrations:gitlab",
-    IntegrationProviderSlug.BITBUCKET.value,
-    "integrations:bitbucket",
-)
-
 MAX_BLOCK_TEXT_LENGTH = 256
 USER_FEEDBACK_MAX_BLOCK_TEXT_LENGTH = 1500
-MAX_SUMMARY_HEADLINE_LENGTH = 50
 MAX_SUGGESTED_ASSIGNEES = 3
 
 
@@ -303,54 +289,6 @@ def get_suggested_assignees(
     return []
 
 
-def get_suspect_commit_text(group: Group) -> str | None:
-    """Build up the suspect commit text for the given event"""
-
-    commit = group.get_suspect_commit()
-    if not commit:
-        return None
-
-    suspect_commit_text = "Suspect Commit: "
-
-    author = commit.author
-    commit_id = commit.key
-    if not (author and commit_id):  # we need both the author and commit id to continue
-        return None
-
-    author_display = author.name if author.name else author.email
-    pull_request = PullRequest.objects.filter(
-        merge_commit_sha=commit.key, organization_id=group.project.organization_id
-    ).first()
-    if pull_request:
-        repo = Repository.objects.get(id=pull_request.repository_id)
-        repo_base = repo.url
-        provider = repo.provider
-        if repo_base and provider in SUPPORTED_COMMIT_PROVIDERS:
-            if IntegrationProviderSlug.BITBUCKET.value in provider:
-                commit_link = f"<{repo_base}/commits/{commit_id}"
-            else:
-                commit_link = f"<{repo_base}/commit/{commit_id}"
-            commit_link += f"|{commit_id[:6]}>"
-            suspect_commit_text += f"{commit_link} by {author_display}"
-        else:  # for unsupported providers
-            suspect_commit_text += f"{commit_id[:6]} by {author_display}"
-
-        if pull_request.date_added:
-            pr_date = time_since(pull_request.date_added)
-        else:
-            pr_date = pull_request.date_added
-        pr_id = pull_request.key
-        pr_title = pull_request.title
-        pr_link = pull_request.get_external_url()
-        if pr_date and pr_id and pr_title and pr_link:
-            suspect_commit_text += (
-                f" {pr_date} \n'{pr_title} (#{pr_id})' <{pr_link}|View Pull Request>"
-            )
-    else:
-        suspect_commit_text += f"{commit_id[:6]} by {author_display}"
-    return suspect_commit_text
-
-
 def get_action_text(actions: Sequence[Any], identity: RpcIdentity) -> str:
     action_text = "\n".join(
         [
@@ -503,9 +441,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.skip_fallback = skip_fallback
         self.notes = notes
         self.issue_summary: dict[str, Any] | None = None
-        self._is_compact = features.has(
-            "organizations:slack-compact-alerts", self.group.organization
-        )
         self._has_autofix = SeerAutofixOperator.has_access(
             organization=self.group.organization, entrypoint_key=SeerEntrypointKey.SLACK
         ) and SeerAutofixOperator.can_trigger_autofix(group=self.group)
@@ -516,11 +451,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         has_action: bool,
         title_link: str | None = None,
     ) -> SlackBlock:
-        summary_headline = self.get_issue_summary_headline(event_or_group)
-        title = summary_headline or build_attachment_title(event_or_group)
+        title = build_attachment_title(event_or_group)
         title_emojis = self.get_title_emoji(has_action)
-        if self._is_compact:
-            title = build_attachment_title(event_or_group)
 
         title_text = f"{title_emojis} <{title_link}|*{escape_slack_text(title)}*>"
         return self.get_markdown_block(title_text)
@@ -544,28 +476,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         return " ".join(title_emojis)
 
-    # Can be removed when 'slack-compact-alerts' is GA
-    def get_issue_summary_headline(self, event_or_group: Event | GroupEvent | Group) -> str | None:
-        if self.issue_summary is None:
-            return None
-
-        # issue summary headline is formatted like ErrorType: message...
-        error_type = build_attachment_title(event_or_group)
-        text = build_attachment_text(self.group, self.event) or ""
-        text = text.strip(" \r\n\u2028\u2029")
-        text = escape_slack_markdown_text(text)
-        text = text.lstrip(" ")
-
-        linebreak_match = re.search(r"\r?\n|\u2028|\u2029", text)
-        if linebreak_match:
-            text = text[: linebreak_match.start()].strip() + "..."
-
-        if len(text) > MAX_SUMMARY_HEADLINE_LENGTH:
-            text = text[:MAX_SUMMARY_HEADLINE_LENGTH] + "..."
-
-        headline = f"{error_type}: {text}" if text else error_type
-        return headline
-
     def get_issue_summary_text(self) -> str | None:
         """Generate formatted text from issue summary fields."""
         if self.issue_summary is None:
@@ -579,34 +489,20 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if not parts:
             return None
 
-        if self._is_compact:
-            return f"*Initial Guess*: {escape_slack_markdown_text('  '.join(parts))}"
-        else:
-            return escape_slack_markdown_text("\n\n".join(parts))
+        return f"*Initial Guess*: {escape_slack_markdown_text('  '.join(parts))}"
 
     def get_culprit_block(self, event_or_group: Event | GroupEvent | Group) -> SlackBlock | None:
         if event_or_group.culprit and isinstance(event_or_group.culprit, str):
             return self.get_context_block(event_or_group.culprit)
         return None
 
-    # 'small' param can be removed when 'slack-compact-alerts' is GA
-    def get_text_block(self, text, small: bool = False) -> SlackBlock:
+    def get_text_block(self, text) -> SlackBlock:
         if self.group.issue_category == GroupCategory.FEEDBACK:
             max_block_text_length = USER_FEEDBACK_MAX_BLOCK_TEXT_LENGTH
         else:
             max_block_text_length = MAX_BLOCK_TEXT_LENGTH
 
-        if not small:
-            return self.get_markdown_quote_block(text, max_block_text_length)
-        else:
-            return self.get_context_block(text)
-
-    # Can be removed when 'slack-compact-alerts' is GA
-    def get_suggested_assignees_block(self, suggested_assignees: list[str]) -> SlackBlock:
-        suggested_assignee_text = "Suggested Assignees: "
-        for assignee in suggested_assignees:
-            suggested_assignee_text += assignee + ", "
-        return self.get_context_block(suggested_assignee_text[:-2])  # get rid of comma at the end
+        return self.get_markdown_quote_block(text, max_block_text_length)
 
     def get_footer(self) -> SlackBlock:
         # This link does not contain user input (it's a static label and a url), must not escape it.
@@ -653,24 +549,12 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             return self.get_context_block(text=footer, timestamp=timestamp)
 
     def build_description_block(self, description_text: str) -> SlackBlock | None:
-        # Use issue summary if available (and not flagged for compact alerts), otherwise use the default text
-        summary_text: str | None = self.get_issue_summary_text()
-        if summary_text and not self._is_compact:
-            return self.get_text_block(summary_text, small=True)
-
         text = description_text.lstrip(" ")
         # XXX(CEO): sometimes text is " " and slack will error if we pass an empty string (now "")
         return self.get_text_block(text) if text else None
 
     def build_group_context_block(self, suggested_assignees: list[str]) -> SlackBlock | None:
         """Combine stats (events, users, state, first seen) with suggested assignees in one context block."""
-        if not self._is_compact:
-            # add event count, user count, substate, first seen
-            context = get_context(self.group, self.rules)
-            if context:
-                return self.get_context_block(context)
-            return None
-
         context_text = get_context(self.group, self.rules)
 
         if suggested_assignees:
@@ -684,20 +568,11 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         return self.get_context_block(context_text)
 
-    def build_pre_footer_context_blocks(self, suggested_assignees: list[str]) -> list[SlackBlock]:
-        blocks = []
-        summary_text: str | None = self.get_issue_summary_text()
-        if self._is_compact and summary_text:
+    def build_pre_footer_context_blocks(self) -> list[SlackBlock]:
+        blocks: list[SlackBlock] = []
+        summary_text = self.get_issue_summary_text()
+        if summary_text:
             blocks.append(self.get_context_block(summary_text))
-
-        if not self._is_compact and len(suggested_assignees) > 0:
-            blocks.append(self.get_suggested_assignees_block(suggested_assignees))
-
-        if not self._is_compact:
-            # add suspect commit info
-            suspect_commit_text = get_suspect_commit_text(self.group)
-            if suspect_commit_text:
-                blocks.append(self.get_context_block(suspect_commit_text))
 
         return blocks
 
@@ -845,7 +720,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             action_block = {"type": "actions", "elements": [action for action in actions]}
             blocks.append(action_block)
 
-        if pre_footer_context_block := self.build_pre_footer_context_blocks(suggested_assignees):
+        if pre_footer_context_block := self.build_pre_footer_context_blocks():
             blocks.extend(pre_footer_context_block)
 
         # add notes
@@ -855,8 +730,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         # build footer block
         blocks.append(self.get_footer())
-        if not self._is_compact:
-            blocks.append(self.get_divider())
 
         chart_block = ImageBlockBuilder(group=self.group).build_image_block()
         if chart_block:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2978,7 +2978,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
 
         optional_org_id = f"&organizationId={org.id}" if alert_page_needs_org_id(alert_type) else ""
         assert (
-            blocks[-2]["elements"][0]["text"]
+            blocks[-1]["elements"][0]["text"]
             == f"{project_slug} | <http://testserver/settings/account/notifications/{alert_type}/?referrer={referrer}-user&notification_uuid={notification_uuid}{optional_org_id}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -174,7 +174,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             fallback_text
             == f"Alert triggered <http://testserver/organizations/{event.organization.slug}/issues/alerts/rules/{event.project.slug}/{self.rule.id}/details/|ja rule>"
         )
-        assert len(blocks) == 5
+        assert len(blocks) == 4
 
     @patch(
         "sentry.services.eventstore.models.GroupEvent.occurrence",
@@ -493,9 +493,11 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             blocks[1]["text"]["text"]
             == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
         )
-        assert blocks[6]["elements"][0]["text"] == f"Suggested Assignees: #{self.team.slug}"
+        # Verify suggested assignees are in the context block and footer is last
+        context_blocks = [b for b in blocks if b.get("type") == "context"]
+        assert any(f"#{self.team.slug}" in b["elements"][0]["text"] for b in context_blocks)
         assert (
-            blocks[7]["elements"][0]["text"]
+            blocks[-1]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/{event.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -644,7 +646,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(title_link)
         assert event.group
         assert (
-            blocks[-2]["elements"][0]["text"]
+            blocks[-1]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -802,7 +804,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(title_link)
         assert event.group
         assert (
-            blocks[-2]["elements"][0]["text"]
+            blocks[-1]["elements"][0]["text"]
             == f"{project2.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -898,7 +900,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(title_link)
         assert event.group
         assert (
-            blocks[-2]["elements"][0]["text"]
+            blocks[-1]["elements"][0]["text"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 
@@ -911,7 +913,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(title_link)
         assert event.group
         assert (
-            blocks[-2]["elements"][0]["text"]
+            blocks[-1]["elements"][0]["text"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}&organizationId={event.organization.id}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -10,7 +10,6 @@ from sentry.integrations.messaging.message_builder import (
     build_attachment_title,
 )
 from sentry.integrations.slack.message_builder.issues import (
-    MAX_SUMMARY_HEADLINE_LENGTH,
     SlackIssuesMessageBuilder,
     build_actions,
     format_release_tag,
@@ -66,7 +65,6 @@ def build_test_message_blocks(
     suggested_assignees: str | None = None,
     initial_assignee: Team | User | None = None,
     notes: str | None = None,
-    suspect_commit_text: str | None = None,
     rule: IssueAlertRule | None = None,
     legacy_rule_id: int | None = None,
 ) -> dict[str, Any]:
@@ -141,13 +139,16 @@ def build_test_message_blocks(
         }
         blocks.append(tags_section)
 
-    # add event and user count, state, first seen
+    # add event and user count, state, first seen, and suggested assignees (compact style)
+    context_text = f"State: *New*   First Seen: *{time_since(group.first_seen)}*"
+    if suggested_assignees:
+        context_text += f"   Suggested: {suggested_assignees}"
     counts_section = {
         "type": "context",
         "elements": [
             {
                 "type": "mrkdwn",
-                "text": f"State: *New*   First Seen: *{time_since(group.first_seen)}*",
+                "text": context_text,
             }
         ],
     }
@@ -205,21 +206,6 @@ def build_test_message_blocks(
             }
     blocks.append(actions)
 
-    if suggested_assignees:
-        suggested_assignees_text = f"Suggested Assignees: {suggested_assignees}"
-        suggested_assignees_section = {
-            "type": "context",
-            "elements": [{"type": "mrkdwn", "text": suggested_assignees_text}],
-        }
-        blocks.append(suggested_assignees_section)
-
-    if suspect_commit_text and event:
-        suspect_commit_section = {
-            "type": "context",
-            "elements": [{"type": "mrkdwn", "text": suspect_commit_text}],
-        }
-        blocks.append(suspect_commit_section)
-
     if notes:
         notes_text = f"notes: {notes}"
         notes_section = {
@@ -240,8 +226,6 @@ def build_test_message_blocks(
         "elements": [{"type": "mrkdwn", "text": context_text}],
     }
     blocks.append(context)
-
-    blocks.append({"type": "divider"})
 
     popup_text = (
         f"[{project.slug}] {title}: {text}" if text is not None else f"[{project.slug}] {title}"
@@ -532,7 +516,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             key="asdfwreqr",
             message="placeholder commit message",
         )
-        pull_request = PullRequest.objects.create(
+        PullRequest.objects.create(
             organization_id=self.organization.id,
             repository_id=self.repo.id,
             key="9",
@@ -564,8 +548,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             context={"commitId": self.commit.id},
         )
 
-        suspect_commit_text = f"Suspect Commit: <{self.repo.url}/commit/{self.commit.key}|{self.commit.key[:6]}> by {commit_author.email} {time_since(pull_request.date_added)} \n'{pull_request.title} (#{pull_request.key})' <{pull_request.get_external_url()}|View Pull Request>"
-
         assert SlackIssuesMessageBuilder(
             group,
             event.for_group(group),
@@ -574,7 +556,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             users={self.user},
             group=group,
             event=event,
-            suspect_commit_text=suspect_commit_text,
             suggested_assignees=commit_author.email,
         )
 
@@ -629,8 +610,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             context={"commitId": self.commit.id},
         )
 
-        suspect_commit_text = f"Suspect Commit: {self.commit.key[:6]} by {commit_author.email}"
-
         assert SlackIssuesMessageBuilder(
             group,
             event.for_group(group),
@@ -639,7 +618,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             users={self.user},
             group=group,
             event=event,
-            suspect_commit_text=suspect_commit_text,
             suggested_assignees=commit_author.email,
         )
 
@@ -712,16 +690,14 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
         # auto assign group
         ProjectOwnership.handle_auto_assignment(self.project.id, event)
-        suspect_commit_text = f"Suspect Commit: {commit.key[:6]} by {user2.email}"  # no commit link because there is no PR
 
         expected_blocks = build_test_message_blocks(
             teams={self.team},
             users={self.user},
             group=group,
             event=event,
-            suggested_assignees=f"#{self.team.slug}, {user2.email}",  # auto-assignee is not included in suggested
+            suggested_assignees=f"#{self.team.slug}, {user2.email}",
             initial_assignee=self.user,
-            suspect_commit_text=suspect_commit_text,
         )
 
         assert (
@@ -733,7 +709,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         with assume_test_silo_mode(SiloMode.CONTROL):
             user2.update(name="Scooby Doo")
         commit.author.update(name=user2.name)
-        suspect_commit_text = f"Suspect Commit: {commit.key[:6]} by {user2.name}"
         expected_blocks = build_test_message_blocks(
             teams={self.team},
             users={self.user},
@@ -741,7 +716,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             event=event,
             suggested_assignees=f"#{self.team.slug}, {user2.name}",
             initial_assignee=self.user,
-            suspect_commit_text=suspect_commit_text,
         )
         assert (
             SlackIssuesMessageBuilder(group, event.for_group(group), tags={"foo"}).build()
@@ -952,155 +926,23 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
             mock_get_summary.assert_called_once_with(group, source=SeerAutomationSource.ALERT)
 
-            # Verify that the original title is \\ present
+            # Verify that the title uses build_attachment_title (error type only)
             assert "IntegrationError" in blocks["blocks"][0]["text"]["text"]
-            assert "Identity not found" in blocks["blocks"][0]["text"]["text"]
 
-            # Verify that the AI content is used in the context block
-            content_block = blocks["blocks"][1]["elements"][0]["text"]
-            assert "This is a possible cause" in content_block
+            # Verify that the AI summary appears as "Initial Guess" in a context block
+            found_initial_guess = False
+            for block in blocks["blocks"]:
+                if block.get("type") == "context":
+                    for element in block.get("elements", []):
+                        if "Initial Guess" in element.get("text", ""):
+                            found_initial_guess = True
+                            assert "This is a possible cause" in element["text"]
+                            break
+            assert found_initial_guess
 
-    @override_options({"alerts.issue_summary_timeout": 5})
-    @with_feature({"organizations:gen-ai-features"})
-    def test_build_group_block_with_ai_summary_text_truncation(self) -> None:
-        # Test case for multi-line exception text
-        multiline_text = "First line of text\nSecond line of text\nThird line of text"
-        event1 = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "IntegrationError",
-                "fingerprint": ["group-1"],
-                "exception": {
-                    "values": [
-                        {
-                            "type": "IntegrationError",
-                            "value": multiline_text,
-                        }
-                    ]
-                },
-                "level": "error",
-                "timestamp": before_now(minutes=1).isoformat(),
-            },
-            project_id=self.project.id,
-        )
-        assert event1.group
-        group1 = event1.group
-        group1.type = ErrorGroupType.type_id
-        group1.save()
-
-        self.project.update_option("sentry:seer_scanner_automation", True)
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
-
-        # Test case for long exception text (over 50 characters)
-        long_text = (
-            "This is a very long text that exceeds the 50 character limit and should be truncated"
-        )
-        event2 = self.store_event(
-            data={
-                "event_id": "b" * 32,
-                "message": "IntegrationError",
-                "fingerprint": ["group-2"],
-                "exception": {
-                    "values": [
-                        {
-                            "type": "IntegrationError",
-                            "value": long_text,
-                        }
-                    ]
-                },
-                "level": "error",
-                "timestamp": before_now(minutes=1).isoformat(),
-            },
-            project_id=self.project.id,
-        )
-        assert event2.group
-        group2 = event2.group
-        group2.type = ErrorGroupType.type_id
-        group2.save()
-
-        self.project.flags.has_releases = True
-        self.project.save(update_fields=["flags"])
-
-        mock_summary = {
-            "headline": "Custom AI Title",
-            "whatsWrong": "Some issue description",
-            "trace": "This is trace information",
-            "possibleCause": "This is a possible cause",
-        }
-
-        patch_path = "sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary"
-        serializer_path = "sentry.api.serializers.models.event.EventSerializer.serialize"
-        serializer_mock = Mock(return_value={})
-
-        # Test multi-line text truncation
-        with (
-            patch(patch_path) as mock_get_summary,
-            patch(serializer_path, serializer_mock),
-        ):
-            mock_get_summary.return_value = (mock_summary, 200)
-            blocks = SlackIssuesMessageBuilder(group1, event1.for_group(group1)).build()
-            title_text = blocks["blocks"][0]["text"]["text"]
-
-            assert "First line of text..." in title_text
-            assert "Second line" not in title_text
-
-        # Test long text truncation
-        with (
-            patch(patch_path) as mock_get_summary,
-            patch(serializer_path, serializer_mock),
-        ):
-            mock_get_summary.return_value = (mock_summary, 200)
-            blocks = SlackIssuesMessageBuilder(group2, event2.for_group(group2)).build()
-            title_text = blocks["blocks"][0]["text"]["text"]
-
-            expected_truncated = long_text[:MAX_SUMMARY_HEADLINE_LENGTH] + "..."
-            assert expected_truncated in title_text
-
-        # Test cases for other line breaks
-        line_break_test_cases = [
-            ("crlf", "CRLF Line1\r\nCRLF Line2", "CRLF Line1..."),
-            ("ls", "LS Line1\u2028LS Line2", "LS Line1..."),
-            ("ps", "PS Line1\u2029PS Line2", "PS Line1..."),
-            ("strip_before_ellipsis", "Space Line1  \r\nSpace Line2", "Space Line1..."),
-        ]
-
-        for name, text_with_break, expected_headline_part in line_break_test_cases:
-            event_lb = self.store_event(
-                data={
-                    "event_id": "c" * 32,
-                    "message": "IntegrationError",
-                    "fingerprint": [f"group-lb-{name}"],
-                    "exception": {
-                        "values": [
-                            {
-                                "type": "IntegrationError",
-                                "value": text_with_break,
-                            }
-                        ]
-                    },
-                    "level": "error",
-                    "timestamp": before_now(minutes=1).isoformat(),
-                },
-                project_id=self.project.id,
-            )
-            assert event_lb.group
-            group_lb = event_lb.group
-            group_lb.type = ErrorGroupType.type_id
-            group_lb.save()
-
-            with (
-                patch(patch_path) as mock_get_summary,
-                patch(serializer_path, serializer_mock),
-            ):
-                mock_get_summary.return_value = (mock_summary, 200)
-                blocks = SlackIssuesMessageBuilder(group_lb, event_lb.for_group(group_lb)).build()
-                title_block = blocks["blocks"][0]["text"]["text"]
-                assert f": {expected_headline_part}*>" in title_block, f"Failed for {name}"
-
-    @with_feature("organizations:slack-compact-alerts")
     def test_compact_alerts_basic_layout(self) -> None:
         """
-        Test that with the slack-compact-alerts flag enabled, the message uses a compact layout:
+        Test that the message uses a compact layout:
         - No divider at the end
         - Context block includes stats
         """
@@ -1134,12 +976,11 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert "IntegrationError" in blocks["blocks"][0]["text"]["text"]
         assert blocks["blocks"][-1]["type"] != "divider"
 
-    @with_feature("organizations:slack-compact-alerts")
     @override_options({"alerts.issue_summary_timeout": 5})
     @with_feature({"organizations:gen-ai-features"})
     def test_compact_alerts_with_ai_summary(self) -> None:
         """
-        Test that with the slack-compact-alerts flag enabled and AI summary available:
+        Test that with AI summary available:
         - Title uses build_attachment_title() (not AI headline)
         - Issue summary appears after action buttons as context with "Initial Guess:" prefix
         """
@@ -1205,7 +1046,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             assert found_initial_guess, "Initial Guess context block not found"
             assert blocks["blocks"][-1]["type"] != "divider"
 
-    @with_feature("organizations:slack-compact-alerts")
     def test_compact_alerts_context_includes_suggested_assignees(self) -> None:
         """
         Test that with compact alerts, suggested assignees are included in the context block

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -388,8 +388,8 @@ class SlackNotifyActionTest(RuleTestCase):
             blocks = orjson.loads(blocks)
 
             assert event.title in blocks[0]["text"]["text"]
-            assert blocks[5]["text"]["text"] == self.organization.slug
-            assert blocks[6]["text"]["text"] == self.integration.id
+            assert blocks[4]["text"]["text"] == self.organization.slug
+            assert blocks[5]["text"]["text"] == self.integration.id
             assert_last_analytics_event(
                 mock_record,
                 AlertSentEvent(

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -46,7 +46,7 @@ class AssignedNotificationAPITest(APITestCase):
         assert fallback_text == msg
 
         assert group.title in blocks[1]["text"]["text"]
-        assert project.slug in blocks[-2]["elements"][0]["text"]
+        assert project.slug in blocks[-1]["elements"][0]["text"]
         channel = mock_post.call_args_list[index].kwargs["channel"]
         assert channel == str(user_id)
 
@@ -104,7 +104,7 @@ class AssignedNotificationAPITest(APITestCase):
         fallback_text = mock_post.call_args.kwargs["text"]
         assert fallback_text == f"Issue assigned to {user.get_display_name()} by themselves"
         assert self.group.title in blocks[1]["text"]["text"]
-        assert self.project.slug in blocks[-2]["elements"][0]["text"]
+        assert self.project.slug in blocks[-1]["elements"][0]["text"]
 
     def test_sends_assignment_notification_with_suspect_commits(self, mock_post):
         """

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -307,7 +307,7 @@ class DigestSlackNotification(SlackActivityNotificationTest):
             fallback_text
             == f"<!date^{timestamp_secs}^2 issues detected {{date_pretty}} in| Digest Report for> <http://testserver/organizations/{self.organization.slug}/projects/{self.project.slug}/|{self.project.name}>"
         )
-        assert len(blocks) == 9
+        assert len(blocks) == 7
         assert blocks[0]["text"]["text"] == fallback_text
 
         assert event1.group
@@ -319,17 +319,17 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         # digest order not definitive
         try:
             assert blocks[1]["text"]["text"] == event1_alert_title
-            assert blocks[5]["text"]["text"] == event2_alert_title
+            assert blocks[4]["text"]["text"] == event2_alert_title
         except AssertionError:
             assert blocks[1]["text"]["text"] == event2_alert_title
-            assert blocks[5]["text"]["text"] == event1_alert_title
+            assert blocks[4]["text"]["text"] == event1_alert_title
 
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/?referrer=digest-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert (
-            blocks[7]["elements"][0]["text"]
+            blocks[6]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/?referrer=digest-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -337,7 +337,7 @@ class DigestSlackNotification(SlackActivityNotificationTest):
     def test_slack_digest_notification_truncates_at_48_blocks(self, digests: MagicMock) -> None:
         """
         Test that digest notifications are truncated to 48 blocks to respect Slack's 50 block limit.
-        With 13+ events generating ~53 blocks, we truncate to 48 content blocks + 1 warning block + 1 title block.
+        With 17+ events generating ~51 blocks, we truncate to 48 content blocks + 1 warning block + 1 title block.
         """
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         backend = RedisBackend()
@@ -348,8 +348,8 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         rule = self.create_project_rule(project=self.project)
         notification_uuid = str(uuid.uuid4())
 
-        # Create 13 events to exceed 49 blocks (assuming each event generates ~4 blocks)
-        for i in range(13):
+        # Create 17 events to exceed 48 blocks (each event generates ~3 blocks)
+        for i in range(17):
             event = self.store_event(
                 data={
                     "timestamp": timestamp,
@@ -382,8 +382,8 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         warning_text_lower = warning_text.lower()
 
         assert "showing" in warning_text_lower
-        # Should show X issues out of Y where X < 13 and Y = 13
-        assert "/13" in warning_text
+        # Should show X issues out of Y where X < 17 and Y = 17
+        assert "/17" in warning_text
         assert "view all issues in sentry" in warning_text_lower
 
         # Check URL components and values (URL-encoded)

--- a/tests/sentry/notifications/platform/slack/renderers/test_issue.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_issue.py
@@ -264,8 +264,6 @@ class IssueSlackRendererTest(IssueAlertInvocationMixin):
             }
         )
 
-        blocks.append({"type": "divider"})
-
         return SlackRenderable(
             blocks=blocks,
             text=f"[{project_slug}] {title}",


### PR DESCRIPTION
remove the `organizations:slack-compact-alerts` feature flag and make the compact slack alert layout the default for all users including self-hosted. removes dead code paths for the non-compact layout (headline formatting, suspect commits block, separate suggested assignees block, trailing divider).

Fixes ISWF-2375