### PR TITLE
feat(autofix): Add copy PR URL button to v3 pull request card

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -25,7 +25,7 @@ import {
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconRefresh} from 'sentry/icons';
+import {IconCopy, IconRefresh} from 'sentry/icons';
 import {IconBot} from 'sentry/icons/iconBot';
 import {IconBug} from 'sentry/icons/iconBug';
 import {IconCode} from 'sentry/icons/iconCode';
@@ -34,6 +34,7 @@ import {IconOpen} from 'sentry/icons/iconOpen';
 import {IconPullRequest} from 'sentry/icons/iconPullRequest';
 import {t, tct, tn} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/fileDiffViewer';
 
 interface AutofixCardProps {
@@ -259,6 +260,7 @@ export function PullRequestsCard({section}: AutofixCardProps) {
     const sectionArtifact = getAutofixArtifactFromSection(section);
     return isPullRequestsArtifact(sectionArtifact) ? sectionArtifact : null;
   }, [section]);
+  const {copy} = useCopyToClipboard();
 
   return (
     <ArtifactCard icon={<IconPullRequest />} title={t('Pull Requests')}>
@@ -277,14 +279,22 @@ export function PullRequestsCard({section}: AutofixCardProps) {
           pullRequest.pr_number
         ) {
           return (
-            <LinkButton
-              key={pullRequest.repo_name}
-              external
-              href={pullRequest.pr_url}
-              priority="primary"
-            >
-              {t('View %s#%s', pullRequest.repo_name, pullRequest.pr_number)}
-            </LinkButton>
+            <Flex key={pullRequest.repo_name} gap="xs" align="center">
+              <LinkButton external href={pullRequest.pr_url} priority="primary">
+                {t('View %s#%s', pullRequest.repo_name, pullRequest.pr_number)}
+              </LinkButton>
+              <Button
+                priority="primary"
+                icon={<IconCopy size="xs" />}
+                aria-label={t('Copy PR URL')}
+                tooltipProps={{title: t('Copy PR URL')}}
+                onClick={() =>
+                  copy(pullRequest.pr_url!, {
+                    successMessage: t('PR URL copied to clipboard.'),
+                  })
+                }
+              />
+            </Flex>
           );
         }
 


### PR DESCRIPTION
Add a copy-to-clipboard button next to each "View PR" link in the autofix v3 `PullRequestsCard` component. This lets users quickly copy the PR URL without having to navigate to the PR and copy from the browser address bar.

Before:
<img width="1504" height="286" alt="CleanShot 2026-04-07 at 14 39 10@2x" src="https://github.com/user-attachments/assets/4048e271-faa2-49ba-a3da-77d1dc7c9e8e" />

After:
<img width="1538" height="274" alt="CleanShot 2026-04-07 at 14 46 21@2x" src="https://github.com/user-attachments/assets/d8da7ead-0ffd-4b9f-9b84-f6f5602d4d8a" />

https://github.com/user-attachments/assets/c87ae62f-ac7e-4df4-8982-e3985d783ce4

Agent transcript: https://claudescope.sentry.dev/share/0s3dF7X9zMvJqcU4xHgQjL4UN_S9Ay92eXE7oFPbOYA