### PR TITLE
fix(test): Fix flaky test_stats_period_limits_time_range

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -2,7 +2,6 @@ from operator import itemgetter
 from unittest import mock
 from uuid import uuid4
 
-import pytest
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
@@ -2513,8 +2512,11 @@ class OrganizationTraceItemAttributeValidateEndpointTest(
         assert attrs["nonexistent.tag"]["valid"] is False
         assert "error" in attrs["nonexistent.tag"]
 
-    @pytest.mark.xfail(reason="Flaky test - PR #111993")  # noqa: F821
     def test_stats_period_limits_time_range(self):
+        # Store a span well outside the narrow query window.  Use a large gap
+        # (30 days) so that even if Snuba rounds time ranges to coarse buckets
+        # (e.g. daily), the span cannot bleed into a 1h window anchored at
+        # "now".
         self.store_segment(
             self.project.id,
             uuid4().hex,
@@ -2522,7 +2524,7 @@ class OrganizationTraceItemAttributeValidateEndpointTest(
             span_id=uuid4().hex[:16],
             organization_id=self.organization.id,
             parent_span_id=None,
-            timestamp=before_now(days=2).replace(microsecond=0),
+            timestamp=before_now(days=30).replace(microsecond=0),
             transaction="foo",
             duration=100,
             exclusive_time=100,
@@ -2532,7 +2534,7 @@ class OrganizationTraceItemAttributeValidateEndpointTest(
         # Wide time range should find the tag
         response = self.do_request(
             payload={"attributes": ["old.tag"]},
-            query_params={"itemType": "spans", "statsPeriod": "7d"},
+            query_params={"itemType": "spans", "statsPeriod": "90d"},
         )
         assert response.status_code == 200
         assert response.data["attributes"]["old.tag"]["valid"] is True


### PR DESCRIPTION
Fix flaky `OrganizationTraceItemAttributeValidateEndpointTest::test_stats_period_limits_time_range`.

The test stored a span 2 days ago and expected a `statsPeriod=1h` query to exclude it. This was flaky because Snuba's `attribute_names_rpc` (`EndpointTraceItemAttributeNames`) uses coarse time granularity for metadata lookups — a 2-day-old span could bleed into a 1h query window depending on how the time buckets align.

Fix by pushing the span to 30 days ago and widening the "find" window to `90d`. This creates a large enough gap that no reasonable time bucketing can cause the old span to appear in the 1h window.

Also removes the `xfail` marker (added in #111993) and the now-unused `pytest` import.