### PR TITLE
feat(preprod): Split Mobile Builds settings into tabbed interface

### DIFF
--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -41,78 +41,78 @@ export default function PreprodSettings() {
 
   const hasSnapshots = organization.features.includes('preprod-snapshots');
 
+  const availableTabs = hasSnapshots
+    ? VALID_TABS
+    : VALID_TABS.filter(tab => tab !== 'snapshots');
   const queryTab = decodeScalar(location?.query?.tab);
-  const tab: PreprodTab =
-    queryTab && VALID_TABS.includes(queryTab as PreprodTab)
-      ? (queryTab as PreprodTab)
-      : 'size';
+  const tab: PreprodTab = availableTabs.includes(queryTab as PreprodTab)
+    ? (queryTab as PreprodTab)
+    : 'size';
 
   const handleTabChange = (newTab: PreprodTab) => {
     navigate({query: {...location.query, tab: newTab}});
   };
 
   return (
-    <Fragment>
-      <Feature features="organizations:preprod-frontend-routes" renderDisabled>
-        <SentryDocumentTitle title={t('Mobile Builds')} />
-        <SettingsPageHeader
-          title={t('Mobile Builds')}
-          subtitle={t(
-            'Configure status checks and thresholds for your mobile build size analysis.'
-          )}
-          action={
-            <Grid flow="column" align="center" gap="lg">
-              <FeedbackButton />
-            </Grid>
-          }
-        />
-        <Stack gap="lg">
-          <PreprodQuotaAlert />
-          <Container borderBottom="primary">
-            <Tabs value={tab} onChange={handleTabChange}>
-              <TabList>
-                <TabList.Item key="size">{t('Size Analysis')}</TabList.Item>
-                <TabList.Item key="distribution">{t('Build Distribution')}</TabList.Item>
-                <TabList.Item key="snapshots" hidden={!hasSnapshots}>
-                  {t('Snapshots')}
-                </TabList.Item>
-              </TabList>
-            </Tabs>
-          </Container>
-          {tab === 'size' && (
-            <Fragment>
-              <FeatureFilter
-                enabledReadKey={SIZE_ENABLED_READ_KEY}
-                enabledWriteKey={SIZE_ENABLED_WRITE_KEY}
-                queryReadKey={SIZE_ENABLED_QUERY_READ_KEY}
-                queryWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
-                title={t('Size Analysis')}
-                successMessage={t('Size analysis settings updated')}
-                docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
-              />
-              <StatusCheckRules />
-            </Fragment>
-          )}
-          {tab === 'distribution' && (
-            <Fragment>
-              <FeatureFilter
-                enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
-                enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}
-                queryReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
-                queryWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
-                title={t('Build Distribution')}
-                successMessage={t('Build distribution settings updated')}
-                docsUrl="https://docs.sentry.io/product/build-distribution/"
-                display={PreprodBuildsDisplay.DISTRIBUTION}
-              />
-              <Feature features="organizations:preprod-build-distribution-pr-comments">
-                <PrCommentsToggle />
-              </Feature>
-            </Fragment>
-          )}
-          {tab === 'snapshots' && hasSnapshots && <SnapshotStatusChecks />}
-        </Stack>
-      </Feature>
-    </Fragment>
+    <Feature features="organizations:preprod-frontend-routes" renderDisabled>
+      <SentryDocumentTitle title={t('Mobile Builds')} />
+      <SettingsPageHeader
+        title={t('Mobile Builds')}
+        subtitle={t(
+          'Configure status checks and thresholds for your mobile build size analysis.'
+        )}
+        action={
+          <Grid flow="column" align="center" gap="lg">
+            <FeedbackButton />
+          </Grid>
+        }
+      />
+      <Stack gap="lg">
+        <PreprodQuotaAlert />
+        <Container borderBottom="primary">
+          <Tabs value={tab} onChange={handleTabChange}>
+            <TabList>
+              <TabList.Item key="size">{t('Size Analysis')}</TabList.Item>
+              <TabList.Item key="distribution">{t('Build Distribution')}</TabList.Item>
+              <TabList.Item key="snapshots" hidden={!hasSnapshots}>
+                {t('Snapshots')}
+              </TabList.Item>
+            </TabList>
+          </Tabs>
+        </Container>
+        {tab === 'size' && (
+          <Fragment>
+            <FeatureFilter
+              enabledReadKey={SIZE_ENABLED_READ_KEY}
+              enabledWriteKey={SIZE_ENABLED_WRITE_KEY}
+              queryReadKey={SIZE_ENABLED_QUERY_READ_KEY}
+              queryWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
+              title={t('Size Analysis')}
+              successMessage={t('Size analysis settings updated')}
+              docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
+            />
+            <StatusCheckRules />
+          </Fragment>
+        )}
+        {tab === 'distribution' && (
+          <Fragment>
+            <FeatureFilter
+              enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
+              enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}
+              queryReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
+              queryWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
+              title={t('Build Distribution')}
+              successMessage={t('Build distribution settings updated')}
+              docsUrl="https://docs.sentry.io/product/build-distribution/"
+              display={PreprodBuildsDisplay.DISTRIBUTION}
+            />
+            <Feature features="organizations:preprod-build-distribution-pr-comments">
+              <PrCommentsToggle />
+            </Feature>
+          </Fragment>
+        )}
+        {tab === 'snapshots' && <SnapshotStatusChecks />}
+      </Stack>
+    </Feature>
   );
 }

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -1,20 +1,26 @@
 import {Fragment} from 'react';
 
