### PR TITLE
feat(nav): Improve What's New panel and primary nav overlays

### DIFF
--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -4,6 +4,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 import {mergeProps} from '@react-aria/utils';
+import {motion} from 'framer-motion';
 import type {LocationDescriptor} from 'history';
 import type {DistributedOmit} from 'type-fest';
 
@@ -757,11 +758,19 @@ export function usePrimaryNavigationButtonOverlay(props: UseOverlayProps = {}) {
  */
 function PrimaryNavigationButtonOverlay(props: PrimaryNavigationButtonOverlayProps) {
   const theme = useTheme();
+  const {layout} = usePrimaryNavigation();
+  const isDesktop = layout !== 'mobile';
 
   return createPortal(
     <FocusScope restoreFocus autoFocus>
       <PositionWrapper zIndex={theme.zIndex.modal} {...props.overlayProps}>
-        <ScrollableOverlay>{props.children}</ScrollableOverlay>
+        <motion.div
+          initial={isDesktop ? {opacity: 0, scale: 0.98} : undefined}
+          animate={isDesktop ? {opacity: 1, scale: 1} : undefined}
+          transition={isDesktop ? theme.motion.framer.enter.moderate : undefined}
+        >
+          <ScrollableOverlay>{props.children}</ScrollableOverlay>
+        </motion.div>
       </PositionWrapper>
     </FocusScope>,
     document.body

--- a/static/app/views/navigation/primary/whatsNew.spec.tsx
+++ b/static/app/views/navigation/primary/whatsNew.spec.tsx
@@ -263,7 +263,11 @@ describe('WhatsNew', () => {
     expect(await screen.findByText('Blog Post')).toBeInTheDocument();
     const titleLink = screen.getByRole('link', {name: broadcast.title});
     expect(titleLink).toHaveAttribute('href', broadcast.link);
-    expect(screen.getByText(broadcast.message)).toBeInTheDocument();
+    expect(screen.getByText(broadcast.message, {exact: false})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Read more'})).toHaveAttribute(
+      'href',
+      broadcast.link
+    );
 
     await userEvent.click(titleLink);
     expect(trackAnalytics).toHaveBeenCalledWith(
@@ -273,6 +277,66 @@ describe('WhatsNew', () => {
         category: 'blog',
       })
     );
+  });
+
+  it('filters out duplicate titles and only shows the first occurrence', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/broadcasts/`,
+      match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
+      body: [
+        BroadcastFixture({id: '1', title: 'Duplicate Title', hasSeen: true}),
+        BroadcastFixture({id: '2', title: 'Duplicate Title', hasSeen: true}),
+        BroadcastFixture({id: '3', title: 'Unique Title', hasSeen: true}),
+      ],
+    });
+
+    render(<PrimaryNavigationWhatsNew />);
+
+    await userEvent.click(screen.getByRole('button', {name: "What's New"}));
+
+    expect(await screen.findByText('Duplicate Title')).toBeInTheDocument();
+    expect(screen.getAllByText('Duplicate Title')).toHaveLength(1);
+    expect(screen.getByText('Unique Title')).toBeInTheDocument();
+  });
+
+  it('marks unseen duplicate broadcasts as seen when the panel is opened', async () => {
+    jest.useFakeTimers();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/broadcasts/`,
+      match: [MockApiClient.matchQuery({show: 'latest', limit: '3'})],
+      body: [
+        BroadcastFixture({id: '1', title: 'Duplicate Title', hasSeen: false}),
+        BroadcastFixture({id: '2', title: 'Duplicate Title', hasSeen: false}),
+        BroadcastFixture({id: '3', title: 'Unique Title', hasSeen: true}),
+      ],
+    });
+
+    const putMock = MockApiClient.addMockResponse({
+      url: '/broadcasts/',
+      method: 'PUT',
+    });
+
+    render(<PrimaryNavigationWhatsNew />);
+
+    await userEvent.click(screen.getByRole('button', {name: "What's New"}), {
+      delay: null,
+    });
+
+    await screen.findByText('Duplicate Title');
+
+    act(() => jest.advanceTimersByTime(2000));
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith(
+        '/broadcasts/',
+        expect.objectContaining({
+          method: 'PUT',
+          query: {id: ['1', '2']},
+          data: {hasSeen: '1'},
+        })
+      );
+    });
   });
 
   it('renders broadcast items for each category type', async () => {

--- a/static/app/views/navigation/primary/whatsNew.tsx
+++ b/static/app/views/navigation/primary/whatsNew.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo} from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Image} from '@sentry/scraps/image';
@@ -32,6 +32,25 @@ const BROADCAST_CATEGORIES: Record<NonNullable<Broadcast['category']>, string> =
   event: t('Event'),
   video: t('Video'),
 };
