### PR TITLE
chore(incidents): Add GroupOpenPeriodActivity to incinerator/cleanup script

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -739,8 +739,10 @@ def remove_old_nodestore_values(days: int) -> None:
 def remove_cross_project_bulk_query_models(
     bulk_query_deletes: list[tuple[type[BaseModel], str, str | None]],
 ) -> list[tuple[type[BaseModel], str, str | None]]:
+    from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity
     from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
 
+    bulk_query_deletes.remove((GroupOpenPeriodActivity, "date_added", None))
     bulk_query_deletes.remove((WorkflowFireHistory, "date_added", None))
     return bulk_query_deletes
 
@@ -749,6 +751,7 @@ def generate_bulk_query_deletes() -> list[tuple[type[BaseModel], str, str | None
     from django.apps import apps
 
     from sentry.models.groupemailthread import GroupEmailThread
+    from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity
     from sentry.models.userreport import UserReport
     from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
 
@@ -763,6 +766,7 @@ def generate_bulk_query_deletes() -> list[tuple[type[BaseModel], str, str | None
     BULK_QUERY_DELETES = [
         (UserReport, "date_added", None),
         (GroupEmailThread, "date", None),
+        (GroupOpenPeriodActivity, "date_added", None),
         (WorkflowFireHistory, "date_added", None),
     ] + additional_bulk_query_deletes
 

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -9,6 +9,7 @@ import pytest
 from sentry.constants import ObjectStatus
 from sentry.models.files.file import File
 from sentry.models.group import Group
+from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity
 from sentry.runner.commands.cleanup import (
     _cleanup,
     generate_bulk_query_deletes,
@@ -234,13 +235,15 @@ class RunBulkQueryDeletesByProjectTest(TestCase):
 
 
 class RemoveCrossProjectBulkQueryModelsTest(TestCase):
-    def test_removes_workflow_fire_history(self) -> None:
+    def test_removes_cross_project_models(self) -> None:
         bulk_query_deletes = generate_bulk_query_deletes()
         models_before = {m for m, _, _ in bulk_query_deletes}
+        assert GroupOpenPeriodActivity in models_before
         assert WorkflowFireHistory in models_before
 
         remove_cross_project_bulk_query_models(bulk_query_deletes)
         models_after = {m for m, _, _ in bulk_query_deletes}
+        assert GroupOpenPeriodActivity not in models_after
         assert WorkflowFireHistory not in models_after
 
 


### PR DESCRIPTION
Not active until we supply the relevant flag, but still going to hold off landing until the current clean-up task clears most of the backlog.


Part of ISWF-2408.
