### PR TITLE
fix(preprod): Add tab=size to size status check settings URL

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -331,11 +331,12 @@ def _get_settings_url(
 ) -> str:
     """Build the settings URL for the project's preprod settings page."""
     base_url = f"/settings/projects/{project.slug}/mobile-builds/"
+    query = "tab=size"
     if triggered_rules:
         unique_rule_ids = list(dict.fromkeys(tr.rule.id for tr in triggered_rules))
         expanded_params = "&".join(f"expanded={rule_id}" for rule_id in unique_rule_ids)
-        return project.organization.absolute_url(base_url, query=expanded_params)
-    return project.organization.absolute_url(base_url)
+        query += "&" + expanded_params
+    return project.organization.absolute_url(base_url, query=query)
 
 
 def _format_failed_checks_details(

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -965,7 +965,9 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
 
         android_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{android_artifact.id}"
         ios_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{ios_artifact.id}"
-        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/"
+        settings_url = (
+            f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?tab=size"
+        )
 
         expected = f"""\
 ### Android Builds
@@ -1314,7 +1316,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         artifact_url = (
             f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}"
         )
-        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-1"
+        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?tab=size&expanded=rule-1"
 
         expected = f"""\
 ## ❌ 1 Failed Size Check
@@ -1463,7 +1465,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         artifact_url = (
             f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}"
         )
-        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-download-absolute&expanded=rule-install-diff&expanded=rule-download-percent"
+        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?tab=size&expanded=rule-download-absolute&expanded=rule-install-diff&expanded=rule-download-percent"
 
         expected = f"""\
 ## ❌ 3 Failed Size Checks
@@ -1576,7 +1578,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         artifact2_url = (
             f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact2.id}"
         )
-        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-1&expanded=rule-2"
+        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?tab=size&expanded=rule-1&expanded=rule-2"
 
         expected = f"""\
 ## ❌ 2 Failed Size Checks
@@ -1680,7 +1682,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
 
         failed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{failed_artifact.id}"
         passed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{passed_artifact.id}"
-        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-1"
+        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?tab=size&expanded=rule-1"
 
         expected = f"""\
 ## ❌ 1 Failed Size Check


### PR DESCRIPTION
The mobile-builds settings page now uses tabs, so the "Configure status
check rules" link in VCS size status checks needs to include `tab=size`
to land on the correct tab instead of the default.