### PR TITLE
fix(ACI): Handle missing sentry app installation

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -641,21 +641,14 @@ class WorkflowEngineRuleSerializer(Serializer):
                     continue  # just keep iterating through the actions in case we have valid ones in there
             actions_with_handlers = list(action_to_handler.keys())
 
-            # action_to_action_data = {}
-            # for action in actions_with_handlers:
-            #     try:
-            #         action_to_action_data[action] = action_to_handler[action].build_rule_action_blob(
-            #             action, workflow.organization_id
-            #         )
-            #     except ValueError:
-            #         continue
-
-            action_to_action_data = {
-                action: action_to_handler[action].build_rule_action_blob(
-                    action, workflow.organization_id
-                )
-                for action in actions_with_handlers  # skip over actions w/o handlers
-            }
+            action_to_action_data = {}
+            for action in actions_with_handlers:
+                try:
+                    action_to_action_data[action] = action_to_handler[
+                        action
+                    ].build_rule_action_blob(action, workflow.organization_id)
+                except ValueError:
+                    continue
 
             sentry_app_installations_by_uuid = self._fetch_sentry_app_installations_by_uuid(
                 workflow, action_to_action_data, actions_with_handlers
@@ -670,7 +663,10 @@ class WorkflowEngineRuleSerializer(Serializer):
                     }
                 )
             for action in actions_with_handlers:
-                action_data = action_to_action_data[action]
+                action_data = action_to_action_data.get(action)
+                if not action_data:
+                    continue
+
                 action_data["name"] = action_to_handler[action].render_label(
                     workflow.organization_id, action_data
                 )

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -550,15 +550,12 @@ class WorkflowEngineRuleSerializer(Serializer):
 
         sentry_app_installations_by_uuid: Mapping[str, RpcSentryAppComponentContext] = {}
         if self.prepare_component_fields:
