### PR TITLE
feat(repos): Add routings for github `installation_repositories` webhook

### DIFF
--- a/src/sentry/integrations/github/webhook_types.py
+++ b/src/sentry/integrations/github/webhook_types.py
@@ -22,7 +22,10 @@ class GithubWebhookType(StrEnum):
 
 
 # Event type strings (X-GitHub-Event header values) that the cell webhook endpoint processes.
-# INSTALLATION is handled in control only.
+# INSTALLATION and INSTALLATION_REPOSITORIES are handled in control only.
+_CONTROL_ONLY_EVENTS = frozenset(
+    {GithubWebhookType.INSTALLATION, GithubWebhookType.INSTALLATION_REPOSITORIES}
+)
 CELL_PROCESSED_GITHUB_EVENTS = frozenset(
-    t.value for t in GithubWebhookType if t != GithubWebhookType.INSTALLATION
+    t.value for t in GithubWebhookType if t not in _CONTROL_ONLY_EVENTS
 )

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -77,7 +77,11 @@ class GithubRequestParser(BaseRequestParser):
     def should_route_to_control_silo(
         self, parsed_event: Mapping[str, Any], request: HttpRequest
     ) -> bool:
-        return request.META.get(GITHUB_WEBHOOK_TYPE_HEADER) == GithubWebhookType.INSTALLATION
+        event_type = request.META.get(GITHUB_WEBHOOK_TYPE_HEADER)
+        return event_type in (
+            GithubWebhookType.INSTALLATION,
+            GithubWebhookType.INSTALLATION_REPOSITORIES,
+        )
 
     @control_silo_function
     def get_integration_from_request(self) -> Integration | None:

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -15,9 +15,9 @@ from sentry.integrations.github.webhook import (
     get_github_external_id,
 )
 from sentry.integrations.github.webhook_types import (
+    _CONTROL_ONLY_EVENTS,
     CELL_PROCESSED_GITHUB_EVENTS,
     GITHUB_WEBHOOK_TYPE_HEADER,
-    GithubWebhookType,
 )
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
@@ -77,11 +77,7 @@ class GithubRequestParser(BaseRequestParser):
     def should_route_to_control_silo(
         self, parsed_event: Mapping[str, Any], request: HttpRequest
     ) -> bool:
-        event_type = request.META.get(GITHUB_WEBHOOK_TYPE_HEADER)
-        return event_type in (
-            GithubWebhookType.INSTALLATION,
-            GithubWebhookType.INSTALLATION_REPOSITORIES,
-        )
+        return request.META.get(GITHUB_WEBHOOK_TYPE_HEADER) in _CONTROL_ONLY_EVENTS
 
     @control_silo_function
     def get_integration_from_request(self) -> Integration | None:


### PR DESCRIPTION
We had to revert https://github.com/getsentry/sentry/pull/111864 because the webhooks were being routed to cells. This is because we deploy cells first, then control, and so the routing wasn't in place. Adding this routing first, then we'll merge the webhook itself after this deploys.

<!-- Describe your PR here. -->