### PR TITLE
ref(options): Make viewer-context.enabled runtime-modifiable

### DIFF
--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -17,13 +17,11 @@ def ViewerContextMiddleware(
     Must be placed **after** ``AuthenticationMiddleware`` so that
     ``request.user`` and ``request.auth`` are already populated.
 
-    Gated by the ``viewer-context.enabled`` option (FLAG_NOSTORE).
-    Set via deploy config; requires restart to change.
+    Gated by the ``viewer-context.enabled`` option.
     """
-    enabled = options.get("viewer-context.enabled")
 
     def ViewerContextMiddleware_impl(request: HttpRequest) -> HttpResponseBase:
-        if not enabled:
+        if not options.get("viewer-context.enabled"):
             return get_response(request)
 
         ctx = _viewer_context_from_request(request)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4103,10 +4103,9 @@ register(
 )
 
 # ViewerContext — unified caller identity for all entrypoints.
-# Set via deploy config (SENTRY_OPTIONS); requires restart to change.
 register(
     "viewer-context.enabled",
     default=False,
     type=Bool,
-    flags=FLAG_NOSTORE,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
Change the `viewer-context.enabled` option from `FLAG_NOSTORE` to
`FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE` so it can be toggled
at runtime via the options API or automator without requiring a restart.

The middleware previously read the option once at init time and captured
it in a closure variable. Now it reads on every request so runtime
changes take effect immediately.

Stacks on #112172.