### PR TITLE
feat: Add repo indexing job

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -291,6 +291,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-streaming", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable context engine for Seer Explorer
     manager.add("organizations:seer-explorer-context-engine", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable context engine experimental contexts
+    manager.add("organizations:context-engine-experiments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable frontend override for context engine (only for AI/ML/Reasoning platform team)
     manager.add("organizations:seer-explorer-context-engine-allow-fe-override", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable frontend override UI component for context engine (only for AI/ML/Reasoning platform team)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -768,6 +768,7 @@ def get_autofix_repos_from_project_code_mappings(
                 "owner": repo_name_sections[0],
                 "name": "/".join(repo_name_sections[1:]),
                 "external_id": repo.external_id,
+                "languages": repo.languages or [],
             }
             repo_key = (repo_dict["provider"], repo_dict["owner"], repo_dict["name"])
 

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -159,7 +159,7 @@ class RepoDetails(TypedDict):
     name: str
     external_id: str
     languages: list[str]
-    integration_id: str | None = None
+    integration_id: NotRequired[str | None]
 
 
 class ExplorerIndexOrgRepoRequest(TypedDict):

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -152,6 +152,35 @@ class LlmGenerateRequest(TypedDict):
     response_schema: NotRequired[dict[str, Any]]
 
 
+class RepoDetails(TypedDict):
+    project_ids: list[int]
+    provider: str
+    owner: str
+    name: str
+    external_id: str
+    languages: list[str]
+    integration_id: str | None = None
+
+
+class ExplorerIndexOrgRepoRequest(TypedDict):
+    org_id: int
+    repos: list[RepoDetails]
+
+
+def make_org_repo_knowledge_index_request(
+    body: ExplorerIndexOrgRepoRequest,
+    timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
+):
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/automation/explorer/index/org-repo-knowledge",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        viewer_context=viewer_context,
+    )
+
+
 def make_org_project_knowledge_index_request(
     body: OrgProjectKnowledgeIndexRequest,
     timeout: int | float | None = None,

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -171,7 +171,7 @@ def make_org_repo_knowledge_index_request(
     body: ExplorerIndexOrgRepoRequest,
     timeout: int | float | None = None,
     viewer_context: SeerViewerContext | None = None,
-):
+) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/automation/explorer/index/org-repo-knowledge",

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -227,7 +227,12 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
         logger.info("explorer.context_engine_indexing.enable flag is disabled")
         return
 
-    organization = Organization.objects.get(id=organization_id)
+    try:
+        organization = Organization.objects.get(id=organization_id)
+    except Organization.DoesNotExist:
+        logger.error("Organization not found", extra={"org_id": organization_id})
+        return
+
     if not features.has("organizations:context-engine-experiments", organization):
         logger.info("organizations:context-engine-experiments flag is disabled")
         return

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -261,7 +261,7 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
     for project_id, project in project_map.items():
         existing_pref = preferences_by_id.get(str(project_id), {})
         project_pref_repos = existing_pref.get("repositories") or []
-        autofix_repos = get_autofix_repos_from_project_code_mappings(project_map[project_id])
+        autofix_repos = get_autofix_repos_from_project_code_mappings(project)
 
         # Use autofix repos to get repo languages
         language_map: dict[tuple[str, str, str], list[str]] = {}
@@ -284,13 +284,16 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
                     "name": repo["name"],
                     "external_id": repo["external_id"],
                     "languages": language_map.get(key, []),
-                    "integration_id": repo["integration_id"],
+                    "integration_id": repo.get("integration_id"),
                 }
 
+    viewer_context = SeerViewerContext(organization_id=organization_id)
     response = make_org_repo_knowledge_index_request(
         ExplorerIndexOrgRepoRequest(
             org_id=organization.id, repos=list(org_repo_definitions.values())
-        )
+        ),
+        timeout=30,
+        viewer_context=viewer_context,
     )
 
     if response.status >= 400:

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -14,6 +14,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.events.types import SnubaParams
+from sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.seer.explorer.context_engine_utils import (
     EVENT_COUNT_LOOKBACK_DAYS,
     ProjectEventCounts,
@@ -45,7 +46,6 @@ from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.hashlib import md5_text
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
-from src.sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
 
 logger = logging.getLogger(__name__)
 
@@ -221,7 +221,6 @@ def build_service_map(organization_id: int, *args, **kwargs) -> None:
     name="sentry.tasks.seer.context_engine_index.index_repos",
     namespace=seer_tasks,
     processing_deadline_duration=10 * 60,  # 10 minutes
-    retry=Retry(times=3, on=(SnubaRPCRateLimitExceeded,), delay=60),
 )
 def index_repos(organization_id: int, *args, **kwargs) -> None:
     if not options.get("explorer.context_engine_indexing.enable"):
