### PR TITLE
fix(objectstore): Set auth token in proxy endpoint, preprod task

### DIFF
--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -1,7 +1,7 @@
 import subprocess
 from datetime import timedelta
-from urllib.parse import urlparse, urlunparse
 from typing import TypedDict, Unpack
+from urllib.parse import urlparse, urlunparse
 
 import urllib3
 from django.conf import settings
@@ -75,7 +75,11 @@ def create_client(token_override: str | None = None) -> Client:
     token = token_override
     if signing_key_options := options.get("token_generator"):
         # We require the `kid` and `secret_key` keys be set, other options are optional
-        if token is None and signing_key_options.get("kid") and signing_key_options.get("secret_key"):
+        if (
+            token is None
+            and signing_key_options.get("kid")
+            and signing_key_options.get("secret_key")
+        ):
             token = TokenGenerator(
                 **signing_key_options,
             )
@@ -102,7 +106,9 @@ def default_client() -> Client:
     return _OBJECTSTORE_CLIENT
 
 
-def _get_session(usecase: Usecase, org: int, project: int | None, client: Client | None = None) -> Session:
+def _get_session(
+    usecase: Usecase, org: int, project: int | None, client: Client | None = None
+) -> Session:
     if client is None:
         client = default_client()
 

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -1,6 +1,7 @@
 import subprocess
 from datetime import timedelta
 from urllib.parse import urlparse, urlunparse
+from typing import TypedDict, Unpack
 
 import urllib3
 from django.conf import settings
@@ -19,7 +20,7 @@ from sentry import options
 from sentry.utils import metrics as sentry_metrics
 from sentry.utils.env import in_test_environment
 
-__all__ = ["get_attachments_session", "parse_accept_encoding"]
+__all__ = ["get_attachments_session", "get_preprod_session", "parse_accept_encoding"]
 
 
 def default_attachment_retention() -> int:
@@ -65,17 +66,17 @@ _ATTACHMENTS_USECASE: Usecase | None = None
 _PREPROD_USECASE = Usecase("preprod", expiration_policy=TimeToLive(timedelta(days=30)))
 
 
-def create_client() -> Client:
+def create_client(token_override: str | None = None) -> Client:
     from sentry import options as options_store
 
     options = options_store.get("objectstore.config")
 
     # Initialize the `TokenGenerator` if key parameters are found.
-    token_generator = None
+    token = token_override
     if signing_key_options := options.get("token_generator"):
         # We require the `kid` and `secret_key` keys be set, other options are optional
-        if signing_key_options.get("kid") and signing_key_options.get("secret_key"):
-            token_generator = TokenGenerator(
+        if token is None and signing_key_options.get("kid") and signing_key_options.get("secret_key"):
+            token = TokenGenerator(
                 **signing_key_options,
             )
 
@@ -90,15 +91,27 @@ def create_client() -> Client:
             # Workaround for 0.0.14's default read timeout. Can be removed with 0.0.15
             {"timeout": urllib3.Timeout(connect=0.1)},
         ),
-        token=token_generator,
+        token=token,
     )
 
 
-def get_client() -> Client:
+def default_client() -> Client:
     global _OBJECTSTORE_CLIENT
     if not _OBJECTSTORE_CLIENT:
         _OBJECTSTORE_CLIENT = create_client()
     return _OBJECTSTORE_CLIENT
+
+
+def _get_session(usecase: Usecase, org: int, project: int | None, client: Client | None = None) -> Session:
+    if client is None:
+        client = default_client()
+
+    if project is None:
+        session = client.session(usecase, org=org)
+    else:
+        session = client.session(usecase, org=org, project=project)
+
+    return session
 
 
 def get_attachments_usecase() -> Usecase:
@@ -112,11 +125,11 @@ def get_attachments_usecase() -> Usecase:
 
 
 def get_attachments_session(org: int, project: int) -> Session:
-    return get_client().session(get_attachments_usecase(), org=org, project=project)
+    return _get_session(get_attachments_usecase(), org, project)
 
 
-def get_preprod_session(org: int, project: int) -> Session:
-    return get_client().session(_PREPROD_USECASE, org=org, project=project)
+def get_preprod_session(org: int, project: int | None, client: Client | None = None) -> Session:
+    return _get_session(_PREPROD_USECASE, org, project, client=client)
 
 
 _IS_SYMBOLICATOR_CONTAINER: bool | None = None

