### PR TITLE
ref(profiles): Remove dead code from `process_profile_task`

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from operator import itemgetter
 from time import time
-from typing import Any, TypedDict
+from typing import Any
 from uuid import UUID
 
 import msgpack
@@ -1093,11 +1093,6 @@ def clean_android_js_profile(profile: Profile) -> None:
     del p["event_id"]
     del p["release"]
     del p["dist"]
-
-
-class _ProjectKeyKwargs(TypedDict):
-    project_id: int
-    use_case: str
 
 
 @metrics.wraps("process_profile.track_outcome")

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -58,7 +58,6 @@ from sentry.profiles.java import (
 from sentry.profiles.utils import (
     Profile,
     apply_stack_trace_rules_to_profile,
-    get_from_profiling_service,
 )
 from sentry.search.utils import DEVICE_CLASS
 from sentry.signals import first_profile_received
@@ -1073,62 +1072,6 @@ def _track_failed_outcome(profile: Profile, project: Project, reason: str) -> No
         categories=categories,
         reason=reason,
     )
-
-
-@metrics.wraps("process_profile.insert_vroom_profile")
-def _insert_vroom_profile(profile: Profile) -> bool:
-    with sentry_sdk.start_span(op="task.profiling.insert_vroom"):
-        try:
-            path = "/chunk" if "profiler_id" in profile else "/profile"
-            response = get_from_profiling_service(
-                method="POST",
-                path=path,
-                json_data=profile,
-                metric=(
-                    "profiling.profile.payload.size",
-                    {
-                        "type": "chunk" if "profiler_id" in profile else "profile",
-                        "platform": profile["platform"],
-                    },
-                ),
-            )
-
-            sentry_sdk.set_tag("vroom.response.status_code", str(response.status))
-
-            reason = "bad status"
-
-            if response.status == 204:
-                return True
-            elif response.status == 429:
-                reason = "gcs timeout"
-            elif response.status == 412:
-                reason = "duplicate profile"
-
-            metrics.incr(
-                "process_profile.insert_vroom_profile.error",
-                tags={
-                    "platform": profile["platform"],
-                    "reason": reason,
-                    "status_code": response.status,
-                },
-                sample_rate=1.0,
-            )
-            return False
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
-            metrics.incr(
-                "process_profile.insert_vroom_profile.error",
-                tags={"platform": profile["platform"], "reason": "encountered error"},
-                sample_rate=1.0,
-            )
-            return False
-
-
-def _push_profile_to_vroom(profile: Profile, project: Project) -> bool:
-    if _insert_vroom_profile(profile=profile):
-        return True
-    _track_failed_outcome(profile, project, "profiling_failed_vroom_insertion")
-    return False
 
 
 def prepare_android_js_profile(profile: Profile) -> None:


### PR DESCRIPTION
Remove dead profile insertion code (unused since https://github.com/getsentry/sentry/pull/102210; insertion now handled by vroomrs) and the dead `_ProjectKeyKwargs` struct (unused since https://github.com/getsentry/sentry/pull/81957).