### PR TITLE
fix(notifications): Handle null provider in organization integrations filter

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -98,12 +98,13 @@ export function NotificationSettingsByType({notificationType}: Props) {
   );
 
   const {data: allOrgIntegrations = [], status: organizationIntegrationStatus} =
-    useApiQuery<OrganizationIntegration[]>(
+    useApiQuery<Array<OrganizationIntegration | null>>(
       [getApiUrl('/users/$userId/organization-integrations/', {path: {userId: 'me'}})],
       {staleTime: 30_000}
     );
-  const organizationIntegrations = allOrgIntegrations.filter(orgIntegration =>
-    ALLOWED_PROVIDERS.has(orgIntegration?.provider?.key as SupportedProviders)
+  const organizationIntegrations = allOrgIntegrations.filter(
+    (orgIntegration): orgIntegration is OrganizationIntegration =>
+      ALLOWED_PROVIDERS.has(orgIntegration?.provider.key as SupportedProviders)
   );
   const {data: defaultSettings, status: defaultSettingsStatus} =
     useApiQuery<DefaultSettings>([getApiUrl('/notification-defaults/')], {

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -103,7 +103,7 @@ export function NotificationSettingsByType({notificationType}: Props) {
       {staleTime: 30_000}
     );
   const organizationIntegrations = allOrgIntegrations.filter(orgIntegration =>
-    ALLOWED_PROVIDERS.has(orgIntegration.provider.key as SupportedProviders)
+    ALLOWED_PROVIDERS.has(orgIntegration?.provider?.key as SupportedProviders)
   );
   const {data: defaultSettings, status: defaultSettingsStatus} =
     useApiQuery<DefaultSettings>([getApiUrl('/notification-defaults/')], {


### PR DESCRIPTION
Handle null provider in the organization integrations filter on the
notification settings page.

The `/users/me/organization-integrations/` API can return entries with a
null `provider` field. The `ALLOWED_PROVIDERS` filter added in #111745
accesses `orgIntegration.provider.key` without null safety, crashing the
page with `TypeError: Cannot read properties of null (reading 'provider')`.

Adds optional chaining to match the pattern already used for the identity
provider filter a few lines above.

handles JAVASCRIPT-38j8 & JAVASCRIPT-38N4