### PR TITLE
feat(supergroups): Filter supergroups to unresolved issues

### DIFF
--- a/static/app/views/issueList/supergroups/useSuperGroups.tsx
+++ b/static/app/views/issueList/supergroups/useSuperGroups.tsx
@@ -45,6 +45,7 @@ export function useSuperGroups(groupIds: string[]): {
       {
         query: {
           group_id: requestedGroupIds,
+          status: 'unresolved',
         },
       },
     ],
@@ -67,6 +68,9 @@ export function useSuperGroups(groupIds: string[]): {
     }
     const result: SupergroupLookup = Object.fromEntries(groupIds.map(id => [id, null]));
     for (const sg of response.data) {
+      if (sg.group_ids.length <= 1) {
+        continue;
+      }
       for (const groupId of sg.group_ids) {
         result[String(groupId)] = sg;
       }


### PR DESCRIPTION
Pass `status=unresolved` to the supergroups by-group endpoint so the backend only returns group_ids for unresolved issues. Also skip supergroups with only 1 issue in the frontend lookup so they don't show up in the list.

Depends on #112216

fixes https://linear.app/getsentry/issue/ID-1440/hide-resolved-issues-from-counts-and-lists