### PR TITLE
fix(coding integrations): fix add integration button on safari

### DIFF
--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -355,6 +355,7 @@ function NextStepTemplate({
                 />
               )}
               position="bottom-end"
+              shouldCloseOnBlur={false}
               menuFooter={
                 <DropdownMenuFooter>
                   <MenuComponents.CTALinkButton


### PR DESCRIPTION
In safari, the "add integration" button was failing to link to the integrations page because you can't focus on <a> elements so the dropdown was closing before the page was routing. Ran this locally and it fixed the issue without changing anything else (we don't see close because page redirects)