### PR TITLE
fix(lint): Close S016 loophole for attribute-access ThreadPoolExecutor

### DIFF
--- a/src/sentry/build/_integration_docs.py
+++ b/src/sentry/build/_integration_docs.py
@@ -87,7 +87,7 @@ def _sync_docs(dest: str, *, quiet: bool = False) -> None:
     # This value is derived from https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor
     MAX_THREADS = 32
     thread_count = min(len(data["platforms"]), multiprocessing.cpu_count() * 5, MAX_THREADS)
-    with concurrent.futures.ThreadPoolExecutor(thread_count) as exe:
+    with concurrent.futures.ThreadPoolExecutor(thread_count) as exe:  # noqa: S016 - build script, no sentry_sdk available
         for future in concurrent.futures.as_completed(
             exe.submit(
                 _sync_one,

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -268,6 +268,26 @@ def test_S016() -> None:
     src = "from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor\n"
     assert _run(src) == []
 
+    # Attribute access via `concurrent.futures.ThreadPoolExecutor()` should be flagged
+    src = "import concurrent.futures\nconcurrent.futures.ThreadPoolExecutor(max_workers=4)\n"
+    errors = _run(src)
+    assert errors == [
+        "t.py:2:0: S016 Use `from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor`"
+        " instead of `concurrent.futures.ThreadPoolExecutor` to ensure contextvars propagation.",
+    ]
+
+    # Attribute access without call should also be flagged
+    src = "import concurrent.futures\nx = concurrent.futures.ThreadPoolExecutor\n"
+    errors = _run(src)
+    assert errors == [
+        "t.py:2:4: S016 Use `from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor`"
+        " instead of `concurrent.futures.ThreadPoolExecutor` to ensure contextvars propagation.",
+    ]
+
+    # Other concurrent.futures attributes are fine
+    src = "import concurrent.futures\nconcurrent.futures.as_completed([])\n"
+    assert _run(src) == []
+
 
 def test_S015_current_or_future_year() -> None:
     cy = datetime.now(timezone.utc).year

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -141,6 +141,14 @@ class SentryVisitor(ast.NodeVisitor):
             self.errors.append((node.lineno, node.col_offset, S001_fmt.format(node.attr)))
         elif node.attr in S004_methods:
             self.errors.append((node.lineno, node.col_offset, S004_msg))
+        elif (
+            node.attr == "ThreadPoolExecutor"
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "futures"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "concurrent"
+        ):
+            self.errors.append((node.lineno, node.col_offset, S016_msg))
 
         self.generic_visit(node)
 


### PR DESCRIPTION
S016 only caught `from concurrent.futures import ThreadPoolExecutor` (the `ImportFrom` AST node). Writing `import concurrent.futures` then using `concurrent.futures.ThreadPoolExecutor(...)` bypassed the rule entirely.

This adds a check in `visit_Attribute` that matches when the attribute chain is exactly `concurrent.futures.ThreadPoolExecutor` — catches both calls and bare references, without flagging other `concurrent.futures.*` usage like `as_completed` or `Future`.

Also fixes the one existing violation in `src/sentry/build/_integration_docs.py`.

Stacks on #112156.