### PR TITLE
fix(aci): Preselect current detector type when clicking create monitor

### DIFF
--- a/static/app/views/detectors/list/common/detectorListActions.tsx
+++ b/static/app/views/detectors/list/common/detectorListActions.tsx
@@ -5,6 +5,7 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {DetectorType} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
@@ -13,9 +14,10 @@ import {useCanCreateDetector} from 'sentry/views/detectors/utils/useCanCreateDet
 
 interface DetectorListActionsProps {
   children?: React.ReactNode;
+  detectorType?: DetectorType;
 }
 
-export function DetectorListActions({children}: DetectorListActionsProps) {
+export function DetectorListActions({children, detectorType}: DetectorListActionsProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
@@ -29,7 +31,7 @@ export function DetectorListActions({children}: DetectorListActionsProps) {
       <LinkButton
         to={{
           pathname: makeMonitorCreatePathname(organization.slug),
-          query: {project},
+          query: {project, detectorType},
         }}
         priority="primary"
         icon={<IconAdd />}

--- a/static/app/views/detectors/list/cron.tsx
+++ b/static/app/views/detectors/list/cron.tsx
@@ -244,7 +244,7 @@ export default function CronDetectorsList() {
     <MonitorViewContext.Provider value={contextValue}>
       <SentryDocumentTitle title={TITLE}>
         <WorkflowEngineListLayout
-          actions={<DetectorListActions />}
+          actions={<DetectorListActions detectorType="monitor_check_in_failure" />}
           title={TITLE}
           description={DESCRIPTION}
           docsUrl={DOCS_URL}

--- a/static/app/views/detectors/list/metric.tsx
+++ b/static/app/views/detectors/list/metric.tsx
@@ -21,7 +21,7 @@ export default function MetricDetectorsList() {
   return (
     <SentryDocumentTitle title={TITLE}>
       <WorkflowEngineListLayout
-        actions={<DetectorListActions />}
+        actions={<DetectorListActions detectorType="metric_issue" />}
         title={TITLE}
         description={DESCRIPTION}
         docsUrl={DOCS_URL}

--- a/static/app/views/detectors/list/mobileBuild.tsx
+++ b/static/app/views/detectors/list/mobileBuild.tsx
@@ -22,7 +22,7 @@ export default function MobileBuildDetectorsList() {
     <Feature features="organizations:preprod-size-monitors-frontend">
       <SentryDocumentTitle title={TITLE}>
         <WorkflowEngineListLayout
-          actions={<DetectorListActions />}
+          actions={<DetectorListActions detectorType="preprod_size_analysis" />}
           title={TITLE}
           description={DESCRIPTION}
           docsUrl={DOCS_URL}

--- a/static/app/views/detectors/list/uptime.tsx
+++ b/static/app/views/detectors/list/uptime.tsx
@@ -105,7 +105,7 @@ export default function UptimeDetectorsList() {
     <MonitorViewContext.Provider value={contextValue}>
       <SentryDocumentTitle title={TITLE}>
         <WorkflowEngineListLayout
-          actions={<DetectorListActions />}
+          actions={<DetectorListActions detectorType="uptime_domain_failure" />}
           title={TITLE}
           description={DESCRIPTION}
           docsUrl={DOCS_URL}


### PR DESCRIPTION
Tiny change, missed this when changing the behavior recently. The specific monitor type pages should pass the `detectorType` in the create new monitor link so that their type is selected automatically (except for error monitors of course)