### PR TITLE
fix(ai-conversations): use all projects for shared conversation links

### DIFF
--- a/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
@@ -229,12 +229,14 @@ describe('useConversation', () => {
     });
 
     // Verify the API was called with correct timestamps (with 1-hour padding)
+    // and ALL_ACCESS_PROJECTS (-1) so it searches across all projects
     expect(mockRequest).toHaveBeenCalledWith(
       expect.stringContaining('/ai-conversations/conv-timestamps/'),
       expect.objectContaining({
         query: expect.objectContaining({
           start: new Date(startTimestamp - 60 * 60 * 1000).toISOString(),
           end: new Date(endTimestamp + 60 * 60 * 1000).toISOString(),
+          project: [-1],
         }),
       })
     );

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.spec.tsx
@@ -228,8 +228,9 @@ describe('useConversation', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    // Verify the API was called with correct timestamps (with 1-hour padding)
-    // and ALL_ACCESS_PROJECTS (-1) so it searches across all projects
+    // Verify the API was called with correct timestamps (with 1-hour padding),
+    // ALL_ACCESS_PROJECTS (-1) so it searches across all projects,
+    // and no environment filter so it searches across all environments
     expect(mockRequest).toHaveBeenCalledWith(
       expect.stringContaining('/ai-conversations/conv-timestamps/'),
       expect.objectContaining({
@@ -240,6 +241,10 @@ describe('useConversation', () => {
         }),
       })
     );
+
+    // Ensure environment is not included in the query when using conversation timestamps
+    const queryArg = mockRequest.mock.calls[0]![1]!.query;
+    expect(queryArg).not.toHaveProperty('environment');
   });
 
   it('falls back to span.name when span.description is empty', async () => {

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useMemo} from 'react';
 
+import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -193,16 +194,23 @@ export function useConversation(
   const hasConversationTimestamps =
     conversation.startTimestamp !== undefined && conversation.endTimestamp !== undefined;
 
+  // When conversation timestamps are provided (e.g. from a shared link),
+  // search across all projects so the conversation is found regardless of
+  // which project the page filter is currently set to.
+  const projectFilter = hasConversationTimestamps
+    ? [ALL_ACCESS_PROJECTS]
+    : selection.projects;
+
   const queryParams = hasConversationTimestamps
     ? {
-        project: selection.projects,
+        project: projectFilter,
         environment: selection.environments,
         start: new Date(conversation.startTimestamp! - ONE_HOUR_MS).toISOString(),
         end: new Date(conversation.endTimestamp! + ONE_HOUR_MS).toISOString(),
         per_page: 1000,
       }
     : {
-        project: selection.projects,
+        project: projectFilter,
         environment: selection.environments,
         ...normalizeDateTimeParams(selection.datetime),
         per_page: 1000,

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -195,22 +195,17 @@ export function useConversation(
     conversation.startTimestamp !== undefined && conversation.endTimestamp !== undefined;
 
   // When conversation timestamps are provided (e.g. from a shared link),
-  // search across all projects so the conversation is found regardless of
-  // which project the page filter is currently set to.
-  const projectFilter = hasConversationTimestamps
-    ? [ALL_ACCESS_PROJECTS]
-    : selection.projects;
-
+  // search across all projects and environments so the conversation is found
+  // regardless of which project/environment the page filter is currently set to.
   const queryParams = hasConversationTimestamps
     ? {
-        project: projectFilter,
-        environment: selection.environments,
+        project: [ALL_ACCESS_PROJECTS],
         start: new Date(conversation.startTimestamp! - ONE_HOUR_MS).toISOString(),
         end: new Date(conversation.endTimestamp! + ONE_HOUR_MS).toISOString(),
         per_page: 1000,
       }
     : {
-        project: projectFilter,
+        project: selection.projects,
         environment: selection.environments,
         ...normalizeDateTimeParams(selection.datetime),
         per_page: 1000,


### PR DESCRIPTION
Fixes: [TET-2186 Project selection issue when sharing conversations](https://linear.app/getsentry/issue/TET-2186/project-selection-issue-when-sharing-conversations)