### PR TITLE
feat(notifications): Hook into the platform in the slack send_alert step for metric laerts

### DIFF
--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
@@ -1,12 +1,19 @@
 import logging
 
-from sentry.incidents.models.incident import TriggerStatus
+import sentry_sdk
+
+from sentry import features
+from sentry.incidents.charts import build_metric_alert_chart
+from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
+from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
+from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
     MetricIssueContext,
     NotificationContext,
     OpenPeriodContext,
 )
+from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.integrations.slack.utils.notifications import send_incident_alert_notification
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
@@ -18,9 +25,104 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
 )
 from sentry.notifications.notification_action.registry import metric_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseMetricAlertHandler
+from sentry.notifications.platform.service import NotificationService
+from sentry.notifications.platform.target import IntegrationNotificationTarget
+from sentry.notifications.platform.templates.metric_alert import MetricAlertNotificationData
+from sentry.notifications.platform.threading import ThreadingOptions, ThreadKey
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationSource,
+    NotificationTargetResourceType,
+)
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
+    DetectorSerializerResponse,
+)
 from sentry.workflow_engine.models import Action, Detector
 
 logger = logging.getLogger(__name__)
+
+
+def _send_via_notification_platform(
+    notification_context: NotificationContext,
+    alert_context: AlertContext,
+    metric_issue_context: MetricIssueContext,
+    open_period_context: OpenPeriodContext,
+    notification_uuid: str,
+    organization: Organization,
+    alert_rule_serialized_response: AlertRuleSerializerResponse,
+    detector_serialized_response: DetectorSerializerResponse,
+    incident_serialized_response: DetailedIncidentSerializerResponse,
+) -> None:
+    if notification_context.integration_id is None:
+        raise ValueError("Integration ID is None")
+
+    if notification_context.target_identifier is None:
+        raise ValueError("Slack channel is None")
+
+    attachment_info = incident_attachment_info(
+        organization=organization,
+        alert_context=alert_context,
+        metric_issue_context=metric_issue_context,
+        notification_uuid=notification_uuid,
+        referrer="metric_alert_slack",
+    )
+
+    chart_url = None
+    if (
+        features.has("organizations:metric-alert-chartcuterie", organization)
+        and alert_rule_serialized_response
+        and incident_serialized_response
+    ):
+        try:
+            chart_url = build_metric_alert_chart(
+                organization=organization,
+                alert_rule_serialized_response=alert_rule_serialized_response,
+                snuba_query=metric_issue_context.snuba_query,
+                alert_context=alert_context,
+                open_period_context=open_period_context,
+                selected_incident_serialized=incident_serialized_response,
+                subscription=metric_issue_context.subscription,
+                detector_serialized_response=detector_serialized_response,
+            )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+
+    data = MetricAlertNotificationData(
+        group_id=metric_issue_context.id,
+        organization_id=organization.id,
+        notification_uuid=notification_uuid,
+        action_id=notification_context.id,
+        open_period_context=open_period_context,
+        new_status=metric_issue_context.new_status.value,
+        title=attachment_info["title"],
+        title_link=attachment_info["title_link"],
+        text=attachment_info["text"],
+        chart_url=chart_url,
+    )
+
+    target = IntegrationNotificationTarget(
+        provider_key=NotificationProviderKey.SLACK,
+        resource_type=NotificationTargetResourceType.CHANNEL,
+        resource_id=notification_context.target_identifier,
+        integration_id=notification_context.integration_id,
+        organization_id=organization.id,
+    )
+
+    threading_options = ThreadingOptions(
+        thread_key=ThreadKey(
+            key_type=NotificationSource.METRIC_ALERT,
+            key_data={
+                "action_id": notification_context.id,
+                "group_id": metric_issue_context.id,
+                "open_period_start": open_period_context.date_started.isoformat(),
+            },
+        ),
+        reply_broadcast=(metric_issue_context.new_status == IncidentStatus.CRITICAL),
+    )
+
+    NotificationService[MetricAlertNotificationData](data=data).notify_sync(
+        targets=[target], threading_options=threading_options
+    )
 
 
 @metric_alert_handler_registry.register(Action.Type.SLACK)
@@ -58,17 +160,30 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
             },
         )
 
