### PR TITLE
style(preprod): Increase gap between approval tag and avatars

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -147,7 +147,7 @@ export function SnapshotHeaderActions({
     <Flex align="center" gap="md">
       {data.approval_info &&
         (isApproved ? (
-          <Flex align="center" gap="sm">
+          <Flex align="center" gap="xl">
             <Tag variant="success" icon={<IconCheckmark />}>
               {t('Approved')}
             </Tag>


### PR DESCRIPTION
before: 
<img width="702" height="248" alt="CleanShot 2026-04-02 at 13 46 01@2x" src="https://github.com/user-attachments/assets/8caaa3b0-4176-4757-b9c0-f0619296ba62" />

after: 
<img width="646" height="254" alt="CleanShot 2026-04-02 at 13 46 05@2x" src="https://github.com/user-attachments/assets/ee89ed5c-0508-4efb-ae5b-db85f77e3c10" />



Increases the spacing between the "Approved" tag and the approver avatar list in the snapshot detail header to match the design spec. The gap was too tight at `sm` — bumped to `xl`.

Closes EME-1007