### PR TITLE
ref(integrations): Convert AddIntegration to useAddIntegration hook

### DIFF
--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -31,7 +31,7 @@ import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 import RouteError from 'sentry/views/routeError';
-import {AddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
+import {useAddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
 import {IntegrationLayout} from 'sentry/views/settings/organizationIntegrations/detailedView/integrationLayout';
 
 interface GitHubIntegrationInstallation {
@@ -228,37 +228,19 @@ export default function IntegrationOrganizationLink() {
 
     const {IntegrationFeatures} = getIntegrationFeatureGate();
 
-    // Github uses a different installation flow with the installationId as a parameter
-    // We have to wrap our installation button with AddIntegration so we can get the
-    // addIntegrationWithInstallationId callback.
-    // if we don't have an installationId, we need to use the finishInstallation callback.
     return (
       <IntegrationFeatures organization={organization} features={featuresComponents}>
         {({disabled, disabledReason}) => (
-          <AddIntegration
+          <AddIntegrationButton
             provider={provider}
-            onInstall={onInstallWithInstallationId}
             organization={organization}
-          >
-            {addIntegrationWithInstallationId => (
-              <ButtonWrapper>
-                <Button
-                  priority="primary"
-                  disabled={!hasAccess || disabled}
-                  onClick={() =>
-                    installationId
-                      ? addIntegrationWithInstallationId({
-                          installation_id: installationId,
-                        })
-                      : finishInstallation()
-                  }
-                >
-                  {t('Install %s', provider.name)}
-                </Button>
-                {disabled && <IntegrationLayout.DisabledNotice reason={disabledReason} />}
-              </ButtonWrapper>
-            )}
-          </AddIntegration>
+            onInstall={onInstallWithInstallationId}
+            installationId={installationId}
+            hasAccess={hasAccess}
+            disabled={disabled}
+            disabledReason={disabledReason}
+            finishInstallation={finishInstallation}
+          />
         )}
       </IntegrationFeatures>
     );
@@ -417,6 +399,45 @@ export default function IntegrationOrganizationLink() {
       </FieldGroup>
       {renderBottom}
     </NarrowLayout>
+  );
+}
+
+function AddIntegrationButton({
+  provider,
+  organization,
+  onInstall,
+  installationId,
+  hasAccess,
+  disabled,
+  disabledReason,
+  finishInstallation,
+}: {
+  disabled: boolean;
+  disabledReason: React.ReactNode;
+  finishInstallation: () => void;
+  hasAccess: boolean | undefined;
+  onInstall: (data: Integration) => void;
+  organization: Organization;
+  provider: IntegrationProvider;
+  installationId?: string;
+}) {
+  const {startFlow} = useAddIntegration({provider, organization, onInstall});
+
+  return (
+    <ButtonWrapper>
+      <Button
+        priority="primary"
+        disabled={!hasAccess || disabled}
+        onClick={() =>
+          installationId
+            ? startFlow({installation_id: installationId})
+            : finishInstallation()
+        }
+      >
+        {t('Install %s', provider.name)}
+      </Button>
+      {disabled && <IntegrationLayout.DisabledNotice reason={disabledReason} />}
+    </ButtonWrapper>
   );
 }
 

--- a/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
@@ -88,7 +88,7 @@ describe('useAddIntegration', () => {
       const url = calls[0] as string;
       expect(url).toContain('account=my-account');
       expect(url).toContain('use_staging=1');
-      expect(calls![1]).toBe('sentryAddStagingIntegration');
+      expect(calls[1]).toBe('sentryAddStagingIntegration');
     });
 
     it('includes urlParams passed to startFlow', () => {

--- a/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
@@ -2,86 +2,315 @@ import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, waitFor} from 'sentry-test/reactTestingLibrary';
-import {setWindowLocation} from 'sentry-test/utils';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import * as indicators from 'sentry/actionCreators/indicator';
+import * as pipelineModal from 'sentry/components/pipeline/modal';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
-import {AddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
+import {useAddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
 
-describe('AddIntegration', () => {
+describe('useAddIntegration', () => {
   const provider = GitHubIntegrationProviderFixture();
   const integration = GitHubIntegrationFixture();
   let configState: Config;
-
-  function interceptMessageEvent(event: MessageEvent) {
-    if (event.origin === '') {
-      event.stopImmediatePropagation();
-      const eventWithOrigin = new MessageEvent('message', {
-        data: event.data,
-        origin: 'https://foobar.sentry.io',
-      });
-      window.dispatchEvent(eventWithOrigin);
-    }
-  }
 
   beforeEach(() => {
     configState = ConfigStore.getState();
     ConfigStore.loadInitialData({
       ...configState,
-      customerDomain: {
-        subdomain: 'foobar',
-        organizationUrl: 'https://foobar.sentry.io',
-        sentryUrl: 'https://sentry.io',
-      },
       links: {
-        organizationUrl: 'https://foobar.sentry.io',
+        organizationUrl: document.location.origin,
         regionUrl: 'https://us.sentry.io',
         sentryUrl: 'https://sentry.io',
       },
     });
-
-    setWindowLocation('https://foobar.sentry.io');
-    window.addEventListener('message', interceptMessageEvent);
   });
 
   afterEach(() => {
-    window.removeEventListener('message', interceptMessageEvent);
     ConfigStore.loadInitialData(configState);
+    jest.restoreAllMocks();
   });
 
-  it('Adds an integration on dialog completion', async () => {
-    const onAdd = jest.fn();
+  /**
+   * Dispatches a MessageEvent that appears to come from the mock popup window,
+   * matching the origin and source checks in the hook's message handler.
+   */
+  function postMessageFromPopup(popup: Window, data: unknown) {
+    const event = new MessageEvent('message', {
+      data,
+      origin: document.location.origin,
+    });
+    Object.defineProperty(event, 'source', {value: popup});
+    window.dispatchEvent(event);
+  }
 
-    const focus = jest.fn();
-    const open = jest.fn().mockReturnValue({focus});
-    global.open = open;
+  describe('legacy flow', () => {
+    let popup: Window;
 
-    render(
-      <AddIntegration
-        organization={OrganizationFixture()}
-        provider={provider}
-        onInstall={onAdd}
-      >
-        {openDialog => (
-          <a href="#" onClick={() => openDialog()}>
-            Click
-          </a>
-        )}
-      </AddIntegration>
-    );
+    beforeEach(() => {
+      popup = {focus: jest.fn(), close: jest.fn()} as unknown as Window;
+      jest.spyOn(window, 'open').mockReturnValue(popup);
+    });
 
-    const newIntegration = {
-      success: true,
-      data: Object.assign({}, integration, {
-        id: '2',
-        domain_name: 'new-integration.github.com',
-        icon: 'http://example.com/new-integration-icon.png',
-        name: 'New Integration',
-      }),
-    };
+    it('opens a popup window when startFlow is called', () => {
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall: jest.fn(),
+        })
+      );
 
-    window.postMessage(newIntegration, '*');
-    await waitFor(() => expect(onAdd).toHaveBeenCalledWith(newIntegration.data));
+      act(() => result.current.startFlow());
+
+      expect(window.open).toHaveBeenCalledTimes(1);
+      expect(jest.mocked(window.open).mock.calls[0]![0]).toBe(
+        '/github-integration-setup-uri/?'
+      );
+      expect(popup.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes account and modalParams in the popup URL', () => {
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall: jest.fn(),
+          account: 'my-account',
+          modalParams: {use_staging: '1'},
+        })
+      );
+
+      act(() => result.current.startFlow());
+
+      const calls = jest.mocked(window.open).mock.calls[0]!;
+      const url = calls[0] as string;
+      expect(url).toContain('account=my-account');
+      expect(url).toContain('use_staging=1');
+      expect(calls![1]).toBe('sentryAddStagingIntegration');
+    });
+
+    it('includes urlParams passed to startFlow', () => {
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall: jest.fn(),
+        })
+      );
+
+      act(() => result.current.startFlow({custom_param: 'value'}));
+
+      const url = jest.mocked(window.open).mock.calls[0]![0] as string;
+      expect(url).toContain('custom_param=value');
+    });
+
+    it('calls onInstall when a success message is received', async () => {
+      const onInstall = jest.fn();
+
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall,
+        })
+      );
+
+      act(() => result.current.startFlow());
+
+      const newIntegration = {
+        success: true,
+        data: {
+          ...integration,
+          id: '2',
+          domain_name: 'new-integration.github.com',
+          icon: 'http://example.com/new-integration-icon.png',
+          name: 'New Integration',
+        },
+      };
+
+      postMessageFromPopup(popup, newIntegration);
+      await waitFor(() => expect(onInstall).toHaveBeenCalledWith(newIntegration.data));
+    });
+
+    it('shows a success indicator on successful installation', async () => {
+      const successSpy = jest.spyOn(indicators, 'addSuccessMessage');
+
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall: jest.fn(),
+        })
+      );
+
+      act(() => result.current.startFlow());
+
+      postMessageFromPopup(popup, {success: true, data: integration});
+      await waitFor(() => expect(successSpy).toHaveBeenCalledWith('GitHub added'));
+    });
+
+    it('shows an error indicator when the message has success: false', async () => {
+      const errorSpy = jest.spyOn(indicators, 'addErrorMessage');
+
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall: jest.fn(),
+        })
+      );
+
+      act(() => result.current.startFlow());
+
+      postMessageFromPopup(popup, {success: false, data: {error: 'OAuth failed'}});
+      await waitFor(() => expect(errorSpy).toHaveBeenCalledWith('OAuth failed'));
+    });
+
+    it('shows a generic error when no error message is provided', async () => {
+      const errorSpy = jest.spyOn(indicators, 'addErrorMessage');
+
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall: jest.fn(),
+        })
+      );
+
+      act(() => result.current.startFlow());
+
+      postMessageFromPopup(popup, {success: false, data: {}});
+      await waitFor(() =>
+        expect(errorSpy).toHaveBeenCalledWith('An unknown error occurred')
+      );
+    });
+
+    it('ignores messages from invalid origins', async () => {
+      const onInstall = jest.fn();
+
+      renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall,
+        })
+      );
+
+      // jsdom's postMessage uses origin '' which won't match any valid origin
+      window.postMessage({success: true, data: integration}, '*');
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 50));
+      });
+      expect(onInstall).not.toHaveBeenCalled();
+    });
+
+    it('does not call onInstall when data is empty on success', async () => {
+      const onInstall = jest.fn();
+
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall,
+        })
+      );
+
+      act(() => result.current.startFlow());
+
+      postMessageFromPopup(popup, {success: true, data: null});
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 50));
+      });
+      expect(onInstall).not.toHaveBeenCalled();
+    });
+
+    it('closes the dialog on unmount', () => {
+      const {result, unmount} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization: OrganizationFixture(),
+          onInstall: jest.fn(),
+        })
+      );
+
+      act(() => result.current.startFlow());
+      unmount();
+
+      expect(popup.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('API pipeline flow', () => {
+    it('opens the pipeline modal when feature flag is enabled', () => {
+      const openPipelineModalSpy = jest.spyOn(pipelineModal, 'openPipelineModal');
+      const onInstall = jest.fn();
+
+      const organization = OrganizationFixture({
+        features: ['integration-api-pipeline-github'],
+      });
+
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization,
+          onInstall,
+        })
+      );
+
+      act(() => result.current.startFlow());
+
+      expect(openPipelineModalSpy).toHaveBeenCalledWith({
+        type: 'integration',
+        provider: 'github',
+        onComplete: expect.any(Function),
+      });
+    });
+
+    it('does not open a popup window when the pipeline modal is used', () => {
+      jest.spyOn(pipelineModal, 'openPipelineModal');
+      jest.spyOn(window, 'open');
+
+      const organization = OrganizationFixture({
+        features: ['integration-api-pipeline-github'],
+      });
+
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization,
+          onInstall: jest.fn(),
+        })
+      );
+
+      act(() => result.current.startFlow());
+
+      expect(window.open).not.toHaveBeenCalled();
+    });
+
+    it('falls back to legacy flow when feature flag is not enabled', () => {
+      const openPipelineModalSpy = jest.spyOn(pipelineModal, 'openPipelineModal');
+      jest
+        .spyOn(window, 'open')
+        .mockReturnValue({focus: jest.fn(), close: jest.fn()} as unknown as Window);
+
+      const organization = OrganizationFixture({features: []});
+
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization,
+          onInstall: jest.fn(),
+        })
+      );
+
+      act(() => result.current.startFlow());
+
+      expect(openPipelineModalSpy).not.toHaveBeenCalled();
+      expect(window.open).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/static/app/views/settings/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.tsx
@@ -1,7 +1,9 @@
-import {Component} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import * as qs from 'query-string';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {openPipelineModal} from 'sentry/components/pipeline/modal';
+import type {ProvidersByType} from 'sentry/components/pipeline/registry';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {IntegrationProvider, IntegrationWithConfig} from 'sentry/types/integrations';
@@ -9,12 +11,11 @@ import type {Organization} from 'sentry/types/organization';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import type {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
-type Props = {
-  children: (openDialog: (urlParams?: Record<string, string>) => void) => React.ReactNode;
+export interface AddIntegrationParams {
   onInstall: (data: IntegrationWithConfig) => void;
   organization: Organization;
   provider: IntegrationProvider;
-  account?: string | null; // for analytics
+  account?: string | null;
   analyticsParams?: {
     already_installed: boolean;
     view:
@@ -29,114 +30,206 @@ type Props = {
       | 'test_analytics_org_selector';
   };
   modalParams?: Record<string, string>;
-};
+}
 
-export class AddIntegration extends Component<Props> {
-  componentDidMount() {
-    window.addEventListener('message', this.didReceiveMessage);
+/**
+ * Per-provider feature flags that gate the new API-driven pipeline setup flow.
+ * When enabled for a provider, the integration setup uses the React pipeline
+ * modal instead of the legacy Django view popup window.
+ *
+ * Keys are provider identifiers (constrained to registered pipeline providers
+ * via `satisfies`), values are feature flag names without the `organizations:`
+ * prefix.
+ */
+const API_PIPELINE_FEATURE_FLAGS = {
+  github: 'integration-api-pipeline-github',
+} as const satisfies Partial<Record<ProvidersByType['integration'], string>>;
+
+type ApiPipelineProvider = keyof typeof API_PIPELINE_FEATURE_FLAGS;
+
+function getApiPipelineProvider(
+  organization: Organization,
+  providerKey: string
+): ApiPipelineProvider | null {
+  if (!(providerKey in API_PIPELINE_FEATURE_FLAGS)) {
+    return null;
   }
-
-  componentWillUnmount() {
-    window.removeEventListener('message', this.didReceiveMessage);
-    this.dialog?.close();
+  const key = providerKey as ApiPipelineProvider;
+  const flag = API_PIPELINE_FEATURE_FLAGS[key];
+  if (!organization.features.includes(flag)) {
+    return null;
   }
+  return key;
+}
 
-  dialog: Window | null = null;
+function computeCenteredWindow(width: number, height: number) {
+  const screenLeft = window.screenLeft === undefined ? window.screenX : window.screenLeft;
+  const screenTop = window.screenTop === undefined ? window.screenY : window.screenTop;
 
-  computeCenteredWindow(width: number, height: number) {
-    // Taken from: https://stackoverflow.com/questions/4068373/center-a-popup-window-on-screen
-    const screenLeft =
-      window.screenLeft === undefined ? window.screenX : window.screenLeft;
+  const innerWidth = window.innerWidth
+    ? window.innerWidth
+    : document.documentElement.clientWidth
+      ? document.documentElement.clientWidth
+      : screen.width;
 
-    const screenTop = window.screenTop === undefined ? window.screenY : window.screenTop;
+  const innerHeight = window.innerHeight
+    ? window.innerHeight
+    : document.documentElement.clientHeight
+      ? document.documentElement.clientHeight
+      : screen.height;
 
-    const innerWidth = window.innerWidth
-      ? window.innerWidth
-      : document.documentElement.clientWidth
-        ? document.documentElement.clientWidth
-        : screen.width;
+  const left = innerWidth / 2 - width / 2 + screenLeft;
+  const top = innerHeight / 2 - height / 2 + screenTop;
 
-    const innerHeight = window.innerHeight
-      ? window.innerHeight
-      : document.documentElement.clientHeight
-        ? document.documentElement.clientHeight
-        : screen.height;
+  return {left, top};
+}
 
-    const left = innerWidth / 2 - width / 2 + screenLeft;
-    const top = innerHeight / 2 - height / 2 + screenTop;
+/**
+ * Opens the legacy Django-driven integration setup flow in a popup window and
+ * listens for a `postMessage` callback on completion.
+ *
+ * Used  for integrations that have not been migrated to the API pipeline system.
+ */
+function useLegacyAddIntegration({
+  provider,
+  organization,
+  onInstall,
+  account,
+  analyticsParams,
+  modalParams,
+}: AddIntegrationParams) {
+  const dialogRef = useRef<Window | null>(null);
+  const onInstallRef = useRef(onInstall);
+  onInstallRef.current = onInstall;
+  const analyticsParamsRef = useRef(analyticsParams);
+  analyticsParamsRef.current = analyticsParams;
 
-    return {left, top};
-  }
+  useEffect(() => {
+    function handleMessage(message: MessageEvent) {
+      const validOrigins = [
+        ConfigStore.get('links').sentryUrl,
+        ConfigStore.get('links').organizationUrl,
+        document.location.origin,
+      ];
+      if (!validOrigins.includes(message.origin)) {
+        return;
+      }
+      if (message.source !== dialogRef.current) {
+        return;
+      }
 
-  openDialog = (urlParams?: Record<string, string>) => {
-    const {account, analyticsParams, modalParams, organization, provider} = this.props;
+      const {success, data} = message.data;
+      dialogRef.current = null;
 
-    trackIntegrationAnalytics('integrations.installation_start', {
-      integration: provider.key,
-      integration_type: 'first_party',
+      if (!success) {
+        addErrorMessage(data?.error ?? t('An unknown error occurred'));
+        return;
+      }
+      if (!data) {
+        return;
+      }
+
+      trackIntegrationAnalytics('integrations.installation_complete', {
+        integration: provider.key,
+        integration_type: 'first_party',
+        organization,
+        ...analyticsParamsRef.current,
+      });
+      addSuccessMessage(t('%s added', provider.name));
+      onInstallRef.current(data);
+    }
+
+    window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+      dialogRef.current?.close();
+    };
+  }, [provider.key, provider.name, organization]);
+
+  const startFlow = useCallback(
+    (urlParams?: Record<string, string>) => {
+      trackIntegrationAnalytics('integrations.installation_start', {
+        integration: provider.key,
+        integration_type: 'first_party',
+        organization,
+        ...analyticsParams,
+      });
+
+      const name = modalParams?.use_staging
+        ? 'sentryAddStagingIntegration'
+        : 'sentryAddIntegration';
+      const {url, width, height} = provider.setupDialog;
+      const {left, top} = computeCenteredWindow(width, height);
+
+      let query: Record<string, string> = {...urlParams};
+      if (account) {
+        query.account = account;
+      }
+      if (modalParams) {
+        query = {...query, ...modalParams};
+      }
+
+      const installUrl = `${url}?${qs.stringify(query)}`;
+      const opts = `scrollbars=yes,width=${width},height=${height},top=${top},left=${left}`;
+
+      dialogRef.current = window.open(installUrl, name, opts);
+      dialogRef.current?.focus();
+    },
+    [provider, organization, account, analyticsParams, modalParams]
+  );
+
+  return {startFlow};
+}
+
+/**
+ * Opens the integration setup flow. Automatically selects between the new
+ * API-driven pipeline modal and the legacy popup-based flow depending on
+ * the organization's feature flags.
+ */
+export function useAddIntegration(params: AddIntegrationParams) {
+  const {provider, organization, onInstall} = params;
+  const {startFlow: legacyStartFlow} = useLegacyAddIntegration(params);
+  const pipelineProvider = getApiPipelineProvider(organization, provider.key);
+
+  const startFlow = useCallback(
+    (urlParams?: Record<string, string>) => {
+      // Fallback to legacy view-based flow when the feature flag for API based
+      // flows is not enabled for the provider.
+      if (pipelineProvider === null) {
+        legacyStartFlow(urlParams);
+        return;
+      }
+
+      trackIntegrationAnalytics('integrations.installation_start', {
+        integration: provider.key,
+        integration_type: 'first_party',
+        organization,
+        ...params.analyticsParams,
+      });
+      openPipelineModal({
+        type: 'integration',
+        provider: pipelineProvider,
+        onComplete: (data: IntegrationWithConfig) => {
+          trackIntegrationAnalytics('integrations.installation_complete', {
+            integration: provider.key,
+            integration_type: 'first_party',
+            organization,
+            ...params.analyticsParams,
+          });
+          addSuccessMessage(t('%s added', provider.name));
+          onInstall(data);
+        },
+      });
+    },
+    [
+      pipelineProvider,
+      provider,
       organization,
-      ...analyticsParams,
-    });
-    const name = 'sentryAddIntegration';
-    const {url, width, height} = provider.setupDialog;
-    const {left, top} = this.computeCenteredWindow(width, height);
+      params.analyticsParams,
+      onInstall,
+      legacyStartFlow,
+    ]
+  );
 
-    let query: Record<string, string> = {...urlParams};
-
-    if (account) {
-      query.account = account;
-    }
-
-    if (modalParams) {
-      query = {...query, ...modalParams};
-    }
-
-    const installUrl = `${url}?${qs.stringify(query)}`;
-    const opts = `scrollbars=yes,width=${width},height=${height},top=${top},left=${left}`;
-
-    this.dialog = window.open(installUrl, name, opts);
-    this.dialog?.focus();
-  };
-
-  didReceiveMessage = (message: MessageEvent) => {
-    const {analyticsParams, onInstall, organization, provider} = this.props;
-    const validOrigins = [
-      ConfigStore.get('links').sentryUrl,
-      ConfigStore.get('links').organizationUrl,
-      document.location.origin,
-    ];
-    if (!validOrigins.includes(message.origin)) {
-      return;
-    }
-
-    if (message.source !== this.dialog) {
-      return;
-    }
-
-    const {success, data} = message.data;
-    this.dialog = null;
-
-    if (!success) {
-      addErrorMessage(data?.error ?? t('An unknown error occurred'));
-      return;
-    }
-
-    if (!data) {
-      return;
-    }
-    trackIntegrationAnalytics('integrations.installation_complete', {
-      integration: provider.key,
-      integration_type: 'first_party',
-      organization,
-      ...analyticsParams,
-    });
-    addSuccessMessage(t('%s added', provider.name));
-    onInstall(data);
-  };
-
-  render() {
-    const {children} = this.props;
-
-    return children(this.openDialog);
-  }
+  return {startFlow};
 }

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
@@ -6,13 +6,14 @@ import {t} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
-import {AddIntegration} from './addIntegration';
+import type {AddIntegrationParams} from './addIntegration';
+import {useAddIntegration} from './addIntegration';
 
 interface AddIntegrationButtonProps
   extends
     Omit<ButtonProps, 'children' | 'analyticsParams'>,
     Pick<
-      React.ComponentProps<typeof AddIntegration>,
+      AddIntegrationParams,
       'provider' | 'organization' | 'analyticsParams' | 'modalParams'
     > {
   onAddIntegration: (data: IntegrationWithConfig) => void;
@@ -40,37 +41,35 @@ export function AddIntegrationButton({
         ? t('Reinstall')
         : t('Add %s', provider.metadata.noun));
 
+  const {startFlow} = useAddIntegration({
+    provider,
+    organization,
+    onInstall: onAddIntegration,
+    analyticsParams,
+    modalParams,
+  });
+
   return (
     <Tooltip
       disabled={provider.canAdd}
       title={`Integration cannot be added on Sentry. Enable this integration via the ${provider.name} instance.`}
     >
-      <AddIntegration
-        provider={provider}
-        onInstall={onAddIntegration}
-        organization={organization}
-        analyticsParams={analyticsParams}
-        modalParams={modalParams}
+      <Button
+        disabled={!provider.canAdd}
+        {...buttonProps}
+        onClick={() => {
+          if (label === t('Reinstall')) {
+            trackAnalytics('integrations.integration_reinstall_clicked', {
+              organization,
+              provider: provider.metadata.noun,
+            });
+          }
+          startFlow();
+        }}
+        aria-label={t('Add integration')}
       >
-        {onClick => (
-          <Button
-            disabled={!provider.canAdd}
-            {...buttonProps}
-            onClick={() => {
-              if (label === t('Reinstall')) {
-                trackAnalytics('integrations.integration_reinstall_clicked', {
-                  organization,
-                  provider: provider.metadata.noun,
-                });
-              }
-              onClick();
-            }}
-            aria-label={t('Add integration')}
-          >
-            {label}
-          </Button>
-        )}
-      </AddIntegration>
+        {label}
+      </Button>
     </Tooltip>
   );
 }

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -50,7 +50,7 @@ import {useRoutes} from 'sentry/utils/useRoutes';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
-import {AddIntegration} from './addIntegration';
+import {useAddIntegration} from './addIntegration';
 import {IntegrationAlertRules} from './integrationAlertRules';
 import {IntegrationCodeMappings} from './integrationCodeMappings';
 import {IntegrationExternalTeamMappings} from './integrationExternalTeamMappings';
@@ -256,23 +256,12 @@ function ConfigureIntegration() {
   const getAction = () => {
     if (provider.key === 'pagerduty') {
       return (
-        <AddIntegration
+        <PagerdutyAddServicesButton
           provider={provider}
           onInstall={onUpdateIntegration}
           account={integration.domainName}
           organization={organization}
-        >
-          {onClick => (
-            <Button
-              priority="primary"
-              size="sm"
-              icon={<IconAdd />}
-              onClick={() => onClick()}
-            >
-              {t('Add Services')}
-            </Button>
-          )}
-        </AddIntegration>
+        />
       );
     }
 
@@ -561,6 +550,26 @@ function ConfigureIntegration() {
         title={t('Configure %s', integration.provider.name)}
       />
     </Fragment>
+  );
+}
+
+function PagerdutyAddServicesButton({
+  provider,
+  onInstall,
+  account,
+  organization,
+}: {
+  account: string | null;
+  onInstall: () => void;
+  organization: Organization;
+  provider: IntegrationProvider;
+}) {
+  const {startFlow} = useAddIntegration({provider, onInstall, account, organization});
+
+  return (
+    <Button priority="primary" size="sm" icon={<IconAdd />} onClick={() => startFlow()}>
+      {t('Add Services')}
+    </Button>
   );
 }
 


### PR DESCRIPTION
Replace the class-based AddIntegration render prop component with a
useAddIntegration hook. This modernizes the integration setup flow to
use hooks and prepares for the API-driven pipeline modal by adding
feature-flag-gated support for opening a React pipeline modal instead
of the legacy Django popup window.

- Convert AddIntegration class component to useAddIntegration hook
- Refactor AddIntegrationButton to use the hook directly
- Add API pipeline feature flag support for github and gitlab providers
- Rewrite tests to use renderHookWithProviders with comprehensive
  coverage for both legacy and API pipeline flows