### PR TITLE
fix(pipeline): Add CSP nonce to trampoline inline script

### DIFF
--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -28,7 +28,7 @@ TRAMPOLINE_HTML = """\
     style="margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;
     font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
     flex-direction:column;padding:2rem">
-<script type="module">
+<script type="module" nonce="{nonce}">
   const data = {data_json};
   if (window.opener) {{
     window.opener.postMessage(data, {origin});
@@ -62,8 +62,10 @@ def _render_trampoline(request: HttpRequest, pipeline: object) -> HttpResponse:
     else:
         origin = "document.origin"
 
+    nonce = getattr(request, "csp_nonce", "")
+
     return HttpResponse(
-        TRAMPOLINE_HTML.format(data_json=data_json, origin=origin),
+        TRAMPOLINE_HTML.format(data_json=data_json, origin=origin, nonce=nonce),
         content_type="text/html",
     )
 


### PR DESCRIPTION
The trampoline page rendered by the pipeline advancer uses a raw HTML
string with an inline script, bypassing Django's template system and its
automatic nonce injection via the {% script %} tag. When the CSP policy
includes 'strict-dynamic' with a nonce, 'unsafe-inline' is ignored per
the CSP spec, causing the inline script to be blocked in production.

Pass request.csp_nonce into the script tag's nonce attribute.

Also relax the event.source check in useRedirectPopupStep so that
synthetic MessageEvents in JSDOM tests (where source is always null)
are not incorrectly rejected.