### PR TITLE
feat(seer): Wrap the seat-based wizard in a feature flag

### DIFF
--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -128,36 +128,24 @@ function useReminderCopywriting() {
   const hasSeatBasedSeer = organization.features.includes('seat-based-seer-enabled');
   const hasLegacySeer = organization.features.includes('seer-added');
 
-  const descriptionByStep: Record<
-    Steps,
-    {description: string; pathname: string; title: string} | null
-  > = {
+  const descriptionByStep: Record<Steps, {description: string; title: string} | null> = {
     [Steps.CONNECT_GITHUB]: {
       title: t('Connect GitHub'),
       description: t(
         'Seer is enabled, but Github is not connected. Connect your GitHub account to enable Root Cause Analysis and Code Review.'
       ),
-      pathname: hasLegacySeer
-        ? `/settings/${organization.slug}/seer/`
-        : `/settings/${organization.slug}/seer/onboarding/`,
     },
     [Steps.SETUP_ROOT_CAUSE_ANALYSIS]: {
       title: t('Start using Seer\u2019s Issue Autofix'),
       description: t(
         'Seer is enabled but Root Cause Analysis is not configured. Configure Seer to automatically look at issues and generate code fixes.'
       ),
-      pathname: hasLegacySeer
-        ? `/settings/${organization.slug}/seer/`
-        : `/settings/${organization.slug}/seer/onboarding/`,
     },
     [Steps.SETUP_CODE_REVIEW]: {
       title: t('Start using Seer\u2019s AI Code Review'),
       description: t(
         'Seer is enabled but Code Review is not configured. Configure Seer to automatically review PRs and flag potential issues.'
       ),
-      pathname: hasLegacySeer
-        ? `/settings/${organization.slug}/seer/`
-        : `/settings/${organization.slug}/seer/onboarding/`,
     },
     [Steps.SETUP_DEFAULTS]: null,
     [Steps.WRAP_UP]: null,
@@ -217,7 +205,7 @@ export function PrimaryNavSeerConfigReminder() {
             <Text>{copy.description}</Text>
             <Flex justify="start">
               <LinkButton
-                to={copy.pathname}
+                to={`/settings/${organization.slug}/seer/`}
                 priority="primary"
                 onClick={() => state.close()}
                 analyticsEventName="Seer Config Reminder: Configure Now Clicked"

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
@@ -24,7 +24,7 @@ export function SeerSettingsPageContent({children}: Props) {
 
   return (
     <Stack gap="lg">
-      <SeerWizardSetupBanner />
+      {organization.features.includes('seer-wizard') ? <SeerWizardSetupBanner /> : null}
       {showNoActiveSeerSubscriptionBanner ? <NoActiveSeerSubscriptionBanner /> : null}
 
       <SettingsPageTabs />

--- a/static/gsApp/views/seerAutomation/onboarding/onboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboarding.tsx
@@ -1,5 +1,7 @@
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
+import {Redirect} from 'sentry/components/redirect';
 import {showNewSeer} from 'sentry/utils/seer/showNewSeer';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {SeerAutomationOnboarding as SeerOnboardingLegacy} from './onboardingLegacy';
@@ -12,11 +14,14 @@ export default function SeerOnboarding() {
   const organization = useOrganization();
 
   if (showNewSeer(organization)) {
-    return (
-      <AnalyticsArea name="onboarding">
-        <SeerOnboardingSeatBased />
-      </AnalyticsArea>
-    );
+    if (organization.features.includes('seer-wizard')) {
+      return (
+        <AnalyticsArea name="onboarding">
+          <SeerOnboardingSeatBased />
+        </AnalyticsArea>
+      );
+    }
+    return <Redirect to={normalizeUrl(`/settings/${organization.slug}/seer/`)} />;
   }
 
   return (


### PR DESCRIPTION
This will let us control whether the wizard is available or not.

If it's not available and you get there somehow then the user will get sent back to the main settings landing page
The only link/redirect to get into the wizard is via the banner, so we also control whether that renders or not.

The legacy settings page has a hard-coded button to it's own onboarding flow, which really should've been removed already... but since that's technically separate i'll leave it for now. we'll be able to cleanup all the onboarding specific flows at the same time, general config and onboarding are not distinct, its the same screens whether it's the first time to get going, or if you're making tweaks.