-            sentry_app_uuids = []
-            for action in actions_with_handlers:
-                if action_to_action_data.get(action):
-                    for sentry_app_uuid in action_to_action_data[action].get(
-                        "sentryAppInstallationUuid"
-                    ):
-                        if sentry_app_uuid is not None:
-                            sentry_app_uuids.append(sentry_app_uuid)
-
+            sentry_app_uuids = [
+                action_to_action_data[action]["sentryAppInstallationUuid"]
+                for action in actions_with_handlers
+                if action_to_action_data.get(action)
+                and action_to_action_data[action].get("sentryAppInstallationUuid") is not None
+            ]
             install_contexts = app_service.get_component_contexts(
                 filter={"uuids": sentry_app_uuids, "organization_id": workflow.organization_id},
                 component_type="alert-rule-action",

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -550,14 +550,15 @@ class WorkflowEngineRuleSerializer(Serializer):
 
         sentry_app_installations_by_uuid: Mapping[str, RpcSentryAppComponentContext] = {}
         if self.prepare_component_fields:
-            sentry_app_uuids = [
-                sentry_app_uuid
-                for sentry_app_uuid in (
-                    action_to_action_data[action].get("sentryAppInstallationUuid")
-                    for action in actions_with_handlers
-                )
-                if sentry_app_uuid is not None
-            ]
+            sentry_app_uuids = []
+            for action in actions_with_handlers:
+                if action_to_action_data.get(action):
+                    for sentry_app_uuid in action_to_action_data[action].get(
+                        "sentryAppInstallationUuid"
+                    ):
+                        if sentry_app_uuid is not None:
+                            sentry_app_uuids.append(sentry_app_uuid)
+
             install_contexts = app_service.get_component_contexts(
                 filter={"uuids": sentry_app_uuids, "organization_id": workflow.organization_id},
                 component_type="alert-rule-action",

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -646,6 +646,7 @@ class WorkflowEngineRuleSerializer(Serializer):
                         action
                     ].build_rule_action_blob(action, workflow.organization_id)
                 except ValueError:
+                    # if we have a missing sentry app installation but the action is still connected to the sentry app, we skip so we can return the rest of the rule
                     continue
 
             sentry_app_installations_by_uuid = self._fetch_sentry_app_installations_by_uuid(

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -640,6 +640,16 @@ class WorkflowEngineRuleSerializer(Serializer):
                 except Exception:
                     continue  # just keep iterating through the actions in case we have valid ones in there
             actions_with_handlers = list(action_to_handler.keys())
+
+            # action_to_action_data = {}
+            # for action in actions_with_handlers:
+            #     try:
+            #         action_to_action_data[action] = action_to_handler[action].build_rule_action_blob(
+            #             action, workflow.organization_id
+            #         )
+            #     except ValueError:
+            #         continue
+
             action_to_action_data = {
                 action: action_to_handler[action].build_rule_action_blob(
                     action, workflow.organization_id

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -65,7 +65,6 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
 from sentry.workflow_engine.models import DataSource, DataSourceDetector, Detector
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.data_condition import Condition
@@ -712,72 +711,6 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         assert "select" == action["formFields"]["optional_fields"][-1]["type"]
         assert "sentry/members" in action["formFields"]["optional_fields"][-1]["uri"]
         assert "bob" == action["formFields"]["optional_fields"][-1]["choices"][0][0]
-
-    @responses.activate
-    def test_uninstalled_sentry_app(self) -> None:
-        self.superuser = self.create_user("admin@localhost", is_superuser=True)
-        self.login_as(user=self.superuser)
-        self.create_team(organization=self.organization, members=[self.superuser])
-
-        sentry_app = self.create_sentry_app(
-            organization=self.organization,
-            published=True,
-            verify_install=False,
-            name="Super Awesome App",
-            schema={"elements": [self.create_alert_rule_action_schema()]},
-        )
-        installation = self.create_sentry_app_installation(
-            slug=sentry_app.slug, organization=self.organization, user=self.superuser
-        )
-        rule = self.create_alert_rule()
-        trigger = self.create_alert_rule_trigger(rule, "hi", 1000)
-        self.create_alert_rule_trigger_action(
-            alert_rule_trigger=trigger,
-            target_identifier=sentry_app.id,
-            type=AlertRuleTriggerAction.Type.SENTRY_APP,
-            target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
-            sentry_app=sentry_app,
-            sentry_app_config=[
-                {"name": "title", "value": "An alert"},
-                {"summary": "Something happened here..."},
-                {"name": "points", "value": "3"},
-                {"name": "assignee", "value": "Nisanthan"},
-            ],
-        )
-        _, _, _, detector, _, ard, _, _ = migrate_alert_rule(rule)
-        fake_detector_id = get_fake_id_from_object_id(ard.detector_id)
-
-        responses.add(
-            responses.GET,
-            "https://example.com/sentry/members",
-            json=[
-                {"value": "bob", "label": "Bob"},
-                {"value": "jess", "label": "Jess"},
-            ],
-            status=200,
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            installation.delete()
-
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, rule.id)
-
-        assert len(responses.calls) == 0
-        assert "errors" not in resp.data
-
-        action = resp.data["triggers"][0]["actions"][0]
-        assert not action.get("formFields")
-
-        with (
-            self.feature("organizations:incidents"),
-            self.feature("organizations:workflow-engine-rule-serializers"),
-        ):
-            resp = self.get_response(self.organization.slug, fake_detector_id)
-
-        assert len(responses.calls) == 0
-        assert "errors" not in resp.data
-
-        assert len(resp.data["triggers"]) == 0
 
     @responses.activate
     def test_with_sentryapp_multiple_installations_filters_by_org(self) -> None:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -65,6 +65,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
 from sentry.workflow_engine.models import DataSource, DataSourceDetector, Detector
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.data_condition import Condition
@@ -711,6 +712,72 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         assert "select" == action["formFields"]["optional_fields"][-1]["type"]
         assert "sentry/members" in action["formFields"]["optional_fields"][-1]["uri"]
         assert "bob" == action["formFields"]["optional_fields"][-1]["choices"][0][0]
+
+    @responses.activate
+    def test_uninstalled_sentry_app(self) -> None:
+        self.superuser = self.create_user("admin@localhost", is_superuser=True)
+        self.login_as(user=self.superuser)
+        self.create_team(organization=self.organization, members=[self.superuser])
+
+        sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            published=True,
+            verify_install=False,
+            name="Super Awesome App",
+            schema={"elements": [self.create_alert_rule_action_schema()]},
+        )
+        installation = self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization, user=self.superuser
+        )
+        rule = self.create_alert_rule()
+        trigger = self.create_alert_rule_trigger(rule, "hi", 1000)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger,
+            target_identifier=sentry_app.id,
+            type=AlertRuleTriggerAction.Type.SENTRY_APP,
+            target_type=AlertRuleTriggerAction.TargetType.SENTRY_APP,
+            sentry_app=sentry_app,
+            sentry_app_config=[
+                {"name": "title", "value": "An alert"},
+                {"summary": "Something happened here..."},
+                {"name": "points", "value": "3"},
+                {"name": "assignee", "value": "Nisanthan"},
+            ],
+        )
+        _, _, _, detector, _, ard, _, _ = migrate_alert_rule(rule)
+        fake_detector_id = get_fake_id_from_object_id(ard.detector_id)
+
+        responses.add(
+            responses.GET,
+            "https://example.com/sentry/members",
+            json=[
+                {"value": "bob", "label": "Bob"},
+                {"value": "jess", "label": "Jess"},
+            ],
+            status=200,
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            installation.delete()
+
+        with self.feature("organizations:incidents"):
+            resp = self.get_response(self.organization.slug, rule.id)
+
+        assert len(responses.calls) == 0
+        assert "errors" not in resp.data
+
+        action = resp.data["triggers"][0]["actions"][0]
+        assert not action.get("formFields")
+
+        with (
+            self.feature("organizations:incidents"),
+            self.feature("organizations:workflow-engine-rule-serializers"),
+        ):
+            resp = self.get_response(self.organization.slug, fake_detector_id)
+
+        assert len(responses.calls) == 0
+        assert "errors" not in resp.data
+
+        assert len(resp.data["triggers"]) == 0
 
     @responses.activate
     def test_with_sentryapp_multiple_installations_filters_by_org(self) -> None:

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -1,17 +1,22 @@
 from datetime import UTC, datetime
 
 import requests
+import responses
 
 from sentry.constants import ObjectStatus
-from sentry.incidents.models.alert_rule import AlertRuleThresholdType
+from sentry.incidents.models.alert_rule import (
+    AlertRuleThresholdType,
+)
 from sentry.incidents.models.incident import IncidentTrigger, TriggerStatus
 from sentry.models.rule import RuleSource
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.monitors.models import MonitorStatus
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
 from sentry.uptime.types import UptimeMonitorMode
 from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
@@ -1518,6 +1523,61 @@ class OrganizationCombinedRuleIndexWorkflowEngineTest(BaseAlertRuleSerializerTes
         # Should only return the error rule, not the transaction rule
         assert len(response.data) == 1
         assert response.data[0]["name"] == "Error Rule"
+
+    @responses.activate
+    def test_uninstalled_sentry_app(self) -> None:
+        self.superuser = self.create_user("hb@localhost", is_superuser=True)
+        self.login_as(user=self.superuser)
+        self.create_team(organization=self.organization, members=[self.superuser])
+
+        sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            published=True,
+            verify_install=False,
+            name="Super Awesome App",
+            schema={"elements": [self.create_alert_rule_action_schema()]},
+        )
+        installation = self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization, user=self.superuser
+        )
+        actions = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "sentryAppInstallationUuid": installation.uuid,
+                "settings": [
+                    {"name": "title", "value": "An alert"},
+                    {"name": "points", "value": "3"},
+                    {"name": "assignee", "value": "Hellboy"},
+                ],
+            }
+        ]
+        self.create_project_rule(
+            project=self.project,
+            action_data=actions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+
+        responses.add(
+            responses.GET,
+            "https://example.com/sentry/members",
+            json=[
+                {"value": "bob", "label": "Bob"},
+                {"value": "jess", "label": "Jess"},
+            ],
+            status=200,
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            installation.delete()
+
+        response = self.get_success_response(
+            self.organization.slug,
+            project=[self.project.id],
+        )
+        assert response.status_code == 200
+
+        assert len(response.data) == 1
+        assert len(response.data[0]["actions"]) == 0
 
 
 class OrganizationCombinedRuleIndexParityTest(BaseAlertRuleSerializerTest, APITestCase):

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -1551,7 +1551,7 @@ class OrganizationCombinedRuleIndexWorkflowEngineTest(BaseAlertRuleSerializerTes
                 ],
             }
         ]
-        self.create_project_rule(
+        rule = self.create_project_rule(
             project=self.project,
             action_data=actions,
             include_legacy_rule_id=False,
@@ -1578,6 +1578,17 @@ class OrganizationCombinedRuleIndexWorkflowEngineTest(BaseAlertRuleSerializerTes
 
         assert len(response.data) == 1
         assert len(response.data[0]["actions"]) == 0
+
+        with self.feature("organizations:incidents"):
+            response = self.get_success_response(
+                self.organization.slug,
+                project=[self.project.id],
+            )
+            assert response.status_code == 200
+
+            assert len(response.data) == 1
+            assert len(response.data[0]["actions"]) == 0
+            assert response.data[0]["id"] == str(rule.id)
 
 
 class OrganizationCombinedRuleIndexParityTest(BaseAlertRuleSerializerTest, APITestCase):


### PR DESCRIPTION
Handle a missing sentry app installation by skipping adding that action data - the same way we do in the regular serializer. 

Fixes https://linear.app/getsentry/issue/ISWF-2369/