### PR TITLE
ref(api): Rename organization serializers for clarity

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -149,7 +149,7 @@ from rest_framework.response import Response
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.organization import DetailedOrganizationSerializer
+from sentry.api.serializers.models.organization import OrganizationSerializer
 
 @cell_silo_endpoint
 class OrganizationDetailsEndpoint(OrganizationEndpoint):
@@ -164,7 +164,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             serialize(
                 organization,
                 request.user,
-                DetailedOrganizationSerializer()
+                OrganizationSerializer()
             )
         )
 

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -15,7 +15,7 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.api.permissions import SentryIsAuthenticated
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import (
-    DetailedOrganizationSerializerWithProjectsAndTeams,
+    OrganizationWithProjectsAndTeamsSerializer,
 )
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.core.endpoints.project_transfer import SALT
@@ -94,7 +94,7 @@ class AcceptProjectTransferEndpoint(Endpoint):
                 "organizations": serialize(
                     list(organizations),
                     request.user,
-                    DetailedOrganizationSerializerWithProjectsAndTeams(),
+                    OrganizationWithProjectsAndTeamsSerializer(),
                     access=request.access,
                 ),
                 "project": {"slug": project.slug, "id": project.id},

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -131,7 +131,7 @@ class OnboardingTasksSerializerResponse(TypedDict):
     data: Any  # JSON objec
 
 
-class OrganizationSerializerResponseOptional(TypedDict, total=False):
+class OrganizationSummarySerializerResponseOptional(TypedDict, total=False):
     features: list[str]  # Only included if include_feature_flags is True
     extraOptions: dict[str, dict[str, Any]]
     access: frozenset[str]  # Only if access=... is passed
@@ -139,7 +139,7 @@ class OrganizationSerializerResponseOptional(TypedDict, total=False):
 
 
 @extend_schema_serializer(exclude_fields=["requireEmailVerification"])
-class OrganizationSerializerResponse(OrganizationSerializerResponseOptional):
+class OrganizationSummarySerializerResponse(OrganizationSummarySerializerResponseOptional):
     id: str
     slug: str
     status: _Status
@@ -286,7 +286,7 @@ class ControlSiloOrganizationSerializer(Serializer):
 
 
 @register(Organization)
