### PR TITLE
feat(source-map-issues): Adding group id and title as attr to processing error trace item

### DIFF
--- a/src/sentry/processing_errors/eap/producer.py
+++ b/src/sentry/processing_errors/eap/producer.py
@@ -44,6 +44,7 @@ def produce_processing_errors_to_eap(
     project: Project,
     event_data: Mapping[str, Any],
     processing_errors: Sequence[Mapping[str, Any]],
+    group_id: int | None = None,
 ) -> None:
     """
     Produces processing errors as TraceItems to the EAP topic.
@@ -65,6 +66,7 @@ def produce_processing_errors_to_eap(
         release = event_data.get("release")
         environment = event_data.get("environment")
         platform = event_data.get("platform")
+        title = event_data.get("title")
         sdk = event_data.get("sdk") or {}
         sdk_name = sdk.get("name")
         sdk_version = sdk.get("version")
@@ -98,6 +100,12 @@ def produce_processing_errors_to_eap(
 
             if sdk_version is not None:
                 attributes["sdk_version"] = sdk_version
+
+            if title is not None:
+                attributes["title"] = title
+
+            if group_id is not None:
+                attributes["group_id"] = str(group_id)
 
             item_id = hex_to_item_id(
                 uuid.uuid5(PROCESSING_ERROR_NAMESPACE, f"{event_data['event_id']}:{index}").hex

--- a/src/sentry/processing_errors/eap/producer.py
+++ b/src/sentry/processing_errors/eap/producer.py
@@ -45,6 +45,7 @@ def produce_processing_errors_to_eap(
     event_data: Mapping[str, Any],
     processing_errors: Sequence[Mapping[str, Any]],
     group_id: int | None = None,
+    title: str | None = None,
 ) -> None:
     """
     Produces processing errors as TraceItems to the EAP topic.
@@ -66,7 +67,6 @@ def produce_processing_errors_to_eap(
         release = event_data.get("release")
         environment = event_data.get("environment")
         platform = event_data.get("platform")
-        title = event_data.get("title")
         sdk = event_data.get("sdk") or {}
         sdk_name = sdk.get("name")
         sdk_version = sdk.get("version")

--- a/src/sentry/processing_errors/eap/producer.py
+++ b/src/sentry/processing_errors/eap/producer.py
@@ -105,7 +105,7 @@ def produce_processing_errors_to_eap(
                 attributes["title"] = title
 
             if group_id is not None:
-                attributes["group_id"] = str(group_id)
+                attributes["group_id"] = group_id
 
             item_id = hex_to_item_id(
                 uuid.uuid5(PROCESSING_ERROR_NAMESPACE, f"{event_data['event_id']}:{index}").hex

--- a/src/sentry/search/eap/processing_errors/attributes.py
+++ b/src/sentry/search/eap/processing_errors/attributes.py
@@ -63,7 +63,7 @@ PROCESSING_ERROR_ATTRIBUTE_DEFINITIONS = {
         ResolvedAttribute(
             public_alias="group_id",
             internal_name="group_id",
-            search_type="string",
+            search_type="integer",
         ),
     ]
 }

--- a/src/sentry/search/eap/processing_errors/attributes.py
+++ b/src/sentry/search/eap/processing_errors/attributes.py
@@ -55,5 +55,15 @@ PROCESSING_ERROR_ATTRIBUTE_DEFINITIONS = {
             internal_name="sdk_version",
             search_type="string",
         ),
+        ResolvedAttribute(
+            public_alias="title",
+            internal_name="title",
+            search_type="string",
+        ),
+        ResolvedAttribute(
+            public_alias="group_id",
+            internal_name="group_id",
+            search_type="string",
+        ),
     ]
 }

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1277,7 +1277,9 @@ def process_processing_errors_eap(job: PostProcessJob) -> None:
 
     from sentry.processing_errors.eap.producer import produce_processing_errors_to_eap
 
-    produce_processing_errors_to_eap(event.project, event.data, processing_errors)
+    produce_processing_errors_to_eap(
+        event.project, event.data, processing_errors, group_id=event.group_id
+    )
 
 
 def process_processing_issue_detection(job: PostProcessJob) -> None:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1278,7 +1278,7 @@ def process_processing_errors_eap(job: PostProcessJob) -> None:
     from sentry.processing_errors.eap.producer import produce_processing_errors_to_eap
 
     produce_processing_errors_to_eap(
-        event.project, event.data, processing_errors, group_id=event.group_id
+        event.project, event.data, processing_errors, group_id=event.group_id, title=event.title
     )
 
 

