### PR TITLE
fix(billing): fix flaky paymentForm test by awaiting button enabled state

### DIFF
--- a/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
+++ b/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
@@ -94,8 +94,11 @@ describe('InvoiceDetails > Payment Form', () => {
     expect(await screen.findByText(/Something bad happened./)).toBeInTheDocument();
     expect(mockget).toHaveBeenCalled();
 
-    // Submit the form anyways
-    expect(screen.getByRole('button', {name: 'Pay Now'})).toBeEnabled();
+    // Submit the form anyways - wait for the button to become enabled
+    // (the mock Stripe PaymentElement fires onChange asynchronously via setTimeout)
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Pay Now'})).toBeEnabled()
+    );
     await userEvent.click(screen.getByRole('button', {name: 'Pay Now'}));
 
     // Should show an error as our intent never loaded.

--- a/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
+++ b/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
@@ -125,7 +125,7 @@ describe('InvoiceDetails > Payment Form', () => {
     await waitFor(() => expect(mockget).toHaveBeenCalled());
     expect(mockget).toHaveBeenCalled();
 
-    expect(screen.getByText('Pay Bill')).toBeInTheDocument();
+    expect(await screen.findByText('Pay Bill')).toBeInTheDocument();
 
     const button = await screen.findByRole('button', {name: 'Pay Now'});
     await userEvent.click(button);


### PR DESCRIPTION
## Summary
- The `paymentForm.spec.tsx` test "renders an error when intent creation fails" was flaky because it asserted `toBeEnabled()` on the "Pay Now" button synchronously
- The mock Stripe `PaymentElement` fires `onChange({complete: true})` inside a `setTimeout(..., 0)`, so the button's enabled state update races with the assertion
- Wrapped the assertion in `waitFor()` to reliably wait for the async state update

## Root Cause
In `tests/js/setup.ts`, the global Stripe mock for `PaymentElement` uses `setTimeout(() => { onChange({complete: true}) }, 0)` to simulate form completion. In `InnerIntentForm`, the submit button starts disabled (`submitDisabled = true`) and only becomes enabled when `onChange` fires with `complete: true`. The synchronous `toBeEnabled()` assertion could run before the setTimeout callback executed, causing intermittent failures.

## Test plan
- [x] Pre-commit passes
- [x] CI passes