### PR TITLE
feat(preprod): Add settings link to build distribution PR comments

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -130,7 +130,7 @@ def create_preprod_pr_comment_task(
             return
 
         existing_comment_id = _find_existing_comment_id(all_for_pr)
-        comment_body = format_pr_comment(installable_siblings)
+        comment_body = format_pr_comment(installable_siblings, project=artifact.project)
 
         try:
             if existing_comment_id:

--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -48,7 +48,7 @@ def format_pr_comment(artifacts: list[PreprodArtifact], project: Project) -> str
             sections.append(f"{header}\n{separator}\n" + "\n".join(android_rows))
 
     settings_url = project.organization.absolute_url(
-        f"/settings/projects/{project.slug}/mobile-builds/"
+        f"/settings/projects/{project.slug}/mobile-builds/", query="tab=distribution"
     )
     sections.append(f"[Configure {project.name} build distribution settings]({settings_url})")
 

--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from sentry.models.project import Project
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.url_utils import get_preprod_artifact_url
 
 
-def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
+def format_pr_comment(artifacts: list[PreprodArtifact], project: Project) -> str:
     if not artifacts:
         raise ValueError("No installable artifacts to format")
 
@@ -45,5 +46,10 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
             sections.append(f"### Android\n\n{header}\n{separator}\n" + "\n".join(android_rows))
         else:
             sections.append(f"{header}\n{separator}\n" + "\n".join(android_rows))
+
+    settings_url = project.organization.absolute_url(
+        f"/settings/projects/{project.slug}/mobile-builds/"
+    )
+    sections.append(f"[Configure {project.name} build distribution settings]({settings_url})")
 
     return "\n\n".join(sections)

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -100,7 +100,7 @@ class FormatPrCommentTest(TestCase):
         result = format_pr_comment([artifact], project=self.project)
 
         assert f"[Configure {self.project.name} build distribution settings](" in result
-        assert f"/settings/projects/{self.project.slug}/mobile-builds/" in result
+        assert f"/settings/projects/{self.project.slug}/mobile-builds/?tab=distribution" in result
 
     def test_empty_list_raises(self) -> None:
         with pytest.raises(ValueError, match="No installable artifacts"):

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -56,7 +56,7 @@ class FormatPrCommentTest(TestCase):
     def test_single_ios_artifact(self) -> None:
         artifact = self._create_artifact()
 
-        result = format_pr_comment([artifact])
+        result = format_pr_comment([artifact], project=self.project)
 
         assert "## Sentry Build Distribution" in result
         assert "| App Name | App ID | Version | Configuration | Install Page |" in result
@@ -74,7 +74,7 @@ class FormatPrCommentTest(TestCase):
             app_name="AndroidApp",
         )
 
-        result = format_pr_comment([artifact])
+        result = format_pr_comment([artifact], project=self.project)
 
         assert "AndroidApp" in result
         assert "### Android" not in result
@@ -87,13 +87,21 @@ class FormatPrCommentTest(TestCase):
             app_name="AndroidApp",
         )
 
-        result = format_pr_comment([ios_artifact, android_artifact])
+        result = format_pr_comment([ios_artifact, android_artifact], project=self.project)
 
         assert "### iOS" in result
         assert "### Android" in result
         assert "iOSApp" in result
         assert "AndroidApp" in result
 
+    def test_settings_link(self) -> None:
+        artifact = self._create_artifact()
+
+        result = format_pr_comment([artifact], project=self.project)
+
+        assert f"[Configure {self.project.name} build distribution settings](" in result
+        assert f"/settings/projects/{self.project.slug}/mobile-builds/" in result
+
     def test_empty_list_raises(self) -> None:
         with pytest.raises(ValueError, match="No installable artifacts"):
-            format_pr_comment([])
+            format_pr_comment([], project=self.project)


### PR DESCRIPTION
Build distribution PR comments now include a footer link to the project's
mobile builds settings page, matching the pattern already used in size
analysis PR comments.

<img width="901" height="302" alt="image" src="https://github.com/user-attachments/assets/e07867f3-2538-49cd-8a1e-5c5b29b73fa1" />


Refs EME-1015