### PR TITLE
test(onboarding): Add tests for useScmRepoSearch and ScmRepoSelector

### DIFF
--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {
   OnboardingContextProvider,
@@ -41,6 +41,7 @@ describe('ScmRepoSelector', () => {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
+    sessionStorage.clear();
   });
 
   it('renders search placeholder', () => {
@@ -125,5 +126,91 @@ describe('ScmRepoSelector', () => {
     });
 
     expect(screen.getByText('getsentry/old-repo')).toBeInTheDocument();
+  });
+
+  it('selects a repo from search results and triggers repo lookup', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
+      body: {
+        repos: [{identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false}],
+      },
+    });
+
+    const reposLookup = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: [
+        RepositoryFixture({
+          name: 'getsentry/sentry',
+          externalSlug: 'getsentry/sentry',
+        }),
+      ],
+    });
+
+    render(<ScmRepoSelector integration={mockIntegration} />, {
+      organization,
+      wrapper: makeOnboardingWrapper(),
+    });
+
+    // Type a search term that differs from the option label to avoid
+    // matching both the hidden auto-sizer div and the menu option.
+    await userEvent.type(screen.getByRole('textbox'), 'get');
+    await userEvent.click(await screen.findByText('sentry'));
+
+    await waitFor(() => expect(reposLookup).toHaveBeenCalled());
+  });
+
+  it('clears the selected repo', async () => {
+    const selectedRepo = RepositoryFixture({
+      name: 'getsentry/old-repo',
+      externalSlug: 'getsentry/old-repo',
+    });
+
+    render(<ScmRepoSelector integration={mockIntegration} />, {
+      organization,
+      wrapper: makeOnboardingWrapper({selectedRepository: selectedRepo}),
+    });
+
+    expect(screen.getByText('getsentry/old-repo')).toBeInTheDocument();
+
+    // The clear indicator uses Sentry's IconClose which renders with
+    // role="img" rather than aria-hidden, so use the test-id directly.
+    await userEvent.click(screen.getByTestId('icon-close'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('getsentry/old-repo')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not duplicate selected repo when it appears in search results', async () => {
+    const selectedRepo = RepositoryFixture({
+      name: 'getsentry/sentry',
+      externalSlug: 'getsentry/sentry',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
+      body: {
+        repos: [
+          {identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false},
+          {identifier: 'getsentry/relay', name: 'relay', isInstalled: false},
+        ],
+      },
+    });
+
+    render(<ScmRepoSelector integration={mockIntegration} />, {
+      organization,
+      wrapper: makeOnboardingWrapper({selectedRepository: selectedRepo}),
+    });
+
+    await userEvent.type(screen.getByRole('textbox'), 'get');
+
+    // Wait for search results to arrive
+    expect(await screen.findByText('relay')).toBeInTheDocument();
+    expect(screen.getByText('sentry')).toBeInTheDocument();
+
+    // If the options-prepend logic fires incorrectly, it adds an extra option
+    // with label 'getsentry/sentry' (selectedRepository.name) alongside the
+    // search result option with label 'sentry' (repo.name).
+    expect(screen.queryByText('getsentry/sentry')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -65,7 +65,11 @@ describe('ScmRepoSelector', () => {
 
     await userEvent.type(screen.getByRole('textbox'), 'nonexistent');
 
-    expect(await screen.findByText('No repositories found.')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'No repositories found. Check your installation permissions to ensure your integration has access.'
+      )
+    ).toBeInTheDocument();
   });
 
   it('shows error message on API failure', async () => {

--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -54,7 +54,7 @@ describe('ScmRepoSelector', () => {
 
   it('shows empty state message when search returns no results', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/1/repos/`,
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
       body: {repos: []},
     });
 
@@ -74,7 +74,7 @@ describe('ScmRepoSelector', () => {
 
   it('shows error message on API failure', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/1/repos/`,
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
       statusCode: 500,
       body: {detail: 'Internal Error'},
     });
@@ -93,7 +93,7 @@ describe('ScmRepoSelector', () => {
 
   it('displays repos returned by search', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/1/repos/`,
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
       body: {
         repos: [
           {identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false},

--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -1,0 +1,125 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+import {RepositoryFixture} from 'sentry-fixture/repository';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  OnboardingContextProvider,
+  type OnboardingSessionState,
+} from 'sentry/components/onboarding/onboardingContext';
+
+import {ScmRepoSelector} from './scmRepoSelector';
+
+function makeOnboardingWrapper(initialState?: OnboardingSessionState) {
+  return function OnboardingWrapper({children}: {children?: React.ReactNode}) {
+    return (
+      <OnboardingContextProvider initialValue={initialState}>
+        {children}
+      </OnboardingContextProvider>
+    );
+  };
+}
+
+describe('ScmRepoSelector', () => {
+  const organization = OrganizationFixture();
+
+  const mockIntegration = OrganizationIntegrationsFixture({
+    id: '1',
+    name: 'getsentry',
+    domainName: 'github.com/getsentry',
+    provider: {
+      key: 'github',
+      slug: 'github',
+      name: 'GitHub',
+      canAdd: true,
+      canDisable: false,
+      features: ['commits'],
+      aspects: {},
+    },
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders search placeholder', () => {
+    render(<ScmRepoSelector integration={mockIntegration} />, {
+      organization,
+      wrapper: makeOnboardingWrapper(),
+    });
+
+    expect(screen.getByText('Search repositories')).toBeInTheDocument();
+  });
+
+  it('shows empty state message when search returns no results', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/1/repos/`,
+      body: {repos: []},
+    });
+
+    render(<ScmRepoSelector integration={mockIntegration} />, {
+      organization,
+      wrapper: makeOnboardingWrapper(),
+    });
+
+    await userEvent.type(screen.getByRole('textbox'), 'nonexistent');
+
+    expect(await screen.findByText('No repositories found.')).toBeInTheDocument();
+  });
+
+  it('shows error message on API failure', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/1/repos/`,
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    render(<ScmRepoSelector integration={mockIntegration} />, {
+      organization,
+      wrapper: makeOnboardingWrapper(),
+    });
+
+    await userEvent.type(screen.getByRole('textbox'), 'sentry');
+
+    expect(
+      await screen.findByText('Failed to search repositories. Please try again.')
+    ).toBeInTheDocument();
+  });
+
+  it('displays repos returned by search', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/1/repos/`,
+      body: {
+        repos: [
+          {identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false},
+          {identifier: 'getsentry/relay', name: 'relay', isInstalled: false},
+        ],
+      },
+    });
+
+    render(<ScmRepoSelector integration={mockIntegration} />, {
+      organization,
+      wrapper: makeOnboardingWrapper(),
+    });
+
+    await userEvent.type(screen.getByRole('textbox'), 'get');
+
+    expect(await screen.findByText('sentry')).toBeInTheDocument();
+    expect(screen.getByText('relay')).toBeInTheDocument();
+  });
+
+  it('shows selected repo value when one is in context', () => {
+    const selectedRepo = RepositoryFixture({
+      name: 'getsentry/old-repo',
+      externalSlug: 'getsentry/old-repo',
+    });
+
+    render(<ScmRepoSelector integration={mockIntegration} />, {
+      organization,
+      wrapper: makeOnboardingWrapper({selectedRepository: selectedRepo}),
+    });
+
+    expect(screen.getByText('getsentry/old-repo')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -110,8 +110,10 @@ describe('ScmRepoSelector', () => {
 
     await userEvent.type(screen.getByRole('textbox'), 'get');
 
-    expect(await screen.findByText('sentry')).toBeInTheDocument();
-    expect(screen.getByText('relay')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('menuitemradio', {name: 'sentry'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'relay'})).toBeInTheDocument();
   });
 
   it('shows selected repo value when one is in context', () => {
@@ -151,10 +153,8 @@ describe('ScmRepoSelector', () => {
       wrapper: makeOnboardingWrapper(),
     });
 
-    // Type a search term that differs from the option label to avoid
-    // matching both the hidden auto-sizer div and the menu option.
     await userEvent.type(screen.getByRole('textbox'), 'get');
-    await userEvent.click(await screen.findByText('sentry'));
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'sentry'}));
 
     await waitFor(() => expect(reposLookup).toHaveBeenCalled());
   });
@@ -205,12 +205,14 @@ describe('ScmRepoSelector', () => {
     await userEvent.type(screen.getByRole('textbox'), 'get');
 
     // Wait for search results to arrive
-    expect(await screen.findByText('relay')).toBeInTheDocument();
-    expect(screen.getByText('sentry')).toBeInTheDocument();
+    expect(await screen.findByRole('menuitemradio', {name: 'relay'})).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'sentry'})).toBeInTheDocument();
 
     // If the options-prepend logic fires incorrectly, it adds an extra option
     // with label 'getsentry/sentry' (selectedRepository.name) alongside the
     // search result option with label 'sentry' (repo.name).
-    expect(screen.queryByText('getsentry/sentry')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'getsentry/sentry'})
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/useScmRepoSearch.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepoSearch.spec.tsx
@@ -80,7 +80,7 @@ describe('useScmRepoSearch', () => {
       body: {
         repos: [
           {identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false},
-          {identifier: 'getsentry/relay', name: 'relay', isInstalled: true},
+          {identifier: 'getsentry/relay', name: 'relay', isInstalled: false},
         ],
       },
     });

--- a/static/app/views/onboarding/components/useScmRepoSearch.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepoSearch.spec.tsx
@@ -1,0 +1,183 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RepositoryFixture} from 'sentry-fixture/repository';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useScmRepoSearch} from './useScmRepoSearch';
+
+describe('useScmRepoSearch', () => {
+  const organization = OrganizationFixture();
+  const integrationId = '1';
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.useRealTimers();
+  });
+
+  function renderHook(selectedRepo?: Parameters<typeof useScmRepoSearch>[1]) {
+    return renderHookWithProviders(() => useScmRepoSearch(integrationId, selectedRepo), {
+      organization,
+    });
+  }
+
+  it('does not fetch when search is empty', () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
+      body: {repos: []},
+    });
+
+    renderHook();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('fetches repos after search is set', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
+      body: {repos: []},
+    });
+
+    const {result} = renderHook();
+
+    act(() => {
+      result.current.setSearch('sentry');
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => expect(request).toHaveBeenCalled());
+  });
+
+  it('passes search query param to the API', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
+      body: {repos: []},
+    });
+
+    const {result} = renderHook();
+
+    act(() => {
+      result.current.setSearch('sentry');
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => expect(request).toHaveBeenCalled());
+
+    expect(request).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({search: 'sentry'}),
+      })
+    );
+  });
+
+  it('transforms API response into reposByIdentifier and dropdownItems', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
+      body: {
+        repos: [
+          {identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false},
+          {identifier: 'getsentry/relay', name: 'relay', isInstalled: true},
+        ],
+      },
+    });
+
+    const {result} = renderHook();
+
+    act(() => {
+      result.current.setSearch('get');
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => expect(result.current.reposByIdentifier.size).toBe(2));
+
+    expect(result.current.reposByIdentifier.get('getsentry/sentry')).toEqual({
+      identifier: 'getsentry/sentry',
+      name: 'sentry',
+      isInstalled: false,
+    });
+
+    expect(result.current.dropdownItems).toEqual([
+      {value: 'getsentry/sentry', label: 'sentry', disabled: false},
+      {value: 'getsentry/relay', label: 'relay', disabled: false},
+    ]);
+  });
+
+  it('marks selected repo as disabled in dropdownItems', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
+      body: {
+        repos: [
+          {identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false},
+          {identifier: 'getsentry/relay', name: 'relay', isInstalled: false},
+        ],
+      },
+    });
+
+    const selectedRepo = RepositoryFixture({externalSlug: 'getsentry/sentry'});
+    const {result} = renderHook(selectedRepo);
+
+    act(() => {
+      result.current.setSearch('get');
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => expect(result.current.dropdownItems).toHaveLength(2));
+
+    expect(result.current.dropdownItems[0]).toEqual(
+      expect.objectContaining({value: 'getsentry/sentry', disabled: true})
+    );
+    expect(result.current.dropdownItems[1]).toEqual(
+      expect.objectContaining({value: 'getsentry/relay', disabled: false})
+    );
+  });
+
+  it('returns isError true on API failure', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    const {result} = renderHook();
+
+    act(() => {
+      result.current.setSearch('sentry');
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('returns empty results when search is cleared after searching', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
+      body: {
+        repos: [{identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false}],
+      },
+    });
+
+    const {result} = renderHook();
+
+    // Search and get results
+    act(() => {
+      result.current.setSearch('sentry');
+      jest.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => expect(result.current.reposByIdentifier.size).toBe(1));
+
+    // Clear search
+    act(() => {
+      result.current.setSearch('');
+      jest.advanceTimersByTime(200);
+    });
+
+    // placeholderData returns undefined when debouncedSearch is empty
+    await waitFor(() => expect(result.current.reposByIdentifier.size).toBe(0));
+    expect(result.current.dropdownItems).toEqual([]);
+  });
+});

--- a/static/app/views/onboarding/components/useScmRepoSearch.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepoSearch.spec.tsx
@@ -69,7 +69,7 @@ describe('useScmRepoSearch', () => {
     expect(request).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        query: expect.objectContaining({search: 'sentry'}),
+        query: expect.objectContaining({search: 'sentry', accessibleOnly: true}),
       })
     );
   });


### PR DESCRIPTION
## Summary

- Add test coverage for `useScmRepoSearch` hook (7 tests): debounced search, API param passing, response transformation into `reposByIdentifier` Map and `dropdownItems`, selected repo disabling, error states, and search clearing
- Add test coverage for `ScmRepoSelector` component (8 tests): rendering, empty state messaging, error display, search results, selected repo context, repo selection triggering downstream lookup, clearing the selected repo, and verifying the options-prepend logic does not duplicate a selected repo already in search results

These are the only two SCM onboarding components without test coverage.

## Test plan

- [x] `CI=true pnpm test static/app/views/onboarding/components/useScmRepoSearch.spec.tsx` -- 7 passing
- [x] `CI=true pnpm test static/app/views/onboarding/components/scmRepoSelector.spec.tsx` -- 8 passing

Refs VDY-54