-class OrganizationSerializer(Serializer):
+class OrganizationSummarySerializer(Serializer):
     def get_attrs(
         self, item_list: Sequence[Organization], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> MutableMapping[Organization, MutableMapping[str, Any]]:
@@ -410,7 +410,7 @@ class OrganizationSerializer(Serializer):
         attrs: Mapping[str, Any],
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
-    ) -> OrganizationSerializerResponse:
+    ) -> OrganizationSummarySerializerResponse:
         if attrs.get("avatar"):
             avatar: SerializedAvatarFields = {
                 "avatarType": attrs["avatar"].get_avatar_type_display(),
@@ -426,7 +426,7 @@ class OrganizationSerializer(Serializer):
 
         has_auth_provider = attrs.get("auth_provider", None) is not None
 
-        context: OrganizationSerializerResponse = {
+        context: OrganizationSummarySerializerResponse = {
             "id": str(obj.id),
             "slug": obj.slug,
             "status": {"id": status.name.lower(), "name": status.label},
@@ -504,7 +504,7 @@ class OnboardingTasksSerializer(Serializer):
         }
 
 
-class _DetailedOrganizationSerializerResponseOptional(OrganizationSerializerResponse, total=False):
+class _OrganizationSerializerResponseOptional(OrganizationSummarySerializerResponse, total=False):
     role: Any  # TODO: replace with enum/literal
     orgRole: str
     targetSampleRate: float
@@ -518,7 +518,7 @@ class _DetailedOrganizationSerializerResponseOptional(OrganizationSerializerResp
 
 
 @extend_schema_serializer(exclude_fields=["availableRoles"])
-class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResponseOptional):
+class OrganizationSerializerResponse(_OrganizationSerializerResponseOptional):
     experiments: dict[str, str]
     isDefault: bool
     defaultRole: str  # TODO: replace with enum/literal
@@ -570,7 +570,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     replayAccessMembers: list[int]
 
 
-class DetailedOrganizationSerializer(OrganizationSerializer):
+class OrganizationSerializer(OrganizationSummarySerializer):
     def get_attrs(
         self, item_list: Sequence[Organization], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> MutableMapping[Organization, MutableMapping[str, Any]]:
@@ -618,7 +618,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         user: User | RpcUser | AnonymousUser,
         access: Access,
         **kwargs: Any,
-    ) -> DetailedOrganizationSerializerResponse:
+    ) -> OrganizationSerializerResponse:
         # TODO: rectify access argument overriding parent if we want to remove above type ignore
 
         include_feature_flags = kwargs.get("include_feature_flags", True)
@@ -650,7 +650,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             sample_rate = quotas.backend.get_blended_sample_rate(organization_id=obj.id)
             is_dynamically_sampled = sample_rate is not None and sample_rate < 1.0
 
-        context: DetailedOrganizationSerializerResponse = {
+        context: OrganizationSerializerResponse = {
             **base,
             "experiments": features.get_experiment_assignments(obj, actor=user),
             "isDefault": obj.is_default,
@@ -847,14 +847,12 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         "replayAccessMembers",
     ]
 )
-class DetailedOrganizationSerializerWithProjectsAndTeamsResponse(
-    DetailedOrganizationSerializerResponse
-):
+class OrganizationWithProjectsAndTeamsSerializerResponse(OrganizationSerializerResponse):
     teams: list[TeamSerializerResponse]
     projects: list[OrganizationProjectResponse]
 
 
-class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSerializer):
+class OrganizationWithProjectsAndTeamsSerializer(OrganizationSerializer):
     def get_attrs(
         self, item_list: Sequence[Organization], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> MutableMapping[Organization, MutableMapping[str, Any]]:
@@ -891,7 +889,7 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
         user: User | RpcUser | AnonymousUser,
         access: Access,
         **kwargs: Any,
-    ) -> DetailedOrganizationSerializerWithProjectsAndTeamsResponse:
+    ) -> OrganizationWithProjectsAndTeamsSerializerResponse:
         from sentry.api.serializers.models.project import (
             LATEST_DEPLOYS_KEY,
             ProjectSummarySerializer,
@@ -899,7 +897,7 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
         from sentry.api.serializers.models.team import TeamSerializer
 
         context = cast(
-            DetailedOrganizationSerializerWithProjectsAndTeamsResponse,
+            OrganizationWithProjectsAndTeamsSerializerResponse,
             super().serialize(obj, attrs, user, access, **kwargs),
         )
 
@@ -922,3 +920,8 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
         )
 
         return context
+
+
+# Backwards-compatible aliases for getsentry
+DetailedOrganizationSerializer = OrganizationSerializer
+DetailedOrganizationSerializerWithProjectsAndTeams = OrganizationWithProjectsAndTeamsSerializer

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -53,7 +53,7 @@ from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 
 if TYPE_CHECKING:
