### PR TITLE
fix(alerts): Reject EAP alerts with invalid time windows

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -211,13 +211,6 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
             )
             self._validate_critical_warning_triggers(threshold_type, critical, warning)
 
-        if data.get("dataset") == Dataset.EventsAnalyticsPlatform:
-            time_window = data["time_window"]
-            if time_window < 5:
-                raise serializers.ValidationError(
-                    "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
-                )
-
         return data
 
     def _translate_thresholds(self, threshold_type, comparison_delta, triggers, data):

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -24,6 +24,7 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.models.project import Project
+from sentry.search.eap.constants import VALID_GRANULARITIES
 from sentry.search.eap.trace_metrics.validator import validate_trace_metrics_aggregate
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import (
@@ -50,6 +51,13 @@ UNSUPPORTED_QUERIES = {"release:latest"}
 
 # Allowed time windows (in seconds) for crash rate alerts
 CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS = [1800, 3600, 7200, 14400, 43200, 86400]
+
+MIN_EAP_ALERT_TIME_WINDOW_SECONDS = 300
+
+# Valid time windows for EAP alerts: valid Snuba granularities at or above the alert minimum.
+EAP_ALERTS_ALLOWED_TIME_WINDOWS = sorted(
+    g for g in VALID_GRANULARITIES if g >= MIN_EAP_ALERT_TIME_WINDOW_SECONDS
+)
 
 
 QUERY_TYPE_VALID_DATASETS = {
@@ -330,6 +338,8 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
         # TODO(edward): Bypass snql query validation for EAP queries. Do we need validation for rpc requests?
         if dataset != Dataset.EventsAnalyticsPlatform:
             self._validate_snql_query(data, entity_subscription, projects)
+        else:
+            self._validate_time_window(data["time_window"], dataset)
 
     def _validate_snql_query(
         self,
@@ -391,9 +401,10 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
                     "30min, 1h, 2h, 4h, 12h and 24h"
                 )
         if dataset == Dataset.EventsAnalyticsPlatform:
-            if time_window_seconds < 300:
+            if time_window_seconds not in EAP_ALERTS_ALLOWED_TIME_WINDOWS:
                 raise serializers.ValidationError(
-                    "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
+                    f"Invalid Time Window: Allowed time windows (in seconds) for this alert type are: "
+                    f"{EAP_ALERTS_ALLOWED_TIME_WINDOWS}"
                 )
         return time_window_seconds
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -2067,13 +2067,18 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         data = deepcopy(self.alert_rule_dict)
         data["dataset"] = "events_analytics_platform"
         data["alertType"] = "eap_metrics"
+
+        # Below the 5-minute floor
         data["timeWindow"] = 1
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
-        assert (
-            resp.data["nonFieldErrors"][0]
-            == "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
-        )
+        assert "Invalid Time Window" in resp.data["nonFieldErrors"][0]
+
+        # Above the floor but not a valid granularity (7 minutes = 420 seconds)
+        data["timeWindow"] = 7
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_error_response(self.organization.slug, status_code=400, **data)
+        assert "Invalid Time Window" in resp.data["nonFieldErrors"][0]
 
     def test_transactions_dataset_deprecation_validation(self) -> None:
         data = deepcopy(self.alert_rule_dict)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -99,7 +99,7 @@ class AlertRuleBase(APITestCase):
         return {
             "aggregate": "count()",
             "query": "",
-            "timeWindow": "300",
+            "timeWindow": "5",
             "resolveThreshold": 100,
             "thresholdType": 0,
             "triggers": [

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -171,21 +171,23 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
         )
 
     def test_span_alert_time_window_validation(self) -> None:
-        params = self.valid_params.copy()
-        params["dataset"] = Dataset.EventsAnalyticsPlatform.value
-        params["event_types"] = [SnubaQueryEventType.EventType.TRACE_ITEM_SPAN.name.lower()]
-        params["time_window"] = 1
-        params["query"] = "span.op:http.client"
-        params["aggregate"] = "count()"
+        base_params = self.valid_params.copy()
+        base_params["dataset"] = Dataset.EventsAnalyticsPlatform.value
+        base_params["event_types"] = [SnubaQueryEventType.EventType.TRACE_ITEM_SPAN.name.lower()]
+        base_params["query"] = "span.op:http.client"
+        base_params["aggregate"] = "count()"
 
-        self.run_fail_validation_test(
-            params,
-            {
-                "nonFieldErrors": [
-                    "Invalid Time Window: Time window for this alert type must be at least 5 minutes."
-                ]
-            },
-        )
+        # Below the 5-minute floor
+        base_params["time_window"] = 1
+        serializer = AlertRuleSerializer(context=self.context, data=base_params)
+        assert not serializer.is_valid()
+        assert "Invalid Time Window" in serializer.errors["nonFieldErrors"][0]
+
+        # Above the floor but not a valid granularity (7 minutes = 420 seconds)
+        base_params["time_window"] = 7
+        serializer = AlertRuleSerializer(context=self.context, data=base_params)
+        assert not serializer.is_valid()
+        assert "Invalid Time Window" in serializer.errors["nonFieldErrors"][0]
 
     def test_dataset(self) -> None:
         invalid_values = ["Invalid dataset, valid values are %s" % [item.value for item in Dataset]]

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -326,6 +326,47 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         self.detector.refresh_from_db()
         assert self.detector.description == "New description for the detector"
 
+    def test_update_eap_invalid_time_window_rejected(self) -> None:
+        data = {**self.valid_data}
+        data["dataSources"] = [
+            {
+                "queryType": SnubaQuery.Type.PERFORMANCE.value,
+                "dataset": Dataset.EventsAnalyticsPlatform.value,
+                "query": "span.op:http.client",
+                "aggregate": "count()",
+                "timeWindow": 60,  # below the 300-second EAP floor
+                "environment": self.environment.name,
+                "eventTypes": [SnubaQueryEventType.EventType.TRACE_ITEM_SPAN.name.lower()],
+            }
+        ]
+        response = self.get_error_response(
+            self.organization.slug,
+            self.detector.id,
+            **data,
+            status_code=400,
+        )
+        assert "Invalid Time Window" in str(response.data)
+
+        # 450 seconds is above the floor but not a valid granularity
+        data["dataSources"][0]["timeWindow"] = 450
+        response = self.get_error_response(
+            self.organization.slug,
+            self.detector.id,
+            **data,
+            status_code=400,
+        )
+        assert "Invalid Time Window" in str(response.data)
+
+        # 300 seconds (5 minutes) is the smallest valid EAP window
+        data["dataSources"][0]["timeWindow"] = 300
+        with self.tasks():
+            self.get_success_response(
+                self.organization.slug,
+                self.detector.id,
+                **data,
+                status_code=200,
+            )
+
     def test_update_add_data_condition(self) -> None:
         """
         Test that we can add an additional data condition

--- a/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
@@ -337,6 +337,47 @@ class OrganizationProjectDetectorIndexPostTest(OrganizationProjectDetectorIndexB
         )
         assert response.data == {"name": ["This field is required."]}
 
+    def test_eap_invalid_time_window_rejected(self) -> None:
+        data = {**self.valid_data}
+        data["dataSources"] = [
+            {
+                "queryType": SnubaQuery.Type.PERFORMANCE.value,
+                "dataset": Dataset.EventsAnalyticsPlatform.value,
+                "query": "span.op:http.client",
+                "aggregate": "count()",
+                "timeWindow": 60,  # 60 seconds — below the 300-second EAP floor
+                "environment": self.environment.name,
+                "eventTypes": [SnubaQueryEventType.EventType.TRACE_ITEM_SPAN.name.lower()],
+            }
+        ]
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert "Invalid Time Window" in str(response.data)
+
+        # 450 seconds is above the floor but not a valid granularity
+        data["dataSources"][0]["timeWindow"] = 450
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert "Invalid Time Window" in str(response.data)
+
+        # 300 seconds (5 minutes) is the smallest valid EAP window
+        data["dataSources"][0]["timeWindow"] = 300
+        with self.tasks():
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                **data,
+                status_code=201,
+            )
+
 
 @cell_silo_test
 class OrganizationProjectDetectorIndexMonitorPostTest(APITestCase):


### PR DESCRIPTION
Use the existing list of valid time granularities to derive the list of valid values for our API.
Derive the error message from our constants; less friendly, but definitionally consistent.
Removed a redundant check elsewhere.

Fixes ISWF-2188.
