### PR TITLE
chore(billing): Added data category constant for trace metric byte(BIL-2213)

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -653,7 +653,7 @@ export const DATA_CATEGORY_INFO = {
     titleName: t('Metrics (Bytes)'),
     productName: t('Metrics'),
     uid: 37,
-    isBilledCategory: false,
+    isBilledCategory: true,
     statsInfo: {
       ...DEFAULT_STATS_INFO,
       showExternalStats: true,
@@ -698,7 +698,7 @@ export const DATA_CATEGORY_INFO = {
     titleName: t('Build Distributions'),
     productName: t('Build Distribution'),
     uid: 36,
-    isBilledCategory: false,
+    isBilledCategory: true,
     statsInfo: {...DEFAULT_STATS_INFO, showExternalStats: true},
     formatting: DEFAULT_COUNT_FORMATTING,
   },

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -698,7 +698,7 @@ export const DATA_CATEGORY_INFO = {
     titleName: t('Build Distributions'),
     productName: t('Build Distribution'),
     uid: 36,
-    isBilledCategory: true,
+    isBilledCategory: false,
     statsInfo: {...DEFAULT_STATS_INFO, showExternalStats: true},
     formatting: DEFAULT_COUNT_FORMATTING,
   },

--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -351,7 +351,6 @@ describe('ProductSelectionAvailability', () => {
         reservedSeerScanner: undefined,
         reservedSeerUsers: undefined,
         reservedSizeAnalyses: 0,
-        reservedInstallableBuilds: 0,
         reservedTraceMetricBytes: 0,
       };
       const mockPlan = PlanFixture({});

--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -351,6 +351,8 @@ describe('ProductSelectionAvailability', () => {
         reservedSeerScanner: undefined,
         reservedSeerUsers: undefined,
         reservedSizeAnalyses: 0,
+        reservedInstallableBuilds: 0,
+        reservedTraceMetricBytes: 0,
       };
       const mockPlan = PlanFixture({});
       const mockPreview = PreviewDataFixture({});

--- a/static/gsApp/components/productUnavailableCTA.spec.tsx
+++ b/static/gsApp/components/productUnavailableCTA.spec.tsx
@@ -219,6 +219,8 @@ describe('ProductUnavailableCTA', () => {
         reservedSeerScanner: undefined,
         reservedSeerUsers: undefined,
         reservedSizeAnalyses: undefined,
+        reservedInstallableBuilds: undefined,
+        reservedTraceMetricBytes: undefined,
       };
       const mockPlan = PlanFixture({});
       const mockPreview = PreviewDataFixture({});

--- a/static/gsApp/components/productUnavailableCTA.spec.tsx
+++ b/static/gsApp/components/productUnavailableCTA.spec.tsx
@@ -219,7 +219,6 @@ describe('ProductUnavailableCTA', () => {
         reservedSeerScanner: undefined,
         reservedSeerUsers: undefined,
         reservedSizeAnalyses: undefined,
-        reservedInstallableBuilds: undefined,
         reservedTraceMetricBytes: undefined,
       };
       const mockPlan = PlanFixture({});

--- a/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
@@ -26,7 +26,6 @@ const mockReservations: Reservations = {
   reservedSeerScanner: 0,
   reservedSeerUsers: 0,
   reservedSizeAnalyses: 100,
-  reservedInstallableBuilds: 25000,
   reservedTraceMetricBytes: undefined,
 };
 

--- a/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
@@ -26,6 +26,8 @@ const mockReservations: Reservations = {
   reservedSeerScanner: 0,
   reservedSeerUsers: 0,
   reservedSizeAnalyses: 100,
+  reservedInstallableBuilds: 25000,
+  reservedTraceMetricBytes: undefined,
 };
 
 const mockPreview = PreviewDataFixture({});

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
@@ -59,7 +59,6 @@ describe('useUpgradeNowParams', () => {
           reservedSeerScanner: 0,
           reservedSeerUsers: 0,
           reservedSizeAnalyses: 100,
-          reservedInstallableBuilds: 25000,
           reservedTraceMetricBytes: undefined,
         },
       })

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
@@ -59,6 +59,8 @@ describe('useUpgradeNowParams', () => {
           reservedSeerScanner: 0,
           reservedSeerUsers: 0,
           reservedSizeAnalyses: 100,
+          reservedInstallableBuilds: 25000,
+          reservedTraceMetricBytes: undefined,
         },
       })
     );

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
@@ -108,6 +108,8 @@ export function useUpgradeNowParams({organization, subscription, enabled = true}
         reservedSeerScanner: reserved.seerScanner,
         reservedSeerUsers: reserved.seerUsers,
         reservedSizeAnalyses: reserved.sizeAnalyses,
+        reservedInstallableBuilds: reserved.installableBuilds,
+        reservedTraceMetricBytes: reserved.traceMetricBytes,
       },
     };
   }, [billingConfig, isPending, subscription, enabled]);

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
@@ -108,7 +108,6 @@ export function useUpgradeNowParams({organization, subscription, enabled = true}
         reservedSeerScanner: reserved.seerScanner,
         reservedSeerUsers: reserved.seerUsers,
         reservedSizeAnalyses: reserved.sizeAnalyses,
-        reservedInstallableBuilds: reserved.installableBuilds,
         reservedTraceMetricBytes: reserved.traceMetricBytes,
       },
     };

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -196,6 +196,13 @@ export const BILLED_DATA_CATEGORY_INFO = {
     ),
     shortenedUnitName: 'GB',
   },
+  [DataCategoryExact.TRACE_METRIC_BYTE]: {
+    ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.TRACE_METRIC_BYTE],
+    canProductTrial: true,
+    freeEventsMultiple: 1,
+    feature: 'expose-category-trace-metric-byte',
+    shortenedUnitName: 'GB',
+  },
   [DataCategoryExact.SEER_USER]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SEER_USER],
     feature: 'seer-user-billing-launch',


### PR DESCRIPTION
https://linear.app/getsentry/issue/BIL-2213/set-billed-data-category-canproduct-for-trace-metrics
https://linear.app/getsentry/issue/BIL-2226/set-isbilledcategory-to-true-for-installable-builds

This PR adds a billed category entry for trace metric bytes. It also sets the isBilledCategory value to true for trace metric bytes. 
