### PR TITLE
feat(billing): Gate trace metric bytes notification behind feature flag

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -326,6 +326,7 @@ describe('NotificationSettingsByType', () => {
         'continuous-profiling-billing',
         'seer-billing',
         'logs-billing',
+        'expose-category-trace-metric-byte',
         'seer-user-billing-launch',
       ],
     });
@@ -501,6 +502,7 @@ describe('NotificationSettingsByType', () => {
         // No continuous-profiling-billing feature
         // No seer-billing feature
         // No logs-billing feature
+        // No expose-category-trace-metric-byte feature
       ],
     });
     renderComponent({
@@ -525,6 +527,7 @@ describe('NotificationSettingsByType', () => {
     expect(screen.queryByText('Transactions')).not.toBeInTheDocument();
     expect(screen.queryByText('Seer Budget')).not.toBeInTheDocument();
     expect(screen.queryByText('Logs')).not.toBeInTheDocument();
+    expect(screen.queryByText('Metrics (Bytes)')).not.toBeInTheDocument();
     expect(screen.queryByText('Active Contributors')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -251,6 +251,10 @@ export function NotificationSettingsByType({notificationType}: Props) {
       organization.features?.includes('logs-billing')
     );
 
+    const hasTraceMetricsBilling = organizations.some(organization =>
+      organization.features?.includes('expose-category-trace-metric-byte')
+    );
+
     const hasSeerUserBilling = organizations.some(organization =>
       organization.features?.includes('seer-user-billing-launch')
     );
@@ -280,6 +284,9 @@ export function NotificationSettingsByType({notificationType}: Props) {
         return false;
       }
       if (field.name.startsWith('quotaLogBytes') && !includeLogs) {
+        return false;
+      }
+      if (field.name.startsWith('quotaTraceMetricBytes') && !hasTraceMetricsBilling) {
         return false;
       }
       if (field.name.startsWith('quotaSeerUsers') && !hasSeerUserBilling) {


### PR DESCRIPTION
The backend notification setting is added in #112282 — this PR handles the frontend ff gating. 

closes https://linear.app/getsentry/issue/BIL-2216/update-notifications-backend-for-trace-metrics-settings