### PR TITLE
fix(profiling): Query `spans` instead of `discover` on landing page

### DIFF
--- a/static/app/utils/profiling/hooks/useProfileEvents.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.spec.tsx
@@ -26,8 +26,9 @@ describe('useProfileEvents', () => {
       body,
       match: [
         MockApiClient.matchQuery({
-          dataset: 'discover',
-          query: '(has:profile.id OR (has:profiler.id has:thread.id)) (transaction:foo)',
+          dataset: 'spans',
+          query:
+            'is_transaction:true (has:profile.id OR (has:profiler.id has:thread.id)) (transaction:foo)',
         }),
       ],
     });
@@ -54,7 +55,7 @@ describe('useProfileEvents', () => {
       url: `/organizations/${organization.slug}/events/`,
       status: 400,
       statusCode: 400,
-      match: [MockApiClient.matchQuery({dataset: 'discover'})],
+      match: [MockApiClient.matchQuery({dataset: 'spans'})],
     });
 
     const {result} = renderHookWithProviders(useProfileEvents, {

--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -35,11 +35,11 @@ export function useProfileEvents<F extends string>({
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
-  query = `(has:profile.id OR (has:profiler.id has:thread.id)) ${query ? `(${query})` : ''}`;
+  query = `is_transaction:true (has:profile.id OR (has:profiler.id has:thread.id)) ${query ? `(${query})` : ''}`;
 
   const endpointOptions = {
     query: {
-      dataset: 'discover',
+      dataset: 'spans',
       referrer,
       project: projects || selection.projects,
       environment: selection.environments,
@@ -88,5 +88,4 @@ type ProfilingFieldType =
   | 'p75()'
   | 'p95()'
   | 'p99()'
-  | 'count()'
-  | 'last_seen()';
+  | 'count()';

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -397,7 +397,6 @@ function ProfilingContentPageHeader() {
 const ALL_FIELDS = [
   'transaction',
   'project.id',
-  'last_seen()',
   'p50()',
   'p75()',
   'p95()',


### PR DESCRIPTION
Searching transactions is going away as we move away from transactions as the SDK's transport for spans. On the **Explore** -> **Profiles** landing page's transactions table, query the `spans` (EAP) dataset with an extra `is_transaction:true` clause instead of the deprecated `discover` (behind the scenes: `transactions`) dataset.

The only consequence is that we lose the **Last Seen** column, because this function is missing from EAP.

Fixes DAIN-1448.

<img width="1566" height="351" alt="Screenshot 2026-04-07 at 15 41 04" src="https://github.com/user-attachments/assets/14ac86c4-f539-4117-b457-d603bebda745" />