### PR TITLE
fix(np): Adds attachment to Slack render type, updates metric renderer

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -115,9 +115,9 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
         try:
             client.chat_postMessage(
                 channel=target.resource_id,
-                blocks=payload["blocks"],
+                blocks=payload["blocks"] if len(payload["blocks"]) > 0 else None,
                 text=payload["text"],
-                attachments=payload.get("attachments", None),
+                attachments=payload.get("attachments"),
                 unfurl_links=False,
                 unfurl_media=False,
             )
@@ -137,9 +137,9 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
         )
         kwargs: dict[str, Any] = dict(
             channel=target.resource_id,
-            blocks=payload["blocks"],
+            blocks=payload["blocks"] if len(payload["blocks"]) > 0 else None,
             text=payload["text"],
-            attachments=payload.get("attachments", None),
+            attachments=payload.get("attachments"),
             unfurl_links=False,
             unfurl_media=False,
         )

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -114,7 +114,12 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
         client = self.get_client()
         try:
             client.chat_postMessage(
-                channel=target.resource_id, blocks=payload["blocks"], text=payload["text"]
+                channel=target.resource_id,
+                blocks=payload["blocks"],
+                text=payload["text"],
+                attachments=payload["attachments"],
+                unfurl_links=False,
+                unfurl_media=False,
             )
         except SlackApiError as e:
             translate_slack_api_error(e)
@@ -134,6 +139,9 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
             channel=target.resource_id,
             blocks=payload["blocks"],
             text=payload["text"],
+            attachments=payload.get("attachments", None),
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
         if threading_context.thread_ts is not None:

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -167,9 +167,12 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
         try:
             client.chat_postMessage(
                 channel=channel_id,
-                blocks=renderable["blocks"],
+                blocks=renderable["blocks"] if len(renderable["blocks"]) > 0 else None,
                 text=renderable["text"],
+                attachments=renderable.get("attachments"),
                 thread_ts=thread_ts,
+                unfurl_links=False,
+                unfurl_media=False,
             )
         except SlackApiError as e:
             translate_slack_api_error(e)
@@ -186,10 +189,13 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
         try:
             client.chat_postEphemeral(
                 channel=channel_id,
-                blocks=renderable["blocks"],
+                blocks=renderable["blocks"] if len(renderable["blocks"]) > 0 else None,
+                attachments=renderable.get("attachments"),
                 text=renderable["text"],
                 thread_ts=thread_ts,
                 user=slack_user_id,
+                unfurl_links=False,
+                unfurl_media=False,
             )
         except SlackApiError as e:
             translate_slack_api_error(e)
@@ -207,7 +213,10 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
                 channel=channel_id,
                 ts=message_ts,
                 text=renderable["text"],
-                blocks=renderable["blocks"],
+                blocks=renderable["blocks"] if len(renderable["blocks"]) > 0 else None,
+                attachments=renderable.get("attachments"),
+                unfurl_links=False,
+                unfurl_media=False,
             )
         except SlackApiError as e:
             translate_slack_api_error(e)

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -171,8 +171,6 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
                 text=renderable["text"],
                 attachments=renderable.get("attachments"),
                 thread_ts=thread_ts,
-                unfurl_links=False,
-                unfurl_media=False,
             )
         except SlackApiError as e:
             translate_slack_api_error(e)
@@ -194,8 +192,6 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
                 text=renderable["text"],
                 thread_ts=thread_ts,
                 user=slack_user_id,
-                unfurl_links=False,
-                unfurl_media=False,
             )
         except SlackApiError as e:
             translate_slack_api_error(e)

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -117,7 +117,7 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation, IntegrationNot
                 channel=target.resource_id,
                 blocks=payload["blocks"],
                 text=payload["text"],
-                attachments=payload["attachments"],
+                attachments=payload.get("attachments", None),
                 unfurl_links=False,
                 unfurl_media=False,
             )

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -12,7 +12,7 @@ from sentry.notifications.platform.discord.provider import DiscordRenderable, Di
 from sentry.notifications.platform.email.provider import EmailRenderer
 from sentry.notifications.platform.msteams.provider import MSTeamsRenderable, MSTeamsRenderer
 from sentry.notifications.platform.registry import template_registry
