### PR TITLE
ref: Remove preprod-size-monitors-frontend feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -245,8 +245,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable preprod size monitors frontend
-    manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod snapshots product feature
     manager.add("organizations:preprod-snapshots", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables PR page

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -245,6 +245,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable preprod size monitors frontend
+    manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod snapshots product feature
     manager.add("organizations:preprod-snapshots", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables PR page

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -69,7 +69,6 @@ interface DetectorTypeOption {
 }
 
 function MonitorTypeField() {
-  const organization = useOrganization();
   const [selectedDetectorType, setDetectorType] = useDetectorTypeQueryState();
 
   const useMetricDetectorLimit =
@@ -121,7 +120,6 @@ function MonitorTypeField() {
       name: getDetectorTypeLabel('preprod_size_analysis'),
       description: t('Monitor mobile app build sizes and detect regressions.'),
       visualization: null,
-      show: !!organization?.features?.includes('preprod-size-monitors-frontend'),
     },
   ];
 

--- a/static/app/views/detectors/components/forms/index.tsx
+++ b/static/app/views/detectors/components/forms/index.tsx
@@ -6,7 +6,6 @@ import {LoadingError} from 'sentry/components/loadingError';
 import {t} from 'sentry/locale';
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
 import {unreachable} from 'sentry/utils/unreachable';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   EditExistingCronDetectorForm,
   NewCronDetectorForm,
@@ -41,8 +40,6 @@ function PlaceholderForm() {
 }
 
 export function NewDetectorForm({detectorType}: {detectorType: DetectorType}) {
-  const organization = useOrganization();
-
   switch (detectorType) {
     case 'metric_issue':
       return <NewMetricDetectorForm />;
@@ -55,9 +52,6 @@ export function NewDetectorForm({detectorType}: {detectorType: DetectorType}) {
     case 'issue_stream':
       return <PlaceholderForm />;
     case 'preprod_size_analysis':
-      if (!organization.features.includes('preprod-size-monitors-frontend')) {
-        return <PlaceholderForm />;
-      }
       return <NewPreprodDetectorForm />;
     default:
       unreachable(detectorType);

--- a/static/app/views/detectors/list/mobileBuild.tsx
+++ b/static/app/views/detectors/list/mobileBuild.tsx
@@ -1,4 +1,3 @@
-import Feature from 'sentry/components/acl/feature';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {WorkflowEngineListLayout} from 'sentry/components/workflowEngine/layout/list';
 import {t} from 'sentry/locale';
@@ -19,18 +18,16 @@ export default function MobileBuildDetectorsList() {
   });
 
   return (
-    <Feature features="organizations:preprod-size-monitors-frontend">
-      <SentryDocumentTitle title={TITLE}>
-        <WorkflowEngineListLayout
-          actions={<DetectorListActions detectorType="preprod_size_analysis" />}
-          title={TITLE}
-          description={DESCRIPTION}
-          docsUrl={DOCS_URL}
-        >
-          <DetectorListHeader showTypeFilter={false} />
-          <DetectorListContent {...detectorListQuery} />
-        </WorkflowEngineListLayout>
-      </SentryDocumentTitle>
-    </Feature>
+    <SentryDocumentTitle title={TITLE}>
+      <WorkflowEngineListLayout
+        actions={<DetectorListActions detectorType="preprod_size_analysis" />}
+        title={TITLE}
+        description={DESCRIPTION}
+        docsUrl={DOCS_URL}
+      >
+        <DetectorListHeader showTypeFilter={false} />
+        <DetectorListContent {...detectorListQuery} />
+      </WorkflowEngineListLayout>
+    </SentryDocumentTitle>
   );
 }

--- a/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
@@ -71,16 +71,14 @@ export function MonitorsSecondaryNavigation() {
                 </SecondaryNavigation.Link>
               </SecondaryNavigation.ListItem>
             </Feature>
-            <Feature features={['organizations:preprod-size-monitors-frontend']}>
-              <SecondaryNavigation.ListItem>
-                <SecondaryNavigation.Link
-                  to={`${baseUrl}/mobile-builds/`}
-                  analyticsItemName="monitors_mobile_builds"
-                >
-                  {t('Mobile Builds')}
-                </SecondaryNavigation.Link>
-              </SecondaryNavigation.ListItem>
-            </Feature>
+            <SecondaryNavigation.ListItem>
+              <SecondaryNavigation.Link
+                to={`${baseUrl}/mobile-builds/`}
+                analyticsItemName="monitors_mobile_builds"
+              >
+                {t('Mobile Builds')}
+              </SecondaryNavigation.Link>
+            </SecondaryNavigation.ListItem>
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
         <SecondaryNavigation.Separator />


### PR DESCRIPTION
Remove frontend usage of the `organizations:preprod-size-monitors-frontend` feature flag, making the mobile build size monitors UI unconditionally rendered. Unwraps `<Feature>` gates in the detector list and secondary nav, and removes flag checks in the detector type form and new detector form.

Note: this does not release the feature to users — the entire monitors UI is still gated behind `organizations:workflow-engine-ui`.