### PR TITLE
fix(cmdk): Omit empty groups and reset scroll on query change

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -577,6 +577,21 @@ describe('CommandPalette', () => {
       expect(screen.getAllByRole('option', {name: 'Action B'})).toHaveLength(1);
     });
 
+    it('a group with no children is omitted from the list', async () => {
+      render(
+        <CommandPaletteProvider>
+          <CMDKGroup display={{label: 'Empty Group'}} />
+          <CMDKAction display={{label: 'Real Action'}} onAction={jest.fn()} />
+          <CommandPalette onAction={jest.fn()} />
+        </CommandPaletteProvider>
+      );
+
+      expect(
+        await screen.findByRole('option', {name: 'Real Action'})
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Empty Group'})).not.toBeInTheDocument();
+    });
+
     it('direct CMDKAction registrations outside slots are not duplicated', async () => {
       render(
         <CommandPaletteProvider>

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useLayoutEffect, useMemo} from 'react';
+import {Fragment, useCallback, useLayoutEffect, useMemo, useRef} from 'react';
 import {preload} from 'react-dom';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -223,6 +223,8 @@ export function CommandPalette(props: CommandPaletteProps) {
     [actions, analytics, dispatch, props]
   );
 
+  const resultsListRef = useRef<HTMLDivElement>(null);
+
   const debouncedQuery = useDebouncedValue(state.query, 300);
 
   const isLoading = state.query.length > 0 && debouncedQuery !== state.query;
@@ -287,6 +289,9 @@ export function CommandPalette(props: CommandPaletteProps) {
                     onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
                       dispatch({type: 'set query', query: e.target.value});
                       treeState.selectionManager.setFocusedKey(null);
+                      if (resultsListRef.current) {
+                        resultsListRef.current.scrollTop = 0;
+                      }
                     },
                     onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
                       if (e.key === 'Backspace' && state.query.length === 0) {
@@ -364,6 +369,7 @@ export function CommandPalette(props: CommandPaletteProps) {
           overflow="auto"
         >
           <ListBox
+            scrollContainerRef={resultsListRef}
             listState={treeState}
             keyDownHandler={() => true}
             overlayIsOpen
@@ -448,6 +454,11 @@ function flattenActions(
     const results: CMDKFlatItem[] = [];
     for (const node of nodes) {
       const isGroup = node.children.length > 0;
+      // Skip groups that have no children and no executable action — they are
+      // empty section headers (e.g. a CMDKGroup whose children didn't render).
+      if (!isGroup && !('to' in node) && !('onAction' in node)) {
+        continue;
+      }
       results.push({...node, listItemType: isGroup ? 'section' : 'action'});
       if (isGroup) {
         for (const child of node.children) {

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -83,6 +83,11 @@ interface ListBoxProps<T extends ObjectLike>
   overlayIsOpen?: boolean;
   ref?: React.Ref<HTMLUListElement>;
   /**
+   * Ref forwarded to the inner scroll container div (the element the virtualizer
+   * uses as its scroll element). Useful for callers that need to reset scrollTop.
+   */
+  scrollContainerRef?: React.Ref<HTMLDivElement>;
+  /**
    * Whether the select has a search input field.
    */
   searchable?: boolean;
@@ -139,6 +144,7 @@ export function ListBox<T extends ObjectLike>({
   showDetails = true,
   onAction,
   virtualized,
+  scrollContainerRef,
   className,
   ...props
 }: ListBoxProps<T>) {
@@ -188,15 +194,15 @@ export function ListBox<T extends ObjectLike>({
   const virtualizer = useVirtualizedItems({listItems, virtualized, size});
 
   const refs = useMemo(() => {
-    const scrollContainerRef = (scrollContainer: HTMLDivElement | null) => {
+    const overflowTracker = (scrollContainer: HTMLDivElement | null) => {
       if (hasEverOverflowed || listItems.length === 0 || !scrollContainer) {
         return;
       }
 
       setHasEverOverflowed(scrollContainer.scrollHeight > scrollContainer.clientHeight);
     };
-    return mergeRefs(scrollContainerRef, virtualizer.scrollElementRef);
-  }, [hasEverOverflowed, virtualizer.scrollElementRef, listItems]);
+    return mergeRefs(overflowTracker, virtualizer.scrollElementRef, scrollContainerRef);
+  }, [hasEverOverflowed, virtualizer.scrollElementRef, listItems, scrollContainerRef]);
 
   return (
     <Fragment>


### PR DESCRIPTION
Two small fixes for the JSX-powered command palette.

**Empty groups are now omitted from the list.** A `CMDKGroup` that renders no children ends up with zero registered nodes in the collection. In browse mode, `flattenActions` was treating such nodes as leaf actions and showing them. These are headless section headers with nothing to show — they should be invisible. The fix skips any node that has no children and no executable action (`to` / `onAction`).

**Scroll resets to the top when the query changes.** Typing a new search query now scrolls the results list back to the top. The tricky part: `ResultsList` is not the actual scroll element — `ListBox` creates its own inner `div` that it hands to TanStack Virtual as the scroll container. The fix adds a `scrollContainerRef` prop to `ListBox` that gets merged into that inner container's refs, then wires it up in the `onChange` handler.

Stacked on #112262.