### PR TITLE
fix(issues): Guard against NaN in supergroup row stats during loading

### DIFF
--- a/static/app/views/issueList/supergroups/aggregateSupergroupStats.spec.ts
+++ b/static/app/views/issueList/supergroups/aggregateSupergroupStats.spec.ts
@@ -1,5 +1,7 @@
 import {GroupFixture} from 'sentry-fixture/group';
 
+import type {Group} from 'sentry/types/group';
+
 import {aggregateSupergroupStats} from './aggregateSupergroupStats';
 
 describe('aggregateSupergroupStats', () => {
@@ -59,6 +61,15 @@ describe('aggregateSupergroupStats', () => {
     expect(result?.filteredEventCount).toBeNull();
     expect(result?.filteredUserCount).toBeNull();
     expect(result?.mergedFilteredStats).toBeNull();
+  });
+
+  it('treats missing counts as zero when stats have not loaded', () => {
+    const result = aggregateSupergroupStats(
+      [GroupFixture({count: '10', userCount: 3}), {} as Group],
+      '24h'
+    );
+    expect(result?.eventCount).toBe(10);
+    expect(result?.userCount).toBe(3);
   });
 
   it('aggregates filtered stats separately', () => {

--- a/static/app/views/issueList/supergroups/aggregateSupergroupStats.ts
+++ b/static/app/views/issueList/supergroups/aggregateSupergroupStats.ts
@@ -51,14 +51,14 @@ export function aggregateSupergroupStats(
   let mergedFilteredStats: TimeseriesValue[] | null = null;
 
   for (const group of groups) {
-    eventCount += parseInt(group.count, 10);
-    userCount += group.userCount;
+    eventCount += parseInt(group.count, 10) || 0;
+    userCount += group.userCount ?? 0;
 
     if (group.filtered) {
       filteredEventCount ??= 0;
       filteredUserCount ??= 0;
-      filteredEventCount += parseInt(group.filtered.count, 10);
-      filteredUserCount += group.filtered.userCount;
+      filteredEventCount += parseInt(group.filtered.count, 10) || 0;
+      filteredUserCount += group.filtered.userCount ?? 0;
 
       const filteredStats = group.filtered.stats?.[statsPeriod];
       if (filteredStats) {


### PR DESCRIPTION
Stats are fetched separately from groups, so when groups are in the
store but stats haven't populated yet, `count`/`userCount` are
undefined. `parseInt(undefined)` returns `NaN` which propagates through
the sum and renders as "NaN" in the supergroup row.

Guards with `|| 0` and `?? 0` so partially-loaded groups contribute zero
instead of poisoning the total.