### PR TITLE
feat(notifications): Pre compute notification fields prior to calling into the platform

### DIFF
--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
@@ -151,6 +151,9 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
         detector_serialized_response = get_detector_serializer(detector)
         incident_serialized_response = get_detailed_incident_serializer(open_period)
 
+        if notification_context.integration_id is None:
+            raise ValueError("Slack integration_id is None")
+
         if notification_context.target_identifier is None:
             raise ValueError("Slack channel (target_identifier) is None")
 

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
@@ -1,13 +1,19 @@
 import logging
 
-from sentry.incidents.models.incident import TriggerStatus
+import sentry_sdk
+
+from sentry import features
+from sentry.incidents.charts import build_metric_alert_chart
+from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
+from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
+from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
     MetricIssueContext,
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.integrations.slack.utils.notifications import send_incident_alert_notification
+from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -18,9 +24,105 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
 )
 from sentry.notifications.notification_action.registry import metric_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseMetricAlertHandler
+from sentry.notifications.platform.service import NotificationService
+from sentry.notifications.platform.target import IntegrationNotificationTarget
+from sentry.notifications.platform.templates.metric_alert import MetricAlertNotificationData
+from sentry.notifications.platform.threading import ThreadingOptions, ThreadKey
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationSource,
+    NotificationTargetResourceType,
+)
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
+    DetectorSerializerResponse,
+)
 from sentry.workflow_engine.models import Action, Detector
 
 logger = logging.getLogger(__name__)
+
+
+def build_metric_alert_notification_data(
+    notification_context: NotificationContext,
+    metric_issue_context: MetricIssueContext,
+    open_period_context: OpenPeriodContext,
+    organization: Organization,
+    notification_uuid: str,
+    alert_rule_serialized_response: AlertRuleSerializerResponse | None,
+    incident_serialized_response: DetailedIncidentSerializerResponse | None,
+    detector_serialized_response: DetectorSerializerResponse | None,
+    alert_context: AlertContext,
+) -> MetricAlertNotificationData:
+    attachment_info = incident_attachment_info(
+        organization=organization,
+        alert_context=alert_context,
+        metric_issue_context=metric_issue_context,
+        notification_uuid=notification_uuid,
+        referrer="metric_alert_slack",
+    )
+
+    chart_url = None
+    if (
+        features.has("organizations:metric-alert-chartcuterie", organization)
+        and alert_rule_serialized_response
+        and incident_serialized_response
+    ):
+        try:
+            chart_url = build_metric_alert_chart(
+                organization=organization,
+                alert_rule_serialized_response=alert_rule_serialized_response,
+                snuba_query=metric_issue_context.snuba_query,
+                alert_context=alert_context,
+                open_period_context=open_period_context,
+                selected_incident_serialized=incident_serialized_response,
+                subscription=metric_issue_context.subscription,
+                detector_serialized_response=detector_serialized_response,
+            )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+
+    return MetricAlertNotificationData(
+        group_id=metric_issue_context.id,
+        organization_id=organization.id,
+        notification_uuid=notification_uuid,
+        action_id=notification_context.id,
+        open_period_context=open_period_context,
+        new_status=metric_issue_context.new_status.value,
+        title=attachment_info["title"],
+        title_link=attachment_info["title_link"],
+        text=attachment_info["text"],
+        chart_url=chart_url,
+    )
+
+
+def build_slack_notification_target(
+    notification_context: NotificationContext,
+    organization: Organization,
+) -> IntegrationNotificationTarget:
+    return IntegrationNotificationTarget(
+        provider_key=NotificationProviderKey.SLACK,
+        resource_type=NotificationTargetResourceType.CHANNEL,
+        resource_id=notification_context.target_identifier,
+        integration_id=notification_context.integration_id,
+        organization_id=organization.id,
+    )
+
+
+def build_metric_alert_threading_options(
+    notification_context: NotificationContext,
+    metric_issue_context: MetricIssueContext,
+    open_period_context: OpenPeriodContext,
+) -> ThreadingOptions:
+    return ThreadingOptions(
+        thread_key=ThreadKey(
+            key_type=NotificationSource.METRIC_ALERT,
+            key_data={
+                "action_id": notification_context.id,
+                "group_id": metric_issue_context.id,
+                "open_period_start": open_period_context.date_started.isoformat(),
+            },
+        ),
+        reply_broadcast=(metric_issue_context.new_status == IncidentStatus.CRITICAL),
+    )
 
 
 @metric_alert_handler_registry.register(Action.Type.SLACK)
@@ -49,6 +151,32 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
         detector_serialized_response = get_detector_serializer(detector)
         incident_serialized_response = get_detailed_incident_serializer(open_period)
 
+        if notification_context.target_identifier is None:
+            raise ValueError("Slack channel (target_identifier) is None")
+
+        data = build_metric_alert_notification_data(
+            notification_context=notification_context,
+            metric_issue_context=metric_issue_context,
+            open_period_context=open_period_context,
+            organization=organization,
+            notification_uuid=notification_uuid,
+            alert_rule_serialized_response=alert_rule_serialized_response,
+            incident_serialized_response=incident_serialized_response,
+            detector_serialized_response=detector_serialized_response,
+            alert_context=alert_context,
+        )
+
+        target = build_slack_notification_target(
+            notification_context=notification_context,
+            organization=organization,
+        )
+
+        threading_options = build_metric_alert_threading_options(
+            notification_context=notification_context,
+            metric_issue_context=metric_issue_context,
+            open_period_context=open_period_context,
+        )
+
         logger.info(
             "notification_action.execute_via_metric_alert_handler.slack",
             extra={
@@ -58,16 +186,8 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
             },
         )
 
