### PR TITLE
ref(utils): Remove dead execute() function

### DIFF
--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -19,27 +19,6 @@ import sentry_sdk.scope
 logger = logging.getLogger(__name__)
 
 
-def execute[T](function: Callable[..., T], daemon=True) -> Future[T]:
-    future: Future[T] = Future()
-
-    def run():
-        if not future.set_running_or_notify_cancel():
-            return
-
-        try:
-            result = function()
-        except Exception as e:
-            future.set_exception(e)
-        else:
-            future.set_result(result)
-
-    t = threading.Thread(target=run)
-    t.daemon = daemon
-    t.start()
-
-    return future
-
-
 @functools.total_ordering
 class PriorityTask[T](NamedTuple):
     priority: int

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,4 +1,3 @@
-import _thread
 import contextvars
 from concurrent.futures import CancelledError, Future
 from contextlib import contextmanager
@@ -16,15 +15,7 @@ from sentry.utils.concurrent import (
     SynchronousExecutor,
     ThreadedExecutor,
     TimedFuture,
-    execute,
 )
-
-
-def test_execute() -> None:
-    assert execute(_thread.get_ident).result() != _thread.get_ident()
-
-    with pytest.raises(Exception):
-        assert execute(mock.Mock(side_effect=Exception("Boom!"))).result()
 
 
 def test_future_set_callback_success() -> None:


### PR DESCRIPTION
Remove the `execute()` function from `sentry/utils/concurrent.py`. It spawns a bare `threading.Thread` that does not propagate `contextvars`, making it a potential hazard for ViewerContext propagation work.

Its last caller was the legacy pre-Arroyo Kafka post-process forwarder, removed in Feb 2023 (#44631). No code in the Sentry codebase imports or calls it today.

Removing it rather than fixing its context propagation since `ContextPropagatingThreadPoolExecutor` is the blessed pattern (enforced by S016 lint rule). One less function that could silently lose context if rediscovered.


Agent transcript: https://claudescope.sentry.dev/share/-gVA8oDYrqoHR4FJeNP_snlwGf7vKDU_cG4AV4FH4pA