### PR TITLE
fix(seer): Dual-delete Seer project preferences on integration uninstall

### DIFF
--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -162,18 +162,18 @@ class DatabaseBackedRepositoryService(RepositoryService):
     ) -> None:
         with transaction.atomic(router.db_for_write(Repository)):
             # Get affected repos before nulling integration_id so we can clean up Seer
-            affected_repos = list(
+            repos = list(
                 Repository.objects.filter(
                     organization_id=organization_id, integration_id=integration_id
                 ).values_list("id", "external_id", "provider")
             )
-            affected_repo_ids = [repo_id for repo_id, _, _ in affected_repos]
+            repo_ids = [repo_id for repo_id, _, _ in repos]
 
             # Disassociate repos from the organization integration being deleted
-            Repository.objects.filter(id__in=affected_repo_ids).update(integration_id=None)
+            Repository.objects.filter(id__in=repo_ids).update(integration_id=None)
 
             # Delete Seer project preferences for the affected repos
-            SeerProjectRepository.objects.filter(repository_id__in=affected_repo_ids).delete()
+            SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
 
             # Delete Code Owners with a Code Mapping using the OrganizationIntegration
             ProjectCodeOwners.objects.filter(
@@ -190,7 +190,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
         # Delete Seer project preferences for the affected repos via Seer API
         repos_to_clean = [
             {"repo_external_id": external_id, "repo_provider": provider}
-            for _, external_id, provider in affected_repos
+            for _, external_id, provider in repos
             if external_id and provider
         ]
         if repos_to_clean:

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -163,7 +163,6 @@ class DatabaseBackedRepositoryService(RepositoryService):
         integration_id: int,
     ) -> None:
         with transaction.atomic(router.db_for_write(Repository)):
-            # Get affected repos before nulling integration_id so we can clean up Seer
             repos = list(
                 Repository.objects.filter(
                     organization_id=organization_id, integration_id=integration_id
@@ -171,19 +170,20 @@ class DatabaseBackedRepositoryService(RepositoryService):
             )
             repo_ids = [repo_id for repo_id, _, _ in repos]
 
-            # Disassociate repos from the organization integration being deleted
-            Repository.objects.filter(id__in=repo_ids).update(integration_id=None)
+            if repo_ids:
+                # Disassociate repos from the organization integration being deleted
+                Repository.objects.filter(id__in=repo_ids).update(integration_id=None)
 
-            # Delete Seer project preferences for the affected repos.
-            # Organization may already be deleted if org deletion and integration
-            # uninstall overlap; skip SeerProjectRepository cleanup in that case
-            # since cascades will handle it.
-            try:
-                organization = Organization.objects.get_from_cache(id=organization_id)
-                if features.has("organizations:seer-project-settings-dual-write", organization):
-                    SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
-            except Organization.DoesNotExist:
-                pass
+                # Delete Seer project preferences for the affected repos.
+                # Organization may already be deleted if org deletion and integration
+                # uninstall overlap; skip SeerProjectRepository cleanup in that case
+                # since cascades will handle it.
+                try:
+                    organization = Organization.objects.get_from_cache(id=organization_id)
+                    if features.has("organizations:seer-project-settings-dual-write", organization):
+                        SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
+                except Organization.DoesNotExist:
+                    pass
 
             # Delete Code Owners with a Code Mapping using the OrganizationIntegration
             ProjectCodeOwners.objects.filter(

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -13,6 +13,8 @@ from sentry.integrations.services.repository.model import RpcCreateRepository
 from sentry.integrations.services.repository.serial import serialize_repository
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.repository import Repository
+from sentry.seer.models.project_repository import SeerProjectRepository
+from sentry.tasks.seer.cleanup import bulk_cleanup_seer_repository_preferences
 from sentry.users.services.user.model import RpcUser
 
 
@@ -159,10 +161,19 @@ class DatabaseBackedRepositoryService(RepositoryService):
         integration_id: int,
     ) -> None:
         with transaction.atomic(router.db_for_write(Repository)):
+            # Get affected repos before nulling integration_id so we can clean up Seer
+            affected_repos = list(
+                Repository.objects.filter(
+                    organization_id=organization_id, integration_id=integration_id
+                ).values_list("id", "external_id", "provider")
+            )
+            affected_repo_ids = [repo_id for repo_id, _, _ in affected_repos]
+
             # Disassociate repos from the organization integration being deleted
-            Repository.objects.filter(
-                organization_id=organization_id, integration_id=integration_id
-            ).update(integration_id=None)
+            Repository.objects.filter(id__in=affected_repo_ids).update(integration_id=None)
+
+            # Delete Seer project preferences for the affected repos
+            SeerProjectRepository.objects.filter(repository_id__in=affected_repo_ids).delete()
 
             # Delete Code Owners with a Code Mapping using the OrganizationIntegration
             ProjectCodeOwners.objects.filter(
@@ -175,3 +186,17 @@ class DatabaseBackedRepositoryService(RepositoryService):
             RepositoryProjectPathConfig.objects.filter(
                 organization_integration_id=organization_integration_id
             ).delete()
+
+        # Delete Seer project preferences for the affected repos via Seer API
+        repos_to_clean = [
+            {"repo_external_id": external_id, "repo_provider": provider}
+            for _, external_id, provider in affected_repos
+            if external_id and provider
+        ]
+        if repos_to_clean:
+            bulk_cleanup_seer_repository_preferences.apply_async(
+                kwargs={
+                    "organization_id": organization_id,
+                    "repos": repos_to_clean,
+                }
+            )

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -174,10 +174,16 @@ class DatabaseBackedRepositoryService(RepositoryService):
             # Disassociate repos from the organization integration being deleted
             Repository.objects.filter(id__in=repo_ids).update(integration_id=None)
 
-            # Delete Seer project preferences for the affected repos
-            organization = Organization.objects.get_from_cache(id=organization_id)
-            if features.has("organizations:seer-project-settings-dual-write", organization):
-                SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
+            # Delete Seer project preferences for the affected repos.
+            # Organization may already be deleted if org deletion and integration
+            # uninstall overlap; skip SeerProjectRepository cleanup in that case
+            # since cascades will handle it.
+            try:
+                organization = Organization.objects.get_from_cache(id=organization_id)
+                if features.has("organizations:seer-project-settings-dual-write", organization):
+                    SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
+            except Organization.DoesNotExist:
+                pass
 
             # Delete Code Owners with a Code Mapping using the OrganizationIntegration
             ProjectCodeOwners.objects.filter(

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from django.db import IntegrityError, router, transaction
 
+from sentry import features
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import enforce_constraints
@@ -11,6 +12,7 @@ from sentry.integrations.models.repository_project_path_config import Repository
 from sentry.integrations.services.repository import RepositoryService, RpcRepository
 from sentry.integrations.services.repository.model import RpcCreateRepository
 from sentry.integrations.services.repository.serial import serialize_repository
+from sentry.models.organization import Organization
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.repository import Repository
 from sentry.seer.models.project_repository import SeerProjectRepository
@@ -173,7 +175,9 @@ class DatabaseBackedRepositoryService(RepositoryService):
             Repository.objects.filter(id__in=repo_ids).update(integration_id=None)
 
             # Delete Seer project preferences for the affected repos
-            SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
+            organization = Organization.objects.get_from_cache(id=organization_id)
+            if features.has("organizations:seer-project-settings-dual-write", organization):
+                SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
 
             # Delete Code Owners with a Code Mapping using the OrganizationIntegration
             ProjectCodeOwners.objects.filter(

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -722,14 +722,15 @@ def _resolve_project_preference(
 
     set_project_seer_preference(preference)
 
-    try:
-        write_preference_to_sentry_db(project, preference)
-    except Exception:
-        logger.exception(
-            "seer.write_preferences.resolve_project_preference.sentry_db_write_failed",
-            extra={"project_id": project.id, "organization_id": organization.id},
-            exc_info=True,
-        )
+    if features.has("organizations:seer-project-settings-dual-write", organization):
+        try:
+            write_preference_to_sentry_db(project, preference)
+        except Exception:
+            logger.exception(
+                "seer.write_preferences.resolve_project_preference.sentry_db_write_failed",
+                extra={"project_id": project.id, "organization_id": organization.id},
+                exc_info=True,
+            )
 
     return preference
 

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -192,6 +192,16 @@ class RemoveRepositoryRequest(TypedDict):
     repo_external_id: str
 
 
+class RepoIdentifier(TypedDict):
+    repo_provider: str
+    repo_external_id: str
+
+
+class BulkRemoveRepositoriesRequest(TypedDict):
+    organization_id: int
+    repositories: list[RepoIdentifier]
+
+
 class ExplorerIndexProject(TypedDict):
     org_id: int
     project_id: int
@@ -252,6 +262,20 @@ def make_remove_repository_request(
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/project-preference/remove-repository",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        viewer_context=viewer_context,
+    )
+
+
+def make_bulk_remove_repositories_request(
+    body: BulkRemoveRepositoriesRequest,
+    timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/project-preference/bulk-remove-repositories",
         body=orjson.dumps(body),
         timeout=timeout,
         viewer_context=viewer_context,

--- a/src/sentry/tasks/seer/cleanup.py
+++ b/src/sentry/tasks/seer/cleanup.py
@@ -4,8 +4,11 @@ import logging
 
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
+    BulkRemoveRepositoriesRequest,
     RemoveRepositoryRequest,
+    RepoIdentifier,
     SeerViewerContext,
+    make_bulk_remove_repositories_request,
     make_remove_repository_request,
 )
 from sentry.silo.base import SiloMode
@@ -27,7 +30,7 @@ def cleanup_seer_repository_preferences(
     """
     Clean up Seer preferences for a deleted repository.
 
-    This task removes a repository from Seer organization preferences when the repository
+    This task removes a repository from Seer project preferences when the repository
     is deleted from an organization's integration.
     """
     # Call Seer API to remove repository from organization preferences
@@ -57,6 +60,56 @@ def cleanup_seer_repository_preferences(
                 "organization_id": organization_id,
                 "repo_external_id": repo_external_id,
                 "repo_provider": repo_provider,
+                "error": str(e),
+            },
+        )
+        raise
+
+
+@instrumented_task(
+    name="sentry.tasks.seer.bulk_cleanup_seer_repository_preferences",
+    namespace=seer_tasks,
+    processing_deadline_duration=60 * 10,
+    silo_mode=SiloMode.CELL,
+)
+def bulk_cleanup_seer_repository_preferences(
+    organization_id: int, repos: list[dict[str, str]]
+) -> None:
+    """
+    Removes multiple repositories from Seer project preferences when the repository
+    is deleted from an organization's integration.
+
+    Each entry in repos should have 'repo_external_id' and 'repo_provider' keys.
+    """
+    body = BulkRemoveRepositoriesRequest(
+        organization_id=organization_id,
+        repositories=[
+            RepoIdentifier(
+                repo_provider=repo["repo_provider"],
+                repo_external_id=repo["repo_external_id"],
+            )
+            for repo in repos
+        ],
+    )
+
+    viewer_context = SeerViewerContext(organization_id=organization_id)
+    try:
+        response = make_bulk_remove_repositories_request(body, viewer_context=viewer_context)
+        if response.status >= 400:
+            raise SeerApiError("Seer request failed", response.status)
+        logger.info(
+            "bulk_cleanup_seer_repository_preferences.success",
+            extra={
+                "organization_id": organization_id,
+                "repo_count": len(repos),
+            },
+        )
+    except Exception as e:
+        logger.exception(
+            "bulk_cleanup_seer_repository_preferences.failed",
+            extra={
+                "organization_id": organization_id,
+                "repo_count": len(repos),
                 "error": str(e),
             },
         )

--- a/src/sentry/tasks/seer/cleanup.py
+++ b/src/sentry/tasks/seer/cleanup.py
@@ -33,7 +33,7 @@ def cleanup_seer_repository_preferences(
     This task removes a repository from Seer project preferences when the repository
     is deleted from an organization's integration.
     """
-    # Call Seer API to remove repository from organization preferences
+    # Call Seer API to remove repository from project preferences
     body = RemoveRepositoryRequest(
         organization_id=organization_id,
         repo_provider=repo_provider,
@@ -78,8 +78,6 @@ def bulk_cleanup_seer_repository_preferences(
     """
     Removes multiple repositories from Seer project preferences when the repository
     is deleted from an organization's integration.
-
-    Each entry in repos should have 'repo_external_id' and 'repo_provider' keys.
     """
     body = BulkRemoveRepositoriesRequest(
         organization_id=organization_id,

--- a/tests/sentry/integrations/models/deletions/test_organizationintegration.py
+++ b/tests/sentry/integrations/models/deletions/test_organizationintegration.py
@@ -58,6 +58,7 @@ class DeleteOrganizationIntegrationTest(TransactionTestCase, HybridCloudTestMixi
 
         assert OrganizationIntegration.objects.filter(id=organization_integration.id).exists()
 
+    @with_feature("organizations:seer-project-settings-dual-write")
     def test_repository_and_identity(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)

--- a/tests/sentry/integrations/models/deletions/test_organizationintegration.py
+++ b/tests/sentry/integrations/models/deletions/test_organizationintegration.py
@@ -9,6 +9,7 @@ from sentry.models.project import Project
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.repository import Repository
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.features import with_feature
@@ -75,6 +76,9 @@ class DeleteOrganizationIntegrationTest(TransactionTestCase, HybridCloudTestMixi
             external_issue = ExternalIssue.objects.create(
                 organization_id=org.id, integration_id=integration.id, key="ABC-123"
             )
+            seer_project_repo = SeerProjectRepository.objects.create(
+                project=project, repository=repository
+            )
         organization_integration.update(status=ObjectStatus.PENDING_DELETION)
         ScheduledDeletion.schedule(instance=organization_integration, days=0)
 
@@ -91,6 +95,7 @@ class DeleteOrganizationIntegrationTest(TransactionTestCase, HybridCloudTestMixi
             assert ExternalIssue.objects.filter(id=external_issue.id).exists()
             repo = Repository.objects.get(id=repository.id)
             assert repo.integration_id is None
+            assert not SeerProjectRepository.objects.filter(id=seer_project_repo.id).exists()
 
     def test_codeowner_links(self) -> None:
         org = self.create_organization()

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1094,6 +1094,7 @@ class TestTriggerAutofixWithHideAiFeatures(APITestCase, SnubaTestCase):
         mock_get_serialized_event.assert_not_called()
 
 
+@with_feature("organizations:seer-project-settings-dual-write")
 class TestResolveProjectPreference(TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/tasks/seer/test_cleanup.py
+++ b/tests/sentry/tasks/seer/test_cleanup.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sentry.seer.models import SeerApiError
-from sentry.tasks.seer.cleanup import cleanup_seer_repository_preferences
+from sentry.tasks.seer.cleanup import (
+    bulk_cleanup_seer_repository_preferences,
+    cleanup_seer_repository_preferences,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -69,3 +72,40 @@ class TestSeerRepositoryCleanup(TestCase):
             "repo_provider": self.repo_provider,
             "repo_external_id": self.repo_external_id,
         }
+
+
+class TestBulkSeerRepositoryCleanup(TestCase):
+    def setUp(self) -> None:
+        self.organization = self.create_organization()
+        self.repos = [
+            {"repo_external_id": "123", "repo_provider": "github"},
+            {"repo_external_id": "456", "repo_provider": "github"},
+        ]
+
+    @patch("sentry.tasks.seer.cleanup.make_bulk_remove_repositories_request")
+    def test_bulk_cleanup_success(self, mock_request: MagicMock) -> None:
+        """Test successful bulk cleanup of Seer repository preferences."""
+        mock_request.return_value.status = 200
+
+        bulk_cleanup_seer_repository_preferences(
+            organization_id=self.organization.id,
+            repos=self.repos,
+        )
+
+        mock_request.assert_called_once()
+        body = mock_request.call_args[0][0]
+        assert body["organization_id"] == self.organization.id
+        assert len(body["repositories"]) == 2
+        assert body["repositories"][0] == {"repo_provider": "github", "repo_external_id": "123"}
+        assert body["repositories"][1] == {"repo_provider": "github", "repo_external_id": "456"}
+
+    @patch("sentry.tasks.seer.cleanup.make_bulk_remove_repositories_request")
+    def test_bulk_cleanup_api_error(self, mock_request: MagicMock) -> None:
+        """Test handling of Seer API errors."""
+        mock_request.return_value.status = 500
+
+        with pytest.raises(SeerApiError):
+            bulk_cleanup_seer_repository_preferences(
+                organization_id=self.organization.id,
+                repos=self.repos,
+            )


### PR DESCRIPTION
Fixes CW-1142, AIML-2705

Depends on https://github.com/getsentry/seer/pull/5641

When an integration is uninstalled, disassociate_organization_integration now deletes SeerProjectRepository rows and notifies Seer via a bulk cleanup task to remove repos from its preferences.