### PR TITLE
ref(grouping): Add false positive parameterization metric

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -401,6 +401,9 @@ class Parameterizer:
         replacement_counts: defaultdict[str, int] = defaultdict(int)
         # Track whether any regex matches don't lead to a replacement
         found_false_positive = False
+        # Flag allowing us to only count false positives during the main parameterization, not the
+        # fallback run
+        emit_false_positive_metric = True
 
         def _handle_regex_match(match: re.Match[str]) -> str:
             # Ensure we're dealing with the flag from the outer scope, rather than shadowing it
@@ -435,6 +438,16 @@ class Parameterizer:
             else:
                 found_false_positive = True
 
+                # This is only true during the main combo-regex parameterization, not during
+                # fallback, so that we don't double-count these occurrences
+                if emit_false_positive_metric:
+                    # Track the number of false positive matches, and what pattern produced them. We
+                    # can compare this to the same key's `grouping.value_parameterized` metric below
+                    # to see how often our maybe-matches pan out to be actual matches.
+                    metrics.incr(
+                        "grouping.parameterization_false_positive", tags={"key": matched_key}
+                    )
+
             return replacement_string
 
         with metrics.timer(
@@ -453,6 +466,9 @@ class Parameterizer:
                 # Reset values before applying the patterns again
                 replacement_counts = defaultdict(int)
                 parameterized = input_str
+
+                # Prevent double-counting of false positives
+                emit_false_positive_metric = False
 
                 # Apply patterns one by one, with no short-circuiting
                 for regex_key, regex in self.compiled_regexes_by_name.items():

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -708,3 +708,12 @@ def test_replacement_callback_false_positive_triggers_individual_regex_fallback(
             )
             == 0
         )
+
+        # We also only counted the false positive once, even though we hit it both during the main
+        # combo-regex parameterization and during fallback
+        assert (
+            count_matching_calls(
+                mock_metrics_incr, "grouping.parameterization_false_positive", tags={"key": "ip"}
+            )
+            == 1
+        )


### PR DESCRIPTION
In the metrics we use to track message parameterization, we tag the overall timing metric with a `false_positive` tag when we hit the fallback case (to see both how often it happens and how much time it adds to the process), but we don't track the individual times we hit a false positive value (which could be more than once per message). This adds a metric to do that, so that we can compare false positive hits to true positive hits (tracked by the existing  `grouping.value_parameterized` metric). If the rate is higher than we'd like, we can consider tightening the "IP-like" regex we use for our initial match.