### PR TITLE
fix(ci): Bandaid fix flaky "Event loop was closed" in CI

### DIFF
--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -67,18 +67,8 @@ async def _stream_response_and_close(response: httpx.Response) -> AsyncGenerator
     try:
         async for chunk in response.aiter_bytes(PROXY_CHUNK_SIZE):
             yield chunk
-    except RuntimeError as e:
-        if "Event loop is closed" not in str(e):
-            raise
-        # All data was received before this point. This error occurs in tests where
-        # Django's sync test client runs the async view on one event loop and
-        # close_streaming_response consumes the response on another, causing httpcore
-        # to attempt connection cleanup on the original (now-closed) loop.
     finally:
-        try:
-            await response.aclose()
-        except RuntimeError:
-            pass
+        await response.aclose()
 
 
 def _adapt_response(response: httpx.Response, remote_url: str) -> StreamingHttpResponse:

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -67,8 +67,18 @@ async def _stream_response_and_close(response: httpx.Response) -> AsyncGenerator
     try:
         async for chunk in response.aiter_bytes(PROXY_CHUNK_SIZE):
             yield chunk
+    except RuntimeError as e:
+        if "Event loop is closed" not in str(e):
+            raise
+        # All data was received before this point. This error occurs in tests where
+        # Django's sync test client runs the async view on one event loop and
+        # close_streaming_response consumes the response on another, causing httpcore
+        # to attempt connection cleanup on the original (now-closed) loop.
     finally:
-        await response.aclose()
+        try:
+            await response.aclose()
+        except RuntimeError:
+            pass
 
 
 def _adapt_response(response: httpx.Response, remote_url: str) -> StreamingHttpResponse:

--- a/src/sentry/testutils/helpers/response.py
+++ b/src/sentry/testutils/helpers/response.py
@@ -19,11 +19,21 @@ def is_streaming_response(response: HttpResponseBase) -> TypeGuard[StreamingHttp
 
 async def _async_streaming_response_content(response: StreamingHttpResponse) -> bytes:
     data = []
-    async for chunk in response:
-        data.append(chunk)
+    try:
+        async for chunk in response:
+            data.append(chunk)
+    except RuntimeError as e:
+        if "Event loop is closed" not in str(e):
+            raise
+        # Occurs when the async view and close_streaming_response run on different event
+        # loops. Harmless — all data was already received before httpcore attempts cleanup.
     iterator = response._iterator  # type: ignore[attr-defined]
     if hasattr(iterator, "aclose"):
-        await iterator.aclose()
+        try:
+            await iterator.aclose()
+        except RuntimeError as e:
+            if "Event loop is closed" not in str(e):
+                raise
     return b"".join(data)
 
 


### PR DESCRIPTION
Acceptance tests in CI have been failing a lot due to `Event loop is closed`, most likely caused by a prior change to make our proxy async. 

We ignore the "Event loop was closed" error because IIRC that only happens at the very end and we already got all the data.