### PR TITLE
feat: Add ViewerContext dataclass and contextvar module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -622,6 +622,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/seer/fetch_issues/                            @getsentry/machine-learning-ai @getsentry/coding-workflows-sentry-backend
 /src/sentry/tasks/seer/                                     @getsentry/machine-learning-ai
 /tests/sentry/tasks/seer/                                   @getsentry/machine-learning-ai
+/src/sentry/viewer_context.py                               @getsentry/machine-learning-ai
+/tests/sentry/test_viewer_context.py                        @getsentry/machine-learning-ai
 ## End of ML & AI
 
 ## Issues

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import dataclasses
+import enum
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sentry.auth.services.auth import AuthenticatedToken
+
+_viewer_context_var: contextvars.ContextVar[ViewerContext | None] = contextvars.ContextVar(
+    "viewer_context", default=None
+)
+
+"""
+ViewerContext is an object propagated across codebase (and crossing service boundary) to deliver
+accurate information regarding the viewer on behalf of which the request is being made.
+
+This can be global, limited to an organization, or particular user.
+
+The proposal for this project alongside needs and specific considerations can be found in:
+https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02
+"""
+
+
+class ActorType(enum.StrEnum):
+    USER = "user"
+    SYSTEM = "system"
+    INTEGRATION = "integration"
+
+
+@dataclasses.dataclass(frozen=True)
+class ViewerContext:
+    """Identity of the caller for the current unit of work.
+
+    Set once at each entrypoint (API request, task, consumer, RPC) via
+    ``viewer_context_scope`` and readable anywhere via ``get_viewer_context``.
+
+    Frozen so that ``copy_context()`` produces a safe shallow copy when
+    propagating across threads.
+    """
+
+    organization_id: int | None = None
+    user_id: int | None = None
+    actor_type: ActorType = ActorType.USER
+
+    # Carries scopes/kind for in-process permission checks.
+    # NOT propagated across process/service boundaries.
+    token: AuthenticatedToken | None = None
+
+
+@contextlib.contextmanager
+def viewer_context_scope(ctx: ViewerContext) -> Generator[None]:
+    """Enter a viewer context for the duration of a unit of work.
+
+    Always use this instead of raw ``_viewer_context_var.set()`` —
+    it guarantees cleanup via ``reset(token)`` even on exceptions.
+    """
+    tok = _viewer_context_var.set(ctx)
+    try:
+        yield
+    finally:
+        _viewer_context_var.reset(tok)
+
+
+def get_viewer_context() -> ViewerContext | None:
+    """Return the current ``ViewerContext``, or ``None`` if not set."""
+    return _viewer_context_var.get()

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -29,6 +29,7 @@ class ActorType(enum.StrEnum):
     USER = "user"
     SYSTEM = "system"
     INTEGRATION = "integration"
+    UNKNOWN = "unknown"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -44,7 +45,7 @@ class ViewerContext:
 
     organization_id: int | None = None
     user_id: int | None = None
-    actor_type: ActorType = ActorType.USER
+    actor_type: ActorType = ActorType.UNKNOWN
 
     # Carries scopes/kind for in-process permission checks.
     # NOT propagated across process/service boundaries.

--- a/tests/sentry/test_viewer_context.py
+++ b/tests/sentry/test_viewer_context.py
@@ -19,6 +19,7 @@ class TestActorType:
         assert ActorType.USER == "user"
         assert ActorType.SYSTEM == "system"
         assert ActorType.INTEGRATION == "integration"
+        assert ActorType.UNKNOWN == "unknown"
 
 
 class TestViewerContext:
@@ -26,7 +27,7 @@ class TestViewerContext:
         ctx = ViewerContext()
         assert ctx.organization_id is None
         assert ctx.user_id is None
-        assert ctx.actor_type is ActorType.USER
+        assert ctx.actor_type is ActorType.UNKNOWN
         assert ctx.token is None
 
     def test_frozen(self):

