### PR TITLE
ref(py): Remove backwards-compatible org serializer aliases

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -920,8 +920,3 @@ class OrganizationWithProjectsAndTeamsSerializer(OrganizationSerializer):
         )
 
         return context
-
-
-# Backwards-compatible aliases for getsentry
-DetailedOrganizationSerializer = OrganizationSerializer
-DetailedOrganizationSerializerWithProjectsAndTeams = OrganizationWithProjectsAndTeamsSerializer


### PR DESCRIPTION
Requires https://github.com/getsentry/getsentry/pull/19768