### PR TITLE
ref(onboarding): Gate platform detection API call to GitHub provider only

### DIFF
--- a/static/app/views/onboarding/components/useScmPlatformDetection.spec.tsx
+++ b/static/app/views/onboarding/components/useScmPlatformDetection.spec.tsx
@@ -1,5 +1,6 @@
 import {DetectedPlatformFixture} from 'sentry-fixture/detectedPlatform';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RepositoryFixture} from 'sentry-fixture/repository';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -7,6 +8,10 @@ import {useScmPlatformDetection} from './useScmPlatformDetection';
 
 describe('useScmPlatformDetection', () => {
   const organization = OrganizationFixture();
+  const githubRepo = RepositoryFixture({
+    id: '42',
+    provider: {id: 'integrations:github', name: 'GitHub'},
+  });
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
@@ -29,7 +34,7 @@ describe('useScmPlatformDetection', () => {
       body: {platforms: mockPlatforms},
     });
 
-    const {result} = renderHookWithProviders(() => useScmPlatformDetection('42'), {
+    const {result} = renderHookWithProviders(() => useScmPlatformDetection(githubRepo), {
       organization,
     });
 
@@ -38,7 +43,7 @@ describe('useScmPlatformDetection', () => {
     });
   });
 
-  it('returns empty array when repoId is undefined', () => {
+  it('returns empty array when repository is undefined', () => {
     const apiMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/undefined/platforms/`,
       body: {platforms: []},
@@ -58,7 +63,7 @@ describe('useScmPlatformDetection', () => {
       body: {platforms: []},
     });
 
-    const {result} = renderHookWithProviders(() => useScmPlatformDetection('42'), {
+    const {result} = renderHookWithProviders(() => useScmPlatformDetection(githubRepo), {
       organization,
     });
 
@@ -72,12 +77,33 @@ describe('useScmPlatformDetection', () => {
       body: {detail: 'Internal Error'},
     });
 
-    const {result} = renderHookWithProviders(() => useScmPlatformDetection('42'), {
+    const {result} = renderHookWithProviders(() => useScmPlatformDetection(githubRepo), {
       organization,
     });
 
     await waitFor(() => {
       expect(result.current.isError).toBe(true);
     });
+  });
+
+  it('skips detection for non-GitHub providers', () => {
+    const gitlabRepo = RepositoryFixture({
+      id: '99',
+      provider: {id: 'integrations:gitlab', name: 'GitLab'},
+    });
+
+    const apiMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/99/platforms/`,
+      body: {platforms: []},
+    });
+
+    const {result} = renderHookWithProviders(() => useScmPlatformDetection(gitlabRepo), {
+      organization,
+    });
+
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(result.current.detectedPlatforms).toEqual([]);
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isError).toBe(false);
   });
 });

--- a/static/app/views/onboarding/components/useScmPlatformDetection.ts
+++ b/static/app/views/onboarding/components/useScmPlatformDetection.ts
@@ -1,3 +1,4 @@
+import type {Repository} from 'sentry/types/integrations';
 import type {PlatformKey} from 'sentry/types/project';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchDataQuery, useQuery} from 'sentry/utils/queryClient';
@@ -15,8 +16,12 @@ interface PlatformDetectionResponse {
   platforms: DetectedPlatform[];
 }
 
