### PR TITLE
ref(plugins): migrate plugin config to BackendJsonSubmitForm

### DIFF
--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
@@ -315,6 +315,37 @@ describe('BackendJsonSubmitForm', () => {
       );
     });
 
+    it('preserves explicit null initialValues over field defaults', async () => {
+      render(
+        <BackendJsonSubmitForm
+          fields={[
+            {
+              name: 'priority',
+              type: 'select',
+              label: 'Priority',
+              choices: [
+                ['high', 'High'],
+                ['medium', 'Medium'],
+                ['low', 'Low'],
+              ],
+              default: 'medium',
+            },
+          ]}
+          initialValues={{priority: null}}
+          onSubmit={onSubmit}
+          submitLabel="Create"
+          isClearable
+        />,
+        {organization: org}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Create'}));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({priority: null}));
+      });
+    });
+
     it('renders footer with SubmitButton when footer prop provided', () => {
       render(
         <BackendJsonSubmitForm

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
@@ -334,7 +334,6 @@ describe('BackendJsonSubmitForm', () => {
           initialValues={{priority: null}}
           onSubmit={onSubmit}
           submitLabel="Create"
-          isClearable
         />,
         {organization: org}
       );

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -276,7 +276,7 @@ export function BackendJsonSubmitForm({
                         </fieldApi.Layout.Stack>
                       );
                     case 'select':
-                    case 'choice':
+                    case 'choice': {
                       if (field.url) {
                         // Async select: fetch options from URL as user types.
                         // Show static choices as initial options before any search.
@@ -316,6 +316,11 @@ export function BackendJsonSubmitForm({
                             },
                           });
                         if (field.multiple) {
+                          const handleMultipleSelectChange = (
+                            value: Array<string | number>
+                          ) => {
+                            handleChange(value);
+                          };
                           return (
                             <fieldApi.Layout.Stack
                               label={field.label}
@@ -324,31 +329,59 @@ export function BackendJsonSubmitForm({
                             >
                               <fieldApi.SelectAsync
                                 multiple
-                                value={(fieldApi.state.value as string[]) ?? []}
-                                onChange={handleChange}
+                                value={
+                                  (fieldApi.state.value as Array<string | number>) ?? []
+                                }
+                                onChange={handleMultipleSelectChange}
                                 disabled={field.disabled}
                                 queryOptions={asyncQueryOptions}
                               />
                             </fieldApi.Layout.Stack>
                           );
                         }
+                        const singleSelectValue = (fieldApi.state.value ?? null) as
+                          | string
+                          | number
+                          | null;
+                        const handleSingleClearableSelectChange = (
+                          value: string | number | null
+                        ) => {
+                          handleChange(value);
+                        };
+                        const handleSingleSelectChange = (value: string | number) => {
+                          handleChange(value);
+                        };
                         return (
                           <fieldApi.Layout.Stack
                             label={field.label}
                             hintText={field.help}
                             required={field.required}
                           >
-                            <fieldApi.SelectAsync
-                              clearable={isClearable}
-                              value={fieldApi.state.value as string | null}
-                              onChange={handleChange}
-                              disabled={field.disabled}
-                              queryOptions={asyncQueryOptions}
-                            />
+                            {isClearable ? (
+                              <fieldApi.SelectAsync
+                                clearable
+                                value={singleSelectValue}
+                                onChange={handleSingleClearableSelectChange}
+                                disabled={field.disabled}
+                                queryOptions={asyncQueryOptions}
+                              />
+                            ) : (
+                              <fieldApi.SelectAsync
+                                value={singleSelectValue}
+                                onChange={handleSingleSelectChange}
+                                disabled={field.disabled}
+                                queryOptions={asyncQueryOptions}
+                              />
+                            )}
                           </fieldApi.Layout.Stack>
                         );
                       }
                       if (field.multiple) {
+                        const handleMultipleSelectChange = (
+                          value: Array<string | number>
+                        ) => {
+                          handleChange(value);
+                        };
                         return (
                           <fieldApi.Layout.Stack
                             label={field.label}
@@ -357,29 +390,53 @@ export function BackendJsonSubmitForm({
                           >
                             <fieldApi.Select
                               multiple
-                              value={(fieldApi.state.value as string[]) ?? []}
-                              onChange={handleChange}
+                              value={
+                                (fieldApi.state.value as Array<string | number>) ?? []
+                              }
+                              onChange={handleMultipleSelectChange}
                               options={transformChoices(field.choices)}
                               disabled={field.disabled}
                             />
                           </fieldApi.Layout.Stack>
                         );
                       }
+                      const singleSelectValue = (fieldApi.state.value ?? null) as
+                        | string
+                        | number
+                        | null;
+                      const handleSingleClearableSelectChange = (
+                        value: string | number | null
+                      ) => {
+                        handleChange(value);
+                      };
+                      const handleSingleSelectChange = (value: string | number) => {
+                        handleChange(value);
+                      };
                       return (
                         <fieldApi.Layout.Stack
                           label={field.label}
                           hintText={field.help}
                           required={field.required}
                         >
-                          <fieldApi.Select
-                            clearable={isClearable}
-                            value={fieldApi.state.value as string | null}
-                            onChange={handleChange}
-                            options={transformChoices(field.choices)}
-                            disabled={field.disabled}
-                          />
+                          {isClearable ? (
+                            <fieldApi.Select
+                              clearable
+                              value={singleSelectValue}
+                              onChange={handleSingleClearableSelectChange}
+                              options={transformChoices(field.choices)}
+                              disabled={field.disabled}
+                            />
+                          ) : (
+                            <fieldApi.Select
+                              value={singleSelectValue}
+                              onChange={handleSingleSelectChange}
+                              options={transformChoices(field.choices)}
+                              disabled={field.disabled}
+                            />
+                          )}
                         </fieldApi.Layout.Stack>
                       );
+                    }
                     case 'secret':
                       return (
                         <fieldApi.Layout.Stack

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -56,11 +56,6 @@ interface BackendJsonSubmitFormProps {
    */
   initialValues?: Record<string, unknown>;
   /**
-   * Enables clearing for single-select fields.
-   * Defaults to false to preserve existing behavior.
-   */
-  isClearable?: boolean;
-  /**
    * Whether the form is in a loading state (e.g., dynamic field refetch in progress).
    */
   isLoading?: boolean;
@@ -164,7 +159,6 @@ export function BackendJsonSubmitForm({
   onAsyncOptionsFetched,
   onFieldChange,
   footer,
-  isClearable = false,
 }: BackendJsonSubmitFormProps) {
   // Ref to avoid including the callback in queryKey (would cause refetches)
   const onAsyncOptionsFetchedRef = useRef(onAsyncOptionsFetched);
@@ -345,7 +339,16 @@ export function BackendJsonSubmitForm({
                             hintText={field.help}
                             required={field.required}
                           >
-                            {isClearable ? (
+                            {field.required ? (
+                              <fieldApi.SelectAsync
+                                value={
+                                  (fieldApi.state.value ?? null) as string | number | null
+                                }
+                                onChange={(value: string | number) => handleChange(value)}
+                                disabled={field.disabled}
+                                queryOptions={asyncQueryOptions}
+                              />
+                            ) : (
                               <fieldApi.SelectAsync
                                 clearable
                                 value={
@@ -354,15 +357,6 @@ export function BackendJsonSubmitForm({
                                 onChange={(value: string | number | null) =>
                                   handleChange(value)
                                 }
-                                disabled={field.disabled}
-                                queryOptions={asyncQueryOptions}
-                              />
-                            ) : (
-                              <fieldApi.SelectAsync
-                                value={
-                                  (fieldApi.state.value ?? null) as string | number | null
-                                }
-                                onChange={(value: string | number) => handleChange(value)}
                                 disabled={field.disabled}
                                 queryOptions={asyncQueryOptions}
                               />
@@ -393,18 +387,18 @@ export function BackendJsonSubmitForm({
                           hintText={field.help}
                           required={field.required}
                         >
-                          {isClearable ? (
+                          {field.required ? (
                             <fieldApi.Select
-                              clearable
                               value={(fieldApi.state.value ?? null) as string | null}
-                              onChange={(value: string | null) => handleChange(value)}
+                              onChange={(value: string) => handleChange(value)}
                               options={transformChoices(field.choices)}
                               disabled={field.disabled}
                             />
                           ) : (
                             <fieldApi.Select
+                              clearable
                               value={(fieldApi.state.value ?? null) as string | null}
-                              onChange={(value: string) => handleChange(value)}
+                              onChange={(value: string | null) => handleChange(value)}
                               options={transformChoices(field.choices)}
                               disabled={field.disabled}
                             />

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -377,9 +377,7 @@ export function BackendJsonSubmitForm({
                         );
                       }
                       if (field.multiple) {
-                        const handleMultipleSelectChange = (
-                          value: Array<string | number>
-                        ) => {
+                        const handleMultipleSelectChange = (value: string[]) => {
                           handleChange(value);
                         };
                         return (
@@ -390,9 +388,7 @@ export function BackendJsonSubmitForm({
                           >
                             <fieldApi.Select
                               multiple
-                              value={
-                                (fieldApi.state.value as Array<string | number>) ?? []
-                              }
+                              value={(fieldApi.state.value as string[]) ?? []}
                               onChange={handleMultipleSelectChange}
                               options={transformChoices(field.choices)}
                               disabled={field.disabled}
@@ -402,14 +398,13 @@ export function BackendJsonSubmitForm({
                       }
                       const singleSelectValue = (fieldApi.state.value ?? null) as
                         | string
-                        | number
                         | null;
                       const handleSingleClearableSelectChange = (
-                        value: string | number | null
+                        value: string | null
                       ) => {
                         handleChange(value);
                       };
-                      const handleSingleSelectChange = (value: string | number) => {
+                      const handleSingleSelectChange = (value: string) => {
                         handleChange(value);
                       };
                       return (

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -56,6 +56,11 @@ interface BackendJsonSubmitFormProps {
    */
   initialValues?: Record<string, unknown>;
   /**
+   * Enables clearing for single-select fields.
+   * Defaults to false to preserve existing behavior.
+   */
+  isClearable?: boolean;
+  /**
    * Whether the form is in a loading state (e.g., dynamic field refetch in progress).
    */
   isLoading?: boolean;
@@ -71,11 +76,6 @@ interface BackendJsonSubmitFormProps {
    * Called when a field with `updatesForm: true` changes value.
    */
   onFieldChange?: (fieldName: string, value: unknown) => void;
-  /**
-   * Enables clearing for single-select fields.
-   * Defaults to false to preserve existing behavior for non-plugin forms.
-   */
-  singleSelectClearable?: boolean;
   /**
    * Whether the submit button should be disabled (e.g., form has errors).
    */
@@ -161,7 +161,7 @@ export function BackendJsonSubmitForm({
   onAsyncOptionsFetched,
   onFieldChange,
   footer,
-  singleSelectClearable = false,
+  isClearable = false,
 }: BackendJsonSubmitFormProps) {
   // Ref to avoid including the callback in queryKey (would cause refetches)
   const onAsyncOptionsFetchedRef = useRef(onAsyncOptionsFetched);
@@ -339,7 +339,7 @@ export function BackendJsonSubmitForm({
                             required={field.required}
                           >
                             <fieldApi.SelectAsync
-                              clearable={singleSelectClearable}
+                              clearable={isClearable}
                               value={fieldApi.state.value as string | null}
                               onChange={handleChange}
                               disabled={field.disabled}
@@ -372,7 +372,7 @@ export function BackendJsonSubmitForm({
                           required={field.required}
                         >
                           <fieldApi.Select
-                            clearable={singleSelectClearable}
+                            clearable={isClearable}
                             value={fieldApi.state.value as string | null}
                             onChange={handleChange}
                             options={transformChoices(field.choices)}

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -120,8 +120,11 @@ function computeDefaultValues(
   const defaults: Record<string, unknown> = {};
   for (const field of fields) {
     if (field.name && field.type !== 'blank') {
+      const initialValue = initialValues?.[field.name];
       defaults[field.name] =
-        initialValues?.[field.name] ?? field.default ?? getDefaultForField(field);
+        initialValue === undefined
+          ? (field.default ?? getDefaultForField(field))
+          : initialValue;
     }
   }
   return defaults;

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -333,6 +333,7 @@ export function BackendJsonSubmitForm({
                             required={field.required}
                           >
                             <fieldApi.SelectAsync
+                              clearable
                               value={fieldApi.state.value as string | null}
                               onChange={handleChange}
                               disabled={field.disabled}
@@ -365,6 +366,7 @@ export function BackendJsonSubmitForm({
                           required={field.required}
                         >
                           <fieldApi.Select
+                            clearable
                             value={fieldApi.state.value as string | null}
                             onChange={handleChange}
                             options={transformChoices(field.choices)}

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -72,6 +72,11 @@ interface BackendJsonSubmitFormProps {
    */
   onFieldChange?: (fieldName: string, value: unknown) => void;
   /**
+   * Enables clearing for single-select fields.
+   * Defaults to false to preserve existing behavior for non-plugin forms.
+   */
+  singleSelectClearable?: boolean;
+  /**
    * Whether the submit button should be disabled (e.g., form has errors).
    */
   submitDisabled?: boolean;
@@ -156,6 +161,7 @@ export function BackendJsonSubmitForm({
   onAsyncOptionsFetched,
   onFieldChange,
   footer,
+  singleSelectClearable = false,
 }: BackendJsonSubmitFormProps) {
   // Ref to avoid including the callback in queryKey (would cause refetches)
   const onAsyncOptionsFetchedRef = useRef(onAsyncOptionsFetched);
@@ -333,7 +339,7 @@ export function BackendJsonSubmitForm({
                             required={field.required}
                           >
                             <fieldApi.SelectAsync
-                              clearable
+                              clearable={singleSelectClearable}
                               value={fieldApi.state.value as string | null}
                               onChange={handleChange}
                               disabled={field.disabled}
@@ -366,7 +372,7 @@ export function BackendJsonSubmitForm({
                           required={field.required}
                         >
                           <fieldApi.Select
-                            clearable
+                            clearable={singleSelectClearable}
                             value={fieldApi.state.value as string | null}
                             onChange={handleChange}
                             options={transformChoices(field.choices)}

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -316,11 +316,6 @@ export function BackendJsonSubmitForm({
                             },
                           });
                         if (field.multiple) {
-                          const handleMultipleSelectChange = (
-                            value: Array<string | number>
-                          ) => {
-                            handleChange(value);
-                          };
                           return (
                             <fieldApi.Layout.Stack
                               label={field.label}
@@ -332,25 +327,15 @@ export function BackendJsonSubmitForm({
                                 value={
                                   (fieldApi.state.value as Array<string | number>) ?? []
                                 }
-                                onChange={handleMultipleSelectChange}
+                                onChange={(value: Array<string | number>) =>
+                                  handleChange(value)
+                                }
                                 disabled={field.disabled}
                                 queryOptions={asyncQueryOptions}
                               />
                             </fieldApi.Layout.Stack>
                           );
                         }
-                        const singleSelectValue = (fieldApi.state.value ?? null) as
-                          | string
-                          | number
-                          | null;
-                        const handleSingleClearableSelectChange = (
-                          value: string | number | null
-                        ) => {
-                          handleChange(value);
-                        };
-                        const handleSingleSelectChange = (value: string | number) => {
-                          handleChange(value);
-                        };
                         return (
                           <fieldApi.Layout.Stack
                             label={field.label}
@@ -360,15 +345,21 @@ export function BackendJsonSubmitForm({
                             {isClearable ? (
                               <fieldApi.SelectAsync
                                 clearable
-                                value={singleSelectValue}
-                                onChange={handleSingleClearableSelectChange}
+                                value={
+                                  (fieldApi.state.value ?? null) as string | number | null
+                                }
+                                onChange={(value: string | number | null) =>
+                                  handleChange(value)
+                                }
                                 disabled={field.disabled}
                                 queryOptions={asyncQueryOptions}
                               />
                             ) : (
                               <fieldApi.SelectAsync
-                                value={singleSelectValue}
-                                onChange={handleSingleSelectChange}
+                                value={
+                                  (fieldApi.state.value ?? null) as string | number | null
+                                }
+                                onChange={(value: string | number) => handleChange(value)}
                                 disabled={field.disabled}
                                 queryOptions={asyncQueryOptions}
                               />
@@ -377,9 +368,6 @@ export function BackendJsonSubmitForm({
                         );
                       }
                       if (field.multiple) {
-                        const handleMultipleSelectChange = (value: string[]) => {
-                          handleChange(value);
-                        };
                         return (
                           <fieldApi.Layout.Stack
                             label={field.label}
@@ -389,24 +377,13 @@ export function BackendJsonSubmitForm({
                             <fieldApi.Select
                               multiple
                               value={(fieldApi.state.value as string[]) ?? []}
-                              onChange={handleMultipleSelectChange}
+                              onChange={(value: string[]) => handleChange(value)}
                               options={transformChoices(field.choices)}
                               disabled={field.disabled}
                             />
                           </fieldApi.Layout.Stack>
                         );
                       }
-                      const singleSelectValue = (fieldApi.state.value ?? null) as
-                        | string
-                        | null;
-                      const handleSingleClearableSelectChange = (
-                        value: string | null
-                      ) => {
-                        handleChange(value);
-                      };
-                      const handleSingleSelectChange = (value: string) => {
-                        handleChange(value);
-                      };
                       return (
                         <fieldApi.Layout.Stack
                           label={field.label}
@@ -416,15 +393,15 @@ export function BackendJsonSubmitForm({
                           {isClearable ? (
                             <fieldApi.Select
                               clearable
-                              value={singleSelectValue}
-                              onChange={handleSingleClearableSelectChange}
+                              value={(fieldApi.state.value ?? null) as string | null}
+                              onChange={(value: string | null) => handleChange(value)}
                               options={transformChoices(field.choices)}
                               disabled={field.disabled}
                             />
                           ) : (
                             <fieldApi.Select
-                              value={singleSelectValue}
-                              onChange={handleSingleSelectChange}
+                              value={(fieldApi.state.value ?? null) as string | null}
+                              onChange={(value: string) => handleChange(value)}
                               options={transformChoices(field.choices)}
                               disabled={field.disabled}
                             />

--- a/static/app/components/pluginConfig.spec.tsx
+++ b/static/app/components/pluginConfig.spec.tsx
@@ -3,8 +3,6 @@ import {WebhookPluginConfigFixture} from 'sentry-fixture/integrationListDirector
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {plugins} from 'sentry/plugins';
-
 import {PluginConfig} from './pluginConfig';
 
 describe('PluginConfig', () => {
@@ -16,7 +14,21 @@ describe('PluginConfig', () => {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/plugins/${webhookPlugin.id}/`,
       method: 'GET',
-      body: webhookPlugin,
+      body: {
+        ...webhookPlugin,
+        config: [
+          {
+            name: 'urls',
+            label: 'Callback URLs',
+            type: 'textarea',
+            placeholder: 'https://sentry.io/callback/url',
+            required: false,
+            help: 'Enter callback URLs, separated by newlines.',
+            value: 'https://example.com/hook',
+            defaultValue: '',
+          },
+        ],
+      },
     });
     const testWebhookMock = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/plugins/${webhookPlugin.id}/`,
@@ -24,11 +36,9 @@ describe('PluginConfig', () => {
       body: {detail: 'No errors returned'},
     });
 
-    expect(plugins.isLoaded(webhookPlugin)).toBe(false);
     render(<PluginConfig plugin={webhookPlugin} project={project} />);
-    expect(plugins.isLoaded(webhookPlugin)).toBe(true);
 
-    await userEvent.click(screen.getByRole('button', {name: 'Test Plugin'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Test Plugin'}));
 
     expect(await screen.findByText('"No errors returned"')).toBeInTheDocument();
     expect(testWebhookMock).toHaveBeenCalledWith(
@@ -38,5 +48,54 @@ describe('PluginConfig', () => {
         data: {test: true},
       })
     );
+  });
+
+  it('renders config fields from backend', async () => {
+    const webhookPlugin = WebhookPluginConfigFixture({enabled: true});
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/plugins/${webhookPlugin.id}/`,
+      method: 'GET',
+      body: {
+        ...webhookPlugin,
+        config: [
+          {
+            name: 'urls',
+            label: 'Callback URLs',
+            type: 'textarea',
+            placeholder: 'https://sentry.io/callback/url',
+            required: false,
+            help: 'Enter callback URLs, separated by newlines.',
+            value: '',
+            defaultValue: '',
+          },
+        ],
+      },
+    });
+
+    render(<PluginConfig plugin={webhookPlugin} project={project} />);
+
+    expect(await screen.findByText('Callback URLs')).toBeInTheDocument();
+  });
+
+  it('renders auth error state', async () => {
+    const webhookPlugin = WebhookPluginConfigFixture({enabled: true});
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/plugins/${webhookPlugin.id}/`,
+      method: 'GET',
+      body: {
+        ...webhookPlugin,
+        config_error: 'You need to associate an identity',
+        auth_url: '/auth/associate/webhooks/',
+      },
+    });
+
+    render(<PluginConfig plugin={webhookPlugin} project={project} />);
+
+    expect(
+      await screen.findByText('You need to associate an identity')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Associate Identity'})).toBeInTheDocument();
   });
 });

--- a/static/app/components/pluginConfig.spec.tsx
+++ b/static/app/components/pluginConfig.spec.tsx
@@ -75,9 +75,7 @@ describe('PluginConfig', () => {
 
     render(<PluginConfig plugin={webhookPlugin} project={project} />);
 
-    expect(
-      await screen.findByRole('textbox', {name: 'Callback URLs'})
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText('Callback URLs')).toBeInTheDocument();
   });
 
   it('renders auth error state', async () => {

--- a/static/app/components/pluginConfig.spec.tsx
+++ b/static/app/components/pluginConfig.spec.tsx
@@ -75,7 +75,9 @@ describe('PluginConfig', () => {
 
     render(<PluginConfig plugin={webhookPlugin} project={project} />);
 
-    expect(await screen.findByText('Callback URLs')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('textbox', {name: 'Callback URLs'})
+    ).toBeInTheDocument();
   });
 
   it('renders auth error state', async () => {

--- a/static/app/components/pluginConfig.spec.tsx
+++ b/static/app/components/pluginConfig.spec.tsx
@@ -1,7 +1,7 @@
 import {WebhookPluginConfigFixture} from 'sentry-fixture/integrationListDirectory';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PluginConfig} from './pluginConfig';
 
@@ -97,5 +97,65 @@ describe('PluginConfig', () => {
       await screen.findByText('You need to associate an identity')
     ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Associate Identity'})).toBeInTheDocument();
+  });
+
+  it('submits typed defaults for unsaved boolean and select fields', async () => {
+    const webhookPlugin = WebhookPluginConfigFixture({enabled: true});
+    const url = `/projects/${organization.slug}/${project.slug}/plugins/${webhookPlugin.id}/`;
+
+    const configBody = {
+      ...webhookPlugin,
+      config: [
+        {
+          name: 'auto_create',
+          label: 'Automatically create tickets',
+          type: 'bool',
+          required: false,
+        },
+        {
+          name: 'repository',
+          label: 'Repository',
+          type: 'select',
+          choices: [
+            ['', 'select a repo'],
+            ['getsentry/sentry', 'getsentry/sentry'],
+          ],
+          required: false,
+        },
+      ],
+    };
+
+    MockApiClient.addMockResponse({
+      url,
+      method: 'GET',
+      body: configBody,
+    });
+    const saveRequest = MockApiClient.addMockResponse({
+      url,
+      method: 'PUT',
+      body: configBody,
+    });
+    MockApiClient.addMockResponse({
+      url,
+      method: 'GET',
+      body: configBody,
+    });
+
+    render(<PluginConfig plugin={webhookPlugin} project={project} />);
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Save Changes'}));
+
+    await waitFor(() =>
+      expect(saveRequest).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          method: 'PUT',
+          data: {
+            auto_create: false,
+            repository: null,
+          },
+        })
+      )
+    );
   });
 });

--- a/static/app/components/pluginConfig.spec.tsx
+++ b/static/app/components/pluginConfig.spec.tsx
@@ -40,7 +40,7 @@ describe('PluginConfig', () => {
 
     await userEvent.click(await screen.findByRole('button', {name: 'Test Plugin'}));
 
-    expect(await screen.findByText('"No errors returned"')).toBeInTheDocument();
+    expect(await screen.findByText('No errors returned')).toBeInTheDocument();
     expect(testWebhookMock).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({

--- a/static/app/components/pluginConfig.spec.tsx
+++ b/static/app/components/pluginConfig.spec.tsx
@@ -99,7 +99,7 @@ describe('PluginConfig', () => {
     expect(screen.getByRole('button', {name: 'Associate Identity'})).toBeInTheDocument();
   });
 
-  it('submits typed defaults for unsaved boolean and select fields', async () => {
+  it('submits typed defaults when backend returns null for non-select fields', async () => {
     const webhookPlugin = WebhookPluginConfigFixture({enabled: true});
     const url = `/projects/${organization.slug}/${project.slug}/plugins/${webhookPlugin.id}/`;
 
@@ -111,6 +111,7 @@ describe('PluginConfig', () => {
           label: 'Automatically create tickets',
           type: 'bool',
           required: false,
+          value: null,
         },
         {
           name: 'repository',
@@ -121,6 +122,7 @@ describe('PluginConfig', () => {
             ['getsentry/sentry', 'getsentry/sentry'],
           ],
           required: false,
+          value: null,
         },
       ],
     };

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -1,7 +1,8 @@
-import {useEffect, useRef, useState} from 'react';
+import {useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from '@sentry/scraps/button';
+import {Alert} from '@sentry/scraps/alert';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex, Grid} from '@sentry/scraps/layout';
 
 import {
@@ -10,18 +11,94 @@ import {
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import {hasEveryAccess} from 'sentry/components/acl/access';
+import {BackendJsonSubmitForm} from 'sentry/components/backendJsonFormAdapter/backendJsonSubmitForm';
+import type {JsonFormAdapterFieldConfig} from 'sentry/components/backendJsonFormAdapter/types';
+import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelAlert} from 'sentry/components/panels/panelAlert';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
-import {plugins} from 'sentry/plugins';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {Plugin} from 'sentry/types/integrations';
 import type {Project} from 'sentry/types/project';
-import {useApi} from 'sentry/utils/useApi';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
+import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
+
+/**
+ * Field config shape returned by the backend's PluginWithConfigSerializer.
+ */
+interface BackendPluginField {
+  label: string;
+  name: string;
+  type: string;
+  choices?: Array<[string, string]>;
+  default?: unknown;
+  defaultValue?: unknown;
+  hasSavedValue?: boolean;
+  help?: string;
+  isDeprecated?: boolean;
+  isHidden?: boolean;
+  placeholder?: string;
+  prefix?: string;
+  readonly?: boolean;
+  required?: boolean;
+  value?: unknown;
+}
+
+interface PluginWithConfig extends Plugin {
+  auth_url?: string;
+  config?: BackendPluginField[];
+  config_error?: string;
+}
+
+/**
+ * Maps a backend plugin field to the JsonFormAdapterFieldConfig shape
+ * expected by BackendJsonSubmitForm.
+ */
+function mapPluginField(field: BackendPluginField): JsonFormAdapterFieldConfig {
+  const base = {
+    name: field.name,
+    label: field.label,
+    required: field.required,
+    help: field.help ?? undefined,
+    placeholder: field.placeholder ?? undefined,
+    disabled: field.readonly,
+    default: field.defaultValue ?? field.default,
+  };
+
+  // Backend uses 'bool', adapter uses 'boolean'
+  const type = field.type === 'bool' ? 'boolean' : field.type;
+
+  switch (type) {
+    case 'boolean':
+      return {...base, type: 'boolean'} as JsonFormAdapterFieldConfig;
+    case 'select':
+    case 'choice':
+      return {
+        ...base,
+        type: type as 'select' | 'choice',
+        choices: field.choices,
+      } as JsonFormAdapterFieldConfig;
+    case 'secret':
+      return {...base, type: 'secret'} as JsonFormAdapterFieldConfig;
+    case 'textarea':
+      return {...base, type: 'textarea'} as JsonFormAdapterFieldConfig;
+    case 'number':
+      return {...base, type: 'number'} as JsonFormAdapterFieldConfig;
+    case 'email':
+      return {...base, type: 'email'} as JsonFormAdapterFieldConfig;
+    case 'url':
+      return {...base, type: 'url'} as JsonFormAdapterFieldConfig;
+    case 'string':
+    case 'text':
+    default:
+      return {...base, type: 'text'} as JsonFormAdapterFieldConfig;
+  }
+}
 
 interface PluginConfigProps {
   plugin: Plugin;
@@ -36,42 +113,66 @@ export function PluginConfig({
   enabled,
   onDisablePlugin,
 }: PluginConfigProps) {
-  const api = useApi();
   const organization = useOrganization();
-  // If passed via props, use that value instead of from `data`
   const isEnabled = typeof enabled === 'undefined' ? plugin.enabled : enabled;
   const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
   const [testResults, setTestResults] = useState('');
-  const [isPluginLoading, setIsPluginLoading] = useState(!plugins.isLoaded(plugin));
-  const loadingPluginIdRef = useRef<string | null>(null);
 
-  useEffect(() => {
-    // Avoid loading the same plugin multiple times
-    if (!plugins.isLoaded(plugin) && loadingPluginIdRef.current !== plugin.id) {
-      setIsPluginLoading(true);
-      loadingPluginIdRef.current = plugin.id;
-      plugins.load(plugin, () => {
-        setIsPluginLoading(false);
-      });
+  const pluginEndpoint = getApiUrl(
+    '/projects/$organizationIdOrSlug/$projectIdOrSlug/plugins/$pluginId/',
+    {
+      path: {
+        organizationIdOrSlug: organization.slug,
+        projectIdOrSlug: project.slug,
+        pluginId: plugin.id,
+      },
     }
-  }, [plugin]);
+  );
+
+  const {
+    data: pluginData,
+    isPending,
+    isError,
+    refetch,
+  } = useApiQuery<PluginWithConfig>([pluginEndpoint], {
+    staleTime: 0,
+  });
+
+  const wasConfiguredRef = useRef(false);
+
+  const {fields, initialValues} = useMemo(() => {
+    if (!pluginData?.config) {
+      return {fields: [], initialValues: {}};
+    }
+
+    let configured = false;
+    const vals: Record<string, unknown> = {};
+    const mapped: JsonFormAdapterFieldConfig[] = [];
+
+    for (const field of pluginData.config) {
+      if (field.value) {
+        configured = true;
+      }
+      vals[field.name] = field.value ?? field.defaultValue ?? '';
+      mapped.push(mapPluginField(field));
+    }
+
+    wasConfiguredRef.current = configured;
+    return {fields: mapped, initialValues: vals};
+  }, [pluginData]);
 
   const handleTestPlugin = async () => {
     setTestResults('');
     addLoadingMessage(t('Sending test...'));
 
     try {
-      const pluginEndpointData = await api.requestPromise(
-        `/projects/${organization.slug}/${project.slug}/plugins/${plugin.id}/`,
-        {
-          method: 'POST',
-          data: {
-            test: true,
-          },
-        }
-      );
+      const response = (await fetchMutation({
+        method: 'POST',
+        url: pluginEndpoint,
+        data: {test: true},
+      })) as {detail: string};
 
-      setTestResults(JSON.stringify(pluginEndpointData.detail));
+      setTestResults(JSON.stringify(response.detail));
       addSuccessMessage(t('Test Complete!'));
     } catch (_err) {
       addErrorMessage(
@@ -83,6 +184,86 @@ export function PluginConfig({
   const handleDisablePlugin = () => {
     onDisablePlugin?.(plugin);
   };
+
+  const handleSubmit = async (values: Record<string, unknown>) => {
+    if (!wasConfiguredRef.current) {
+      trackIntegrationAnalytics('integrations.installation_start', {
+        integration: plugin.id,
+        integration_type: 'plugin',
+        view: 'plugin_details',
+        already_installed: false,
+        organization,
+      });
+    }
+
+    addLoadingMessage(t('Saving changes\u2026'));
+
+    try {
+      await fetchMutation({
+        method: 'PUT',
+        url: pluginEndpoint,
+        data: values,
+      });
+
+      addSuccessMessage(t('Success!'));
+
+      trackIntegrationAnalytics('integrations.config_saved', {
+        integration: plugin.id,
+        integration_type: 'plugin',
+        view: 'plugin_details',
+        already_installed: wasConfiguredRef.current,
+        organization,
+      });
+
+      if (!wasConfiguredRef.current) {
+        trackIntegrationAnalytics('integrations.installation_complete', {
+          integration: plugin.id,
+          integration_type: 'plugin',
+          view: 'plugin_details',
+          already_installed: false,
+          organization,
+        });
+      }
+
+      refetch();
+    } catch (_err) {
+      addErrorMessage(t('Unable to save changes. Please try again.'));
+    }
+  };
+
+  // Auth error state (e.g. OAuth plugins needing identity association)
+  if (pluginData?.config_error) {
+    let authUrl = pluginData.auth_url ?? '';
+    if (authUrl.includes('?')) {
+      authUrl += '&next=' + encodeURIComponent(document.location.pathname);
+    } else {
+      authUrl += '?next=' + encodeURIComponent(document.location.pathname);
+    }
+    return (
+      <Panel
+        className={`plugin-config ref-plugin-config-${plugin.id}`}
+        data-test-id="plugin-config"
+      >
+        <PanelHeader hasButtons>
+          <Flex align="center" flex="1">
+            <StyledPluginIcon pluginId={plugin.id} />
+            <span>{plugin.name}</span>
+          </Flex>
+        </PanelHeader>
+        <StyledPanelBody>
+          <div dangerouslySetInnerHTML={{__html: plugin.doc}} />
+          <Alert.Container>
+            <Alert variant="warning" showIcon={false}>
+              {pluginData.config_error}
+            </Alert>
+          </Alert.Container>
+          <LinkButton priority="primary" href={authUrl}>
+            {t('Associate Identity')}
+          </LinkButton>
+        </StyledPanelBody>
+      </Panel>
+    );
+  }
 
   return (
     <Panel
@@ -124,14 +305,19 @@ export function PluginConfig({
 
       <StyledPanelBody>
         <div dangerouslySetInnerHTML={{__html: plugin.doc}} />
-        {isPluginLoading ? (
+        {isPending ? (
           <LoadingIndicator />
-        ) : (
-          plugins.get(plugin).renderSettings({
-            organization,
-            project,
-          })
-        )}
+        ) : isError ? (
+          <LoadingError onRetry={refetch} />
+        ) : fields.length > 0 ? (
+          <BackendJsonSubmitForm
+            fields={fields}
+            initialValues={initialValues}
+            onSubmit={handleSubmit}
+            submitLabel={t('Save Changes')}
+            submitDisabled={!hasWriteAccess}
+          />
+        ) : null}
       </StyledPanelBody>
     </Panel>
   );

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -183,7 +183,13 @@ export function PluginConfig({
     .join(',');
   const initialValues: Record<string, unknown> = {};
   for (const field of config) {
-    initialValues[field.name] = field.value ?? field.defaultValue ?? '';
+    if (field.value === undefined) {
+      continue;
+    }
+
+    const type = field.type === 'bool' ? 'boolean' : field.type;
+    initialValues[field.name] =
+      (type === 'select' || type === 'choice') && field.value === '' ? null : field.value;
   }
 
   const handleTestPlugin = async () => {

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -25,7 +24,7 @@ import type {Plugin} from 'sentry/types/integrations';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
+import {fetchMutation, useApiQuery, useMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 /**
@@ -51,20 +50,18 @@ interface PluginWithConfig extends Plugin {
   config_error?: string;
 }
 
-function getDetailMessage(response: unknown): string {
-  if (
-    typeof response === 'object' &&
-    response !== null &&
-    'detail' in response &&
-    response.detail !== undefined &&
-    response.detail !== null
-  ) {
-    if (typeof response.detail === 'string') {
-      return response.detail;
-    }
-    return JSON.stringify(response.detail);
+interface PluginTestResponse {
+  detail?: string | unknown;
+}
+
+function getDetailMessage(response: PluginTestResponse): string {
+  if (response.detail === null || response.detail === undefined) {
+    return '';
   }
-  return '';
+  if (typeof response.detail === 'string') {
+    return response.detail;
+  }
+  return JSON.stringify(response.detail);
 }
 
 /**
@@ -153,7 +150,6 @@ export function PluginConfig({
   const organization = useOrganization();
   const isEnabled = enabled ?? plugin.enabled;
   const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
-  const [testResults, setTestResults] = useState('');
 
   const pluginEndpoint = getApiUrl(
     '/projects/$organizationIdOrSlug/$projectIdOrSlug/plugins/$pluginId/',
@@ -203,25 +199,21 @@ export function PluginConfig({
     initialValues[field.name] = isSelect && field.value === '' ? null : field.value;
   }
 
-  const handleTestPlugin = async () => {
-    setTestResults('');
-    addLoadingMessage(t('Sending test...'));
-
-    try {
-      const response = await fetchMutation({
+  const testMutation = useMutation<PluginTestResponse>({
+    mutationFn: () => {
+      addLoadingMessage(t('Sending test...'));
+      return fetchMutation<PluginTestResponse>({
         method: 'POST',
         url: pluginEndpoint,
         data: {test: true},
       });
-      const detail = getDetailMessage(response);
-      setTestResults(detail);
-      addSuccessMessage(t('Test Complete!'));
-    } catch {
+    },
+    onSuccess: () => addSuccessMessage(t('Test Complete!')),
+    onError: () =>
       addErrorMessage(
         t('An unexpected error occurred while testing your plugin. Please try again.')
-      );
-    }
-  };
+      ),
+  });
 
   const handleSubmit = async (values: Record<string, unknown>) => {
     if (!wasConfigured) {
@@ -317,7 +309,7 @@ export function PluginConfig({
         {plugin.canDisable && isEnabled && (
           <Grid flow="column" align="center" gap="md">
             {plugin.isTestable && (
-              <Button onClick={handleTestPlugin} size="xs">
+              <Button onClick={() => testMutation.mutate()} size="xs">
                 {t('Test Plugin')}
               </Button>
             )}
@@ -338,10 +330,10 @@ export function PluginConfig({
         </PanelAlert>
       )}
 
-      {testResults !== '' && (
+      {testMutation.data && (
         <PanelAlert variant="info">
           <strong>Test Results</strong>
-          <div>{testResults}</div>
+          <div>{getDetailMessage(testMutation.data)}</div>
         </PanelAlert>
       )}
 

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -199,7 +199,7 @@ export function PluginConfig({
       const detail = getDetailMessage(response);
       setTestResults(JSON.stringify(detail));
       addSuccessMessage(t('Test Complete!'));
-    } catch (_err) {
+    } catch {
       addErrorMessage(
         t('An unexpected error occurred while testing your plugin. Please try again.')
       );
@@ -247,7 +247,7 @@ export function PluginConfig({
       }
 
       refetch();
-    } catch (_err) {
+    } catch {
       addErrorMessage(t('Unable to save changes. Please try again.'));
     }
   };

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -55,6 +55,26 @@ interface PluginWithConfig extends Plugin {
   config_error?: string;
 }
 
+function toBooleanOrUndefined(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function toNumberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function getDetailMessage(response: unknown): string {
+  if (
+    typeof response === 'object' &&
+    response !== null &&
+    'detail' in response &&
+    typeof response.detail === 'string'
+  ) {
+    return response.detail;
+  }
+  return '';
+}
+
 /**
  * Maps a backend plugin field to the JsonFormAdapterFieldConfig shape
  * expected by BackendJsonSubmitForm.
@@ -76,7 +96,7 @@ function mapPluginField(field: BackendPluginField): JsonFormAdapterFieldConfig {
 
   switch (type) {
     case 'boolean':
-      return {...base, type: 'boolean', default: defaultValue as boolean | undefined};
+      return {...base, type: 'boolean', default: toBooleanOrUndefined(defaultValue)};
     case 'select':
     case 'choice': {
       const emptyChoiceLabel = field.choices?.find(([value]) => value === '')?.[1];
@@ -105,7 +125,7 @@ function mapPluginField(field: BackendPluginField): JsonFormAdapterFieldConfig {
     case 'textarea':
       return {...base, type: 'textarea', default: defaultValue};
     case 'number':
-      return {...base, type: 'number', default: defaultValue as number | undefined};
+      return {...base, type: 'number', default: toNumberOrUndefined(defaultValue)};
     case 'email':
       return {...base, type: 'email', default: defaultValue};
     case 'url':
@@ -175,13 +195,13 @@ export function PluginConfig({
     addLoadingMessage(t('Sending test...'));
 
     try {
-      const response = await fetchMutation<{detail: string}>({
+      const response = await fetchMutation({
         method: 'POST',
         url: pluginEndpoint,
         data: {test: true},
       });
-
-      setTestResults(JSON.stringify(response.detail));
+      const detail = getDetailMessage(response);
+      setTestResults(JSON.stringify(detail));
       addSuccessMessage(t('Test Complete!'));
     } catch (_err) {
       addErrorMessage(

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useRef, useState} from 'react';
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -67,36 +67,38 @@ function mapPluginField(field: BackendPluginField): JsonFormAdapterFieldConfig {
     help: field.help ?? undefined,
     placeholder: field.placeholder ?? undefined,
     disabled: field.readonly,
-    default: field.defaultValue ?? field.default,
   };
+
+  const defaultValue = field.defaultValue ?? field.default;
 
   // Backend uses 'bool', adapter uses 'boolean'
   const type = field.type === 'bool' ? 'boolean' : field.type;
 
   switch (type) {
     case 'boolean':
-      return {...base, type: 'boolean'} as JsonFormAdapterFieldConfig;
+      return {...base, type: 'boolean', default: defaultValue as boolean | undefined};
     case 'select':
     case 'choice':
       return {
         ...base,
         type: type as 'select' | 'choice',
+        default: defaultValue,
         choices: field.choices,
-      } as JsonFormAdapterFieldConfig;
+      };
     case 'secret':
-      return {...base, type: 'secret'} as JsonFormAdapterFieldConfig;
+      return {...base, type: 'secret', default: defaultValue};
     case 'textarea':
-      return {...base, type: 'textarea'} as JsonFormAdapterFieldConfig;
+      return {...base, type: 'textarea', default: defaultValue};
     case 'number':
-      return {...base, type: 'number'} as JsonFormAdapterFieldConfig;
+      return {...base, type: 'number', default: defaultValue as number | undefined};
     case 'email':
-      return {...base, type: 'email'} as JsonFormAdapterFieldConfig;
+      return {...base, type: 'email', default: defaultValue};
     case 'url':
-      return {...base, type: 'url'} as JsonFormAdapterFieldConfig;
+      return {...base, type: 'url', default: defaultValue};
     case 'string':
     case 'text':
     default:
-      return {...base, type: 'text'} as JsonFormAdapterFieldConfig;
+      return {...base, type: 'text', default: defaultValue};
   }
 }
 
@@ -138,39 +140,25 @@ export function PluginConfig({
     staleTime: 0,
   });
 
-  const wasConfiguredRef = useRef(false);
+  const config = pluginData?.config ?? [];
+  const wasConfigured = config.some(field => field.value);
 
-  const {fields, initialValues} = useMemo(() => {
-    if (!pluginData?.config) {
-      return {fields: [], initialValues: {}};
-    }
-
-    let configured = false;
-    const vals: Record<string, unknown> = {};
-    const mapped: JsonFormAdapterFieldConfig[] = [];
-
-    for (const field of pluginData.config) {
-      if (field.value) {
-        configured = true;
-      }
-      vals[field.name] = field.value ?? field.defaultValue ?? '';
-      mapped.push(mapPluginField(field));
-    }
-
-    wasConfiguredRef.current = configured;
-    return {fields: mapped, initialValues: vals};
-  }, [pluginData]);
+  const fields = config.map(mapPluginField);
+  const initialValues: Record<string, unknown> = {};
+  for (const field of config) {
+    initialValues[field.name] = field.value ?? field.defaultValue ?? '';
+  }
 
   const handleTestPlugin = async () => {
     setTestResults('');
     addLoadingMessage(t('Sending test...'));
 
     try {
-      const response = (await fetchMutation({
+      const response = await fetchMutation<{detail: string}>({
         method: 'POST',
         url: pluginEndpoint,
         data: {test: true},
-      })) as {detail: string};
+      });
 
       setTestResults(JSON.stringify(response.detail));
       addSuccessMessage(t('Test Complete!'));
@@ -181,12 +169,8 @@ export function PluginConfig({
     }
   };
 
-  const handleDisablePlugin = () => {
-    onDisablePlugin?.(plugin);
-  };
-
   const handleSubmit = async (values: Record<string, unknown>) => {
-    if (!wasConfiguredRef.current) {
+    if (!wasConfigured) {
       trackIntegrationAnalytics('integrations.installation_start', {
         integration: plugin.id,
         integration_type: 'plugin',
@@ -211,11 +195,11 @@ export function PluginConfig({
         integration: plugin.id,
         integration_type: 'plugin',
         view: 'plugin_details',
-        already_installed: wasConfiguredRef.current,
+        already_installed: wasConfigured,
         organization,
       });
 
-      if (!wasConfiguredRef.current) {
+      if (!wasConfigured) {
         trackIntegrationAnalytics('integrations.installation_complete', {
           integration: plugin.id,
           integration_type: 'plugin',
@@ -283,7 +267,11 @@ export function PluginConfig({
                 {t('Test Plugin')}
               </Button>
             )}
-            <Button size="xs" onClick={handleDisablePlugin} disabled={!hasWriteAccess}>
+            <Button
+              size="xs"
+              onClick={() => onDisablePlugin?.(plugin)}
+              disabled={!hasWriteAccess}
+            >
               {t('Disable')}
             </Button>
           </Grid>

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -199,7 +199,7 @@ export function PluginConfig({
     initialValues[field.name] = isSelect && field.value === '' ? null : field.value;
   }
 
-  const testMutation = useMutation<PluginTestResponse>({
+  const testMutation = useMutation({
     mutationFn: () => {
       addLoadingMessage(t('Sending test...'));
       return fetchMutation<PluginTestResponse>({

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -56,9 +56,13 @@ function getDetailMessage(response: unknown): string {
     typeof response === 'object' &&
     response !== null &&
     'detail' in response &&
-    typeof response.detail === 'string'
+    response.detail !== undefined &&
+    response.detail !== null
   ) {
-    return response.detail;
+    if (typeof response.detail === 'string') {
+      return response.detail;
+    }
+    return JSON.stringify(response.detail);
   }
   return '';
 }
@@ -210,7 +214,7 @@ export function PluginConfig({
         data: {test: true},
       });
       const detail = getDetailMessage(response);
-      setTestResults(JSON.stringify(detail));
+      setTestResults(detail);
       addSuccessMessage(t('Test Complete!'));
     } catch {
       addErrorMessage(

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -172,7 +172,9 @@ export function PluginConfig({
   });
 
   const config = pluginData?.config ?? [];
-  const wasConfigured = config.some(field => field.value);
+  const wasConfigured = config.some(
+    field => field.value !== null && field.value !== undefined && field.value !== ''
+  );
 
   const fields = config.map(mapPluginField);
   const formKey = config

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -38,12 +38,8 @@ interface BackendPluginField {
   choices?: Array<[string, string]>;
   default?: unknown;
   defaultValue?: unknown;
-  hasSavedValue?: boolean;
   help?: null | string;
-  isDeprecated?: boolean;
-  isHidden?: boolean;
   placeholder?: null | string;
-  prefix?: string;
   readonly?: boolean;
   required?: boolean;
   value?: unknown;

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -215,28 +215,26 @@ export function PluginConfig({
       ),
   });
 
-  const handleSubmit = async (values: Record<string, unknown>) => {
-    if (!wasConfigured) {
-      trackAnalytics('integrations.installation_start', {
-        integration: plugin.id,
-        integration_type: 'plugin',
-        view: 'plugin_details',
-        already_installed: false,
-        organization,
-      });
-    }
-
-    addLoadingMessage(t('Saving changes\u2026'));
-
-    try {
-      await fetchMutation({
+  const submitMutation = useMutation({
+    mutationFn: (values: Record<string, unknown>) => {
+      if (!wasConfigured) {
+        trackAnalytics('integrations.installation_start', {
+          integration: plugin.id,
+          integration_type: 'plugin',
+          view: 'plugin_details',
+          already_installed: false,
+          organization,
+        });
+      }
+      addLoadingMessage(t('Saving changes\u2026'));
+      return fetchMutation({
         method: 'PUT',
         url: pluginEndpoint,
         data: values,
       });
-
+    },
+    onSuccess: () => {
       addSuccessMessage(t('Success!'));
-
       trackAnalytics('integrations.config_saved', {
         integration: plugin.id,
         integration_type: 'plugin',
@@ -244,7 +242,6 @@ export function PluginConfig({
         already_installed: wasConfigured,
         organization,
       });
-
       if (!wasConfigured) {
         trackAnalytics('integrations.installation_complete', {
           integration: plugin.id,
@@ -254,12 +251,10 @@ export function PluginConfig({
           organization,
         });
       }
-
       refetch();
-    } catch {
-      addErrorMessage(t('Unable to save changes. Please try again.'));
-    }
-  };
+    },
+    onError: () => addErrorMessage(t('Unable to save changes. Please try again.')),
+  });
 
   // Auth error state (e.g. OAuth plugins needing identity association)
   if (pluginData?.config_error) {
@@ -348,7 +343,7 @@ export function PluginConfig({
             key={formKey}
             fields={fields}
             initialValues={initialValues}
-            onSubmit={handleSubmit}
+            onSubmit={values => submitMutation.mutate(values)}
             submitLabel={t('Save Changes')}
             submitDisabled={!hasWriteAccess}
             footer={({SubmitButton, disabled}) => (

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -81,12 +81,17 @@ function mapPluginField(field: BackendPluginField): JsonFormAdapterFieldConfig {
     case 'choice':
       return {
         ...base,
-        type: type as 'select' | 'choice',
+        type,
         default: defaultValue,
         choices: field.choices,
       };
     case 'secret':
-      return {...base, type: 'secret', default: defaultValue};
+      return {
+        ...base,
+        type: 'secret',
+        default: defaultValue,
+        placeholder: field.placeholder ?? t('Enter a secret'),
+      };
     case 'textarea':
       return {...base, type: 'textarea', default: defaultValue};
     case 'number':
@@ -304,6 +309,19 @@ export function PluginConfig({
             onSubmit={handleSubmit}
             submitLabel={t('Save Changes')}
             submitDisabled={!hasWriteAccess}
+            footer={({SubmitButton, disabled}) => (
+              <Flex
+                justify="end"
+                borderTop="primary"
+                paddingTop="lg"
+                paddingBottom="xl"
+                marginTop="xl"
+              >
+                <SubmitButton size="sm" disabled={disabled}>
+                  {t('Save Changes')}
+                </SubmitButton>
+              </Flex>
+            )}
           />
         ) : null}
       </StyledPanelBody>

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -346,6 +346,7 @@ export function PluginConfig({
             onSubmit={handleSubmit}
             submitLabel={t('Save Changes')}
             submitDisabled={!hasWriteAccess}
+            singleSelectClearable
             footer={({SubmitButton, disabled}) => (
               <Flex
                 justify="end"

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -188,8 +188,13 @@ export function PluginConfig({
     }
 
     const type = field.type === 'bool' ? 'boolean' : field.type;
-    initialValues[field.name] =
-      (type === 'select' || type === 'choice') && field.value === '' ? null : field.value;
+    const isSelect = type === 'select' || type === 'choice';
+
+    if (field.value === null && !isSelect) {
+      continue;
+    }
+
+    initialValues[field.name] = isSelect && field.value === '' ? null : field.value;
   }
 
   const handleTestPlugin = async () => {

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -342,7 +342,7 @@ export function PluginConfig({
             onSubmit={handleSubmit}
             submitLabel={t('Save Changes')}
             submitDisabled={!hasWriteAccess}
-            singleSelectClearable
+            isClearable
             footer={({SubmitButton, disabled}) => (
               <Flex
                 justify="end"

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -39,10 +39,10 @@ interface BackendPluginField {
   default?: unknown;
   defaultValue?: unknown;
   hasSavedValue?: boolean;
-  help?: string;
+  help?: null | string;
   isDeprecated?: boolean;
   isHidden?: boolean;
-  placeholder?: string;
+  placeholder?: null | string;
   prefix?: string;
   readonly?: boolean;
   required?: boolean;
@@ -78,13 +78,23 @@ function mapPluginField(field: BackendPluginField): JsonFormAdapterFieldConfig {
     case 'boolean':
       return {...base, type: 'boolean', default: defaultValue as boolean | undefined};
     case 'select':
-    case 'choice':
+    case 'choice': {
+      const emptyChoiceLabel = field.choices?.find(([value]) => value === '')?.[1];
+      const normalizedChoices = field.choices?.filter(([value]) => value !== '');
+
+      // Legacy plugin configs often encode placeholder text as an empty option.
+      // Preserve that UX by treating it as placeholder, not as a selectable value.
+      const placeholder = base.placeholder ?? emptyChoiceLabel ?? undefined;
+      const normalizedDefault = defaultValue === '' ? undefined : defaultValue;
+
       return {
         ...base,
         type,
-        default: defaultValue,
-        choices: field.choices,
+        placeholder,
+        default: normalizedDefault,
+        choices: normalizedChoices,
       };
+    }
     case 'secret':
       return {
         ...base,
@@ -121,7 +131,7 @@ export function PluginConfig({
   onDisablePlugin,
 }: PluginConfigProps) {
   const organization = useOrganization();
-  const isEnabled = typeof enabled === 'undefined' ? plugin.enabled : enabled;
+  const isEnabled = enabled ?? plugin.enabled;
   const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
   const [testResults, setTestResults] = useState('');
 
@@ -149,6 +159,12 @@ export function PluginConfig({
   const wasConfigured = config.some(field => field.value);
 
   const fields = config.map(mapPluginField);
+  const formKey = config
+    .map(
+      field =>
+        `${field.name}:${JSON.stringify(field.value)}:${JSON.stringify(field.defaultValue)}`
+    )
+    .join(',');
   const initialValues: Record<string, unknown> = {};
   for (const field of config) {
     initialValues[field.name] = field.value ?? field.defaultValue ?? '';
@@ -304,6 +320,7 @@ export function PluginConfig({
           <LoadingError onRetry={refetch} />
         ) : fields.length > 0 ? (
           <BackendJsonSubmitForm
+            key={formKey}
             fields={fields}
             initialValues={initialValues}
             onSubmit={handleSubmit}

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -23,8 +23,8 @@ import {t} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {Plugin} from 'sentry/types/integrations';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -212,7 +212,7 @@ export function PluginConfig({
 
   const handleSubmit = async (values: Record<string, unknown>) => {
     if (!wasConfigured) {
-      trackIntegrationAnalytics('integrations.installation_start', {
+      trackAnalytics('integrations.installation_start', {
         integration: plugin.id,
         integration_type: 'plugin',
         view: 'plugin_details',
@@ -232,7 +232,7 @@ export function PluginConfig({
 
       addSuccessMessage(t('Success!'));
 
-      trackIntegrationAnalytics('integrations.config_saved', {
+      trackAnalytics('integrations.config_saved', {
         integration: plugin.id,
         integration_type: 'plugin',
         view: 'plugin_details',
@@ -241,7 +241,7 @@ export function PluginConfig({
       });
 
       if (!wasConfigured) {
-        trackIntegrationAnalytics('integrations.installation_complete', {
+        trackAnalytics('integrations.installation_complete', {
           integration: plugin.id,
           integration_type: 'plugin',
           view: 'plugin_details',

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -359,7 +359,6 @@ export function PluginConfig({
             onSubmit={handleSubmit}
             submitLabel={t('Save Changes')}
             submitDisabled={!hasWriteAccess}
-            isClearable
             footer={({SubmitButton, disabled}) => (
               <Flex
                 justify="end"

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -55,14 +55,6 @@ interface PluginWithConfig extends Plugin {
   config_error?: string;
 }
 
-function toBooleanOrUndefined(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined;
-}
-
-function toNumberOrUndefined(value: unknown): number | undefined {
-  return typeof value === 'number' ? value : undefined;
-}
-
 function getDetailMessage(response: unknown): string {
   if (
     typeof response === 'object' &&
@@ -96,7 +88,11 @@ function mapPluginField(field: BackendPluginField): JsonFormAdapterFieldConfig {
 
   switch (type) {
     case 'boolean':
-      return {...base, type: 'boolean', default: toBooleanOrUndefined(defaultValue)};
+      return {
+        ...base,
+        type: 'boolean',
+        default: typeof defaultValue === 'boolean' ? defaultValue : undefined,
+      };
     case 'select':
     case 'choice': {
       const emptyChoiceLabel = field.choices?.find(([value]) => value === '')?.[1];
@@ -125,7 +121,11 @@ function mapPluginField(field: BackendPluginField): JsonFormAdapterFieldConfig {
     case 'textarea':
       return {...base, type: 'textarea', default: defaultValue};
     case 'number':
-      return {...base, type: 'number', default: toNumberOrUndefined(defaultValue)};
+      return {
+        ...base,
+        type: 'number',
+        default: typeof defaultValue === 'number' ? defaultValue : undefined,
+      };
     case 'email':
       return {...base, type: 'email', default: defaultValue};
     case 'url':

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -265,10 +265,7 @@ export function PluginConfig({
       authUrl += '?next=' + encodeURIComponent(document.location.pathname);
     }
     return (
-      <Panel
-        className={`plugin-config ref-plugin-config-${plugin.id}`}
-        data-test-id="plugin-config"
-      >
+      <Panel>
         <PanelHeader hasButtons>
           <Flex align="center" flex="1">
             <StyledPluginIcon pluginId={plugin.id} />
@@ -291,10 +288,7 @@ export function PluginConfig({
   }
 
   return (
-    <Panel
-      className={`plugin-config ref-plugin-config-${plugin.id}`}
-      data-test-id="plugin-config"
-    >
+    <Panel>
       <PanelHeader hasButtons>
         <Flex align="center" flex="1">
           <StyledPluginIcon pluginId={plugin.id} />

--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -93,6 +93,7 @@ export default function ProjectPluginDetails() {
         view: 'plugin_details',
         organization,
       });
+      // Keep both the toggle state and config form in sync after reset.
       await Promise.all([refetchPlugins(), refetchPluginDetails()]);
     },
     onError: () => {

--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -85,7 +85,7 @@ export default function ProjectPluginDetails() {
         organization,
       });
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       addSuccessMessage(t('Plugin was reset'));
       trackAnalytics('integrations.uninstall_completed', {
         integration: pluginId,
@@ -93,6 +93,7 @@ export default function ProjectPluginDetails() {
         view: 'plugin_details',
         organization,
       });
+      await Promise.all([refetchPlugins(), refetchPluginDetails()]);
     },
     onError: () => {
       addErrorMessage(t('An error occurred'));


### PR DESCRIPTION
Migrate the project-level plugin configuration forms from the legacy
`PluginSettings` class component + `GenericField` rendering to the new
`BackendJsonSubmitForm` adapter.

`PluginConfig` now fetches field definitions directly via `useApiQuery`
from `GET /projects/{org}/{project}/plugins/{id}/` and maps the backend
field types (`bool` → `boolean`, `readonly` → `disabled`, etc.) to the
`JsonFormAdapterFieldConfig` shape. This removes the dependency on the
client-side plugin module system (`plugins.get(plugin).renderSettings()`)
for rendering settings.

I considered preserving some plugin-specific legacy UX in the migrated
forms. Jira previously used a multi-step settings flow and SessionStack
used a collapsible advanced section. I did not carry those behaviors
forward here; the migrated form is intentionally flat because restoring
that legacy custom UI did not seem worth the extra complexity for these
hidden/deprecated plugin settings.

closes https://linear.app/getsentry/issue/DE-1054/endpoint-4-get-api0organizationsorgpluginsconfigs