### PR TITLE
feat(dashboards): Add ESC key to dismiss widget builder slideout

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -234,6 +234,16 @@ export function WidgetBuilderSlideout({
     });
   }, [initialState, onClose, state]);
 
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        onCloseWithModal();
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onCloseWithModal]);
+
   const breadcrumbs = customizeFromLibrary
     ? [
         {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -1,4 +1,11 @@
-import {Fragment, useCallback, useMemo, useState, type RefCallback} from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type RefCallback,
+} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -240,8 +240,10 @@ export function WidgetBuilderSlideout({
   useHotkeys([
     {
       match: 'Escape',
-      callback: () => {
+      skipPreventDefault: true,
+      callback: (evt: KeyboardEvent) => {
         if (!isModalVisible) {
+          evt.preventDefault();
           onCloseWithModal();
         }
       },

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -19,6 +19,7 @@ import {SlideOverPanel} from '@sentry/scraps/slideOverPanel';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import {useGlobalModal} from 'sentry/components/globalModal/useGlobalModal';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
 import {t, tctCode} from 'sentry/locale';
@@ -99,6 +100,7 @@ export function WidgetBuilderSlideout({
 }: WidgetBuilderSlideoutProps) {
   const organization = useOrganization();
   const location = useLocation();
+  const {visible: isModalVisible} = useGlobalModal();
   const {state, dispatch} = useWidgetBuilderContext();
   const [initialState] = useState(state);
   const [customizeFromLibrary, setCustomizeFromLibrary] = useState(false);
@@ -236,13 +238,13 @@ export function WidgetBuilderSlideout({
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
+      if (event.key === 'Escape' && !event.defaultPrevented && !isModalVisible) {
         onCloseWithModal();
       }
     }
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onCloseWithModal]);
+  }, [onCloseWithModal, isModalVisible]);
 
   const breadcrumbs = customizeFromLibrary
     ? [

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -1,17 +1,11 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type RefCallback,
-} from 'react';
+import {Fragment, useCallback, useMemo, useState, type RefCallback} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
+import {useHotkeys} from '@sentry/scraps/hotkey';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {SlideOverPanel} from '@sentry/scraps/slideOverPanel';
@@ -236,15 +230,16 @@ export function WidgetBuilderSlideout({
     });
   }, [initialState, onClose, state]);
 
-  useEffect(() => {
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape' && !event.defaultPrevented && !isModalVisible) {
-        onCloseWithModal();
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onCloseWithModal, isModalVisible]);
+  useHotkeys([
+    {
+      match: 'Escape',
+      callback: () => {
+        if (!isModalVisible) {
+          onCloseWithModal();
+        }
+      },
+    },
+  ]);
 
   const breadcrumbs = customizeFromLibrary
     ? [


### PR DESCRIPTION
Pressing Escape while the widget builder slideout is open now triggers the same close flow as the Close button. If there are unsaved changes, the confirmation modal appears; otherwise the panel closes immediately.

Previously there was no keyboard shortcut to dismiss the slideout — you had to click the Close or Cancel buttons.