### PR TITLE
fix(textarea): Use correct prop for minRows in autosized textarea

### DIFF
--- a/static/app/components/core/textarea/textarea.tsx
+++ b/static/app/components/core/textarea/textarea.tsx
@@ -34,7 +34,7 @@ function TextAreaControl({
   ...p
 }: TextAreaProps) {
   return autosize ? (
-    <TextareaAutosize {...p} ref={ref} rows={rows} maxRows={maxRows} />
+    <TextareaAutosize {...p} ref={ref} minRows={rows} maxRows={maxRows} />
   ) : (
     <textarea ref={ref} {...p} rows={rows} />
   );


### PR DESCRIPTION
`react-textarea-autosize` accepts `minRows`, not `rows`:

```tsx
export interface TextareaAutosizeProps extends Omit<TextareaProps, 'style'> {
    maxRows?: number;
    minRows?: number;
    onHeightChange?: (height: number, meta: TextareaHeightChangeMeta) => void;
    cacheMeasurements?: boolean;
    style?: Style;
}
```

I'm noticing that TextArea doesn't have a story file?

Also, I tried adding snapshot tests for this component but I couldn't get the snapshots to render the autosizing correctly. I may be missing something, or this could be a gap with the snapshotting framework (cc @rbro112)