### PR TITLE
feat(preprod): Add installable attribute to EAP alias mappings

### DIFF
--- a/src/sentry/search/eap/preprod_size/attributes.py
+++ b/src/sentry/search/eap/preprod_size/attributes.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from sentry.search.eap import constants
 from sentry.search.eap.columns import ResolvedAttribute, datetime_processor
 from sentry.search.eap.common_columns import COMMON_COLUMNS
@@ -57,6 +59,11 @@ PREPROD_SIZE_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
+            public_alias="installable",
+            internal_name="has_installable_file",
+            search_type="boolean",
+        ),
+        ResolvedAttribute(
             public_alias="timestamp",
             internal_name="sentry.timestamp",
             internal_type=constants.DOUBLE,
@@ -64,4 +71,24 @@ PREPROD_SIZE_ATTRIBUTE_DEFINITIONS = {
             processor=datetime_processor,
         ),
     ]
+}
+
+PREPROD_SIZE_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
+    Literal["string", "number", "boolean"], dict[str, str]
+] = {
+    "string": {
+        definition.internal_name: definition.public_alias
+        for definition in PREPROD_SIZE_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "string"
+    },
+    "boolean": {
+        definition.internal_name: definition.public_alias
+        for definition in PREPROD_SIZE_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type == "boolean"
+    },
+    "number": {
+        definition.internal_name: definition.public_alias
+        for definition in PREPROD_SIZE_ATTRIBUTE_DEFINITIONS.values()
+        if not definition.secondary_alias and definition.search_type != "string"
+    },
 }

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -16,6 +16,9 @@ from sentry.search.eap.ourlogs.attributes import (
     OURLOG_ATTRIBUTE_DEFINITIONS,
 )
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
+from sentry.search.eap.preprod_size.attributes import (
+    PREPROD_SIZE_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
+)
 from sentry.search.eap.profile_functions.attributes import (
     PROFILE_FUNCTIONS_ATTRIBUTE_DEFINITIONS,
     PROFILE_FUNCTIONS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
@@ -69,6 +72,7 @@ INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
     SupportedTraceItemType.LOGS: LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     SupportedTraceItemType.TRACEMETRICS: TRACE_METRICS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     SupportedTraceItemType.PROFILE_FUNCTIONS: PROFILE_FUNCTIONS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
+    SupportedTraceItemType.PREPROD: PREPROD_SIZE_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
 }
 
 PUBLIC_ALIAS_TO_INTERNAL_MAPPING: dict[SupportedTraceItemType, dict[str, ResolvedAttribute]] = {


### PR DESCRIPTION
Register PREPROD in the shared `INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS` infrastructure so the EAP attributes endpoint translates `has_installable_file` → `installable`. This makes the `installable` boolean filter appear in the mobile builds search bar dropdown on the Distribution view.

Previously, the PREPROD trace item type had no entry in the alias mapping dicts in `search/eap/utils.py`, so `translate_internal_to_public_alias()` returned the raw internal name `has_installable_file`. The frontend `filterToAllowedKeys()` then couldn't match it against the allowlist (which expects `installable`), so the attribute was silently filtered out.

The mapping dict is built dynamically from `PREPROD_SIZE_ATTRIBUTE_DEFINITIONS`, so any future aliased PREPROD attributes will automatically be included.

Refs EME-868