### PR TITLE
feat(middleware): Enable viewer context middleware by default

### DIFF
--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from django.conf import settings
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 
@@ -24,6 +25,12 @@ def ViewerContextMiddleware(
 
     def ViewerContextMiddleware_impl(request: HttpRequest) -> HttpResponseBase:
         if not enabled:
+            return get_response(request)
+
+        # This avoids touching user session, which means we avoid
+        # setting `Vary: Cookie` as a response header which will
+        # break HTTP caching entirely.
+        if request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES):
             return get_response(request)
 
         ctx = _viewer_context_from_request(request)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4106,7 +4106,7 @@ register(
 # Set via deploy config (SENTRY_OPTIONS); requires restart to change.
 register(
     "viewer-context.enabled",
-    default=False,
+    default=True,
     type=Bool,
     flags=FLAG_NOSTORE,
 )

--- a/tests/sentry/middleware/test_viewer_context.py
+++ b/tests/sentry/middleware/test_viewer_context.py
@@ -103,6 +103,7 @@ class ViewerContextMiddlewareTest(TestCase):
         super().setUp()
         self.factory = RequestFactory()
 
+    @override_options({"viewer-context.enabled": False})
     def test_skipped_when_disabled(self):
         captured: list = []
 
@@ -110,7 +111,6 @@ class ViewerContextMiddlewareTest(TestCase):
             captured.append(get_viewer_context())
             return MagicMock(status_code=200)
 
-        # Default: viewer-context.enabled is False
         middleware = ViewerContextMiddleware(get_response)
 
         request = self.factory.get("/")


### PR DESCRIPTION
Enable the `ViewerContextMiddleware` by setting the `viewer-context.enabled`
option default to `True`. This causes the middleware to populate a
`ViewerContext` (unified caller identity) on every authenticated request.

The option uses `FLAG_NOSTORE` so the value is read at process startup from
deploy config (`SENTRY_OPTIONS`). Changing the default here means it will be
active everywhere unless explicitly overridden to `False` in deploy config.