### PR TITLE
feat(integrations): Set ViewerContext on webhook handlers

### DIFF
--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -24,6 +24,7 @@ from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.source_code_management.webhook import SCMWebhook
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
+from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
@@ -258,11 +259,14 @@ class BitbucketWebhookEndpoint(Endpoint):
 
         event_handler = handler()
 
-        with IntegrationWebhookEvent(
-            interaction_type=event_handler.event_type,
-            domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-            provider_key=event_handler.provider,
-        ).capture():
+        with (
+            webhook_viewer_context(organization.id),
+            IntegrationWebhookEvent(
+                interaction_type=event_handler.event_type,
+                domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
+                provider_key=event_handler.provider,
+            ).capture(),
+        ):
             event_handler(event, repo=repo, organization=organization)
 
         return HttpResponse(status=204)

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -21,6 +21,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.source_code_management.webhook import SCMWebhook
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
+from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
@@ -210,6 +211,7 @@ class BitbucketServerWebhookEndpoint(Endpoint):
 
         event_handler = handler()
 
-        event_handler(event, organization=organization, integration_id=integration_id)
+        with webhook_viewer_context(organization.id):
+            event_handler(event, organization=organization, integration_id=integration_id)
 
         return HttpResponse(status=204)

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -21,6 +21,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.integrations.cursor.integration import CursorAgentIntegration
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
 from sentry.seer.autofix.utils import (
     CodingAgentResult,
     CodingAgentStatus,
@@ -58,7 +59,8 @@ class CursorWebhookEndpoint(Endpoint):
             logger.warning("cursor_webhook.invalid_signature")
             raise PermissionDenied("Invalid signature")
 
-        self._process_webhook(payload)
+        with webhook_viewer_context(organization_id):
+            self._process_webhook(payload)
         logger.info("cursor_webhook.success", extra={"event_type": event_type})
         return self.respond(status=204)
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -44,6 +44,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.integrations.utils.sync import sync_group_assignee_inbound_by_external_actor
+from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange, post_bulk_create
@@ -263,14 +264,15 @@ class GitHubWebhook(SCMWebhook, ABC):
 
             for repo in repos.exclude(status=ObjectStatus.HIDDEN):
                 self.update_repo_data(repo, event)
-                self._handle(
-                    github_event=github_event,
-                    integration=integration,
-                    event=event,
-                    organization=orgs[repo.organization_id],
-                    repo=repo,
-                    github_delivery_id=github_delivery_id,
-                )
+                with webhook_viewer_context(repo.organization_id):
+                    self._handle(
+                        github_event=github_event,
+                        integration=integration,
+                        event=event,
+                        organization=orgs[repo.organization_id],
+                        repo=repo,
+                        github_delivery_id=github_delivery_id,
+                    )
 
     def update_repo_data(self, repo: Repository, event: Mapping[str, Any]) -> None:
         """

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -28,6 +28,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.integrations.utils.sync import sync_group_assignee_inbound_by_external_actor
+from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.pullrequest import PullRequest
@@ -516,11 +517,14 @@ class GitlabWebhookEndpoint(Endpoint):
                 organization = org_context.organization
                 event_handler = handler()
 
-                with IntegrationWebhookEvent(
-                    interaction_type=event_handler.event_type,
-                    domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-                    provider_key=event_handler.provider,
-                ).capture():
+                with (
+                    webhook_viewer_context(install.organization_id),
+                    IntegrationWebhookEvent(
+                        interaction_type=event_handler.event_type,
+                        domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
+                        provider_key=event_handler.provider,
+                    ).capture(),
+                ):
                     event_handler(event, integration=integration, organization=organization)
 
         return HttpResponse(status=204)

--- a/src/sentry/integrations/utils/webhook_viewer_context.py
+++ b/src/sentry/integrations/utils/webhook_viewer_context.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Generator
+
+from sentry import options
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
+
+
+@contextlib.contextmanager
+def webhook_viewer_context(organization_id: int) -> Generator[None]:
+    """Set ViewerContext for a webhook handler processing an org-scoped event.
+
+    Gated by the ``viewer-context.enabled`` option so it rolls out alongside
+    the rest of the ViewerContext infrastructure.
+    """
+    if not options.get("viewer-context.enabled"):
+        yield
+        return
+
+    with viewer_context_scope(
+        ViewerContext(
+            organization_id=organization_id,
+            actor_type=ActorType.INTEGRATION,
+        )
+    ):
+        yield

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -788,7 +788,6 @@ class PushEventWebhookTest(APITestCase):
         )
 
         captured_contexts: list = []
-        original_handle = type(self)._original_push_handle = None
 
         from sentry.integrations.github.webhook import PushEventWebhook
 

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -774,6 +774,41 @@ class PushEventWebhookTest(APITestCase):
         assert_success_metric(mock_record)
 
     @responses.activate
+    @override_options({"viewer-context.enabled": True})
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_viewer_context_set_during_handler(self, mock_record: MagicMock) -> None:
+        """ViewerContext is set with org_id and actor_type=INTEGRATION during webhook processing."""
+        from sentry.viewer_context import ActorType, get_viewer_context
+
+        Repository.objects.create(
+            organization_id=self.project.organization.id,
+            external_id="35129377",
+            provider="integrations:github",
+            name="baxterthehacker/repo",
+        )
+
+        captured_contexts: list = []
+        original_handle = type(self)._original_push_handle = None
+
+        from sentry.integrations.github.webhook import PushEventWebhook
+
+        original_handle = PushEventWebhook._handle
+
+        def capturing_handle(self_handler, **kwargs):
+            captured_contexts.append(get_viewer_context())
+            return original_handle(self_handler, **kwargs)
+
+        with patch.object(PushEventWebhook, "_handle", capturing_handle):
+            self._create_integration_and_send_push_event()
+
+        assert len(captured_contexts) == 1
+        ctx = captured_contexts[0]
+        assert ctx is not None
+        assert ctx.organization_id == self.project.organization.id
+        assert ctx.actor_type == ActorType.INTEGRATION
+        assert ctx.user_id is None
+
+    @responses.activate
     @patch("sentry.integrations.github.webhook.metrics")
     def test_creates_missing_repo(self, mock_metrics: MagicMock) -> None:
         self._create_integration_and_send_push_event()

--- a/tests/sentry/integrations/utils/test_webhook_viewer_context.py
+++ b/tests/sentry/integrations/utils/test_webhook_viewer_context.py
@@ -1,0 +1,23 @@
+from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.viewer_context import ActorType, get_viewer_context
+
+
+class WebhookViewerContextTest(TestCase):
+    @override_options({"viewer-context.enabled": True})
+    def test_sets_viewer_context_when_enabled(self):
+        with webhook_viewer_context(42):
+            ctx = get_viewer_context()
+            assert ctx is not None
+            assert ctx.organization_id == 42
+            assert ctx.actor_type == ActorType.INTEGRATION
+            assert ctx.user_id is None
+            assert ctx.token is None
+
+        assert get_viewer_context() is None
+
+    @override_options({"viewer-context.enabled": False})
+    def test_noop_when_disabled(self):
+        with webhook_viewer_context(42):
+            assert get_viewer_context() is None


### PR DESCRIPTION
Add `webhook_viewer_context(org_id)` helper that wraps webhook per-org processing in `viewer_context_scope` with `actor_type=INTEGRATION`. Gated behind the `viewer-context.enabled` option so it rolls out with the rest of the ViewerContext infrastructure.

Wired into 5 webhook handlers at the point where `organization_id` is known:
- **GitHub** — inside per-repo loop in `GitHubWebhook.__call__`
- **GitLab** — inside per-install loop in `GitlabWebhookEndpoint.post`
- **Bitbucket** — wrapping handler call (org from URL param)
- **Bitbucket Server** — wrapping handler call (org from URL param)
- **Cursor** — wrapping `_process_webhook` (org from URL param)

Remaining integrations (Slack, Jira Server, MS Teams, Vercel) resolve the organization deeper in the stack and need separate work — they're tracked but not in scope here.

Part of the [ViewerContext RFC](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02).