### PR TITLE
feat(taskworker): Add ViewerContext propagation via context hooks

### DIFF
--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -174,7 +174,7 @@ class ViewerContextHook:
             return contextlib.nullcontext()
         try:
             ctx = ViewerContext.deserialize(orjson.loads(raw))
-        except (orjson.JSONDecodeError, TypeError, KeyError):
+        except (orjson.JSONDecodeError, TypeError, KeyError, AttributeError):
             logger.exception("Failed to deserialize viewer context header")
             return contextlib.nullcontext()
         return viewer_context_scope(ctx)

--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -13,6 +13,7 @@ from collections.abc import MutableMapping
 from contextlib import contextmanager
 from typing import Any, Generator
 
+import orjson
 from arroyo.backends.kafka import KafkaProducer
 from django.conf import settings
 from django.core.cache.backends.base import BaseCache
@@ -28,7 +29,7 @@ from sentry.utils import json
 from sentry.utils import metrics as sentry_metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.memory import track_memory_usage as sentry_track_memory_usage
-from sentry.viewer_context import ActorType, ViewerContext, get_viewer_context, viewer_context_scope
+from sentry.viewer_context import ViewerContext, get_viewer_context, viewer_context_scope
 
 
 class DjangoCacheAtMostOnceStore(AtMostOnceStore):
@@ -151,33 +152,24 @@ class SentryRouter(LibraryRouter):
 class ViewerContextHook:
     """
     ContextHook that propagates ViewerContext through task headers.
+
+    Uses a single JSON header, matching the RPC layer's serialization
+    via ViewerContext.serialize() / ViewerContext.deserialize().
     """
 
-    HEADER_ORG = "sentry-viewer-org"
-    HEADER_USER = "sentry-viewer-user"
-    HEADER_ACTOR = "sentry-viewer-actor"
+    HEADER = "sentry-viewer-context"
 
     def on_dispatch(self, headers: MutableMapping[str, Any]) -> None:
         ctx = get_viewer_context()
         if ctx is None:
             return
-        if ctx.organization_id is not None:
-            headers[self.HEADER_ORG] = str(ctx.organization_id)
-        if ctx.user_id is not None:
-            headers[self.HEADER_USER] = str(ctx.user_id)
-        headers[self.HEADER_ACTOR] = ctx.actor_type.value
+        headers[self.HEADER] = orjson.dumps(ctx.serialize()).decode()
 
     def on_execute(self, headers: dict[str, str]) -> contextlib.AbstractContextManager[None]:
-        actor = headers.get(self.HEADER_ACTOR)
-        org = headers.get(self.HEADER_ORG)
-        user = headers.get(self.HEADER_USER)
-        if not actor and not org and not user:
+        raw = headers.get(self.HEADER)
+        if not raw:
             return contextlib.nullcontext()
-        ctx = ViewerContext(
-            organization_id=int(org) if org else None,
-            user_id=int(user) if user else None,
-            actor_type=ActorType(actor) if actor else ActorType.UNKNOWN,
-        )
+        ctx = ViewerContext.deserialize(orjson.loads(raw))
         return viewer_context_scope(ctx)
 
 

--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -8,6 +8,7 @@ interfaces defined by the taskbroker-client library.
 from __future__ import annotations
 
 import contextlib
+import logging
 import threading
 from collections.abc import MutableMapping
 from contextlib import contextmanager
@@ -30,6 +31,8 @@ from sentry.utils import metrics as sentry_metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.memory import track_memory_usage as sentry_track_memory_usage
 from sentry.viewer_context import ViewerContext, get_viewer_context, viewer_context_scope
+
+logger = logging.getLogger(__name__)
 
 
 class DjangoCacheAtMostOnceStore(AtMostOnceStore):
@@ -169,7 +172,11 @@ class ViewerContextHook:
         raw = headers.get(self.HEADER)
         if not raw:
             return contextlib.nullcontext()
