### PR TITLE
ref(cells): DestinationType.SENTRY_REGION -> DestinationType.SENTRY_CELL

### DIFF
--- a/src/sentry/hybridcloud/models/webhookpayload.py
+++ b/src/sentry/hybridcloud/models/webhookpayload.py
@@ -20,7 +20,7 @@ BACKOFF_RATE = 1.4
 
 
 class DestinationType(TextChoices):
-    SENTRY_REGION = "sentry_region"
+    SENTRY_CELL = "sentry_region"
     CODECOV = "codecov"
 
 
@@ -34,7 +34,7 @@ class WebhookPayload(Model):
     # Destination attributes
     # Table is constantly being deleted from so let's make this non-nullable with a default value, since the table should be small at any given point in time.
     destination_type = models.CharField(
-        choices=DestinationType.choices, null=False, db_default=DestinationType.SENTRY_REGION
+        choices=DestinationType.choices, null=False, db_default=DestinationType.SENTRY_CELL
     )
     cell_name = models.CharField(null=True, db_column="region_name")
 
@@ -81,7 +81,7 @@ class WebhookPayload(Model):
 
         constraints = [
             models.CheckConstraint(
-                condition=~Q(destination_type=DestinationType.SENTRY_REGION)
+                condition=~Q(destination_type=DestinationType.SENTRY_CELL)
                 | Q(cell_name__isnull=False),
                 name="webhookpayload_region_name_not_null",
             ),

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -436,9 +436,7 @@ def _record_delivery_time_metrics(payload: WebhookPayload) -> None:
     """Record delivery time metrics for a successfully delivered webhook payload."""
     duration = timezone.now() - payload.date_added
     cell_sent_to = (
-        payload.cell_name
-        if payload.destination_type == DestinationType.SENTRY_REGION
-        else "codecov"
+        payload.cell_name if payload.destination_type == DestinationType.SENTRY_CELL else "codecov"
     )
     tags = {"region_sent_to": cell_sent_to} | _get_github_delivery_time_tags(payload)
     metrics.distribution(
@@ -622,7 +620,7 @@ def perform_request(payload: WebhookPayload) -> None:
     destination_type = payload.destination_type
 
     match destination_type:
-        case DestinationType.SENTRY_REGION:
+        case DestinationType.SENTRY_CELL:
             assert payload.cell_name is not None
             cell = get_cell_by_name(name=payload.cell_name)
             perform_cell_request(cell, payload)

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -181,7 +181,7 @@ class BaseRequestParser(ABC):
         # this loop. Create all payloads first, then trigger a single drain.
         payloads = [
             WebhookPayload.create_from_request(
-                destination_type=DestinationType.SENTRY_REGION,
+                destination_type=DestinationType.SENTRY_CELL,
                 cell=cell.name,
                 provider=self.provider,
                 identifier=shard_identifier,

--- a/tests/sentry/hybridcloud/models/test_webhookpayload.py
+++ b/tests/sentry/hybridcloud/models/test_webhookpayload.py
@@ -24,7 +24,7 @@ class WebhookPayloadTest(TestCase):
             content_type="application/json",
         )
         hook = WebhookPayload.create_from_request(
-            destination_type=DestinationType.SENTRY_REGION,
+            destination_type=DestinationType.SENTRY_CELL,
             cell="us",
             provider="github",
             identifier=123,

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -128,7 +128,7 @@ class BaseRequestParserTest(TestCase):
             assert payload.mailbox_name == "slack:0"
             assert payload.request_path
             assert payload.request_method
-            assert payload.destination_type == DestinationType.SENTRY_REGION
+            assert payload.destination_type == DestinationType.SENTRY_CELL
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_options({"codecov.forward-webhooks.rollout": 1.0})

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -188,7 +188,7 @@ class GithubRequestParserTest(TestCase):
             request=request,
             mailbox_name=f"github:{integration.id}",
             cell_names=[cell.name],
-            destination_types={DestinationType.SENTRY_REGION: 1},
+            destination_types={DestinationType.SENTRY_CELL: 1},
         )
         assert_webhook_payloads_for_mailbox(
             request=request,
@@ -224,7 +224,7 @@ class GithubRequestParserTest(TestCase):
             request=request,
             mailbox_name=f"github:{integration.id}",
             cell_names=[cell.name],
-            destination_types={DestinationType.SENTRY_REGION: 1},
+            destination_types={DestinationType.SENTRY_CELL: 1},
         )
         with pytest.raises(
             Exception,
@@ -265,7 +265,7 @@ class GithubRequestParserTest(TestCase):
             request=request,
             mailbox_name=f"github:{integration.id}",
             cell_names=[cell.name],
-            destination_types={DestinationType.SENTRY_REGION: 1},
+            destination_types={DestinationType.SENTRY_CELL: 1},
         )
         with pytest.raises(
             Exception,
@@ -341,7 +341,7 @@ class GithubRequestParserTest(TestCase):
             request=request,
             mailbox_name=f"github:{integration.id}",
             cell_names=[cell.name],
-            destination_types={DestinationType.SENTRY_REGION: 1},
+            destination_types={DestinationType.SENTRY_CELL: 1},
         )
 
 


### PR DESCRIPTION
this updates the enum name in line with the proper cell naming conventions,

the enum value is unchanged since it's already stored in the db