@@ -266,11 +265,14 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
                     "integration_id": repo["integration_id"],
                 }
 
-    make_org_repo_knowledge_index_request(
+    response = make_org_repo_knowledge_index_request(
         ExplorerIndexOrgRepoRequest(
             org_id=organization.id, repos=list(org_repo_definitions.values())
         )
     )
+
+    if response.status >= 400:
+        raise SeerApiError("Seer request failed", response.status)
 
 
 def get_allowed_org_ids_context_engine_indexing() -> list[int]:

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -274,7 +274,7 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
 
-    logger.info("Successfully indexted repos for org", extra={"org_id": organization_id})
+    logger.info("Successfully indexed repos for org", extra={"org_id": organization_id})
 
 
 def get_allowed_org_ids_context_engine_indexing() -> list[int]:

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -259,7 +259,7 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
     preferences_by_id = bulk_get_project_preferences(organization_id, list(project_map.keys()))
 
     for project_id, project in project_map.items():
-        existing_pref = preferences_by_id.get(str(project_id))
+        existing_pref = preferences_by_id.get(str(project_id), {})
         project_pref_repos = existing_pref.get("repositories") or []
         autofix_repos = get_autofix_repos_from_project_code_mappings(project_map[project_id])
 

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -14,7 +14,10 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.events.types import SnubaParams
-from sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
+from sentry.seer.autofix.utils import (
+    bulk_get_project_preferences,
+    get_autofix_repos_from_project_code_mappings,
+)
 from sentry.seer.explorer.context_engine_utils import (
     EVENT_COUNT_LOOKBACK_DAYS,
     ProjectEventCounts,
@@ -245,28 +248,40 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
     projects = list(
         Project.objects.filter(organization_id=organization_id, status=ObjectStatus.ACTIVE)
     )
+    project_map = {p.id: p for p in projects}
 
-    if not projects:
+    if not project_map:
         logger.info("No projects found for organization", extra={"org_id": organization_id})
         return
 
     org_repo_definitions: dict[tuple[str, str, str], RepoDetails] = {}
 
-    for project in projects:
-        repos = get_autofix_repos_from_project_code_mappings(project)
+    preferences_by_id = bulk_get_project_preferences(organization_id, list(project_map.keys()))
+
+    for project_id, project in project_map.items():
+        existing_pref = preferences_by_id.get(str(project_id))
+        project_pref_repos = existing_pref.get("repositories") or []
+        autofix_repos = get_autofix_repos_from_project_code_mappings(project_map[project_id])
+
+        language_map: dict[tuple[str, str, str], list[str]] = {}
+        for autofix_repo in autofix_repos:
+            key = (autofix_repo["provider"], autofix_repo["owner"], autofix_repo["name"])
+            language_map[key] = autofix_repo["languages"]
+
+        repos = project_pref_repos if project_pref_repos else autofix_repos
         for repo in repos:
             key = (repo["provider"], repo["owner"], repo["name"])
             if key in org_repo_definitions:
                 repo_definition = org_repo_definitions[key]
-                repo_definition["project_ids"].append(project.id)
+                repo_definition["project_ids"].append(project_id)
             else:
                 org_repo_definitions[key] = {
-                    "project_ids": [project.id],
+                    "project_ids": [project_id],
                     "provider": repo["provider"],
                     "owner": repo["owner"],
                     "name": repo["name"],
                     "external_id": repo["external_id"],
-                    "languages": repo["languages"],
+                    "languages": language_map.get(key, []),
                     "integration_id": repo["integration_id"],
                 }
 

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -274,6 +274,8 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
 
+    logger.info("Successfully indexted repos for org", extra={"org_id": organization_id})
+
 
 def get_allowed_org_ids_context_engine_indexing() -> list[int]:
     """

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -30,18 +30,22 @@ from sentry.seer.explorer.explorer_service_map_utils import (
 )
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
+    ExplorerIndexOrgRepoRequest,
     ExplorerIndexSentryKnowledgeRequest,
     OrgProjectKnowledgeIndexRequest,
     OrgProjectKnowledgeProjectData,
+    RepoDetails,
     SeerViewerContext,
     make_index_sentry_knowledge_request,
     make_org_project_knowledge_index_request,
+    make_org_repo_knowledge_index_request,
 )
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.hashlib import md5_text
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
+from src.sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +217,62 @@ def build_service_map(organization_id: int, *args, **kwargs) -> None:
         raise
 
 
+@instrumented_task(
+    name="sentry.tasks.seer.context_engine_index.index_repos",
+    namespace=seer_tasks,
+    processing_deadline_duration=10 * 60,  # 10 minutes
+    retry=Retry(times=3, on=(SnubaRPCRateLimitExceeded,), delay=60),
+)
+def index_repos(organization_id: int, *args, **kwargs) -> None:
+    if not options.get("explorer.context_engine_indexing.enable"):
+        logger.info("explorer.context_engine_indexing.enable flag is disabled")
+        return
+
+    organization = Organization.objects.get(id=organization_id)
+    if not features.has("organizations:context-engine-experiments", organization):
+        logger.info("organizations:context-engine-experiments flag is disabled")
+        return
+
+    logger.info(
+        "Starting repo index task",
+        extra={"org_id": organization_id},
+    )
+
+    projects = list(
+        Project.objects.filter(organization_id=organization_id, status=ObjectStatus.ACTIVE)
+    )
+
+    if not projects:
+        logger.info("No projects found for organization", extra={"org_id": organization_id})
+        return
+
+    org_repo_definitions: dict[tuple[str, str, str], RepoDetails] = {}
+
+    for project in projects:
+        repos = get_autofix_repos_from_project_code_mappings(project)
+        for repo in repos:
+            key = (repo["provider"], repo["owner"], repo["name"])
+            if key in org_repo_definitions:
+                repo_definition = org_repo_definitions[key]
+                repo_definition["project_ids"].append(project.id)
+            else:
+                org_repo_definitions[key] = {
+                    "project_ids": [project.id],
+                    "provider": repo["provider"],
+                    "owner": repo["owner"],
+                    "name": repo["name"],
+                    "external_id": repo["external_id"],
+                    "languages": repo["languages"],
+                    "integration_id": repo["integration_id"],
+                }
+
+    make_org_repo_knowledge_index_request(
+        ExplorerIndexOrgRepoRequest(
+            org_id=organization.id, repos=list(org_repo_definitions.values())
+        )
+    )
+
+
 def get_allowed_org_ids_context_engine_indexing() -> list[int]:
     """
     Get the list of allowed organizations for context engine indexing.
@@ -283,12 +343,17 @@ def schedule_context_engine_indexing_tasks() -> None:
         return
 
     allowed_org_ids = get_allowed_org_ids_context_engine_indexing()
+    now = datetime.now(UTC)
 
     dispatched = 0
     for org_id in allowed_org_ids:
         try:
             index_org_project_knowledge.apply_async(args=[org_id])
             build_service_map.apply_async(args=[org_id])
+
+            if now.weekday() == 6:  # Sunday
+                index_repos.apply_async(args=[org_id])
+
             dispatched += 1
         except Exception:
             logger.exception(

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -263,11 +263,13 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
         project_pref_repos = existing_pref.get("repositories") or []
         autofix_repos = get_autofix_repos_from_project_code_mappings(project_map[project_id])
 
+        # Use autofix repos to get repo languages
         language_map: dict[tuple[str, str, str], list[str]] = {}
         for autofix_repo in autofix_repos:
             key = (autofix_repo["provider"], autofix_repo["owner"], autofix_repo["name"])
             language_map[key] = autofix_repo["languages"]
 
+        # Use seer project rpeferences if available, else fallback to autofix repos
         repos = project_pref_repos if project_pref_repos else autofix_repos
         for repo in repos:
             key = (repo["provider"], repo["owner"], repo["name"])

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -224,6 +224,7 @@ def build_service_map(organization_id: int, *args, **kwargs) -> None:
     name="sentry.tasks.seer.context_engine_index.index_repos",
     namespace=seer_tasks,
     processing_deadline_duration=10 * 60,  # 10 minutes
+    retry=Retry(times=3, on=(SeerApiError,), delay=60),
 )
 def index_repos(organization_id: int, *args, **kwargs) -> None:
     if not options.get("explorer.context_engine_indexing.enable"):

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -260,19 +260,20 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
     preferences_by_id = bulk_get_project_preferences(organization_id, list(project_map.keys()))
 
     for project_id, project in project_map.items():
-        existing_pref = preferences_by_id.get(str(project_id), {})
-        project_pref_repos = existing_pref.get("repositories") or []
-        autofix_repos = get_autofix_repos_from_project_code_mappings(project)
+        existing_pref = preferences_by_id.get(str(project_id))
+        if not existing_pref:
+            continue
 
+        project_pref_repos = existing_pref.get("repositories") or []
+
+        autofix_repos = get_autofix_repos_from_project_code_mappings(project)
         # Use autofix repos to get repo languages
         language_map: dict[tuple[str, str, str], list[str]] = {}
         for autofix_repo in autofix_repos:
             key = (autofix_repo["provider"], autofix_repo["owner"], autofix_repo["name"])
             language_map[key] = autofix_repo["languages"]
 
-        # Use seer project rpeferences if available, else fallback to autofix repos
-        repos = project_pref_repos if project_pref_repos else autofix_repos
-        for repo in repos:
+        for repo in project_pref_repos:
             key = (repo["provider"], repo["owner"], repo["name"])
             if key in org_repo_definitions:
                 repo_definition = org_repo_definitions[key]

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -44,6 +44,7 @@ class TestGetRepoFromCodeMappings(TestCase):
                 "owner": "getsentry",
                 "name": "sentry",
                 "external_id": "123",
+                "languages": [],
             }
         ]
         assert repos == expected_repos

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -287,7 +287,30 @@ class TestIndexRepos(TestCase):
     def test_calls_seer_with_correct_org_and_repos(
         self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
     ) -> None:
