### PR TITLE
feat(data_export): add logging for data-export-failure

### DIFF
--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -169,7 +169,19 @@ class ExportedData(Model):
             error_payload=self.payload,
             creation_date=self.date_added,
         )
-        if NotificationService.has_access(self.organization, data.source):
+        has_access = NotificationService.has_access(self.organization, data.source)
+        logger.info(
+            "notification.platform.data-export-failure.has_access",
+            extra={
+                "organization_id": self.organization.id,
+                "data_export_id": self.id,
+                "data_source": data.source,
+                "has_access": has_access,
+                "user_email": user.email,
+            },
+        )
+
+        if has_access:
             NotificationService(data=data).notify_async(
                 targets=[
                     GenericNotificationTarget(

--- a/tests/sentry/data_export/test_models.py
+++ b/tests/sentry/data_export/test_models.py
@@ -224,6 +224,22 @@ class ExportedDataTest(TestCase):
             html_content
         )
 
+    @patch("sentry.data_export.models.logger")
+    def test_email_failure_logging(self, mock_logger: MagicMock) -> None:
+        data_export_id = self.data_export.id
+        with self.tasks():
+            self.data_export.email_failure("failed to export data!")
+        mock_logger.info.assert_any_call(
+            "notification.platform.data-export-failure.has_access",
+            extra={
+                "organization_id": self.organization.id,
+                "data_export_id": data_export_id,
+                "data_source": "data-export-failure",
+                "has_access": False,
+                "user_email": self.user.email,
+            },
+        )
+
     @override_options(
         {"notifications.platform-rollout.internal-testing": {"data-export-failure": 1.0}}
     )


### PR DESCRIPTION
We already have logging for `data-export-success`. That success log includes the user's email, which makes it nice and easy to tell if someone's data export has succeeded (at least this far in code). But there's no equivalent log for failure. Which is what @narsaynorath and I were trying to debug earlier today and having to do all sorts of log/trace query workarounds for.

Fixes LOGS-673.