### PR TITLE
feat(onboarding): Gate SCM onboarding flow with useExperiment hook

### DIFF
--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -22,14 +22,11 @@ import {
   useOnboardingContext,
 } from 'sentry/components/onboarding/onboardingContext';
 import * as useRecentCreatedProjectHook from 'sentry/components/onboarding/useRecentCreatedProject';
-import {HookStore} from 'sentry/stores/hookStore';
 import {OnboardingDrawerStore} from 'sentry/stores/onboardingDrawerStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {PlatformKey} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type {UseExperimentOptions} from 'sentry/utils/useExperiment';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {OnboardingWithoutContext} from 'sentry/views/onboarding/onboarding';
 
 jest.mock('sentry/utils/analytics');
@@ -633,7 +630,7 @@ describe('Onboarding', () => {
 
   describe('SCM onboarding flow', () => {
     const scmOrganization = OrganizationFixture({
-      experiments: {'onboarding-scm-experiment': 'active'},
+      features: ['onboarding-scm-experiment'],
     });
 
     const githubProvider = GitHubIntegrationProviderFixture({
@@ -649,19 +646,7 @@ describe('Onboarding', () => {
       link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
     };
 
-    // In production, gsApp's registerHooks() registers the real useExperiment
-    // hook into HookStore. That doesn't run in tests, so useExperiment falls
-    // back to a noop that always returns inExperiment: false. We register a
-    // minimal implementation here (can't import the real one due to boundary
-    // lint rules).
-    function useTestExperiment(options: UseExperimentOptions) {
-      const organization = useOrganization();
-      const assignment = organization.experiments?.[options.feature] ?? 'control';
-      return {inExperiment: assignment === 'active', experimentAssignment: assignment};
-    }
-
     beforeEach(() => {
-      HookStore.add('react-hook:use-experiment', useTestExperiment);
       MockApiClient.addMockResponse({
         url: `/organizations/${scmOrganization.slug}/config/integrations/`,
         body: {providers: [githubProvider]},
@@ -674,10 +659,6 @@ describe('Onboarding', () => {
         url: `/organizations/${scmOrganization.slug}/repos/`,
         body: [],
       });
-    });
-
-    afterEach(() => {
-      HookStore.remove('react-hook:use-experiment', useTestExperiment);
     });
 
     function renderOnboarding(

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -22,11 +22,14 @@ import {
   useOnboardingContext,
 } from 'sentry/components/onboarding/onboardingContext';
 import * as useRecentCreatedProjectHook from 'sentry/components/onboarding/useRecentCreatedProject';
+import {HookStore} from 'sentry/stores/hookStore';
 import {OnboardingDrawerStore} from 'sentry/stores/onboardingDrawerStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {PlatformKey} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {UseExperimentOptions} from 'sentry/utils/useExperiment';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {OnboardingWithoutContext} from 'sentry/views/onboarding/onboarding';
 
 jest.mock('sentry/utils/analytics');
@@ -630,7 +633,7 @@ describe('Onboarding', () => {
 
   describe('SCM onboarding flow', () => {
     const scmOrganization = OrganizationFixture({
-      features: ['onboarding-scm'],
+      experiments: {'onboarding-scm-experiment': 'active'},
     });
 
     const githubProvider = GitHubIntegrationProviderFixture({
@@ -646,7 +649,19 @@ describe('Onboarding', () => {
       link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
     };
 
+    // In production, gsApp's registerHooks() registers the real useExperiment
+    // hook into HookStore. That doesn't run in tests, so useExperiment falls
+    // back to a noop that always returns inExperiment: false. We register a
+    // minimal implementation here (can't import the real one due to boundary
+    // lint rules).
+    function useTestExperiment(options: UseExperimentOptions) {
+      const organization = useOrganization();
+      const assignment = organization.experiments?.[options.feature] ?? 'control';
+      return {inExperiment: assignment === 'active', experimentAssignment: assignment};
+    }
+
     beforeEach(() => {
+      HookStore.add('react-hook:use-experiment', useTestExperiment);
       MockApiClient.addMockResponse({
         url: `/organizations/${scmOrganization.slug}/config/integrations/`,
         body: {providers: [githubProvider]},
@@ -659,6 +674,10 @@ describe('Onboarding', () => {
         url: `/organizations/${scmOrganization.slug}/repos/`,
         body: [],
       });
+    });
+
+    afterEach(() => {
+      HookStore.remove('react-hook:use-experiment', useTestExperiment);
     });
 
     function renderOnboarding(

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -24,6 +24,7 @@ import type {PlatformKey} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -163,7 +164,10 @@ export function OnboardingWithoutContext() {
     onboardingContext.createdProjectSlug ?? onboardingContext.selectedPlatform?.key;
 
   const hasNewWelcomeUI = useHasNewWelcomeUI();
-  const hasScmOnboarding = organization.features.includes('onboarding-scm');
+  const {inExperiment: hasScmOnboarding} = useExperiment({
+    feature: 'onboarding-scm-experiment',
+  });
+
   const onboardingSteps = hasScmOnboarding ? scmOnboardingSteps : legacyOnboardingSteps;
 
   const stepObj = onboardingSteps.find(({id}) => stepId === id);

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -68,7 +68,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
         with (
             self.feature(
                 {
-                    "organizations:onboarding-scm": True,
+                    "organizations:onboarding-scm-experiment": True,
                     "organizations:integrations-github-platform-detection": True,
                 }
             ),
@@ -122,7 +122,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
     def test_scm_onboarding_skip_integration(self) -> None:
         """Skip flow: welcome → skip connect → manual platform → create project."""
-        with self.feature({"organizations:onboarding-scm": True}):
+        with self.feature({"organizations:onboarding-scm-experiment": True}):
             self.start_onboarding()
 
             # SCM Connect: skip
@@ -178,7 +178,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
         with (
             self.feature(
                 {
-                    "organizations:onboarding-scm": True,
+                    "organizations:onboarding-scm-experiment": True,
                     "organizations:integrations-github-platform-detection": True,
                 }
             ),
@@ -279,7 +279,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
         with (
             self.feature(
                 {
-                    "organizations:onboarding-scm": True,
+                    "organizations:onboarding-scm-experiment": True,
                     "organizations:integrations-github-platform-detection": True,
                 }
             ),
@@ -339,7 +339,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
         self.create_github_integration()
 
         with (
-            self.feature({"organizations:onboarding-scm": True}),
+            self.feature({"organizations:onboarding-scm-experiment": True}),
             mock.patch(
                 "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
                 return_value=[],


### PR DESCRIPTION
Gate the SCM onboarding flow behind the `onboarding-scm-experiment` experiment using `useExperiment` instead of checking `organization.features` for the `onboarding-scm` feature flag. This allows us to run the SCM onboarding as a proper A/B experiment with exposure tracking.

Updates the test to provide the experiment assignment via `OrganizationFixture` and registers a minimal `useExperiment` hook in HookStore (since gsApp's `registerHooks()` doesn't run in the test environment).

Refs VDY-64