### PR TITLE
Revert "ref(assisted-query): Remove old ai_query analytics events and analyticsSource prop"

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer/askSeerOption.tsx
@@ -42,6 +42,11 @@ export function AskSeerOption<T>({state}: {state: ComboBoxState<T>}) {
 
   const handleClick = () => {
     if (optionDisableOverride) return;
+
+    trackAnalytics('trace.explorer.ai_query_interface', {
+      organization,
+      action: 'opened',
+    });
     trackAnalytics('ai_query.interface', {
       organization,
       area: analyticsArea,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -67,6 +67,7 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
+          analyticsSource="test"
           feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
@@ -87,6 +88,7 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
+          analyticsSource="test"
           feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
@@ -106,6 +108,7 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
+          analyticsSource="test"
           feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
@@ -124,6 +127,7 @@ describe('AskSeerComboBox', () => {
           initialQuery="test"
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
+          analyticsSource="test"
           feedbackSource="test"
         />
       ) : (
@@ -160,6 +164,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
+          analyticsSource="test"
           feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
@@ -183,6 +188,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={applySeerSearchQuery}
+          analyticsSource="test"
           feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
@@ -220,6 +226,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
+          analyticsSource="test"
           feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,
@@ -244,6 +251,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
+          analyticsSource="test"
           feedbackSource="test"
         />
       </SearchQueryBuilderProvider>
@@ -258,6 +266,7 @@ describe('AskSeerComboBox', () => {
           initialQuery=""
           askSeerMutationOptions={askSeerMutationOptions}
           applySeerSearchQuery={() => {}}
+          analyticsSource="test"
           feedbackSource="test"
         />
       </SearchQueryBuilderProvider>,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -88,6 +88,17 @@ interface AskSeerComboBoxProps<T extends QueryTokensProps> extends Omit<
   AriaComboBoxProps<unknown>,
   'children'
 > {
+  /**
+   * The source of the analytics event, must be a dot-separated identifier like "trace.
+   * explorer" or "issue.list"
+   * @example 'trace.explorer'
+   *
+   * The combobox has the following analytic events, that will need to be tracked with your provided analyticsSource:
+   * - `<analyticsSource>.ai_query_rejected`
+   * - `<analyticsSource>.ai_query_interface`
+   * - `<analyticsSource>.ai_query_submitted`
+   */
+  analyticsSource: string;
   applySeerSearchQuery: (item: T) => void;
   askSeerMutationOptions: MutationOptions<
     {
@@ -111,6 +122,7 @@ interface AskSeerComboBoxProps<T extends QueryTokensProps> extends Omit<
 export function AskSeerComboBox<T extends QueryTokensProps>({
   initialQuery,
   feedbackSource,
+  analyticsSource,
   ...props
 }: AskSeerComboBoxProps<T>) {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -206,6 +218,11 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
       if (typeof key !== 'string') return;
 
       if (key === 'none-of-these') {
+        trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
+          organization,
+          natural_language_query: searchQuery,
+          num_queries_returned: data?.queries?.length ?? 0,
+        });
         trackAnalytics('ai_query.rejected', {
           organization,
           area: analyticsArea,
@@ -277,6 +294,10 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
         switch (e.key) {
           case 'Escape':
             if (!state.isOpen) {
+              trackAnalytics(`${analyticsSource}.ai_query_interface`, {
+                organization,
+                action: 'closed',
+              });
               trackAnalytics('ai_query.interface', {
                 organization,
                 area: analyticsArea,
@@ -290,6 +311,11 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             return;
           case 'Enter':
             if (state.isOpen && state.selectionManager.focusedKey === 'none-of-these') {
+              trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
+                organization,
+                natural_language_query: searchQuery,
+                num_queries_returned: data?.queries?.length ?? 0,
+              });
               trackAnalytics('ai_query.rejected', {
                 organization,
                 area: analyticsArea,
@@ -321,6 +347,10 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
               searchQuery.trim() !== null &&
               searchQuery.trim() !== ''
             ) {
+              trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
+                organization,
+                natural_language_query: searchQuery.trim(),
+              });
               trackAnalytics('ai_query.submitted', {
                 organization,
                 area: analyticsArea,
@@ -386,6 +416,10 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
 
   useLayoutEffect(() => {
     if (autoSubmitSeer && searchQuery.trim()) {
+      trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
+        organization,
+        natural_language_query: searchQuery.trim(),
+      });
       trackAnalytics('ai_query.submitted', {
         organization,
         area: analyticsArea,
@@ -396,6 +430,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     }
   }, [
     analyticsArea,
+    analyticsSource,
     autoSubmitSeer,
     organization,
     searchQuery,
@@ -431,6 +466,10 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
           icon={<IconClose />}
           onFocus={() => !state.isOpen && state.open()}
           onClick={() => {
+            trackAnalytics(`${analyticsSource}.ai_query_interface`, {
+              organization,
+              action: 'closed',
+            });
             trackAnalytics('ai_query.interface', {
               organization,
               area: analyticsArea,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -89,6 +89,12 @@ interface AskSeerPollingComboBoxProps<T extends QueryTokensProps> extends Omit<
   AriaComboBoxProps<unknown>,
   'children'
 > {
+  /**
+   * The source of the analytics event, must be a dot-separated identifier like "trace.
+   * explorer" or "issue.list"
+   * @example 'trace.explorer'
+   */
+  analyticsSource: string;
   applySeerSearchQuery: (item: T) => void;
   /**
    * The owner of the feedback form, must be an underscore-separated identifier like
@@ -115,6 +121,7 @@ interface AskSeerPollingComboBoxProps<T extends QueryTokensProps> extends Omit<
 export function AskSeerPollingComboBox<T extends QueryTokensProps>({
   initialQuery,
   feedbackSource,
+  analyticsSource,
   projectIds,
   strategy,
   transformResponse,
@@ -232,6 +239,11 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
       if (typeof key !== 'string') return;
 
       if (key === 'none-of-these') {
+        trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
+          organization,
+          natural_language_query: searchQuery,
+          num_queries_returned: queries.length ?? 0,
+        });
         trackAnalytics('ai_query.rejected', {
           organization,
           area: analyticsArea,
@@ -304,6 +316,10 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
         switch (e.key) {
           case 'Escape':
             if (!state.isOpen) {
+              trackAnalytics(`${analyticsSource}.ai_query_interface`, {
+                organization,
+                action: 'closed',
+              });
               trackAnalytics('ai_query.interface', {
                 organization,
                 area: analyticsArea,
@@ -318,6 +334,11 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             return;
           case 'Enter':
             if (state.isOpen && state.selectionManager.focusedKey === 'none-of-these') {
+              trackAnalytics(`${analyticsSource}.ai_query_rejected`, {
+                organization,
+                natural_language_query: searchQuery,
+                num_queries_returned: queries.length ?? 0,
+              });
               trackAnalytics('ai_query.rejected', {
                 organization,
                 area: analyticsArea,
@@ -350,6 +371,10 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
               searchQuery.trim() !== null &&
               searchQuery.trim() !== ''
             ) {
+              trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
+                organization,
+                natural_language_query: searchQuery.trim(),
+              });
               trackAnalytics('ai_query.submitted', {
                 organization,
                 area: analyticsArea,
@@ -415,6 +440,10 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
 
   useLayoutEffect(() => {
     if (autoSubmitSeer && searchQuery.trim()) {
+      trackAnalytics(`${analyticsSource}.ai_query_submitted`, {
+        organization,
+        natural_language_query: searchQuery.trim(),
+      });
       trackAnalytics('ai_query.submitted', {
         organization,
         area: analyticsArea,
@@ -425,6 +454,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
     }
   }, [
     analyticsArea,
+    analyticsSource,
     autoSubmitSeer,
     organization,
     searchQuery,
@@ -447,6 +477,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
         initialQuery={initialQuery}
         askSeerMutationOptions={fallbackMutationOptions}
         applySeerSearchQuery={props.applySeerSearchQuery}
+        analyticsSource={analyticsSource}
         feedbackSource={feedbackSource}
       />
     );
@@ -475,6 +506,10 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
           icon={<IconClose />}
           onFocus={() => !state.isOpen && state.open()}
           onClick={() => {
+            trackAnalytics(`${analyticsSource}.ai_query_interface`, {
+              organization,
+              action: 'closed',
+            });
             trackAnalytics('ai_query.interface', {
               organization,
               area: analyticsArea,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -5158,6 +5158,7 @@ describe('SearchQueryBuilder', () => {
           return displayAskSeer ? (
             <AskSeerComboBox
               initialQuery={query}
+              analyticsSource="test"
               feedbackSource="test"
               applySeerSearchQuery={() => {}}
               askSeerMutationOptions={mutationOptions({

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -64,6 +64,10 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       const newFilterValueType = getFilterValueType(token, newFieldDef);
 
       if (keyName === ASK_SEER_ITEM_KEY) {
+        trackAnalytics('trace.explorer.ai_query_interface', {
+          organization,
+          action: 'opened',
+        });
         trackAnalytics('ai_query.interface', {
           organization,
           area: analyticsArea,
@@ -81,6 +85,10 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       }
 
       if (keyName === ASK_SEER_CONSENT_ITEM_KEY) {
+        trackAnalytics('trace.explorer.ai_query_interface', {
+          organization,
+          action: 'consent_accepted',
+        });
         trackAnalytics('ai_query.interface', {
           organization,
           area: analyticsArea,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -421,6 +421,10 @@ export function useFilterKeyListBox({filterValue}: UseFilterKeyListBoxArgs) {
   const handleOptionSelected = useCallback(
     (option: FilterKeyItem) => {
       if (option.type === 'ask-seer') {
+        trackAnalytics('trace.explorer.ai_query_interface', {
+          organization,
+          action: 'opened',
+        });
         trackAnalytics('ai_query.interface', {
           organization,
           area: analyticsArea,
@@ -438,6 +442,10 @@ export function useFilterKeyListBox({filterValue}: UseFilterKeyListBoxArgs) {
       }
 
       if (option.type === 'ask-seer-consent') {
+        trackAnalytics('trace.explorer.ai_query_interface', {
+          organization,
+          action: 'consent_accepted',
+        });
         trackAnalytics('ai_query.interface', {
           organization,
           area: analyticsArea,

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -56,6 +56,9 @@ export type IssueEventParameters = {
   'device.classification.unclassified.ios.device': {
     model: string;
   };
+  'errors.ai_query_applied': {
+    query: string;
+  };
   'highlights.edit_modal.add_context_key': Record<string, unknown>;
   'highlights.edit_modal.add_tag': Record<string, unknown>;
   'highlights.edit_modal.cancel_clicked': Record<string, unknown>;
@@ -74,6 +77,9 @@ export type IssueEventParameters = {
     group_id: number;
     issue_type: string;
     project_id: number;
+  };
+  'issue.list.ai_query_applied': {
+    query: string;
   };
   'issue.shared_publicly': Record<string, unknown>;
   'issue_details.activity_drawer.filter_changed': {
@@ -292,6 +298,7 @@ type IssueEventKey = keyof IssueEventParameters;
 
 export const issueEventMap: Record<IssueEventKey, string | null> = {
   'breadcrumbs.issue_details.change_time_display': 'Breadcrumb Time Display Toggled',
+  'errors.ai_query_applied': 'Errors: AI Query Applied',
   'breadcrumbs.issue_details.drawer_opened': 'Breadcrumb Drawer Opened',
   'breadcrumbs.drawer.action': 'Breadcrumb Drawer Action Taken',
   'highlights.edit_modal.add_context_key': 'Highlights: Add Context in Edit Modal',
@@ -354,6 +361,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_views.star_view': 'Issue Views: Star View',
   'issue_search.failed': 'Issue Search: Failed',
   'issue_search.empty': 'Issue Search: Empty',
+  'issue.list.ai_query_applied': 'Issue List: AI Query Applied',
   'issues_stream.archived': 'Issues Stream: Archived',
   'issues_stream.updated_priority': 'Issues Stream: Updated Priority',
   'issues_stream.realtime_clicked': 'Issues Stream: Realtime Clicked',

--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -9,6 +9,11 @@ export enum LogsAnalyticsPageSource {
 }
 
 export type LogsAnalyticsEventParameters = {
+  'logs.ai_query_applied': {
+    group_by_count: number;
+    organization: Organization;
+    query: string;
+  };
   'logs.auto_refresh.timeout': {
     organization: Organization;
     page_source: LogsAnalyticsPageSource;
@@ -112,4 +117,5 @@ export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null>
   'logs.onboarding_platform_docs_viewed':
     'Logs Explore Empty State (Onboarding) - Platform Docs Viewed',
   'logs.table.row_copied_as_json': 'Logs Row Copied as JSON',
+  'logs.ai_query_applied': 'Logs AI Query Applied',
 };

--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -11,6 +11,22 @@ export type TracingEventParameters = {
   'trace.configurations_docs_link_clicked': {
     title: string;
   };
+
+  'trace.explorer.ai_query_applied': {
+    group_by_count: number;
+    query: string;
+    visualize_count: number;
+  };
+  'trace.explorer.ai_query_interface': {
+    action: 'opened' | 'closed' | 'consent_accepted';
+  };
+  'trace.explorer.ai_query_rejected': {
+    natural_language_query: string;
+    num_queries_returned: number;
+  };
+  'trace.explorer.ai_query_submitted': {
+    natural_language_query: string;
+  };
   'trace.explorer.cross_event_added': {
     type: CrossEventType;
   };
@@ -209,6 +225,10 @@ export const tracingEventMap: Record<TracingEventKey, string | null> = {
   'trace.metadata': 'Trace Load Metadata',
   'trace.load.empty_state': 'Trace Load Empty State',
   'trace.load.error_state': 'Trace Load Error State',
+  'trace.explorer.ai_query_applied': 'Trace Explorer: AI Query Applied',
+  'trace.explorer.ai_query_rejected': 'Trace Explorer: AI Query Rejected',
+  'trace.explorer.ai_query_submitted': 'Trace Explorer: AI Query Submitted',
+  'trace.explorer.ai_query_interface': 'Trace Explorer: AI Query Interface',
   'trace.explorer.metadata': 'Improved Trace Explorer Pageload Metadata',
   'trace.explorer.cross_event_added': 'Trace Explorer: Cross Event Added',
   'trace.explorer.cross_event_changed': 'Trace Explorer: Cross Event Changed',

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -232,6 +232,10 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         columns,
       });
 
+      trackAnalytics('errors.ai_query_applied', {
+        organization,
+        query: queryToUse,
+      });
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
@@ -289,8 +293,8 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
       location,
       navigate,
       onSearch,
-      pageFilters.selection.datetime,
       organization,
+      pageFilters.selection.datetime,
     ]
   );
 
@@ -305,6 +309,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
       strategy="Errors"
       applySeerSearchQuery={applySeerSearchQuery}
       transformResponse={transformResponse}
+      analyticsSource="errors"
       feedbackSource="errors_ai_query"
       fallbackMutationOptions={issueListAskSeerMutationOptions}
     />

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -241,6 +241,11 @@ export function LogsTabSeerComboBox() {
         mode,
       });
 
+      trackAnalytics('logs.ai_query_applied', {
+        organization,
+        query: queryToUse,
+        group_by_count: groupBys.length,
+      });
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
@@ -316,6 +321,7 @@ export function LogsTabSeerComboBox() {
       strategy="Logs"
       applySeerSearchQuery={applySeerSearchQuery}
       transformResponse={transformResponse}
+      analyticsSource="logs"
       feedbackSource="logs_ai_query"
       fallbackMutationOptions={logsTabAskSeerMutationOptions}
     />

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -259,6 +259,12 @@ export function SpansTabSeerComboBox() {
         sort,
         mode,
       });
+      trackAnalytics('trace.explorer.ai_query_applied', {
+        organization,
+        query: queryToUse,
+        group_by_count: groupBys.length,
+        visualize_count: visualizations.length,
+      });
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
@@ -345,6 +351,7 @@ export function SpansTabSeerComboBox() {
         strategy="Traces"
         applySeerSearchQuery={applySeerSearchQuery}
         transformResponse={transformResponse}
+        analyticsSource="trace.explorer"
         feedbackSource="trace_explorer_ai_query"
         fallbackMutationOptions={spansTabAskSeerMutationOptions}
       />
@@ -356,6 +363,7 @@ export function SpansTabSeerComboBox() {
       initialQuery={initialSeerQuery}
       askSeerMutationOptions={spansTabAskSeerMutationOptions}
       applySeerSearchQuery={applySeerSearchQuery}
+      analyticsSource="trace.explorer"
       feedbackSource="trace_explorer_ai_query"
     />
   );

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -186,6 +186,10 @@ export function IssueListSeerComboBox() {
         end: resultEnd,
       });
 
+      trackAnalytics('issue.list.ai_query_applied', {
+        organization,
+        query: queryToUse,
+      });
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
@@ -250,6 +254,7 @@ export function IssueListSeerComboBox() {
       strategy="Issues"
       applySeerSearchQuery={applySeerSearchQuery}
       transformResponse={transformResponse}
+      analyticsSource="issue.list"
       feedbackSource="issue_list_ai_query"
       fallbackMutationOptions={issueListAskSeerMutationOptions}
     />


### PR DESCRIPTION
Reverts getsentry/sentry#112083
Keeping this for a few weeks for smooth migration from old dashboard (owned by Dhrumil) to a new one