### PR TITLE
ref(selective-testing): Add tests to always be executed in selective testing

### DIFF
--- a/.github/workflows/scripts/selective-testing/compute-selected-tests.py
+++ b/.github/workflows/scripts/selective-testing/compute-selected-tests.py
@@ -35,6 +35,11 @@ EXTRA_FILE_TO_TEST_MAPPING: dict[str, list[str]] = {
     ".github/CODEOWNERS": ["tests/sentry/api/test_api_owners.py"],
 }
 
+# Tests that should always be run, even if no files are changed.
+TESTS_TO_ALWAYS_RUN: set[str] = {
+    "tests/sentry/taskworker/test_config.py",
+}
+
 
 def _matches_trigger(file_path: str, trigger: str | re.Pattern[str]) -> bool:
     if isinstance(trigger, re.Pattern):
@@ -163,6 +168,9 @@ def main() -> int:
         if existing_changed_test_files:
             print(f"Including {len(existing_changed_test_files)} directly changed test files")
             affected_test_files.update(existing_changed_test_files)
+
+        # Include tests that should always be run
+        affected_test_files.update(TESTS_TO_ALWAYS_RUN)
 
     # Filter out any test files found via coverage lookup that no longer exist
     # (e.g. a deleted test file that covered the same source as another changed file).

--- a/.github/workflows/scripts/selective-testing/compute-selected-tests.py
+++ b/.github/workflows/scripts/selective-testing/compute-selected-tests.py
@@ -35,8 +35,8 @@ EXTRA_FILE_TO_TEST_MAPPING: dict[str, list[str]] = {
     ".github/CODEOWNERS": ["tests/sentry/api/test_api_owners.py"],
 }
 
-# Tests that should always be run, even if no files are changed.
-TESTS_TO_ALWAYS_RUN: set[str] = {
+# Tests that should always be run even if not explicitly selected.
+ALWAYS_RUN_TESTS: set[str] = {
     "tests/sentry/taskworker/test_config.py",
 }
 
@@ -170,7 +170,7 @@ def main() -> int:
             affected_test_files.update(existing_changed_test_files)
 
         # Include tests that should always be run
-        affected_test_files.update(TESTS_TO_ALWAYS_RUN)
+        affected_test_files.update(ALWAYS_RUN_TESTS)
 
     # Filter out any test files found via coverage lookup that no longer exist
     # (e.g. a deleted test file that covered the same source as another changed file).


### PR DESCRIPTION
Adds an explicit list of tests to always be ran, agnostic of what is selected in selective testing. Adds `tests/sentry/taskworker/test_config.py` as a first candidate as per @markstory 's request