### PR TITLE
feat(seer): Add preamble to structured page context markdown

### DIFF
--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -369,4 +369,7 @@ def snapshot_to_markdown(snapshot: dict[str, Any]) -> str:
     nodes = snapshot.get("nodes", [])
     if not nodes:
         return ""
-    return _render_node(nodes[0], 0)
+    preamble = (
+        "> This is a structured summary of the page the user is viewing, not an exact screenshot.\n"
+    )
+    return preamble + _render_node(nodes[0], 0)

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -242,7 +242,8 @@ class SnapshotToMarkdownTest(TestCase):
             "nodes": [{"nodeType": "dashboard", "data": None, "children": []}],
         }
         result = snapshot_to_markdown(snapshot)
-        assert result == "# dashboard"
+        assert "# dashboard" in result
+        assert "not an exact screenshot" in result
 
     def test_node_with_non_dict_data(self) -> None:
         snapshot = {


### PR DESCRIPTION
+ Prepend a blockquote explaining that the content is a structured summary, not an exact screenshot. This helps the LLM understand the context type and also serves as a marker to differentiate structured context from raw ASCII screenshots downstream.
+ Planning to add a few more lines to this preamble later too
