### PR TITLE
chore(workflows): Schedule prune_old_open_period_activity

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1016,6 +1016,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "workflow_engine:sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         "schedule": timedelta(seconds=15),
     },
+    "prune-old-open-period-activity": {
+        "task": "workflow_engine:sentry.workflow_engine.tasks.cleanup.prune_old_open_period_activity",
+        "schedule": timedelta(minutes=2),
+    },
     "resolve-stale-sourcemap-detectors": {
         "task": "workflow_engine:sentry.processing_errors.tasks.resolve_stale_sourcemap_detectors",
         "schedule": crontab("*/5", "*", "*", "*", "*"),


### PR DESCRIPTION
Every two minutes gives the database ample breathing room, but allows us to burn through our backlog of old data quickly.
If there are issues, the task itself has options that should allow us to be gentler or disable altogether.
After this deploys, we'd expect old data to be clear within a few hours.

Fixes ISWF-771.