--- a/tests/sentry/processing_errors/eap/test_producer.py
+++ b/tests/sentry/processing_errors/eap/test_producer.py
@@ -103,11 +103,12 @@ class ProduceProcessingErrorsToEAPTest(TestCase):
             release="1.0.0",
             environment="production",
             platform="javascript",
+            title="ReferenceError: undefined variable",
             sdk={"name": "sentry.javascript.browser", "version": "7.0.0"},
         )
         errors = [{"type": "js_no_source", "symbolicator_type": "missing_sourcemap"}]
 
-        produce_processing_errors_to_eap(self.project, event_data, errors)
+        produce_processing_errors_to_eap(self.project, event_data, errors, group_id=12345)
 
         payload = mock_producer.produce.call_args[0][1]
         trace_item = codec.decode(payload.value)
@@ -117,6 +118,8 @@ class ProduceProcessingErrorsToEAPTest(TestCase):
         assert trace_item.attributes["platform"].string_value == "javascript"
         assert trace_item.attributes["sdk_name"].string_value == "sentry.javascript.browser"
         assert trace_item.attributes["sdk_version"].string_value == "7.0.0"
+        assert trace_item.attributes["title"].string_value == "ReferenceError: undefined variable"
+        assert trace_item.attributes["group_id"].string_value == "12345"
 
     @patch("sentry.processing_errors.eap.producer._eap_producer")
     @patch("sentry.processing_errors.eap.producer.get_topic_definition")
@@ -138,6 +141,8 @@ class ProduceProcessingErrorsToEAPTest(TestCase):
         assert "sdk_name" not in trace_item.attributes
         assert "sdk_version" not in trace_item.attributes
         assert "symbolicator_type" not in trace_item.attributes
+        assert "title" not in trace_item.attributes
+        assert "group_id" not in trace_item.attributes
 
     @patch("sentry.processing_errors.eap.producer.logger")
     @patch("sentry.processing_errors.eap.producer._eap_producer")

--- a/tests/sentry/processing_errors/eap/test_producer.py
+++ b/tests/sentry/processing_errors/eap/test_producer.py
@@ -124,7 +124,7 @@ class ProduceProcessingErrorsToEAPTest(TestCase):
         assert trace_item.attributes["sdk_name"].string_value == "sentry.javascript.browser"
         assert trace_item.attributes["sdk_version"].string_value == "7.0.0"
         assert trace_item.attributes["title"].string_value == "ReferenceError: undefined variable"
-        assert trace_item.attributes["group_id"].string_value == "12345"
+        assert trace_item.attributes["group_id"].int_value == 12345
 
     @patch("sentry.processing_errors.eap.producer._eap_producer")
     @patch("sentry.processing_errors.eap.producer.get_topic_definition")

--- a/tests/sentry/processing_errors/eap/test_producer.py
+++ b/tests/sentry/processing_errors/eap/test_producer.py
@@ -103,12 +103,17 @@ class ProduceProcessingErrorsToEAPTest(TestCase):
             release="1.0.0",
             environment="production",
             platform="javascript",
-            title="ReferenceError: undefined variable",
             sdk={"name": "sentry.javascript.browser", "version": "7.0.0"},
         )
         errors = [{"type": "js_no_source", "symbolicator_type": "missing_sourcemap"}]
 
-        produce_processing_errors_to_eap(self.project, event_data, errors, group_id=12345)
+        produce_processing_errors_to_eap(
+            self.project,
+            event_data,
+            errors,
+            group_id=12345,
+            title="ReferenceError: undefined variable",
+        )
 
         payload = mock_producer.produce.call_args[0][1]
         trace_item = codec.decode(payload.value)


### PR DESCRIPTION
- The sample events should be links that take us to the corresponding issue details
- Sending title and group id as attributes so that we don't have to 
- - 1) fetch the trace items for the event_ids and then
- - 2) fetch the full events using the event details endpoints
<img width="693" height="384" alt="Screenshot 2026-04-07 at 11 49 57 PM" src="https://github.com/user-attachments/assets/7e351577-af8e-447c-a4d4-5af0a77b8bd1" />