+
+function BroadcastImage({src, alt}: {alt: string; src: string}) {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <Fragment>
+      {!loaded && <Placeholder width="100%" height="140px" />}
+      <Image
+        width="100%"
+        src={src}
+        alt={alt}
+        radius="md"
+        loading="eager"
+        onLoad={() => setLoaded(true)}
+        style={loaded ? undefined : {display: 'none'}}
+      />
+    </Fragment>
+  );
+}
 
 function WhatsNewContent({
   unseenPostIds,
@@ -159,7 +178,7 @@ function WhatsNewContent({
                 </ExternalLink>
               </Text>
               {item.mediaUrl ? (
-                <Image width="100%" src={item.mediaUrl} alt={item.title} radius="md" />
+                <BroadcastImage src={item.mediaUrl} alt={item.title} />
               ) : null}
               {idx < broadcasts.length - 1 && <Stack.Separator />}
             </Stack>

--- a/static/app/views/navigation/primary/whatsNew.tsx
+++ b/static/app/views/navigation/primary/whatsNew.tsx
@@ -143,7 +143,21 @@ function WhatsNewContent({
                   </Tag>
                 ) : null}
               </Flex>
-              <Text>{item.message}</Text>
+              <Text>
+                {item.message}{' '}
+                <ExternalLink
+                  href={item.link}
+                  onClick={() =>
+                    trackAnalytics('whats_new.link_clicked', {
+                      organization,
+                      title: item.title,
+                      category: item.category,
+                    })
+                  }
+                >
+                  {t('Read more')}
+                </ExternalLink>
+              </Text>
               {item.mediaUrl ? (
                 <Image width="100%" src={item.mediaUrl} alt={item.title} radius="md" />
               ) : null}
@@ -173,13 +187,24 @@ export function PrimaryNavigationWhatsNew() {
       refetchOnWindowFocus: true,
     }
   );
-  const unseenPostIds = useMemo(
-    () =>
-      (Array.isArray(broadcasts) ? broadcasts : [])
-        .filter(item => !item.hasSeen)
-        .map(item => item.id),
+  const allBroadcasts = useMemo(
+    () => (Array.isArray(broadcasts) ? broadcasts : []),
     [broadcasts]
   );
+
+  const unseenPostIds = useMemo(
+    () => allBroadcasts.filter(item => !item.hasSeen).map(item => item.id),
+    [allBroadcasts]
+  );
+
+  const uniqueBroadcasts = useMemo(() => {
+    const seenTitles = new Set<string>();
+    return allBroadcasts.filter(item => {
+      if (seenTitles.has(item.title)) return false;
+      seenTitles.add(item.title);
+      return true;
+    });
+  }, [allBroadcasts]);
 
   const {
     isOpen,
@@ -203,7 +228,7 @@ export function PrimaryNavigationWhatsNew() {
           <WhatsNewContent
             unseenPostIds={unseenPostIds}
             isPending={isPending}
-            broadcasts={Array.isArray(broadcasts) ? broadcasts : []}
+            broadcasts={uniqueBroadcasts}
           />
         </PrimaryNavigation.ButtonOverlay>
       )}


### PR DESCRIPTION
Improves the What's New panel in the primary navigation and the overlay
animation behaviour, as part of DE-1071.

**What's New panel changes:**
- Deduplicate broadcasts by title before rendering — the same post won't
  appear more than once. All unseen duplicates are still included in the
  mark-seen request so the backend clears them correctly.
- Add an inline "Read more" link after each broadcast message, linking to
  the full post and firing the existing `whats_new.link_clicked` analytics
  event.
- Add a `BroadcastImage` component that shows a 140px skeleton placeholder
  while the media image loads, preventing layout shift. Uses `loading="eager"`
  so the browser fetches the image even before it is visible in the DOM.

**Primary nav overlay changes:**
- Wrap the overlay panel in a `motion.div` with a scale (0.98 → 1) and
  opacity (0 → 1) entrance animation using `theme.motion.framer.enter.moderate`
  (160ms ease-out). Animation only runs on desktop — mobile renders statically
  to preserve the existing sheet behaviour.

Refs LINEAR-DE-1071
Co-Authored-By: Claude <noreply@anthropic.com>