-        mock_bulk_get_project_preferences.return_value = {}
+        mock_bulk_get_project_preferences.return_value = {
+            str(self.project1.id): {
+                "repositories": [
+                    {
+                        "name": "sentry",
+                        "owner": "getsentry",
+                        "provider": "integrations:github",
+                        "external_id": "123",
+                        "integration_id": str(self.integration.id),
+                    }
+                ],
+            },
+            str(self.project2.id): {
+                "repositories": [
+                    {
+                        "name": "relay",
+                        "owner": "getsentry",
+                        "provider": "integrations:github",
+                        "external_id": "456",
+                        "integration_id": str(self.integration.id),
+                    }
+                ],
+            },
+        }
         mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
         with override_options({"explorer.context_engine_indexing.enable": True}):
             with self.feature({"organizations:context-engine-experiments": True}):
@@ -321,7 +344,30 @@ class TestIndexRepos(TestCase):
     def test_deduplicates_repos_across_projects(
         self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
     ) -> None:
-        mock_bulk_get_project_preferences.return_value = {}
+        mock_bulk_get_project_preferences.return_value = {
+            str(self.project1.id): {
+                "repositories": [
+                    {
+                        "name": "sentry",
+                        "owner": "getsentry",
+                        "provider": "integrations:github",
+                        "external_id": "123",
+                        "integration_id": str(self.integration.id),
+                    }
+                ],
+            },
+            str(self.project2.id): {
+                "repositories": [
+                    {
+                        "name": "sentry",
+                        "owner": "getsentry",
+                        "provider": "integrations:github",
+                        "external_id": "123",
+                        "integration_id": str(self.integration.id),
+                    }
+                ],
+            },
+        }
         mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
         # Map project2 to the same repo as project1
         self.create_code_mapping(
@@ -385,8 +431,43 @@ class TestIndexRepos(TestCase):
         repos = body["repos"]
         repos_by_name = {r["name"]: r for r in repos}
 
+        assert len(repos) == 1
         sentry_repo = repos_by_name["sentry-seer"]
         assert sorted(sentry_repo["project_ids"]) == sorted([self.project1.id])
+
+    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
+    @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
+    def test_skips_projects_without_seer_preferences(
+        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+    ) -> None:
+        mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
+
+        # Only project1 has preferences; project2 is absent from the map
+        mock_bulk_get_project_preferences.return_value = {
+            str(self.project1.id): {
+                "repositories": [
+                    {
+                        "name": "sentry",
+                        "owner": "getsentry",
+                        "provider": "integrations:github",
+                        "external_id": "123",
+                        "integration_id": str(self.integration.id),
+                    }
+                ],
+            },
+        }
+
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            with self.feature({"organizations:context-engine-experiments": True}):
+                index_repos(self.org.id)
+
+        mock_mock_make_org_repo_knowledge_index_request.assert_called_once()
+        body = mock_mock_make_org_repo_knowledge_index_request.call_args[0][0]
+        repos = body["repos"]
+
+        assert len(repos) == 1
+        assert repos[0]["name"] == "sentry"
+        assert repos[0]["project_ids"] == [self.project1.id]
 
 
 @django_db_all

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -391,33 +391,66 @@ class TestIndexRepos(TestCase):
 
 @django_db_all
 class TestScheduleContextEngineIndexingTasks(TestCase):
+    @mock.patch("sentry.tasks.seer.context_engine_index.index_repos.apply_async")
     @mock.patch("sentry.tasks.seer.context_engine_index.build_service_map.apply_async")
     @mock.patch("sentry.tasks.seer.context_engine_index.index_org_project_knowledge.apply_async")
     @mock.patch(
         "sentry.tasks.seer.context_engine_index.get_allowed_org_ids_context_engine_indexing"
     )
-    def test_dispatches_for_allowed_orgs(self, mock_get_orgs, mock_index, mock_build):
+    def test_dispatches_for_allowed_orgs(
+        self, mock_get_orgs, mock_index, mock_build, mock_index_repos
+    ):
         org1 = self.create_organization()
         org2 = self.create_organization()
         mock_get_orgs.return_value = [org1.id, org2.id]
 
-        with override_options(
-            {
-                "explorer.context_engine_indexing.enable": True,
-            }
-        ):
-            schedule_context_engine_indexing_tasks()
+        # Freeze to a Wednesday so index_repos is not called
+        with freeze_time("2024-01-10 12:00:00"):
+            with override_options(
+                {
+                    "explorer.context_engine_indexing.enable": True,
+                }
+            ):
+                schedule_context_engine_indexing_tasks()
 
         assert mock_index.call_count == 2
         assert mock_build.call_count == 2
+        mock_index_repos.assert_not_called()
         dispatched_index_ids = [c[1]["args"][0] for c in mock_index.call_args_list]
         assert dispatched_index_ids == [org1.id, org2.id]
 
+    @mock.patch("sentry.tasks.seer.context_engine_index.index_repos.apply_async")
     @mock.patch("sentry.tasks.seer.context_engine_index.build_service_map.apply_async")
     @mock.patch("sentry.tasks.seer.context_engine_index.index_org_project_knowledge.apply_async")
-    def test_noop_when_no_allowed_orgs(self, mock_index, mock_build):
+    @mock.patch(
+        "sentry.tasks.seer.context_engine_index.get_allowed_org_ids_context_engine_indexing"
+    )
+    def test_dispatches_index_repos_on_sunday(
+        self, mock_get_orgs, mock_index, mock_build, mock_index_repos
+    ):
+        org1 = self.create_organization()
+        mock_get_orgs.return_value = [org1.id]
+
+        # Freeze to a Sunday so index_repos is called
+        with freeze_time("2024-01-14 12:00:00"):
+            with override_options(
+                {
+                    "explorer.context_engine_indexing.enable": True,
+                }
+            ):
+                schedule_context_engine_indexing_tasks()
+
+        assert mock_index.call_count == 1
+        assert mock_build.call_count == 1
+        mock_index_repos.assert_called_once_with(args=[org1.id])
+
+    @mock.patch("sentry.tasks.seer.context_engine_index.index_repos.apply_async")
+    @mock.patch("sentry.tasks.seer.context_engine_index.build_service_map.apply_async")
+    @mock.patch("sentry.tasks.seer.context_engine_index.index_org_project_knowledge.apply_async")
+    def test_noop_when_no_allowed_orgs(self, mock_index, mock_build, mock_index_repos):
         with override_options({"explorer.context_engine_indexing.enable": True}):
             schedule_context_engine_indexing_tasks()
 
         mock_index.assert_not_called()
         mock_build.assert_not_called()
+        mock_index_repos.assert_not_called()

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -6,6 +6,7 @@ from sentry.seer.explorer.context_engine_utils import ProjectEventCounts
 from sentry.tasks.seer.context_engine_index import (
     get_allowed_org_ids_context_engine_indexing,
     index_org_project_knowledge,
+    index_repos,
     schedule_context_engine_indexing_tasks,
 )
 from sentry.testutils.cases import TestCase
@@ -205,6 +206,126 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
                 eligible = get_allowed_org_ids_context_engine_indexing()
 
         assert org_without_github.id not in eligible
+
+
+@django_db_all
+class TestIndexRepos(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.org = self.create_organization()
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            organization=self.org,
+            user=None,
+            provider="github",
+            external_id=f"github:{self.org.id}",
+        )
+        self.project1 = self.create_project(organization=self.org)
+        self.project2 = self.create_project(organization=self.org)
+
+        self.repo1 = self.create_repo(
+            project=self.project1,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=self.integration.id,
+        )
+        self.repo1.languages = ["python", "javascript"]
+        self.repo1.save()
+
+        self.repo2 = self.create_repo(
+            project=self.project2,
+            name="getsentry/relay",
+            provider="integrations:github",
+            external_id="456",
+            integration_id=self.integration.id,
+        )
+        self.repo2.languages = ["rust"]
+        self.repo2.save()
+
+        self.create_code_mapping(
+            project=self.project1,
+            repo=self.repo1,
+            organization_integration=self.org_integration,
+        )
+        self.create_code_mapping(
+            project=self.project2,
+            repo=self.repo2,
+            organization_integration=self.org_integration,
+        )
+
+    @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
+    def test_returns_early_when_option_disabled(self, mock_request) -> None:
+        with override_options({"explorer.context_engine_indexing.enable": False}):
+            index_repos(self.org.id)
+        mock_request.assert_not_called()
+
+    @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
+    def test_returns_early_when_feature_flag_disabled(self, mock_request) -> None:
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            index_repos(self.org.id)
+        mock_request.assert_not_called()
+
+    @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
+    def test_returns_early_when_no_projects(self, mock_request) -> None:
+        org_without_projects = self.create_organization()
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            with self.feature({"organizations:context-engine-experiments": True}):
+                index_repos(org_without_projects.id)
+        mock_request.assert_not_called()
+
+    @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
+    def test_calls_seer_with_correct_org_and_repos(self, mock_request) -> None:
+        mock_request.return_value.status = 200
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            with self.feature({"organizations:context-engine-experiments": True}):
+                index_repos(self.org.id)
+
+        mock_request.assert_called_once()
+        body = mock_request.call_args[0][0]
+        assert body["org_id"] == self.org.id
+        repos = body["repos"]
+        assert len(repos) == 2
+
+        repos_by_name = {r["name"]: r for r in repos}
+        sentry_repo = repos_by_name["sentry"]
+        assert sentry_repo["provider"] == "integrations:github"
+        assert sentry_repo["owner"] == "getsentry"
+        assert sentry_repo["external_id"] == "123"
+        assert sentry_repo["languages"] == ["python", "javascript"]
+        assert sentry_repo["project_ids"] == [self.project1.id]
+        assert sentry_repo["integration_id"] == str(self.integration.id)
+
+        relay_repo = repos_by_name["relay"]
+        assert relay_repo["provider"] == "integrations:github"
+        assert relay_repo["owner"] == "getsentry"
+        assert relay_repo["external_id"] == "456"
+        assert relay_repo["languages"] == ["rust"]
+        assert relay_repo["project_ids"] == [self.project2.id]
+        assert relay_repo["integration_id"] == str(self.integration.id)
+
+    @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
+    def test_deduplicates_repos_across_projects(self, mock_request) -> None:
+        mock_request.return_value.status = 200
+        # Map project2 to the same repo as project1
+        self.create_code_mapping(
+            project=self.project2,
+            repo=self.repo1,
+            organization_integration=self.org_integration,
+            stack_root="src/",
+            source_root="src/",
+        )
+
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            with self.feature({"organizations:context-engine-experiments": True}):
+                index_repos(self.org.id)
+
+        mock_request.assert_called_once()
+        body = mock_request.call_args[0][0]
+        repos = body["repos"]
+        repos_by_name = {r["name"]: r for r in repos}
+
+        sentry_repo = repos_by_name["sentry"]
+        assert sorted(sentry_repo["project_ids"]) == sorted([self.project1.id, self.project2.id])
 
 
 @django_db_all

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -253,35 +253,48 @@ class TestIndexRepos(TestCase):
             organization_integration=self.org_integration,
         )
 
