### PR TITLE
ref(ci-st): fast calculate-shards heuristics

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -184,14 +184,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         if: needs.select-tests.outputs.has-selected-tests == 'true'
 
-      - name: Setup sentry env
-        if: needs.select-tests.outputs.has-selected-tests == 'true'
-        uses: ./.github/actions/setup-sentry
-        id: setup
-        with:
-          mode: backend-ci
-          skip-devservices: true
-
       - name: Download selected tests artifact
         if: needs.select-tests.outputs.has-selected-tests == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/scripts/calculate-backend-test-shards.py
+++ b/.github/workflows/scripts/calculate-backend-test-shards.py
@@ -97,7 +97,9 @@ def count_tests_in_file(filepath: Path) -> int:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith(
             "test_"
         ):
-            counts = filter(None, (_parametrize_count(d, scope) for d in node.decorator_list))
+            counts = (
+                c for d in node.decorator_list if (c := _parametrize_count(d, scope)) is not None
+            )
             total += math.prod(counts, start=1)
     return total
 

--- a/.github/workflows/scripts/calculate-backend-test-shards.py
+++ b/.github/workflows/scripts/calculate-backend-test-shards.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
+"""Calculate the number of backend test shards needed for CI.
+
+Uses AST-based static analysis to count tests instead of running
+pytest --collect-only, which requires importing every module and
+bootstrapping Django (~100s). AST parsing takes a few seconds.
+"""
+
+from __future__ import annotations
+
+import ast
 import json
 import math
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -12,85 +21,123 @@ MIN_SHARDS = 1
 MAX_SHARDS = 22
 DEFAULT_SHARDS = MAX_SHARDS
 
