### PR TITLE
ref(preprod): Remove PreprodStaticGroupType and PreprodDeltaGroupType

### DIFF
--- a/src/sentry/preprod/grouptype.py
+++ b/src/sentry/preprod/grouptype.py
@@ -1,54 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import sentry.preprod.size_analysis.grouptype  # noqa: F401,F403
-from sentry.issues.grouptype import GroupCategory, GroupType
-from sentry.types.group import PriorityLevel
 
 # We have to import sentry.preprod.size_analysis.grouptype above.
 # grouptype modules in root packages (src/sentry/*) are auto imported
 # but more deeply nested ones are not.
-
-
-@dataclass(frozen=True)
-class PreprodStaticGroupType(GroupType):
-    """
-    Issues detected in a single uploaded artifact. For example an
-    Android app not being 16kb page size ready.
-    Typically these end up grouped across multiple builds e.g. if CI
-    uploads a build of an app for each commit to main each of those
-    uploads could result in an occurrence of some issue like the 16kb
-    page size.
-    """
-
-    type_id = 11001
-    slug = "preprod_static"
-    description = "Static Analysis"
-    category = GroupCategory.PREPROD.value
-    category_v2 = GroupCategory.PREPROD.value
-    default_priority = PriorityLevel.LOW
-    released = False
-    enable_auto_resolve = True
-    enable_escalation_detection = False
-
-
-@dataclass(frozen=True)
-class PreprodDeltaGroupType(GroupType):
-    """
-    Issues detected examining the delta between two uploaded artifacts.
-    For example a binary size regression. These are typically *not*
-    grouped. A size regression between v1 and v2 likely does not have
-    the same root cause (and hence resolution) as another regression
-    between v2 and v3.
-    """
-
-    type_id = 11002
-    slug = "preprod_delta"
-    description = "Static Analysis Delta"
-    category = GroupCategory.PREPROD.value
-    category_v2 = GroupCategory.PREPROD.value
-    default_priority = PriorityLevel.LOW
-    released = False
-    enable_auto_resolve = True
-    enable_escalation_detection = False


### PR DESCRIPTION
Remove the unused `PreprodStaticGroupType` (type_id 11001) and `PreprodDeltaGroupType` (type_id 11002) group types. Neither class was referenced anywhere in the codebase. The `grouptype.py` module is retained for its side-effect import of `sentry.preprod.size_analysis.grouptype`.

Agent transcript: https://claudescope.sentry.dev/share/TB-Jn6n67lNj6NQ-Hu4JOrlbup4fW28mdJdywsxjyoY