### PR TITLE
chore(ACI): Add a flag to incident details GET method

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -447,6 +447,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for OrganizationCombinedRuleIndexEndpoint.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-combinedruleindex-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use workflow engine exclusively for OrganizationIncidentDetailsEndpoint.get results.
+    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
+    manager.add("organizations:workflow-engine-orgincidentdetails-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use workflow engine exclusively for legacy issue alert rule.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-issue-alert-endpoints-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -72,9 +72,11 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
-        if request.method == "GET" and features.has(
-            "organizations:workflow-engine-rule-serializers", organization
-        ):
+        has_workflow_engine_flags = features.has(
+            "organizations:workflow-engine-orgincidentdetails-get", organization
+        ) or features.has("organizations:workflow-engine-rule-serializers", organization)
+
+        if request.method == "GET" and has_workflow_engine_flags:
             gop: GroupOpenPeriod | None = None
 
             # Try the association table first (dual-written data).


### PR DESCRIPTION
We're ready to roll out the metric alert and incident GET methods so this PR puts a flag around the incident details GET method to use the backwards compatible serializer.