### PR TITLE
fix(test): Fix flaky stackTrace tooltip URL link test

### DIFF
--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -902,10 +902,10 @@ describe('Core StackTrace', () => {
     );
 
     await userEvent.hover(screen.getByText('app.js'), {delay: null});
-    act(() => jest.advanceTimersByTime(2000));
+    await act(() => jest.advanceTimersByTime(2000));
 
     expect(
-      await screen.findByRole('link', {name: 'https://example.com/static/app.js'})
+      screen.getByRole('link', {name: 'https://example.com/static/app.js'})
     ).toBeInTheDocument();
     jest.useRealTimers();
   });

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -878,7 +878,6 @@ describe('Core StackTrace', () => {
   });
 
   it('shows URL link in tooltip when absPath is an http URL', async () => {
-    jest.useFakeTimers();
     const {event, stacktrace} = makeStackTraceData();
     const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
 
@@ -901,12 +900,10 @@ describe('Core StackTrace', () => {
       </TestStackTraceProvider>
     );
 
-    await userEvent.hover(screen.getByText('app.js'), {delay: null});
-    act(() => jest.advanceTimersByTime(2000));
+    await userEvent.hover(screen.getByText('app.js'));
 
     expect(
-      screen.getByRole('link', {name: 'https://example.com/static/app.js'})
+      await screen.findByRole('link', {name: 'https://example.com/static/app.js'})
     ).toBeInTheDocument();
-    jest.useRealTimers();
   });
 });

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -902,7 +902,7 @@ describe('Core StackTrace', () => {
     );
 
     await userEvent.hover(screen.getByText('app.js'), {delay: null});
-    await act(async () => jest.advanceTimersByTime(2000));
+    act(() => jest.advanceTimersByTime(2000));
 
     expect(
       screen.getByRole('link', {name: 'https://example.com/static/app.js'})

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -902,7 +902,7 @@ describe('Core StackTrace', () => {
     );
 
     await userEvent.hover(screen.getByText('app.js'), {delay: null});
-    await act(() => jest.advanceTimersByTime(2000));
+    await act(async () => jest.advanceTimersByTime(2000));
 
     expect(
       screen.getByRole('link', {name: 'https://example.com/static/app.js'})

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -878,6 +878,7 @@ describe('Core StackTrace', () => {
   });
 
   it('shows URL link in tooltip when absPath is an http URL', async () => {
+    jest.useFakeTimers();
     const {event, stacktrace} = makeStackTraceData();
     const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
 
@@ -900,10 +901,16 @@ describe('Core StackTrace', () => {
       </TestStackTraceProvider>
     );
 
-    await userEvent.hover(screen.getByText('app.js'));
+    await userEvent.hover(screen.getByText('app.js'), {delay: null});
+    act(() => jest.advanceTimersByTime(2000));
 
     expect(
-      await screen.findByRole('link', {name: 'https://example.com/static/app.js'})
+      screen.getByRole('link', {name: 'https://example.com/static/app.js'})
     ).toBeInTheDocument();
+
+    // Flush any remaining timers (e.g. AnimatePresence) inside act
+    // before restoring real timers to avoid state updates outside act
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
Fix flaky test `shows URL link in tooltip when absPath is an http URL` in `stackTrace.spec.tsx`.

The test mixed `jest.useFakeTimers()` with `await screen.findByRole()`. `findByRole` polls using real `setTimeout` internally, but fake timers freeze those retry timeouts — creating a race condition where the query times out intermittently.

Two changes:
- **`screen.getByRole` instead of `screen.findByRole`** — after properly awaiting `act`, the tooltip is already in the DOM, so synchronous query avoids the fake-timer-vs-async-polling conflict entirely