### PR TITLE
feat(seer): Fall back to contextvar ViewerContext for Seer requests

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -11,7 +11,7 @@ from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
 from sentry.net.http import connection_from_url
 from sentry.utils import metrics
-from sentry.viewer_context import get_viewer_context
+from sentry.viewer_context import ViewerContext, get_viewer_context
 
 
 class SeerViewerContext(TypedDict, total=False):
@@ -49,43 +49,65 @@ seer_grouping_default_connection_pool = connection_from_url(
 
 
 def _resolve_viewer_context(
-    explicit: SeerViewerContext | None,
-) -> dict[str, Any] | None:
-    """Build the viewer context payload for Seer requests.
+    explicit: SeerViewerContext | None = None,
+) -> ViewerContext | None:
+    """Merge explicit SeerViewerContext with the contextvar.
 
-    Uses the contextvar as the base. If an explicit SeerViewerContext was
-    passed, its non-None fields win (with a warning on disagreement).
+    Converts the legacy SeerViewerContext into a ViewerContext, then merges
+    with the contextvar. Explicit non-None fields win. On disagreement,
+    logs a warning and strips the token for safety.
     """
     vc = get_viewer_context()
-    if vc is None and explicit is None:
+
+    if explicit is None and vc is None:
         return None
+    if explicit is None:
+        return vc
 
-    result: dict[str, Any] = {}
-    if vc is not None:
-        if vc.organization_id is not None:
-            result["organization_id"] = vc.organization_id
-        if vc.user_id is not None:
-            result["user_id"] = vc.user_id
-        result["actor_type"] = vc.actor_type.value
-        if vc.token is not None:
-            result["token"] = {"kind": vc.token.kind, "scopes": list(vc.token.get_scopes())}
+    explicit_vc = ViewerContext(
+        organization_id=explicit.get("organization_id"),
+        user_id=explicit.get("user_id"),
+    )
 
-    if explicit:
-        has_mismatch = False
-        for field in ("organization_id", "user_id"):
-            val = explicit.get(field)  # type: ignore[literal-required]
-            if val is not None and field in result and result[field] != val:
-                logger.warning(
-                    "seer.viewer_context_mismatch",
-                    extra={"field": field, "contextvar": result[field], "explicit": val},
-                )
-                has_mismatch = True
-            if val is not None:
-                result[field] = val
-        if has_mismatch:
-            result.pop("token", None)
+    if vc is None:
+        return explicit_vc
 
-    return result or None
+    has_mismatch = False
+    org_id = vc.organization_id
+    user_id = vc.user_id
+
+    if explicit_vc.organization_id is not None:
+        if org_id is not None and org_id != explicit_vc.organization_id:
+            logger.warning(
+                "seer.viewer_context_mismatch",
+                extra={
+                    "field": "organization_id",
+                    "contextvar": org_id,
+                    "explicit": explicit_vc.organization_id,
+                },
+            )
+            has_mismatch = True
+        org_id = explicit_vc.organization_id
+
+    if explicit_vc.user_id is not None:
+        if user_id is not None and user_id != explicit_vc.user_id:
+            logger.warning(
+                "seer.viewer_context_mismatch",
+                extra={
+                    "field": "user_id",
+                    "contextvar": user_id,
+                    "explicit": explicit_vc.user_id,
+                },
+            )
+            has_mismatch = True
+        user_id = explicit_vc.user_id
+
+    return ViewerContext(
+        organization_id=org_id,
+        user_id=user_id,
+        actor_type=vc.actor_type,
+        token=None if has_mismatch else vc.token,
+    )
 
 
 @sentry_sdk.tracing.trace
@@ -113,11 +135,11 @@ def make_signed_seer_api_request(
         **auth_headers,
     }
 
-    resolved_context = _resolve_viewer_context(viewer_context)
-    if resolved_context:
+    resolved = _resolve_viewer_context(viewer_context)
+    if resolved:
         if settings.SEER_API_SHARED_SECRET:
             try:
-                context_bytes = orjson.dumps(resolved_context)
+                context_bytes = orjson.dumps(resolved.serialize())
                 context_signature = sign_viewer_context(context_bytes)
                 headers["X-Viewer-Context"] = context_bytes.decode("utf-8")
                 headers["X-Viewer-Context-Signature"] = context_signature

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -11,6 +11,7 @@ from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
 from sentry.net.http import connection_from_url
 from sentry.utils import metrics
+from sentry.viewer_context import get_viewer_context
 
 
 class SeerViewerContext(TypedDict, total=False):
@@ -47,6 +48,46 @@ seer_grouping_default_connection_pool = connection_from_url(
 )
 
 
+def _resolve_viewer_context(
+    explicit: SeerViewerContext | None,
+) -> dict[str, Any] | None:
+    """Build the viewer context payload for Seer requests.
+
+    Uses the contextvar as the base. If an explicit SeerViewerContext was
+    passed, its non-None fields win (with a warning on disagreement).
+    """
+    vc = get_viewer_context()
+    if vc is None and explicit is None:
+        return None
+
+    result: dict[str, Any] = {}
+    if vc is not None:
+        if vc.organization_id is not None:
+            result["organization_id"] = vc.organization_id
+        if vc.user_id is not None:
+            result["user_id"] = vc.user_id
+        result["actor_type"] = vc.actor_type.value
+        if vc.token is not None:
+            result["token"] = {"kind": vc.token.kind, "scopes": list(vc.token.get_scopes())}
+
+    if explicit:
+        has_mismatch = False
+        for field in ("organization_id", "user_id"):
+            val = explicit.get(field)  # type: ignore[literal-required]
+            if val is not None and field in result and result[field] != val:
+                logger.warning(
+                    "seer.viewer_context_mismatch",
+                    extra={"field": field, "contextvar": result[field], "explicit": val},
+                )
+                has_mismatch = True
+            if val is not None:
+                result[field] = val
+        if has_mismatch:
+            result.pop("token", None)
+
+    return result or None
+
+
 @sentry_sdk.tracing.trace
 def make_signed_seer_api_request(
     connection_pool: HTTPConnectionPool,
@@ -72,10 +113,11 @@ def make_signed_seer_api_request(
         **auth_headers,
     }
 
-    if viewer_context:
+    resolved_context = _resolve_viewer_context(viewer_context)
+    if resolved_context:
         if settings.SEER_API_SHARED_SECRET:
             try:
-                context_bytes = orjson.dumps(viewer_context)
+                context_bytes = orjson.dumps(resolved_context)
                 context_signature = sign_viewer_context(context_bytes)
                 headers["X-Viewer-Context"] = context_bytes.decode("utf-8")
                 headers["X-Viewer-Context-Signature"] = context_signature

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -5,7 +5,7 @@ import contextvars
 import dataclasses
 import enum
 from collections.abc import Generator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from sentry.auth.services.auth import AuthenticatedToken
@@ -50,6 +50,17 @@ class ViewerContext:
     # Carries scopes/kind for in-process permission checks.
     # NOT propagated across process/service boundaries.
     token: AuthenticatedToken | None = None
+
+    def serialize(self) -> dict[str, Any]:
+        """Serialize to a dict for cross-service headers (e.g. X-Viewer-Context)."""
+        result: dict[str, Any] = {"actor_type": self.actor_type.value}
+        if self.organization_id is not None:
+            result["organization_id"] = self.organization_id
+        if self.user_id is not None:
+            result["user_id"] = self.user_id
+        if self.token is not None:
+            result["token"] = {"kind": self.token.kind, "scopes": list(self.token.get_scopes())}
+        return result
 
 
 @contextlib.contextmanager

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -88,7 +88,9 @@ class TestGetEventSeverity(TestCase):
             override_settings(SEER_API_SHARED_SECRET="some-secret"),
         ):
             _get_severity_score(event)
-            viewer_context_bytes = orjson.dumps({"organization_id": self.project.organization_id})
+            viewer_context_bytes = orjson.dumps(
+                {"actor_type": "unknown", "organization_id": self.project.organization_id}
+            )
             mock_urlopen.assert_called_with(
                 "POST",
                 "/v0/issues/severity-score",

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -3,7 +3,13 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from django.test import override_settings
 
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.auth.services.auth import AuthenticatedToken
+from sentry.seer.signed_seer_api import (
+    SeerViewerContext,
+    _resolve_viewer_context,
+    make_signed_seer_api_request,
+)
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 REQUEST_BODY = b'{"b": 12, "thing": "thing"}'
 PATH = "/v0/some/url"
@@ -111,3 +117,79 @@ def test_times_request(mock_metrics_timer: MagicMock, path: str) -> None:
             "endpoint": PATH,
         },
     )
+
+
+class TestResolveViewerContext:
+    def test_both_none(self) -> None:
+        assert _resolve_viewer_context(None) is None
+
+    def test_contextvar_only(self) -> None:
+        ctx = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        with viewer_context_scope(ctx):
+            result = _resolve_viewer_context(None)
+
+        assert result is not None
+        assert result.organization_id == 42
+        assert result.user_id == 7
+        assert result.actor_type == ActorType.USER
+
+    def test_explicit_only(self) -> None:
+        result = _resolve_viewer_context(SeerViewerContext(organization_id=99, user_id=5))
+        assert result is not None
+        assert result.organization_id == 99
+        assert result.user_id == 5
+
+    def test_contextvar_with_token(self) -> None:
+        token = AuthenticatedToken(
+            kind="api_token",
+            scopes=["org:read", "project:write"],
+            allowed_origins=[],
+        )
+        ctx = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER, token=token)
+        with viewer_context_scope(ctx):
+            result = _resolve_viewer_context(None)
+
+        assert result is not None
+        assert result.token is not None
+        assert result.token.kind == "api_token"
+        assert set(result.token.get_scopes()) == {"org:read", "project:write"}
+
+    def test_explicit_overrides_contextvar(self) -> None:
+        ctx = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        with viewer_context_scope(ctx):
+            result = _resolve_viewer_context(SeerViewerContext(organization_id=42, user_id=99))
+
+        assert result is not None
+        assert result.organization_id == 42
+        assert result.user_id == 99
+        assert result.actor_type == ActorType.USER
+
+    @patch("sentry.seer.signed_seer_api.logger")
+    def test_mismatch_warns_and_strips_token(self, mock_logger: MagicMock) -> None:
+        token = AuthenticatedToken(
+            kind="api_token",
+            scopes=["org:read"],
+            allowed_origins=[],
+        )
+        ctx = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER, token=token)
+        with viewer_context_scope(ctx):
+            result = _resolve_viewer_context(SeerViewerContext(organization_id=999))
+
+        assert result is not None
+        assert result.organization_id == 999
+        assert result.token is None
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args[0][0] == "seer.viewer_context_mismatch"
+
+    def test_no_mismatch_keeps_token(self) -> None:
+        token = AuthenticatedToken(
+            kind="api_token",
+            scopes=["org:read"],
+            allowed_origins=[],
+        )
+        ctx = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER, token=token)
+        with viewer_context_scope(ctx):
+            result = _resolve_viewer_context(SeerViewerContext(organization_id=42, user_id=7))
+
+        assert result is not None
+        assert result.token is not None


### PR DESCRIPTION
`make_signed_seer_api_request` now auto-reads from the `ViewerContext` contextvar when no explicit `viewer_context` parameter is passed. This means Seer calls made during API requests (where the middleware sets the contextvar) automatically get identity context without callers needing to construct and pass `SeerViewerContext`.

**Behavior:**
- Contextvar is the base — includes `actor_type` and `token` (kind + scopes) when available
- Explicit `SeerViewerContext` param overrides `organization_id` / `user_id` if passed
- If both exist and disagree on non-None values, logs `seer.viewer_context_mismatch` warning and strips the token from the payload

This is safe to land independently — it's a no-op until the ViewerContext middleware is enabled (`viewer-context.enabled` option). Existing callers that pass explicit context continue to work unchanged.

Part of the [ViewerContext RFC](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02).