### PR TITLE
ref(seer): Capitalize node type headings in markdown renderer

### DIFF
--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -345,7 +345,7 @@ def poll_until_done(
 def _render_node(node: dict[str, Any], depth: int) -> str:
     """Recursively render an LLMContextSnapshot node and its children as markdown."""
     heading = "#" * min(depth + 1, 6)
-    lines = [f"{heading} {node.get('nodeType', 'unknown').capitalize()}"]
+    lines = [f"{heading} {(node.get('nodeType') or 'unknown').capitalize()}"]
 
     data = node.get("data")
     if isinstance(data, dict):

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -345,7 +345,7 @@ def poll_until_done(
 def _render_node(node: dict[str, Any], depth: int) -> str:
     """Recursively render an LLMContextSnapshot node and its children as markdown."""
     heading = "#" * min(depth + 1, 6)
-    lines = [f"{heading} {node.get('nodeType', 'unknown')}"]
+    lines = [f"{heading} {node.get('nodeType', 'unknown').capitalize()}"]
 
     data = node.get("data")
     if isinstance(data, dict):

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -252,7 +252,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.status_code == 200
         call_kwargs = mock_client.start_run.call_args[1]
         context = call_kwargs["on_page_context"]
-        assert "# dashboard" in context
+        assert "# Dashboard" in context
         assert '- **title**: "My Dashboard"' in context
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -200,7 +200,7 @@ class SnapshotToMarkdownTest(TestCase):
             ],
         }
         result = snapshot_to_markdown(snapshot)
-        assert "# dashboard" in result
+        assert "# Dashboard" in result
         assert '- **title**: "Backend Health"' in result
         assert "- **widgetCount**: 3" in result
 
@@ -228,9 +228,9 @@ class SnapshotToMarkdownTest(TestCase):
             ],
         }
         result = snapshot_to_markdown(snapshot)
-        assert "# dashboard" in result
-        assert "## widget" in result
-        assert "### chart" in result
+        assert "# Dashboard" in result
+        assert "## Widget" in result
+        assert "### Chart" in result
         assert '- **query**: "count()"' in result
 
     def test_empty_nodes(self) -> None:
@@ -242,7 +242,7 @@ class SnapshotToMarkdownTest(TestCase):
             "nodes": [{"nodeType": "dashboard", "data": None, "children": []}],
         }
         result = snapshot_to_markdown(snapshot)
-        assert "# dashboard" in result
+        assert "# Dashboard" in result
         assert "not an exact screenshot" in result
 
     def test_node_with_non_dict_data(self) -> None:
@@ -251,5 +251,5 @@ class SnapshotToMarkdownTest(TestCase):
             "nodes": [{"nodeType": "widget", "data": "some string", "children": []}],
         }
         result = snapshot_to_markdown(snapshot)
-        assert "# widget" in result
+        assert "# Widget" in result
         assert '- "some string"' in result


### PR DESCRIPTION
+ Apply .capitalize() to nodeType in _render_node so markdown headings render as "# Dashboard", "## Widget" instead of lowercase.
