### PR TITLE
test(uptime): Fix flaky tooltip hover test in percent.spec

### DIFF
--- a/static/app/views/insights/uptime/components/percent.spec.tsx
+++ b/static/app/views/insights/uptime/components/percent.spec.tsx
@@ -1,6 +1,6 @@
 import {UptimeSummaryFixture} from 'sentry-fixture/uptimeSummary';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {UptimePercent} from './percent';
 
@@ -86,11 +86,12 @@ describe('UptimePercent', () => {
   it('shows tooltip with detailed breakdown on hover', async () => {
     render(<UptimePercent summary={mockSummary} note="This is a test" />);
 
-    const percentageText = screen.getByText('94.736%');
-    await userEvent.hover(percentageText);
+    await userEvent.hover(screen.getByText('94.736%'));
 
-    expect(await screen.findByText('This is a test')).toBeInTheDocument();
-    expect(screen.getByText('Up Checks')).toBeInTheDocument();
-    expect(screen.getByText('Down Checks')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('This is a test')).toBeInTheDocument();
+      expect(screen.getByText('Up Checks')).toBeInTheDocument();
+      expect(screen.getByText('Down Checks')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Fix flaky test `shows tooltip with detailed breakdown on hover` in `percent.spec.tsx`.

The `Tooltip` component uses a 50ms `OPEN_DELAY` (via `useHoverOverlay`) before rendering content into a portal with `AnimatePresence` animation. The previous test used `findByText` for only the first tooltip assertion and synchronous `getByText` for the remaining two, creating a timing race where the tooltip portal content may not have fully rendered.

Wraps all tooltip content assertions in `waitFor` so they retry as a group until the tooltip is visible, consistent with how other tooltip tests in the codebase handle this timing.