### PR TITLE
fix(autofix): On repo hide, delete corresponding SeerProjectRepository rows

### DIFF
--- a/src/sentry/deletions/defaults/repository.py
+++ b/src/sentry/deletions/defaults/repository.py
@@ -10,11 +10,13 @@ def _get_repository_child_relations(instance: Repository) -> list[BaseRelation]:
     )
     from sentry.models.commit import Commit
     from sentry.models.pullrequest import PullRequest
+    from sentry.seer.models.project_repository import SeerProjectRepository
 
     return [
         ModelRelation(Commit, {"repository_id": instance.id}),
         ModelRelation(PullRequest, {"repository_id": instance.id}),
         ModelRelation(RepositoryProjectPathConfig, {"repository_id": instance.id}),
+        ModelRelation(SeerProjectRepository, {"repository_id": instance.id}),
     ]
 
 

--- a/tests/sentry/deletions/test_repository.py
+++ b/tests/sentry/deletions/test_repository.py
@@ -14,6 +14,7 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.models.repository import Repository
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 
@@ -21,6 +22,7 @@ from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 class DeleteRepositoryTest(TransactionTestCase, HybridCloudTestMixin):
     def test_simple(self) -> None:
         org = self.create_organization()
+        project = self.create_project(organization=org)
         repo = Repository.objects.create(
             organization_id=org.id,
             provider="dummy",
@@ -63,6 +65,10 @@ class DeleteRepositoryTest(TransactionTestCase, HybridCloudTestMixin):
             created_at=timezone.now(),
             updated_at=timezone.now(),
         )
+        seer_project_repo = SeerProjectRepository.objects.create(
+            project=project,
+            repository=repo,
+        )
 
         self.ScheduledDeletion.schedule(instance=repo, days=0)
 
@@ -73,6 +79,7 @@ class DeleteRepositoryTest(TransactionTestCase, HybridCloudTestMixin):
         assert not Commit.objects.filter(id=commit.id).exists()
         assert not PullRequest.objects.filter(id=pull.id).exists()
         assert not PullRequestComment.objects.filter(id=comment.id).exists()
+        assert not SeerProjectRepository.objects.filter(id=seer_project_repo.id).exists()
         assert Commit.objects.filter(id=commit2.id).exists()
 
     def test_codeowners(self) -> None:


### PR DESCRIPTION
When repo is hidden, add `SeerProjectRepository` to list of repo child relations to make sure it gets deleted. Corresponds to Seer's [`remove_repository_from_project_preference`](https://github.com/getsentry/seer/blob/fe644b6d5cff9e58ecfc1c846ba59545f468a5e5/src/seer/automation/preferences.py#L172). 