### PR TITLE
(fix) add pendo as a known outside click

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -105,6 +105,13 @@ export function BreadcrumbsDataSection({
             if (viewAllButton?.contains(element)) {
               return false;
             }
+            // Third-party packages (e.g. Pendo) use a container with id "pendo-guide-container".
+            // If the click is inside that container, treat it as an internal click.
+            if (element instanceof HTMLElement) {
+              if (element.closest('#pendo-guide-container')) {
+                return false;
+              }
+            }
             return true;
           },
         }

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -107,10 +107,8 @@ export function BreadcrumbsDataSection({
             }
             // Third-party packages (e.g. Pendo) use a container with id "pendo-guide-container".
             // If the click is inside that container, treat it as an internal click.
-            if (element instanceof HTMLElement) {
-              if (element.closest('#pendo-guide-container')) {
-                return false;
-              }
+            if (element.closest('#pendo-guide-container')) {
+              return false;
             }
             return true;
           },


### PR DESCRIPTION
<!-- Describe your PR here. -->
Third-party packages (e.g. Pendo) aren't considered as outside clicks for the breadcrumb drawer, this adds its container as an additional condition to check.
<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
