### PR TITLE
test(onboarding): Add acceptance tests for SCM onboarding flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -607,6 +607,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/gettingStartedDocs/                                                  @getsentry/value-discovery
 /static/app/types/project.tsx                                                    @getsentry/value-discovery
 /static/app/views/onboarding/                                                    @getsentry/value-discovery
+/tests/acceptance/test_scm_onboarding.py                                         @getsentry/value-discovery
 /tests/js/fixtures/detectedPlatform.ts                                           @getsentry/value-discovery
 /static/app/views/projectInstall/                                                @getsentry/value-discovery
 /src/sentry/onboarding_tasks/                                                    @getsentry/value-discovery

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from django.core.serializers.json import DjangoJSONEncoder
 
 from sentry.api.serializers import serialize
@@ -9,6 +10,8 @@ from sentry.testutils.asserts import assert_existing_projects_status
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
 from sentry.utils import json
+
+pytestmark = pytest.mark.sentry_metrics
 
 
 @no_silo_test

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
 import pytest
-from django.core.serializers.json import DjangoJSONEncoder
 
 from sentry.api.serializers import serialize
+from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.project import Project
 from sentry.shared_integrations.exceptions import ApiError
@@ -27,7 +27,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
         )
         self.login_as(self.user)
 
-    def create_github_integration(self):
+    def create_github_integration(self) -> Integration:
         integration = self.create_provider_integration(
             provider="github",
             name="getsentry",
@@ -37,7 +37,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
         integration.add_organization(self.org, self.user)
         return integration
 
-    def start_onboarding(self):
+    def start_onboarding(self) -> None:
         self.browser.get(f"/onboarding/{self.org.slug}/")
         self.browser.wait_until('[data-test-id="onboarding-step-welcome"]')
         self.browser.click('[data-test-id="onboarding-welcome-start"]')
@@ -225,9 +225,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             )
             # Resolve Django lazy objects (translations, datetimes) so
             # Selenium can JSON-serialize the data for execute_script.
-            serialized = json.loads(
-                json.dumps(serialize(org_integration, self.user), cls=DjangoJSONEncoder)
-            )
+            serialized = json.loads(json.dumps(serialize(org_integration, self.user)))
             self.browser.driver.execute_script(
                 "window.postMessage(arguments[0], window.location.origin);",
                 {"success": True, "data": serialized},

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -1,11 +1,15 @@
 from unittest import mock
 
 import pytest
+from django.core.serializers.json import DjangoJSONEncoder
 
+from sentry.api.serializers import serialize
+from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.project import Project
 from sentry.testutils.asserts import assert_existing_projects_status
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
+from sentry.utils import json
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -212,32 +216,20 @@ class ScmOnboardingTest(AcceptanceTestCase):
             assert self.browser.driver.execute_script("return window.__testOpenCalled")
 
             # Simulate the OAuth pipeline: create the integration in the DB,
-            # then inject a postMessage matching what dialog-complete.html sends.
+            # then serialize it with the same code path as pipeline.py:406
+            # to avoid mock-drift between the test data and the real serializer.
             integration = self.create_github_integration()
+            org_integration = OrganizationIntegration.objects.get(
+                integration=integration, organization_id=self.org.id
+            )
+            # Resolve Django lazy objects (translations, datetimes) so
+            # Selenium can JSON-serialize the data for execute_script.
+            serialized = json.loads(
+                json.dumps(serialize(org_integration, self.user), cls=DjangoJSONEncoder)
+            )
             self.browser.driver.execute_script(
                 "window.postMessage(arguments[0], window.location.origin);",
-                {
-                    "success": True,
-                    "data": {
-                        "id": str(integration.id),
-                        "name": "getsentry",
-                        "provider": {
-                            "key": "github",
-                            "name": "GitHub",
-                            "slug": "github",
-                            "canAdd": True,
-                            "canDisable": False,
-                            "features": ["commits", "alert-rule"],
-                            "aspects": {},
-                        },
-                        "status": "active",
-                        "organizationIntegrationStatus": "active",
-                        "accountType": None,
-                        "domainName": "github.com/getsentry",
-                        "gracePeriodEnd": None,
-                        "icon": None,
-                    },
-                },
+                {"success": True, "data": serialized},
             )
 
             # Wait for the component to process the message and show connected state.

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -6,6 +6,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from sentry.api.serializers import serialize
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.project import Project
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.asserts import assert_existing_projects_status
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
@@ -294,7 +295,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             ),
             mock.patch(
                 "sentry.integrations.api.endpoints.organization_repository_platforms.detect_platforms",
-                side_effect=Exception("GitHub API error"),
+                side_effect=ApiError("GitHub API error"),
             ),
         ):
             self.start_onboarding()
