### PR TITLE
feat(supergroups): Add status filter to supergroups by-group endpoint

### DIFF
--- a/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
@@ -12,7 +12,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
-from sentry.models.group import Group
+from sentry.models.group import STATUS_QUERY_CHOICES, Group
 from sentry.models.organization import Organization
 from sentry.seer.signed_seer_api import (
     SeerViewerContext,
@@ -55,12 +55,21 @@ class OrganizationSupergroupsByGroupEndpoint(OrganizationEndpoint):
                 status=status_codes.HTTP_400_BAD_REQUEST,
             )
 
-        valid_group_ids = set(
-            Group.objects.filter(
-                id__in=group_ids,
-                project__organization=organization,
-            ).values_list("id", flat=True)
+        group_qs = Group.objects.filter(
+            id__in=group_ids,
+            project__organization=organization,
         )
+
+        status_param = request.GET.get("status")
+        if status_param is not None:
+            if status_param not in STATUS_QUERY_CHOICES:
+                return Response(
+                    {"detail": "Invalid status parameter"},
+                    status=status_codes.HTTP_400_BAD_REQUEST,
+                )
+            group_qs = group_qs.filter(status=STATUS_QUERY_CHOICES[status_param])
+
+        valid_group_ids = set(group_qs.values_list("id", flat=True))
         group_ids = [gid for gid in group_ids if gid in valid_group_ids]
 
         if not group_ids:

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import orjson
+
+from sentry.models.group import GroupStatus
+from sentry.testutils.cases import APITestCase
+
+
+def mock_seer_response(data):
+    response = MagicMock()
+    response.status = 200
+    response.data = orjson.dumps(data)
+    return response
+
+
+class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-supergroups-by-group"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.unresolved_group = self.create_group(
+            project=self.project, status=GroupStatus.UNRESOLVED
+        )
+        self.resolved_group = self.create_group(project=self.project, status=GroupStatus.RESOLVED)
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroups_by_group.make_supergroups_get_by_group_ids_request"
+    )
+    def test_status_filter(self, mock_seer):
+        mock_seer.return_value = mock_seer_response({"supergroups": []})
+
+        with self.feature("organizations:top-issues-ui"):
+            self.get_success_response(
+                self.organization.slug,
+                group_id=[self.unresolved_group.id, self.resolved_group.id],
+                status="unresolved",
+            )
+
+        body = mock_seer.call_args[0][0]
+        assert body["group_ids"] == [self.unresolved_group.id]
+
+    def test_status_filter_invalid(self):
+        with self.feature("organizations:top-issues-ui"):
+            self.get_error_response(
+                self.organization.slug,
+                group_id=[self.unresolved_group.id],
+                status="bogus",
+                status_code=400,
+            )
+
+    def test_status_filter_all_filtered_out(self):
+        with self.feature("organizations:top-issues-ui"):
+            self.get_error_response(
+                self.organization.slug,
+                group_id=[self.resolved_group.id],
+                status="unresolved",
+                status_code=404,
+            )


### PR DESCRIPTION
Allow filtering groups by status (unresolved, resolved, etc.) via a query parameter so the frontend can request supergroup assignments for only the relevant subset of issues.

fixes https://linear.app/getsentry/issue/ID-1440/hide-resolved-issues-from-counts-and-lists