-        ctx = ViewerContext.deserialize(orjson.loads(raw))
+        try:
+            ctx = ViewerContext.deserialize(orjson.loads(raw))
+        except (orjson.JSONDecodeError, TypeError, KeyError):
+            logger.exception("Failed to deserialize viewer context header")
+            return contextlib.nullcontext()
         return viewer_context_scope(ctx)
 
 

--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -7,9 +7,11 @@ interfaces defined by the taskbroker-client library.
 
 from __future__ import annotations
 
+import contextlib
 import threading
+from collections.abc import MutableMapping
 from contextlib import contextmanager
-from typing import Generator
+from typing import Any, Generator
 
 from arroyo.backends.kafka import KafkaProducer
 from django.conf import settings
@@ -26,6 +28,7 @@ from sentry.utils import json
 from sentry.utils import metrics as sentry_metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.memory import track_memory_usage as sentry_track_memory_usage
+from sentry.viewer_context import ActorType, ViewerContext, get_viewer_context, viewer_context_scope
 
 
 class DjangoCacheAtMostOnceStore(AtMostOnceStore):
@@ -143,6 +146,39 @@ class SentryRouter(LibraryRouter):
         if name in self._route_map:
             return Topic(self._route_map[name]).value
         return self._default_topic.value
+
+
+class ViewerContextHook:
+    """
+    ContextHook that propagates ViewerContext through task headers.
+    """
+
+    HEADER_ORG = "sentry-viewer-org"
+    HEADER_USER = "sentry-viewer-user"
+    HEADER_ACTOR = "sentry-viewer-actor"
+
+    def on_dispatch(self, headers: MutableMapping[str, Any]) -> None:
+        ctx = get_viewer_context()
+        if ctx is None:
+            return
+        if ctx.organization_id is not None:
+            headers[self.HEADER_ORG] = str(ctx.organization_id)
+        if ctx.user_id is not None:
+            headers[self.HEADER_USER] = str(ctx.user_id)
+        headers[self.HEADER_ACTOR] = ctx.actor_type.value
+
+    def on_execute(self, headers: dict[str, str]) -> contextlib.AbstractContextManager[None]:
+        actor = headers.get(self.HEADER_ACTOR)
+        org = headers.get(self.HEADER_ORG)
+        user = headers.get(self.HEADER_USER)
+        if not actor and not org and not user:
+            return contextlib.nullcontext()
+        ctx = ViewerContext(
+            organization_id=int(org) if org else None,
+            user_id=int(user) if user else None,
+            actor_type=ActorType(actor) if actor else ActorType.UNKNOWN,
+        )
+        return viewer_context_scope(ctx)
 
 
 _producer_local = threading.local()

--- a/src/sentry/taskworker/runtime.py
+++ b/src/sentry/taskworker/runtime.py
@@ -6,6 +6,7 @@ from sentry.taskworker.adapters import (
     DjangoCacheAtMostOnceStore,
     SentryMetricsBackend,
     SentryRouter,
+    ViewerContextHook,
     make_producer,
 )
 
