### PR TITLE
feat(seer): Thread short-lived API token to Explorer MCP tools

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -317,6 +317,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-context-engine-fe-override-ui-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code editing tools in Seer Explorer chat
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable general-purpose MCP tools (sentry_api_search/execute) in Seer Explorer
+    manager.add("organizations:seer-explorer-mcp-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable structured LLM context (JSON snapshot) instead of ASCII DOM snapshot
     manager.add("organizations:context-engine-structured-page-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Seer Overview sections for Seat-Based users

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -317,8 +317,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-context-engine-fe-override-ui-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code editing tools in Seer Explorer chat
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable general-purpose MCP tools (sentry_api_search/execute) in Seer Explorer
-    manager.add("organizations:seer-explorer-mcp-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable code mode tools (sentry_api_search/execute) in Seer Explorer
+    manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable structured LLM context (JSON snapshot) instead of ASCII DOM snapshot
     manager.add("organizations:context-engine-structured-page-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Seer Overview sections for Seat-Based users

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -318,7 +318,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable code editing tools in Seer Explorer chat
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code mode tools (sentry_api_search/execute) in Seer Explorer
-    manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable structured LLM context (JSON snapshot) instead of ASCII DOM snapshot
     manager.add("organizations:context-engine-structured-page-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Seer Overview sections for Seat-Based users

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -194,6 +194,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
                     on_page_context=on_page_context,
                     page_name=page_name,
                     override_ce_enable=override_ce_enable,
+                    request=request,
                 )
 
             return Response({"run_id": result_run_id})

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -172,15 +172,15 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
             ) and features.has(
                 "organizations:seer-explorer-chat-coding", organization, actor=request.user
             )
-            enable_mcp_tools = features.has(
-                "organizations:seer-explorer-mcp-tools", organization, actor=request.user
+            enable_code_mode_tools = features.has(
+                "organizations:seer-explorer-code-mode-tools", organization, actor=request.user
             )
             client = SeerExplorerClient(
                 organization,
                 request.user,
                 is_interactive=True,
                 enable_coding=enable_coding,
-                enable_mcp_tools=enable_mcp_tools,
+                enable_code_mode_tools=enable_code_mode_tools,
             )
             if run_id:
                 # Continue existing conversation

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -172,11 +172,15 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
             ) and features.has(
                 "organizations:seer-explorer-chat-coding", organization, actor=request.user
             )
+            enable_mcp_tools = features.has(
+                "organizations:seer-explorer-mcp-tools", organization, actor=request.user
+            )
             client = SeerExplorerClient(
                 organization,
                 request.user,
                 is_interactive=True,
                 enable_coding=enable_coding,
+                enable_mcp_tools=enable_mcp_tools,
             )
             if run_id:
                 # Continue existing conversation
@@ -186,6 +190,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
                     insert_index=insert_index,
                     on_page_context=on_page_context,
                     page_name=page_name,
+                    request=request,
                 )
             else:
                 # Start new conversation

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -266,6 +266,8 @@ class SeerExplorerClient:
         if bool(artifact_schema) != bool(artifact_key):
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
+        user_org_context = collect_user_org_context(self.user, self.organization, request=request)
+
         chat_body: ExplorerChatRequest = ExplorerChatRequest(
             organization_id=self.organization.id,
             query=prompt,
@@ -273,12 +275,20 @@ class SeerExplorerClient:
             insert_index=None,
             on_page_context=on_page_context,
             page_name=page_name,
-            user_org_context=collect_user_org_context(
-                self.user, self.organization, request=request
-            ),
+            user_org_context=user_org_context,
             intelligence_level=self.intelligence_level,
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
+            user_auth_token=user_org_context.get("user_auth_token"),
+        )
+
+        _token = user_org_context.get("user_auth_token")
+        logger.info(
+            "seer_explorer.start_run.auth_token",
+            extra={
+                "has_token": _token is not None,
+                "token_prefix": _token[:12] + "..." if _token else None,
+            },
         )
 
         if self.max_iterations is not None:

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -273,6 +273,8 @@ class SeerExplorerClient:
         user_auth_token = (
             create_explorer_api_token(self.user, self.organization)
             if self.enable_code_mode_tools
+            and self.user
+            and not isinstance(self.user, AnonymousUser)
             else None
         )
 
@@ -380,6 +382,8 @@ class SeerExplorerClient:
         user_auth_token = (
             create_explorer_api_token(self.user, self.organization)
             if self.enable_code_mode_tools
+            and self.user
+            and not isinstance(self.user, AnonymousUser)
             else None
         )
 

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -196,6 +196,7 @@ class SeerExplorerClient:
         intelligence_level: Literal["low", "medium", "high"] = "medium",
         is_interactive: bool = False,
         enable_coding: bool = False,
+        enable_mcp_tools: bool = False,
         max_iterations: int | None = None,
     ):
         self.organization = organization
@@ -207,6 +208,7 @@ class SeerExplorerClient:
         self.category_key = category_key
         self.category_value = category_value
         self.is_interactive = is_interactive
+        self.enable_mcp_tools = enable_mcp_tools
         self.max_iterations = max_iterations
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
@@ -279,6 +281,7 @@ class SeerExplorerClient:
             intelligence_level=self.intelligence_level,
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
+            enable_mcp_tools=self.enable_mcp_tools,
             user_auth_token=user_org_context.get("user_auth_token"),
         )
 
