### PR TITLE
ref(preprod): Add snapshots option for builds endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -89,6 +89,8 @@ class BuildsEndpoint(OrganizationEndpoint):
             display = request.GET.get("display")
             if display in ("size", "distribution"):
                 queryset = queryset.filter(preprodsnapshotmetrics__isnull=True)
+            elif display == "snapshot":
+                queryset = queryset.filter(preprodsnapshotmetrics__isnull=False)
         except InvalidSearchQuery as e:
             # CodeQL complains about str(e) below but ~all handlers
             # of InvalidSearchQuery do the same as this.


### PR DESCRIPTION
Add a `display=snapshot` filter option to the builds endpoint.

The existing `display` parameter supports `size` and `distribution` values, which filter to builds **without** snapshot metrics. This adds the inverse — `display=snapshot` filters to builds that **have** snapshot metrics attached (`preprodsnapshotmetrics__isnull=False`), enabling the frontend to fetch only snapshot-relevant builds.