@@ -15,6 +16,7 @@ app = TaskbrokerApp(
     metrics_class=SentryMetricsBackend(),
     router_class=SentryRouter(),
     at_most_once_store=DjangoCacheAtMostOnceStore(cache),
+    context_hooks=[ViewerContextHook()],
 )
 app.set_config(
     {

--- a/tests/sentry/taskworker/test_adapters.py
+++ b/tests/sentry/taskworker/test_adapters.py
@@ -1,10 +1,18 @@
+import contextlib
+
 import pytest
 from django.test.utils import override_settings
 from taskbroker_client.registry import TaskRegistry
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.silo.base import SiloMode
-from sentry.taskworker.adapters import SentryMetricsBackend, SentryRouter, make_producer
+from sentry.taskworker.adapters import (
+    SentryMetricsBackend,
+    SentryRouter,
+    ViewerContextHook,
+    make_producer,
+)
+from sentry.viewer_context import ActorType, ViewerContext, get_viewer_context, viewer_context_scope
 
 
 @pytest.mark.django_db
@@ -51,3 +59,83 @@ def test_default_router_topic_control_silo() -> None:
         router = SentryRouter()
         topic = router.route_namespace("test.tasks.test_router.control")
         assert topic == Topic.TASKWORKER_CONTROL.value
+
+
+class TestViewerContextHook:
+    def test_on_dispatch_with_context(self) -> None:
+        hook = ViewerContextHook()
+        headers: dict[str, str] = {}
+        ctx = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        with viewer_context_scope(ctx):
+            hook.on_dispatch(headers)
+
+        assert headers["sentry-viewer-org"] == "42"
+        assert headers["sentry-viewer-user"] == "7"
+        assert headers["sentry-viewer-actor"] == "user"
+
+    def test_on_dispatch_without_context(self) -> None:
+        hook = ViewerContextHook()
+        headers: dict[str, str] = {}
+        hook.on_dispatch(headers)
+
+        assert "sentry-viewer-org" not in headers
+        assert "sentry-viewer-user" not in headers
+        assert "sentry-viewer-actor" not in headers
+
+    def test_on_dispatch_partial_context(self) -> None:
+        hook = ViewerContextHook()
+        headers: dict[str, str] = {}
+        ctx = ViewerContext(organization_id=42, actor_type=ActorType.SYSTEM)
+        with viewer_context_scope(ctx):
+            hook.on_dispatch(headers)
+
+        assert headers["sentry-viewer-org"] == "42"
+        assert "sentry-viewer-user" not in headers
+        assert headers["sentry-viewer-actor"] == "system"
+
+    def test_on_execute_restores_context(self) -> None:
+        hook = ViewerContextHook()
+        headers = {
+            "sentry-viewer-org": "42",
+            "sentry-viewer-user": "7",
+            "sentry-viewer-actor": "user",
+        }
+        with hook.on_execute(headers):
+            ctx = get_viewer_context()
+            assert ctx is not None
+            assert ctx.organization_id == 42
+            assert ctx.user_id == 7
+            assert ctx.actor_type == ActorType.USER
+
+        assert get_viewer_context() is None
+
+    def test_on_execute_no_headers(self) -> None:
+        hook = ViewerContextHook()
+        cm = hook.on_execute({})
+        assert isinstance(cm, contextlib.nullcontext)
+
+    def test_on_execute_partial_headers(self) -> None:
+        hook = ViewerContextHook()
+        headers = {"sentry-viewer-org": "99", "sentry-viewer-actor": "integration"}
+        with hook.on_execute(headers):
+            ctx = get_viewer_context()
+            assert ctx is not None
+            assert ctx.organization_id == 99
+            assert ctx.user_id is None
+            assert ctx.actor_type == ActorType.INTEGRATION
+
+    def test_roundtrip(self) -> None:
+        """Dispatch then execute produces the same ViewerContext."""
+        hook = ViewerContextHook()
+        headers: dict[str, str] = {}
+
+        original = ViewerContext(organization_id=123, user_id=456, actor_type=ActorType.USER)
+        with viewer_context_scope(original):
+            hook.on_dispatch(headers)
+
+        with hook.on_execute(headers):
+            restored = get_viewer_context()
+            assert restored is not None
+            assert restored.organization_id == original.organization_id
+            assert restored.user_id == original.user_id
+            assert restored.actor_type == original.actor_type

--- a/tests/sentry/taskworker/test_adapters.py
+++ b/tests/sentry/taskworker/test_adapters.py
@@ -1,5 +1,6 @@
 import contextlib
 
+import orjson
 import pytest
 from django.test.utils import override_settings
 from taskbroker_client.registry import TaskRegistry
@@ -69,18 +70,17 @@ class TestViewerContextHook:
         with viewer_context_scope(ctx):
             hook.on_dispatch(headers)
 
-        assert headers["sentry-viewer-org"] == "42"
-        assert headers["sentry-viewer-user"] == "7"
-        assert headers["sentry-viewer-actor"] == "user"
+        payload = orjson.loads(headers["sentry-viewer-context"])
+        assert payload["organization_id"] == 42
+        assert payload["user_id"] == 7
+        assert payload["actor_type"] == "user"
 
     def test_on_dispatch_without_context(self) -> None:
         hook = ViewerContextHook()
         headers: dict[str, str] = {}
         hook.on_dispatch(headers)
 
-        assert "sentry-viewer-org" not in headers
-        assert "sentry-viewer-user" not in headers
-        assert "sentry-viewer-actor" not in headers
+        assert "sentry-viewer-context" not in headers
 
     def test_on_dispatch_partial_context(self) -> None:
         hook = ViewerContextHook()
@@ -89,16 +89,17 @@ class TestViewerContextHook:
         with viewer_context_scope(ctx):
             hook.on_dispatch(headers)
 
-        assert headers["sentry-viewer-org"] == "42"
-        assert "sentry-viewer-user" not in headers
-        assert headers["sentry-viewer-actor"] == "system"
+        payload = orjson.loads(headers["sentry-viewer-context"])
+        assert payload["organization_id"] == 42
+        assert "user_id" not in payload
+        assert payload["actor_type"] == "system"
 
     def test_on_execute_restores_context(self) -> None:
         hook = ViewerContextHook()
         headers = {
-            "sentry-viewer-org": "42",
-            "sentry-viewer-user": "7",
-            "sentry-viewer-actor": "user",
+            "sentry-viewer-context": orjson.dumps(
+                {"organization_id": 42, "user_id": 7, "actor_type": "user"}
+            ).decode(),
         }
         with hook.on_execute(headers):
             ctx = get_viewer_context()
@@ -116,7 +117,11 @@ class TestViewerContextHook:
 
     def test_on_execute_partial_headers(self) -> None:
         hook = ViewerContextHook()
-        headers = {"sentry-viewer-org": "99", "sentry-viewer-actor": "integration"}
+        headers = {
+            "sentry-viewer-context": orjson.dumps(
+                {"organization_id": 99, "actor_type": "integration"}
+            ).decode(),
+        }
         with hook.on_execute(headers):
             ctx = get_viewer_context()
             assert ctx is not None

--- a/tests/sentry/taskworker/test_adapters.py
+++ b/tests/sentry/taskworker/test_adapters.py
@@ -144,3 +144,9 @@ class TestViewerContextHook:
             assert restored.organization_id == original.organization_id
             assert restored.user_id == original.user_id
             assert restored.actor_type == original.actor_type
+
+    def test_on_execute_malformed_json(self) -> None:
+        hook = ViewerContextHook()
+        headers = {"sentry-viewer-context": "not-valid-json{"}
+        cm = hook.on_execute(headers)
+        assert isinstance(cm, contextlib.nullcontext)

--- a/tests/sentry/taskworker/test_adapters.py
+++ b/tests/sentry/taskworker/test_adapters.py
@@ -150,3 +150,9 @@ class TestViewerContextHook:
         headers = {"sentry-viewer-context": "not-valid-json{"}
         cm = hook.on_execute(headers)
         assert isinstance(cm, contextlib.nullcontext)
+
+    def test_on_execute_non_dict_json(self) -> None:
+        hook = ViewerContextHook()
+        headers = {"sentry-viewer-context": "[1, 2, 3]"}
+        cm = hook.on_execute(headers)
+        assert isinstance(cm, contextlib.nullcontext)


### PR DESCRIPTION
Add `ViewerContextHook` that implicitly propagates ViewerContext through TaskBroker task headers.

**On dispatch**: the hook reads from the `get_viewer_context()` contextvar and injects `sentry-viewer-org`, `sentry-viewer-user`, and `sentry-viewer-actor` into task activation headers. This happens automatically in `create_activation()` — no callsite changes needed.

**On execution**: the hook reads those headers back and wraps the task callable in `viewer_context_scope()`, making `get_viewer_context()` available inside every task.

This is the Sentry-side implementation. The taskbroker-client `ContextHook` protocol that powers this lives in https://github.com/getsentry/taskbroker/pull/587 — this PR depends on that being merged and the `taskbroker-client` dependency bumped.

Part of the [ViewerContext RFC](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02).