### PR TITLE
chore(ci): Disable codeowners-coverage workflow

### DIFF
--- a/.github/workflows/codeowners-coverage.yml
+++ b/.github/workflows/codeowners-coverage.yml
@@ -6,7 +6,8 @@ on:
   # push:
   #   branches:
   #     - master
-  pull_request:
+  # pull_request:
+  workflow_dispatch:
 
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value


### PR DESCRIPTION
Disabling the `codeowners-coverage` for now as it is an optional check and people are getting flagged to fix things unrelated to their PR.  We should only be flagging people that touch unowned things as the implication is they’re in a position to understand those things.  We will re-enable after improving this check.

Disables the `codeowners-coverage` GitHub Actions workflow by commenting out the `pull_request` trigger and switching to `workflow_dispatch` only. This prevents the workflow from running automatically on PRs while still allowing manual triggering if needed.