-        send_incident_alert_notification(
-            notification_context=notification_context,
-            alert_context=alert_context,
-            metric_issue_context=metric_issue_context,
-            open_period_context=open_period_context,
-            organization=organization,
-            notification_uuid=notification_uuid,
-            alert_rule_serialized_response=alert_rule_serialized_response,
-            incident_serialized_response=incident_serialized_response,
-            detector_serialized_response=detector_serialized_response,
+        NotificationService(data=data).notify_target(
+            target=target, threading_options=threading_options
         )
 
 

--- a/src/sentry/notifications/platform/slack/renderers/metric_alert.py
+++ b/src/sentry/notifications/platform/slack/renderers/metric_alert.py
@@ -1,59 +1,20 @@
 from __future__ import annotations
 
-import sentry_sdk
-
-from sentry import features
-from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.typings.metric_detector import MetricIssueContext
-from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
-from sentry.models.group import Group
-from sentry.models.organization import Organization
-from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detector_serializer,
-)
-from sentry.notifications.notification_action.types import BaseMetricAlertHandler
+from sentry.incidents.models.incident import IncidentStatus
+from sentry.integrations.messaging.types import LEVEL_TO_COLOR
+from sentry.integrations.metric_alerts import get_status_text
+from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
+from sentry.integrations.slack.message_builder.incidents import get_started_at
+from sentry.integrations.slack.message_builder.types import INCIDENT_COLOR_MAPPING
+from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.notifications.platform.renderer import NotificationRenderer
 from sentry.notifications.platform.slack.provider import SlackRenderable
-from sentry.notifications.platform.templates.metric_alert import (
-    ActivityMetricAlertNotificationData,
-    BaseMetricAlertNotificationData,
-    MetricAlertNotificationData,
-)
+from sentry.notifications.platform.templates.metric_alert import MetricAlertNotificationData
 from sentry.notifications.platform.types import (
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
 )
-from sentry.services import eventstore
-from sentry.services.eventstore.models import GroupEvent
-from sentry.workflow_engine.models.detector import Detector
-
-
-def _build_metric_issue_context_from_group_event(
-    data: MetricAlertNotificationData,
-) -> MetricIssueContext:
-    event = eventstore.backend.get_event_by_id(
-        data.project_id, data.event_id, group_id=data.group_id
-    )
-    if event is None:
-        raise ValueError(f"Event {data.event_id} not found")
-    elif not isinstance(event, GroupEvent):
-        raise ValueError(f"Event {data.event_id} is not a GroupEvent")
-
-    evidence_data, priority = BaseMetricAlertHandler._extract_from_group_event(event)
-    return MetricIssueContext.from_group_event(event.group, evidence_data, priority)
-
-
-def _build_metric_issue_context_from_activity(
-    data: ActivityMetricAlertNotificationData,
-) -> MetricIssueContext:
-    from sentry.models.activity import Activity
-
-    activity = Activity.objects.get(id=data.activity_id)
-    group = Group.objects.get_from_cache(id=data.group_id)
-    evidence_data, priority = BaseMetricAlertHandler._extract_from_activity(activity)
-    return MetricIssueContext.from_group_event(group, evidence_data, priority)
 
 
 class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
@@ -63,42 +24,23 @@ class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
     def render[DataT: NotificationData](
         cls, *, data: DataT, rendered_template: NotificationRenderedTemplate
     ) -> SlackRenderable:
-        if not isinstance(data, BaseMetricAlertNotificationData):
+        if not isinstance(data, MetricAlertNotificationData):
             raise ValueError(f"SlackMetricAlertRenderer does not support {data.__class__.__name__}")
 
-        if isinstance(data, MetricAlertNotificationData):
-            metric_issue_context = _build_metric_issue_context_from_group_event(data)
-        elif isinstance(data, ActivityMetricAlertNotificationData):
-            metric_issue_context = _build_metric_issue_context_from_activity(data)
+        incident_text = f"{data.text}\n{get_started_at(data.open_period_context.date_started)}"
+        blocks = [BlockSlackMessageBuilder.get_markdown_block(text=incident_text)]
 
-        organization = Organization.objects.get_from_cache(id=data.organization_id)
-        detector = Detector.objects.get(id=data.detector_id)
-        alert_context = data.alert_context.to_alert_context()
-        open_period_context = data.open_period_context
+        if data.chart_url:
+            blocks.append(
+                BlockSlackMessageBuilder.get_image_block(data.chart_url, alt="Metric Alert Chart")
+            )
 
