### PR TITLE
ref(preprod): Call status check tasks synchronously

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
@@ -89,11 +89,9 @@ class OrganizationPreprodArtifactApproveEndpoint(OrganizationEndpoint):
         ).delete()
 
         task = STATUS_CHECK_TASK_MAP[feature_type]
-        task.apply_async(
-            kwargs={
-                "preprod_artifact_id": artifact.id,
-                "caller": "approval_endpoint",
-            }
+        task(
+            preprod_artifact_id=artifact.id,
+            caller="approval_endpoint",
         )
 
         return Response({"detail": "Approved"}, status=201)

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -215,18 +215,14 @@ def handle_preprod_check_run_event(
         )
 
     if identifier == APPROVE_SIZE_ACTION_IDENTIFIER:
-        create_preprod_status_check_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": artifact.id,
-                "caller": "github_approve_webhook",
-            }
+        create_preprod_status_check_task(
+            preprod_artifact_id=artifact.id,
+            caller="github_approve_webhook",
         )
     elif identifier == APPROVE_SNAPSHOT_ACTION_IDENTIFIER:
-        create_preprod_snapshot_status_check_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": artifact.id,
-                "caller": "github_approve_webhook",
-            }
+        create_preprod_snapshot_status_check_task(
+            preprod_artifact_id=artifact.id,
+            caller="github_approve_webhook",
         )
     else:
         raise ValueError(f"Unknown identifier: {identifier}")

--- a/tests/sentry/preprod/vcs/webhooks/test_github_check_run.py
+++ b/tests/sentry/preprod/vcs/webhooks/test_github_check_run.py
@@ -193,11 +193,9 @@ class HandlePreprodCheckRunEventTest(TestCase):
         assert approval.extras == {"github": {"id": 12345, "login": "octocat"}}
         assert approval.approved_at is not None
 
-        mock_task.apply_async.assert_called_once_with(
-            kwargs={
-                "preprod_artifact_id": artifact.id,
-                "caller": "github_approve_webhook",
-            }
+        mock_task.assert_called_once_with(
+            preprod_artifact_id=artifact.id,
+            caller="github_approve_webhook",
         )
 
     def test_creates_approvals_for_all_sibling_artifacts(self) -> None:


### PR DESCRIPTION
Replace `apply_async` calls with direct synchronous invocations for preprod
status check tasks in the approval endpoint and GitHub check run webhook handler.

This ensures status checks run inline rather than being dispatched to the Celery
task queue, giving immediate feedback on approval actions.

[sentry URL for tracking the latency of our status check tasks](https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22avg%28span.duration%29%22%2C%22p95%28span.duration%29%22%2C%22count%28%29%22%5D%7D&mode=aggregate&project=1&query=is_transaction%3Atrue%20%28transaction%3A%22sentry.preprod.tasks.create_preprod_status_check%22%20OR%20transaction%3A%22sentry.preprod.tasks.create_preprod_snapshot_status_check%22%20%29&sort=-p95%28span.duration%29&statsPeriod=7d&table=span)