### PR TITLE
ref(preprod): Add organization_slug to size analysis log

### DIFF
--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -562,7 +562,7 @@ def _assemble_preprod_artifact_size_analysis(
                 "was_created": was_created,
                 "project_id": project.id,
                 "organization_id": org_id,
-                "organization_slug": project.organization.slug,
+                "organization_slug": organization.slug,
             },
         )
 

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -562,6 +562,7 @@ def _assemble_preprod_artifact_size_analysis(
                 "was_created": was_created,
                 "project_id": project.id,
                 "organization_id": org_id,
+                "organization_slug": project.organization.slug,
             },
         )
 


### PR DESCRIPTION
Add `organization_slug` to the size analysis metrics log entry in preprod tasks for easier debugging and log correlation when investigating size analysis issues.