### PR TITLE
fix(integrations): Handle null items in organization integrations serialization

### DIFF
--- a/src/sentry/api/endpoints/user_organizationintegrations.py
+++ b/src/sentry/api/endpoints/user_organizationintegrations.py
@@ -53,6 +53,6 @@ class UserOrganizationIntegrationsEndpoint(UserEndpoint):
         return self.paginate(
             request=request,
             queryset=queryset,
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: [item for item in serialize(x, request.user) if item is not None],
             paginator_cls=OffsetPaginator,
         )

--- a/src/sentry/integrations/api/endpoints/organization_integrations_index.py
+++ b/src/sentry/integrations/api/endpoints/organization_integrations_index.py
@@ -125,7 +125,11 @@ class OrganizationIntegrationsEndpoint(OrganizationIntegrationBaseEndpoint):
         def on_results(results: Sequence[OrganizationIntegration]) -> Sequence[Mapping[str, Any]]:
             if feature_filters:
                 results = filter_by_features(results, feature_filters)
-            return serialize(results, request.user, include_config=include_config)
+            return [
+                item
+                for item in serialize(results, request.user, include_config=include_config)
+                if item is not None
+            ]
 
         return self.paginate(
             queryset=queryset,

--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -135,7 +135,7 @@ class OrganizationIntegrationSerializer(Serializer):
         )
         integrations_by_id: dict[int, RpcIntegration] = {i.id: i for i in integrations}
         return {
-            item: {"integration": integrations_by_id[item.integration_id]} for item in item_list
+            item: {"integration": integrations_by_id.get(item.integration_id)} for item in item_list
         }
 
     def serialize(
@@ -145,26 +145,39 @@ class OrganizationIntegrationSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         include_config: bool = True,
         **kwargs: Any,
-    ) -> MutableMapping[str, Any]:
+    ) -> MutableMapping[str, Any] | None:
+        logging_name = "sentry.serializers.model.organizationintegration"
+        logging_ctx = {"organization_integration_id": obj.id, "integration_id": obj.integration_id}
         # XXX(epurkhiser): This is O(n) for integrations, especially since
         # we're using the IntegrationConfigSerializer which pulls in the
         # integration installation config object which very well may be making
         # API request for config options.
-        integration: RpcIntegration = attrs.get("integration")  # type: ignore[assignment]
+        integration: RpcIntegration | None = attrs.get("integration")
+        if integration is None:
+            logger.warning(f"{logging_name}.missing_integration", extra=logging_ctx)
+            return None
+
         serialized_integration: MutableMapping[str, Any] = serialize(
             objects=integration,
             user=user,
             serializer=IntegrationConfigSerializer(obj.organization_id, params=self.params),
             include_config=include_config,
         )
+        if serialized_integration is None:
+            logger.warning(f"{logging_name}.serialize_integration_failed", extra=logging_ctx)
+            return None
 
         dynamic_display_information = None
         config_data = None
+        logging_ctx["provider"] = integration.provider
 
         try:
             installation = integration.get_installation(organization_id=obj.organization_id)
         except NotImplementedError:
             # slack doesn't have an installation implementation
+            config_data = obj.config if include_config else None
+        except Exception:
+            logger.exception(f"{logging_name}.get_installation_failed", extra=logging_ctx)
             config_data = obj.config if include_config else None
         else:
             try:
@@ -183,6 +196,8 @@ class OrganizationIntegrationSerializer(Serializer):
                     "integration_provider": integration.provider,
                 }
                 logger.info(name, extra=log_info)
+            except Exception:
+                logger.exception(f"{logging_name}.serialize_installation_failed", extra=logging_ctx)
 
         serialized_integration.update(
             {

--- a/tests/sentry/integrations/api/endpoints/test_user_organizationintegration.py
+++ b/tests/sentry/integrations/api/endpoints/test_user_organizationintegration.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import orjson
 
+from sentry.integrations.models.integration import Integration
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -72,3 +73,32 @@ class UserOrganizationIntegationTest(APITestCase):
             assert response.status_code == 200
             content = orjson.loads(response.content)
             assert content == []
+
+    def test_missing_integration_filtered_from_response(self) -> None:
+        """OrganizationIntegrations whose Integration was deleted don't produce null entries."""
+        integration = self.create_provider_integration(provider="github")
+        self.create_organization_integration(
+            organization_id=self.organization.id, integration_id=integration.id
+        )
+
+        # Delete the Integration row directly to simulate orphaned state
+        Integration.objects.filter(id=integration.id).delete()
+
+        response = self.get_success_response(self.user.id)
+        assert response.data == []
+
+    def test_installation_error_still_returns_item(self) -> None:
+        """An exception in get_dynamic_display_information shouldn't null out the item."""
+        integration = self.create_provider_integration(provider="github")
+        self.create_organization_integration(
+            organization_id=self.organization.id, integration_id=integration.id
+        )
+
+        with patch(
+            "sentry.integrations.base.IntegrationInstallation.get_dynamic_display_information",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = self.get_success_response(self.user.id)
+
+        assert len(response.data) == 1
+        assert response.data[0]["organizationId"] == self.organization.id


### PR DESCRIPTION
some integrations failed to serialize, causing `null`s to appear in the list apis:

<img width="1380" height="208" alt="image" src="https://github.com/user-attachments/assets/1c90c40d-edd1-43ff-bcae-930bc4be9d9d" />

this breaks frontend type assertions which necessitated the patch in https://github.com/getsentry/sentry/pull/112368
to avoid the page crashing

[the logs in sentry](https://sentry.sentry.io/issues/7384876727/?project=11276#logs) confirm that there were entries that failed to serialize here:

<img width="473" height="90" alt="image" src="https://github.com/user-attachments/assets/3733161c-5df1-4907-830b-1bc262476bba" />

This fix will omit `None` entries from the response, so the frontend can be reset to being type safe, and add some more logging we can look into about why certain bad integrations can't be serialized. +tests