### PR TITLE
fix(hybrid-cloud): Add projectkey-cell-mappings to control silo URL patterns

### DIFF
--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -167,6 +167,7 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^api/0/internal/integration-proxy/$'),
   new RegExp('^api/0/internal/demo/email-capture/$'),
   new RegExp('^api/0/internal/org-cell-mappings/$'),
+  new RegExp('^api/0/internal/projectkey-cell-mappings/$'),
   new RegExp('^api/0/internal/notifications/registered-templates/$'),
   new RegExp('^api/0/tempest-ips/$'),
   new RegExp('^api/0/secret-scanning/github/$'),


### PR DESCRIPTION
Add the missing `api/0/internal/projectkey-cell-mappings/` pattern to the control silo URL inventory.

The new internal endpoint introduced in https://github.com/getsentry/sentry/pull/112017 was not added to the generated `controlsiloUrlPatterns.ts`, causing `test_no_missing_urls` to fail. Normally this file is regenerated via `getsentry django generate_controlsilo_urls`, but since that requires a getsentry environment, the pattern is added manually here.