### PR TITLE
feat(seer): Convert structured LLMContext JSON to markdown for on_page_context

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -15,10 +15,14 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.explorer.client import SeerExplorerClient
-from sentry.seer.explorer.client_utils import has_seer_explorer_access_with_detail
+from sentry.seer.explorer.client_utils import (
+    has_seer_explorer_access_with_detail,
+    snapshot_to_markdown,
+)
 from sentry.seer.models import SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +156,15 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
         on_page_context = validated_data.get("on_page_context")
         page_name = validated_data.get("page_name")
         override_ce_enable = validated_data["override_ce_enable"]
+
+        # If the frontend sent a structured LLMContext JSON snapshot, convert to markdown.
+        if on_page_context:
+            try:
+                snapshot = json.loads(on_page_context)
+                if isinstance(snapshot, dict) and "nodes" in snapshot:
+                    on_page_context = snapshot_to_markdown(snapshot)
+            except (json.JSONDecodeError, TypeError, AttributeError):
+                pass
 
         try:
             enable_coding = organization.get_option(

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -340,3 +340,33 @@ def poll_until_done(
 
         # Wait before next poll
         time.sleep(poll_interval)
+
+
+def _render_node(node: dict[str, Any], depth: int) -> str:
+    """Recursively render an LLMContextSnapshot node and its children as markdown."""
+    heading = "#" * min(depth + 1, 6)
+    lines = [f"{heading} {node.get('nodeType', 'unknown')}"]
+
+    data = node.get("data")
+    if isinstance(data, dict):
+        for key, value in data.items():
+            lines.append(f"- **{key}**: {orjson.dumps(value).decode()}")
+    elif data is not None:
+        lines.append(f"- {orjson.dumps(data).decode()}")
+
+    for child in node.get("children", []):
+        lines.append(_render_node(child, depth + 1))
+
+    return "\n".join(lines)
+
+
+def snapshot_to_markdown(snapshot: dict[str, Any]) -> str:
+    """Convert an LLMContextSnapshot dict to a markdown string.
+
+    Expected shape: ``{"version": int, "nodes": [{"nodeType": str, "data": ..., "children": [...]}]}``
+    The top-level nodes list contains a single root node (the page).
+    """
+    nodes = snapshot.get("nodes", [])
+    if not nodes:
+        return ""
+    return _render_node(nodes[0], 0)

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
+from sentry.utils import json
 
 
 @with_feature("organizations:seer-explorer")
@@ -226,6 +227,47 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             response = self.client.get(self.url)
 
         assert response.status_code == 403
+
+    @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
+    def test_post_json_on_page_context_converted_to_markdown(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = 456
+        mock_client_class.return_value = mock_client
+
+        snapshot = {
+            "version": 1,
+            "nodes": [
+                {
+                    "nodeType": "dashboard",
+                    "data": {"title": "My Dashboard", "widgetCount": 2},
+                    "children": [],
+                }
+            ],
+        }
+        data = {"query": "Help me", "on_page_context": json.dumps(snapshot)}
+        response = self.client.post(self.url, data, format="json")
+
+        assert response.status_code == 200
+        call_kwargs = mock_client.start_run.call_args[1]
+        context = call_kwargs["on_page_context"]
+        assert "# dashboard" in context
+        assert '- **title**: "My Dashboard"' in context
+
+    @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
+    def test_post_ascii_on_page_context_passed_through(self, mock_client_class: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = 456
+        mock_client_class.return_value = mock_client
+
+        ascii_screenshot = "+--------+\n| chart  |\n+--------+"
+        data = {"query": "Help me", "on_page_context": ascii_screenshot}
+        response = self.client.post(self.url, data, format="json")
+
+        assert response.status_code == 200
+        call_kwargs = mock_client.start_run.call_args[1]
+        assert call_kwargs["on_page_context"] == ascii_screenshot
 
 
 @with_feature("organizations:seer-explorer")

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -2,6 +2,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
     has_seer_explorer_access_with_detail,
+    snapshot_to_markdown,
 )
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
@@ -184,3 +185,70 @@ class CollectUserOrgContextTest(TestCase):
 
         assert context is not None
         assert context.get("user_ip") == request.META.get("REMOTE_ADDR")
+
+
+class SnapshotToMarkdownTest(TestCase):
+    def test_single_node(self) -> None:
+        snapshot = {
+            "version": 1,
+            "nodes": [
+                {
+                    "nodeType": "dashboard",
+                    "data": {"title": "Backend Health", "widgetCount": 3},
+                    "children": [],
+                }
+            ],
+        }
+        result = snapshot_to_markdown(snapshot)
+        assert "# dashboard" in result
+        assert '- **title**: "Backend Health"' in result
+        assert "- **widgetCount**: 3" in result
+
+    def test_nested_nodes(self) -> None:
+        snapshot = {
+            "version": 1,
+            "nodes": [
+                {
+                    "nodeType": "dashboard",
+                    "data": {"title": "My Dashboard"},
+                    "children": [
+                        {
+                            "nodeType": "widget",
+                            "data": {"title": "Error Rate"},
+                            "children": [
+                                {
+                                    "nodeType": "chart",
+                                    "data": {"query": "count()"},
+                                    "children": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        result = snapshot_to_markdown(snapshot)
+        assert "# dashboard" in result
+        assert "## widget" in result
+        assert "### chart" in result
+        assert '- **query**: "count()"' in result
+
+    def test_empty_nodes(self) -> None:
+        assert snapshot_to_markdown({"version": 1, "nodes": []}) == ""
+
+    def test_node_with_no_data(self) -> None:
+        snapshot = {
+            "version": 1,
+            "nodes": [{"nodeType": "dashboard", "data": None, "children": []}],
+        }
+        result = snapshot_to_markdown(snapshot)
+        assert result == "# dashboard"
+
+    def test_node_with_non_dict_data(self) -> None:
+        snapshot = {
+            "version": 1,
+            "nodes": [{"nodeType": "widget", "data": "some string", "children": []}],
+        }
+        result = snapshot_to_markdown(snapshot)
+        assert "# widget" in result
+        assert '- "some string"' in result


### PR DESCRIPTION
+ When the frontend sends a structured LLMContextSnapshot as JSON in on_page_context (instead of the legacy ASCII DOM screenshot), the explorer chat endpoint now detects it and converts it to a readable markdown string  before forwarding to Seer. Non-JSON on_page_context (the existing ASCII screenshot) passes through unchanged.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       + This is the backend half of the structured page context feature. The frontend counterpart (conditionally sending JSON instead of ASCII when organizations:context-engine-structured-page-context flag is on + dashboards page) will follow in a separate PR per the frontend/backend split deploy requirement.   

+ This won't do anything currently right cuz the this is always false - snapshot = json.loads(on_page_context)                                                                                                                                  
                                                                                                                                                                                                                            
  Follow-up PRs                                                                                                                                                                                                             
                                                                                                                                                                                                                            
  1. Frontend PR: Wire getLLMContext() into useSeerExplorer.tsx — when the feature flag is on and the user is on a dashboards page, send JSON.stringify(getLLMContext()) as on_page_context instead of the ASCII screenshot 
  2. Widget/chart context nodes: Add registerLLMContext('widget', ...) and registerLLMContext('chart', ...) to dashboard widget and chart components so the snapshot tree has richer data (query config, filters, etc. — not
   raw timeseries data)
