### PR TITLE
feat(seer): Send structured LLMContext JSON as on_page_context

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -2,12 +2,22 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {usePageReferrer} from 'sentry/views/seerExplorer/utils';
+
 import {useSeerExplorer} from './useSeerExplorer';
+
+jest.mock('sentry/views/seerExplorer/utils', () => ({
+  ...jest.requireActual('sentry/views/seerExplorer/utils'),
+  usePageReferrer: jest.fn(),
+}));
 
 describe('useSeerExplorer', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     sessionStorage.clear();
+    (usePageReferrer as jest.Mock).mockReturnValue({
+      getPageReferrer: () => '/issues/',
+    });
   });
 
   const organization = OrganizationFixture({
@@ -95,6 +105,72 @@ describe('useSeerExplorer', () => {
           }),
         })
       );
+    });
+
+    it('sends structured JSON on dashboard page with feature flag', async () => {
+      (usePageReferrer as jest.Mock).mockReturnValue({
+        getPageReferrer: () => '/dashboard/:dashboardId/',
+      });
+      const org = OrganizationFixture({
+        features: ['seer-explorer', 'context-engine-structured-page-context'],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'GET',
+        body: {session: null},
+      });
+      const postMock = MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'POST',
+        body: {run_id: 1},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/1/`,
+        method: 'GET',
+        body: {session: {blocks: [], run_id: 1, status: 'completed', updated_at: ''}},
+      });
+
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
+        organization: org,
+      });
+      await act(async () => {
+        await result.current.sendMessage('q');
+      });
+
+      const ctx = postMock.mock.calls[0][1].data.on_page_context;
+      expect(JSON.parse(ctx)).toHaveProperty('nodes');
+    });
+
+    it('falls back to ASCII screenshot on non-dashboard page', async () => {
+      const org = OrganizationFixture({
+        features: ['seer-explorer', 'context-engine-structured-page-context'],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'GET',
+        body: {session: null},
+      });
+      const postMock = MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'POST',
+        body: {run_id: 1},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/1/`,
+        method: 'GET',
+        body: {session: {blocks: [], run_id: 1, status: 'completed', updated_at: ''}},
+      });
+
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
+        organization: org,
+      });
+      await act(async () => {
+        await result.current.sendMessage('q');
+      });
+
+      // usePageReferrer returns '/issues/' by default (from beforeEach) — not in STRUCTURED_CONTEXT_ROUTES
+      const ctx = postMock.mock.calls[0][1].data.on_page_context;
+      expect(() => JSON.parse(ctx)).toThrow();
     });
 
     it('handles API errors gracefully', async () => {

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -191,12 +191,11 @@ export const useSeerExplorer = () => {
 
       // Send structured LLMContext JSON on supported pages when the feature flag
       // is enabled; fall back to a coarse ASCII screenshot otherwise.
-      const useStructuredContext =
+      const screenshot =
         STRUCTURED_CONTEXT_ROUTES.has(getPageReferrer()) &&
-        organization?.features.includes('context-engine-structured-page-context');
-      const screenshot = useStructuredContext
-        ? JSON.stringify(getLLMContext())
-        : captureAsciiSnapshot?.();
+        organization?.features.includes('context-engine-structured-page-context')
+          ? JSON.stringify(getLLMContext())
+          : captureAsciiSnapshot?.();
 
       setWaitingForResponse(true);
       setWasJustInterrupted(false);

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -15,6 +15,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {useAsciiSnapshot} from 'sentry/views/seerExplorer/hooks/useAsciiSnapshot';
 import type {Block, RepoPRState} from 'sentry/views/seerExplorer/types';
 import {useExplorerPanel} from 'sentry/views/seerExplorer/useExplorerPanel';
@@ -48,6 +49,9 @@ type SeerExplorerChatResponse = {
 };
 
 const POLL_INTERVAL = 500; // Poll every 500ms
+
+/** Routes where the LLMContext tree provides structured page context. */
+const STRUCTURED_CONTEXT_ROUTES = new Set(['/dashboard/:dashboardId/']);
 
 const OPTIMISTIC_ASSISTANT_TEXTS = [
   'Looking around...',
@@ -110,6 +114,7 @@ export const useSeerExplorer = () => {
   const organization = useOrganization({allowNull: true});
   const orgSlug = organization?.slug;
   const captureAsciiSnapshot = useAsciiSnapshot();
+  const {getLLMContext} = useLLMContext();
   const [overrideCtxEngEnable, setOverrideCtxEngEnable] = useState<boolean>(true);
 
   const [runId, setRunId] = useSessionStorage<number | null>(
@@ -184,8 +189,14 @@ export const useSeerExplorer = () => {
       // explicitRunId: undefined = use current runId, null = force new run, number = use that run
       const effectiveRunId = explicitRunId === undefined ? runId : explicitRunId;
 
-      // Capture a coarse ASCII screenshot of the user's screen for extra context
-      const screenshot = captureAsciiSnapshot?.();
+      // Send structured LLMContext JSON on supported pages when the feature flag
+      // is enabled; fall back to a coarse ASCII screenshot otherwise.
+      const useStructuredContext =
+        STRUCTURED_CONTEXT_ROUTES.has(getPageReferrer()) &&
+        organization?.features.includes('context-engine-structured-page-context');
+      const screenshot = useStructuredContext
+        ? JSON.stringify(getLLMContext())
+        : captureAsciiSnapshot?.();
 
       setWaitingForResponse(true);
       setWasJustInterrupted(false);
@@ -279,6 +290,7 @@ export const useSeerExplorer = () => {
       apiData,
       deletedFromIndex,
       captureAsciiSnapshot,
+      getLLMContext,
       setRunId,
       getPageReferrer,
       organization,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -191,11 +191,19 @@ export const useSeerExplorer = () => {
 
       // Send structured LLMContext JSON on supported pages when the feature flag
       // is enabled; fall back to a coarse ASCII screenshot otherwise.
-      const screenshot =
+      let screenshot: string | undefined;
+      if (
         STRUCTURED_CONTEXT_ROUTES.has(getPageReferrer()) &&
         organization?.features.includes('context-engine-structured-page-context')
-          ? JSON.stringify(getLLMContext())
-          : captureAsciiSnapshot?.();
+      ) {
+        try {
+          screenshot = JSON.stringify(getLLMContext());
+        } catch {
+          screenshot = captureAsciiSnapshot?.();
+        }
+      } else {
+        screenshot = captureAsciiSnapshot?.();
+      }
 
       setWaitingForResponse(true);
       setWasJustInterrupted(false);

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -198,7 +199,8 @@ export const useSeerExplorer = () => {
       ) {
         try {
           screenshot = JSON.stringify(getLLMContext());
-        } catch {
+        } catch (e) {
+          Sentry.captureException(e);
           screenshot = captureAsciiSnapshot?.();
         }
       } else {


### PR DESCRIPTION
+ When on dashboard pages with the context-engine-structured-page-context feature flag enabled, send JSON.stringify(getLLMContext()) instead of an ASCII DOM screenshot as on_page_context. The backend (already merged) detects JSON and converts it to markdown before forwarding to Seer.
+ Uses an explicit STRUCTURED_CONTEXT_ROUTES set for route matching rather than string includes, making it easy to extend as more pages register LLMContext providers.