-        chart_url = None
-        if features.has("organizations:metric-alert-chartcuterie", organization):
-            try:
-                chart_url = build_metric_alert_chart(
-                    organization=organization,
-                    alert_rule_serialized_response=get_alert_rule_serializer(detector),
-                    snuba_query=metric_issue_context.snuba_query,
-                    alert_context=alert_context,
-                    open_period_context=open_period_context,
-                    subscription=metric_issue_context.subscription,
-                    detector_serialized_response=get_detector_serializer(detector),
-                )
-            except Exception as e:
-                sentry_sdk.capture_exception(e)
-
-        slack_body = SlackIncidentsMessageBuilder(
-            alert_context=alert_context,
-            metric_issue_context=metric_issue_context,
-            organization=organization,
-            date_started=open_period_context.date_started,
-            chart_url=chart_url,
-            notification_uuid=data.notification_uuid,
-        ).build()
+        status = get_status_text(IncidentStatus(data.new_status))
+        color = LEVEL_TO_COLOR.get(INCIDENT_COLOR_MAPPING.get(status, ""))
+        fallback_text = f"<{data.title_link}|*{escape_slack_text(data.title)}*>"
+        slack_body = BlockSlackMessageBuilder._build_blocks(
+            *blocks, fallback_text=fallback_text, color=color
+        )
 
         renderable = SlackRenderable(
             blocks=slack_body.get("blocks", []),

--- a/src/sentry/notifications/platform/templates/__init__.py
+++ b/src/sentry/notifications/platform/templates/__init__.py
@@ -1,13 +1,12 @@
 from .data_export import DataExportFailureTemplate, DataExportSuccessTemplate
 from .issue import IssueNotificationTemplate
-from .metric_alert import ActivityMetricAlertNotificationTemplate, MetricAlertNotificationTemplate
+from .metric_alert import MetricAlertNotificationTemplate
 
 __all__ = (
     "DataExportSuccessTemplate",
     "DataExportFailureTemplate",
     "IssueNotificationTemplate",
     "MetricAlertNotificationTemplate",
-    "ActivityMetricAlertNotificationTemplate",
 )
 # All templates should be imported here so they are registered in the notifications Django app.
 # See sentry/notifications/apps.py

--- a/src/sentry/notifications/platform/templates/metric_alert.py
+++ b/src/sentry/notifications/platform/templates/metric_alert.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Self
 
-from pydantic import BaseModel, ConfigDict
-
-from sentry.incidents.typings.metric_detector import AlertContext, OpenPeriodContext
+from sentry.incidents.typings.metric_detector import OpenPeriodContext
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -14,94 +11,28 @@ from sentry.notifications.platform.types import (
     NotificationSource,
     NotificationTemplate,
 )
-from sentry.seer.anomaly_detection.types import AnomalyDetectionThresholdType
 
 
-class SerializableAlertContext(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
-    name: str
-    action_identifier_id: int
-    threshold_type: int | None = None  # AlertRuleThresholdType or AnomalyDetectionThresholdType
-    detection_type: str  # AlertRuleDetectionType value (TextChoices str)
-    comparison_delta: int | None = None
-    sensitivity: str | None = None
-    resolve_threshold: float | None = None
-    alert_threshold: float | None = None
-
-    @classmethod
-    def from_alert_context(cls, ac: AlertContext) -> Self:
-        return cls(
-            name=ac.name,
-            action_identifier_id=ac.action_identifier_id,
-            threshold_type=int(ac.threshold_type.value) if ac.threshold_type is not None else None,
-            detection_type=ac.detection_type.value,
-            comparison_delta=ac.comparison_delta,
-            sensitivity=ac.sensitivity,
-            resolve_threshold=ac.resolve_threshold,
-            alert_threshold=ac.alert_threshold,
-        )
-
-    def to_alert_context(self) -> AlertContext:
-        from sentry.incidents.models.alert_rule import (
-            AlertRuleDetectionType,
-            AlertRuleThresholdType,
-        )
-
-        detection_type = AlertRuleDetectionType(self.detection_type)
-
-        threshold_type: AlertRuleThresholdType | AnomalyDetectionThresholdType | None = None
-        if self.threshold_type is not None:
-            if detection_type == AlertRuleDetectionType.DYNAMIC:
-                threshold_type = AnomalyDetectionThresholdType(self.threshold_type)
-            else:
-                threshold_type = AlertRuleThresholdType(self.threshold_type)
-
-        return AlertContext(
-            name=self.name,
-            action_identifier_id=self.action_identifier_id,
-            threshold_type=threshold_type,
-            detection_type=detection_type,
-            comparison_delta=self.comparison_delta,
-            sensitivity=self.sensitivity,
-            resolve_threshold=self.resolve_threshold,
-            alert_threshold=self.alert_threshold,
-        )
-
-
-class BaseMetricAlertNotificationData(NotificationData):
-    group_id: int
-    organization_id: int
-    detector_id: int
-
-    alert_context: SerializableAlertContext
-    open_period_context: OpenPeriodContext
-
-    notification_uuid: str
-
-
-class MetricAlertNotificationData(BaseMetricAlertNotificationData):
-    """GroupEvent / firing path. Renderer re-fetches GroupEvent from Snuba."""
-
+class MetricAlertNotificationData(NotificationData):
     source: NotificationSource = NotificationSource.METRIC_ALERT
 
-    event_id: str
-    project_id: int
+    # Identity / threading
+    group_id: int
+    organization_id: int
+    notification_uuid: str
+    action_id: int  # for ThreadKey key_data
+    open_period_context: OpenPeriodContext  # id + date_started used in renderer and threading
+    new_status: int  # IncidentStatus value; determines reply_broadcast
+
+    # Pre-computed from incident_attachment_info() — all serializable strings
+    title: str
+    title_link: str
+    text: str
+
+    # Pre-computed chart URL (None if feature disabled or build failed)
+    chart_url: str | None = None
 
 
-class ActivityMetricAlertNotificationData(BaseMetricAlertNotificationData):
-    """Activity / SET_RESOLVED path. Renderer re-fetches Activity from Postgres."""
-
-    source: NotificationSource = NotificationSource.ACTIVITY_METRIC_ALERT
-
-    activity_id: int
-
-
-_EXAMPLE_ALERT_CONTEXT = SerializableAlertContext(
-    name="Example Alert",
-    action_identifier_id=1,
-    detection_type="static",
-)
 _EXAMPLE_OPEN_PERIOD_CONTEXT = OpenPeriodContext(
     id=1,
     date_started=datetime(2024, 1, 1, 0, 0, 0),
@@ -113,35 +44,16 @@ class MetricAlertNotificationTemplate(NotificationTemplate[MetricAlertNotificati
     category = NotificationCategory.METRIC_ALERT
     hide_from_debugger = True
     example_data = MetricAlertNotificationData(
-        event_id="abc123",
-        project_id=1,
         group_id=1,
         organization_id=1,
-        detector_id=1,
-        alert_context=_EXAMPLE_ALERT_CONTEXT,
-        open_period_context=_EXAMPLE_OPEN_PERIOD_CONTEXT,
         notification_uuid="test-uuid",
+        action_id=1,
+        open_period_context=_EXAMPLE_OPEN_PERIOD_CONTEXT,
+        new_status=20,  # IncidentStatus.CRITICAL
+        title="Critical: Example Alert",
+        title_link="https://sentry.io/organizations/example/alerts/rules/details/1/",
+        text="123 events in the last 5 minutes",
     )
 
     def render(self, data: MetricAlertNotificationData) -> NotificationRenderedTemplate:
-        return NotificationRenderedTemplate(subject="Metric Alert", body=[])
-
-
-@template_registry.register(NotificationSource.ACTIVITY_METRIC_ALERT)
-class ActivityMetricAlertNotificationTemplate(
-    NotificationTemplate[ActivityMetricAlertNotificationData]
-):
-    category = NotificationCategory.METRIC_ALERT
-    hide_from_debugger = True
-    example_data = ActivityMetricAlertNotificationData(
-        group_id=1,
-        organization_id=1,
-        detector_id=1,
-        alert_context=_EXAMPLE_ALERT_CONTEXT,
-        open_period_context=_EXAMPLE_OPEN_PERIOD_CONTEXT,
-        notification_uuid="test-uuid",
-        activity_id=1,
-    )
-
-    def render(self, data: ActivityMetricAlertNotificationData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(subject="Metric Alert", body=[])

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -58,7 +58,6 @@ class NotificationSource(StrEnum):
 
     # METRIC_ALERT
     METRIC_ALERT = "metric-alert"
-    ACTIVITY_METRIC_ALERT = "activity-metric-alert"
 
     # SEER
     SEER_AUTOFIX_ERROR = "seer-autofix-error"
@@ -94,7 +93,6 @@ NOTIFICATION_SOURCE_MAP: dict[NotificationCategory, list[NotificationSource]] = 
     ],
     NotificationCategory.METRIC_ALERT: [
         NotificationSource.METRIC_ALERT,
-        NotificationSource.ACTIVITY_METRIC_ALERT,
     ],
     NotificationCategory.SEER: [
         NotificationSource.SEER_AUTOFIX_TRIGGER,

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -13,11 +13,6 @@ from sentry.incidents.typings.metric_detector import (
 from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import SlackMetricAlertHandler
-from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_alert_rule_serializer,
-    get_detailed_incident_serializer,
-    get_detector_serializer,
-)
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
@@ -43,10 +38,13 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
         self.handler = SlackMetricAlertHandler()
 
     @mock.patch(
-        "sentry.notifications.notification_action.metric_alert_registry.handlers.slack_metric_alert_handler.send_incident_alert_notification"
+        "sentry.notifications.notification_action.metric_alert_registry.handlers.slack_metric_alert_handler.NotificationService"
     )
     @freeze_time("2021-01-01 00:00:00")
-    def test_send_alert(self, mock_send_incident_alert_notification: mock.MagicMock) -> None:
+    def test_send_alert(self, mock_notification_service: mock.MagicMock) -> None:
+        mock_service_instance = mock.MagicMock()
+        mock_notification_service.return_value = mock_service_instance
+
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
         assert self.group_event.occurrence.priority is not None
@@ -75,17 +73,35 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             notification_uuid=notification_uuid,
         )
 
-        mock_send_incident_alert_notification.assert_called_once_with(
-            organization=self.detector.project.organization,
-            alert_context=alert_context,
-            notification_context=notification_context,
-            metric_issue_context=metric_issue_context,
-            open_period_context=open_period_context,
-            alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
-            incident_serialized_response=get_detailed_incident_serializer(self.open_period),
-            detector_serialized_response=get_detector_serializer(self.detector),
-            notification_uuid=notification_uuid,
-        )
+        # Verify NotificationService was instantiated with MetricAlertNotificationData
+        mock_notification_service.assert_called_once()
+        call_kwargs = mock_notification_service.call_args.kwargs
+        data = call_kwargs["data"]
+
+        from sentry.notifications.platform.templates.metric_alert import MetricAlertNotificationData
+
+        assert isinstance(data, MetricAlertNotificationData)
+        assert data.group_id == self.group.id
+        assert data.organization_id == self.organization.id
+        assert data.notification_uuid == notification_uuid
+        assert data.action_id == notification_context.id
+
+        # Verify notify_target was called with a Slack target and threading options
+        mock_service_instance.notify_target.assert_called_once()
+        notify_kwargs = mock_service_instance.notify_target.call_args.kwargs
+
+        from sentry.notifications.platform.target import IntegrationNotificationTarget
+        from sentry.notifications.platform.threading import ThreadingOptions
+
+        target = notify_kwargs["target"]
+        assert isinstance(target, IntegrationNotificationTarget)
+        assert target.resource_id == "channel123"
+        assert target.integration_id == 1234567890
+
+        threading_options = notify_kwargs["threading_options"]
+        assert isinstance(threading_options, ThreadingOptions)
+        assert threading_options.thread_key.key_data["action_id"] == notification_context.id
+        assert threading_options.thread_key.key_data["group_id"] == self.group.id
 
     @mock.patch(
         "sentry.notifications.notification_action.metric_alert_registry.SlackMetricAlertHandler.send_alert"

--- a/tests/sentry/notifications/platform/slack/renderers/test_metric_alert.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_metric_alert.py
@@ -1,33 +1,21 @@
 from __future__ import annotations
 
-from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any
-from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sentry.incidents.typings.metric_detector import AlertContext, OpenPeriodContext
-from sentry.models.activity import Activity
+from sentry.incidents.models.incident import IncidentStatus
+from sentry.incidents.typings.metric_detector import OpenPeriodContext
 from sentry.notifications.platform.slack.provider import SlackNotificationProvider
-from sentry.notifications.platform.slack.renderers.metric_alert import (
-    SlackMetricAlertRenderer,
-    _build_metric_issue_context_from_activity,
-)
-from sentry.notifications.platform.templates.metric_alert import (
-    ActivityMetricAlertNotificationData,
-    MetricAlertNotificationData,
-    SerializableAlertContext,
-)
+from sentry.notifications.platform.slack.renderers.metric_alert import SlackMetricAlertRenderer
+from sentry.notifications.platform.templates.metric_alert import MetricAlertNotificationData
 from sentry.notifications.platform.templates.seer import SeerAutofixError
 from sentry.notifications.platform.types import (
     NotificationCategory,
     NotificationRenderedTemplate,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
-from sentry.types.activity import ActivityType
-from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -35,23 +23,20 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
 MOCK_CHART_URL = "https://chart.example.com/metric.png"
 
 
-def _make_notification_data(**overrides: object) -> MetricAlertNotificationData:
-    defaults: dict[str, object] = dict(
-        event_id="abc123",
-        project_id=1,
+def _make_notification_data(**overrides: Any) -> MetricAlertNotificationData:
+    defaults: dict[str, Any] = dict(
         group_id=1,
         organization_id=1,
-        detector_id=1,
-        alert_context=SerializableAlertContext(
-            name="Test Alert",
-            action_identifier_id=1,
-            detection_type="static",
-        ),
+        notification_uuid="test-uuid",
+        action_id=1,
         open_period_context=OpenPeriodContext(
             id=1,
             date_started=datetime(2024, 1, 1, tzinfo=timezone.utc),
         ),
-        notification_uuid="test-uuid",
+        new_status=IncidentStatus.CRITICAL.value,
+        title="Critical: Test Alert",
+        title_link="https://sentry.io/alerts/1/",
+        text="123 events in the last 5 minutes",
     )
     defaults.update(overrides)
     return MetricAlertNotificationData(**defaults)
@@ -92,43 +77,27 @@ class SlackMetricAlertRendererTest(MetricAlertHandlerBase):
         super().setUp()
         self.create_models()
 
-        alert_context = AlertContext.from_workflow_engine_models(
-            self.detector,
-            self.evidence_data,
-            self.group.status,
-            DetectorPriorityLevel.HIGH,
-        )
         open_period_context = OpenPeriodContext.from_group(self.group)
 
-        self.notification_data = MetricAlertNotificationData(
-            event_id=self.group_event.event_id,
-            project_id=self.project.id,
+        self.notification_data = _make_notification_data(
             group_id=self.group.id,
             organization_id=self.organization.id,
-            detector_id=self.detector.id,
-            alert_context=SerializableAlertContext.from_alert_context(alert_context),
+            action_id=1,
             open_period_context=open_period_context,
-            notification_uuid="test-uuid",
+            new_status=IncidentStatus.CRITICAL.value,
+            title=f"Critical: {self.detector.name}",
+            title_link="https://sentry.io/alerts/1/",
+            text="123.45 events in the last minute",
         )
         self.rendered_template = NotificationRenderedTemplate(subject="Metric Alert", body=[])
 
-    @patch(
-        "sentry.notifications.platform.slack.renderers.metric_alert.build_metric_alert_chart",
-        return_value=None,
-    )
-    @patch(
-        "sentry.notifications.platform.slack.renderers.metric_alert.eventstore.backend.get_event_by_id"
-    )
-    def test_render_produces_blocks(self, mock_get_event: MagicMock, mock_chart: MagicMock) -> None:
-        mock_get_event.return_value = self.group_event
-
+    def test_render_produces_blocks(self) -> None:
         result = SlackMetricAlertRenderer.render(
             data=self.notification_data,
             rendered_template=self.rendered_template,
         )
 
         # Without a chart: exactly one section block with the metric text
-        # This is annoying but since Block is not indexable and we want to test the structure we need to say Any
         blocks: list[Any] = result["blocks"]
         assert len(blocks) == 1
         assert blocks[0]["type"] == "section"
@@ -137,26 +106,24 @@ class SlackMetricAlertRendererTest(MetricAlertHandlerBase):
         # Fallback text should reference the detector/alert name
         assert self.detector.name in result["text"]
 
-    @patch(
-        "sentry.notifications.platform.slack.renderers.metric_alert.build_metric_alert_chart",
-        return_value=MOCK_CHART_URL,
-    )
-    @patch(
-        "sentry.notifications.platform.slack.renderers.metric_alert.eventstore.backend.get_event_by_id"
-    )
-    @with_feature({"organizations:metric-alert-chartcuterie": True})
-    def test_render_includes_image_block_when_chart_enabled(
-        self, mock_get_event: MagicMock, mock_chart: MagicMock
-    ) -> None:
-        mock_get_event.return_value = self.group_event
+    def test_render_includes_image_block_when_chart_url_present(self) -> None:
+        data_with_chart = _make_notification_data(
+            group_id=self.group.id,
+            organization_id=self.organization.id,
+            open_period_context=OpenPeriodContext.from_group(self.group),
+            new_status=IncidentStatus.CRITICAL.value,
+            title=f"Critical: {self.detector.name}",
+            title_link="https://sentry.io/alerts/1/",
+            text="123.45 events in the last minute",
+            chart_url=MOCK_CHART_URL,
+        )
 
         result = SlackMetricAlertRenderer.render(
-            data=self.notification_data,
+            data=data_with_chart,
             rendered_template=self.rendered_template,
         )
 
         # With a chart: section block + image block
-        # This is annoying but since Block is not indexable and we want to test the structure we need to say Any
         blocks: list[Any] = result["blocks"]
         assert len(blocks) == 2
         assert blocks[0]["type"] == "section"
@@ -165,67 +132,7 @@ class SlackMetricAlertRendererTest(MetricAlertHandlerBase):
         assert blocks[1]["image_url"] == MOCK_CHART_URL
         assert blocks[1]["alt_text"] == "Metric Alert Chart"
 
-    @patch("sentry.notifications.platform.slack.renderers.metric_alert.sentry_sdk")
-    @patch(
-        "sentry.notifications.platform.slack.renderers.metric_alert.build_metric_alert_chart",
-        side_effect=Exception("chart service unavailable"),
-    )
-    @patch(
-        "sentry.notifications.platform.slack.renderers.metric_alert.eventstore.backend.get_event_by_id"
-    )
-    def test_render_continues_when_chart_fails(
-        self, mock_get_event: MagicMock, mock_chart: MagicMock, mock_sdk: MagicMock
-    ) -> None:
-        mock_get_event.return_value = self.group_event
-
-        with self.feature("organizations:metric-alert-chartcuterie"):
-            result = SlackMetricAlertRenderer.render(
-                data=self.notification_data,
-                rendered_template=self.rendered_template,
-            )
-
-        mock_sdk.capture_exception.assert_called_once()
-        # Render completes without the chart — just the section block
-        # This is annoying but since Block is not indexable and we want to test the structure we need to say Any
-        blocks: list[Any] = result["blocks"]
-        assert len(blocks) == 1
-        assert blocks[0]["type"] == "section"
-
-
-class SlackActivityMetricAlertRendererTest(MetricAlertHandlerBase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.create_models()
-
-        activity = Activity(
-            project=self.project,
-            group=self.group,
-            type=ActivityType.SET_RESOLVED.value,
-            data=asdict(self.evidence_data),
-        )
-        activity.save()
-
-        alert_context = AlertContext.from_workflow_engine_models(
-            self.detector,
-            self.evidence_data,
-            self.group.status,
-            DetectorPriorityLevel.HIGH,
-        )
-        open_period_context = OpenPeriodContext.from_group(self.group)
-
-        self.notification_data = ActivityMetricAlertNotificationData(
-            group_id=self.group.id,
-            organization_id=self.organization.id,
-            detector_id=self.detector.id,
-            alert_context=SerializableAlertContext.from_alert_context(alert_context),
-            open_period_context=open_period_context,
-            activity_id=activity.id,
-            notification_uuid="test-uuid",
-        )
-        self.rendered_template = NotificationRenderedTemplate(subject="Metric Alert", body=[])
-
-    def test_render_produces_blocks_without_snuba(self) -> None:
-        # The Activity path re-fetches from Postgres only (no Snuba) — no eventstore mock needed
+    def test_render_without_chart_url(self) -> None:
         result = SlackMetricAlertRenderer.render(
             data=self.notification_data,
             rendered_template=self.rendered_template,
@@ -234,66 +141,22 @@ class SlackActivityMetricAlertRendererTest(MetricAlertHandlerBase):
         blocks: list[Any] = result["blocks"]
         assert len(blocks) == 1
         assert blocks[0]["type"] == "section"
-        assert blocks[0]["text"]["type"] == "mrkdwn"
-        # "Resolved" appears in the fallback title (result["text"]), not the metric body block
+
+    def test_render_resolved_status(self) -> None:
+        resolved_data = _make_notification_data(
+            group_id=self.group.id,
+            organization_id=self.organization.id,
+            open_period_context=OpenPeriodContext.from_group(self.group),
+            new_status=IncidentStatus.CLOSED.value,
+            title=f"Resolved: {self.detector.name}",
+            title_link="https://sentry.io/alerts/1/",
+            text="",
+        )
+
+        result = SlackMetricAlertRenderer.render(
+            data=resolved_data,
+            rendered_template=self.rendered_template,
+        )
+
         assert "Resolved" in result["text"]
         assert self.detector.name in result["text"]
-
-    @patch(
-        "sentry.notifications.platform.slack.renderers.metric_alert.build_metric_alert_chart",
-        return_value=MOCK_CHART_URL,
-    )
-    @with_feature({"organizations:metric-alert-chartcuterie": True})
-    def test_render_includes_image_block_when_chart_enabled(self, mock_chart: MagicMock) -> None:
-        result = SlackMetricAlertRenderer.render(
-            data=self.notification_data,
-            rendered_template=self.rendered_template,
-        )
-
-        blocks: list[Any] = result["blocks"]
-        assert len(blocks) == 2
-        assert blocks[0]["type"] == "section"
-        assert "Resolved" in result["text"]
-        assert blocks[1]["type"] == "image"
-        assert blocks[1]["image_url"] == MOCK_CHART_URL
-        assert blocks[1]["alt_text"] == "Metric Alert Chart"
-
-
-class MetricIssueContextBuildersTest(MetricAlertHandlerBase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.create_models()
-
-    def test_build_from_activity_uses_ok_priority(self) -> None:
-        from sentry.incidents.models.incident import IncidentStatus
-
-        activity = Activity(
-            project=self.project,
-            group=self.group,
-            type=ActivityType.SET_RESOLVED.value,
-            data=asdict(self.evidence_data),
-        )
-        activity.save()
-
-        data = ActivityMetricAlertNotificationData(
-            group_id=self.group.id,
-            organization_id=self.organization.id,
-            detector_id=self.detector.id,
-            alert_context=SerializableAlertContext.from_alert_context(
-                AlertContext.from_workflow_engine_models(
-                    self.detector,
-                    self.evidence_data,
-                    self.group.status,
-                    DetectorPriorityLevel.HIGH,
-                )
-            ),
-            open_period_context=OpenPeriodContext.from_group(self.group),
-            activity_id=activity.id,
-            notification_uuid="test-uuid",
-        )
-
-        context = _build_metric_issue_context_from_activity(data)
-
-        # Activity path always resolves with DetectorPriorityLevel.OK → IncidentStatus.CLOSED
-        assert context.new_status == IncidentStatus.CLOSED
-        assert context.metric_value == self.evidence_data.value

--- a/tests/sentry/notifications/platform/templates/test_metric_alert.py
+++ b/tests/sentry/notifications/platform/templates/test_metric_alert.py
@@ -3,98 +3,36 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
-from sentry.incidents.typings.metric_detector import AlertContext, OpenPeriodContext
+from sentry.incidents.models.incident import IncidentStatus
+from sentry.incidents.typings.metric_detector import OpenPeriodContext
 from sentry.notifications.platform.templates.metric_alert import (
-    ActivityMetricAlertNotificationData,
-    ActivityMetricAlertNotificationTemplate,
     MetricAlertNotificationData,
     MetricAlertNotificationTemplate,
-    SerializableAlertContext,
 )
 from sentry.notifications.platform.types import NotificationRenderedTemplate, NotificationSource
-from sentry.seer.anomaly_detection.types import AnomalyDetectionThresholdType
 from sentry.testutils.cases import TestCase
-from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
 
 
 def _make_notification_data(**overrides: Any) -> MetricAlertNotificationData:
-    defaults = {
-        "event_id": "abc123",
-        "project_id": 1,
+    defaults: dict[str, Any] = {
         "group_id": 1,
         "organization_id": 1,
-        "detector_id": 1,
-        "alert_context": SerializableAlertContext(
-            name="Test Alert",
-            action_identifier_id=1,
-            detection_type="static",
-        ),
+        "notification_uuid": "test-uuid",
+        "action_id": 1,
         "open_period_context": OpenPeriodContext(
             id=1,
             date_started=datetime(2024, 1, 1, tzinfo=timezone.utc),
         ),
-        "notification_uuid": "test-uuid",
+        "new_status": IncidentStatus.CRITICAL.value,
+        "title": "Critical: Test Alert",
+        "title_link": "https://sentry.io/alerts/1/",
+        "text": "123 events in the last 5 minutes",
     }
     defaults.update(overrides)
     return MetricAlertNotificationData(**defaults)
-
-
-class SerializableAlertContextTest(TestCase):
-    def test_round_trip_alert_rule_threshold_type(self) -> None:
-        original = AlertContext(
-            name="My Alert",
-            action_identifier_id=42,
-            threshold_type=AlertRuleThresholdType.ABOVE,
-            detection_type=AlertRuleDetectionType.STATIC,
-            comparison_delta=3600,
-            sensitivity=None,
-            resolve_threshold=5.0,
-            alert_threshold=10.0,
-        )
-        round_tripped = SerializableAlertContext.from_alert_context(original).to_alert_context()
-
-        assert round_tripped.threshold_type == AlertRuleThresholdType.ABOVE
-        assert round_tripped.detection_type == AlertRuleDetectionType.STATIC
-        assert round_tripped.comparison_delta == original.comparison_delta
-        assert round_tripped.resolve_threshold == original.resolve_threshold
-        assert round_tripped.alert_threshold == original.alert_threshold
-
-    def test_round_trip_anomaly_detection_threshold_type(self) -> None:
-        original = AlertContext(
-            name="Anomaly Alert",
-            action_identifier_id=99,
-            threshold_type=AnomalyDetectionThresholdType.ABOVE_AND_BELOW,
-            detection_type=AlertRuleDetectionType.DYNAMIC,
-            comparison_delta=None,
-            sensitivity="medium",
-            resolve_threshold=0.0,
-            alert_threshold=0.0,
-        )
-        round_tripped = SerializableAlertContext.from_alert_context(original).to_alert_context()
-
-        assert isinstance(round_tripped.threshold_type, AnomalyDetectionThresholdType)
-        assert round_tripped.threshold_type == AnomalyDetectionThresholdType.ABOVE_AND_BELOW
-        assert round_tripped.detection_type == AlertRuleDetectionType.DYNAMIC
-        assert round_tripped.sensitivity == original.sensitivity
-
-    def test_round_trip_none_threshold_type(self) -> None:
-        original = AlertContext(
-            name="No Threshold",
-            action_identifier_id=3,
-            threshold_type=None,
-            detection_type=AlertRuleDetectionType.STATIC,
-            comparison_delta=None,
-            sensitivity=None,
-            resolve_threshold=None,
-            alert_threshold=None,
-        )
-        round_tripped = SerializableAlertContext.from_alert_context(original).to_alert_context()
-
-        assert round_tripped.threshold_type is None
 
 
 class OpenPeriodContextTest(TestCase):
@@ -130,123 +68,48 @@ class MetricAlertNotificationDataTest(TestCase):
         assert data.source == NotificationSource.METRIC_ALERT
 
     def test_pydantic_serialization_round_trip(self) -> None:
-        alert_ctx = SerializableAlertContext(
-            name="Round Trip Alert",
-            action_identifier_id=5,
-            threshold_type=int(AlertRuleThresholdType.ABOVE.value),
-            detection_type="static",
-            comparison_delta=1800,
-            sensitivity=None,
-            resolve_threshold=1.0,
-            alert_threshold=10.0,
-        )
         open_period_ctx = OpenPeriodContext(
             id=77,
             date_started=datetime(2024, 3, 1, 0, 0, 0, tzinfo=timezone.utc),
             date_closed=datetime(2024, 3, 1, 1, 0, 0, tzinfo=timezone.utc),
         )
         original = MetricAlertNotificationData(
-            event_id="evt-999",
-            project_id=10,
             group_id=20,
             organization_id=30,
-            detector_id=40,
-            alert_context=alert_ctx,
-            open_period_context=open_period_ctx,
             notification_uuid="round-trip-uuid",
+            action_id=5,
+            open_period_context=open_period_ctx,
+            new_status=IncidentStatus.CRITICAL.value,
+            title="Critical: My Alert",
+            title_link="https://sentry.io/alerts/99/",
+            text="100 events in the last minute",
+            chart_url="https://chart.example.com/1.png",
         )
 
         as_dict = original.dict()
         restored = MetricAlertNotificationData.validate(as_dict)
 
-        assert restored.event_id == original.event_id
-        assert restored.project_id == original.project_id
         assert restored.group_id == original.group_id
         assert restored.organization_id == original.organization_id
-        assert restored.detector_id == original.detector_id
         assert restored.notification_uuid == original.notification_uuid
-        assert restored.alert_context == original.alert_context
+        assert restored.action_id == original.action_id
+        assert restored.new_status == original.new_status
+        assert restored.title == original.title
+        assert restored.title_link == original.title_link
+        assert restored.text == original.text
+        assert restored.chart_url == original.chart_url
         assert restored.open_period_context == original.open_period_context
         assert restored.source == NotificationSource.METRIC_ALERT
 
-
-def _make_activity_notification_data(**overrides: Any) -> ActivityMetricAlertNotificationData:
-    defaults = {
-        "group_id": 1,
-        "organization_id": 1,
-        "detector_id": 1,
-        "alert_context": SerializableAlertContext(
-            name="Test Alert",
-            action_identifier_id=1,
-            detection_type="static",
-        ),
-        "open_period_context": OpenPeriodContext(
-            id=1,
-            date_started=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        ),
-        "activity_id": 1,
-        "notification_uuid": "test-uuid",
-    }
-    defaults.update(overrides)
-    return ActivityMetricAlertNotificationData(**defaults)
-
-
-class ActivityMetricAlertNotificationDataTest(TestCase):
-    def test_source(self) -> None:
-        data = _make_activity_notification_data()
-        assert data.source == NotificationSource.ACTIVITY_METRIC_ALERT
-
-    def test_pydantic_serialization_round_trip(self) -> None:
-        original = _make_activity_notification_data(
-            group_id=10,
-            organization_id=20,
-            detector_id=30,
-            notification_uuid="activity-uuid",
-        )
-
-        as_dict = original.dict()
-        restored = ActivityMetricAlertNotificationData.validate(as_dict)
-
-        assert restored.group_id == original.group_id
-        assert restored.organization_id == original.organization_id
-        assert restored.detector_id == original.detector_id
-        assert restored.notification_uuid == original.notification_uuid
-        assert restored.activity_id == original.activity_id
-        assert restored.source == NotificationSource.ACTIVITY_METRIC_ALERT
-
-
-class ActivityMetricAlertNotificationTemplateTest(TestCase):
-    def test_render_returns_minimal_rendered_template(self) -> None:
-        template = ActivityMetricAlertNotificationTemplate()
-        data = _make_activity_notification_data()
-
-        result = template.render(data)
-
-        assert isinstance(result, NotificationRenderedTemplate)
-        assert result.subject == "Metric Alert"
-        assert result.body == []
+    def test_chart_url_defaults_to_none(self) -> None:
+        data = _make_notification_data()
+        assert data.chart_url is None
 
 
 class MetricAlertNotificationDataContextsTest(MetricAlertHandlerBase):
     def setUp(self) -> None:
         super().setUp()
         self.create_models()
-
-    def test_alert_context_round_trips_from_workflow_engine_models(self) -> None:
-        alert_context = AlertContext.from_workflow_engine_models(
-            self.detector,
-            self.evidence_data,
-            self.group.status,
-            DetectorPriorityLevel.HIGH,
-        )
-        serialized = SerializableAlertContext.from_alert_context(alert_context)
-        restored = serialized.to_alert_context()
-
-        assert restored.name == alert_context.name
-        assert restored.action_identifier_id == alert_context.action_identifier_id
-        assert restored.detection_type == alert_context.detection_type
-        assert restored.threshold_type == alert_context.threshold_type
-        assert restored.comparison_delta == alert_context.comparison_delta
 
     def test_open_period_context_round_trips_from_real_group(self) -> None:
         open_period_context = OpenPeriodContext.from_group(self.group)


### PR DESCRIPTION
Summary

  - Hooks SlackMetricAlertHandler into the Notification Platform (NP) replacing the send_incident_alert_notification() call
  - Pre-computes attachment info and chart URL in the handler and placing those into the data (reducing lookups)
  - Eliminates Activity vs GroupEvent branching in the renderer — invoke_legacy_registry already resolves both paths into the same context objects before send_alert() is called

Note:
- We're no longer hooking in at the noa layer atp (diff from original spec), so we didn;t really get rid of the invoke_legacy_registry part which may have been a goal?