### PR TITLE
feat(features): Add SENTRY_EXPERIMENTS fallback for experiment assignments

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1442,6 +1442,11 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # the manager.add() call that defines the feature.
 }
 
+# Override experiment assignments for local development and testing.
+# Maps experiment name (without "organizations:" prefix) to assignment string.
+# Example: SENTRY_EXPERIMENTS = {"my-experiment": "active"}
+SENTRY_EXPERIMENTS: dict[str, str] = {}
+
 # Default time zone for localization in the UI.
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 SENTRY_DEFAULT_TIME_ZONE = "UTC"

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -424,7 +424,9 @@ class FeatureManager(RegisteredFeatureManager):
         Returns a dict mapping experiment name (without scope prefix) to
         assignment ("active" or "control") for all flags with experiment_mode set.
 
-        Delegates to the entity handler (FlagpoleFeatureHandler in getsentry).
+        Delegates to the entity handler (FlagpoleFeatureHandler in getsentry),
+        then falls back to settings.SENTRY_EXPERIMENTS for local development
+        and testing environments where the entity handler is not available.
         """
         try:
             if self._entity_handler:
@@ -432,7 +434,7 @@ class FeatureManager(RegisteredFeatureManager):
         except Exception:
             if in_random_rollout("features.error.capture_rate"):
                 logger.exception("Failed to get experiment assignments")
-        return {}
+        return dict(settings.SENTRY_EXPERIMENTS)
 
     @staticmethod
     def _shim_feature_strategy(

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -183,7 +183,7 @@ from ..snuba.metrics.naming_layer.mri import SessionMRI, TransactionMRI, parse_m
 from .asserts import assert_status_code
 from .factories import Factories
 from .fixtures import Fixtures
-from .helpers import Feature, TaskRunner, override_options
+from .helpers import Experiment, Feature, TaskRunner, override_options
 from .silo import assume_test_silo_mode
 from .skips import requires_snuba
 
@@ -256,6 +256,13 @@ class BaseTestCase(Fixtures):
         >>>     # ...
         """
         return Feature(names)
+
+    def experiment(self, assignments):
+        """
+        >>> with self.experiment({'experiment-name': 'active'})
+        >>>     # ...
+        """
+        return Experiment(assignments)
 
     def save_session(self):
         self.session.save()

--- a/src/sentry/testutils/helpers/__init__.py
+++ b/src/sentry/testutils/helpers/__init__.py
@@ -1,4 +1,5 @@
 from .auth_header import *  # NOQA
+from .experiments import *  # NOQA
 from .features import *  # NOQA
 from .link_header import *  # NOQA
 from .options import *  # NOQA

--- a/src/sentry/testutils/helpers/experiments.py
+++ b/src/sentry/testutils/helpers/experiments.py
@@ -1,0 +1,37 @@
+from collections.abc import Generator, Mapping
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import sentry.features
+
+__all__ = ("Experiment",)
+
+
+@contextmanager
+def Experiment(assignments: str | dict[str, str]) -> Generator[None]:
+    """
+    Control experiment assignments for testing.
+
+    >>> with Experiment({"my-experiment": "active"}):
+    >>>     # organization.experiments will include {"my-experiment": "active"}
+
+    A single experiment name defaults to "active":
+
+    >>> with Experiment("my-experiment"):
+    >>>     # equivalent to {"my-experiment": "active"}
+    """
+    if isinstance(assignments, str):
+        assignments = {assignments: "active"}
+    elif not isinstance(assignments, Mapping):
+        assignments = {k: "active" for k in assignments}
+
+    default_get = sentry.features.get_experiment_assignments
+
+    def override(organization, actor=None):
+        result = default_get(organization, actor)
+        result.update(assignments)
+        return result
+
+    with patch("sentry.features.get_experiment_assignments") as mock_get:
+        mock_get.side_effect = override
+        yield

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -470,6 +470,29 @@ class FeatureManagerTest(TestCase):
 
         assert result == {}
 
+    @override_settings(SENTRY_EXPERIMENTS={"test-experiment": "active"})
+    def test_get_experiment_assignments_falls_back_to_settings(self) -> None:
+        test_org = self.create_organization()
+
+        manager = features.FeatureManager()
+        result = manager.get_experiment_assignments(test_org)
+
+        assert result == {"test-experiment": "active"}
+
+    @override_settings(SENTRY_EXPERIMENTS={"test-experiment": "active"})
+    def test_get_experiment_assignments_entity_handler_takes_precedence(self) -> None:
+        test_org = self.create_organization()
+
+        handler = mock.Mock(spec=features.FeatureHandler)
+        handler.get_experiment_assignments.return_value = {"test-experiment": "control"}
+
+        manager = features.FeatureManager()
+        manager.add_entity_handler(handler)
+
+        result = manager.get_experiment_assignments(test_org, actor=None)
+
+        assert result == {"test-experiment": "control"}
+
     def test_get_experiment_assignments_handles_exception(self) -> None:
         test_org = self.create_organization()
 


### PR DESCRIPTION
Add a fallback for `get_experiment_assignments` so experiments can be tested in plain sentry (without getsentry) and in acceptance tests.

Currently `get_experiment_assignments` delegates to the entity handler (getsentry's `FlagpoleFeatureHandler`) and returns `{}` when no handler is available. This means experiment-gated features can't be tested locally via `devservices serve` or in CI acceptance tests.

This adds:
- `SENTRY_EXPERIMENTS` dict in `server.py` for local dev overrides (analogous to `SENTRY_FEATURES`)
- Fallback in `get_experiment_assignments` to return `SENTRY_EXPERIMENTS` when no entity handler is present
- `Experiment` context manager and `self.experiment()` test helper (analogous to `Feature` / `self.feature()`)

Usage in `sentry.conf.py`:
```python
SENTRY_EXPERIMENTS["onboarding-scm-experiment"] = "active"
```

Usage in tests:
```python
with self.experiment({"onboarding-scm-experiment": "active"}):
    ...
```

Note: A follow-up could derive experiment assignments directly from `SENTRY_FEATURES` by tracking `experiment_mode` on feature registrations, removing the need for a separate dict. This PR takes the simpler approach first.

Refs VDY-64