+    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
-    def test_returns_early_when_option_disabled(self, mock_request) -> None:
+    def test_returns_early_when_option_disabled(
+        self, mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+    ) -> None:
         with override_options({"explorer.context_engine_indexing.enable": False}):
             index_repos(self.org.id)
-        mock_request.assert_not_called()
+        mock_make_org_repo_knowledge_index_request.assert_not_called()
 
+    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
-    def test_returns_early_when_feature_flag_disabled(self, mock_request) -> None:
+    def test_returns_early_when_feature_flag_disabled(
+        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+    ) -> None:
         with override_options({"explorer.context_engine_indexing.enable": True}):
             index_repos(self.org.id)
-        mock_request.assert_not_called()
+        mock_mock_make_org_repo_knowledge_index_request.assert_not_called()
 
+    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
-    def test_returns_early_when_no_projects(self, mock_request) -> None:
+    def test_returns_early_when_no_projects(
+        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+    ) -> None:
         org_without_projects = self.create_organization()
         with override_options({"explorer.context_engine_indexing.enable": True}):
             with self.feature({"organizations:context-engine-experiments": True}):
                 index_repos(org_without_projects.id)
-        mock_request.assert_not_called()
+        mock_mock_make_org_repo_knowledge_index_request.assert_not_called()
 
