### PR TITLE
feat(seer): Send page_name in explorer chat requests from frontend

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -243,6 +243,7 @@ export const useSeerExplorer = () => {
             query,
             insert_index: calculatedInsertIndex,
             on_page_context: screenshot,
+            page_name: getPageReferrer(),
             override_ce_enable: overrideCtxEngEnable,
           },
         })) as SeerExplorerChatResponse;


### PR DESCRIPTION
+ Send the normalized route string as page_name in the explorer chat POST payload so Seer can track which UI page the user was on. The value comes from getPageReferrer() (e.g., /organizations/:orgSlug/issues/).

+ Backend PR is merged: https://github.com/getsentry/sentry/pull/112065
