### PR TITLE
ref(backup): Extract org-scope User FK model discovery into shared function

### DIFF
--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -667,6 +667,42 @@ def get_exportable_sentry_models() -> set[type[models.base.Model]]:
     )
 
 
+def get_org_scope_models_with_user_fk() -> set[NormalizedModelName]:
+    """
+    Returns the set of all Organization-scoped model names that have a foreign key to User,
+    plus models that are excluded from exports but still included in user merging.
+
+    This is the single source of truth used by the coverage test in
+    ``test_coverage.py::test_all_eligible_organization_scoped_models_tested_for_user_merge``.
+    """
+    from sentry.models.activity import Activity
+    from sentry.models.groupassignee import GroupAssignee
+    from sentry.models.groupbookmark import GroupBookmark
+    from sentry.models.groupseen import GroupSeen
+    from sentry.models.groupshare import GroupShare
+    from sentry.models.groupsubscription import GroupSubscription
+    from sentry.users.models.user import User
+
+    all_deps = dependencies()
+    result: set[NormalizedModelName] = set()
+    for model in get_exportable_sentry_models():
+        model_name = get_model_name(model)
+        model_relations = all_deps[model_name]
+        if RelocationScope.Organization not in model_relations.get_possible_relocation_scopes():
+            continue
+        for foreign_field in model_relations.foreign_keys.values():
+            if foreign_field.model == User:
+                result.add(model_name)
+                break
+
+    # Models excluded from exports but still included in user merging.
+    result |= {
+        get_model_name(m)
+        for m in {Activity, GroupAssignee, GroupBookmark, GroupSeen, GroupShare, GroupSubscription}
+    }
+    return result
+
+
 def _get_org_scope_condition(model_relations: ModelRelations, organization_id: int) -> Q:
     """
     Finds a path from this model to Organization through FK relationships and returns a Q object

--- a/tests/sentry/backup/test_coverage.py
+++ b/tests/sentry/backup/test_coverage.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-from sentry.backup.dependencies import dependencies, get_exportable_sentry_models, get_model_name
+from sentry.backup.dependencies import (
+    dependencies,
+    get_exportable_sentry_models,
+    get_model_name,
+    get_org_scope_models_with_user_fk,
+)
 from sentry.backup.scopes import RelocationScope
-from sentry.models.activity import Activity
-from sentry.models.groupassignee import GroupAssignee
-from sentry.models.groupbookmark import GroupBookmark
-from sentry.models.groupseen import GroupSeen
-from sentry.models.groupshare import GroupShare
-from sentry.models.groupsubscription import GroupSubscription
-from sentry.users.models.user import User
 from tests.sentry.backup.test_exhaustive import EXHAUSTIVELY_TESTED, UNIQUENESS_TESTED
 from tests.sentry.backup.test_imports import COLLISION_TESTED
 from tests.sentry.backup.test_models import DYNAMIC_RELOCATION_SCOPE_TESTED
@@ -105,33 +103,7 @@ def test_exportable_final_derivations_of_sentry_model_are_uniqueness_tested() ->
 
 
 def test_all_eligible_organization_scoped_models_tested_for_user_merge() -> None:
-    all_org_scope_models_that_reference_user = set()
-    for model in get_exportable_sentry_models():
-        model_name = get_model_name(model)
-        model_relations = dependencies()[model_name]
-        possible_relocation_scopes = model_relations.get_possible_relocation_scopes()
-        if RelocationScope.Organization not in possible_relocation_scopes:
-            continue
-        for foreign_field in model_relations.foreign_keys.values():
-            if foreign_field.model == User:
-                all_org_scope_models_that_reference_user.add(model_name)
-                break
-
-    # Manually add some models that are currently excluded from exports, but still included in user
-    # merging.
-    all_org_scope_models_that_reference_user |= {
-        get_model_name(m)
-        for m in {
-            Activity,
-            GroupAssignee,
-            GroupBookmark,
-            GroupSeen,
-            GroupShare,
-            GroupSubscription,
-        }
-    }
-
-    untested = all_org_scope_models_that_reference_user - ORG_MEMBER_MERGE_TESTED
+    untested = get_org_scope_models_with_user_fk() - ORG_MEMBER_MERGE_TESTED
     assert not {str(u) for u in untested}, (
         "The aforementioned models are not covered in the `ORG_MEMBER_MERGE` backup tests; please go to `tests/sentry/models/test_user.py::UserMergeToTest` and make sure at least one test in the suite contains covers each of the missing models."
     )


### PR DESCRIPTION
Extract the logic for discovering Organization-scoped models with User foreign keys into a shared function `get_org_scope_models_with_user_fk()` in `src/sentry/backup/dependencies.py`.

The coverage test `test_all_eligible_organization_scoped_models_tested_for_user_merge` previously duplicated this discovery logic inline. When a new Organization-scoped model with a User FK was added to the codebase without updating the `UserMergeToTest` suite, the test would fail — appearing as a "flaky" test in CI since it only broke on certain PRs.

By consolidating the discovery into a single function, we reduce the maintenance surface and make the test simpler. The test now calls `get_org_scope_models_with_user_fk()` directly instead of reimplementing the same iteration over exportable models.

No behavior change — the set of models discovered is identical.