### PR TITLE
ref(experiments): Gate useExperiment on organization.features

### DIFF
--- a/static/app/utils/useExperiment.spec.tsx
+++ b/static/app/utils/useExperiment.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {useExperiment} from 'sentry/utils/useExperiment';
@@ -13,9 +15,16 @@ function TestComponent({feature}: {feature: string}) {
 }
 
 describe('useExperiment (open-source fallback)', () => {
-  it('returns control group when no gsApp hook is registered', () => {
+  it('returns control group when feature is not enabled', () => {
     render(<TestComponent feature="test-experiment" />);
     expect(screen.getByTestId('in-experiment')).toHaveTextContent('false');
+    expect(screen.getByTestId('assignment')).toHaveTextContent('control');
+  });
+
+  it('returns inExperiment true when feature is enabled', () => {
+    const org = OrganizationFixture({features: ['test-experiment']});
+    render(<TestComponent feature="test-experiment" />, {organization: org});
+    expect(screen.getByTestId('in-experiment')).toHaveTextContent('true');
     expect(screen.getByTestId('assignment')).toHaveTextContent('control');
   });
 });

--- a/static/app/utils/useExperiment.tsx
+++ b/static/app/utils/useExperiment.tsx
@@ -1,4 +1,5 @@
 import {HookStore} from 'sentry/stores/hookStore';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 export interface UseExperimentResult {
   /**
@@ -34,10 +35,14 @@ export interface UseExperimentOptions {
 }
 
 /**
- * Open-source fallback: always returns control group with no exposure logging.
+ * Open-source fallback: gates on organization.features with no exposure logging.
  */
-function noopUseExperiment(_options: UseExperimentOptions): UseExperimentResult {
-  return {inExperiment: false, experimentAssignment: 'control'};
+function useNoopExperiment(options: UseExperimentOptions): UseExperimentResult {
+  const organization = useOrganization();
+  return {
+    inExperiment: organization.features.includes(options.feature),
+    experimentAssignment: 'control',
+  };
 }
 
 /**
@@ -77,6 +82,6 @@ function noopUseExperiment(_options: UseExperimentOptions): UseExperimentResult 
  */
 export function useExperiment(options: UseExperimentOptions): UseExperimentResult {
   const useExperimentHook =
-    HookStore.get('react-hook:use-experiment')[0] ?? noopUseExperiment;
+    HookStore.get('react-hook:use-experiment')[0] ?? useNoopExperiment;
   return useExperimentHook(options);
 }

--- a/static/gsApp/hooks/useExperiment.spec.tsx
+++ b/static/gsApp/hooks/useExperiment.spec.tsx
@@ -28,8 +28,9 @@ describe('useExperiment (gsApp)', () => {
     _resetExposureTracking();
   });
 
-  it('returns inExperiment: true when assignment is active', () => {
+  it('returns inExperiment: true when feature is enabled', () => {
     const org = OrganizationFixture({
+      features: ['test-experiment'],
       experiments: {'test-experiment': 'active'},
     });
     render(<TestComponent feature="test-experiment" reportExposure={false} />, {
@@ -39,7 +40,7 @@ describe('useExperiment (gsApp)', () => {
     expect(screen.getByTestId('assignment')).toHaveTextContent('active');
   });
 
-  it('returns inExperiment: false when assignment is control', () => {
+  it('returns inExperiment: false when feature is not enabled', () => {
     const org = OrganizationFixture({
       experiments: {'test-experiment': 'control'},
     });
@@ -47,6 +48,17 @@ describe('useExperiment (gsApp)', () => {
       organization: org,
     });
     expect(screen.getByTestId('in-experiment')).toHaveTextContent('false');
+    expect(screen.getByTestId('assignment')).toHaveTextContent('control');
+  });
+
+  it('returns inExperiment: true with feature flag even without experiments entry', () => {
+    const org = OrganizationFixture({
+      features: ['test-experiment'],
+    });
+    render(<TestComponent feature="test-experiment" reportExposure={false} />, {
+      organization: org,
+    });
+    expect(screen.getByTestId('in-experiment')).toHaveTextContent('true');
     expect(screen.getByTestId('assignment')).toHaveTextContent('control');
   });
 
@@ -59,8 +71,9 @@ describe('useExperiment (gsApp)', () => {
     expect(screen.getByTestId('assignment')).toHaveTextContent('control');
   });
 
-  it('posts exposure on mount when reportExposure is true', async () => {
+  it('posts exposure on mount when reportExposure is true and experiments entry exists', async () => {
     const org = OrganizationFixture({
+      features: ['test-experiment'],
       experiments: {'test-experiment': 'active'},
     });
     const mockExposure = MockApiClient.addMockResponse({
@@ -84,6 +97,7 @@ describe('useExperiment (gsApp)', () => {
 
   it('does not post exposure when reportExposure is false', () => {
     const org = OrganizationFixture({
+      features: ['test-experiment'],
       experiments: {'test-experiment': 'active'},
     });
     const mockExposure = MockApiClient.addMockResponse({
@@ -101,6 +115,7 @@ describe('useExperiment (gsApp)', () => {
 
   it('reports exposure when reportExposure changes from false to true', async () => {
     const org = OrganizationFixture({
+      features: ['test-experiment'],
       experiments: {'test-experiment': 'active'},
     });
     const mockExposure = MockApiClient.addMockResponse({
@@ -123,6 +138,7 @@ describe('useExperiment (gsApp)', () => {
 
   it('deduplicates exposure reports across remounts', async () => {
     const org = OrganizationFixture({
+      features: ['test-experiment'],
       experiments: {'test-experiment': 'active'},
     });
     const mockExposure = MockApiClient.addMockResponse({
@@ -146,10 +162,6 @@ describe('useExperiment (gsApp)', () => {
     expect(mockExposure).toHaveBeenCalledTimes(1);
   });
 
-  // This verifies the dedupe key includes the assignment so a changed
-  // assignment is treated as a distinct exposure. This scenario is unlikely in
-  // practice since we don't typically reload the organization after the app
-  // boots.
   it('re-reports exposure when assignment changes', async () => {
     const org = OrganizationFixture({
       experiments: {'test-experiment': 'control'},
@@ -169,6 +181,7 @@ describe('useExperiment (gsApp)', () => {
     unmount();
 
     const updatedOrg = OrganizationFixture({
+      features: ['test-experiment'],
       experiments: {'test-experiment': 'active'},
     });
 

--- a/static/gsApp/hooks/useExperiment.tsx
+++ b/static/gsApp/hooks/useExperiment.tsx
@@ -18,8 +18,14 @@ export function useExperiment(options: UseExperimentOptions): UseExperimentResul
   const {feature, reportExposure = true} = options;
   const organization = useOrganization();
 
+  // Gate on organization.features so that SENTRY_FEATURES, self.feature(),
+  // and devlocal.py all work without needing experiment-specific overrides.
+  const inExperiment = organization.features.includes(feature);
+
+  // Use organization.experiments only for exposure tracking — this field is
+  // populated by get_experiment_assignments which requires the getsentry
+  // entity handler and is empty in plain sentry / test environments.
   const assignment = organization.experiments?.[feature] ?? 'control';
-  const inExperiment = assignment === 'active';
 
   const {mutate: logExposure} = useMutation({
     mutationFn: () =>


### PR DESCRIPTION
Change `useExperiment` to use `organization.features` for the `inExperiment` boolean instead of `organization.experiments`. Reserve `organization.experiments` exclusively for determining what to POST to the experiment-exposure endpoint.

In production, both fields are derived from the same flagpole evaluation so they stay in sync. The difference matters in dev and test environments where `organization.experiments` is empty (it requires getsentry's entity handler), but `organization.features` works everywhere via `SENTRY_FEATURES`, `self.feature()`, and `devlocal.py`.

This means experiment-gated features can now be tested in acceptance tests and local dev without any experiment-specific infrastructure.

Refs VDY-64