--- a/tests/sentry/test_viewer_context.py
+++ b/tests/sentry/test_viewer_context.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import contextvars
+import dataclasses
+import threading
+
+import pytest
+
+from sentry.viewer_context import (
+    ActorType,
+    ViewerContext,
+    get_viewer_context,
+    viewer_context_scope,
+)
+
+
+class TestActorType:
+    def test_values_are_strings(self):
+        assert ActorType.USER == "user"
+        assert ActorType.SYSTEM == "system"
+        assert ActorType.INTEGRATION == "integration"
+
+
+class TestViewerContext:
+    def test_defaults(self):
+        ctx = ViewerContext()
+        assert ctx.organization_id is None
+        assert ctx.user_id is None
+        assert ctx.actor_type is ActorType.USER
+        assert ctx.token is None
+
+    def test_frozen(self):
+        ctx = ViewerContext(user_id=1)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ctx.user_id = 2  # type: ignore[misc]
+
+    def test_construction(self):
+        ctx = ViewerContext(
+            organization_id=10,
+            user_id=42,
+            actor_type=ActorType.SYSTEM,
+        )
+        assert ctx.organization_id == 10
+        assert ctx.user_id == 42
+        assert ctx.actor_type is ActorType.SYSTEM
+
+
+class TestViewerContextScope:
+    def test_get_returns_none_outside_scope(self):
+        assert get_viewer_context() is None
+
+    def test_scope_sets_and_resets(self):
+        ctx = ViewerContext(user_id=1)
+        assert get_viewer_context() is None
+
+        with viewer_context_scope(ctx):
+            assert get_viewer_context() is ctx
+
+        assert get_viewer_context() is None
+
+    def test_nested_scopes(self):
+        outer = ViewerContext(user_id=1)
+        inner = ViewerContext(user_id=2)
+
+        with viewer_context_scope(outer):
+            assert get_viewer_context() is outer
+
+            with viewer_context_scope(inner):
+                assert get_viewer_context() is inner
+
+            assert get_viewer_context() is outer
+
+        assert get_viewer_context() is None
+
+    def test_cleanup_on_exception(self):
+        ctx = ViewerContext(user_id=1)
+
+        with pytest.raises(RuntimeError):
+            with viewer_context_scope(ctx):
+                assert get_viewer_context() is ctx
+                raise RuntimeError("boom")
+
+        assert get_viewer_context() is None
+
+    def test_copy_context_propagates_to_thread(self):
+        ctx = ViewerContext(user_id=1, organization_id=10)
+        result: list[ViewerContext | None] = [None]
+
+        with viewer_context_scope(ctx):
+            copied = contextvars.copy_context()
+
+            def _worker():
+                result[0] = copied.run(get_viewer_context)
+
+            t = threading.Thread(target=_worker)
+            t.start()
+            t.join()
+
+        assert result[0] is ctx
+
+    def test_context_propagating_thread_pool_executor(self):
+        from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
+
+        ctx = ViewerContext(user_id=7, organization_id=99, actor_type=ActorType.INTEGRATION)
+
+        with viewer_context_scope(ctx):
+            with ContextPropagatingThreadPoolExecutor(max_workers=1) as pool:
+                result = pool.submit(get_viewer_context).result()
+
+        assert result is ctx
+
+    def test_context_propagating_executor_does_not_leak_across_submissions(self):
+        from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
+
+        ctx = ViewerContext(user_id=1)
+
+        with ContextPropagatingThreadPoolExecutor(max_workers=1) as pool:
+            # Submit inside a scope — worker should see ctx
+            with viewer_context_scope(ctx):
+                inside = pool.submit(get_viewer_context).result()
+
+            # Submit outside any scope — worker should see None
+            outside = pool.submit(get_viewer_context).result()
+
+        assert inside is ctx
+        assert outside is None


### PR DESCRIPTION
Add the foundational `ViewerContext` module (`src/sentry/viewer_context.py`) for unified caller identity tracking across all Sentry entrypoints.

Today Sentry has no single way to know "who is making this request" deep in the call stack. API requests use a threadlocal `env.request`, but tasks, consumers, and RPC paths can't access it. Code that needs viewer identity bifurcates based on execution context. The `ViewerContext` flips that — one API, all entrypoints.

This PR introduces:
- **`ViewerContext`** — a frozen dataclass holding `organization_id`, `user_id`, `actor_type` (StrEnum), and an optional `AuthenticatedToken`. Frozen to ensure safe shallow copies when `copy_context()` propagates across threads.
- **`ActorType`** — a `StrEnum` (`user`, `system`, `integration`) that serializes naturally to/from strings for task headers and RPC payloads.
- **`viewer_context_scope()`** — a context manager that sets the `ContextVar` on entry and `reset(token)`s on exit, guaranteeing cleanup even on exceptions. This is the only way to set the var.
- **`get_viewer_context()`** — accessor returning `None` when no scope is active.

Tests cover: defaults, immutability, scope lifecycle, nested scopes, exception cleanup, raw `copy_context()` thread propagation, `ContextPropagatingThreadPoolExecutor` propagation, and cross-submission leak prevention.

This is Phase 1 of the [Unified ViewerContext RFC](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02). Next steps are wiring entrypoints (middleware, tasks, consumers, RPC) and migrating downstream callers off `SeerViewerContext`.