+    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
-    def test_calls_seer_with_correct_org_and_repos(self, mock_request) -> None:
-        mock_request.return_value.status = 200
+    def test_calls_seer_with_correct_org_and_repos(
+        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+    ) -> None:
+        mock_bulk_get_project_preferences.return_value = {}
+        mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
         with override_options({"explorer.context_engine_indexing.enable": True}):
             with self.feature({"organizations:context-engine-experiments": True}):
                 index_repos(self.org.id)
 
-        mock_request.assert_called_once()
-        body = mock_request.call_args[0][0]
+        mock_mock_make_org_repo_knowledge_index_request.assert_called_once()
+        body = mock_mock_make_org_repo_knowledge_index_request.call_args[0][0]
         assert body["org_id"] == self.org.id
         repos = body["repos"]
         assert len(repos) == 2
@@ -303,9 +316,13 @@ class TestIndexRepos(TestCase):
         assert relay_repo["project_ids"] == [self.project2.id]
         assert relay_repo["integration_id"] == str(self.integration.id)
 
+    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
-    def test_deduplicates_repos_across_projects(self, mock_request) -> None:
-        mock_request.return_value.status = 200
+    def test_deduplicates_repos_across_projects(
+        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+    ) -> None:
+        mock_bulk_get_project_preferences.return_value = {}
+        mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
         # Map project2 to the same repo as project1
         self.create_code_mapping(
             project=self.project2,
@@ -319,13 +336,57 @@ class TestIndexRepos(TestCase):
             with self.feature({"organizations:context-engine-experiments": True}):
                 index_repos(self.org.id)
 
-        mock_request.assert_called_once()
-        body = mock_request.call_args[0][0]
+        mock_mock_make_org_repo_knowledge_index_request.assert_called_once()
+        body = mock_mock_make_org_repo_knowledge_index_request.call_args[0][0]
         repos = body["repos"]
         repos_by_name = {r["name"]: r for r in repos}
 
         sentry_repo = repos_by_name["sentry"]
         assert sorted(sentry_repo["project_ids"]) == sorted([self.project1.id, self.project2.id])
+
+    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
+    @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
+    def test_uses_seer_project_preferences_if_available(
+        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+    ) -> None:
+        mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
+        # Map project2 to the same repo as project1
+        self.create_code_mapping(
+            project=self.project2,
+            repo=self.repo1,
+            organization_integration=self.org_integration,
+            stack_root="src/",
+            source_root="src/",
+        )
+
+        mock_bulk_get_project_preferences.return_value = {
+            str(self.project1.id): {
+                "repositories": [
+                    {
+                        "name": "sentry-seer",
+                        "owner": "getsentry",
+                        "provider": "integrations:github",
+                        "external_id": "999",
+                        "integration_id": "000",
+                    }
+                ],
+            },
+            str(self.project2.id): {
+                "repositories": None,
+            },
+        }
+
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            with self.feature({"organizations:context-engine-experiments": True}):
+                index_repos(self.org.id)
+
+        mock_mock_make_org_repo_knowledge_index_request.assert_called_once()
+        body = mock_mock_make_org_repo_knowledge_index_request.call_args[0][0]
+        repos = body["repos"]
+        repos_by_name = {r["name"]: r for r in repos}
+
+        sentry_repo = repos_by_name["sentry-seer"]
+        assert sorted(sentry_repo["project_ids"]) == sorted([self.project1.id])
 
 
 @django_db_all


### PR DESCRIPTION
Schedule repo indexing job for context engine. This is behind a new
"experimental" feature flag so we can see how this context works
out on sentry seer explorer runs. Only runs index
job on Sunday because we don't want to eat into GH API quotas and
interfere with code review and autofix.

Depends on: https://github.com/getsentry/seer/pull/5594