### PR TITLE
fix(aci): Handle invalid project IDs in monitor form

### DIFF
--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -7,7 +7,13 @@ import {
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
 import {OrganizationStore} from 'sentry/stores/organizationStore';
@@ -101,6 +107,27 @@ describe('DetectorEdit', () => {
       url: `/organizations/${organization.slug}/monitors-schedule-buckets/`,
       body: [],
     });
+  });
+
+  it('selects the first project when an invalid project is provided in the URL', async () => {
+    render(<DetectorNewSettings />, {
+      organization,
+      initialRouterConfig: {
+        ...initialRouterConfig,
+        location: {
+          ...initialRouterConfig.location,
+          query: {detectorType: 'metric_issue', project: 'not-a-project-id'},
+        },
+      },
+    });
+
+    await screen.findByText('New Monitor');
+
+    // Verify the project dropdown has the first project selected
+    const projectSection = screen
+      .getByText(/Choose the Project and Environment/)
+      .closest('section')!;
+    expect(within(projectSection).getByText(project.slug)).toBeInTheDocument();
   });
 
   describe('Metric Detector', () => {

--- a/static/app/views/detectors/new-settings.tsx
+++ b/static/app/views/detectors/new-settings.tsx
@@ -40,9 +40,13 @@ export default function DetectorNewSettings() {
     );
   }
 
-  const project = projectId
-    ? projects.find(p => p.id === projectId)
-    : orderBy(projects, ['isMember', 'isBookmarked'], ['desc', 'desc'])[0];
+  const sortedProjects = orderBy(
+    projects,
+    ['isMember', 'isBookmarked'],
+    ['desc', 'desc']
+  );
+  const project =
+    (projectId ? projects.find(p => p.id === projectId) : null) ?? sortedProjects[0];
 
   if (!project) {
     return <LoadingError message={t('Project not found')} />;


### PR DESCRIPTION
Closes ISWF-2339

When All projects is selected, the Save as monitor link sends `project=-1`, which in turn displays "no project found" on the monitor form. This PR handles this situation by falling back to the first available project.