### PR TITLE
fix(test): open overlays immediately when in test mode

### DIFF
--- a/static/app/components/core/tooltip/tooltip.spec.tsx
+++ b/static/app/components/core/tooltip/tooltip.spec.tsx
@@ -27,7 +27,7 @@ describe('Tooltip', () => {
 
   it('renders', async () => {
     render(
-      <Tooltip delay={0} title="test">
+      <Tooltip title="test">
         <span>My Button</span>
       </Tooltip>
     );
@@ -46,14 +46,14 @@ describe('Tooltip', () => {
 
   it('updates title', async () => {
     const {rerender} = render(
-      <Tooltip delay={0} title="test">
+      <Tooltip title="test">
         <span>My Button</span>
       </Tooltip>
     );
 
     // Change title
     rerender(
-      <Tooltip delay={0} title="bar">
+      <Tooltip title="bar">
         <span>My Button</span>
       </Tooltip>
     );
@@ -69,7 +69,7 @@ describe('Tooltip', () => {
 
   it('disables and does not render', async () => {
     render(
-      <Tooltip delay={0} title="test" disabled>
+      <Tooltip title="test" disabled>
         <span>My Button</span>
       </Tooltip>
     );
@@ -83,7 +83,7 @@ describe('Tooltip', () => {
 
   it('resets visibility when becoming disabled', async () => {
     const {rerender} = render(
-      <Tooltip delay={0} title="test" disabled={false}>
+      <Tooltip title="test" disabled={false}>
         <span>My Button</span>
       </Tooltip>
     );
@@ -92,7 +92,7 @@ describe('Tooltip', () => {
     expect(screen.getByText('test')).toBeInTheDocument();
 
     rerender(
-      <Tooltip delay={0} title="test" disabled>
+      <Tooltip title="test" disabled>
         <span>My Button</span>
       </Tooltip>
     );
@@ -100,7 +100,7 @@ describe('Tooltip', () => {
 
     // Becomes enabled again
     rerender(
-      <Tooltip delay={0} title="test" disabled={false}>
+      <Tooltip title="test" disabled={false}>
         <span>My Button</span>
       </Tooltip>
     );
@@ -109,7 +109,7 @@ describe('Tooltip', () => {
 
   it('does not render an empty tooltip', async () => {
     render(
-      <Tooltip delay={0} title="">
+      <Tooltip title="">
         <span>My Button</span>
       </Tooltip>
     );
@@ -125,7 +125,7 @@ describe('Tooltip', () => {
     mockOverflow(100, 50);
 
     render(
-      <Tooltip delay={0} title="test" showOnlyOnOverflow>
+      <Tooltip title="test" showOnlyOnOverflow>
         <div>This text overflows</div>
       </Tooltip>
     );
@@ -141,7 +141,7 @@ describe('Tooltip', () => {
     mockOverflow(50, 100);
 
     render(
-      <Tooltip delay={0} title="test" showOnlyOnOverflow>
+      <Tooltip title="test" showOnlyOnOverflow>
         <div>This text does not overflow</div>
       </Tooltip>
     );

--- a/static/app/components/hovercard.spec.tsx
+++ b/static/app/components/hovercard.spec.tsx
@@ -62,18 +62,16 @@ describe('Hovercard', () => {
 
     jest.useFakeTimers();
     await userEvent.hover(screen.getByText('Hovercard Trigger'), {delay: null});
-    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT - 1));
-
     await userEvent.unhover(screen.getByText('Hovercard Trigger'), {delay: null});
 
-    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT + 1));
+    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT - 1));
     jest.useRealTimers();
 
-    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Hovercard Body/)).toBeInTheDocument();
+    expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
   });
 
-  it('does not leak timeout when hover is removed', async () => {
+  it('hides the cards after the display timeout when hover is removed', async () => {
     const DISPLAY_TIMEOUT = 100;
     render(
       <Hovercard
@@ -88,11 +86,9 @@ describe('Hovercard', () => {
 
     jest.useFakeTimers();
     await userEvent.hover(screen.getByText('Hovercard Trigger'), {delay: null});
-    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT - 1));
-
     await userEvent.unhover(screen.getByText('Hovercard Trigger'), {delay: null});
 
-    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT + 1));
+    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT));
     jest.useRealTimers();
 
     expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();

--- a/static/app/components/hovercard.spec.tsx
+++ b/static/app/components/hovercard.spec.tsx
@@ -7,14 +7,20 @@ describe('Hovercard', () => {
     jest.clearAllMocks();
   });
 
-  it('Displays card', async () => {
+  it('does not display card before hover', () => {
     render(
-      <Hovercard
-        position="top"
-        body="Hovercard Body"
-        header="Hovercard Header"
-        displayTimeout={0}
-      >
+      <Hovercard position="top" body="Hovercard Body" header="Hovercard Header">
+        Hovercard Trigger
+      </Hovercard>
+    );
+
+    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+  });
+
+  it('displays the card when hovered', async () => {
+    render(
+      <Hovercard position="top" body="Hovercard Body" header="Hovercard Header">
         Hovercard Trigger
       </Hovercard>
     );
@@ -25,32 +31,12 @@ describe('Hovercard', () => {
     expect(await screen.findByText(/Hovercard Header/)).toBeInTheDocument();
   });
 
-  it('Does not display card', async () => {
+  it('always displays card when forceVisible is true', async () => {
     render(
       <Hovercard
         position="top"
         body="Hovercard Body"
         header="Hovercard Header"
-        displayTimeout={0}
-        forceVisible={false}
-      >
-        Hovercard Trigger
-      </Hovercard>
-    );
-
-    await userEvent.hover(screen.getByText('Hovercard Trigger'));
-
-    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
-  });
-
-  it('Always displays card', async () => {
-    render(
-      <Hovercard
-        position="top"
-        body="Hovercard Body"
-        header="Hovercard Header"
-        displayTimeout={0}
         forceVisible
       >
         Hovercard Trigger
@@ -61,14 +47,13 @@ describe('Hovercard', () => {
     expect(screen.getByText(/Hovercard Header/)).toBeInTheDocument();
   });
 
-  it('Respects displayTimeout displays card', async () => {
+  it('respects displayTimeout to delay hiding card when hover is removed', async () => {
     const DISPLAY_TIMEOUT = 100;
     render(
       <Hovercard
         position="top"
         body="Hovercard Body"
         header="Hovercard Header"
-        delay={DISPLAY_TIMEOUT}
         displayTimeout={DISPLAY_TIMEOUT}
       >
         Hovercard Trigger
@@ -78,41 +63,36 @@ describe('Hovercard', () => {
     jest.useFakeTimers();
     await userEvent.hover(screen.getByText('Hovercard Trigger'), {delay: null});
     act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT - 1));
-
-    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
-
-    act(() => jest.advanceTimersByTime(1));
-
-    expect(await screen.findByText(/Hovercard Body/)).toBeInTheDocument();
-    expect(await screen.findByText(/Hovercard Header/)).toBeInTheDocument();
-    jest.useRealTimers();
-  });
-
-  it('Doesnt leak timeout', async () => {
-    const DISPLAY_TIMEOUT = 100;
-    render(
-      <Hovercard
-        position="top"
-        body="Hovercard Body"
-        header="Hovercard Header"
-        delay={DISPLAY_TIMEOUT}
-        displayTimeout={DISPLAY_TIMEOUT}
-      >
-        Hovercard Trigger
-      </Hovercard>
-    );
-
-    jest.useFakeTimers();
-    await userEvent.hover(screen.getByText('Hovercard Trigger'), {delay: null});
-    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT - 1));
-
-    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
 
     await userEvent.unhover(screen.getByText('Hovercard Trigger'), {delay: null});
 
-    act(() => jest.advanceTimersByTime(1));
+    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT + 1));
+    jest.useRealTimers();
+
+    expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hovercard Header/)).not.toBeInTheDocument();
+  });
+
+  it('does not leak timeout when hover is removed', async () => {
+    const DISPLAY_TIMEOUT = 100;
+    render(
+      <Hovercard
+        position="top"
+        body="Hovercard Body"
+        header="Hovercard Header"
+        displayTimeout={DISPLAY_TIMEOUT}
+      >
+        Hovercard Trigger
+      </Hovercard>
+    );
+
+    jest.useFakeTimers();
+    await userEvent.hover(screen.getByText('Hovercard Trigger'), {delay: null});
+    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT - 1));
+
+    await userEvent.unhover(screen.getByText('Hovercard Trigger'), {delay: null});
+
+    act(() => jest.advanceTimersByTime(DISPLAY_TIMEOUT + 1));
     jest.useRealTimers();
 
     expect(screen.queryByText(/Hovercard Body/)).not.toBeInTheDocument();

--- a/static/app/components/stackTrace/issueStackTrace/index.spec.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.spec.tsx
@@ -246,7 +246,9 @@ describe('IssueStackTrace', () => {
 
     await userEvent.hover(screen.getByLabelText('Line 112'));
 
-    expect(await screen.findByText('Line uncovered by tests')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getAllByText('Line uncovered by tests')).toHaveLength(2)
+    );
   });
 
   it('renders annotated text when exception value has PII scrubbing metadata', async () => {

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -13,6 +13,7 @@ import {usePopper} from 'react-popper';
 import {useTheme} from '@emotion/react';
 import {mergeProps, mergeRefs} from '@react-aria/utils';
 
+import {NODE_ENV} from 'sentry/constants';
 import type {Theme} from 'sentry/utils/theme';
 
 function makeDefaultPopperModifiers(arrowElement: HTMLElement | null, offset: number) {
@@ -251,7 +252,7 @@ function useHoverOverlay({
     maybeClearRefTimeout(delayHideTimeoutRef);
     maybeClearRefTimeout(delayOpenTimeoutRef);
 
-    if (delay === 0) {
+    if (delay === 0 || NODE_ENV === 'test') {
       setIsVisible(true);
       return;
     }

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -117,6 +117,18 @@ describe('Dashboards > Detail', () => {
     };
   }
 
+  /**
+   * Clicks the edit dashboard button and waits for a known button to be visible.
+   * Note that this bypasses hover state to avoid overlays intercepting clicks.
+   */
+  async function activateDashboardEditMode() {
+    const button = await screen.findByRole('button', {name: 'edit-dashboard'});
+    act(() => {
+      button.click();
+    });
+    await screen.findByRole('button', {name: 'Save and Finish'});
+  }
+
   window.IntersectionObserver = MockIntersectionObserver as any;
 
   describe('prebuilt dashboards', () => {
@@ -502,8 +514,7 @@ describe('Dashboards > Detail', () => {
 
       await waitFor(() => expect(mockVisit).toHaveBeenCalledTimes(1));
 
-      // Enter edit mode.
-      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
+      await activateDashboardEditMode();
 
       // Remove the second and third widgets
       await userEvent.click(
@@ -581,8 +592,7 @@ describe('Dashboards > Detail', () => {
         })
       );
 
-      // Enter edit mode.
-      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
+      await activateDashboardEditMode();
       expect(await screen.findByRole('button', {name: 'Add Widget'})).toBeInTheDocument();
     });
 
@@ -630,8 +640,7 @@ describe('Dashboards > Detail', () => {
         })
       );
 
-      // Enter edit mode.
-      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
+      await activateDashboardEditMode();
       expect(screen.queryByRole('button', {name: 'Add widget'})).not.toBeInTheDocument();
     });
 
@@ -725,7 +734,7 @@ describe('Dashboards > Detail', () => {
         organization: initialData.organization,
       });
 
-      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
+      await activateDashboardEditMode();
       await userEvent.click(await screen.findByText('Save and Finish'));
 
       expect(screen.getByRole('button', {name: 'edit-dashboard'})).toBeInTheDocument();
@@ -767,7 +776,7 @@ describe('Dashboards > Detail', () => {
         organization: initialData.organization,
       });
 
-      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
+      await activateDashboardEditMode();
       const widget = (await screen.findByText('First Widget')).closest(
         '.react-grid-item'
       ) as HTMLElement;
@@ -811,7 +820,7 @@ describe('Dashboards > Detail', () => {
         organization: initialData.organization,
       });
 
-      await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
+      await activateDashboardEditMode();
       await userEvent.click(await screen.findByText('Cancel'));
 
       expect(window.confirm).not.toHaveBeenCalled();

--- a/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
@@ -93,7 +93,7 @@ describe('Quick Context', () => {
 
       await userEvent.hover(screen.getByText('Text from Child'));
 
-      expect(await screen.findByText(/Issue/i)).toBeInTheDocument();
+      expect(await screen.findByText('Issue', {exact: true})).toBeInTheDocument();
       expect(screen.getByText(/SENTRY-VVY/i)).toBeInTheDocument();
       expect(
         screen.getByTestId('quick-context-hover-header-copy-button')

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -781,7 +781,9 @@ describe('CreateProject', () => {
       expect(await screen.findByText('Channel not found')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Create Project'})).toBeDisabled();
       await userEvent.hover(screen.getByRole('button', {name: 'Create Project'}));
-      expect(await screen.findByText('Channel not found')).toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.getAllByText('Channel not found')).toHaveLength(2)
+      );
       await userEvent.click(screen.getByLabelText('Clear choices'));
       await userEvent.hover(screen.getByRole('button', {name: 'Create Project'}));
       expect(


### PR DESCRIPTION
Removes the pattern of passing `delay={0}` / `displayTimeout={0}` in specs: for _opening_ hover overlays immediately. That's now done automatically in `useHoverOverlay` when `NODE_ENV === "test"`. This way we don't need to manually create & pipe zero-value delay props around various components.

Note that _closing_ timing is unchanged. That way any triggers to portal content / async events still have a grace period in tests.

A few seemingly-unrelated tests had to be updated to account for overlays now suddenly being available. I think this is good, actually, because they previously were relying on timed opening not having happened yet. See 92f377910c3a15022fd0a8c979334098c7e206dc.

Fixes ENG-7208. Fixes ENG-7211. Fixes ENG-7212.

Supersedes #111926, #111928, #111929, and #112004.