### PR TITLE
docs(agents): Add dev server URLs and dev-ui proxy details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ make reset-db
 # Start the full development server (requires devservices up)
 pnpm run dev
 
-# Start only the UI development server with hot reload (no backend needed)
+# Start only the UI development server with hot reload
 # Proxies API requests to production sentry.io
 pnpm run dev-ui
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,12 +119,20 @@ make reset-db
 #### Development Setup
 
 ```bash
-# Start the development server
+# Start the full development server (requires devservices up)
 pnpm run dev
 
-# Start only the UI development server with hot reload
+# Start only the UI development server with hot reload (no backend needed)
+# Proxies API requests to production sentry.io
 pnpm run dev-ui
 ```
+
+**Dev server URLs:**
+
+- Full devserver (`devservices serve`): http://dev.getsentry.net:8000
+- Frontend-only (`pnpm run dev-ui`): https://sentry.dev.getsentry.net:7999/
+
+The `dev-ui` server proxies `/api/*` to production `sentry.io`, so you must be logged into sentry.io in the same browser. No local backend or devservices needed.
 
 #### Typechecking
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,10 +129,8 @@ pnpm run dev-ui
 
 **Dev server URLs:**
 
-- Full devserver (`devservices serve`): http://dev.getsentry.net:8000
-- Frontend-only (`pnpm run dev-ui`): https://sentry.dev.getsentry.net:7999/
-
-The `dev-ui` server proxies `/api/*` to production `sentry.io`, so you must be logged into sentry.io in the same browser. No local backend or devservices needed.
+- Full devserver: http://dev.getsentry.net:8000
+- Frontend-only (`dev-ui`): https://sentry.dev.getsentry.net:7999/
 
 #### Typechecking
 


### PR DESCRIPTION
## Summary
- Document the correct URLs for local dev servers (`dev.getsentry.net:8000` and `sentry.dev.getsentry.net:7999`)
- Clarify that `pnpm run dev-ui` proxies API requests to production sentry.io and requires no local backend
- Improve command comments to distinguish full devserver vs frontend-only modes

## Test plan
- [ ] Verify URLs are correct by running `pnpm run dev-ui` and accessing `https://sentry.dev.getsentry.net:7999/`