@@ -329,6 +330,11 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
             project = Project.objects.get(organization=self.org)
             assert project.platform == "javascript-react"
+            assert project.name == "javascript-react"
+            assert project.slug == "javascript-react"
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
 
     def test_scm_onboarding_repo_search_no_results(self) -> None:
         """Empty search results show a helpful message about permissions."""

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from sentry.models.project import Project
+from sentry.testutils.asserts import assert_existing_projects_status
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
 
@@ -103,11 +104,16 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
             self.browser.click(xpath='//button[contains(., "Create project")]')
 
-            # Setup Docs
-            self.browser.wait_until('[data-test-id="onboarding-step-setup-docs"]')
+            # Setup Docs: verify SDK heading renders, not just the step container
+            self.browser.wait_until(xpath='//h2[text()="Configure Django SDK"]')
 
             project = Project.objects.get(organization=self.org)
             assert project.platform == "python-django"
+            assert project.name == "python-django"
+            assert project.slug == "python-django"
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
 
     def test_scm_onboarding_skip_integration(self) -> None:
         """Skip flow: welcome → skip connect → manual platform → create project."""
@@ -134,10 +140,15 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.browser.click(xpath='//button[contains(., "Create project")]')
 
             # Setup Docs
-            self.browser.wait_until('[data-test-id="onboarding-step-setup-docs"]')
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
 
             project = Project.objects.get(organization=self.org)
             assert project.platform == "javascript-react"
+            assert project.name == "javascript-react"
+            assert project.slug == "javascript-react"
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
 
     def test_scm_onboarding_with_integration_install(self) -> None:
         """Install flow: welcome → install GitHub → repo search → detected platform → create project."""
@@ -252,7 +263,96 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.browser.click(xpath='//button[contains(., "Create project")]')
 
             # Setup Docs
-            self.browser.wait_until('[data-test-id="onboarding-step-setup-docs"]')
+            self.browser.wait_until(xpath='//h2[text()="Configure Django SDK"]')
 
             project = Project.objects.get(organization=self.org)
             assert project.platform == "python-django"
