### PR TITLE
fix(ui): Remove overflow hidden from GuidedSteps StepDetails

### DIFF
--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -371,7 +371,6 @@ const ChildrenWrapper = styled('div')<{isActive: boolean}>`
 `;
 
 const StepDetails = styled('div')`
-  overflow: hidden;
   grid-area: details;
   min-width: 0;
 `;


### PR DESCRIPTION
Remove `overflow: hidden` from `StepDetails` in the `GuidedSteps` component.

### Background

`StepDetails` is a grid item in a `34px 1fr` layout. When content inside it (like a code block with long lines) had a large intrinsic width, it would push past its `1fr` column and break the layout on small viewports. To prevent this, `overflow: hidden` was added — it worked, but it also clipped everything that extended beyond the container bounds, including focus rings on form elements (which use `box-shadow` in Sentry's design system): 

<img width="427" height="241" alt="image" src="https://github.com/user-attachments/assets/f693c434-1027-4237-b643-52d974f94897" />


### What happened

On **Mar 25**, Evans noticed the clipping issue and removed `overflow: hidden` in #111462. But without it, content started overflowing on small screens again, so on **Mar 27** it was reverted in 939e726b947.

Then on **Mar 31**, Lazar landed #111657 which added `min-width: 0` to `StepDetails` to fix a code block overflow issue in the Metrics onboarding. Since the revert had already restored `overflow: hidden`, the overflow was no longer visible — but `min-width: 0` was still the right addition, and it also happens to solve the clipping issue, since it lets the grid item respect its track width without needing to clip its contents.

### This PR

Now that `min-width: 0` handles the overflow problem, `overflow: hidden` is redundant and can be safely removed — finishing what Evans started in #111462.


closes https://linear.app/getsentry/issue/DE-1048/stepper-overflow-hidden-clips-focus-rings