### PR TITLE
fix(preprod): Use RPC service for cross-silo user lookup in snapshot endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
@@ -59,9 +59,6 @@ class OrganizationPreprodArtifactApproveEndpoint(OrganizationEndpoint):
         except (PreprodArtifact.DoesNotExist, ValueError):
             return Response({"detail": "Artifact not found"}, status=404)
 
-        # TODO(hybrid-cloud): approved_by is a User FK (control silo). This cell silo
-        # endpoint stores the ID, and the snapshot GET resolves it via User.objects.filter().
-        # Both will need to use an RPC service when hybrid cloud enforcement is enabled.
         # exists()+create() instead of get_or_create — no unique constraint on this model
         # (see snapshots/tasks.py for rationale)
         already_approved = PreprodComparisonApproval.objects.filter(

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -61,7 +61,7 @@ from sentry.preprod.vcs.status_checks.snapshots.tasks import (
 )
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.users.models.user import User
+from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -349,7 +349,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         if approved:
             sentry_user_ids = list({a.approved_by_id for a in approved if a.approved_by_id})
-            users_by_id = {u.id: u for u in User.objects.filter(id__in=sentry_user_ids)}
+            users_by_id = {u.id: u for u in user_service.get_many_by_id(ids=sentry_user_ids)}
 
             approver_list: list[SnapshotApprover] = []
             seen_approver_keys: set[str] = set()


### PR DESCRIPTION
The snapshot GET endpoint (`preprod_artifact_snapshot.py`) was querying
`User.objects.filter()` directly to resolve approver info. Since `User` is
a control silo model and this is a cell silo endpoint, this raises
`SiloLimit.AvailabilityError` in production when running in REGION mode.

Replaces the direct ORM query with `user_service.get_many_by_id()` — the
standard RPC service for cross-silo user resolution. `RpcUser` exposes the
same `get_display_name()`, `.email`, and `.username` API so no other
changes are needed.

Also removes the now-resolved TODO comment in the approve endpoint that
referenced this issue.

Fixes SENTRY-5MQ6