-import {Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {TabList, Tabs} from '@sentry/scraps/tabs';
 
 import Feature from 'sentry/components/acl/feature';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {PreprodQuotaAlert} from 'sentry/views/preprod/components/preprodQuotaAlert';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 import {FeatureFilter} from './featureFilter';
 import {PrCommentsToggle} from './prCommentsToggle';
 import {SnapshotStatusChecks} from './snapshotStatusChecks';
 import {StatusCheckRules} from './statusCheckRules';
+
+type PreprodTab = 'size' | 'distribution' | 'snapshots';
 
 const SIZE_ENABLED_READ_KEY = 'sentry:preprod_size_enabled_by_customer';
 const SIZE_ENABLED_WRITE_KEY = 'preprodSizeEnabledByCustomer';
@@ -26,52 +32,85 @@ const DISTRIBUTION_ENABLED_WRITE_KEY = 'preprodDistributionEnabledByCustomer';
 const DISTRIBUTION_ENABLED_QUERY_READ_KEY = 'sentry:preprod_distribution_enabled_query';
 const DISTRIBUTION_ENABLED_QUERY_WRITE_KEY = 'preprodDistributionEnabledQuery';
 
+const VALID_TABS: PreprodTab[] = ['size', 'distribution', 'snapshots'];
+
 export default function PreprodSettings() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const organization = useOrganization();
+
+  const hasSnapshots = organization.features.includes('preprod-snapshots');
+
+  const queryTab = decodeScalar(location?.query?.tab);
+  const tab: PreprodTab =
+    queryTab && VALID_TABS.includes(queryTab as PreprodTab)
+      ? (queryTab as PreprodTab)
+      : 'size';
+
+  const handleTabChange = (newTab: PreprodTab) => {
+    navigate({query: {...location.query, tab: newTab}});
+  };
+
   return (
     <Fragment>
       <Feature features="organizations:preprod-frontend-routes" renderDisabled>
         <SentryDocumentTitle title={t('Mobile Builds')} />
         <SettingsPageHeader
           title={t('Mobile Builds')}
+          subtitle={t(
+            'Configure status checks and thresholds for your mobile build size analysis.'
+          )}
           action={
             <Grid flow="column" align="center" gap="lg">
               <FeedbackButton />
             </Grid>
           }
         />
-        <TextBlock>
-          {t(
-            'Configure status checks and thresholds for your mobile build size analysis.'
-          )}
-        </TextBlock>
-        <PreprodQuotaAlert />
         <Stack gap="lg">
-          <FeatureFilter
-            enabledReadKey={SIZE_ENABLED_READ_KEY}
-            enabledWriteKey={SIZE_ENABLED_WRITE_KEY}
-            queryReadKey={SIZE_ENABLED_QUERY_READ_KEY}
-            queryWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
-            title={t('Size Analysis')}
-            successMessage={t('Size analysis settings updated')}
-            docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
-          />
-          <StatusCheckRules />
-          <Feature features="organizations:preprod-snapshots">
-            <SnapshotStatusChecks />
-          </Feature>
-          <FeatureFilter
-            enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
-            enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}
-            queryReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
-            queryWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
-            title={t('Build Distribution')}
-            successMessage={t('Build distribution settings updated')}
-            docsUrl="https://docs.sentry.io/product/build-distribution/"
-            display={PreprodBuildsDisplay.DISTRIBUTION}
-          />
-          <Feature features="organizations:preprod-build-distribution-pr-comments">
-            <PrCommentsToggle />
-          </Feature>
+          <PreprodQuotaAlert />
+          <Container borderBottom="primary">
+            <Tabs value={tab} onChange={handleTabChange}>
+              <TabList>
+                <TabList.Item key="size">{t('Size Analysis')}</TabList.Item>
+                <TabList.Item key="distribution">{t('Build Distribution')}</TabList.Item>
+                <TabList.Item key="snapshots" hidden={!hasSnapshots}>
+                  {t('Snapshots')}
+                </TabList.Item>
+              </TabList>
+            </Tabs>
+          </Container>
+          {tab === 'size' && (
+            <Fragment>
+              <FeatureFilter
+                enabledReadKey={SIZE_ENABLED_READ_KEY}
+                enabledWriteKey={SIZE_ENABLED_WRITE_KEY}
+                queryReadKey={SIZE_ENABLED_QUERY_READ_KEY}
+                queryWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
+                title={t('Size Analysis')}
+                successMessage={t('Size analysis settings updated')}
+                docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
+              />
+              <StatusCheckRules />
+            </Fragment>
+          )}
+          {tab === 'distribution' && (
+            <Fragment>
+              <FeatureFilter
+                enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
+                enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}
+                queryReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
+                queryWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
+                title={t('Build Distribution')}
+                successMessage={t('Build distribution settings updated')}
+                docsUrl="https://docs.sentry.io/product/build-distribution/"
+                display={PreprodBuildsDisplay.DISTRIBUTION}
+              />
+              <Feature features="organizations:preprod-build-distribution-pr-comments">
+                <PrCommentsToggle />
+              </Feature>
+            </Fragment>
+          )}
+          {tab === 'snapshots' && hasSnapshots && <SnapshotStatusChecks />}
         </Stack>
       </Feature>
     </Fragment>

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -45,7 +45,7 @@ export default function PreprodSettings() {
     ? VALID_TABS
     : VALID_TABS.filter(tab => tab !== 'snapshots');
   const queryTab = decodeScalar(location?.query?.tab);
-  const tab: PreprodTab = availableTabs.includes(queryTab as PreprodTab)
+  const tab = availableTabs.includes(queryTab as PreprodTab)
     ? (queryTab as PreprodTab)
     : 'size';
 


### PR DESCRIPTION
Split the Mobile Builds settings page into Size Analysis, Build Distribution, and Snapshots tabs using query parameter routing (`?tab=size|distribution|snapshots`).

Previously all settings were rendered in a single vertical stack. As more settings are added per product area, this becomes hard to navigate. Tabs give each area its own focused view.

- Follows the Seer/Tempest settings tab pattern with `@sentry/scraps/tabs`
- Snapshots tab hidden behind the `preprod-snapshots` feature flag
- Subtitle moved into `SettingsPageHeader` prop to match Seer layout spacing
- Tabs wrapped in `Container borderBottom="primary"` for bottom border

Refs EME-799