-export function useScmPlatformDetection(repoId: string | undefined) {
+const SUPPORTED_PROVIDER = 'integrations:github';
+
+export function useScmPlatformDetection(repository: Repository | undefined) {
   const organization = useOrganization();
+  const repoId = repository?.id;
+  const isSupported = repository?.provider.id === SUPPORTED_PROVIDER;
 
   const query = useQuery({
     queryKey: [
@@ -32,14 +37,16 @@ export function useScmPlatformDetection(repoId: string | undefined) {
       return fetchDataQuery<PlatformDetectionResponse>(context);
     },
     staleTime: 30_000,
-    enabled: !!repoId,
+    enabled: !!repoId && isSupported,
   });
 
   const {data} = query;
 
   return {
     detectedPlatforms: data?.[0]?.platforms ?? [],
-    isPending: query.isPending,
+    // Use isLoading (isPending && isFetching) so that disabled queries
+    // (non-GitHub providers) report false instead of the idle-pending state.
+    isPending: query.isPending && query.fetchStatus !== 'idle',
     isError: query.isError,
   };
 }

--- a/static/app/views/onboarding/components/useScmPlatformDetection.ts
+++ b/static/app/views/onboarding/components/useScmPlatformDetection.ts
@@ -1,7 +1,8 @@
+import {skipToken, useQuery} from '@tanstack/react-query';
+
 import type {Repository} from 'sentry/types/integrations';
 import type {PlatformKey} from 'sentry/types/project';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {fetchDataQuery, useQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export interface DetectedPlatform {
@@ -23,27 +24,21 @@ export function useScmPlatformDetection(repository: Repository | undefined) {
   const repoId = repository?.id;
   const isSupported = repository?.provider.id === SUPPORTED_PROVIDER;
 
-  const query = useQuery({
-    queryKey: [
-      getApiUrl('/organizations/$organizationIdOrSlug/repos/$repoId/platforms/', {
-        path: {
-          organizationIdOrSlug: organization.slug,
-          repoId: repoId!,
-        },
-      }),
-      {method: 'GET'},
-    ] as const,
-    queryFn: async context => {
-      return fetchDataQuery<PlatformDetectionResponse>(context);
-    },
-    staleTime: 30_000,
-    enabled: !!repoId && isSupported,
-  });
-
-  const {data} = query;
+  const query = useQuery(
+    apiOptions.as<PlatformDetectionResponse>()(
+      '/organizations/$organizationIdOrSlug/repos/$repoId/platforms/',
+      {
+        path:
+          repoId && isSupported
+            ? {organizationIdOrSlug: organization.slug, repoId}
+            : skipToken,
+        staleTime: 30_000,
+      }
+    )
+  );
 
   return {
-    detectedPlatforms: data?.[0]?.platforms ?? [],
+    detectedPlatforms: query.data?.platforms ?? [],
     // Use isLoading so that disabled queries (non-GitHub providers)
     // report false instead of the idle-pending state.
     isPending: query.isLoading,

--- a/static/app/views/onboarding/components/useScmPlatformDetection.ts
+++ b/static/app/views/onboarding/components/useScmPlatformDetection.ts
@@ -44,9 +44,9 @@ export function useScmPlatformDetection(repository: Repository | undefined) {
 
   return {
     detectedPlatforms: data?.[0]?.platforms ?? [],
-    // Use isLoading (isPending && isFetching) so that disabled queries
-    // (non-GitHub providers) report false instead of the idle-pending state.
-    isPending: query.isPending && query.fetchStatus !== 'idle',
+    // Use isLoading so that disabled queries (non-GitHub providers)
+    // report false instead of the idle-pending state.
+    isPending: query.isLoading,
     isError: query.isError,
   };
 }

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -42,7 +42,7 @@ export function ScmConnect({onComplete}: StepProps) {
   } = useScmProviders();
 
   // Pre-warm platform detection so results are cached when the user advances
-  useScmPlatformDetection(selectedRepository?.id);
+  useScmPlatformDetection(selectedRepository);
 
   // Derive integration from explicit selection, falling back to existing
   const effectiveIntegration = selectedIntegration ?? activeIntegrationExisting;

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -59,7 +59,10 @@ function makeOnboardingWrapper(initialState?: OnboardingSessionState) {
   };
 }
 
-const mockRepository = RepositoryFixture({id: '42'});
+const mockRepository = RepositoryFixture({
+  id: '42',
+  provider: {id: 'integrations:github', name: 'GitHub'},
+});
 
 describe('ScmPlatformFeatures', () => {
   const organization = OrganizationFixture({

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -108,7 +108,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     detectedPlatforms,
     isPending: isDetecting,
     isError: isDetectionError,
-  } = useScmPlatformDetection(hasScmConnected ? selectedRepository.id : undefined);
+  } = useScmPlatformDetection(selectedRepository);
 
   const currentFeatures = useMemo(
     () => selectedFeatures ?? [ProductSolution.ERROR_MONITORING],
@@ -445,7 +445,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
               }}
               styles={{container: base => ({...base, width: '100%'})}}
             />
-            {hasScmConnected && !isDetectionError && (
+            {hasScmConnected && !isDetectionError && hasDetectedPlatforms && (
               <Button size="xs" priority="link" onClick={handleBackToRecommended}>
                 {t('Back to recommended platforms')}
               </Button>


### PR DESCRIPTION
The `useScmPlatformDetection` hook fires the platform detection API call for any connected repository, but the backend only supports GitHub. For non-GitHub providers (GitLab, Bitbucket, etc.) this causes a pointless loading spinner followed by an error, then a fallback to the manual picker.

Gate the query on `repository.provider.id === 'integrations:github'` so non-GitHub providers skip detection entirely and land directly on the manual picker with no flash of loading/error UI. Also hides the "Back to recommended platforms" link when there are no detected platforms to go back to.

Refs LINEAR-VDY-65