### PR TITLE
fix(workflows): Rule.status derived from snooze, not Workflow.status

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -796,9 +796,15 @@ class WorkflowEngineRuleSerializer(Serializer):
             "createdBy": attrs.get("created_by", None),
             "environment": environment.name if environment is not None else None,
             "projects": [p.slug for p in attrs["projects"]],
-            "status": "active" if obj.enabled else "disabled",
-            "snooze": "snooze" in attrs,
+            # Workflow.enabled is toggled by snooze-for-everyone, but "disabled" in the
+            # UI means a broken/misconfigured rule (matching legacy Rule.status/ObjectStatus).
+            # Snooze state is communicated via the snooze fields instead.
+            "status": "active",
+            "snooze": not obj.enabled,
         }
+        if not obj.enabled:
+            workflow_rule["snoozeForEveryone"] = True
+
         if "last_triggered" in attrs:
             workflow_rule["lastTriggered"] = attrs["last_triggered"]
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1977,6 +1977,47 @@ class GetProjectRuleDetailsDeltaTest(ProjectRuleDetailsBaseTestCase):
         assert legacy_response.data["id"] == str(rule.id)
         assert_serializer_parity(old=legacy_response.data, new=we_response.data)
 
+    def test_snoozed_rule_for_everyone_parity(self) -> None:
+        rule = self.create_project_rule(
+            project=self.project,
+            name="Snoozed for everyone alert",
+            action_match="any",
+            frequency=60,
+            condition_data=[
+                {
+                    "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                    "name": "A new issue is created",
+                },
+            ],
+            action_data=[
+                {
+                    "targetType": "IssueOwners",
+                    "fallthroughType": "ActiveMembers",
+                    "id": "sentry.mail.actions.NotifyEmailAction",
+                    "targetIdentifier": "",
+                    "name": "Send a notification to IssueOwners and if none can be found then send a notification to ActiveMembers",
+                }
+            ],
+        )
+        self.snooze_rule(owner_id=self.user.id, rule=rule)
+
+        legacy_response = self.get_success_response(
+            self.organization.slug, self.project.slug, rule.id, status_code=200
+        )
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            we_response = self.get_success_response(
+                self.organization.slug, self.project.slug, rule.id, status_code=200
+            )
+
+        assert legacy_response.data["id"] == str(rule.id)
+        assert legacy_response.data["snooze"]
+        assert legacy_response.data["snoozeForEveryone"]
+        assert_serializer_parity(
+            old=legacy_response.data,
+            new=we_response.data,
+            known_differences={"snoozeCreatedBy"},
+        )
+
     def test_dual_written_rule_with_filters_parity(self) -> None:
         rule = self.create_project_rule(
             project=self.project,

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -1673,3 +1673,53 @@ class GetProjectRulesDeltaTest(APITestCase):
         assert legacy_rule["id"] == str(rule.id)
 
         assert_serializer_parity(old=legacy_rule, new=we_rule)
+
+    def test_snoozed_rule_for_everyone_parity(self) -> None:
+        self.login_as(user=self.user)
+        rule = self.create_project_rule(
+            project=self.project,
+            name="Snoozed for everyone alert",
+            action_match="any",
+            frequency=60,
+            condition_data=[
+                {
+                    "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                    "name": "A new issue is created",
+                },
+            ],
+            action_data=[
+                {
+                    "targetType": "IssueOwners",
+                    "fallthroughType": "ActiveMembers",
+                    "id": "sentry.mail.actions.NotifyEmailAction",
+                    "targetIdentifier": "",
+                    "name": "Send a notification to IssueOwners and if none can be found then send a notification to ActiveMembers",
+                }
+            ],
+        )
+        self.snooze_rule(owner_id=self.user.id, rule=rule)
+
+        legacy_response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=status.HTTP_200_OK,
+        )
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            we_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                status_code=status.HTTP_200_OK,
+            )
+
+        assert len(legacy_response.data) == 1
+        assert len(we_response.data) == 1
+        legacy_rule = legacy_response.data[0]
+        we_rule = we_response.data[0]
+        assert legacy_rule["id"] == str(rule.id)
+        assert legacy_rule["snooze"]
+        assert_serializer_parity(
+            old=legacy_rule,
+            new=we_rule,
+            known_differences={"snoozeCreatedBy"},
+        )


### PR DESCRIPTION
Snooze status should be stored in appropriate fields; using 'status=disabled' just results in the UI showing a warning banner as if the rule is broken.

Fixes ISWF-2402.