### PR TITLE
chore(billing): added trace metrics to byte categories(BIL-2221)

### DIFF
--- a/static/gsApp/utils/dataCategory.spec.tsx
+++ b/static/gsApp/utils/dataCategory.spec.tsx
@@ -416,9 +416,10 @@ describe('listDisplayNames', () => {
 });
 
 describe('isByteCategory', () => {
-  it('verifies isByteCategory function handles both ATTACHMENTS and LOG_BYTE', () => {
+  it('verifies isByteCategory function handles ATTACHMENTS, LOG_BYTE, and TRACE_METRIC_BYTE', () => {
     expect(isByteCategory(DataCategory.ATTACHMENTS)).toBe(true);
     expect(isByteCategory(DataCategory.LOG_BYTE)).toBe(true);
+    expect(isByteCategory(DataCategory.TRACE_METRIC_BYTE)).toBe(true);
     expect(isByteCategory(DataCategory.ERRORS)).toBe(false);
     expect(isByteCategory(DataCategory.TRANSACTIONS)).toBe(false);
   });

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -246,7 +246,11 @@ export function isContinuousProfiling(category: DataCategory | string) {
 }
 
 export function isByteCategory(category: DataCategory | string) {
-  return category === DataCategory.ATTACHMENTS || category === DataCategory.LOG_BYTE;
+  return (
+    category === DataCategory.ATTACHMENTS ||
+    category === DataCategory.LOG_BYTE ||
+    category === DataCategory.TRACE_METRIC_BYTE
+  );
 }
 
 /**


### PR DESCRIPTION
https://linear.app/getsentry/issue/BIL-2221/convert-units-for-usage-total-cards-isbytecategory

This PR adds byte usage formatting for trace metrics.
