### PR TITLE
fix(autofix): Only write handoff.auto_create_pr ProjectOption if not default

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -561,9 +561,12 @@ def _write_preference_project_options(project: Project, preference: SeerProjectP
         project.update_option(
             "sentry:seer_automation_handoff_integration_id", handoff.integration_id
         )
-        project.update_option(
-            "sentry:seer_automation_handoff_auto_create_pr", handoff.auto_create_pr
-        )
+        if handoff.auto_create_pr is not False:
+            project.update_option(
+                "sentry:seer_automation_handoff_auto_create_pr", handoff.auto_create_pr
+            )
+        else:
+            project.delete_option("sentry:seer_automation_handoff_auto_create_pr")
     else:
         project.delete_option("sentry:seer_automation_handoff_point")
         project.delete_option("sentry:seer_automation_handoff_target")

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -561,7 +561,7 @@ def _write_preference_project_options(project: Project, preference: SeerProjectP
         project.update_option(
             "sentry:seer_automation_handoff_integration_id", handoff.integration_id
         )
-        if handoff.auto_create_pr is not False:
+        if handoff.auto_create_pr:
             project.update_option(
                 "sentry:seer_automation_handoff_auto_create_pr", handoff.auto_create_pr
             )


### PR DESCRIPTION
When handoff is not None and auto_create_pr is False (its registered default), delete the option rather than writing it. The other handoff fields are fine because they can't be None if handoff is not None. 