### PR TITLE
ref(grouping): Remove lookahead and lookbehind from parameterization regex class

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -18,8 +18,6 @@ class ParameterizationRegex:
     name: str  # name of the pattern (also used as group name in combined regex)
     raw_pattern: str  # regex pattern w/o matching group name
     raw_pattern_experimental: str | None = None
-    lookbehind: str | None = None  # positive lookbehind prefix if needed
-    lookahead: str | None = None  # positive lookahead postfix if needed
     # Function which takes the matched value and returns the replacement value.
     replacement_callback: ParameterizationReplacementFunction | None = None
 
@@ -40,9 +38,7 @@ class ParameterizationRegex:
         """
         Returns the regex pattern with a named matching group and lookbehind/lookahead if needed.
         """
-        prefix = rf"(?<={self.lookbehind})" if self.lookbehind else ""
-        postfix = rf"(?={self.lookahead})" if self.lookahead else ""
-        return rf"{prefix}(?P<{self.name}>{raw_pattern}){postfix}"
+        return rf"(?P<{self.name}>{raw_pattern})"
 
 
 def is_valid_ip(maybe_ip_str: str) -> bool:

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -311,23 +311,25 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
     ParameterizationRegex(
         name="quoted_str",
         raw_pattern=r"""
-            '([^']+)' | "([^"]+)"
+            # Lookbehind to ensure we'll only match the value half of `<key>=<value>`-type key-value
+            # pairs, rather than all quoted strings
+            (?<=[=])
+            (
+                '([^']+)' |
+                "([^"]+)"
+            )
         """,
-        # Using an `=` lookbehind guarantees we'll only match the value half of key-value pairs,
-        # rather than all quoted strings
-        lookbehind="=",
     ),
     ParameterizationRegex(
         name="bool",
         raw_pattern=r"""
-            True |
-            true |
-            False |
-            false
+            # Lookbehind to ensure we'll only match the value half of `<key>=<value>`-type key-value
+            # pairs, rather than all instances of the words 'true' and 'false'
+            (?<=[=])
+            (
+                True | true | False | false
+            )
         """,
-        # Using an `=` lookbehind guarantees we'll only match the value half of key-value pairs,
-        # rather than all instances of the words 'true' and 'false'.
-        lookbehind="=",
     ),
 ]
 

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -36,7 +36,7 @@ class ParameterizationRegex:
 
     def _get_pattern(self, raw_pattern: str) -> str:
         """
-        Returns the regex pattern with a named matching group and lookbehind/lookahead if needed.
+        Returns the regex pattern inside of a named matching group.
         """
         return rf"(?P<{self.name}>{raw_pattern})"
 


### PR DESCRIPTION
In a number of our parameterization regex patterns, we use lookaheads and lookbehinds to control when the pattern applies. There's theoretically a mechanism built into the `ParameterizationRegex` class for that: `lookahead` and `lookbehind` values can be set when defining the regex, and they'll automatically be included in the final pattern string. Most of our regexes which use lookaheads and lookbehinds don't use it, though, opting instead to include the lookahead or lookbehind directly in the pattern. Not only is this more explicit, it also accommodates patterns which need negative rather than positive lookaheads/lookbehinds, and patterns which need multiple lookaheads/lookbehinds.

This PR therefore switches the only two regexes using the attributes to also use explicit lookbehinds instead, and then deletes the now-unused attributes. No behavior changes here - just an attempt to make the code a touch simpler and more consistent.