### PR TITLE
ref(dashboards): Consolidate Seer dashboard utils and extract session polling hook

### DIFF
--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -9,87 +9,21 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
-import {fetchMutation, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {CreateFromSeerLoading} from 'sentry/views/dashboards/createFromSeerLoading';
 import {CreateFromSeerPrompt} from 'sentry/views/dashboards/createFromSeerPrompt';
-import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
-import {makeSeerExplorerQueryKey} from 'sentry/views/seerExplorer/utils';
 
 import {WidgetErrorProvider} from './contexts/widgetErrorContext';
-import {applySeerWidgetDefaults} from './createFromSeerUtils';
+import {statusIsTerminal} from './createFromSeerUtils';
 import {DashboardChatPanel, type WidgetError} from './dashboardChatPanel';
 import {EMPTY_DASHBOARD} from './data';
 import {DashboardDetailWithInjectedProps as DashboardDetail} from './detail';
-import {assignDefaultLayout, assignTempId, getInitialColumnDepths} from './layoutUtils';
 import type {DashboardDetails, Widget} from './types';
 import {DashboardState} from './types';
+import {useSeerDashboardSession} from './useSeerDashboardSession';
 
-const POLL_INTERVAL_MS = 500;
-const DASHBOARD_ARTIFACT_KEY = 'dashboard';
-const POST_COMPLETE_POLL_MS = 5000;
 const EMPTY_DASHBOARDS: never[] = [];
-
-type DashboardArtifact = {
-  title: string;
-  widgets: WidgetArtifact[];
-};
-
-type WidgetArtifact = {
-  display_type: Widget['displayType'];
-  interval: string;
-  layout: {h: number; min_h: number; w: number; x: number; y: number};
-  queries: Widget['queries'];
-  title: string;
-  widget_type: Widget['widgetType'];
-  description?: string;
-  limit?: number;
-};
-
-function normalizeWidget(raw: WidgetArtifact): Widget {
-  const {display_type, widget_type, ...rest} = raw;
-  return {
-    ...rest,
-    displayType: display_type,
-    widgetType: widget_type,
-    layout: raw.layout
-      ? {
-          x: raw.layout.x,
-          y: raw.layout.y,
-          w: raw.layout.w,
-          h: raw.layout.h,
-          minH: raw.layout.min_h,
-        }
-      : undefined,
-  };
-}
-
-function extractDashboardFromSession(
-  session: NonNullable<SeerExplorerResponse['session']>
-): {
-  title: string;
-  widgets: Widget[];
-} | null {
-  // Newest dashboard artifacts appear closer to the end of the array
-  for (let i = session.blocks.length - 1; i >= 0; i--) {
-    const artifact = session.blocks[i]!.artifacts?.find(
-      a => a.key === DASHBOARD_ARTIFACT_KEY && a.data
-    );
-    if (artifact) {
-      const data = artifact.data as DashboardArtifact;
-      return {
-        title: data.title,
-        widgets: assignDefaultLayout(
-          applySeerWidgetDefaults(data.widgets.map(normalizeWidget)).map(assignTempId),
-          getInitialColumnDepths()
-        ),
-      };
-    }
-  }
-  return null;
-}
 
 async function validateDashboardAndRecordMetrics(
   organization: Organization,
@@ -119,14 +53,9 @@ async function validateDashboardAndRecordMetrics(
   }
 }
 
-function statusIsTerminal(status?: string | null) {
-  return status === 'completed' || status === 'error' || status === 'awaiting_user_input';
-}
-
 export default function CreateFromSeer() {
   const organization = useOrganization();
   const location = useLocation();
-  const queryClient = useQueryClient();
 
   const seerRunId = location.query?.seerRunId ? Number(location.query.seerRunId) : null;
   const hasFeature =
@@ -134,95 +63,52 @@ export default function CreateFromSeer() {
     organization.features.includes('dashboards-ai-generate');
 
   const [dashboard, setDashboard] = useState<DashboardDetails>(EMPTY_DASHBOARD);
-  const [isUpdating, setisUpdating] = useState(false); // State tracks if dashboard is being updated from user chat input
-  const prevSessionStatusRef = useRef<{
-    status: string | null;
-    updated_at: string | null;
-  }>({status: null, updated_at: null});
-
-  // Timestamp of when we observe a "completed" status.
-  // This is required to poll for POST_COMPLETE_POLL_MS
-  // since backend hooks can resume runs in case of
-  // validation errors.
-  const completedAtRef = useRef<number | null>(null);
 
   // Additional guards to prevent duplicate metrics recording and on reload
   const hasValidatedRef = useRef(false);
   const hasSeenNonTerminalRef = useRef(false);
 
-  const {data, isError} = useApiQuery<SeerExplorerResponse>(
-    makeSeerExplorerQueryKey(organization.slug, seerRunId),
-    {
-      staleTime: 0,
-      retry: false,
-      enabled: !!seerRunId && hasFeature,
-      refetchInterval: query => {
-        const status = query.state.data?.[0]?.session?.status;
-        if (statusIsTerminal(status)) {
-          if (completedAtRef.current === null) {
-            completedAtRef.current = Date.now();
-          }
-          if (Date.now() - completedAtRef.current < POST_COMPLETE_POLL_MS) {
-            return POLL_INTERVAL_MS;
-          }
-          if (!hasValidatedRef.current && hasSeenNonTerminalRef.current) {
-            hasValidatedRef.current = true;
-            validateDashboardAndRecordMetrics(organization, dashboard, seerRunId);
-          }
-          return false;
-        }
-        if (status !== undefined && !statusIsTerminal(status)) {
-          hasSeenNonTerminalRef.current = true;
-          hasValidatedRef.current = false;
-          completedAtRef.current = null;
-        }
-        return POLL_INTERVAL_MS;
-      },
-    }
-  );
-
-  const session = data?.session;
-  const sessionStatus = session?.status ?? null;
-  const sessionUpdatedAt = session?.updated_at ?? null;
-
-  useEffect(() => {
-    if (!session) {
-      return;
-    }
-    const prevUpdatedAt = prevSessionStatusRef.current.updated_at;
-    const prevStatus = prevSessionStatusRef.current.status;
-    prevSessionStatusRef.current = {
-      status: sessionStatus,
-      updated_at: sessionUpdatedAt,
-    };
-
-    const isTerminal = statusIsTerminal(sessionStatus);
-    const wasTerminal = statusIsTerminal(prevStatus);
-
-    // Only trigger Dashboard rerender when transition to a new completed state
-    if (prevUpdatedAt !== sessionUpdatedAt && isTerminal && !wasTerminal) {
-      if (isUpdating) {
-        setisUpdating(false);
-      }
-      const dashboardData = extractDashboardFromSession(session);
-      if (dashboardData) {
-        const newDashboard = {
-          ...EMPTY_DASHBOARD,
-          title: dashboardData.title,
-          widgets: dashboardData.widgets,
-        };
-        setDashboard(newDashboard);
-        reportedWidgetErrors.current.clear();
-      }
-    }
-  }, [organization, seerRunId, isUpdating, sessionStatus, session, sessionUpdatedAt]);
-
-  const isLoading = !statusIsTerminal(sessionStatus) && !isError;
-
   // Prevent repeat errors on the same widget
   const reportedWidgetErrors = useRef(new Set<string>());
   // Maps widget tempId to error message
   const widgetErrorsMap = useRef(new Map<string, WidgetError>());
+
+  const handleDashboardUpdate = useCallback(
+    (data: {title: string; widgets: Widget[]}) => {
+      const newDashboard = {
+        ...EMPTY_DASHBOARD,
+        title: data.title,
+        widgets: data.widgets,
+      };
+      setDashboard(newDashboard);
+      reportedWidgetErrors.current.clear();
+    },
+    []
+  );
+
+  const handlePostCompletePollEnd = useCallback(() => {
+    if (!hasValidatedRef.current && hasSeenNonTerminalRef.current) {
+      hasValidatedRef.current = true;
+      validateDashboardAndRecordMetrics(organization, dashboard, seerRunId);
+    }
+  }, [organization, dashboard, seerRunId]);
+
+  const {session, isUpdating, setIsUpdating, isError, sendFollowUpMessage} =
+    useSeerDashboardSession({
+      seerRunId,
+      onDashboardUpdate: handleDashboardUpdate,
+      enabled: hasFeature,
+      onPostCompletePollEnd: handlePostCompletePollEnd,
+    });
+
+  const sessionStatus = session?.status ?? null;
+
+  useEffect(() => {
+    if (sessionStatus !== null && !statusIsTerminal(sessionStatus)) {
+      hasSeenNonTerminalRef.current = true;
+      hasValidatedRef.current = false;
+    }
+  }, [sessionStatus]);
 
   const handleWidgetError = useCallback(
     (widget: Widget, errorMessage: string) => {
@@ -269,25 +155,12 @@ export default function CreateFromSeer() {
       if (!seerRunId) {
         return;
       }
-      setisUpdating(true);
-      completedAtRef.current = null;
+      setIsUpdating(true);
       hasValidatedRef.current = false;
       reportedWidgetErrors.current.clear();
-      try {
-        const queryKey = makeSeerExplorerQueryKey(organization.slug, seerRunId);
-        const {url} = parseQueryKey(queryKey);
-        await fetchMutation({
-          url,
-          method: 'POST',
-          data: {query: message},
-        });
-        queryClient.invalidateQueries({queryKey});
-      } catch {
-        setisUpdating(false);
-        addErrorMessage(t('Failed to send message'));
-      }
+      await sendFollowUpMessage(message);
     },
-    [organization.slug, queryClient, seerRunId]
+    [seerRunId, setIsUpdating, sendFollowUpMessage]
   );
 
   if (!hasFeature) {
@@ -305,6 +178,8 @@ export default function CreateFromSeer() {
   if (!seerRunId) {
     return <CreateFromSeerPrompt />;
   }
+
+  const isLoading = !statusIsTerminal(sessionStatus) && !isError;
 
   if (isLoading && !isUpdating) {
     return <CreateFromSeerLoading blocks={session?.blocks ?? []} seerRunId={seerRunId} />;

--- a/static/app/views/dashboards/createFromSeerUtils.spec.tsx
+++ b/static/app/views/dashboards/createFromSeerUtils.spec.tsx
@@ -1,6 +1,11 @@
 import {applySeerWidgetDefaults} from 'sentry/views/dashboards/createFromSeerUtils';
+import {
+  extractDashboardFromSession,
+  statusIsTerminal,
+} from 'sentry/views/dashboards/createFromSeerUtils';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
+import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
 
 function makeWidget(overrides: Partial<Widget> = {}): Widget {
   return {
@@ -17,6 +22,18 @@ function makeWidget(overrides: Partial<Widget> = {}): Widget {
         orderby: '',
       },
     ],
+    ...overrides,
+  };
+}
+
+function makeSession(
+  overrides: Partial<NonNullable<SeerExplorerResponse['session']>> = {}
+): NonNullable<SeerExplorerResponse['session']> {
+  return {
+    run_id: 1,
+    status: 'completed',
+    updated_at: new Date().toISOString(),
+    blocks: [],
     ...overrides,
   };
 }
@@ -49,5 +66,69 @@ describe('applySeerWidgetDefaults', () => {
 
       expect(result!.limit).toBe(5);
     });
+  });
+});
+
+describe('statusIsTerminal', () => {
+  it.each(['completed', 'error', 'awaiting_user_input'])(
+    'returns true for %s',
+    status => {
+      expect(statusIsTerminal(status)).toBe(true);
+    }
+  );
+
+  it.each(['processing', 'pending', undefined, null])('returns false for %s', status => {
+    expect(statusIsTerminal(status)).toBe(false);
+  });
+});
+
+describe('extractDashboardFromSession', () => {
+  it('extracts dashboard from session blocks', () => {
+    const session = makeSession({
+      blocks: [
+        {
+          id: 'block-1',
+          message: {content: 'Here is your dashboard', role: 'assistant'},
+          timestamp: new Date().toISOString(),
+          artifacts: [
+            {
+              key: 'dashboard',
+              reason: 'generated',
+              data: {
+                title: 'My Dashboard',
+                widgets: [
+                  {
+                    title: 'Count',
+                    display_type: 'line',
+                    widget_type: 'spans',
+                    queries: [
+                      {
+                        name: '',
+                        conditions: '',
+                        fields: ['count()'],
+                        columns: [],
+                        aggregates: ['count()'],
+                        orderby: '',
+                      },
+                    ],
+                    layout: {x: 0, y: 0, w: 3, h: 2, min_h: 2},
+                    interval: '1h',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = extractDashboardFromSession(session);
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('My Dashboard');
+    expect(result!.widgets).toHaveLength(1);
+    expect(result!.widgets[0]!.title).toBe('Count');
+    expect(result!.widgets[0]!.displayType).toBe('line');
+    expect(result!.widgets[0]!.widgetType).toBe('spans');
   });
 });

--- a/static/app/views/dashboards/createFromSeerUtils.tsx
+++ b/static/app/views/dashboards/createFromSeerUtils.tsx
@@ -10,14 +10,14 @@ import {
 import {DEFAULT_TABLE_LIMIT} from './types';
 import type {Widget, WidgetLayout} from './types';
 
-export const DASHBOARD_ARTIFACT_KEY = 'dashboard';
+const DASHBOARD_ARTIFACT_KEY = 'dashboard';
 
-export type DashboardArtifact = {
+type DashboardArtifact = {
   title: string;
   widgets: WidgetArtifact[];
 };
 
-export type WidgetArtifact = {
+type WidgetArtifact = {
   display_type: Widget['displayType'];
   interval: string;
   layout: {h: number; min_h: number; w: number; x: number; y: number};

--- a/static/app/views/dashboards/createFromSeerUtils.tsx
+++ b/static/app/views/dashboards/createFromSeerUtils.tsx
@@ -1,10 +1,53 @@
+import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
+
 import {
+  assignDefaultLayout,
+  assignTempId,
   DEFAULT_WIDGET_WIDTH,
   getDefaultWidgetHeight,
-} from 'sentry/views/dashboards/layoutUtils';
-import type {Widget, WidgetLayout} from 'sentry/views/dashboards/types';
+  getInitialColumnDepths,
+} from './layoutUtils';
+import {DEFAULT_TABLE_LIMIT} from './types';
+import type {Widget, WidgetLayout} from './types';
 
-const DEFAULT_LIMIT = 5;
+export const DASHBOARD_ARTIFACT_KEY = 'dashboard';
+
+export type DashboardArtifact = {
+  title: string;
+  widgets: WidgetArtifact[];
+};
+
+export type WidgetArtifact = {
+  display_type: Widget['displayType'];
+  interval: string;
+  layout: {h: number; min_h: number; w: number; x: number; y: number};
+  queries: Widget['queries'];
+  title: string;
+  widget_type: Widget['widgetType'];
+  description?: string;
+  limit?: number;
+};
+
+/**
+ * Converts a Seer-generated widget artifact (snake_case) to a frontend Widget (camelCase).
+ */
+function normalizeWidgetCase(raw: WidgetArtifact): Widget {
+  const {display_type, widget_type, ...rest} = raw;
+  return {
+    ...rest,
+    displayType: display_type,
+    widgetType: widget_type,
+    layout: raw.layout
+      ? {
+          x: raw.layout.x,
+          y: raw.layout.y,
+          w: raw.layout.w,
+          h: raw.layout.h,
+          minH: raw.layout.min_h,
+        }
+      : undefined,
+  };
+}
 
 /**
  * This function serves as a fallback to fill out any commonly missing or transform
@@ -48,7 +91,40 @@ function applyLayoutDefaults(
 
 function applyLimitDefaults(limit: number | null | undefined): number {
   if (limit === null || limit === undefined) {
-    return DEFAULT_LIMIT;
+    return DEFAULT_TABLE_LIMIT;
   }
   return limit;
+}
+
+/**
+ * Extracts the latest dashboard artifact from a Seer Explorer session's blocks.
+ */
+export function extractDashboardFromSession(
+  session: NonNullable<SeerExplorerResponse['session']>
+): {
+  title: string;
+  widgets: Widget[];
+} | null {
+  for (let i = session.blocks.length - 1; i >= 0; i--) {
+    const artifact = session.blocks[i]!.artifacts?.find(
+      a => a.key === DASHBOARD_ARTIFACT_KEY && a.data
+    );
+    if (artifact) {
+      const data = artifact.data as DashboardArtifact;
+      return {
+        title: data.title,
+        widgets: assignDefaultLayout(
+          applySeerWidgetDefaults(data.widgets.map(normalizeWidgetCase)).map(
+            assignTempId
+          ),
+          getInitialColumnDepths()
+        ),
+      };
+    }
+  }
+  return null;
+}
+
+export function statusIsTerminal(status?: string | null) {
+  return status === 'completed' || status === 'error' || status === 'awaiting_user_input';
 }

--- a/static/app/views/dashboards/useSeerDashboardSession.spec.tsx
+++ b/static/app/views/dashboards/useSeerDashboardSession.spec.tsx
@@ -1,0 +1,122 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useSeerDashboardSession} from 'sentry/views/dashboards/useSeerDashboardSession';
+
+const SEER_RUN_ID = 456;
+
+function makeSeerApiUrl(orgSlug: string, runId: number) {
+  return `/organizations/${orgSlug}/seer/explorer-chat/${runId}/`;
+}
+
+const COMPLETED_SESSION = {
+  session: {
+    run_id: SEER_RUN_ID,
+    status: 'completed',
+    updated_at: '2026-01-01T00:00:00Z',
+    blocks: [
+      {
+        id: 'block-1',
+        message: {content: 'Here is your dashboard', role: 'assistant'},
+        timestamp: '2026-01-01T00:00:00Z',
+        artifacts: [
+          {
+            key: 'dashboard',
+            reason: 'generated',
+            data: {
+              title: 'Generated Dashboard',
+              widgets: [
+                {
+                  title: 'Error Count',
+                  display_type: 'line',
+                  widget_type: 'error-events',
+                  queries: [
+                    {
+                      name: '',
+                      conditions: '',
+                      fields: ['count()'],
+                      columns: [],
+                      aggregates: ['count()'],
+                      orderby: '',
+                    },
+                  ],
+                  layout: {x: 0, y: 0, w: 3, h: 2, min_h: 2},
+                  interval: '1h',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe('useSeerDashboardSession', () => {
+  const organization = OrganizationFixture();
+  const apiUrl = makeSeerApiUrl(organization.slug, SEER_RUN_ID);
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('returns session data when polling a completed session', async () => {
+    MockApiClient.addMockResponse({
+      url: apiUrl,
+      body: COMPLETED_SESSION,
+    });
+
+    const onDashboardUpdate = jest.fn();
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useSeerDashboardSession({
+          seerRunId: SEER_RUN_ID,
+          onDashboardUpdate,
+        }),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.session).toBeDefined();
+      expect(result.current.session?.status).toBe('completed');
+    });
+  });
+
+  it('sends follow-up messages to the Seer session', async () => {
+    MockApiClient.addMockResponse({
+      url: apiUrl,
+      body: COMPLETED_SESSION,
+    });
+
+    const postMock = MockApiClient.addMockResponse({
+      url: apiUrl,
+      method: 'POST',
+      body: {},
+    });
+
+    const onDashboardUpdate = jest.fn();
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useSeerDashboardSession({
+          seerRunId: SEER_RUN_ID,
+          onDashboardUpdate,
+        }),
+      {organization}
+    );
+
+    await act(async () => {
+      await result.current.sendFollowUpMessage('Add an error rate widget');
+    });
+
+    expect(postMock).toHaveBeenCalledWith(
+      apiUrl,
+      expect.objectContaining({
+        method: 'POST',
+        data: {query: 'Add an error rate widget'},
+      })
+    );
+  });
+});

--- a/static/app/views/dashboards/useSeerDashboardSession.tsx
+++ b/static/app/views/dashboards/useSeerDashboardSession.tsx
@@ -1,0 +1,137 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
+import {fetchMutation, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
+import {makeSeerExplorerQueryKey} from 'sentry/views/seerExplorer/utils';
+
+import {extractDashboardFromSession, statusIsTerminal} from './createFromSeerUtils';
+import type {Widget} from './types';
+
+const POLL_INTERVAL_MS = 500;
+const POST_COMPLETE_POLL_MS = 5000;
+
+interface UseSeerDashboardSessionOptions {
+  onDashboardUpdate: (data: {title: string; widgets: Widget[]}) => void;
+  seerRunId: number | null;
+  enabled?: boolean;
+  onPostCompletePollEnd?: () => void;
+}
+
+interface UseSeerDashboardSessionResult {
+  isError: boolean;
+  isUpdating: boolean;
+  sendFollowUpMessage: (message: string) => Promise<void>;
+  session: SeerExplorerResponse['session'] | undefined;
+  setIsUpdating: (updating: boolean) => void;
+}
+
+/**
+ * Hook that encapsulates polling a Seer Explorer session for dashboard artifacts,
+ * detecting terminal-state transitions, and sending follow-up messages.
+ */
+export function useSeerDashboardSession({
+  seerRunId,
+  onDashboardUpdate,
+  enabled = true,
+  onPostCompletePollEnd,
+}: UseSeerDashboardSessionOptions): UseSeerDashboardSessionResult {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const prevSessionStatusRef = useRef<{
+    status: string | null;
+    updated_at: string | null;
+  }>({status: null, updated_at: null});
+  const completedAtRef = useRef<number | null>(null);
+
+  const {data, isError} = useApiQuery<SeerExplorerResponse>(
+    makeSeerExplorerQueryKey(organization.slug, seerRunId),
+    {
+      staleTime: 0,
+      retry: false,
+      enabled: !!seerRunId && enabled,
+      refetchInterval: query => {
+        const status = query.state.data?.[0]?.session?.status;
+        if (statusIsTerminal(status)) {
+          if (completedAtRef.current === null) {
+            completedAtRef.current = Date.now();
+          }
+          if (Date.now() - completedAtRef.current < POST_COMPLETE_POLL_MS) {
+            return POLL_INTERVAL_MS;
+          }
+          onPostCompletePollEnd?.();
+          return false;
+        }
+        return POLL_INTERVAL_MS;
+      },
+    }
+  );
+
+  const session = data?.session;
+  const sessionStatus = session?.status ?? null;
+  const sessionUpdatedAt = session?.updated_at ?? null;
+
+  useEffect(() => {
+    if (!session) {
+      return;
+    }
+    const prevUpdatedAt = prevSessionStatusRef.current.updated_at;
+    const prevStatus = prevSessionStatusRef.current.status;
+    prevSessionStatusRef.current = {
+      status: sessionStatus,
+      updated_at: sessionUpdatedAt,
+    };
+
+    const isTerminal = statusIsTerminal(sessionStatus);
+    const wasTerminal = statusIsTerminal(prevStatus);
+
+    // Update states when transitioning from non-terminal to terminal session
+    if (prevUpdatedAt !== sessionUpdatedAt && isTerminal && !wasTerminal) {
+      if (isUpdating) {
+        setIsUpdating(false);
+      }
+      const dashboardData = extractDashboardFromSession(session);
+      if (dashboardData) {
+        onDashboardUpdate(dashboardData);
+      }
+    }
+  }, [isUpdating, sessionStatus, session, sessionUpdatedAt, onDashboardUpdate]);
+
+  const sendFollowUpMessage = useCallback(
+    async (message: string) => {
+      if (!seerRunId) {
+        return;
+      }
+      setIsUpdating(true);
+      completedAtRef.current = null;
+      try {
+        const queryKey = makeSeerExplorerQueryKey(organization.slug, seerRunId);
+        const {url} = parseQueryKey(queryKey);
+        await fetchMutation({
+          url,
+          method: 'POST',
+          data: {query: message},
+        });
+        queryClient.invalidateQueries({queryKey});
+      } catch {
+        setIsUpdating(false);
+        addErrorMessage(t('Failed to send message'));
+      }
+    },
+    [organization.slug, queryClient, seerRunId]
+  );
+
+  return {
+    session,
+    isUpdating,
+    setIsUpdating,
+    isError,
+    sendFollowUpMessage,
+  };
+}

--- a/static/app/views/dashboards/useSeerDashboardSession.tsx
+++ b/static/app/views/dashboards/useSeerDashboardSession.tsx
@@ -68,6 +68,7 @@ export function useSeerDashboardSession({
           onPostCompletePollEnd?.();
           return false;
         }
+        completedAtRef.current = null;
         return POLL_INTERVAL_MS;
       },
     }


### PR DESCRIPTION
Consolidates Seer dashboard utility functions and extracts a shared session polling hook:
- Move several Seer dashboard utilities from `createFromSeer.tsx` into `createFromSeerUtils.tsx`
- Extracts `useSeerDashboardSession` hook into its own file, encapsulating the polling loop, terminal-state detection, and follow-up message sending