### PR TITLE
fix: correct typo "occured" to "occurred"

### DIFF
--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -51,7 +51,7 @@ class SentryAppBaseError(Exception):
         return f"{type(self).__name__}: message={self.message} status_code={self.status_code} error_type={self.error_type}"
 
 
-# Represents a user/client error that occured during a Sentry App process
+# Represents a user/client error that occurred during a Sentry App process
 class SentryAppError(SentryAppBaseError):
     error_type = SentryAppErrorType.CLIENT
     status_code = 400
@@ -71,7 +71,7 @@ class SentryAppSentryError(SentryAppBaseError):
     def to_public_dict(self) -> SentryAppPublicErrorBody:
         error_id = sentry_sdk.capture_exception(self, level="info")
         return {
-            "detail": f"An issue occured during the integration platform process. Sentry error ID: {error_id}"
+            "detail": f"An issue occurred during the integration platform process. Sentry error ID: {error_id}"
         }
 
     def response_from_exception(self) -> Response:


### PR DESCRIPTION
## Summary

Fix typo "occured" → "occurred" in `src/sentry/sentry_apps/utils/errors.py`.

**Changes:**
```python
# Before
# Represents a user/client error that occured during a Sentry App process
"An issue occured during the integration platform process."

# After
# Represents a user/client error that occurred during a Sentry App process
"An issue occurred during the integration platform process."
```

## Testing
No behavior change — typo fix only in a comment and error message string.