### PR TITLE
feat(logs): Move continue scanning into full button

### DIFF
--- a/static/app/components/emptyStateWarning.tsx
+++ b/static/app/components/emptyStateWarning.tsx
@@ -7,11 +7,13 @@ type Props = {
   children?: React.ReactNode;
   className?: string;
   small?: boolean;
+  variant?: React.ComponentProps<typeof IconSearch>['variant'];
   withIcon?: boolean;
 };
 
 export function EmptyStateWarning({
   small = false,
+  variant = 'muted',
   withIcon = true,
   children,
   className,
@@ -19,13 +21,13 @@ export function EmptyStateWarning({
   return small ? (
     <EmptyMessage className={className}>
       <SmallMessage>
-        {withIcon && <StyledIconSearch variant="accent" size="lg" />}
+        {withIcon && <StyledIconSearch variant={variant} size="lg" />}
         {children}
       </SmallMessage>
     </EmptyMessage>
   ) : (
     <EmptyStreamWrapper data-test-id="empty-state" className={className}>
-      {withIcon && <IconSearch variant="accent" legacySize="54px" />}
+      {withIcon && <IconSearch variant={variant} legacySize="54px" />}
       {children}
     </EmptyStreamWrapper>
   );

--- a/static/app/components/emptyStateWarning.tsx
+++ b/static/app/components/emptyStateWarning.tsx
@@ -19,13 +19,13 @@ export function EmptyStateWarning({
   return small ? (
     <EmptyMessage className={className}>
       <SmallMessage>
-        {withIcon && <StyledIconSearch variant="muted" size="lg" />}
+        {withIcon && <StyledIconSearch variant="accent" size="lg" />}
         {children}
       </SmallMessage>
     </EmptyMessage>
   ) : (
     <EmptyStreamWrapper data-test-id="empty-state" className={className}>
-      {withIcon && <IconSearch variant="muted" legacySize="54px" />}
+      {withIcon && <IconSearch variant="accent" legacySize="54px" />}
       {children}
     </EmptyStreamWrapper>
   );

--- a/static/app/components/emptyStateWarning.tsx
+++ b/static/app/components/emptyStateWarning.tsx
@@ -2,12 +2,13 @@ import styled from '@emotion/styled';
 
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {IconSearch} from 'sentry/icons';
+import type {IconVariant} from 'sentry/icons/svgIcon';
 
 type Props = {
   children?: React.ReactNode;
   className?: string;
   small?: boolean;
-  variant?: React.ComponentProps<typeof IconSearch>['variant'];
+  variant?: IconVariant;
   withIcon?: boolean;
 };
 

--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -4,6 +4,8 @@ import type {ContentVariant, IconSize} from 'sentry/utils/theme';
 
 import {useIconDefaults} from './useIconDefaults';
 
+export type IconVariant = ContentVariant | 'muted';
+
 export interface SVGIconProps extends Omit<
   React.SVGAttributes<SVGSVGElement>,
   'color' | 'type'
@@ -16,7 +18,7 @@ export interface SVGIconProps extends Omit<
   legacySize?: string;
   ref?: React.Ref<SVGSVGElement>;
   size?: IconSize;
-  variant?: ContentVariant | 'muted';
+  variant?: IconVariant;
 }
 
 export function SvgIcon(props: SVGIconProps) {

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -693,7 +693,7 @@ function EmptyRenderer({
         <EmptyStateText size="xl">{t('No logs found')}</EmptyStateText>
         <EmptyStateText size="md">
           {tct(
-            'Try adjusting your filters or get started with sending logs by checking these [instructions]',
+            'Try adjusting your filters or get started with sending logs by checking these [instructions].',
             {
               instructions: (
                 <ExternalLink href={LOGS_INSTRUCTIONS_URL}>

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -6,7 +6,7 @@ import type {Virtualizer} from '@tanstack/react-virtual';
 import {useVirtualizer, useWindowVirtualizer} from '@tanstack/react-virtual';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -666,22 +666,22 @@ function EmptyRenderer({
           <EmptyStateText size="xl">{t('No logs found yet')}</EmptyStateText>
           <EmptyStateText size="md">
             {tct(
-              'We scanned [bytesScanned] already but did not find any matching logs yet.[break]You can narrow your time range or you can [continueScanning].',
-              {
-                bytesScanned: <FileSize bytes={bytesScanned} base={2} />,
-                break: <br />,
-                continueScanning: (
-                  <Button
-                    priority="link"
-                    onClick={resumeAutoFetch}
-                    aria-label={t('continue scanning')}
-                  >
-                    {t('Continue Scanning')}
-                  </Button>
-                ),
-              }
+              'We scanned [bytesScanned] so far but have not found anything matching your filters',
+              {bytesScanned: <FileSize bytes={bytesScanned} base={2} />}
             )}
           </EmptyStateText>
+          <EmptyStateText size="md">
+            {t('We can keep digging or you can narrow down your search.')}
+          </EmptyStateText>
+          <Container paddingTop="md">
+            <Button
+              priority="default"
+              onClick={resumeAutoFetch}
+              aria-label={t('continue scanning')}
+            >
+              {t('Continue Scanning')}
+            </Button>
+          </Container>
         </EmptyStateWarning>
       </TableStatus>
     );

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -662,7 +662,7 @@ function EmptyRenderer({
   if (bytesScanned && canResumeAutoFetch && resumeAutoFetch) {
     return (
       <TableStatus>
-        <EmptyStateWarning withIcon>
+        <EmptyStateWarning withIcon variant="accent">
           <EmptyStateText size="xl">{t('No logs found yet')}</EmptyStateText>
           <EmptyStateText size="md">
             {tct(
@@ -689,7 +689,7 @@ function EmptyRenderer({
 
   return (
     <TableStatus>
-      <EmptyStateWarning withIcon>
+      <EmptyStateWarning withIcon variant="accent">
         <EmptyStateText size="xl">{t('No logs found')}</EmptyStateText>
         <EmptyStateText size="md">
           {tct(

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -1,8 +1,8 @@
-import type {ComponentProps, CSSProperties} from 'react';
+import type {ComponentProps} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, type Responsive} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Panel} from 'sentry/components/panels/panel';
@@ -130,11 +130,11 @@ export function EmptyStateText({
 }: {
   children: React.ReactNode;
   size: 'xl' | 'md';
-  textAlign?: CSSProperties['textAlign'];
+  textAlign?: Responsive<'left' | 'center' | 'right' | 'justify'>;
 }) {
   return (
     <Container>
-      <Text size={size} style={{textAlign}}>
+      <Text size={size} align={textAlign}>
         {children}
       </Text>
     </Container>

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -134,7 +134,7 @@ export function EmptyStateText({
 }) {
   return (
     <Container>
-      <Text size={size} align={textAlign}>
+      <Text size={size} align={textAlign} variant="muted">
         {children}
       </Text>
     </Container>

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -2,7 +2,7 @@ import type {ComponentProps, CSSProperties} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Panel} from 'sentry/components/panels/panel';
@@ -123,15 +123,23 @@ export const BreakdownPanelItem = styled(StyledPanelItem)<{highlightedSliceName:
         `}
 `;
 
-export const EmptyStateText = styled('div')<{
+export function EmptyStateText({
+  children,
+  size,
+  textAlign,
+}: {
+  children: React.ReactNode;
   size: 'xl' | 'md';
   textAlign?: CSSProperties['textAlign'];
-}>`
-  color: ${p => p.theme.tokens.content.secondary};
-  font-size: ${p => p.theme.font.size[p.size]};
-  padding-bottom: ${p => p.theme.space.md};
-  ${p => p.textAlign && `text-align: ${p.textAlign}`};
-`;
+}) {
+  return (
+    <Container>
+      <Text size={size} style={{textAlign}}>
+        {children}
+      </Text>
+    </Container>
+  );
+}
 
 export const EmptyValueContainer = styled('span')`
   color: ${p => p.theme.tokens.content.secondary};

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -134,7 +134,7 @@ export function EmptyStateText({
 }) {
   return (
     <Container>
-      <Text size={size} align={textAlign} variant="muted">
+      <Text as="div" size={size} align={textAlign} variant="muted">
         {children}
       </Text>
     </Container>


### PR DESCRIPTION
This PR refreshes the continue scanning logs experience to really call out to users that they're able to continue scanning for more data, as the previous setup was a bit harder to read.

Refs LOGS-644

Example:

No Logs Found:

<img width="1637" height="320" alt="Screenshot 2026-04-07 at 10 35 34" src="https://github.com/user-attachments/assets/37debd5d-9e66-4494-a870-c11e7a9ff675" />

Continue Scanning:

<img width="1619" height="396" alt="Screenshot 2026-04-07 at 10 35 44" src="https://github.com/user-attachments/assets/2aed95d3-df92-4638-b3c4-c48178210c2a" />