@@ -354,6 +357,7 @@ class SeerExplorerClient:
         page_name: str | None = None,
         artifact_key: str | None = None,
         artifact_schema: type[BaseModel] | None = None,
+        request: Request | None = None,
     ) -> int:
         """
         Continue an existing Seer Explorer session. This allows you to add follow-up queries to an ongoing conversation.
@@ -376,6 +380,8 @@ class SeerExplorerClient:
         if bool(artifact_schema) != bool(artifact_key):
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
+        user_org_context = collect_user_org_context(self.user, self.organization, request=request)
+
         chat_body: ExplorerChatRequest = ExplorerChatRequest(
             organization_id=self.organization.id,
             query=prompt,
@@ -385,6 +391,8 @@ class SeerExplorerClient:
             page_name=page_name,
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
+            enable_mcp_tools=self.enable_mcp_tools,
+            user_auth_token=user_org_context.get("user_auth_token"),
         )
 
         if prompt_metadata:

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -269,6 +269,7 @@ class SeerExplorerClient:
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
         user_org_context = collect_user_org_context(self.user, self.organization, request=request)
+        user_auth_token = user_org_context.pop("user_auth_token", None)
 
         chat_body: ExplorerChatRequest = ExplorerChatRequest(
             organization_id=self.organization.id,
@@ -282,7 +283,7 @@ class SeerExplorerClient:
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
             enable_code_mode_tools=self.enable_code_mode_tools,
-            user_auth_token=user_org_context.get("user_auth_token"),
+            user_auth_token=user_auth_token,
         )
 
         if self.max_iterations is not None:
@@ -372,6 +373,7 @@ class SeerExplorerClient:
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
         user_org_context = collect_user_org_context(self.user, self.organization, request=request)
+        user_auth_token = user_org_context.pop("user_auth_token", None)
 
         chat_body: ExplorerChatRequest = ExplorerChatRequest(
             organization_id=self.organization.id,
@@ -383,7 +385,7 @@ class SeerExplorerClient:
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
             enable_code_mode_tools=self.enable_code_mode_tools,
-            user_auth_token=user_org_context.get("user_auth_token"),
+            user_auth_token=user_auth_token,
         )
 
         if prompt_metadata:

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -285,15 +285,6 @@ class SeerExplorerClient:
             user_auth_token=user_org_context.get("user_auth_token"),
         )
 
-        _token = user_org_context.get("user_auth_token")
-        logger.info(
-            "seer_explorer.start_run.auth_token",
-            extra={
-                "has_token": _token is not None,
-                "token_prefix": _token[:12] + "..." if _token else None,
-            },
-        )
-
         if self.max_iterations is not None:
             chat_body["max_iterations"] = self.max_iterations
 

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -20,6 +20,7 @@ from sentry.seer.explorer.client_utils import (
     ExplorerRunsRequest,
     ExplorerUpdateRequest,
     collect_user_org_context,
+    create_explorer_api_token,
     fetch_run_status,
     make_explorer_chat_request,
     make_explorer_runs_request,
@@ -269,7 +270,11 @@ class SeerExplorerClient:
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
         user_org_context = collect_user_org_context(self.user, self.organization, request=request)
-        user_auth_token = user_org_context.pop("user_auth_token", None)
+        user_auth_token = (
+            create_explorer_api_token(self.user, self.organization)
+            if self.enable_code_mode_tools
+            else None
+        )
 
         chat_body: ExplorerChatRequest = ExplorerChatRequest(
             organization_id=self.organization.id,
@@ -372,8 +377,11 @@ class SeerExplorerClient:
         if bool(artifact_schema) != bool(artifact_key):
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
-        user_org_context = collect_user_org_context(self.user, self.organization, request=request)
-        user_auth_token = user_org_context.pop("user_auth_token", None)
+        user_auth_token = (
+            create_explorer_api_token(self.user, self.organization)
+            if self.enable_code_mode_tools
+            else None
+        )
 
         chat_body: ExplorerChatRequest = ExplorerChatRequest(
             organization_id=self.organization.id,

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -196,7 +196,7 @@ class SeerExplorerClient:
         intelligence_level: Literal["low", "medium", "high"] = "medium",
         is_interactive: bool = False,
         enable_coding: bool = False,
-        enable_mcp_tools: bool = False,
+        enable_code_mode_tools: bool = False,
         max_iterations: int | None = None,
     ):
         self.organization = organization
@@ -208,7 +208,7 @@ class SeerExplorerClient:
         self.category_key = category_key
         self.category_value = category_value
         self.is_interactive = is_interactive
-        self.enable_mcp_tools = enable_mcp_tools
+        self.enable_code_mode_tools = enable_code_mode_tools
         self.max_iterations = max_iterations
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
@@ -281,7 +281,7 @@ class SeerExplorerClient:
             intelligence_level=self.intelligence_level,
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
-            enable_mcp_tools=self.enable_mcp_tools,
+            enable_code_mode_tools=self.enable_code_mode_tools,
             user_auth_token=user_org_context.get("user_auth_token"),
         )
 
@@ -391,7 +391,7 @@ class SeerExplorerClient:
             page_name=page_name,
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
-            enable_mcp_tools=self.enable_mcp_tools,
+            enable_code_mode_tools=self.enable_code_mode_tools,
             user_auth_token=user_org_context.get("user_auth_token"),
         )
 

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, NotRequired, TypedDict
 
 import orjson
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.utils import timezone
 from rest_framework.request import Request
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool
 
@@ -68,6 +69,7 @@ class ExplorerChatRequest(TypedDict):
     metadata: NotRequired[dict[str, Any]]
     is_context_engine_enabled: NotRequired[bool]
     max_iterations: NotRequired[int]
+    user_auth_token: NotRequired[str | None]
 
 
 class ExplorerRunsRequest(TypedDict):
@@ -284,6 +286,32 @@ def collect_user_org_context(
     # Get IP address from http request, if provided
     user_ip: str | None = request.META.get("REMOTE_ADDR") if request else None
 
+    # Create a short-lived API token for Seer to call back into Sentry on behalf of the user
+    user_auth_token: str | None = None
+    try:
+        from sentry.models.apitoken import ApiToken
+        from sentry.types.token import AuthTokenType
+
+        token = ApiToken.objects.create(
+            user=user,
+            token_type=AuthTokenType.USER,
+            scoping_organization_id=organization.id,
+            scope_list=["org:read", "project:read", "event:read"],
+            expires_at=timezone.now() + timedelta(hours=1),
+        )
+        user_auth_token = token.plaintext_token
+        logger.info(
+            "seer_explorer.auth_token_created",
+            extra={
+                "user_id": user.id,
+                "org_id": organization.id,
+                "token_prefix": user_auth_token[:12] + "..." if user_auth_token else None,
+                "expires_at": str(token.expires_at),
+            },
+        )
+    except Exception:
+        logger.exception("Failed to create short-lived API token for Seer Explorer")
+
     return {
         "org_slug": organization.slug,
         "user_id": user.id,
@@ -294,6 +322,7 @@ def collect_user_org_context(
         "user_teams": user_teams,
         "user_projects": user_projects,
         "all_org_projects": all_org_projects,
+        "user_auth_token": user_auth_token,
     }
 
 

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -291,12 +291,27 @@ def collect_user_org_context(
     try:
         from sentry.models.apitoken import ApiToken
         from sentry.types.token import AuthTokenType
+        from sentry.users.models.user import User
+
+        # request.user may be an RpcUser proxy — ApiToken needs the real User model
+        real_user = User.objects.get(id=user.id)
 
         token = ApiToken.objects.create(
-            user=user,
+            user=real_user,
             token_type=AuthTokenType.USER,
             scoping_organization_id=organization.id,
-            scope_list=["org:read", "project:read", "event:read"],
+            scope_list=[
+                "org:read",
+                "org:write",
+                "project:read",
+                "project:write",
+                "event:read",
+                "event:write",
+                "alerts:read",
+                "alerts:write",
+                "member:read",
+                "team:read",
+            ],
             expires_at=timezone.now() + timedelta(hours=1),
         )
         user_auth_token = token.plaintext_token

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -287,16 +287,27 @@ def collect_user_org_context(
     # Get IP address from http request, if provided
     user_ip: str | None = request.META.get("REMOTE_ADDR") if request else None
 
-    # Create a short-lived API token for Seer to call back into Sentry on behalf of the user
-    user_auth_token: str | None = None
+    return {
+        "org_slug": organization.slug,
+        "user_id": user.id,
+        "user_ip": user_ip,
+        "user_name": user_name,
+        "user_email": user.email,
+        "user_timezone": user_timezone,
+        "user_teams": user_teams,
+        "user_projects": user_projects,
+        "all_org_projects": all_org_projects,
+    }
+
+
+def create_explorer_api_token(user: SentryUser | RpcUser, organization: Organization) -> str | None:
+    """Create a short-lived read-only API token for Seer to call back into Sentry."""
     try:
         from sentry.models.apitoken import ApiToken
         from sentry.types.token import AuthTokenType
-        from sentry.users.models.user import User
+        from sentry.users.models.user import User as UserModel
 
-        # request.user may be an RpcUser proxy — ApiToken needs the real User model
-        real_user = User.objects.get(id=user.id)
-
+        real_user = UserModel.objects.get(id=user.id)
         token = ApiToken.objects.create(
             user=real_user,
             token_type=AuthTokenType.USER,
@@ -311,30 +322,10 @@ def collect_user_org_context(
             ],
             expires_at=timezone.now() + timedelta(hours=1),
         )
-        user_auth_token = token.plaintext_token
-        logger.info(
-            "seer_explorer.auth_token_created",
-            extra={
-                "user_id": user.id,
-                "org_id": organization.id,
-                "expires_at": str(token.expires_at),
-            },
-        )
+        return token.plaintext_token
     except Exception:
         logger.exception("Failed to create short-lived API token for Seer Explorer")
-
-    return {
-        "org_slug": organization.slug,
-        "user_id": user.id,
-        "user_ip": user_ip,
-        "user_name": user_name,
-        "user_email": user.email,
-        "user_timezone": user_timezone,
-        "user_teams": user_teams,
-        "user_projects": user_projects,
-        "all_org_projects": all_org_projects,
-        "user_auth_token": user_auth_token,
-    }
+        return None
 
 
 def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -58,7 +58,7 @@ class ExplorerChatRequest(TypedDict):
     intelligence_level: NotRequired[str]
     is_interactive: NotRequired[bool]
     enable_coding: NotRequired[bool]
-    enable_mcp_tools: NotRequired[bool]
+    enable_code_mode_tools: NotRequired[bool]
     project_id: NotRequired[int]
     query_metadata: NotRequired[dict[str, str]]
     artifact_key: NotRequired[str]

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -303,13 +303,9 @@ def collect_user_org_context(
             scoping_organization_id=organization.id,
             scope_list=[
                 "org:read",
-                "org:write",
                 "project:read",
-                "project:write",
                 "event:read",
-                "event:write",
                 "alerts:read",
-                "alerts:write",
                 "member:read",
                 "team:read",
             ],

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -321,7 +321,6 @@ def collect_user_org_context(
             extra={
                 "user_id": user.id,
                 "org_id": organization.id,
-                "token_prefix": user_auth_token[:12] + "..." if user_auth_token else None,
                 "expires_at": str(token.expires_at),
             },
         )

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -58,6 +58,7 @@ class ExplorerChatRequest(TypedDict):
     intelligence_level: NotRequired[str]
     is_interactive: NotRequired[bool]
     enable_coding: NotRequired[bool]
+    enable_mcp_tools: NotRequired[bool]
     project_id: NotRequired[int]
     query_metadata: NotRequired[dict[str, str]]
     artifact_key: NotRequired[str]

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -76,6 +76,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             on_page_context=None,
             page_name=None,
             override_ce_enable=True,
+            request=ANY,
         )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -105,6 +105,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
                 ANY,
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
+                enable_mcp_tools=False,
             )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
@@ -130,6 +131,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             insert_index=2,
             on_page_context=None,
             page_name=None,
+            request=ANY,
         )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
@@ -153,6 +155,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
                 ANY,
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
+                enable_mcp_tools=False,
             )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -69,7 +69,11 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data == {"run_id": 456}
         mock_client_class.assert_called_once_with(
-            self.organization, ANY, is_interactive=True, enable_coding=False, enable_mcp_tools=False
+            self.organization,
+            ANY,
+            is_interactive=True,
+            enable_coding=False,
+            enable_code_mode_tools=False,
         )
         mock_client.start_run.assert_called_once_with(
             prompt="What is this error about?",
@@ -105,7 +109,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
                 ANY,
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
-                enable_mcp_tools=False,
+                enable_code_mode_tools=False,
             )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
@@ -123,7 +127,11 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data == {"run_id": 789}
         mock_client_class.assert_called_once_with(
-            self.organization, ANY, is_interactive=True, enable_coding=False, enable_mcp_tools=False
+            self.organization,
+            ANY,
+            is_interactive=True,
+            enable_coding=False,
+            enable_code_mode_tools=False,
         )
         mock_client.continue_run.assert_called_once_with(
             run_id=789,
@@ -155,7 +163,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
                 ANY,
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
-                enable_mcp_tools=False,
+                enable_code_mode_tools=False,
             )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -69,7 +69,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data == {"run_id": 456}
         mock_client_class.assert_called_once_with(
-            self.organization, ANY, is_interactive=True, enable_coding=False
+            self.organization, ANY, is_interactive=True, enable_coding=False, enable_mcp_tools=False
         )
         mock_client.start_run.assert_called_once_with(
             prompt="What is this error about?",
@@ -122,7 +122,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data == {"run_id": 789}
         mock_client_class.assert_called_once_with(
-            self.organization, ANY, is_interactive=True, enable_coding=False
+            self.organization, ANY, is_interactive=True, enable_coding=False, enable_mcp_tools=False
         )
         mock_client.continue_run.assert_called_once_with(
             run_id=789,


### PR DESCRIPTION
Create a short-lived (1-hour), org-scoped API token when the user opens
the Seer Explorer and pass it to Seer via `user_auth_token` on the
`ExplorerChatRequest`. This enables the new MCP `sentry_api_execute`
tool to call the Sentry API on behalf of the user.

## What

- Create `ApiToken` in `collect_user_org_context()` with scopes:
  `org:read/write`, `project:read/write`, `event:read/write`,
  `alerts:read/write`, `member:read`, `team:read`
- Resolve `RpcUser` → real `User` model for token creation
- Pass `request=request` through to `start_run()` so the token
  can be created with the authenticated user
- Add `user_auth_token` field to `ExplorerChatRequest` TypedDict
- Add instrumentation logging at each stage

## Security

- Token scoped to single org via `scoping_organization_id`
- 1-hour expiry
- Created per-session, not reused

## Companion PR

Seer-side changes (tool registration + threading): getsentry/seer#5626