### PR TITLE
ref(preprod): Dispatch only taskbroker when rollout flag is enabled

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
@@ -24,7 +24,7 @@ from sentry.preprod.models import (
 )
 from sentry.preprod.producer import PreprodFeature, produce_preprod_artifact_to_kafka
 from sentry.preprod.quotas import should_run_distribution, should_run_size
-from sentry.preprod.tasks import _dispatch_taskbroker
+from sentry.preprod.tasks import dispatch_taskbroker
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ class PreprodArtifactRerunAnalysisEndpoint(PreprodArtifactEndpoint):
         reset_artifact_data(head_artifact)
 
         if features.has("organizations:launchpad-taskbroker-rollout", organization):
-            dispatched = _dispatch_taskbroker(
+            dispatched = dispatch_taskbroker(
                 head_artifact.project.id, organization.id, head_artifact_id
             )
         else:
@@ -183,7 +183,7 @@ class PreprodArtifactAdminRerunAnalysisEndpoint(Endpoint):
 
         organization = preprod_artifact.project.organization
         if features.has("organizations:launchpad-taskbroker-rollout", organization):
-            dispatched = _dispatch_taskbroker(
+            dispatched = dispatch_taskbroker(
                 preprod_artifact.project.id, organization.id, preprod_artifact_id
             )
         else:

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
@@ -8,7 +8,7 @@ from django.db import router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint, internal_cell_silo_endpoint
@@ -24,6 +24,7 @@ from sentry.preprod.models import (
 )
 from sentry.preprod.producer import PreprodFeature, produce_preprod_artifact_to_kafka
 from sentry.preprod.quotas import should_run_distribution, should_run_size
+from sentry.preprod.tasks import _dispatch_taskbroker
 
 logger = logging.getLogger(__name__)
 
@@ -79,26 +80,35 @@ class PreprodArtifactRerunAnalysisEndpoint(PreprodArtifactEndpoint):
             cleanup_old_metrics(head_artifact)
         reset_artifact_data(head_artifact)
 
-        try:
-            produce_preprod_artifact_to_kafka(
-                project_id=head_artifact.project.id,
-                organization_id=organization.id,
-                artifact_id=head_artifact_id,
-                requested_features=requested_features,
+        if features.has("organizations:launchpad-taskbroker-rollout", organization):
+            dispatched = _dispatch_taskbroker(
+                head_artifact.project.id, organization.id, head_artifact_id
             )
-        except Exception:
-            logger.exception(
-                "preprod_artifact.rerun_analysis.kafka_error",
-                extra={
-                    "artifact_id": head_artifact_id,
-                    "user_id": request.user.id,
-                    "organization_id": organization.id,
-                    "project_id": head_artifact.project.id,
-                },
-            )
+        else:
+            try:
+                produce_preprod_artifact_to_kafka(
+                    project_id=head_artifact.project.id,
+                    organization_id=organization.id,
+                    artifact_id=head_artifact_id,
+                    requested_features=requested_features,
+                )
+                dispatched = True
+            except Exception:
+                logger.exception(
+                    "preprod_artifact.rerun_analysis.dispatch_error",
+                    extra={
+                        "artifact_id": head_artifact_id,
+                        "user_id": request.user.id,
+                        "organization_id": organization.id,
+                        "project_id": head_artifact.project.id,
+                    },
+                )
+                dispatched = False
+
+        if not dispatched:
             return Response(
                 {
-                    "error": f"Failed to queue analysis for artifact {head_artifact_id}",
+                    "detail": f"Failed to queue analysis for artifact {head_artifact_id}",
                 },
                 status=500,
             )
@@ -171,31 +181,40 @@ class PreprodArtifactAdminRerunAnalysisEndpoint(Endpoint):
         cleanup_stats = cleanup_old_metrics(preprod_artifact)
         reset_artifact_data(preprod_artifact)
 
-        try:
-            # Admin endpoint bypasses quota checks and requests all features
-            produce_preprod_artifact_to_kafka(
-                project_id=preprod_artifact.project.id,
-                organization_id=preprod_artifact.project.organization_id,
-                artifact_id=preprod_artifact_id,
-                requested_features=[
-                    PreprodFeature.SIZE_ANALYSIS,
-                    PreprodFeature.BUILD_DISTRIBUTION,
-                ],
+        organization = preprod_artifact.project.organization
+        if features.has("organizations:launchpad-taskbroker-rollout", organization):
+            dispatched = _dispatch_taskbroker(
+                preprod_artifact.project.id, organization.id, preprod_artifact_id
             )
-        except Exception as e:
-            logger.exception(
-                "preprod_artifact.admin_rerun_analysis.kafka_error",
-                extra={
-                    "artifact_id": preprod_artifact_id,
-                    "user_id": request.user.id,
-                    "organization_id": preprod_artifact.project.organization_id,
-                    "project_id": preprod_artifact.project.id,
-                    "error": str(e),
-                },
-            )
+        else:
+            try:
+                produce_preprod_artifact_to_kafka(
+                    project_id=preprod_artifact.project.id,
+                    organization_id=organization.id,
+                    artifact_id=preprod_artifact_id,
+                    requested_features=[
+                        PreprodFeature.SIZE_ANALYSIS,
+                        PreprodFeature.BUILD_DISTRIBUTION,
+                    ],
+                )
+                dispatched = True
+            except Exception as e:
+                logger.exception(
+                    "preprod_artifact.admin_rerun_analysis.dispatch_error",
+                    extra={
+                        "artifact_id": preprod_artifact_id,
+                        "user_id": request.user.id,
+                        "organization_id": organization.id,
+                        "project_id": preprod_artifact.project.id,
+                        "error": str(e),
+                    },
+                )
+                dispatched = False
+
+        if not dispatched:
             return Response(
                 {
-                    "error": f"Failed to queue analysis for artifact {preprod_artifact_id}",
+                    "detail": f"Failed to queue analysis for artifact {preprod_artifact_id}",
                 },
                 status=500,
             )

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
@@ -151,14 +151,14 @@ class PreprodArtifactAdminRerunAnalysisEndpoint(Endpoint):
         try:
             data = orjson.loads(request.body)
         except (orjson.JSONDecodeError, TypeError):
-            return Response({"error": "Invalid JSON body"}, status=400)
+            return Response({"detail": "Invalid JSON body"}, status=400)
 
         preprod_artifact_id = data.get("preprod_artifact_id")
         try:
             preprod_artifact_id = int(preprod_artifact_id)
         except (ValueError, TypeError):
             return Response(
-                {"error": "preprod_artifact_id is required and must be a valid integer"},
+                {"detail": "preprod_artifact_id is required and must be a valid integer"},
                 status=400,
             )
 
@@ -166,7 +166,7 @@ class PreprodArtifactAdminRerunAnalysisEndpoint(Endpoint):
             preprod_artifact = PreprodArtifact.objects.get(id=preprod_artifact_id)
         except PreprodArtifact.DoesNotExist:
             return Response(
-                {"error": f"Preprod artifact {preprod_artifact_id} not found"}, status=404
+                {"detail": f"Preprod artifact {preprod_artifact_id} not found"}, status=404
             )
 
         analytics.record(

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -166,7 +166,9 @@ def assemble_preprod_artifact(
             pass
 
     if features.has("organizations:launchpad-taskbroker-rollout", organization):
-        _dispatch_taskbroker_shadow(project_id, org_id, artifact_id)
+        taskbroker_dispatched = _dispatch_taskbroker(project_id, org_id, artifact_id)
+        if not taskbroker_dispatched:
+            return
     else:
         kafka_dispatched = _dispatch_kafka(project_id, org_id, artifact_id, checksum)
         if not kafka_dispatched:
@@ -1013,13 +1015,10 @@ def _dispatch_kafka(project_id: int, org_id: int, artifact_id: int, checksum: st
         return False
 
 
-def _dispatch_taskbroker_shadow(project_id: int, org_id: int, artifact_id: int) -> None:
-    # TODO: When taskbroker becomes the primary path, add PreprodArtifactSizeMetrics
-    # state management here (mirroring project_preprod_artifact_update.py). Currently
-    # omitted to avoid racing with the primary Kafka consumer path.
+def _dispatch_taskbroker(project_id: int, org_id: int, artifact_id: int) -> bool:
     try:
         logger.info(
-            "preprod.dispatch_taskbroker_shadow",
+            "preprod.dispatch_taskbroker",
             extra={
                 "project_id": project_id,
                 "organization_id": org_id,
@@ -1032,12 +1031,27 @@ def _dispatch_taskbroker_shadow(project_id: int, org_id: int, artifact_id: int) 
             project_id=str(project_id),
             organization_id=str(org_id),
         )
-    except Exception:
+        return True
+    except Exception as e:
+        user_friendly_error_message = "Failed to dispatch preprod artifact event for analysis"
+        sentry_sdk.capture_exception(e)
         logger.exception(
-            "Failed to dispatch shadow taskbroker event",
+            user_friendly_error_message,
             extra={
                 "project_id": project_id,
                 "organization_id": org_id,
                 "preprod_artifact_id": artifact_id,
             },
         )
+        PreprodArtifact.objects.filter(id=artifact_id).update(
+            state=PreprodArtifact.ArtifactState.FAILED,
+            error_code=PreprodArtifact.ErrorCode.ARTIFACT_PROCESSING_ERROR,
+            error_message=user_friendly_error_message,
+        )
+        create_preprod_status_check_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": artifact_id,
+                "caller": "assemble_dispatch_error",
+            }
+        )
+        return False

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -167,13 +167,13 @@ def assemble_preprod_artifact(
 
     if features.has("organizations:launchpad-taskbroker-rollout", organization):
         _dispatch_taskbroker_shadow(project_id, org_id, artifact_id)
-
-    kafka_dispatched = _dispatch_kafka(project_id, org_id, artifact_id, checksum)
-    if not kafka_dispatched:
-        return
+    else:
+        kafka_dispatched = _dispatch_kafka(project_id, org_id, artifact_id, checksum)
+        if not kafka_dispatched:
+            return
 
     logger.info(
-        "Finished preprod artifact row creation and kafka dispatch",
+        "Finished preprod artifact dispatch",
         extra={
             "preprod_artifact_id": artifact_id,
             "project_id": project_id,

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -166,7 +166,7 @@ def assemble_preprod_artifact(
             pass
 
     if features.has("organizations:launchpad-taskbroker-rollout", organization):
-        taskbroker_dispatched = _dispatch_taskbroker(project_id, org_id, artifact_id)
+        taskbroker_dispatched = dispatch_taskbroker(project_id, org_id, artifact_id)
         if not taskbroker_dispatched:
             return
     else:
@@ -1015,7 +1015,7 @@ def _dispatch_kafka(project_id: int, org_id: int, artifact_id: int, checksum: st
         return False
 
 
-def _dispatch_taskbroker(project_id: int, org_id: int, artifact_id: int) -> bool:
+def dispatch_taskbroker(project_id: int, org_id: int, artifact_id: int) -> bool:
     try:
         logger.info(
             "preprod.dispatch_taskbroker",

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -1032,9 +1032,8 @@ def dispatch_taskbroker(project_id: int, org_id: int, artifact_id: int) -> bool:
             organization_id=str(org_id),
         )
         return True
-    except Exception as e:
+    except Exception:
         user_friendly_error_message = "Failed to dispatch preprod artifact event for analysis"
-        sentry_sdk.capture_exception(e)
         logger.exception(
             user_friendly_error_message,
             extra={

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_analysis.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_analysis.py
@@ -275,14 +275,14 @@ class PreprodArtifactRerunAnalysisTest(BaseRerunAnalysisTest):
         assert PreprodFeature.BUILD_DISTRIBUTION in call_kwargs["requested_features"]
 
     @patch(
-        "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis._dispatch_taskbroker",
+        "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis.dispatch_taskbroker",
         return_value=True,
     )
     @patch(
         "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis.produce_preprod_artifact_to_kafka"
     )
     def test_rerun_dispatches_via_taskbroker_when_flag_enabled(
-        self, mock_produce_to_kafka, mock_dispatch_taskbroker
+        self, mock_produce_to_kafka, mockdispatch_taskbroker
     ):
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -297,7 +297,7 @@ class PreprodArtifactRerunAnalysisTest(BaseRerunAnalysisTest):
             self.get_success_response(self.organization.slug, artifact.id, status_code=200)
 
         mock_produce_to_kafka.assert_not_called()
-        mock_dispatch_taskbroker.assert_called_once()
+        mockdispatch_taskbroker.assert_called_once()
 
     @patch(
         "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis.produce_preprod_artifact_to_kafka"
@@ -426,14 +426,14 @@ class PreprodArtifactAdminRerunAnalysisTest(BaseRerunAnalysisTest):
         )
 
     @patch(
-        "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis._dispatch_taskbroker",
+        "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis.dispatch_taskbroker",
         return_value=True,
     )
     @patch(
         "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis.produce_preprod_artifact_to_kafka"
     )
     def test_rerun_dispatches_via_taskbroker_when_flag_enabled(
-        self, mock_produce_to_kafka, mock_dispatch_taskbroker
+        self, mock_produce_to_kafka, mockdispatch_taskbroker
     ):
         artifact = self.create_preprod_artifact(
             project=self.project,
@@ -448,4 +448,4 @@ class PreprodArtifactAdminRerunAnalysisTest(BaseRerunAnalysisTest):
             self.get_success_response(preprod_artifact_id=artifact.id, status_code=200)
 
         mock_produce_to_kafka.assert_not_called()
-        mock_dispatch_taskbroker.assert_called_once()
+        mockdispatch_taskbroker.assert_called_once()

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_analysis.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_analysis.py
@@ -275,6 +275,31 @@ class PreprodArtifactRerunAnalysisTest(BaseRerunAnalysisTest):
         assert PreprodFeature.BUILD_DISTRIBUTION in call_kwargs["requested_features"]
 
     @patch(
+        "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis._dispatch_taskbroker",
+        return_value=True,
+    )
+    @patch(
+        "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis.produce_preprod_artifact_to_kafka"
+    )
+    def test_rerun_dispatches_via_taskbroker_when_flag_enabled(
+        self, mock_produce_to_kafka, mock_dispatch_taskbroker
+    ):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            app_name="MyApp",
+            app_id="com.my.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        with self.feature("organizations:launchpad-taskbroker-rollout"):
+            self.get_success_response(self.organization.slug, artifact.id, status_code=200)
+
+        mock_produce_to_kafka.assert_not_called()
+        mock_dispatch_taskbroker.assert_called_once()
+
+    @patch(
         "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis.produce_preprod_artifact_to_kafka"
     )
     def test_rerun_analysis_includes_feature_on_invalid_query(self, mock_produce_to_kafka):
@@ -399,3 +424,28 @@ class PreprodArtifactAdminRerunAnalysisTest(BaseRerunAnalysisTest):
         assert (
             "preprod_artifact_id is required and must be a valid integer" in response.data["error"]
         )
+
+    @patch(
+        "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis._dispatch_taskbroker",
+        return_value=True,
+    )
+    @patch(
+        "sentry.preprod.api.endpoints.preprod_artifact_rerun_analysis.produce_preprod_artifact_to_kafka"
+    )
+    def test_rerun_dispatches_via_taskbroker_when_flag_enabled(
+        self, mock_produce_to_kafka, mock_dispatch_taskbroker
+    ):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            app_name="MyApp",
+            app_id="com.my.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        with self.feature("organizations:launchpad-taskbroker-rollout"):
+            self.get_success_response(preprod_artifact_id=artifact.id, status_code=200)
+
+        mock_produce_to_kafka.assert_not_called()
+        mock_dispatch_taskbroker.assert_called_once()

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_analysis.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_rerun_analysis.py
@@ -417,12 +417,12 @@ class PreprodArtifactAdminRerunAnalysisTest(BaseRerunAnalysisTest):
 
     def test_rerun_analysis_not_found(self) -> None:
         response = self.get_error_response(preprod_artifact_id=999999, status_code=404)
-        assert "not found" in response.data["error"]
+        assert "not found" in response.data["detail"]
 
     def test_rerun_analysis_invalid_id(self) -> None:
         response = self.get_error_response(preprod_artifact_id="invalid", status_code=400)
         assert (
-            "preprod_artifact_id is required and must be a valid integer" in response.data["error"]
+            "preprod_artifact_id is required and must be a valid integer" in response.data["detail"]
         )
 
     @patch(

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -469,7 +469,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
 
     @patch("sentry.preprod.tasks._dispatch_taskbroker_shadow")
     @patch("sentry.preprod.tasks.produce_preprod_artifact_to_kafka")
-    def test_shadow_taskbroker_dispatched_when_flag_enabled(
+    def test_only_taskbroker_dispatched_when_flag_enabled(
         self, mock_produce_to_kafka, mock_shadow
     ) -> None:
         content = b"test shadow taskbroker dispatch"
@@ -495,7 +495,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
                 artifact_id=artifact.id,
             )
 
-        mock_produce_to_kafka.assert_called_once()
+        mock_produce_to_kafka.assert_not_called()
         mock_shadow.assert_called_once_with(self.project.id, self.organization.id, artifact.id)
 
     @patch("sentry.preprod.tasks._dispatch_taskbroker_shadow")
@@ -530,10 +530,10 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
 
     @patch("sentry.preprod.tasks._dispatch_taskbroker_shadow")
     @patch("sentry.preprod.tasks.produce_preprod_artifact_to_kafka")
-    def test_shadow_taskbroker_dispatched_after_kafka(
+    def test_only_kafka_dispatched_when_flag_disabled(
         self, mock_produce_to_kafka, mock_shadow
     ) -> None:
-        content = b"test shadow taskbroker dispatch ordering"
+        content = b"test only kafka dispatch when flag disabled"
         fileobj = ContentFile(content)
         total_checksum = sha1(content).hexdigest()
 
@@ -547,17 +547,16 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         )
         assert artifact is not None
 
-        with self.feature("organizations:launchpad-taskbroker-rollout"):
-            assemble_preprod_artifact(
-                org_id=self.organization.id,
-                project_id=self.project.id,
-                checksum=total_checksum,
-                chunks=[blob.checksum],
-                artifact_id=artifact.id,
-            )
+        assemble_preprod_artifact(
+            org_id=self.organization.id,
+            project_id=self.project.id,
+            checksum=total_checksum,
+            chunks=[blob.checksum],
+            artifact_id=artifact.id,
+        )
 
         mock_produce_to_kafka.assert_called_once()
-        mock_shadow.assert_called_once()
+        mock_shadow.assert_not_called()
         artifact.refresh_from_db()
         assert artifact.state != PreprodArtifact.ArtifactState.FAILED
 

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -467,7 +467,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         call_kwargs = mock_produce_to_kafka.call_args[1]
         assert PreprodFeature.SIZE_ANALYSIS in call_kwargs["requested_features"]
 
-    @patch("sentry.preprod.tasks._dispatch_taskbroker")
+    @patch("sentry.preprod.tasks.dispatch_taskbroker")
     @patch("sentry.preprod.tasks.produce_preprod_artifact_to_kafka")
     def test_only_taskbroker_dispatched_when_flag_enabled(
         self, mock_produce_to_kafka, mock_shadow
@@ -498,37 +498,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         mock_produce_to_kafka.assert_not_called()
         mock_shadow.assert_called_once_with(self.project.id, self.organization.id, artifact.id)
 
-    @patch("sentry.preprod.tasks._dispatch_taskbroker")
-    @patch("sentry.preprod.tasks.produce_preprod_artifact_to_kafka")
-    def test_shadow_taskbroker_not_dispatched_when_flag_disabled(
-        self, mock_produce_to_kafka, mock_shadow
-    ) -> None:
-        content = b"test shadow taskbroker not dispatched"
-        fileobj = ContentFile(content)
-        total_checksum = sha1(content).hexdigest()
-
-        blob = FileBlob.from_file_with_organization(fileobj, self.organization)
-
-        artifact = create_preprod_artifact(
-            org_id=self.organization.id,
-            project_id=self.project.id,
-            checksum=total_checksum,
-            build_configuration_name="release",
-        )
-        assert artifact is not None
-
-        assemble_preprod_artifact(
-            org_id=self.organization.id,
-            project_id=self.project.id,
-            checksum=total_checksum,
-            chunks=[blob.checksum],
-            artifact_id=artifact.id,
-        )
-
-        mock_produce_to_kafka.assert_called_once()
-        mock_shadow.assert_not_called()
-
-    @patch("sentry.preprod.tasks._dispatch_taskbroker")
+    @patch("sentry.preprod.tasks.dispatch_taskbroker")
     @patch("sentry.preprod.tasks.produce_preprod_artifact_to_kafka")
     def test_only_kafka_dispatched_when_flag_disabled(
         self, mock_produce_to_kafka, mock_shadow

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -467,7 +467,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         call_kwargs = mock_produce_to_kafka.call_args[1]
         assert PreprodFeature.SIZE_ANALYSIS in call_kwargs["requested_features"]
 
-    @patch("sentry.preprod.tasks._dispatch_taskbroker_shadow")
+    @patch("sentry.preprod.tasks._dispatch_taskbroker")
     @patch("sentry.preprod.tasks.produce_preprod_artifact_to_kafka")
     def test_only_taskbroker_dispatched_when_flag_enabled(
         self, mock_produce_to_kafka, mock_shadow
@@ -498,7 +498,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         mock_produce_to_kafka.assert_not_called()
         mock_shadow.assert_called_once_with(self.project.id, self.organization.id, artifact.id)
 
-    @patch("sentry.preprod.tasks._dispatch_taskbroker_shadow")
+    @patch("sentry.preprod.tasks._dispatch_taskbroker")
     @patch("sentry.preprod.tasks.produce_preprod_artifact_to_kafka")
     def test_shadow_taskbroker_not_dispatched_when_flag_disabled(
         self, mock_produce_to_kafka, mock_shadow
@@ -528,7 +528,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         mock_produce_to_kafka.assert_called_once()
         mock_shadow.assert_not_called()
 
-    @patch("sentry.preprod.tasks._dispatch_taskbroker_shadow")
+    @patch("sentry.preprod.tasks._dispatch_taskbroker")
     @patch("sentry.preprod.tasks.produce_preprod_artifact_to_kafka")
     def test_only_kafka_dispatched_when_flag_disabled(
         self, mock_produce_to_kafka, mock_shadow


### PR DESCRIPTION
When `launchpad-taskbroker-rollout` is enabled, the preprod artifact assembly
was dispatching to both taskbroker and kafka. This changes it to dispatch
exclusively via taskbroker when the flag is on, with kafka remaining the sole
dispatch path when the flag is off.

This is the expected behavior for a rollout flag — it should switch between
the old and new path, not run both simultaneously.