-from sentry.notifications.platform.slack.provider import SlackRenderer
+from sentry.notifications.platform.slack.provider import SlackNotificationProvider
 from sentry.notifications.platform.types import (
     NotificationData,
     NotificationProviderKey,
@@ -92,13 +92,14 @@ def serialize_slack_preview[T: NotificationData](
 ) -> dict[str, Any]:
     data = template.example_data
     rendered_template = template.render_example()
-    message = SlackRenderer.render(data=data, rendered_template=rendered_template)
+    renderer = SlackNotificationProvider.get_renderer(data=data, category=template.category)
+    message = renderer.render(data=data, rendered_template=rendered_template)
 
     serialized_blocks = []
     for block in message.get("blocks", []):
         serialized_blocks.append(block.to_dict())
 
-    return {"blocks": serialized_blocks}
+    return {"blocks": serialized_blocks, "attachments": message.get("attachments", None)}
 
 
 def serialize_discord_preview[T: NotificationData](

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -99,7 +99,7 @@ def serialize_slack_preview[T: NotificationData](
     for block in message.get("blocks", []):
         serialized_blocks.append(block.to_dict())
 
-    return {"blocks": serialized_blocks, "attachments": message.get("attachments", None)}
+    return {"blocks": serialized_blocks, "attachments": message.get("attachments")}
 
 
 def serialize_discord_preview[T: NotificationData](

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from slack_sdk.models.blocks import (
     ActionsBlock,
@@ -58,9 +58,8 @@ class SlackProviderThreadingContext(ProviderThreadingContext):
 
 class SlackRenderable(TypedDict):
     blocks: list[Block]
-    attachments: NotRequired[list[Block]]
+    attachments: NotRequired[list[dict[str, Any]]]
     text: str
-    color: NotRequired[str]
 
 
 class SlackRenderer(NotificationRenderer[SlackRenderable]):

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -58,6 +58,7 @@ class SlackProviderThreadingContext(ProviderThreadingContext):
 
 class SlackRenderable(TypedDict):
     blocks: list[Block]
+    attachments: NotRequired[list[Block]]
     text: str
     color: NotRequired[str]
 

--- a/src/sentry/notifications/platform/slack/renderers/metric_alert.py
+++ b/src/sentry/notifications/platform/slack/renderers/metric_alert.py
@@ -43,12 +43,14 @@ class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
             *blocks, fallback_text=fallback_text, color=color
         )
 
+        attachment_blocks = [
+            {"blocks": slack_body.get("blocks", []), "color": slack_body.get("color", "")}
+        ]
+
         renderable = SlackRenderable(
-            blocks=slack_body.get("blocks", []),
-            attachments=slack_body.get("attachments", []),
+            blocks=[],
+            attachments=attachment_blocks,
             text=slack_body.get("text", ""),
         )
-        if (color := slack_body.get("color")) is not None:
-            renderable["color"] = color
 
         return renderable

--- a/src/sentry/notifications/platform/slack/renderers/metric_alert.py
+++ b/src/sentry/notifications/platform/slack/renderers/metric_alert.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from sentry.incidents.models.incident import IncidentStatus
 from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.integrations.metric_alerts import get_status_text
@@ -15,6 +17,8 @@ from sentry.notifications.platform.types import (
     NotificationProviderKey,
     NotificationRenderedTemplate,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
@@ -46,6 +50,8 @@ class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
         attachment_blocks = [
             {"blocks": slack_body.get("blocks", []), "color": slack_body.get("color", "")}
         ]
+
+        logger.info(f"attachment_blocks: {attachment_blocks}")
 
         renderable = SlackRenderable(
             blocks=[],

--- a/src/sentry/notifications/platform/slack/renderers/metric_alert.py
+++ b/src/sentry/notifications/platform/slack/renderers/metric_alert.py
@@ -45,6 +45,7 @@ class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
 
         renderable = SlackRenderable(
             blocks=slack_body.get("blocks", []),
+            attachments=slack_body.get("attachments", []),
             text=slack_body.get("text", ""),
         )
         if (color := slack_body.get("color")) is not None:

--- a/src/sentry/notifications/platform/slack/renderers/metric_alert.py
+++ b/src/sentry/notifications/platform/slack/renderers/metric_alert.py
@@ -43,9 +43,10 @@ class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
             *blocks, fallback_text=fallback_text, color=color
         )
 
-        attachment_blocks = [
-            {"blocks": slack_body.get("blocks", []), "color": slack_body.get("color", "")}
-        ]
+        attachment_blocks = [{"blocks": slack_body.get("blocks", [])}]
+
+        if color:
+            attachment_blocks[0]["color"] = color
 
         renderable = SlackRenderable(
             blocks=[],

--- a/src/sentry/notifications/platform/slack/renderers/metric_alert.py
+++ b/src/sentry/notifications/platform/slack/renderers/metric_alert.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 from sentry.incidents.models.incident import IncidentStatus
 from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.integrations.metric_alerts import get_status_text
@@ -17,8 +15,6 @@ from sentry.notifications.platform.types import (
     NotificationProviderKey,
     NotificationRenderedTemplate,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
@@ -50,8 +46,6 @@ class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
         attachment_blocks = [
             {"blocks": slack_body.get("blocks", []), "color": slack_body.get("color", "")}
         ]
-
-        logger.info(f"attachment_blocks: {attachment_blocks}")
 
         renderable = SlackRenderable(
             blocks=[],

--- a/src/sentry/notifications/platform/templates/metric_alert.py
+++ b/src/sentry/notifications/platform/templates/metric_alert.py
@@ -42,7 +42,6 @@ _EXAMPLE_OPEN_PERIOD_CONTEXT = OpenPeriodContext(
 @template_registry.register(NotificationSource.METRIC_ALERT)
 class MetricAlertNotificationTemplate(NotificationTemplate[MetricAlertNotificationData]):
     category = NotificationCategory.METRIC_ALERT
-    hide_from_debugger = True
     example_data = MetricAlertNotificationData(
         group_id=1,
         organization_id=1,

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -544,6 +544,9 @@ class SlackIntegrationNotificationPlatformTest(TestCase):
             channel="C1234567890",
             blocks=self.slack_renderable.get("blocks", []),
             text="Mock Notification",
+            attachments=None,
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -572,7 +572,10 @@ class SlackIntegrationNotificationPlatformTest(TestCase):
             channel=self.channel_id,
             thread_ts=self.thread_ts,
             blocks=self.slack_renderable.get("blocks", []),
+            attachments=self.slack_renderable.get("attachments"),
             text=self.slack_renderable.get("text", ""),
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
@@ -599,9 +602,12 @@ class SlackIntegrationNotificationPlatformTest(TestCase):
         mock_chat_ephemeral.assert_called_once_with(
             channel=self.channel_id,
             thread_ts=self.thread_ts,
+            attachments=self.slack_renderable.get("attachments"),
             user=self.slack_user_id,
             blocks=self.slack_renderable.get("blocks", []),
             text=self.slack_renderable.get("text", ""),
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postEphemeral")

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -574,8 +574,6 @@ class SlackIntegrationNotificationPlatformTest(TestCase):
             blocks=self.slack_renderable.get("blocks", []),
             attachments=self.slack_renderable.get("attachments"),
             text=self.slack_renderable.get("text", ""),
-            unfurl_links=False,
-            unfurl_media=False,
         )
 
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
@@ -606,8 +604,6 @@ class SlackIntegrationNotificationPlatformTest(TestCase):
             user=self.slack_user_id,
             blocks=self.slack_renderable.get("blocks", []),
             text=self.slack_renderable.get("text", ""),
-            unfurl_links=False,
-            unfurl_media=False,
         )
 
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postEphemeral")

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -105,7 +105,10 @@ class TestSlackMetricAlertHandlerSendAlert(MetricAlertHandlerBase):
         mock_client_instance.chat_postMessage.assert_called_once()
         call_kwargs = mock_client_instance.chat_postMessage.call_args.kwargs
         assert call_kwargs["channel"] == "channel123"
-        blocks = call_kwargs["blocks"]
+        assert call_kwargs["attachments"] is not None
+        attachments: list[Any] = call_kwargs["attachments"]
+        assert len(attachments) == 1
+        blocks: list[Any] = attachments[0]["blocks"]
         assert len(blocks) >= 1
         assert blocks[0]["type"] == "section"
         assert blocks[0]["text"]["type"] == "mrkdwn"

--- a/tests/sentry/notifications/platform/slack/renderers/test_metric_alert.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_metric_alert.py
@@ -96,7 +96,10 @@ class SlackMetricAlertRendererTest(MetricAlertHandlerBase):
         )
 
         # Without a chart: exactly one section block
-        blocks: list[Any] = result["blocks"]
+        assert result.get("attachments", None) is not None
+        attachments: list[Any] = result["attachments"]
+        assert len(attachments) == 1
+        blocks: list[Any] = attachments[0]["blocks"]
         assert len(blocks) == 1
         assert blocks[0]["type"] == "section"
         assert blocks[0]["text"]["type"] == "mrkdwn"
@@ -120,8 +123,10 @@ class SlackMetricAlertRendererTest(MetricAlertHandlerBase):
             rendered_template=self.rendered_template,
         )
 
+        assert result.get("attachments", None) is not None
+
         # With a chart: section block + image block
-        blocks: list[Any] = result["blocks"]
+        blocks: list[Any] = result["attachments"][0]["blocks"]
         assert len(blocks) == 2
         assert blocks[0]["type"] == "section"
         assert "123.45 events in the last minute" in blocks[0]["text"]["text"]
@@ -135,7 +140,10 @@ class SlackMetricAlertRendererTest(MetricAlertHandlerBase):
             rendered_template=self.rendered_template,
         )
 
-        blocks: list[Any] = result["blocks"]
+        assert result.get("attachments", None) is not None
+        attachments: list[Any] = result["attachments"]
+        assert len(attachments) == 1
+        blocks: list[Any] = attachments[0]["blocks"]
         assert len(blocks) == 1
         assert blocks[0]["type"] == "section"
 

--- a/tests/sentry/notifications/platform/slack/renderers/test_metric_alert.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_metric_alert.py
@@ -96,7 +96,7 @@ class SlackMetricAlertRendererTest(MetricAlertHandlerBase):
         )
 
         # Without a chart: exactly one section block
-        assert result.get("attachments", None) is not None
+        assert result.get("attachments") is not None
         attachments: list[Any] = result["attachments"]
         assert len(attachments) == 1
         blocks: list[Any] = attachments[0]["blocks"]
@@ -123,7 +123,7 @@ class SlackMetricAlertRendererTest(MetricAlertHandlerBase):
             rendered_template=self.rendered_template,
         )
 
-        assert result.get("attachments", None) is not None
+        assert result.get("attachments") is not None
 
         # With a chart: section block + image block
         blocks: list[Any] = result["attachments"][0]["blocks"]
@@ -140,7 +140,7 @@ class SlackMetricAlertRendererTest(MetricAlertHandlerBase):
             rendered_template=self.rendered_template,
         )
 
-        assert result.get("attachments", None) is not None
+        assert result.get("attachments") is not None
         attachments: list[Any] = result["attachments"]
         assert len(attachments) == 1
         blocks: list[Any] = attachments[0]["blocks"]

--- a/tests/sentry/notifications/platform/slack/test_provider.py
+++ b/tests/sentry/notifications/platform/slack/test_provider.py
@@ -148,7 +148,12 @@ class SlackNotificationProviderSendTest(TestCase):
         assert isinstance(result, SendSuccessResult)
         assert result.provider_message_id is None
         mock_client_instance.chat_postMessage.assert_called_once_with(
-            channel="C1234567890", blocks=renderable["blocks"], text=renderable["text"]
+            channel="C1234567890",
+            blocks=renderable["blocks"],
+            text=renderable["text"],
+            attachments=None,
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
     def test_send_invalid_target_class(self) -> None:
@@ -185,7 +190,12 @@ class SlackNotificationProviderSendTest(TestCase):
         SlackNotificationProvider.send(target=target, renderable=renderable)
 
         mock_client_instance.chat_postMessage.assert_called_once_with(
-            channel="U1234567890", blocks=renderable["blocks"], text=renderable["text"]
+            channel="U1234567890",
+            blocks=renderable["blocks"],
+            text=renderable["text"],
+            attachments=None,
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
 
@@ -278,6 +288,9 @@ class SlackNotificationProviderThreadingTest(TestCase):
             blocks=renderable["blocks"],
             text=renderable["text"],
             thread_ts="1111111111.111111",
+            attachments=None,
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
     @patch("sentry.integrations.slack.integration.SlackSdkClient")
@@ -316,6 +329,9 @@ class SlackNotificationProviderThreadingTest(TestCase):
             text=renderable["text"],
             thread_ts="1111111111.111111",
             reply_broadcast=True,
+            attachments=None,
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
     @patch("sentry.integrations.slack.integration.SlackSdkClient")
@@ -349,6 +365,9 @@ class SlackNotificationProviderThreadingTest(TestCase):
             channel="C1234567890",
             blocks=renderable["blocks"],
             text=renderable["text"],
+            attachments=None,
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
     @patch("sentry.integrations.slack.integration.SlackSdkClient")


### PR DESCRIPTION
Updates the `SlackRenderable` type to include `attachments` as a renderable type, which allows for some legacy functionality, like colored borders on blocks. This is currently needed for feature parity with our metric alerting, and can be used by the default renderer in the future if we so choose.

This PR also adds the metric alert template to our debug UI, since the rendering has been simplified significantly.
