### PR TITLE
Add additional label after attribute and tag fields in issue alert editor and details page

### DIFF
--- a/static/app/views/automations/components/actionFilters/eventAttribute.tsx
+++ b/static/app/views/automations/components/actionFilters/eventAttribute.tsx
@@ -13,7 +13,7 @@ import type {ValidateDataConditionProps} from 'sentry/views/automations/componen
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
 export function EventAttributeDetails({condition}: {condition: DataCondition}) {
-  return tct("The event's [attribute] [match] [value]", {
+  return tct("The event's [attribute] attribute [match] [value]", {
     attribute: condition.comparison.attribute,
     match:
       MATCH_CHOICES.find(choice => choice.value === condition.comparison.match)?.label ||
@@ -23,7 +23,7 @@ export function EventAttributeDetails({condition}: {condition: DataCondition}) {
 }
 
 export function EventAttributeNode() {
-  return tct("The event's [attribute] [match] [value]", {
+  return tct("The event's [attribute] attribute [match] [value]", {
     attribute: <AttributeField />,
     match: <MatchField />,
     value: <ValueField />,

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -28,7 +28,7 @@ export function TaggedEventDetails({condition}: {condition: DataCondition}) {
 }
 
 export function TaggedEventNode() {
-  return tct("The event's [key] [match] [value]", {
+  return tct("The event's [key] tag [match] [value]", {
     key: <KeyField />,
     match: <MatchField />,
     value: <ValueField />,


### PR DESCRIPTION
Event attribute and tagged event condition nodes were missing the words "tag" and "attribute" in the label after the text field, making existing conditions harder to understand at a glance.

Also added 'attribute' and 'tag' words to match the read-only details views and make the editor and details phrasing consistent.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
