### PR TITLE
ci(st): expand list of full suite triggers

### DIFF
--- a/.github/workflows/scripts/compute-sentry-selected-tests.py
+++ b/.github/workflows/scripts/compute-sentry-selected-tests.py
@@ -50,7 +50,7 @@ TEST_DIRS = (
 # test.
 FULL_SUITE_TRIGGERS: list[str | re.Pattern[str]] = [
     re.compile(r"^src/sentry/testutils/pytest/"),
-    "conftest.py",
+    re.compile(r"(^|/)conftest\.py$"),
     "src/sentry/runner/initializer.py",
     "src/sentry/constants.py",
     # option defaults registered at startup via initialize_app()

--- a/.github/workflows/scripts/compute-sentry-selected-tests.py
+++ b/.github/workflows/scripts/compute-sentry-selected-tests.py
@@ -41,12 +41,36 @@ TEST_DIRS = (
     "tests/integration/",
 )
 
+# Most of these won't have coverage info because they're evaluated at
+# module load time and app warmup, before any per-test coverage context is active.
+#
+# Tracking a "startup" coverage context doesn't work: django.setup()
+# eagerly imports models, fields, validators, utils, etc. We also have
+# large dynamic __init__'s so a startup context would select nearly every
+# test.
 FULL_SUITE_TRIGGERS: list[str | re.Pattern[str]] = [
-    "src/sentry/testutils/pytest/sentry.py",
+    re.compile(r"^src/sentry/testutils/pytest/"),
+    "conftest.py",
+    "src/sentry/runner/initializer.py",
     "src/sentry/constants.py",
-    "pyproject.toml",
+    # option defaults registered at startup via initialize_app()
+    re.compile(r"^src/sentry/options/"),
+    # feature flags registered via manager.add() at import time
+    re.compile(r"^src/sentry/features/"),
+    # signal definitions created at module level; receivers depend on these
+    "src/sentry/signals.py",
+    # signal handlers registered globally via initialize_receivers()
+    re.compile(r"^src/sentry/receivers/"),
+    # stdlib/third-party monkey-patches applied before Django setup
+    re.compile(r"^src/sentry/monkey/"),
+    # monkeypatches transaction.atomic for silo-aware DB routing
+    re.compile(r"^src/sentry/silo/patches/"),
+    # SiloRouter loaded via DATABASE_ROUTERS; affects every DB query
+    "src/sentry/db/router.py",
     "src/sentry/conf/server.py",
     "src/sentry/web/urls.py",
+    "pyproject.toml",
+    "uv.lock",
     re.compile(r"/migrations/\d{4}_[^/]+\.py$"),
 ]
 


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/112293 didn't select anything in sentry or getsentry dispatch for src/sentry/options/defaults.py - this kind of stuff is evaluated at module load (before any test context is active) so we don't have coverage data for it

added `src/sentry/options` FULL_SUITE_TRIGGERS and also had claude audit for more stuff to put in there