### PR TITLE
feat: Add ViewerContext middleware for API requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -624,6 +624,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/tasks/seer/                                   @getsentry/machine-learning-ai
 /src/sentry/viewer_context.py                               @getsentry/machine-learning-ai
 /tests/sentry/test_viewer_context.py                        @getsentry/machine-learning-ai
+/src/sentry/middleware/viewer_context.py                     @getsentry/machine-learning-ai
+/tests/sentry/middleware/test_viewer_context.py              @getsentry/machine-learning-ai
 ## End of ML & AI
 
 ## Issues

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -391,6 +391,7 @@ MIDDLEWARE: tuple[str, ...] = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "sentry.middleware.auth.AuthenticationMiddleware",
+    "sentry.middleware.viewer_context.ViewerContextMiddleware",
     "sentry.middleware.ai_agent.AIAgentMiddleware",
     "sentry.middleware.integrations.IntegrationControlMiddleware",
     APIGW_MIDDLEWARE,

--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from django.http.request import HttpRequest
+from django.http.response import HttpResponseBase
+
+from sentry import options
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
+
+
+def ViewerContextMiddleware(
+    get_response: Callable[[HttpRequest], HttpResponseBase],
+) -> Callable[[HttpRequest], HttpResponseBase]:
+    """Set :class:`ViewerContext` for every request after authentication.
+
+    Must be placed **after** ``AuthenticationMiddleware`` so that
+    ``request.user`` and ``request.auth`` are already populated.
+
+    Gated by the ``viewer-context.enabled`` option (FLAG_NOSTORE).
+    Set via deploy config; requires restart to change.
+    """
+    enabled = options.get("viewer-context.enabled")
+
+    def ViewerContextMiddleware_impl(request: HttpRequest) -> HttpResponseBase:
+        if not enabled:
+            return get_response(request)
+
+        ctx = _viewer_context_from_request(request)
+        with viewer_context_scope(ctx):
+            return get_response(request)
+
+    return ViewerContextMiddleware_impl
+
+
+def _viewer_context_from_request(request: HttpRequest) -> ViewerContext:
+    user = request.user
+    auth = getattr(request, "auth", None)
+
+    user_id: int | None = None
+    if user.is_authenticated:
+        user_id = user.id
+
+    organization_id: int | None = None
+    if auth is not None and hasattr(auth, "organization_id"):
+        organization_id = auth.organization_id
+
+    return ViewerContext(
+        user_id=user_id,
+        organization_id=organization_id,
+        actor_type=ActorType.USER,
+        token=auth,
+    )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4070,3 +4070,12 @@ register(
     type=Bool,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# ViewerContext — unified caller identity for all entrypoints.
+# Set via deploy config (SENTRY_OPTIONS); requires restart to change.
+register(
+    "viewer-context.enabled",
+    default=False,
+    type=Bool,
+    flags=FLAG_NOSTORE,
+)

--- a/tests/sentry/middleware/test_viewer_context.py
+++ b/tests/sentry/middleware/test_viewer_context.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+from sentry.auth.services.auth import AuthenticatedToken
+from sentry.middleware.viewer_context import ViewerContextMiddleware, _viewer_context_from_request
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.viewer_context import ActorType, get_viewer_context
+
+
+class ViewerContextFromRequestTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+
+    def test_anonymous_request(self):
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        request.auth = None
+
+        ctx = _viewer_context_from_request(request)
+
+        assert ctx.user_id is None
+        assert ctx.organization_id is None
+        assert ctx.actor_type is ActorType.USER
+        assert ctx.token is None
+
+    def test_session_authenticated_user(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        request.auth = None
+
+        ctx = _viewer_context_from_request(request)
+
+        assert ctx.user_id == self.user.id
+        assert ctx.organization_id is None
+        assert ctx.actor_type is ActorType.USER
+        assert ctx.token is None
+
+    def test_token_authenticated_user(self):
+        request = self.factory.get("/")
+        token = AuthenticatedToken(
+            allowed_origins=["*"],
+            scopes=["org:read"],
+            entity_id=1,
+            kind="api_token",
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+        )
+        request.user = self.user
+        request.auth = token
+
+        ctx = _viewer_context_from_request(request)
+
+        assert ctx.user_id == self.user.id
+        assert ctx.organization_id == self.organization.id
+        assert ctx.actor_type is ActorType.USER
+        assert ctx.token is token
+
+    def test_org_scoped_token_without_user(self):
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        token = AuthenticatedToken(
+            allowed_origins=[],
+            scopes=["org:read"],
+            entity_id=1,
+            kind="org_auth_token",
+            organization_id=self.organization.id,
+        )
+        request.auth = token
+
+        ctx = _viewer_context_from_request(request)
+
+        assert ctx.user_id is None
+        assert ctx.organization_id == self.organization.id
+        assert ctx.token is token
+
+    def test_token_without_organization(self):
+        request = self.factory.get("/")
+        token = AuthenticatedToken(
+            allowed_origins=[],
+            scopes=["org:read"],
+            entity_id=1,
+            kind="api_token",
+            user_id=self.user.id,
+        )
+        request.user = self.user
+        request.auth = token
+
+        ctx = _viewer_context_from_request(request)
+
+        assert ctx.user_id == self.user.id
+        assert ctx.organization_id is None
+        assert ctx.token is token
+
+
+class ViewerContextMiddlewareTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+
+    def test_skipped_when_disabled(self):
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        # Default: viewer-context.enabled is False
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get("/")
+        request.user = self.user
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        assert captured[0] is None
+
+    @override_options({"viewer-context.enabled": True})
+    def test_sets_context_during_request(self):
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get("/")
+        request.user = self.user
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        assert captured[0] is not None
+        assert captured[0].user_id == self.user.id
+
+    @override_options({"viewer-context.enabled": True})
+    def test_cleans_up_after_request(self):
+        middleware = ViewerContextMiddleware(lambda r: MagicMock(status_code=200))
+
+        request = self.factory.get("/")
+        request.user = self.user
+        request.auth = None
+
+        middleware(request)
+
+        assert get_viewer_context() is None
+
+    @override_options({"viewer-context.enabled": True})
+    def test_cleans_up_on_exception(self):
+        def get_response(request):
+            raise RuntimeError("boom")
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        request.auth = None
+
+        try:
+            middleware(request)
+        except RuntimeError:
+            pass
+
+        assert get_viewer_context() is None
+
+    @override_options({"viewer-context.enabled": True})
+    def test_anonymous_request_sets_empty_context(self):
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx is not None
+        assert ctx.user_id is None
+        assert ctx.organization_id is None
+        assert ctx.token is None


### PR DESCRIPTION
Add a Django middleware that sets `ViewerContext` on every HTTP request, positioned immediately after `AuthenticationMiddleware` in the stack.

After auth runs, `request.user` and `request.auth` are populated. The middleware reads them to construct a `ViewerContext` with `user_id`, `organization_id` (from org-scoped tokens), `actor_type`, and the `AuthenticatedToken` — then wraps the rest of the request lifecycle in `viewer_context_scope()`. Downstream code can call `get_viewer_context()` at any depth without needing the request object.

The middleware follows the same functional pattern as `SentryEnvMiddleware` — a closure wrapping `get_response(request)` in a context manager.

Tests cover:
- Anonymous requests (no user, no token)
- Session-authenticated users (user_id set, no token)
- Token-authenticated users (user_id + organization_id + token)
- Org-scoped tokens without a user
- Tokens without an organization
- Context is available during request processing
- Context is cleaned up after normal completion
- Context is cleaned up on exceptions

This is Phase 2 of the [Unified ViewerContext RFC](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02) — the first entrypoint instrumented.

Stacks on #112156.