### PR TITLE
ref(admin): Replace `useRouter` usage in `InstanceLevelOAuthDetails`

### DIFF
--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -20,6 +20,7 @@ type ParamKeys =
   | 'baseArtifactId'
   | 'beaconId'
   | 'broadcastId'
+  | 'clientID'
   | 'codeId'
   | 'dashboardId'
   | 'dataExportId'

--- a/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
@@ -14,7 +14,7 @@ import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useApi} from 'sentry/utils/useApi';
-import {useRouter} from 'sentry/utils/useRouter';
+import {useParams} from 'sentry/utils/useParams';
 
 import {PageHeader} from 'admin/components/pageHeader';
 
@@ -40,7 +40,7 @@ const fieldProps = {
 
 export function InstanceLevelOAuthDetails() {
   const api = useApi();
-  const router = useRouter();
+  const params = useParams<{clientID: string}>();
 
   const [clientDetails, setClientDetails] = useState<ClientDetails | null>();
   const [errorMessage, setErrorMessage] = useState<string | null>();
@@ -49,7 +49,7 @@ export function InstanceLevelOAuthDetails() {
   const fetchClientData = useCallback(async () => {
     try {
       const response = await api.requestPromise(
-        `/_admin/instance-level-oauth/${router.params.clientID}/`,
+        `/_admin/instance-level-oauth/${params.clientID}/`,
         {}
       );
 
@@ -72,7 +72,7 @@ export function InstanceLevelOAuthDetails() {
     } finally {
       setLoading(false);
     }
-  }, [router.params.clientID, api]);
+  }, [params.clientID, api]);
 
   useEffect(() => {
     fetchClientData();


### PR DESCRIPTION
https://github.com/getsentry/frontend-tsc/issues/78

Replaces `useRouter` usage in `InstanceLevelOAuthDetails` with `useParams`.