### PR TITLE
feat(flagpole): Register onboarding-scm-experiment feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -189,6 +189,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-new-welcome-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable SCM-first onboarding flow with provider connection, platform detection, and feature selection steps
     manager.add("organizations:onboarding-scm", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Experiment: SCM onboarding A/B test measuring conversion impact
+    manager.add("organizations:onboarding-scm-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable large ownership rule file size limit
     manager.add("organizations:ownership-size-limit-large", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable xlarge ownership rule file size limit


### PR DESCRIPTION
## Summary
- Registers `organizations:onboarding-scm-experiment` in `temporary.py` for the SCM onboarding A/B test
- Uses `FLAGPOLE` handler with `api_expose=True` for frontend experiment access via `useExperiment()`

Companion PRs:
- https://github.com/getsentry/sentry-options-automator/pull/7089
- https://github.com/getsentry/sentry-options-automator/pull/7088

## Test plan
- [ ] Verify flag is accessible via org serializer
- [ ] Confirm experiment assignment works with `useExperiment()` hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)