### PR TITLE
fix(supergroups): Use placeholder data to avoid loading flash on group changes

### DIFF
--- a/static/app/utils/supergroup/useSuperGroups.spec.tsx
+++ b/static/app/utils/supergroup/useSuperGroups.spec.tsx
@@ -1,0 +1,78 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useSuperGroups} from 'sentry/utils/supergroup/useSuperGroups';
+import type {SupergroupDetail} from 'sentry/views/issueList/supergroups/types';
+
+const organization = OrganizationFixture({features: ['top-issues-ui']});
+const API_URL = `/organizations/${organization.slug}/seer/supergroups/by-group/`;
+
+function makeSupergroup(overrides: Partial<SupergroupDetail> = {}): SupergroupDetail {
+  return {
+    id: 1,
+    title: 'Test Supergroup',
+    summary: 'A test supergroup',
+    error_type: 'TypeError',
+    code_area: 'frontend',
+    group_ids: [1, 2, 3],
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('useSuperGroups', () => {
+  it('does not show loading state when archiving a group backfills a new one', async () => {
+    const supergroup = makeSupergroup({group_ids: [1, 2, 3]});
+    const mockRequest = MockApiClient.addMockResponse({
+      url: API_URL,
+      body: {data: [supergroup]},
+    });
+
+    const {result, rerender} = renderHookWithProviders(
+      (props: {groupIds: string[]}) => useSuperGroups(props.groupIds),
+      {
+        organization,
+        initialProps: {groupIds: ['1', '2', '3']},
+      }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+
+    // Group '3' is archived and removed from the list
+    rerender({groupIds: ['1', '2']});
+    expect(result.current.isLoading).toBe(false);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+
+    // A new group backfills into the list — should refetch in the background
+    rerender({groupIds: ['1', '2', '4']});
+    expect(result.current.isLoading).toBe(false);
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows loading state when navigating to an entirely new page', async () => {
+    const supergroup = makeSupergroup({group_ids: [1, 2, 3]});
+    const mockRequest = MockApiClient.addMockResponse({
+      url: API_URL,
+      body: {data: [supergroup]},
+    });
+
+    const {result, rerender} = renderHookWithProviders(
+      (props: {groupIds: string[]}) => useSuperGroups(props.groupIds),
+      {
+        organization,
+        initialProps: {groupIds: ['1', '2', '3']},
+      }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+
+    // Navigate to a completely different page of results
+    rerender({groupIds: ['4', '5', '6']});
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/static/app/utils/supergroup/useSuperGroups.tsx
+++ b/static/app/utils/supergroup/useSuperGroups.tsx
@@ -19,20 +19,21 @@ export function useSuperGroups(groupIds: string[]): {
   const organization = useOrganization();
   const requestedGroupIdsRef = useRef(groupIds);
   const hasTopIssuesUI = organization.features.includes('top-issues-ui');
-  const shouldReuseRequestedGroupIds = useMemo(() => {
-    const requestedGroupIds = requestedGroupIdsRef.current;
 
-    if (groupIds.length === 0 || requestedGroupIds.length < groupIds.length) {
-      return false;
+  const previousRequestedGroupIds = requestedGroupIdsRef.current;
+
+  // Stabilize the query key: if the new groupIds are a subset of what we
+  // already requested (groups were removed), reuse the previous set to
+  // avoid a redundant refetch.
+  const requestedGroupIds = useMemo(() => {
+    const prev = requestedGroupIdsRef.current;
+    if (groupIds.length === 0 || prev.length < groupIds.length) {
+      return groupIds;
     }
-
-    const requestedGroupIdSet = new Set(requestedGroupIds);
-    return groupIds.every(groupId => requestedGroupIdSet.has(groupId));
+    const prevSet = new Set(prev);
+    return groupIds.every(id => prevSet.has(id)) ? prev : groupIds;
   }, [groupIds]);
 
-  const requestedGroupIds = shouldReuseRequestedGroupIds
-    ? requestedGroupIdsRef.current
-    : groupIds;
   requestedGroupIdsRef.current = requestedGroupIds;
   const enabled = hasTopIssuesUI && requestedGroupIds.length > 0;
 
@@ -50,6 +51,13 @@ export function useSuperGroups(groupIds: string[]): {
     {
       staleTime: 30_000,
       enabled,
+      placeholderData: previousData => {
+        if (!previousData) {
+          return undefined;
+        }
+        const prevSet = new Set(previousRequestedGroupIds);
+        return groupIds.some(id => prevSet.has(id)) ? previousData : undefined;
+      },
     }
   );
 
@@ -57,7 +65,6 @@ export function useSuperGroups(groupIds: string[]): {
     if (!response?.data) {
       return {};
     }
-
     const result: SupergroupLookup = Object.fromEntries(groupIds.map(id => [id, null]));
     for (const sg of response.data) {
       for (const groupId of sg.group_ids) {


### PR DESCRIPTION
When a group is archived and a new one backfills in, keep the previous supergroup data visible while the new query fetches in the background. Only show a loading state when navigating to an entirely new page of results (no overlap with previous group IDs).