-    from sentry.api.serializers.models.organization import OrganizationSerializerResponse
+    from sentry.api.serializers.models.organization import OrganizationSummarySerializerResponse
 
 STATUS_LABELS = {
     ObjectStatus.ACTIVE: "active",
@@ -951,7 +951,7 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     secondaryGroupingExpiry: int
     secondaryGroupingConfig: str | None
     fingerprintingRules: str
-    organization: OrganizationSerializerResponse
+    organization: OrganizationSummarySerializerResponse
     plugins: list[Plugin]
     platforms: list[str]
     processingIssues: int

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -34,7 +34,7 @@ from sentry.utils.query import RangeQuerySetWrapper
 
 if TYPE_CHECKING:
     from sentry.api.serializers import SCIMMeta
-    from sentry.api.serializers.models.organization import OrganizationSerializerResponse
+    from sentry.api.serializers.models.organization import OrganizationSummarySerializerResponse
     from sentry.api.serializers.models.project import ProjectSerializerResponse
     from sentry.integrations.api.serializers.models.external_actor import ExternalActorResponse
 
@@ -124,7 +124,7 @@ def get_access_requests(
 
 class _TeamSerializerResponseOptional(TypedDict, total=False):
     externalTeams: list[ExternalActorResponse]
-    organization: OrganizationSerializerResponse
+    organization: OrganizationSummarySerializerResponse
     projects: list[ProjectSerializerResponse]
 
 

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -26,7 +26,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models import organization as org_serializers
 from sentry.api.serializers.models.organization import (
     BaseOrganizationSerializer,
-    DetailedOrganizationSerializerWithProjectsAndTeams,
+    OrganizationWithProjectsAndTeamsSerializer,
     TrustedRelaySerializer,
 )
 from sentry.apidocs.constants import (
@@ -1138,7 +1138,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         parameters=[GlobalParams.ORG_ID_OR_SLUG, OrganizationParams.DETAILED],
         request=None,
         responses={
-            200: org_serializers.OrganizationSerializer,
+            200: org_serializers.OrganizationSummarySerializer,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
@@ -1153,14 +1153,14 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         # This param will be used to determine if we should include feature flags in the response
         include_feature_flags = request.GET.get("include_feature_flags", "0") != "0"
 
-        serializer = org_serializers.OrganizationSerializer
+        serializer = org_serializers.OrganizationSummarySerializer
 
         if request.access.has_scope("org:read") or is_active_staff(request):
             is_detailed = request.GET.get("detailed", "1") != "0"
 
-            serializer = org_serializers.DetailedOrganizationSerializer
+            serializer = org_serializers.OrganizationSerializer
             if is_detailed:
-                serializer = org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams
+                serializer = org_serializers.OrganizationWithProjectsAndTeamsSerializer
 
         context = serialize(
             organization,
@@ -1179,7 +1179,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         ],
         request=OrganizationDetailsPutSerializer,
         responses={
-            200: DetailedOrganizationSerializerWithProjectsAndTeams,
+            200: OrganizationWithProjectsAndTeamsSerializer,
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
@@ -1344,7 +1344,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             context = serialize(
                 organization,
                 request.user,
-                org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams(),
+                org_serializers.OrganizationWithProjectsAndTeamsSerializer(),
                 access=request.access,
                 include_feature_flags=include_feature_flags,
             )
@@ -1422,7 +1422,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         context = serialize(
             organization,
             request.user,
-            org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams(),
+            org_serializers.OrganizationWithProjectsAndTeamsSerializer(),
             access=request.access,
         )
         return self.respond(context, status=202)

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -22,7 +22,7 @@ from sentry.api.paginator import DateTimePaginator, OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import (
     BaseOrganizationSerializer,
-    OrganizationSerializerResponse,
+    OrganizationSummarySerializerResponse,
 )
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.user_examples import UserExamples
@@ -88,7 +88,7 @@ class OrganizationIndexEndpoint(Endpoint):
         request=None,
         responses={
             200: inline_sentry_response_serializer(
-                "ListOrganizations", list[OrganizationSerializerResponse]
+                "ListOrganizations", list[OrganizationSummarySerializerResponse]
             ),
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,

--- a/src/sentry/templatetags/sentry_api.py
+++ b/src/sentry/templatetags/sentry_api.py
@@ -3,7 +3,7 @@ from django.http import HttpRequest
 
 from sentry.api.serializers.base import serialize as serialize_func
 from sentry.api.serializers.models.organization import (
-    DetailedOrganizationSerializerWithProjectsAndTeams,
+    OrganizationWithProjectsAndTeamsSerializer,
 )
 from sentry.auth.access import NoAccess, from_user
 from sentry.utils import json
@@ -35,9 +35,7 @@ def serialize_detailed_org(context, obj):
         user = None
         access = NoAccess()
 
-    context = serialize_func(
-        obj, user, DetailedOrganizationSerializerWithProjectsAndTeams(), access=access
-    )
+    context = serialize_func(obj, user, OrganizationWithProjectsAndTeamsSerializer(), access=access)
 
     return convert_to_json(context)
 

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -6,9 +6,9 @@ from django.utils import timezone
 
 from sentry import features, killswitches, options
 from sentry.api.serializers import (
-    DetailedOrganizationSerializer,
-    DetailedOrganizationSerializerWithProjectsAndTeams,
     OnboardingTasksSerializer,
+    OrganizationSerializer,
+    OrganizationWithProjectsAndTeamsSerializer,
     serialize,
 )
 from sentry.api.serializers.models.organization import ORGANIZATION_OPTIONS_AS_FEATURES
@@ -54,7 +54,7 @@ mock_options_as_features = {
 }
 
 
-class OrganizationSerializerTest(TestCase):
+class OrganizationSummarySerializerTest(TestCase):
     def test_simple(self) -> None:
         user = self.create_user()
         organization = self.create_organization(owner=user)
@@ -145,13 +145,13 @@ class OrganizationSerializerTest(TestCase):
             assert feature not in features
 
 
-class DetailedOrganizationSerializerTest(TestCase):
+class OrganizationSerializerTest(TestCase):
     def test_detailed(self) -> None:
         user = self.create_user()
         organization = self.create_organization(owner=user)
         acc = access.from_user(user, organization)
 
-        serializer = DetailedOrganizationSerializer()
+        serializer = OrganizationSerializer()
         result = serialize(organization, user, serializer, access=acc)
 
         assert result["id"] == str(organization.id)
@@ -167,7 +167,7 @@ class DetailedOrganizationSerializerTest(TestCase):
         organization = self.create_organization(owner=user)
         acc = access.from_user(user, organization)
 
-        serializer = DetailedOrganizationSerializer()
+        serializer = OrganizationSerializer()
         result = serialize(organization, user, serializer, access=acc)
 
         assert result["hasGranularReplayPermissions"] is False
@@ -184,7 +184,7 @@ class DetailedOrganizationSerializerTest(TestCase):
             value=True,
         )
 
-        serializer = DetailedOrganizationSerializer()
+        serializer = OrganizationSerializer()
         result = serialize(organization, user, serializer, access=acc)
         assert result["hasGranularReplayPermissions"] is True
         assert result["replayAccessMembers"] == []
@@ -202,7 +202,7 @@ class DetailedOrganizationSerializerTest(TestCase):
         OrganizationMemberReplayAccess.objects.create(organizationmember=member2)
         acc = access.from_user(user, organization)
 
-        serializer = DetailedOrganizationSerializer()
+        serializer = OrganizationSerializer()
         result = serialize(organization, user, serializer, access=acc)
         assert set(result["replayAccessMembers"]) == set()
 
@@ -225,7 +225,7 @@ class DetailedOrganizationSerializerTest(TestCase):
             value=True,
         )
 
-        serializer = DetailedOrganizationSerializer()
+        serializer = OrganizationSerializer()
         result = serialize(organization, user, serializer, access=acc)
         assert result["hasGranularReplayPermissions"] is True
         assert set(result["replayAccessMembers"]) == {member1.user_id, member2.user_id}
@@ -235,7 +235,7 @@ class DetailedOrganizationSerializerTest(TestCase):
         organization = self.create_organization(owner=user)
         acc = access.from_user(user, organization)
 
-        serializer = DetailedOrganizationSerializer()
+        serializer = OrganizationSerializer()
         result = serialize(organization, user, serializer, access=acc)
 
         assert result["replayAccessMembers"] == []
@@ -245,7 +245,7 @@ class DetailedOrganizationSerializerTest(TestCase):
         organization = self.create_organization(owner=user)
         acc = access.from_user(user, organization)
 
-        serializer = DetailedOrganizationSerializer()
+        serializer = OrganizationSerializer()
         result = serialize(organization, user, serializer, access=acc)
 
         assert result["experiments"] == {}
@@ -262,7 +262,7 @@ class DetailedOrganizationSerializerTest(TestCase):
 
         features.default_manager.add_entity_handler(handler)
         try:
-            serializer = DetailedOrganizationSerializer()
+            serializer = OrganizationSerializer()
             result = serialize(organization, user, serializer, access=acc)
 
             assert result["experiments"] == {"experiment-test": "active"}
@@ -270,13 +270,13 @@ class DetailedOrganizationSerializerTest(TestCase):
             features.default_manager._entity_handler = None
 
 
-class DetailedOrganizationSerializerWithProjectsAndTeamsTest(TestCase):
+class OrganizationWithProjectsAndTeamsSerializerTest(TestCase):
     def test_detailed_org_projs_teams(self) -> None:
         # access the test fixtures so they're initialized
         self.team
         self.project
         acc = access.from_user(self.user, self.organization)
-        serializer = DetailedOrganizationSerializerWithProjectsAndTeams()
+        serializer = OrganizationWithProjectsAndTeamsSerializer()
         result = serialize(self.organization, self.user, serializer, access=acc)
 
         assert result["id"] == str(self.organization.id)
@@ -309,7 +309,7 @@ class DetailedOrganizationSerializerWithProjectsAndTeamsTest(TestCase):
             last_deploy_id=deploy.id,
         )
         acc = access.from_user(self.user, self.organization)
-        serializer = DetailedOrganizationSerializerWithProjectsAndTeams()
+        serializer = OrganizationWithProjectsAndTeamsSerializer()
         result = serialize(self.organization, self.user, serializer, access=acc)
 
         assert result["projects"][0]["latestDeploys"]


### PR DESCRIPTION
- OrganizationSerializer → OrganizationSummarySerializer (summary/list view)
- DetailedOrganizationSerializer → OrganizationSerializer (standard view)
- DetailedOrganizationSerializerWithProjectsAndTeams → OrganizationWithProjectsAndTeamsSerializer