### PR TITLE
feat(cmd-k): Add 'superuser' keyword to admin actions

### DIFF
--- a/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
+++ b/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
@@ -6,6 +6,7 @@ import {ProjectAvatar} from '@sentry/scraps/avatar';
 
 import {addLoadingMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
+import {openSudo} from 'sentry/actionCreators/sudoModal';
 import {useCommandPaletteActionsRegister} from 'sentry/components/commandPalette/context';
 import type {
   CMDKQueryOptions,
@@ -366,6 +367,22 @@ export function useGlobalCommandPaletteActions() {
                   'noreferrer'
                 ),
             },
+            ...(isActiveSuperuser()
+              ? []
+              : [
+                  {
+                    display: {
+                      label: t('Open Superuser Modal'),
+                      icon: <IconLock locked />,
+                    },
+                    keywords: [t('superuser')],
+                    onAction: () =>
+                      openSudo({
+                        isSuperuser: true,
+                        needsReload: true,
+                      }),
+                  },
+                ]),
             ...(isActiveSuperuser()
               ? [
                   {

--- a/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
+++ b/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
@@ -361,7 +361,7 @@ export function useGlobalCommandPaletteActions() {
               keywords: [t('superuser')],
               onAction: () =>
                 window.open(
-                  `/_admin/organizations/${organization.slug}/`,
+                  `/_admin/customers/${organization.slug}/`,
                   '_blank',
                   'noreferrer'
                 ),
@@ -373,6 +373,7 @@ export function useGlobalCommandPaletteActions() {
                       label: t('Exit Superuser'),
                       icon: <IconLock locked={false} />,
                     },
+                    keywords: [t('superuser')],
                     onAction: () => exitSuperuser(),
                   },
                 ]

--- a/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
+++ b/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
@@ -350,6 +350,7 @@ export function useGlobalCommandPaletteActions() {
                 label: t('Open _admin'),
                 icon: <IconOpen />,
               },
+              keywords: [t('superuser')],
               onAction: () => window.open('/_admin/', '_blank', 'noreferrer'),
             },
             {
@@ -357,6 +358,7 @@ export function useGlobalCommandPaletteActions() {
                 label: t('Open %s in _admin', organization.name),
                 icon: <IconOpen />,
               },
+              keywords: [t('superuser')],
               onAction: () =>
                 window.open(
                   `/_admin/organizations/${organization.slug}/`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds the `superuser` keyword to all admin CMD-K actions and restores the "Open Superuser Modal" action from the old command palette to match the old workflow and improve discoverability. Also updates the organization admin URL to use the correct customers endpoint.

This addresses the issue where users were trying to search for "superuser" in the new CMD-K but couldn't find the admin actions or the superuser escalation modal.

## Changes

- Added `keywords: [t('superuser')]` to "Open _admin" action
- Added `keywords: [t('superuser')]` to "Open org in _admin" action
- Added `keywords: [t('superuser')]` to "Exit Superuser" action
- **Added "Open Superuser Modal" action** - allows staff users to escalate to superuser mode (only shown when not already a superuser)
- Changed organization admin URL from `/_admin/organizations/${organization.slug}/` to `/_admin/customers/${organization.slug}/`

## Testing

Users can now type "superuser" in CMD-K and see:
- "Open _admin" - opens the Django admin interface
- "Open org in _admin" - opens the organization's customer page in Django admin
- "Open Superuser Modal" - opens the authentication modal to escalate to superuser (only shown when not already superuser)
- "Exit Superuser" - exits superuser mode (only shown when already superuser)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C08QLT0PYQK/p1775510843648239?thread_ts=1775510843.648239&cid=C08QLT0PYQK)

<div><a href="https://cursor.com/agents/bc-3faa6305-783b-5a27-be62-31d6ae10d612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3faa6305-783b-5a27-be62-31d6ae10d612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

