### PR TITLE
feat(preprod): Add snapshot PR comments toggle to project settings

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -88,6 +88,7 @@ export type Project = {
   preprodSizeEnabledQuery?: string | null;
   preprodSizeStatusChecksEnabled?: boolean;
   preprodSizeStatusChecksRules?: unknown[];
+  preprodSnapshotPrCommentsEnabled?: boolean;
   preprodSnapshotStatusChecksEnabled?: boolean;
   preprodSnapshotStatusChecksFailOnAdded?: boolean;
   preprodSnapshotStatusChecksFailOnRemoved?: boolean;

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -17,6 +17,7 @@ import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageH
 
 import {FeatureFilter} from './featureFilter';
 import {PrCommentsToggle} from './prCommentsToggle';
+import {SnapshotPrCommentsToggle} from './snapshotPrCommentsToggle';
 import {SnapshotStatusChecks} from './snapshotStatusChecks';
 import {StatusCheckRules} from './statusCheckRules';
 
@@ -111,7 +112,14 @@ export default function PreprodSettings() {
             </Feature>
           </Fragment>
         )}
-        {tab === 'snapshots' && <SnapshotStatusChecks />}
+        {tab === 'snapshots' && (
+          <Fragment>
+            <SnapshotStatusChecks />
+            <Feature features="organizations:preprod-snapshot-pr-comments">
+              <SnapshotPrCommentsToggle />
+            </Feature>
+          </Fragment>
+        )}
       </Stack>
     </Feature>
   );

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
@@ -1,0 +1,64 @@
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Switch} from '@sentry/scraps/switch';
+import {Text} from '@sentry/scraps/text';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {Panel} from 'sentry/components/panels/panel';
+import {PanelBody} from 'sentry/components/panels/panelBody';
+import {PanelHeader} from 'sentry/components/panels/panelHeader';
+import {t} from 'sentry/locale';
+import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
+import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
+
+const READ_KEY = 'sentry:preprod_snapshot_pr_comments_enabled';
+const WRITE_KEY = 'preprodSnapshotPrCommentsEnabled';
+
+export function SnapshotPrCommentsToggle() {
+  const {project} = useProjectSettingsOutlet();
+  const {mutate: updateProject} = useUpdateProject(project);
+
+  const enabled = (project[WRITE_KEY] ?? project.options?.[READ_KEY]) !== false;
+
+  function handleToggle() {
+    addLoadingMessage(t('Saving...'));
+    updateProject(
+      {[WRITE_KEY]: !enabled},
+      {
+        onSuccess: () => {
+          addSuccessMessage(t('PR comment settings updated'));
+        },
+        onError: () => {
+          addErrorMessage(t('Failed to save changes. Please try again.'));
+        },
+      }
+    );
+  }
+
+  return (
+    <Panel>
+      <PanelHeader>{t('Snapshots - Pull Request Comments')}</PanelHeader>
+      <PanelBody>
+        <Flex align="center" justify="between" padding="xl">
+          <Stack gap="xs">
+            <Text size="lg" bold>
+              {t('Snapshot Pull Request Comments')}
+            </Text>
+            <Text size="sm" variant="muted">
+              {t('Post snapshot comparison results as comments on pull requests.')}
+            </Text>
+          </Stack>
+          <Switch
+            size="lg"
+            checked={enabled}
+            onChange={handleToggle}
+            aria-label={t('Toggle snapshot PR comments')}
+          />
+        </Flex>
+      </PanelBody>
+    </Panel>
+  );
+}


### PR DESCRIPTION
Add a toggle on the Snapshots tab in Mobile Builds project settings to
enable/disable snapshot PR comments per project. Mirrors the existing
build distribution PR comments toggle on the Distribution tab.

The backend project option (`sentry:preprod_snapshot_pr_comments_enabled`)
and serializer field (`preprodSnapshotPrCommentsEnabled`) were already
registered — this PR adds the frontend toggle and the `Project` type
field. Gated behind `organizations:preprod-snapshot-pr-comments`.

Refs EME-999

Added this here in the UI:
<img width="948" height="566" alt="Screenshot 2026-04-07 at 16 38 56" src="https://github.com/user-attachments/assets/68f042cc-6bd2-40fe-b4c8-ad8719c3de1a" />