+IGNORED_DIRS = frozenset(("tests/acceptance", "tests/apidocs", "tests/js", "tests/tools"))
+
+
+def _resolve(node: ast.expr, scope: dict[str, ast.expr]) -> ast.expr:
+    """Chase Name and Subscript references back to a concrete AST node."""
+    if isinstance(node, ast.Name) and node.id in scope:
+        return _resolve(scope[node.id], scope)
+    if (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and isinstance(node.slice, ast.Constant)
+        and isinstance(node.slice.value, int)
+        and node.value.id in scope
+    ):
+        target = _resolve(scope[node.value.id], scope)
+        i = node.slice.value
+        if isinstance(target, (ast.List, ast.Tuple)) and 0 <= i < len(target.elts):
+            return _resolve(target.elts[i], scope)
+    return node
+
+
+def _parametrize_count(dec: ast.expr, scope: dict[str, ast.expr]) -> int | None:
+    """If *dec* is a ``@pytest.mark.parametrize``, return the case count."""
+    dec = _resolve(dec, scope)
+    if not isinstance(dec, ast.Call) or len(dec.args) < 2:
+        return None
+    f = dec.func
+    if not (
+        isinstance(f, ast.Attribute)
+        and f.attr == "parametrize"
+        and isinstance(f.value, ast.Attribute)
+        and f.value.attr == "mark"
+        and isinstance(f.value.value, ast.Name)
+        and f.value.value.id == "pytest"
+    ):
+        return None
+    argvals = _resolve(dec.args[1], scope)
+    return len(argvals.elts) if isinstance(argvals, (ast.List, ast.Tuple)) else None
+
+
+_TEST_FUNC_RE = re.compile(r"^\s*(?:async\s+)?def\s+test_", re.MULTILINE)
+
+
+def count_tests_in_file(filepath: Path) -> int:
+    """Count the test items *filepath* would produce.
+
+    Accounts for ``@pytest.mark.parametrize`` multipliers including
+    stacked decorators.
+    """
+    try:
+        source = filepath.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return 0
+
+    # Fast path: no parametrize means each def test_ is exactly one test.
+    if "parametrize" not in source:
+        return len(_TEST_FUNC_RE.findall(source))
+
+    try:
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError:
+        return len(_TEST_FUNC_RE.findall(source))
+
+    scope = {
+        target.id: node.value
+        for node in ast.iter_child_nodes(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+
+    total = 0
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith(
+            "test_"
+        ):
+            counts = filter(None, (_parametrize_count(d, scope) for d in node.decorator_list))
+            total += math.prod(counts, start=1)
+    return total
+
 
 def collect_test_count() -> int | None:
-    """Collect the number of tests to run, either from selected files or full suite."""
+    """Count tests via AST analysis of test files."""
     selected_tests_file = os.environ.get("SELECTED_TESTS_FILE")
 
     if selected_tests_file:
         path = Path(selected_tests_file)
         if not path.exists():
-            print(f"Selected tests file not found: {selected_tests_file}", file=sys.stderr)
+            print(
+                f"Selected tests file not found: {selected_tests_file}",
+                file=sys.stderr,
+            )
             return None
 
-        with path.open() as f:
-            selected_files = [line.strip() for line in f if line.strip()]
+        test_files = [Path(line.strip()) for line in path.read_text().splitlines() if line.strip()]
 
-        if not selected_files:
+        if not test_files:
             print("No selected test files, running 0 tests", file=sys.stderr)
             return 0
 
-        print(f"Counting tests in {len(selected_files)} selected files", file=sys.stderr)
-
-    pytest_args = [
-        "pytest",
-        # Always pass tests/ directory to ensure proper conftest loading order.
-        # SELECTED_TESTS_FILE env var triggers filtering in pytest_collection_modifyitems.
-        "tests",
-        "--collect-only",
-        "--quiet",
-        "--ignore=tests/acceptance",
-        "--ignore=tests/apidocs",
-        "--ignore=tests/js",
-        "--ignore=tests/tools",
-    ]
-
-    try:
-        result = subprocess.run(
-            pytest_args,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-        # Parse output for test count
-        # Format without deselection: "27000 tests collected in 18.53s"
-        # Format with deselection: "29/31510 tests collected (31481 deselected) in 18.13s"
-        output = result.stdout + result.stderr
-
-        # Try format with deselection first (selected/total)
-        match = re.search(r"(\d+)/\d+ tests? collected", output)
-        if match:
-            count = int(match.group(1))
-            print(f"Collected {count} tests", file=sys.stderr)
-            return count
-
-        # Fall back to format without deselection
-        match = re.search(r"(\d+) tests? collected", output)
-        if match:
-            count = int(match.group(1))
-            print(f"Collected {count} tests", file=sys.stderr)
-            return count
-
-        if result.returncode == 5:
-            # Exit code 5 indicates no tests collected (https://docs.pytest.org/en/stable/reference/exit-codes.html)
-            # This can stem from files being deleted in a branch/PR.
-            print("No tests collected (exit 5)", file=sys.stderr)
-            return 0
-
-        if result.returncode != 0:
-            print(
-                f"Pytest collection failed (exit {result.returncode})",
-                file=sys.stderr,
-            )
-            print(result.stderr, file=sys.stderr)
+        print(f"Counting tests in {len(test_files)} selected files", file=sys.stderr)
+    else:
+        tests_dir = Path("tests")
+        if not tests_dir.is_dir():
+            print("tests/ directory not found", file=sys.stderr)
             return None
 
-        print("No tests collected", file=sys.stderr)
-        return 0
-    except Exception as e:
-        print(f"Error collecting tests: {e}", file=sys.stderr)
-        return None
+        test_files = sorted(
+            p
+            for p in tests_dir.rglob("test_*.py")
+            if not any(str(p).startswith(d) for d in IGNORED_DIRS)
+        )
+        print(f"Found {len(test_files)} test files", file=sys.stderr)
+
+    total = sum(count_tests_in_file(f) for f in test_files)
+    print(f"Counted {total} tests via AST analysis", file=sys.stderr)
+    return total
 
 
 def calculate_shards(test_count: int | None) -> int:

--- a/.github/workflows/scripts/calculate-backend-test-shards.py
+++ b/.github/workflows/scripts/calculate-backend-test-shards.py
@@ -21,7 +21,7 @@ MIN_SHARDS = 1
 MAX_SHARDS = 22
 DEFAULT_SHARDS = MAX_SHARDS
 
-IGNORED_DIRS = frozenset(("tests/acceptance", "tests/apidocs", "tests/js", "tests/tools"))
+IGNORED_DIRS = frozenset(("tests/acceptance/", "tests/apidocs/", "tests/js/", "tests/tools/"))
 
 
 def _resolve(node: ast.expr, scope: dict[str, ast.expr]) -> ast.expr:
@@ -84,13 +84,14 @@ def count_tests_in_file(filepath: Path) -> int:
     except SyntaxError:
         return len(_TEST_FUNC_RE.findall(source))
 
-    scope = {
-        target.id: node.value
-        for node in ast.iter_child_nodes(tree)
-        if isinstance(node, ast.Assign)
-        for target in node.targets
-        if isinstance(target, ast.Name)
-    }
+    scope: dict[str, ast.expr] = {}
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    scope[target.id] = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value:
+            scope[node.target.id] = node.value
 
     total = 0
     for node in ast.walk(tree):

--- a/.github/workflows/scripts/test_calculate_backend_test_shards.py
+++ b/.github/workflows/scripts/test_calculate_backend_test_shards.py
@@ -140,6 +140,22 @@ class TestCountTestsInFile:
         )
         assert count_tests_in_file(p) == 4
 
+    def test_annotated_assignment_variable(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            from typing import Any
+            import pytest
+
+            CASES: list[dict[str, Any]] = [{"a": 1}, {"a": 2}, {"a": 3}]
+
+            @pytest.mark.parametrize("case", CASES)
+            def test_vals(case):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 3
+
     def test_stored_decorator(self, tmp_path):
         p = _write(
             tmp_path,
@@ -422,6 +438,19 @@ class TestCollectTestCount:
             d = tests / excluded
             d.mkdir()
             (d / "test_skip.py").write_text("def test_no(): pass\n")
+
+        assert collect_test_count() == 1
+
+    def test_ignored_dirs_prefix_does_not_over_match(self, tmp_path, monkeypatch):
+        """tests/js/ must not exclude tests/json/."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("SELECTED_TESTS_FILE", raising=False)
+
+        tests = tmp_path / "tests"
+        (tests / "js").mkdir(parents=True)
+        (tests / "js" / "test_skip.py").write_text("def test_no(): pass\n")
+        (tests / "json").mkdir()
+        (tests / "json" / "test_keep.py").write_text("def test_yes(): pass\n")
 
         assert collect_test_count() == 1
 

--- a/.github/workflows/scripts/test_calculate_backend_test_shards.py
+++ b/.github/workflows/scripts/test_calculate_backend_test_shards.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import importlib
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Module has a hyphen in its name, so use importlib.
+_mod = importlib.import_module("calculate-backend-test-shards")
+count_tests_in_file = _mod.count_tests_in_file
+calculate_shards = _mod.calculate_shards
+collect_test_count = _mod.collect_test_count
+
+
+def _write(tmp_path: Path, source: str) -> Path:
+    p = tmp_path / "test_example.py"
+    p.write_text(textwrap.dedent(source))
+    return p
+
+
+class TestCountTestsInFile:
+    def test_plain_functions(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            def test_a():
+                pass
+
+            def test_b():
+                pass
+
+            def helper():
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 2
+
+    def test_methods_in_class(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            class TestFoo:
+                def test_one(self):
+                    pass
+
+                def test_two(self):
+                    pass
+
+                def helper(self):
+                    pass
+            """,
+        )
+        assert count_tests_in_file(p) == 2
+
+    def test_parametrize_list(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            @pytest.mark.parametrize("x", [1, 2, 3])
+            def test_vals(x):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 3
+
+    def test_parametrize_tuple(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            @pytest.mark.parametrize("x", (True, False))
+            def test_vals(x):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 2
+
+    def test_parametrize_with_pytest_param(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            @pytest.mark.parametrize(
+                "x",
+                [
+                    pytest.param(1, id="one"),
+                    pytest.param(2, id="two"),
+                ],
+            )
+            def test_vals(x):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 2
+
+    def test_stacked_parametrize(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            @pytest.mark.parametrize("a", [1, 2])
+            @pytest.mark.parametrize("b", ["x", "y", "z"])
+            def test_combo(a, b):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 6
+
+    def test_variable_reference(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            CASES = [1, 2, 3, 4]
+
+            @pytest.mark.parametrize("x", CASES)
+            def test_vals(x):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 4
+
+    def test_stored_decorator(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            clients = pytest.mark.parametrize(
+                "client",
+                [
+                    pytest.param("redis", id="redis"),
+                    pytest.param("memcached", id="memcached"),
+                ],
+            )
+
+            @clients
+            def test_get(client):
+                pass
+
+            @clients
+            def test_set(client):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 4
+
+    def test_subscript_reference(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            CASES = (
+                ["query", "mode"],
+                [("q1", "m1"), ("q2", "m2"), ("q3", "m3")],
+            )
+
+            @pytest.mark.parametrize(CASES[0], CASES[1])
+            def test_query(query, mode):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 3
+
+    def test_unresolvable_parametrize_counts_as_one(self, tmp_path):
+        """Function calls and attribute access can't be resolved statically."""
+        p = _write(
+            tmp_path,
+            """\
+            import os
+            import pytest
+
+            @pytest.mark.parametrize("f", os.listdir("/tmp"))
+            def test_files(f):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 1
+
+    def test_mixed_resolvable_and_unresolvable(self, tmp_path):
+        """One stacked parametrize resolved, one not — resolved one still multiplies."""
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            @pytest.mark.parametrize("a", [1, 2])
+            @pytest.mark.parametrize("b", some_func())
+            def test_combo(a, b):
+                pass
+            """,
+        )
+        # [1, 2] resolves to 2; some_func() does not, so treated as 1.
+        # Total = 2 * 1 = 2.
+        assert count_tests_in_file(p) == 2
+
+    def test_parametrize_with_ids_kwarg(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            @pytest.mark.parametrize(
+                "enabled",
+                [True, False],
+                ids=["with_feature", "without_feature"],
+            )
+            def test_feature(enabled):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 2
+
+    def test_async_def(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            async def test_async():
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 1
+
+    def test_non_test_functions_ignored(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            def helper():
+                pass
+
+            def setup_module():
+                pass
+
+            def teardown_function():
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 0
+
+    def test_empty_file(self, tmp_path):
+        p = tmp_path / "test_empty.py"
+        p.write_text("")
+        assert count_tests_in_file(p) == 0
+
+    def test_syntax_error(self, tmp_path):
+        p = tmp_path / "test_bad.py"
+        p.write_text("def test_a(:\n")
+        # Regex fast path still finds the def — best-effort count.
+        assert count_tests_in_file(p) == 1
+
+    def test_nonexistent_file(self, tmp_path):
+        p = tmp_path / "test_nope.py"
+        assert count_tests_in_file(p) == 0
+
+    def test_parametrize_tuple_argnames(self, tmp_path):
+        """Argnames passed as tuple instead of string."""
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            @pytest.mark.parametrize(
+                ("name", "value"),
+                [("a", 1), ("b", 2)],
+            )
+            def test_pairs(name, value):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 2
+
+    def test_class_with_parametrize_on_method(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            class TestMath:
+                @pytest.mark.parametrize("n", [1, 2, 3])
+                def test_square(self, n):
+                    pass
+
+                def test_plain(self):
+                    pass
+            """,
+        )
+        assert count_tests_in_file(p) == 4
+
+    def test_multiple_classes_and_functions(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            def test_standalone():
+                pass
+
+            class TestA:
+                def test_one(self):
+                    pass
+
+            class TestB:
+                @pytest.mark.parametrize("x", [1, 2])
+                def test_two(self, x):
+                    pass
+            """,
+        )
+        assert count_tests_in_file(p) == 4
+
+    def test_non_parametrize_decorators_ignored(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            @pytest.mark.slow
+            @pytest.mark.django_db
+            def test_decorated():
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 1
+
+
+class TestCalculateShards:
+    def test_none_returns_default(self):
+        assert calculate_shards(None) == 22
+
+    def test_zero_returns_zero(self):
+        assert calculate_shards(0) == 0
+
+    def test_small_count(self):
+        assert calculate_shards(100) == 1
+
+    def test_exact_boundary(self):
+        assert calculate_shards(300) == 1
+
+    def test_just_over_boundary(self):
+        assert calculate_shards(301) == 2
+
+    def test_large_count_capped(self):
+        assert calculate_shards(100_000) == 22
+
+    def test_mid_range(self):
+        # 1500 / 300 = 5
+        assert calculate_shards(1500) == 5
+
+    def test_rounds_up(self):
+        # 301 / 300 = 1.003 → ceil = 2
+        assert calculate_shards(301) == 2
+
+
+class TestCollectTestCount:
+    def test_selected_tests_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        # Create two test files.
+        (tmp_path / "test_a.py").write_text("def test_one(): pass\ndef test_two(): pass\n")
+        (tmp_path / "test_b.py").write_text("def test_three(): pass\n")
+
+        selected = tmp_path / "selected.txt"
+        selected.write_text(f"{tmp_path / 'test_a.py'}\n{tmp_path / 'test_b.py'}\n")
+        monkeypatch.setenv("SELECTED_TESTS_FILE", str(selected))
+
+        assert collect_test_count() == 3
+
+    def test_selected_tests_file_empty(self, tmp_path, monkeypatch):
+        selected = tmp_path / "selected.txt"
+        selected.write_text("\n")
+        monkeypatch.setenv("SELECTED_TESTS_FILE", str(selected))
+
+        assert collect_test_count() == 0
+
+    def test_selected_tests_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELECTED_TESTS_FILE", str(tmp_path / "nope.txt"))
+        assert collect_test_count() is None
+
+    def test_full_suite_walks_tests_dir(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("SELECTED_TESTS_FILE", raising=False)
+
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_foo.py").write_text("def test_a(): pass\n")
+
+        sub = tests / "sub"
+        sub.mkdir()
+        (sub / "test_bar.py").write_text("def test_b(): pass\ndef test_c(): pass\n")
+
+        assert collect_test_count() == 3
+
+    def test_full_suite_ignores_excluded_dirs(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("SELECTED_TESTS_FILE", raising=False)
+
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_ok.py").write_text("def test_a(): pass\n")
+
+        for excluded in ("acceptance", "apidocs", "js", "tools"):
+            d = tests / excluded
+            d.mkdir()
+            (d / "test_skip.py").write_text("def test_no(): pass\n")
+
+        assert collect_test_count() == 1
+
+    def test_no_tests_dir(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("SELECTED_TESTS_FILE", raising=False)
+        assert collect_test_count() is None
+
+
+SENTRY_TESTS = Path(__file__).resolve().parent.parent.parent.parent / "tests"
+
+
+@pytest.mark.skipif(
+    not SENTRY_TESTS.is_dir(),
+    reason="sentry tests/ directory not found",
+)
+def test_all_sentry_test_files():
+    """Parse every test file in the repo — no crashes, every file returns >= 0."""
+    ignored = {"tests/acceptance", "tests/apidocs", "tests/js", "tests/tools"}
+    files = sorted(
+        p
+        for p in SENTRY_TESTS.rglob("test_*.py")
+        if not any(str(p.relative_to(SENTRY_TESTS.parent)).startswith(d) for d in ignored)
+    )
+    assert len(files) > 2000, f"expected >2000 test files, found {len(files)}"
+
+    failures = []
+    total = 0
+    for f in files:
+        try:
+            n = count_tests_in_file(f)
+            assert n >= 0
+            total += n
+        except Exception as exc:
+            failures.append((f, exc))
+
+    assert not failures, f"{len(failures)} files failed:\n" + "\n".join(
+        f"  {f}: {e}" for f, e in failures[:20]
+    )
+    # Sanity-check: the sentry test suite has ~30k tests at the time of writing.
+    assert total > 29_000, f"total {total} seems too low"

--- a/.github/workflows/scripts/test_calculate_backend_test_shards.py
+++ b/.github/workflows/scripts/test_calculate_backend_test_shards.py
@@ -98,6 +98,19 @@ class TestCountTestsInFile:
         )
         assert count_tests_in_file(p) == 2
 
+    def test_parametrize_empty_list(self, tmp_path):
+        p = _write(
+            tmp_path,
+            """\
+            import pytest
+
+            @pytest.mark.parametrize("x", [])
+            def test_vals(x):
+                pass
+            """,
+        )
+        assert count_tests_in_file(p) == 0
+
     def test_stacked_parametrize(self, tmp_path):
         p = _write(
             tmp_path,


### PR DESCRIPTION
no more setup-sentry and pytest --collect-only! test count is only used to calculate shards and we don't need 100% accuracy, even ~90% is acceptable.

this completely eliminates 2m serial per-workflow!

we now count test_ with a regex across SELECTED_FILES and ast-based parsing for `@pytest.mark.parametrize multipliers` (inline lists, variable references, subscript access, stacked decorators, stored decorators).

this is ~99% accurate because there are only 7 `@pytest.fixture(params=...)` which cannot be statically determined, and we have ~30k tests