--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -28,7 +28,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationReleasePermission
 from sentry.models.organization import Organization
-from sentry.objectstore import parse_accept_encoding
+from sentry.objectstore import get_preprod_session, parse_accept_encoding
 
 
 @cell_silo_endpoint
@@ -58,33 +58,34 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
     ) -> Response | StreamingHttpResponse:
         if response := self._check_flag(request, organization):
             return response
-        return self._proxy(request, path)
+        return self._proxy(request, path, organization)
 
     def put(
         self, request: Request, organization: Organization, path: str
     ) -> Response | StreamingHttpResponse:
         if response := self._check_flag(request, organization):
             return response
-        return self._proxy(request, path)
+        return self._proxy(request, path, organization)
 
     def post(
         self, request: Request, organization: Organization, path: str
     ) -> Response | StreamingHttpResponse:
         if response := self._check_flag(request, organization):
             return response
-        return self._proxy(request, path)
+        return self._proxy(request, path, organization)
 
     def delete(
         self, request: Request, organization: Organization, path: str
     ) -> Response | StreamingHttpResponse:
         if response := self._check_flag(request, organization):
             return response
-        return self._proxy(request, path)
+        return self._proxy(request, path, organization)
 
     def _proxy(
         self,
         request: Request,
         path: str,
+        organization: Organization,
     ) -> Response | StreamingHttpResponse:
         assert request.method
         target_url = get_target_url(path)
@@ -93,6 +94,14 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
         headers.pop("Host", None)
         headers.pop("Content-Length", None)
         headers.pop("Transfer-Encoding", None)
+
+        # Create an Objectstore session to mint a token
+        session = get_preprod_session(organization.id, None)
+        if token := session.mint_token():
+            headers["Authorization"] = f"Bearer {token}"
+        else:
+            # Objectstore can't parse Sentry's auth headers, must pop it
+            headers.pop("Authorization", None)
 
         response = requests.request(
             request.method,

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -11,7 +11,7 @@ from objectstore_client.client import RequestError
 from pydantic import ValidationError
 from taskbroker_client.retry import Retry
 
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import create_client, get_preprod_session
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.image_diff.compare import compare_images_batch
 from sentry.preprod.snapshots.image_diff.odiff import OdiffServer
@@ -125,6 +125,7 @@ def compare_snapshots(
     org_id: int,
     head_artifact_id: int,
     base_artifact_id: int,
+    storage_token: str | None = None,
 ) -> None:
     task_start_time = timezone.now()
     logger.info(
@@ -219,7 +220,8 @@ def compare_snapshots(
         )
 
     try:
-        session = get_preprod_session(org_id, project_id)
+        client_with_token = create_client(token_override=storage_token)
+        session = get_preprod_session(org_id, project_id, client=client_with_token)
 
         head_manifest_key = (head_metrics.extras or {}).get("manifest_key")
         base_manifest_key = (base_metrics.extras or {}).get("manifest_key")


### PR DESCRIPTION
these appear to be the last objectstore auth integration issues to fix before we can turn on auth enforcement

### proxy endpoint issue

there is a low volume of `validation_failure` / `InvalidToken` errors which only occur for requests to our batch endpoint. the only user of the batch endpoint appears to be `sentry-cli`, and those requests go through a Sentry proxy endpoint. the proxy endpoint forwards its request's headers mostly unmodified to Objectstore, including the `Authorization` header which contains a Sentry bearer token that Objectstore doesn't understand.

this PR creates a preprod objectstore session in the proxy endpoint and calls `mint_token()` to get a valid Objectstore token for the request

**QUESTION**: is it valid to assume the organization-based proxy endpoint will only deal with org-scoped resources? or do we need to make that a project-based endpoint

### preprod task issue

we saw a surge in "no authorization token provided" issues coming from what i'm guessing are taskworker tasks? so i prepared the relevant task to receive a token kwarg. i assume actually setting it has to come in a separate PR, but i don't know how taskbroker tasks and whatall are deployed

Ref FS-321

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
