### PR TITLE
feat(assisted-query): Add metrics search feature flag and forward options

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -124,6 +124,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the 'translate' functionality for GenAI on the explore > traces page
     manager.add("organizations:gen-ai-search-agent-translate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable AI search bar on the explore > metrics tab
+    manager.add("organizations:gen-ai-explore-metrics-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable increased issue_owners rate limit for auto-assignment

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -66,7 +66,7 @@ def send_search_agent_start_request(
     strategy: str = "Traces",
     user_email: str | None = None,
     timezone: str | None = None,
-    model_name: str | None = None,
+    options: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
 ) -> dict[str, Any]:
     """
@@ -83,10 +83,6 @@ def send_search_agent_start_request(
         body["user_email"] = user_email
     if timezone:
         body["timezone"] = timezone
-
-    options: dict[str, Any] = {}
-    if model_name is not None:
-        options["model_name"] = model_name
     if options:
         body["options"] = options
 
@@ -128,16 +124,22 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
         natural_language_query = validated_data["natural_language_query"]
         strategy = validated_data.get("strategy", "Traces")
         options = validated_data.get("options") or {}
-        model_name = options.get("model_name")
 
         projects = self.get_projects(
             request, organization, project_ids=set(validated_data["project_ids"])
         )
         project_ids = [project.id for project in projects]
 
-        if not features.has(
+        has_feature = features.has(
             "organizations:gen-ai-search-agent-translate", organization, actor=request.user
-        ):
+        )
+        if strategy == "Metrics":
+            has_feature = has_feature or features.has(
+                "organizations:gen-ai-explore-metrics-search",
+                organization,
+                actor=request.user,
+            )
+        if not has_feature:
             return Response(
                 {"detail": "Feature flag not enabled"},
                 status=status.HTTP_403_FORBIDDEN,
@@ -173,7 +175,7 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
                 strategy=strategy,
                 user_email=user_email,
                 timezone=timezone,
-                model_name=model_name,
+                options=options if options else None,
                 viewer_context=viewer_context,
             )
 

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -134,7 +134,7 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
             "organizations:gen-ai-search-agent-translate", organization, actor=request.user
         )
         if strategy == "Metrics":
-            has_feature = has_feature or features.has(
+            has_feature = has_feature and features.has(
                 "organizations:gen-ai-explore-metrics-search",
                 organization,
                 actor=request.user,

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -66,7 +66,8 @@ def send_search_agent_start_request(
     strategy: str = "Traces",
     user_email: str | None = None,
     timezone: str | None = None,
-    options: dict[str, Any] | None = None,
+    model_name: str | None = None,
+    metric_context: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
 ) -> dict[str, Any]:
     """
@@ -83,6 +84,12 @@ def send_search_agent_start_request(
         body["user_email"] = user_email
     if timezone:
         body["timezone"] = timezone
+
+    options: dict[str, Any] = {}
+    if model_name is not None:
+        options["model_name"] = model_name
+    if metric_context is not None:
+        options["metric_context"] = metric_context
     if options:
         body["options"] = options
 
@@ -124,6 +131,8 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
         natural_language_query = validated_data["natural_language_query"]
         strategy = validated_data.get("strategy", "Traces")
         options = validated_data.get("options") or {}
+        model_name = options.get("model_name")
+        metric_context = options.get("metric_context")
 
         projects = self.get_projects(
             request, organization, project_ids=set(validated_data["project_ids"])
@@ -175,7 +184,8 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
                 strategy=strategy,
                 user_email=user_email,
                 timezone=timezone,
-                options=options if options else None,
+                model_name=model_name,
+                metric_context=metric_context,
                 viewer_context=viewer_context,
             )
 

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -81,9 +81,12 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
                 }
             }
         """
-        if not features.has(
+        has_feature = features.has(
             "organizations:gen-ai-search-agent-translate", organization, actor=request.user
-        ):
+        ) or features.has(
+            "organizations:gen-ai-explore-metrics-search", organization, actor=request.user
+        )
+        if not has_feature:
             return Response(
                 {"detail": "Feature flag not enabled"},
                 status=status.HTTP_403_FORBIDDEN,

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -83,7 +83,7 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
         """
         has_feature = features.has(
             "organizations:gen-ai-search-agent-translate", organization, actor=request.user
-        ) or features.has(
+        ) and features.has(
             "organizations:gen-ai-explore-metrics-search", organization, actor=request.user
         )
         if not has_feature:

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -83,7 +83,7 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
         """
         has_feature = features.has(
             "organizations:gen-ai-search-agent-translate", organization, actor=request.user
-        ) and features.has(
+        ) or features.has(
             "organizations:gen-ai-explore-metrics-search", organization, actor=request.user
         )
         if not has_feature:


### PR DESCRIPTION
## Summary
- Register `gen-ai-explore-metrics-search` feature flag to gate the metrics AI search bar independently
- Update `SearchAgentStartEndpoint` to accept the new flag when strategy is "Metrics"
- Forward the full `options` dict to Seer instead of extracting only `model_name`, so strategy-specific context (like `metric_context`) passes through

## Test plan
- [ ] Verify the `gen-ai-explore-metrics-search` flag is registered and exposed to the frontend
- [ ] Verify the endpoint accepts requests with `strategy: "Metrics"` when the new flag is enabled
- [ ] Verify the full `options` dict is forwarded to Seer