### PR TITLE
ref(pipeline): Use `_pipeline_source` in tranpoline

### DIFF
--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -46,7 +46,7 @@ TRAMPOLINE_HTML = """\
 
 def _render_trampoline(request: HttpRequest, pipeline: object) -> HttpResponse:
     """Render a minimal page that posts callback params back to the opener."""
-    params: dict[str, str] = {"source": "sentry-pipeline"}
+    params: dict[str, str] = {"_pipeline_source": "sentry-pipeline"}
     for key, values in parse_qs(request.META.get("QUERY_STRING", "")).items():
         if values:
             params[key] = values[0]

--- a/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
+++ b/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
@@ -109,7 +109,7 @@ describe('OAuthLoginStep', () => {
 
     dispatchPipelineMessage({
       data: {
-        source: 'sentry-pipeline',
+        _pipeline_source: 'sentry-pipeline',
         code: 'auth-code-123',
         state: 'state-456',
         installation_id: 'inst-789',
@@ -153,7 +153,11 @@ describe('OAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
 
     dispatchPipelineMessage({
-      data: {source: 'sentry-pipeline', code: 'auth-code-123', state: 'state-456'},
+      data: {
+        _pipeline_source: 'sentry-pipeline',
+        code: 'auth-code-123',
+        state: 'state-456',
+      },
       origin: 'https://evil.example.com',
     });
 
@@ -172,7 +176,11 @@ describe('OAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
 
     dispatchPipelineMessage({
-      data: {source: 'sentry-pipeline', code: 'auth-code-123', state: 'state-456'},
+      data: {
+        _pipeline_source: 'sentry-pipeline',
+        code: 'auth-code-123',
+        state: 'state-456',
+      },
       source: null,
     });
 

--- a/static/app/components/pipeline/shared/useRedirectPopupStep.tsx
+++ b/static/app/components/pipeline/shared/useRedirectPopupStep.tsx
@@ -89,14 +89,15 @@ export function useRedirectPopupStep({
   );
 
   // Listen for postMessage from the trampoline page in the popup.
-  // The trampoline includes a `source: "sentry-pipeline"` key so we can
-  // distinguish it from unrelated messages (browser extensions, devtools, etc.).
+  // The trampoline includes a `_pipeline_source: "sentry-pipeline"` key so we
+  // can distinguish it from unrelated messages (browser extensions, devtools, etc.).
+  // Prefixed with underscore to avoid colliding with provider callback query params.
   useEffect(() => {
     function handleMessage(event: MessageEvent) {
       if (!event.data || typeof event.data !== 'object') {
         return;
       }
-      if (event.data.source !== 'sentry-pipeline') {
+      if (event.data._pipeline_source !== 'sentry-pipeline') {
         return;
       }
 
@@ -119,7 +120,7 @@ export function useRedirectPopupStep({
       popupRef.current = null;
 
       setPopupStatus('not-open');
-      const {source: _source, ...callbackData} = event.data as Record<string, string>;
+      const {_pipeline_source, ...callbackData} = event.data as Record<string, string>;
       onCallback(callbackData);
     }
 


### PR DESCRIPTION
This fixes an edge case where the trampoline may be passing through a
`source` key from the query string, but we would have overwritten it.