+            assert project.name == "python-django"
+            assert project.slug == "python-django"
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
+
+    def test_scm_onboarding_detection_error_falls_back_to_manual_picker(self) -> None:
+        """When platform detection fails, user can still select a platform manually."""
+        self.create_github_integration()
+
+        mock_repos = [
+            {
+                "name": "sentry",
+                "identifier": "getsentry/sentry",
+                "default_branch": "master",
+            },
+        ]
+
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm": True,
+                    "organizations:integrations-github-platform-detection": True,
+                }
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+                return_value=mock_repos,
+            ),
+            mock.patch(
+                "sentry.integrations.github.repository.GitHubRepositoryProvider._validate_repo",
+                return_value={"id": "12345"},
+            ),
+            mock.patch(
+                "sentry.integrations.api.endpoints.organization_repository_platforms.detect_platforms",
+                side_effect=Exception("GitHub API error"),
+            ),
+        ):
+            self.start_onboarding()
+
+            # SCM Connect: select a repo
+            self.browser.wait_until(xpath='//*[contains(text(), "Connected to")]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("sentry")
+            self.browser.wait_until('[data-test-id="menu-list-item-label"]')
+            self.browser.click('[data-test-id="menu-list-item-label"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            # Platform Features: detection failed, should show manual picker
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until(xpath='//h3[text()="Select a platform"]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("React")
+            self.browser.wait_until(
+                xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]'
+            )
+            self.browser.click(xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            # Project Details
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+            self.browser.click(xpath='//button[contains(., "Create project")]')
+
+            # Setup Docs
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+
+            project = Project.objects.get(organization=self.org)
+            assert project.platform == "javascript-react"
+
+    def test_scm_onboarding_repo_search_no_results(self) -> None:
+        """Empty search results show a helpful message about permissions."""
+        self.create_github_integration()
+
+        with (
+            self.feature({"organizations:onboarding-scm": True}),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+                return_value=[],
+            ),
+        ):
+            self.start_onboarding()
+
+            # SCM Connect: integration detected, search returns no results
+            self.browser.wait_until(xpath='//*[contains(text(), "Connected to")]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("nonexistent-repo")
+            self.browser.wait_until(xpath='//*[contains(text(), "No repositories found")]')

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-import pytest
 from django.core.serializers.json import DjangoJSONEncoder
 
 from sentry.api.serializers import serialize
@@ -10,8 +9,6 @@ from sentry.testutils.asserts import assert_existing_projects_status
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
 from sentry.utils import json
-
-pytestmark = pytest.mark.sentry_metrics
 
 
 @no_silo_test
@@ -216,7 +213,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             assert self.browser.driver.execute_script("return window.__testOpenCalled")
 
             # Simulate the OAuth pipeline: create the integration in the DB,
-            # then serialize it with the same code path as pipeline.py:406
+            # then serialize it with the same code path as IntegrationPipeline._dialog_response
             # to avoid mock-drift between the test data and the real serializer.
             integration = self.create_github_integration()
             org_integration = OrganizationIntegration.objects.get(

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -1,0 +1,140 @@
+from unittest import mock
+
+import pytest
+
+from sentry.models.project import Project
+from sentry.testutils.cases import AcceptanceTestCase
+from sentry.testutils.silo import no_silo_test
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+@no_silo_test
+class ScmOnboardingTest(AcceptanceTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user("foo@example.com")
+        self.org = self.create_organization(name="Rowdy Tiger", owner=None)
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.member = self.create_member(
+            user=self.user, organization=self.org, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+
+    def create_github_integration(self):
+        integration = self.create_provider_integration(
+            provider="github",
+            name="getsentry",
+            external_id="12345",
+            metadata={"access_token": "ghu_xxxxx"},
+        )
+        integration.add_organization(self.org, self.user)
+        return integration
+
+    def start_onboarding(self):
+        self.browser.get(f"/onboarding/{self.org.slug}/")
+        self.browser.wait_until('[data-test-id="onboarding-step-welcome"]')
+        self.browser.click('[data-test-id="onboarding-welcome-start"]')
+        self.browser.wait_until('[data-test-id="onboarding-step-scm-connect"]')
+
+    def test_scm_onboarding_happy_path(self) -> None:
+        """Full flow: welcome → connect repo → detected platform → create project."""
+        self.create_github_integration()
+
+        mock_repos = [
+            {
+                "name": "sentry",
+                "identifier": "getsentry/sentry",
+                "default_branch": "master",
+            },
+        ]
+
+        mock_platforms = [
+            {
+                "platform": "python-django",
+                "language": "Python",
+                "bytes": 50000,
+                "confidence": "high",
+                "priority": 1,
+            }
+        ]
+
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm": True,
+                    "organizations:integrations-github-platform-detection": True,
+                }
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+                return_value=mock_repos,
+            ),
+            mock.patch(
+                "sentry.integrations.github.repository.GitHubRepositoryProvider._validate_repo",
+                return_value={"id": "12345"},
+            ),
+            mock.patch(
+                "sentry.integrations.api.endpoints.organization_repository_platforms.detect_platforms",
+                return_value=mock_platforms,
+            ),
+        ):
+            self.start_onboarding()
+
+            # SCM Connect: wait for integration to be detected, then search
+            self.browser.wait_until(xpath='//*[contains(text(), "Connected to")]')
+            # react-select renders a separate placeholder element, not an HTML
+            # placeholder attribute, so target the input by its ARIA role.
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("sentry")
+            self.browser.wait_until('[data-test-id="menu-list-item-label"]')
+            self.browser.click('[data-test-id="menu-list-item-label"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            # Platform Features: select detected platform, then continue
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until('[role="radio"]')
+            self.browser.click('[role="radio"]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            # Project Details: defaults auto-fill from platform + team
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+            self.browser.click(xpath='//button[contains(., "Create project")]')
+
+            # Setup Docs
+            self.browser.wait_until('[data-test-id="onboarding-step-setup-docs"]')
+
+            project = Project.objects.get(organization=self.org)
+            assert project.platform == "python-django"
+
+    def test_scm_onboarding_skip_integration(self) -> None:
+        """Skip flow: welcome → skip connect → manual platform → create project."""
+        with self.feature({"organizations:onboarding-scm": True}):
+            self.start_onboarding()
+
+            # SCM Connect: skip
+            self.browser.click(xpath='//button[contains(., "Skip for now")]')
+
+            # Platform Features: manual picker
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until(xpath='//h3[text()="Select a platform"]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("React")
+            self.browser.wait_until(
+                xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]'
+            )
+            self.browser.click(xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            # Project Details: defaults auto-fill
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+            self.browser.click(xpath='//button[contains(., "Create project")]')
+
+            # Setup Docs
+            self.browser.wait_until('[data-test-id="onboarding-step-setup-docs"]')
+
+            project = Project.objects.get(organization=self.org)
+            assert project.platform == "javascript-react"

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -138,3 +138,121 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
             project = Project.objects.get(organization=self.org)
             assert project.platform == "javascript-react"
+
+    def test_scm_onboarding_with_integration_install(self) -> None:
+        """Install flow: welcome → install GitHub → repo search → detected platform → create project."""
+        mock_repos = [
+            {
+                "name": "sentry",
+                "identifier": "getsentry/sentry",
+                "default_branch": "master",
+            },
+        ]
+
+        mock_platforms = [
+            {
+                "platform": "python-django",
+                "language": "Python",
+                "bytes": 50000,
+                "confidence": "high",
+                "priority": 1,
+            }
+        ]
+
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm": True,
+                    "organizations:integrations-github-platform-detection": True,
+                }
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+                return_value=mock_repos,
+            ),
+            mock.patch(
+                "sentry.integrations.github.repository.GitHubRepositoryProvider._validate_repo",
+                return_value={"id": "12345"},
+            ),
+            mock.patch(
+                "sentry.integrations.api.endpoints.organization_repository_platforms.detect_platforms",
+                return_value=mock_platforms,
+            ),
+        ):
+            self.start_onboarding()
+
+            # SCM Connect: no integration installed, provider pills are shown.
+            # Override window.open so that AddIntegration stores `window` as the
+            # dialog reference.  When we later inject a postMessage from the same
+            # window, `message.source === this.dialog` passes.
+            self.browser.driver.execute_script(
+                """
+                window.__testOpenCalled = false;
+                window.open = function() {
+                    window.__testOpenCalled = true;
+                    return window;
+                };
+                """
+            )
+
+            # Wait for the providers to load, then click Install GitHub.
+            self.browser.wait_until(xpath='//button[contains(., "GitHub")]')
+            self.browser.click(xpath='//button[contains(., "GitHub")]')
+            assert self.browser.driver.execute_script("return window.__testOpenCalled")
+
+            # Simulate the OAuth pipeline: create the integration in the DB,
+            # then inject a postMessage matching what dialog-complete.html sends.
+            integration = self.create_github_integration()
+            self.browser.driver.execute_script(
+                "window.postMessage(arguments[0], window.location.origin);",
+                {
+                    "success": True,
+                    "data": {
+                        "id": str(integration.id),
+                        "name": "getsentry",
+                        "provider": {
+                            "key": "github",
+                            "name": "GitHub",
+                            "slug": "github",
+                            "canAdd": True,
+                            "canDisable": False,
+                            "features": ["commits", "alert-rule"],
+                            "aspects": {},
+                        },
+                        "status": "active",
+                        "organizationIntegrationStatus": "active",
+                        "accountType": None,
+                        "domainName": "github.com/getsentry",
+                        "gracePeriodEnd": None,
+                        "icon": None,
+                    },
+                },
+            )
+
+            # Wait for the component to process the message and show connected state.
+            self.browser.wait_until(xpath='//*[contains(text(), "Connected to")]')
+
+            # Repo search (same flow as happy path from here on).
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("sentry")
+            self.browser.wait_until('[data-test-id="menu-list-item-label"]')
+            self.browser.click('[data-test-id="menu-list-item-label"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            # Platform Features
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until('[role="radio"]')
+            self.browser.click('[role="radio"]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            # Project Details
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+            self.browser.click(xpath='//button[contains(., "Create project")]')
+
+            # Setup Docs
+            self.browser.wait_until('[data-test-id="onboarding-step-setup-docs"]')
+
+            project = Project.objects.get(organization=self.org)
+            assert project.platform == "python-django"


### PR DESCRIPTION
Add Selenium acceptance tests for the SCM onboarding flow. The SCM flow had zero acceptance test coverage -- existing tests only cover the legacy onboarding path.

Five tests covering the three main user paths plus error states:

- **Happy path**: welcome -> connect repo -> detected platform -> create project. Pre-installs a GitHub integration and mocks `get_repositories`, `_validate_repo`, and `detect_platforms` to avoid real GitHub API calls.
- **Skip path**: welcome -> skip integration -> manual SDK picker -> create project. Validates the flow works end-to-end without an integration.
- **Install path**: welcome -> install GitHub (simulated OAuth via postMessage injection) -> repo search -> detected platform -> create project. Overrides `window.open` to return `window` itself so the `message.source === this.dialog` check in `AddIntegration` passes. Uses the real `OrganizationIntegrationSerializer` to generate the postMessage payload, avoiding mock-drift.
- **Detection error fallback**: platform detection fails -> manual picker appears -> user can still complete the flow.
- **Empty repo search**: search returns no results -> "No repositories found" permissions hint is displayed.

All project-creating tests assert on the setup-docs SDK heading content, project name/slug/platform, and `assert_existing_projects_status` -- matching the bar set by the legacy `test_onboarding.py`.

Refs VDY-54