-        send_incident_alert_notification(
-            notification_context=notification_context,
-            alert_context=alert_context,
-            metric_issue_context=metric_issue_context,
-            open_period_context=open_period_context,
-            organization=organization,
-            notification_uuid=notification_uuid,
-            alert_rule_serialized_response=alert_rule_serialized_response,
-            incident_serialized_response=incident_serialized_response,
-            detector_serialized_response=detector_serialized_response,
-        )
+        if NotificationService.has_access(organization, NotificationSource.METRIC_ALERT):
+            _send_via_notification_platform(
+                notification_context=notification_context,
+                alert_context=alert_context,
+                metric_issue_context=metric_issue_context,
+                open_period_context=open_period_context,
+                notification_uuid=notification_uuid,
+                organization=organization,
+                alert_rule_serialized_response=alert_rule_serialized_response,
+                detector_serialized_response=detector_serialized_response,
+                incident_serialized_response=incident_serialized_response,
+            )
+        else:
+            send_incident_alert_notification(
+                notification_context=notification_context,
+                alert_context=alert_context,
+                metric_issue_context=metric_issue_context,
+                open_period_context=open_period_context,
+                organization=organization,
+                notification_uuid=notification_uuid,
+                alert_rule_serialized_response=alert_rule_serialized_response,
+                incident_serialized_response=incident_serialized_response,
+                detector_serialized_response=detector_serialized_response,
+            )
 
 
 @metric_alert_handler_registry.register(Action.Type.SLACK_STAGING)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 import uuid
 from dataclasses import asdict
+from typing import Any
 from unittest import mock
+from unittest.mock import patch
+
+from slack_sdk.web import SlackResponse
 
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
@@ -10,6 +16,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import SlackMetricAlertHandler
@@ -19,6 +26,8 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.uti
     get_detector_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import ActionInvocation, DetectorPriorityLevel, WorkflowEventData
@@ -26,8 +35,106 @@ from tests.sentry.notifications.notification_action.test_metric_alert_registry_h
     MetricAlertHandlerBase,
 )
 
+_HANDLER_PATH = "sentry.notifications.notification_action.metric_alert_registry.handlers.slack_metric_alert_handler"
 
-class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
+
+class TestSlackMetricAlertHandlerSendAlert(MetricAlertHandlerBase):
+    def setUp(self) -> None:
+        self.create_models()
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            provider=IntegrationProviderSlug.SLACK,
+            organization=self.organization,
+            user=self.user,
+            name="test-slack",
+            metadata={"domain_name": "test-workspace.slack.com"},
+        )
+        self.action = self.create_action(
+            type=Action.Type.SLACK,
+            integration_id=self.integration.id,
+            config={
+                "target_identifier": "channel123",
+                "target_display": "Channel 123",
+                "target_type": ActionTarget.SPECIFIC,
+            },
+        )
+        self.handler = SlackMetricAlertHandler()
+
+    def _make_send_alert_kwargs(self) -> dict[str, Any]:
+        notification_context = NotificationContext.from_action_model(self.action)
+        assert self.group_event.occurrence is not None
+        assert self.group_event.occurrence.priority is not None
+        priority = DetectorPriorityLevel(self.group_event.occurrence.priority)
+        return dict(
+            notification_context=notification_context,
+            alert_context=AlertContext.from_workflow_engine_models(
+                self.detector,
+                self.evidence_data,
+                self.group_event.group.status,
+                priority,
+            ),
+            metric_issue_context=MetricIssueContext.from_group_event(
+                self.group, self.evidence_data, priority
+            ),
+            open_period_context=OpenPeriodContext.from_group(self.group),
+            trigger_status=TriggerStatus.ACTIVE,
+            project=self.detector.project,
+            organization=self.detector.project.organization,
+            notification_uuid=str(uuid.uuid4()),
+        )
+
+    @override_options({"notifications.platform-rollout.internal-testing": {"metric-alert": 1.0}})
+    @with_feature("organizations:notification-platform.internal-testing")
+    @patch("sentry.integrations.slack.integration.SlackSdkClient")
+    @freeze_time("2021-01-01 00:00:00")
+    def test_send_alert_via_np_sends_to_slack_channel(
+        self, mock_slack_client: mock.MagicMock
+    ) -> None:
+        mock_client_instance = mock_slack_client.return_value
+        mock_client_instance.chat_postMessage.return_value = SlackResponse(
+            client=mock_client_instance,
+            http_verb="POST",
+            api_url="https://slack.com/api/chat.postMessage",
+            req_args={},
+            data={"ok": True, "ts": "123.456"},
+            headers={},
+            status_code=200,
+        )
+
+        self.handler.send_alert(**self._make_send_alert_kwargs())
+
+        mock_client_instance.chat_postMessage.assert_called_once()
+        call_kwargs = mock_client_instance.chat_postMessage.call_args.kwargs
+        assert call_kwargs["channel"] == "channel123"
+        blocks = call_kwargs["blocks"]
+        assert len(blocks) >= 1
+        assert blocks[0]["type"] == "section"
+        assert blocks[0]["text"]["type"] == "mrkdwn"
+
+    @patch(f"{_HANDLER_PATH}.send_incident_alert_notification")
+    @freeze_time("2021-01-01 00:00:00")
+    def test_send_alert_falls_back_to_legacy_when_no_access(
+        self, mock_send_incident: mock.MagicMock
+    ) -> None:
+        # No feature flag enabled → has_access returns False → legacy path
+        kwargs = self._make_send_alert_kwargs()
+        self.handler.send_alert(**kwargs)
+
+        mock_send_incident.assert_called_once_with(
+            organization=kwargs["organization"],
+            alert_context=kwargs["alert_context"],
+            notification_context=kwargs["notification_context"],
+            metric_issue_context=kwargs["metric_issue_context"],
+            open_period_context=kwargs["open_period_context"],
+            alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
+            incident_serialized_response=get_detailed_incident_serializer(self.open_period),
+            detector_serialized_response=get_detector_serializer(self.detector),
+            notification_uuid=kwargs["notification_uuid"],
+        )
+
+
+class TestSlackMetricAlertHandlerInvokeRegistry(MetricAlertHandlerBase):
+    """Tests for invoke_legacy_registry — verifies context extraction from GroupEvent and Activity."""
+
     def setUp(self) -> None:
         self.create_models()
         self.action = self.create_action(
@@ -39,53 +146,7 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
                 "target_type": ActionTarget.SPECIFIC,
             },
         )
