### PR TITLE
ref(slot): simplify slot API

### DIFF
--- a/static/app/components/core/slot/index.tsx
+++ b/static/app/components/core/slot/index.tsx
@@ -1,1 +1,1 @@
-export {slot} from './slot';
+export {slot, withSlots} from './slot';

--- a/static/app/components/core/slot/slot.spec.tsx
+++ b/static/app/components/core/slot/slot.spec.tsx
@@ -3,43 +3,40 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {slot} from './';
 
 describe('slot', () => {
-  it('returns a Provider and slot components with Root and Fallback sub-components', () => {
+  it('returns a Provider with Slot, Outlet, and Fallback sub-components', () => {
     const SlotModule = slot(['header', 'footer'] as const);
-    expect(SlotModule.Provider).toBeDefined();
-    expect(SlotModule.slot.header).toBeDefined();
-    expect(SlotModule.slot.footer).toBeDefined();
-    expect(SlotModule.slot.header.Root).toBeDefined();
-    expect(SlotModule.slot.footer.Root).toBeDefined();
-    expect(SlotModule.slot.header.Fallback).toBeDefined();
-    expect(SlotModule.slot.footer.Fallback).toBeDefined();
+    expect(SlotModule).toBeDefined();
+    expect(SlotModule.Slot).toBeDefined();
+    expect(SlotModule.Outlet).toBeDefined();
+    expect(SlotModule.Fallback).toBeDefined();
   });
 
-  it('slot component renders children in place when no Root is registered', () => {
+  it('Slot renders children in place when no Outlet is registered', () => {
     const SlotModule = slot(['header'] as const);
 
     render(
-      <SlotModule.Provider>
-        <SlotModule.slot.header>
+      <SlotModule>
+        <SlotModule.Slot name="header">
           <span>inline content</span>
-        </SlotModule.slot.header>
-      </SlotModule.Provider>
+        </SlotModule.Slot>
+      </SlotModule>
     );
 
     expect(screen.getByText('inline content')).toBeInTheDocument();
   });
 
-  it('slot component portals children to the Root element', () => {
+  it('Slot portals children to the Outlet element', () => {
     const SlotModule = slot(['content'] as const);
 
     render(
-      <SlotModule.Provider>
-        <SlotModule.slot.content.Root>
+      <SlotModule>
+        <SlotModule.Outlet name="content">
           {props => <div {...props} data-test-id="slot-target" />}
-        </SlotModule.slot.content.Root>
-        <SlotModule.slot.content>
+        </SlotModule.Outlet>
+        <SlotModule.Slot name="content">
           <span>portaled content</span>
-        </SlotModule.slot.content>
-      </SlotModule.Provider>
+        </SlotModule.Slot>
+      </SlotModule>
     );
 
     expect(screen.getByTestId('slot-target')).toContainHTML(
@@ -47,97 +44,90 @@ describe('slot', () => {
     );
   });
 
-  it('multiple slot components render their children independently', () => {
+  it('multiple Slot components render their children independently', () => {
     const SlotModule = slot(['a', 'b'] as const);
 
     render(
-      <SlotModule.Provider>
-        <SlotModule.slot.a>
+      <SlotModule>
+        <SlotModule.Slot name="a">
           <span>slot a content</span>
-        </SlotModule.slot.a>
-        <SlotModule.slot.b>
+        </SlotModule.Slot>
+        <SlotModule.Slot name="b">
           <span>slot b content</span>
-        </SlotModule.slot.b>
-      </SlotModule.Provider>
+        </SlotModule.Slot>
+      </SlotModule>
     );
 
     expect(screen.getByText('slot a content')).toBeInTheDocument();
     expect(screen.getByText('slot b content')).toBeInTheDocument();
   });
 
-  it('slot component throws when rendered outside provider', () => {
+  it('Slot throws when rendered outside provider', () => {
     const SlotModule = slot(['nav'] as const);
 
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(() =>
       render(
-        <SlotModule.slot.nav>
+        <SlotModule.Slot name="nav">
           <span>content</span>
-        </SlotModule.slot.nav>
+        </SlotModule.Slot>
       )
     ).toThrow('SlotContext not found');
 
     consoleError.mockRestore();
   });
 
-  it('Root throws when rendered outside provider', () => {
+  it('Outlet throws when rendered outside provider', () => {
     const SlotModule = slot(['aside'] as const);
 
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(() =>
       render(
-        <SlotModule.slot.aside.Root>
-          {props => <div {...props} />}
-        </SlotModule.slot.aside.Root>
+        <SlotModule.Outlet name="aside">{props => <div {...props} />}</SlotModule.Outlet>
       )
     ).toThrow('SlotContext not found');
 
     consoleError.mockRestore();
   });
 
-  it('Root renders the element returned by the render prop', () => {
+  it('Outlet renders the element returned by the render prop', () => {
     const SlotModule = slot(['sidebar'] as const);
 
     render(
-      <SlotModule.Provider>
-        <SlotModule.slot.sidebar.Root>
+      <SlotModule>
+        <SlotModule.Outlet name="sidebar">
           {props => <div {...props} data-test-id="sidebar-root" />}
-        </SlotModule.slot.sidebar.Root>
-      </SlotModule.Provider>
+        </SlotModule.Outlet>
+      </SlotModule>
     );
 
     expect(screen.getByTestId('sidebar-root')).toBeInTheDocument();
   });
 
-  it('Root registers and unregisters the element on mount/unmount', () => {
+  it('Outlet registers and unregisters the element on mount/unmount', () => {
     const SlotModule = slot(['panel'] as const);
 
     const {unmount} = render(
-      <SlotModule.Provider>
-        <SlotModule.slot.panel.Root>
+      <SlotModule>
+        <SlotModule.Outlet name="panel">
           {props => <div {...props} data-test-id="panel-root" />}
-        </SlotModule.slot.panel.Root>
-      </SlotModule.Provider>
+        </SlotModule.Outlet>
+      </SlotModule>
     );
 
     expect(screen.getByTestId('panel-root')).toBeInTheDocument();
     expect(() => unmount()).not.toThrow();
   });
 
-  it('slot component has the correct display name', () => {
-    const SlotModule = slot(['toolbar'] as const);
-    expect(SlotModule.slot.toolbar.displayName).toBe('Slot.(toolbar)');
-  });
-
   it('provider renders its children', () => {
     const SlotModule = slot(['x'] as const);
 
     render(
-      <SlotModule.Provider>
+      <SlotModule>
         <span>child content</span>
-      </SlotModule.Provider>
+      </SlotModule>
     );
 
     expect(screen.getByText('child content')).toBeInTheDocument();
@@ -151,11 +141,11 @@ describe('slot', () => {
 
     expect(() =>
       render(
-        <SlotModule1.Provider>
-          <SlotModule2.slot.zone>
+        <SlotModule1>
+          <SlotModule2.Slot name="zone">
             <span>content</span>
-          </SlotModule2.slot.zone>
-        </SlotModule1.Provider>
+          </SlotModule2.Slot>
+        </SlotModule1>
       )
     ).toThrow('SlotContext not found');
 
@@ -163,18 +153,18 @@ describe('slot', () => {
   });
 
   describe('Fallback', () => {
-    it('renders children into Root when no slot consumer is mounted', () => {
+    it('renders children into Outlet when no Slot consumer is mounted', () => {
       const SlotModule = slot(['feedback'] as const);
 
       render(
-        <SlotModule.Provider>
-          <SlotModule.slot.feedback.Root>
+        <SlotModule>
+          <SlotModule.Outlet name="feedback">
             {props => <div {...props} data-test-id="feedback-root" />}
-          </SlotModule.slot.feedback.Root>
-          <SlotModule.slot.feedback.Fallback>
+          </SlotModule.Outlet>
+          <SlotModule.Fallback name="feedback">
             <span>default feedback</span>
-          </SlotModule.slot.feedback.Fallback>
-        </SlotModule.Provider>
+          </SlotModule.Fallback>
+        </SlotModule>
       );
 
       expect(screen.getByTestId('feedback-root')).toContainHTML(
@@ -182,21 +172,21 @@ describe('slot', () => {
       );
     });
 
-    it('does not render when a slot consumer is mounted', () => {
+    it('does not render when a Slot consumer is mounted', () => {
       const SlotModule = slot(['feedback'] as const);
 
       render(
-        <SlotModule.Provider>
-          <SlotModule.slot.feedback.Root>
+        <SlotModule>
+          <SlotModule.Outlet name="feedback">
             {props => <div {...props} data-test-id="feedback-root" />}
-          </SlotModule.slot.feedback.Root>
-          <SlotModule.slot.feedback.Fallback>
+          </SlotModule.Outlet>
+          <SlotModule.Fallback name="feedback">
             <span>default feedback</span>
-          </SlotModule.slot.feedback.Fallback>
-          <SlotModule.slot.feedback>
+          </SlotModule.Fallback>
+          <SlotModule.Slot name="feedback">
             <span>custom feedback</span>
-          </SlotModule.slot.feedback>
-        </SlotModule.Provider>
+          </SlotModule.Slot>
+        </SlotModule>
       );
 
       expect(screen.queryByText('default feedback')).not.toBeInTheDocument();
@@ -205,15 +195,15 @@ describe('slot', () => {
       );
     });
 
-    it('does not render when Root is not registered', () => {
+    it('does not render when Outlet is not registered', () => {
       const SlotModule = slot(['feedback'] as const);
 
       render(
-        <SlotModule.Provider>
-          <SlotModule.slot.feedback.Fallback>
+        <SlotModule>
+          <SlotModule.Fallback name="feedback">
             <span>default feedback</span>
-          </SlotModule.slot.feedback.Fallback>
-        </SlotModule.Provider>
+          </SlotModule.Fallback>
+        </SlotModule>
       );
 
       expect(screen.queryByText('default feedback')).not.toBeInTheDocument();
@@ -226,9 +216,9 @@ describe('slot', () => {
 
       expect(() =>
         render(
-          <SlotModule.slot.x.Fallback>
+          <SlotModule.Fallback name="x">
             <span>fallback</span>
-          </SlotModule.slot.x.Fallback>
+          </SlotModule.Fallback>
         )
       ).toThrow('SlotContext not found');
 
@@ -236,32 +226,32 @@ describe('slot', () => {
     });
   });
 
-  describe('Root ref stability', () => {
+  describe('Outlet ref stability', () => {
     it('ref callback passed to render prop is stable across re-renders', () => {
       const SlotModule = slot(['menu'] as const);
       const refs: Array<React.RefCallback<HTMLElement | null>> = [];
 
       function TestComponent() {
         return (
-          <SlotModule.slot.menu.Root>
+          <SlotModule.Outlet name="menu">
             {props => {
               refs.push(props.ref);
               return <div {...props} />;
             }}
-          </SlotModule.slot.menu.Root>
+          </SlotModule.Outlet>
         );
       }
 
       const {rerender} = render(
-        <SlotModule.Provider>
+        <SlotModule>
           <TestComponent />
-        </SlotModule.Provider>
+        </SlotModule>
       );
 
       rerender(
-        <SlotModule.Provider>
+        <SlotModule>
           <TestComponent />
-        </SlotModule.Provider>
+        </SlotModule>
       );
 
       expect(refs[0]).toBe(refs[refs.length - 1]);

--- a/static/app/components/core/slot/slot.spec.tsx
+++ b/static/app/components/core/slot/slot.spec.tsx
@@ -1,42 +1,42 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {slot} from './';
+import {slot, withSlots} from './';
 
 describe('slot', () => {
-  it('returns a Provider with Slot, Outlet, and Fallback sub-components', () => {
+  it('returns a module with Provider, Outlet, and Fallback sub-components', () => {
     const SlotModule = slot(['header', 'footer'] as const);
     expect(SlotModule).toBeDefined();
-    expect(SlotModule.Slot).toBeDefined();
+    expect(SlotModule.Provider).toBeDefined();
     expect(SlotModule.Outlet).toBeDefined();
     expect(SlotModule.Fallback).toBeDefined();
   });
 
-  it('Slot renders children in place when no Outlet is registered', () => {
+  it('renders children in place when no Outlet is registered', () => {
     const SlotModule = slot(['header'] as const);
 
     render(
-      <SlotModule>
-        <SlotModule.Slot name="header">
+      <SlotModule.Provider>
+        <SlotModule name="header">
           <span>inline content</span>
-        </SlotModule.Slot>
-      </SlotModule>
+        </SlotModule>
+      </SlotModule.Provider>
     );
 
     expect(screen.getByText('inline content')).toBeInTheDocument();
   });
 
-  it('Slot portals children to the Outlet element', () => {
+  it('portals children to the Outlet element', () => {
     const SlotModule = slot(['content'] as const);
 
     render(
-      <SlotModule>
+      <SlotModule.Provider>
         <SlotModule.Outlet name="content">
           {props => <div {...props} data-test-id="slot-target" />}
         </SlotModule.Outlet>
-        <SlotModule.Slot name="content">
+        <SlotModule name="content">
           <span>portaled content</span>
-        </SlotModule.Slot>
-      </SlotModule>
+        </SlotModule>
+      </SlotModule.Provider>
     );
 
     expect(screen.getByTestId('slot-target')).toContainHTML(
@@ -44,34 +44,34 @@ describe('slot', () => {
     );
   });
 
-  it('multiple Slot components render their children independently', () => {
+  it('multiple slot consumers render their children independently', () => {
     const SlotModule = slot(['a', 'b'] as const);
 
     render(
-      <SlotModule>
-        <SlotModule.Slot name="a">
+      <SlotModule.Provider>
+        <SlotModule name="a">
           <span>slot a content</span>
-        </SlotModule.Slot>
-        <SlotModule.Slot name="b">
+        </SlotModule>
+        <SlotModule name="b">
           <span>slot b content</span>
-        </SlotModule.Slot>
-      </SlotModule>
+        </SlotModule>
+      </SlotModule.Provider>
     );
 
     expect(screen.getByText('slot a content')).toBeInTheDocument();
     expect(screen.getByText('slot b content')).toBeInTheDocument();
   });
 
-  it('Slot throws when rendered outside provider', () => {
+  it('consumer throws when rendered outside provider', () => {
     const SlotModule = slot(['nav'] as const);
 
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(() =>
       render(
-        <SlotModule.Slot name="nav">
+        <SlotModule name="nav">
           <span>content</span>
-        </SlotModule.Slot>
+        </SlotModule>
       )
     ).toThrow('SlotContext not found');
 
@@ -96,11 +96,11 @@ describe('slot', () => {
     const SlotModule = slot(['sidebar'] as const);
 
     render(
-      <SlotModule>
+      <SlotModule.Provider>
         <SlotModule.Outlet name="sidebar">
           {props => <div {...props} data-test-id="sidebar-root" />}
         </SlotModule.Outlet>
-      </SlotModule>
+      </SlotModule.Provider>
     );
 
     expect(screen.getByTestId('sidebar-root')).toBeInTheDocument();
@@ -110,11 +110,11 @@ describe('slot', () => {
     const SlotModule = slot(['panel'] as const);
 
     const {unmount} = render(
-      <SlotModule>
+      <SlotModule.Provider>
         <SlotModule.Outlet name="panel">
           {props => <div {...props} data-test-id="panel-root" />}
         </SlotModule.Outlet>
-      </SlotModule>
+      </SlotModule.Provider>
     );
 
     expect(screen.getByTestId('panel-root')).toBeInTheDocument();
@@ -125,9 +125,9 @@ describe('slot', () => {
     const SlotModule = slot(['x'] as const);
 
     render(
-      <SlotModule>
+      <SlotModule.Provider>
         <span>child content</span>
-      </SlotModule>
+      </SlotModule.Provider>
     );
 
     expect(screen.getByText('child content')).toBeInTheDocument();
@@ -141,11 +141,11 @@ describe('slot', () => {
 
     expect(() =>
       render(
-        <SlotModule1>
-          <SlotModule2.Slot name="zone">
+        <SlotModule1.Provider>
+          <SlotModule2 name="zone">
             <span>content</span>
-          </SlotModule2.Slot>
-        </SlotModule1>
+          </SlotModule2>
+        </SlotModule1.Provider>
       )
     ).toThrow('SlotContext not found');
 
@@ -153,18 +153,21 @@ describe('slot', () => {
   });
 
   describe('Fallback', () => {
-    it('renders children into Outlet when no Slot consumer is mounted', () => {
+    it('renders children into Outlet when no consumer is mounted', () => {
       const SlotModule = slot(['feedback'] as const);
 
       render(
-        <SlotModule>
+        <SlotModule.Provider>
           <SlotModule.Outlet name="feedback">
-            {props => <div {...props} data-test-id="feedback-root" />}
+            {props => (
+              <div {...props} data-test-id="feedback-root">
+                <SlotModule.Fallback>
+                  <span>default feedback</span>
+                </SlotModule.Fallback>
+              </div>
+            )}
           </SlotModule.Outlet>
-          <SlotModule.Fallback name="feedback">
-            <span>default feedback</span>
-          </SlotModule.Fallback>
-        </SlotModule>
+        </SlotModule.Provider>
       );
 
       expect(screen.getByTestId('feedback-root')).toContainHTML(
@@ -172,41 +175,30 @@ describe('slot', () => {
       );
     });
 
-    it('does not render when a Slot consumer is mounted', () => {
+    it('does not render when a consumer is mounted', () => {
       const SlotModule = slot(['feedback'] as const);
 
       render(
-        <SlotModule>
+        <SlotModule.Provider>
           <SlotModule.Outlet name="feedback">
-            {props => <div {...props} data-test-id="feedback-root" />}
+            {props => (
+              <div {...props} data-test-id="feedback-root">
+                <SlotModule.Fallback>
+                  <span>default feedback</span>
+                </SlotModule.Fallback>
+              </div>
+            )}
           </SlotModule.Outlet>
-          <SlotModule.Fallback name="feedback">
-            <span>default feedback</span>
-          </SlotModule.Fallback>
-          <SlotModule.Slot name="feedback">
+          <SlotModule name="feedback">
             <span>custom feedback</span>
-          </SlotModule.Slot>
-        </SlotModule>
+          </SlotModule>
+        </SlotModule.Provider>
       );
 
       expect(screen.queryByText('default feedback')).not.toBeInTheDocument();
       expect(screen.getByTestId('feedback-root')).toContainHTML(
         '<span>custom feedback</span>'
       );
-    });
-
-    it('does not render when Outlet is not registered', () => {
-      const SlotModule = slot(['feedback'] as const);
-
-      render(
-        <SlotModule>
-          <SlotModule.Fallback name="feedback">
-            <span>default feedback</span>
-          </SlotModule.Fallback>
-        </SlotModule>
-      );
-
-      expect(screen.queryByText('default feedback')).not.toBeInTheDocument();
     });
 
     it('throws when rendered outside provider', () => {
@@ -216,11 +208,29 @@ describe('slot', () => {
 
       expect(() =>
         render(
-          <SlotModule.Fallback name="x">
+          <SlotModule.Fallback>
             <span>fallback</span>
           </SlotModule.Fallback>
         )
       ).toThrow('SlotContext not found');
+
+      consoleError.mockRestore();
+    });
+
+    it('throws when rendered outside Outlet', () => {
+      const SlotModule = slot(['x'] as const);
+
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() =>
+        render(
+          <SlotModule.Provider>
+            <SlotModule.Fallback>
+              <span>fallback</span>
+            </SlotModule.Fallback>
+          </SlotModule.Provider>
+        )
+      ).toThrow('Slot.Fallback must be rendered inside Slot.Outlet');
 
       consoleError.mockRestore();
     });
@@ -243,18 +253,61 @@ describe('slot', () => {
       }
 
       const {rerender} = render(
-        <SlotModule>
+        <SlotModule.Provider>
           <TestComponent />
-        </SlotModule>
+        </SlotModule.Provider>
       );
 
       rerender(
-        <SlotModule>
+        <SlotModule.Provider>
           <TestComponent />
-        </SlotModule>
+        </SlotModule.Provider>
       );
 
       expect(refs[0]).toBe(refs[refs.length - 1]);
+    });
+  });
+
+  describe('withSlots', () => {
+    it('attaches a Slot property to a component', () => {
+      const SlotModule = slot(['header'] as const);
+
+      function MyComponent() {
+        return <div data-test-id="my-component" />;
+      }
+
+      const WithSlots = withSlots(MyComponent, SlotModule);
+
+      expect(WithSlots.Slot).toBe(SlotModule);
+    });
+
+    it('renders the wrapped component and allows slot injection', () => {
+      const SlotModule = slot(['title'] as const);
+
+      function MyComponent() {
+        return (
+          <div data-test-id="my-component">
+            <SlotModule.Outlet name="title">
+              {props => <span {...props} data-test-id="title-outlet" />}
+            </SlotModule.Outlet>
+          </div>
+        );
+      }
+
+      const WithSlots = withSlots(MyComponent, SlotModule);
+
+      render(
+        <WithSlots.Slot.Provider>
+          <WithSlots />
+          <WithSlots.Slot name="title">
+            <span>injected title</span>
+          </WithSlots.Slot>
+        </WithSlots.Slot.Provider>
+      );
+
+      expect(screen.getByTestId('title-outlet')).toContainHTML(
+        '<span>injected title</span>'
+      );
     });
   });
 });

--- a/static/app/components/core/slot/slot.tsx
+++ b/static/app/components/core/slot/slot.tsx
@@ -97,30 +97,47 @@ function makeSlotReducer<T extends Slot>(): SlotReducer<T> {
   };
 }
 
-interface SlotComponentProps {
+interface SlotProviderProps {
   children: React.ReactNode;
 }
 
-type SlotComponent<T extends Slot> = React.FunctionComponent<SlotComponentProps> & {
-  Fallback: ReturnType<typeof makeSlotFallback<T>>;
-  Root: ReturnType<typeof makeSlotRoot<T>>;
-};
+interface SlotConsumerProps<T extends Slot> {
+  children: React.ReactNode;
+  name: T;
+}
 
-function makeSlotComponent<T extends Slot>(
-  name: T,
+interface SlotOutletProps<T extends Slot> {
+  children: (props: {ref: React.RefCallback<HTMLElement | null>}) => React.ReactNode;
+  name: T;
+}
+
+interface SlotFallbackProps<T extends Slot> {
+  children: React.ReactNode;
+  name: T;
+}
+
+type SlotProviderComponent<T extends Slot> =
+  React.FunctionComponent<SlotProviderProps> & {
+    Fallback: React.ComponentType<SlotFallbackProps<T>>;
+    Outlet: React.ComponentType<SlotOutletProps<T>>;
+    Slot: React.ComponentType<SlotConsumerProps<T>>;
+  };
+
+function makeSlotConsumer<T extends Slot>(
   context: React.Context<SlotContextValue<T> | null>
 ) {
-  function SlotComponent(props: SlotComponentProps): React.ReactNode {
+  function SlotConsumer(props: SlotConsumerProps<T>): React.ReactNode {
     const ctx = useContext(context);
     if (!ctx) {
       throw new Error('SlotContext not found');
     }
 
     const [state, dispatch] = ctx;
+    const {name} = props;
     useLayoutEffect(() => {
       dispatch({type: 'increment counter', name});
       return () => dispatch({type: 'decrement counter', name});
-    }, [dispatch]);
+    }, [dispatch, name]);
 
     const element = state[name]?.element;
     if (!element) {
@@ -130,22 +147,14 @@ function makeSlotComponent<T extends Slot>(
     return createPortal(props.children, element);
   }
 
-  SlotComponent.Fallback = makeSlotFallback(name, context);
-  SlotComponent.Root = makeSlotRoot(name, context);
-  SlotComponent.displayName = `Slot.(${name})`;
-
-  return SlotComponent;
+  SlotConsumer.displayName = 'Slot.Consumer';
+  return SlotConsumer;
 }
 
-interface SlotRootProps {
-  children: (props: {ref: React.RefCallback<HTMLElement | null>}) => React.ReactNode;
-}
-
-function makeSlotRoot<T extends Slot>(
-  name: T,
+function makeSlotOutlet<T extends Slot>(
   context: React.Context<SlotContextValue<T> | null>
 ) {
-  return function SlotRoot(props: SlotRootProps): React.ReactNode {
+  function SlotOutlet(props: SlotOutletProps<T>): React.ReactNode {
     const ctx = useContext(context);
 
     if (!ctx) {
@@ -153,6 +162,7 @@ function makeSlotRoot<T extends Slot>(
     }
 
     const [, dispatch] = ctx;
+    const {name} = props;
     const ref = useCallback(
       (element: HTMLElement | null) => {
         if (!element) {
@@ -161,34 +171,37 @@ function makeSlotRoot<T extends Slot>(
         }
         dispatch({type: 'register', name, element});
       },
-      [dispatch]
+      [dispatch, name]
     );
 
     return props.children({ref});
-  };
+  }
+
+  SlotOutlet.displayName = 'Slot.Outlet';
+  return SlotOutlet;
 }
+
 function makeSlotFallback<T extends Slot>(
-  name: T,
   context: React.Context<SlotContextValue<T> | null>
 ) {
-  return function SlotFallback(props: SlotComponentProps): React.ReactNode {
+  function SlotFallback(props: SlotFallbackProps<T>): React.ReactNode {
     const ctx = useContext(context);
     if (!ctx) {
       throw new Error('SlotContext not found');
     }
 
     const [state] = ctx;
+    const {name} = props;
 
     if ((state[name]?.counter ?? 0) > 0 || !state[name]?.element) {
       return null;
     }
 
     return createPortal(props.children, state[name]?.element);
-  };
-}
+  }
 
-interface SlotProviderProps {
-  children: React.ReactNode;
+  SlotFallback.displayName = 'Slot.Fallback';
+  return SlotFallback;
 }
 
 function makeSlotProvider<T extends Slot>(
@@ -210,24 +223,22 @@ function makeSlotProvider<T extends Slot>(
   return SlotProvider as (props: SlotProviderProps) => React.ReactNode;
 }
 
-interface SlotModule<T extends readonly Slot[]> {
-  Provider: React.ComponentType<SlotProviderProps>;
-  slot: {[K in T[number]]: SlotComponent<K>};
-}
-
-export function slot<T extends readonly Slot[]>(names: T): SlotModule<T> {
+export function slot<T extends readonly Slot[]>(
+  names: T
+): SlotProviderComponent<T[number]> {
   type SlotName = T[number];
 
   const SlotContext = createContext<SlotContextValue<SlotName> | null>(null);
-  const SlotProvider = makeSlotProvider<SlotName>(SlotContext);
+  const Provider = makeSlotProvider<SlotName>(
+    SlotContext
+  ) as SlotProviderComponent<SlotName>;
 
-  const slots = {} as {[K in SlotName]: SlotComponent<K>};
-  for (const name of names) {
-    slots[name as SlotName] = makeSlotComponent<SlotName>(name, SlotContext);
-  }
+  Provider.Slot = makeSlotConsumer<SlotName>(SlotContext);
+  Provider.Outlet = makeSlotOutlet<SlotName>(SlotContext);
+  Provider.Fallback = makeSlotFallback<SlotName>(SlotContext);
 
-  return {
-    Provider: SlotProvider,
-    slot: slots,
-  };
+  // Keep `names` reference to preserve the const-narrowed type T
+  void names;
+
+  return Provider;
 }

--- a/static/app/components/core/slot/slot.tsx
+++ b/static/app/components/core/slot/slot.tsx
@@ -111,17 +111,15 @@ interface SlotOutletProps<T extends Slot> {
   name: T;
 }
 
-interface SlotFallbackProps<T extends Slot> {
+interface SlotFallbackProps {
   children: React.ReactNode;
-  name: T;
 }
 
-type SlotProviderComponent<T extends Slot> =
-  React.FunctionComponent<SlotProviderProps> & {
-    Fallback: React.ComponentType<SlotFallbackProps<T>>;
-    Outlet: React.ComponentType<SlotOutletProps<T>>;
-    Slot: React.ComponentType<SlotConsumerProps<T>>;
-  };
+type SlotModule<T extends Slot> = React.FunctionComponent<SlotConsumerProps<T>> & {
+  Fallback: React.ComponentType<SlotFallbackProps>;
+  Outlet: React.ComponentType<SlotOutletProps<T>>;
+  Provider: React.ComponentType<SlotProviderProps>;
+};
 
 function makeSlotConsumer<T extends Slot>(
   context: React.Context<SlotContextValue<T> | null>
@@ -152,7 +150,8 @@ function makeSlotConsumer<T extends Slot>(
 }
 
 function makeSlotOutlet<T extends Slot>(
-  context: React.Context<SlotContextValue<T> | null>
+  context: React.Context<SlotContextValue<T> | null>,
+  outletNameContext: React.Context<T | null>
 ) {
   function SlotOutlet(props: SlotOutletProps<T>): React.ReactNode {
     const ctx = useContext(context);
@@ -174,7 +173,11 @@ function makeSlotOutlet<T extends Slot>(
       [dispatch, name]
     );
 
-    return props.children({ref});
+    return (
+      <outletNameContext.Provider value={name}>
+        {props.children({ref})}
+      </outletNameContext.Provider>
+    );
   }
 
   SlotOutlet.displayName = 'Slot.Outlet';
@@ -182,22 +185,26 @@ function makeSlotOutlet<T extends Slot>(
 }
 
 function makeSlotFallback<T extends Slot>(
-  context: React.Context<SlotContextValue<T> | null>
+  context: React.Context<SlotContextValue<T> | null>,
+  outletNameContext: React.Context<T | null>
 ) {
-  function SlotFallback(props: SlotFallbackProps<T>): React.ReactNode {
+  function SlotFallback({children}: SlotFallbackProps): React.ReactNode {
     const ctx = useContext(context);
     if (!ctx) {
       throw new Error('SlotContext not found');
     }
 
-    const [state] = ctx;
-    const {name} = props;
+    const name = useContext(outletNameContext);
+    if (name === null) {
+      throw new Error('Slot.Fallback must be rendered inside Slot.Outlet');
+    }
 
+    const [state] = ctx;
     if ((state[name]?.counter ?? 0) > 0 || !state[name]?.element) {
       return null;
     }
 
-    return createPortal(props.children, state[name]?.element);
+    return createPortal(children, state[name].element!);
   }
 
   SlotFallback.displayName = 'Slot.Fallback';
@@ -223,22 +230,31 @@ function makeSlotProvider<T extends Slot>(
   return SlotProvider as (props: SlotProviderProps) => React.ReactNode;
 }
 
-export function slot<T extends readonly Slot[]>(
-  names: T
-): SlotProviderComponent<T[number]> {
+export function slot<T extends readonly Slot[]>(names: T): SlotModule<T[number]> {
   type SlotName = T[number];
 
   const SlotContext = createContext<SlotContextValue<SlotName> | null>(null);
-  const Provider = makeSlotProvider<SlotName>(
-    SlotContext
-  ) as SlotProviderComponent<SlotName>;
+  const OutletNameContext = createContext<SlotName | null>(null);
 
-  Provider.Slot = makeSlotConsumer<SlotName>(SlotContext);
-  Provider.Outlet = makeSlotOutlet<SlotName>(SlotContext);
-  Provider.Fallback = makeSlotFallback<SlotName>(SlotContext);
+  const Slot = makeSlotConsumer<SlotName>(SlotContext) as SlotModule<SlotName>;
+  Slot.Provider = makeSlotProvider<SlotName>(SlotContext);
+  Slot.Outlet = makeSlotOutlet<SlotName>(SlotContext, OutletNameContext);
+  Slot.Fallback = makeSlotFallback<SlotName>(SlotContext, OutletNameContext);
 
   // Keep `names` reference to preserve the const-narrowed type T
   void names;
 
-  return Provider;
+  return Slot;
+}
+
+export function withSlots<
+  TComponent extends React.ComponentType<any>,
+  TSlot extends Slot,
+>(
+  Component: TComponent,
+  slotModule: SlotModule<TSlot>
+): TComponent & {Slot: SlotModule<TSlot>} {
+  const WithSlots = Component as TComponent & {Slot: SlotModule<TSlot>};
+  WithSlots.Slot = slotModule;
+  return WithSlots;
 }

--- a/static/app/components/core/slot/slot.tsx
+++ b/static/app/components/core/slot/slot.tsx
@@ -204,7 +204,7 @@ function makeSlotFallback<T extends Slot>(
       return null;
     }
 
-    return createPortal(children, state[name].element!);
+    return createPortal(children, state[name].element);
   }
 
   SlotFallback.displayName = 'Slot.Fallback';

--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {SizeProvider} from '@sentry/scraps/sizeContext';
-import {slot} from '@sentry/scraps/slot';
+import {slot, withSlots} from '@sentry/scraps/slot';
 
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {IconSeer} from 'sentry/icons';
@@ -18,9 +18,9 @@ import {
   PRIMARY_HEADER_HEIGHT,
 } from './constants';
 
-export const TopBarSlot = slot(['Title', 'Actions', 'Feedback'] as const);
+const Slot = slot(['title', 'actions', 'feedback'] as const);
 
-export function TopBar() {
+function TopBarContent() {
   const theme = useTheme();
   const organization = useOrganization({allowNull: true});
   const hasPageFrame = useHasPageFrameFeature();
@@ -49,14 +49,14 @@ export function TopBar() {
       }}
     >
       <SizeProvider size="sm">
-        <TopBarSlot.Outlet name="Title">
+        <Slot.Outlet name="title">
           {props => <Flex {...props} align="center" gap="sm" />}
-        </TopBarSlot.Outlet>
+        </Slot.Outlet>
 
         <Flex align="center" gap="sm">
-          <TopBarSlot.Outlet name="Actions">
+          <Slot.Outlet name="actions">
             {props => <Flex {...props} align="center" gap="sm" />}
-          </TopBarSlot.Outlet>
+          </Slot.Outlet>
 
           {organization && isSeerExplorerEnabled(organization) ? (
             <Button icon={<IconSeer />} onClick={openExplorerPanel}>
@@ -64,23 +64,25 @@ export function TopBar() {
             </Button>
           ) : null}
 
-          <TopBarSlot.Outlet name="Feedback">
+          <Slot.Outlet name="feedback">
             {props => (
               <Flex {...props}>
                 {/* If no component registers a feedback button, show the default one */}
-                <TopBarSlot.Fallback name="Feedback">
+                <Slot.Fallback>
                   <FeedbackButton
                     aria-label={t('Give Feedback')}
                     feedbackOptions={{tags: {'feedback.source': 'top_navigation'}}}
                   >
                     {null}
                   </FeedbackButton>
-                </TopBarSlot.Fallback>
+                </Slot.Fallback>
               </Flex>
             )}
-          </TopBarSlot.Outlet>
+          </Slot.Outlet>
         </Flex>
       </SizeProvider>
     </Flex>
   );
 }
+
+export const TopBar = withSlots(TopBarContent, Slot);

--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -18,13 +18,7 @@ import {
   PRIMARY_HEADER_HEIGHT,
 } from './constants';
 
-const topBarSlot = slot(['Title', 'Actions', 'Feedback'] as const);
-
-export const TopBarSlotProvider = topBarSlot.Provider;
-
-export const TopBarSlots = {
-  ...topBarSlot.slot,
-};
+export const TopBarSlot = slot(['Title', 'Actions', 'Feedback'] as const);
 
 export function TopBar() {
   const theme = useTheme();
@@ -55,16 +49,14 @@ export function TopBar() {
       }}
     >
       <SizeProvider size="sm">
-        <TopBarSlots.Title.Root>
+        <TopBarSlot.Outlet name="Title">
           {props => <Flex {...props} align="center" gap="sm" />}
-        </TopBarSlots.Title.Root>
+        </TopBarSlot.Outlet>
 
         <Flex align="center" gap="sm">
-          <TopBarSlots.Actions.Root>
-            {props => {
-              return <Flex {...props} align="center" gap="sm" />;
-            }}
-          </TopBarSlots.Actions.Root>
+          <TopBarSlot.Outlet name="Actions">
+            {props => <Flex {...props} align="center" gap="sm" />}
+          </TopBarSlot.Outlet>
 
           {organization && isSeerExplorerEnabled(organization) ? (
             <Button icon={<IconSeer />} onClick={openExplorerPanel}>
@@ -72,21 +64,21 @@ export function TopBar() {
             </Button>
           ) : null}
 
-          <TopBarSlots.Feedback.Root>
+          <TopBarSlot.Outlet name="Feedback">
             {props => (
               <Flex {...props}>
                 {/* If no component registers a feedback button, show the default one */}
-                <TopBarSlots.Feedback.Fallback>
+                <TopBarSlot.Fallback name="Feedback">
                   <FeedbackButton
                     aria-label={t('Give Feedback')}
                     feedbackOptions={{tags: {'feedback.source': 'top_navigation'}}}
                   >
                     {null}
                   </FeedbackButton>
-                </TopBarSlots.Feedback.Fallback>
+                </TopBarSlot.Fallback>
               </Flex>
             )}
-          </TopBarSlots.Feedback.Root>
+          </TopBarSlot.Outlet>
         </Flex>
       </SizeProvider>
     </Flex>

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -22,7 +22,7 @@ import {AppBodyContent} from 'sentry/views/app/appBodyContent';
 import {useRegisterDomainViewUsage} from 'sentry/views/insights/common/utils/domainRedirect';
 import {Navigation} from 'sentry/views/navigation';
 import {PrimaryNavigationContextProvider} from 'sentry/views/navigation/primaryNavigationContext';
-import {TopBar, TopBarSlotProvider} from 'sentry/views/navigation/topBar';
+import {TopBar, TopBarSlot} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {OrganizationContainer} from 'sentry/views/organizationContainer';
 import {useReleasesDrawer} from 'sentry/views/releases/drawer/useReleasesDrawer';
@@ -93,13 +93,13 @@ function AppLayout({organization}: LayoutProps) {
           <AppBodyContent>
             {organization && <OrganizationHeader organization={organization} />}
             <OrganizationDetailsBody>
-              <TopBarSlotProvider>
+              <TopBarSlot>
                 <TopBar />
                 <Layout.Page>
                   <Outlet />
                   <Footer />
                 </Layout.Page>
-              </TopBarSlotProvider>
+              </TopBarSlot>
             </OrganizationDetailsBody>
           </AppBodyContent>
         </ContentStack>

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -22,7 +22,7 @@ import {AppBodyContent} from 'sentry/views/app/appBodyContent';
 import {useRegisterDomainViewUsage} from 'sentry/views/insights/common/utils/domainRedirect';
 import {Navigation} from 'sentry/views/navigation';
 import {PrimaryNavigationContextProvider} from 'sentry/views/navigation/primaryNavigationContext';
-import {TopBar, TopBarSlot} from 'sentry/views/navigation/topBar';
+import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {OrganizationContainer} from 'sentry/views/organizationContainer';
 import {useReleasesDrawer} from 'sentry/views/releases/drawer/useReleasesDrawer';
@@ -93,13 +93,13 @@ function AppLayout({organization}: LayoutProps) {
           <AppBodyContent>
             {organization && <OrganizationHeader organization={organization} />}
             <OrganizationDetailsBody>
-              <TopBarSlot>
+              <TopBar.Slot.Provider>
                 <TopBar />
                 <Layout.Page>
                   <Outlet />
                   <Footer />
                 </Layout.Page>
-              </TopBarSlot>
+              </TopBar.Slot.Provider>
             </OrganizationDetailsBody>
           </AppBodyContent>
         </ContentStack>

--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -5,7 +5,7 @@ import {Container, Flex} from '@sentry/scraps/layout';
 
 import {useParams} from 'sentry/utils/useParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
-import {TopBarSlot} from 'sentry/views/navigation/topBar';
+import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import {SettingsBreadcrumb} from './settingsBreadcrumb';
@@ -26,12 +26,12 @@ export function SettingsLayout({children}: Props) {
     <SettingsColumn>
       {hasPageFrame ? (
         <Fragment>
-          <TopBarSlot.Slot name="Title">
+          <TopBar.Slot name="title">
             <StyledSettingsBreadcrumb params={params} routes={routes} />
-          </TopBarSlot.Slot>
-          <TopBarSlot.Slot name="Actions">
+          </TopBar.Slot>
+          <TopBar.Slot name="actions">
             <SettingsSearch />
-          </TopBarSlot.Slot>
+          </TopBar.Slot>
         </Fragment>
       ) : (
         <SettingsHeader>

--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -5,7 +5,7 @@ import {Container, Flex} from '@sentry/scraps/layout';
 
 import {useParams} from 'sentry/utils/useParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
-import {TopBarSlots} from 'sentry/views/navigation/topBar';
+import {TopBarSlot} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import {SettingsBreadcrumb} from './settingsBreadcrumb';
@@ -26,12 +26,12 @@ export function SettingsLayout({children}: Props) {
     <SettingsColumn>
       {hasPageFrame ? (
         <Fragment>
-          <TopBarSlots.Title>
+          <TopBarSlot.Slot name="Title">
             <StyledSettingsBreadcrumb params={params} routes={routes} />
-          </TopBarSlots.Title>
-          <TopBarSlots.Actions>
+          </TopBarSlot.Slot>
+          <TopBarSlot.Slot name="Actions">
             <SettingsSearch />
-          </TopBarSlots.Actions>
+          </TopBarSlot.Slot>
         </Fragment>
       ) : (
         <SettingsHeader>

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -29,7 +29,7 @@ import type {Organization} from 'sentry/types/organization';
 import {DANGEROUS_SET_REACT_ROUTER_6_HISTORY} from 'sentry/utils/browserHistory';
 import {ProvideAriaRouter} from 'sentry/utils/provideAriaRouter';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {TopBarSlotProvider} from 'sentry/views/navigation/topBar';
+import {TopBar} from 'sentry/views/navigation/topBar';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import {LLMContextProvider} from 'sentry/views/seerExplorer/contexts/llmContext';
 
@@ -121,7 +121,7 @@ function makeAllTheProviders(options: ProviderOptions) {
 
   return function ({children}: {children?: React.ReactNode}) {
     const content = (
-      <TopBarSlotProvider>
+      <TopBar.Slot.Provider>
         <LLMContextProvider>
           <OrganizationContext value={optionalOrganization}>
             <GlobalDrawer>
@@ -129,7 +129,7 @@ function makeAllTheProviders(options: ProviderOptions) {
             </GlobalDrawer>
           </OrganizationContext>
         </LLMContextProvider>
-      </TopBarSlotProvider>
+      </TopBar.Slot.Provider>
     );
 
     const wrappedContent = <ProvideAriaRouter>{content}</ProvideAriaRouter>;


### PR DESCRIPTION
Stacked changes on top of #112032 

Simplifies the `@sentry/scraps/slot` API
- Collapses nested namespaced components per-slot with a single typed `name` prop
- Renames `Root` -> `Outlet`
- Exposes `withSlot` as a helper for compound components (`TopBar, TopBarSlot` becomes `TopBar` and `TopBar.Slot`)
- `Slot` consumer becomes the default prop, Provider moved to `Slot.Provider` (internal api, can be more verbose)
- Enforces that `Fallback` is rendered inside of `Outlet`, which allows us to drop the `name` prop

```tsx
// layout.tsx
const Slot = slot(['header', 'footer'] as const);
const Content = ({children}) => (
	<Stack>
		<Slot.Outlet name="header">{props => <header {...props} />}</Slot.Outlet>
			{children}
		<Slot.Outlet name="footer">{props => <footer {...props} />}</Slot.Outlet>
	</Stack>
)
export const Layout = withSlots(Content, Slot);

// my-page.tsx
<Layout.Slot.Provider>
	<Layout>
		<h1>Hello world!</h1>
	</Layout>

	<Layout.Slot name="header">My Page</Layout.Slot>
	<Layout.Slot name="footer">&copy; 2026</Layout.Slot>
</Layout.Slot.Provider>

```