-
         self.handler = SlackMetricAlertHandler()
-
-    @mock.patch(
-        "sentry.notifications.notification_action.metric_alert_registry.handlers.slack_metric_alert_handler.send_incident_alert_notification"
-    )
-    @freeze_time("2021-01-01 00:00:00")
-    def test_send_alert(self, mock_send_incident_alert_notification: mock.MagicMock) -> None:
-        notification_context = NotificationContext.from_action_model(self.action)
-        assert self.group_event.occurrence is not None
-        assert self.group_event.occurrence.priority is not None
-        alert_context = AlertContext.from_workflow_engine_models(
-            self.detector,
-            self.evidence_data,
-            self.group_event.group.status,
-            DetectorPriorityLevel(self.group_event.occurrence.priority),
-        )
-        metric_issue_context = MetricIssueContext.from_group_event(
-            self.group,
-            self.evidence_data,
-            DetectorPriorityLevel(self.group_event.occurrence.priority),
-        )
-        open_period_context = OpenPeriodContext.from_group(self.group)
-        notification_uuid = str(uuid.uuid4())
-
-        self.handler.send_alert(
-            notification_context=notification_context,
-            alert_context=alert_context,
-            metric_issue_context=metric_issue_context,
-            open_period_context=open_period_context,
-            trigger_status=TriggerStatus.ACTIVE,
-            project=self.detector.project,
-            organization=self.detector.project.organization,
-            notification_uuid=notification_uuid,
-        )
-
-        mock_send_incident_alert_notification.assert_called_once_with(
-            organization=self.detector.project.organization,
-            alert_context=alert_context,
-            notification_context=notification_context,
-            metric_issue_context=metric_issue_context,
-            open_period_context=open_period_context,
-            alert_rule_serialized_response=get_alert_rule_serializer(self.detector),
-            incident_serialized_response=get_detailed_incident_serializer(self.open_period),
-            detector_serialized_response=get_detector_serializer(self.detector),
-            notification_uuid=notification_uuid,
-        )
 
     @mock.patch(
         "sentry.notifications.notification_action.metric_alert_registry.SlackMetricAlertHandler.send_alert"
@@ -158,31 +219,25 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
     )
     @freeze_time("2021-01-01 00:00:00")
     def test_invoke_legacy_registry_with_activity(self, mock_send_alert: mock.MagicMock) -> None:
-        # Create an Activity instance with evidence data and priority
-        activity_data = asdict(self.evidence_data)
-
         activity = Activity(
             project=self.project,
             group=self.group,
             type=ActivityType.SET_RESOLVED.value,
-            data=activity_data,
+            data=asdict(self.evidence_data),
         )
         activity.save()
 
-        # Create event data with Activity instead of GroupEvent
         event_data_with_activity = WorkflowEventData(
             event=activity,
             workflow_env=self.workflow.environment,
             group=self.group,
         )
 
-        notification_uuid = str(uuid.uuid4())
-
         invocation = ActionInvocation(
             event_data=event_data_with_activity,
             action=self.action,
             detector=self.detector,
-            notification_uuid=notification_uuid,
+            notification_uuid=str(uuid.uuid4()),
         )
 
         self.handler.invoke_legacy_registry(invocation)
@@ -197,7 +252,6 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             notification_uuid,
         ) = self.unpack_kwargs(mock_send_alert)
 
-        # Verify that the same data is extracted from Activity.data as from GroupEvent.occurrence.evidence_data
         self.assert_notification_context(
             notification_context,
             integration_id=1234567890,


### PR DESCRIPTION
the hooking into metric alert send path part of https://github.com/getsentry/sentry/pull/112160 . This time with a has_access check!