### PR TITLE
feat(eslint): enable @typescript-eslint/no-unnecessary-type-parameters

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -608,6 +608,7 @@ export default typescript.config([
           '@typescript-eslint/no-for-in-array': 'error',
           '@typescript-eslint/no-unnecessary-template-expression': 'error',
           '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+          '@typescript-eslint/no-unnecessary-type-parameters': 'error',
           '@typescript-eslint/switch-exhaustiveness-check': [
             'error',
             {considerDefaultExhaustiveForUnions: true},

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -36,7 +36,7 @@ export function getSearchConfig<Value extends SelectKey>(
   return search;
 }
 
-export function getEscapedKey<Value extends SelectKey | undefined>(value: Value): string {
+export function getEscapedKey(value: SelectKey): string {
   return CSS.escape(String(value));
 }
 
@@ -287,8 +287,8 @@ export function getSortedItems<Value extends SelectKey>(
  * selected, then this function selects all of them. If all of the options are selected,
  * then this function unselects all of them.
  */
-function toggleOptions<Value extends SelectKey>(
-  optionKeys: Value[],
+function toggleOptions(
+  optionKeys: SelectKey[],
   selectionManager: ListState<any>['selectionManager']
 ) {
   const {selectedKeys} = selectionManager;

--- a/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
@@ -17,9 +17,7 @@ interface Props {
 /**
  * @deprecated Use organizationRepositoriesInfiniteOptions instead.
  */
-export function useOrganizationRepositories<T extends Repository = Repository>(
-  {query = {}} = {} as Props
-) {
+export function useOrganizationRepositories({query = {}} = {} as Props) {
   const queryRef = useRef<Record<string, string>>(query);
   useEffect(() => {
     queryRef.current = query;
@@ -39,7 +37,7 @@ export function useOrganizationRepositories<T extends Repository = Repository>(
     [organization.slug]
   );
 
-  const {pages, isFetching, ...rest} = useFetchSequentialPages<T[]>({
+  const {pages, isFetching, ...rest} = useFetchSequentialPages<Repository[]>({
     getQueryKey,
     perPage: 100,
     enabled: true,
@@ -47,7 +45,7 @@ export function useOrganizationRepositories<T extends Repository = Repository>(
 
   const data = useMemo(() => {
     const flattenedRepos = pages.flat();
-    const uniqueReposMap = new Map<string, T>();
+    const uniqueReposMap = new Map<string, Repository>();
     flattenedRepos.forEach(repo => {
       if (repo.externalId && !uniqueReposMap.has(repo.externalId)) {
         uniqueReposMap.set(repo.externalId, repo);

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -133,6 +133,7 @@ export function getRelativeTimeFromEventDateCreated(
 
 type KnownDataDetails = Omit<KeyValueListDataItem, 'key'> | undefined;
 
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 export function getKnownData<Data, DataType>({
   data,
   knownDataTypes,

--- a/static/app/components/events/interfaces/spans/waterfallModel.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.tsx
@@ -200,7 +200,6 @@ export class WaterfallModel {
       threshold: 0.6,
       location: 0,
       distance: 100,
-      maxPatternLength: 32,
     });
   }
 

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -176,7 +176,7 @@ export function GroupList({
   const hasLogicBoolean = useMemo(
     () =>
       parsedQuery
-        ? treeResultLocator<boolean>({
+        ? treeResultLocator({
             tree: parsedQuery,
             noResultValue: false,
             visitorTest: ({token, returnResult}) => {

--- a/static/app/components/pipeline/types.tsx
+++ b/static/app/components/pipeline/types.tsx
@@ -49,10 +49,11 @@ export interface PipelineStepProps<
 }
 
 /**
- * Identity function that casts the raw completion data to a typed shape.
+ * Identity function that asserts the raw completion data to a typed shape.
  * Avoids the verbose `(data: Record<string, unknown>) => data as unknown as T`
  * boilerplate in every pipeline definition.
  */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 export function pipelineComplete<T>(data: Record<string, unknown>): T {
   return data as unknown as T;
 }

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -177,7 +177,7 @@ function menuIsOpen({
   return openState && totalOptions > hiddenOptions.size;
 }
 
-function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
+function useHiddenItems({
   items,
   filterValue,
   maxOptions,
@@ -185,7 +185,7 @@ function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
   showAskSeerOption,
 }: {
   filterValue: string;
-  items: T[];
+  items: Array<SelectOptionOrSectionWithKey<string>>;
   showAskSeerOption: boolean;
   maxOptions?: number;
   shouldFilterResults?: boolean;

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -886,7 +886,7 @@ export class TokenConverter {
   /**
    * Checks a filter against some non-grammar validation rules
    */
-  checkFilterWarning = <T extends FilterType>(key: FilterMap[T]['key']) => {
+  checkFilterWarning = (key: FilterMap[FilterType]['key']) => {
     if (
       ![
         Token.KEY_SIMPLE,
@@ -1513,10 +1513,12 @@ export const defaultConfig: SearchConfig = {
   },
 };
 
-function tryParseSearch<T extends {config: SearchConfig}>(
-  query: string,
-  config: T
-): ParseResult | null {
+interface SearchParseConfig {
+  [i: string]: any;
+  config: SearchConfig;
+}
+
+function tryParseSearch(query: string, config: SearchParseConfig): ParseResult | null {
   try {
     return parse(query, config);
   } catch (e: any) {

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1513,14 +1513,9 @@ export const defaultConfig: SearchConfig = {
   },
 };
 
-interface SearchParseConfig {
-  [i: string]: any;
-  config: SearchConfig;
-}
-
-function tryParseSearch(query: string, config: SearchParseConfig): ParseResult | null {
+function tryParseSearch(...args: Parameters<typeof parse>): ParseResult | null {
   try {
-    return parse(query, config);
+    return parse(...args);
   } catch (e: any) {
     Sentry.logger.error('Search syntax parse error', {
       message: e.message?.slice(-100),

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -26,11 +26,11 @@ class TokenResultFoundError extends Error {
  */
 const skipTokenMarker = Symbol('Returned to skip visiting a token');
 
-type VisitorFn = (opts: {
+type VisitorFn<T> = (opts: {
   /**
    * Call this to return the provided value as the result of treeResultLocator
    */
-  returnResult: (result: any) => TokenResultFoundError;
+  returnResult: (result: T) => TokenResultFoundError;
   /**
    * Return this to skip visiting any inner tokens
    */
@@ -41,12 +41,12 @@ type VisitorFn = (opts: {
   token: TokenResult<Token>;
 }) => null | TokenResultFoundError | typeof skipTokenMarker;
 
-type TreeResultLocatorOpts = {
+type TreeResultLocatorOpts<T> = {
   /**
    * The value to return when returnValue was never called and all nodes of the
    * search tree were visited.
    */
-  noResultValue: any;
+  noResultValue: T;
   /**
    * The tree to visit
    */
@@ -56,7 +56,7 @@ type TreeResultLocatorOpts = {
    * visiting. May also indicate that we want to skip any further traversal of
    * inner nodes.
    */
-  visitorTest: VisitorFn;
+  visitorTest: VisitorFn<T>;
 };
 
 /**
@@ -72,7 +72,7 @@ export function treeResultLocator<T>({
   tree,
   visitorTest,
   noResultValue,
-}: TreeResultLocatorOpts): T {
+}: TreeResultLocatorOpts<T>): T {
   const returnResult = (result: any) => new TokenResultFoundError(result);
 
   const nodeVisitor = (token: TokenResult<Token> | null) => {

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -60,14 +60,14 @@ interface ComboBoxProps {
   tabIndex?: number;
 }
 
-function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
+function useHiddenItems({
   items,
   filterValue,
   maxOptions,
   shouldFilterResults,
 }: {
   filterValue: string;
-  items: T[];
+  items: Array<SelectOptionOrSectionWithKey<string>>;
   maxOptions?: number;
   shouldFilterResults?: boolean;
 }) {

--- a/static/app/components/workflowEngine/form/getFormFieldValue.tsx
+++ b/static/app/components/workflowEngine/form/getFormFieldValue.tsx
@@ -5,10 +5,10 @@ import type {FieldValue} from 'sentry/components/forms/types';
  * The form values returned by form.getValue are not typed, so this is a
  * convenient helper to do a type assertion while getting the value.
  */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 export function getFormFieldValue<T extends FieldValue = FieldValue>(
   form: FormModel,
   field: string
 ): T {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  return form.getValue(field) as FieldValue;
+  return form.getValue(field);
 }

--- a/static/app/components/workflowEngine/form/useFormField.tsx
+++ b/static/app/components/workflowEngine/form/useFormField.tsx
@@ -6,6 +6,7 @@ import {FormContext} from 'sentry/components/forms/formContext';
 import type {FieldValue} from 'sentry/components/forms/types';
 import {getFormFieldValue} from 'sentry/components/workflowEngine/form/getFormFieldValue';
 
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 export function useFormField<Value extends FieldValue = FieldValue>(
   field: string
 ): Value | undefined {

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -15,13 +15,9 @@ type HookCallback = (...args: any[]) => void;
 interface HookStoreDefinition extends StoreDefinition, Internals {
   add<H extends HookName>(hookName: H, callback: Hooks[H]): void;
   get<H extends HookName>(hookName: H): Array<Hooks[H]>;
-  getCallback<H extends HookName>(hookName: H, key: string): HookCallback | undefined;
+  getCallback(hookName: HookName, key: string): HookCallback | undefined;
   init(): void;
-  persistCallback<H extends HookName>(
-    hookName: H,
-    key: string,
-    value: HookCallback
-  ): void;
+  persistCallback(hookName: HookName, key: string, value: HookCallback): void;
   remove<H extends HookName>(hookName: H, callback: Hooks[H]): void;
 }
 

--- a/static/app/utils/analytics/makeAnalyticsFunction.tsx
+++ b/static/app/utils/analytics/makeAnalyticsFunction.tsx
@@ -18,6 +18,9 @@ type Options = Parameters<Hooks['analytics:raw-track-event']>[1];
  */
 export function makeAnalyticsFunction<
   EventParameters extends Record<string, Record<string, any>>,
+  // This is used to provide a nice curried type for consumers.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+  OrgRequirement extends OptionalOrg = OptionalOrg,
 >(
   eventKeyToNameMap: Record<keyof EventParameters, string | null>,
   defaultOptions?: Options
@@ -30,7 +33,7 @@ export function makeAnalyticsFunction<
    */
   return <EventKey extends keyof EventParameters & string>(
     eventKey: EventKey,
-    analyticsParams: EventParameters[EventKey] & OptionalOrg,
+    analyticsParams: EventParameters[EventKey] & OrgRequirement,
     options?: Options
   ) => {
     const eventName = eventKeyToNameMap[eventKey];

--- a/static/app/utils/analytics/makeAnalyticsFunction.tsx
+++ b/static/app/utils/analytics/makeAnalyticsFunction.tsx
@@ -18,7 +18,6 @@ type Options = Parameters<Hooks['analytics:raw-track-event']>[1];
  */
 export function makeAnalyticsFunction<
   EventParameters extends Record<string, Record<string, any>>,
-  OrgRequirement extends OptionalOrg = OptionalOrg,
 >(
   eventKeyToNameMap: Record<keyof EventParameters, string | null>,
   defaultOptions?: Options
@@ -31,7 +30,7 @@ export function makeAnalyticsFunction<
    */
   return <EventKey extends keyof EventParameters & string>(
     eventKey: EventKey,
-    analyticsParams: EventParameters[EventKey] & OrgRequirement,
+    analyticsParams: EventParameters[EventKey] & OptionalOrg,
     options?: Options
   ) => {
     const eventName = eventKeyToNameMap[eventKey];

--- a/static/app/utils/api/apiOptions.ts
+++ b/static/app/utils/api/apiOptions.ts
@@ -34,6 +34,7 @@ export const selectJsonWithHeaders = <TData>(
 ): ApiResponse<TData> => data;
 
 function _apiOptions<
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   TManualData = never,
   TApiPath extends KnownApiUrls = KnownApiUrls,
   // todo: infer the actual data type from the ApiMapping
@@ -69,6 +70,7 @@ function parsePageParam<TQueryFnData = unknown>(dir: 'previous' | 'next') {
 }
 
 function _apiOptionsInfinite<
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   TManualData = never,
   TApiPath extends KnownApiUrls = KnownApiUrls,
   // todo: infer the actual data type from the ApiMapping

--- a/static/app/utils/api/useAggregatedQueryKeys.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.tsx
@@ -49,8 +49,8 @@ interface Props<AggregatableQueryKey, Data> {
   onError?: (error: Error) => void;
 }
 
-function isQueryKeyInList<AggregatableQueryKey>(queryList: AggregatableQueryKey[]) {
-  return ({queryKey}: any) => queryList.includes(queryKey[4] as AggregatableQueryKey);
+function isQueryKeyInList(queryList: unknown[]) {
+  return ({queryKey}: any) => queryList.includes(queryKey[4]);
 }
 
 /**

--- a/static/app/utils/fuzzySearch.tsx
+++ b/static/app/utils/fuzzySearch.tsx
@@ -11,10 +11,10 @@ const DEFAULT_FUSE_OPTIONS: Fuse.IFuseOptions<any> = {
   minMatchCharLength: 2,
 };
 
-export async function createFuzzySearch<
-  T = string,
-  Options extends Fuse.IFuseOptions<T> = Fuse.IFuseOptions<T>,
->(objects: T[], options: Options): Promise<Fuse<T>> {
+export async function createFuzzySearch<T = string>(
+  objects: T[],
+  options: Fuse.IFuseOptions<T>
+): Promise<Fuse<T>> {
   if (!options.keys) {
     throw new Error('You need to define `options.keys`');
   }
@@ -31,10 +31,10 @@ export async function createFuzzySearch<
 // re-export fuse type to make it easier to use
 export type {Fuse};
 
-export function useFuzzySearch<
-  T = string,
-  Options extends Fuse.IFuseOptions<T> = Fuse.IFuseOptions<T>,
->(objects: T[], options: Options): Fuse<T> | null {
+export function useFuzzySearch<T = string>(
+  objects: T[],
+  options: Fuse.IFuseOptions<T>
+): Fuse<T> | null {
   const [fuse, setFuse] = useState<Fuse<T> | null>(null);
 
   useEffect(() => {

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -174,6 +174,7 @@ export function fetchDataQuery<TResponseData = unknown>(
  * response data. This does not include the ApiResult type. For that you can
  * manually call queryClient.getQueryData.
  */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 export function getApiQueryData<TResponseData>(
   queryClient: QueryClient,
   queryKey: ApiQueryKey

--- a/static/app/utils/url/useLocationQuery.tsx
+++ b/static/app/utils/url/useLocationQuery.tsx
@@ -41,6 +41,7 @@ type Decoder = KnownDecoder | GenericDecoder;
  */
 export function useLocationQuery<
   InferredRequestShape extends Record<string, Scalar | Scalar[] | Decoder>,
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   InferredResponseShape extends {
     readonly [Property in keyof InferredRequestShape]: InferredRequestShape[Property] extends Decoder
       ? ReturnType<InferredRequestShape[Property]>

--- a/static/app/utils/useLocalStorageState.ts
+++ b/static/app/utils/useLocalStorageState.ts
@@ -9,7 +9,8 @@ const SUPPORTS_LOCAL_STORAGE = window && 'localStorage' in window;
 // Attempt to parse JSON. If it fails, swallow the error and return null.
 // As an improvement, we should maybe allow users to intercept here or possibly use
 // a different parsing function from JSON.parse
-function tryParseStorage<T>(jsonEncodedValue: string): T | null {
+// eslint-disable-next-line @typescript-eslint/no-restricted-types
+function tryParseStorage(jsonEncodedValue: string): object | null {
   try {
     return JSON.parse(jsonEncodedValue);
   } catch (e) {
@@ -83,7 +84,7 @@ function initializeStorage<S>(
   }
 
   // We may have failed to parse the value, so just pass it down raw to the initializer
-  const decodedValue = tryParseStorage<S>(jsonEncodedValue);
+  const decodedValue = tryParseStorage(jsonEncodedValue) as S | null;
   if (decodedValue === null) {
     return defaultOrInitializer(defaultValueOrInitializeFn, undefined, jsonEncodedValue);
   }

--- a/static/app/utils/useLocalStorageState.ts
+++ b/static/app/utils/useLocalStorageState.ts
@@ -9,8 +9,7 @@ const SUPPORTS_LOCAL_STORAGE = window && 'localStorage' in window;
 // Attempt to parse JSON. If it fails, swallow the error and return null.
 // As an improvement, we should maybe allow users to intercept here or possibly use
 // a different parsing function from JSON.parse
-// eslint-disable-next-line @typescript-eslint/no-restricted-types
-function tryParseStorage(jsonEncodedValue: string): object | null {
+function tryParseStorage(jsonEncodedValue: string): unknown {
   try {
     return JSON.parse(jsonEncodedValue);
   } catch (e) {

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -75,6 +75,7 @@ type ParamKeys =
  * const params = useParams<{projectId: string}>();
  * ```
  */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 export function useParams<P extends Partial<Record<ParamKeys, string | undefined>>>(): P {
   const contextParams = useReactRouter6Params() as P;
 

--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -4,7 +4,7 @@ import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
 const isBrowser = typeof window !== 'undefined';
 
-export function readStorageValue<T>(key: string, initialValue: T) {
+export function readStorageValue(key: string, initialValue: unknown) {
   const value = sessionStorageWrapper.getItem(key);
 
   // We check for 'undefined' because the value may have

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -33,8 +33,9 @@ import {useOrganization} from './useOrganization';
  * If either a customer domain is not being used, or if :orgId is not present in the route path, then WrappedComponent
  * is rendered.
  */
-export function withDomainRedirect<P>(WrappedComponent: RouteComponent) {
-  return function WithDomainRedirectWrapper(props: P) {
+export function withDomainRedirect(WrappedComponent: RouteComponent) {
+  // eslint-disable-next-line @typescript-eslint/no-restricted-types
+  return function WithDomainRedirectWrapper(props: object) {
     const {customerDomain, links, features} = ConfigStore.getState();
     const {sentryUrl} = links;
     const currentOrganization = useOrganization({allowNull: true});

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -30,8 +30,9 @@ import {useParams} from 'sentry/utils/useParams';
  *
  * Whenever https://orgslug.sentry.io/ is accessed in the browser, then both conditions above will be satisfied.
  */
-export function withDomainRequired<P>(WrappedComponent: RouteComponent) {
-  return function WithDomainRequiredWrapper(props: P) {
+export function withDomainRequired(WrappedComponent: RouteComponent) {
+  // eslint-disable-next-line @typescript-eslint/no-restricted-types
+  return function WithDomainRequiredWrapper(props: object) {
     const params = useParams();
     const {features, customerDomain, links} = ConfigStore.getState();
     const {sentryUrl} = links;

--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -141,7 +141,7 @@ function TransactionWrapper({
     for (const node of nodes) {
       const parent = getIsAiAgentNode(node)
         ? node
-        : (node as AITraceSpanNode).findParent<AITraceSpanNode>(p => getIsAiAgentNode(p));
+        : (node as AITraceSpanNode).findParent(p => getIsAiAgentNode(p));
       if (parent) {
         parents[node.id] = parent;
       }

--- a/static/app/views/insights/pages/agents/hooks/useAITrace.tsx
+++ b/static/app/views/insights/pages/agents/hooks/useAITrace.tsx
@@ -90,13 +90,15 @@ export function useAITrace(traceSlug: string, timestamp?: number): UseAITraceRes
         await Promise.all(zoomPromises);
 
         // Keep only transactions that include AI spans and the AI spans themselves
-        const flattenedNodes = tree.root.findAllChildren<AITraceSpanNode>(node => {
-          if (!isTransactionNode(node) && !isSpanNode(node) && !isEAPSpanNode(node)) {
-            return false;
-          }
+        const flattenedNodes = tree.root.findAllChildren<AITraceSpanNode>(
+          (node): node is AITraceSpanNode => {
+            if (!isTransactionNode(node) && !isSpanNode(node) && !isEAPSpanNode(node)) {
+              return false;
+            }
 
-          return getIsAiNode(node);
-        });
+            return getIsAiNode(node);
+          }
+        );
 
         setNodes(flattenedNodes);
         setIsLoading(false);

--- a/static/app/views/navigation/primary/organizationDropdown.spec.tsx
+++ b/static/app/views/navigation/primary/organizationDropdown.spec.tsx
@@ -114,8 +114,6 @@ describe('OrganizationDropdown', () => {
     );
     // onClick should take precedence setting session storage value and navigationigating:
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Projects'}));
-    expect(readStorageValue<string | null>(CUSTOM_REFERRER_KEY, null)).toBe(
-      'org-dropdown'
-    );
+    expect(readStorageValue(CUSTOM_REFERRER_KEY, null)).toBe('org-dropdown');
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
@@ -459,12 +459,16 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
   }
 
   findChild<ChildType extends BaseNode = BaseNode>(
-    predicate: (child: BaseNode) => boolean
+    predicate: (child: BaseNode) => child is ChildType
+  ): ChildType | null;
+  findChild(predicate: (child: BaseNode) => boolean): BaseNode | null;
+  findChild<ChildType extends BaseNode = BaseNode>(
+    predicate: (child: BaseNode) => child is ChildType
   ): ChildType | null {
     let result: ChildType | null = null;
     this.traverseChildren(node => {
       if (predicate(node)) {
-        result = node as ChildType;
+        result = node;
         return true;
       }
       return undefined;
@@ -473,12 +477,16 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
   }
 
   findAllChildren<ChildType extends BaseNode = BaseNode>(
-    predicate: (child: BaseNode) => boolean
+    predicate: (child: BaseNode) => child is ChildType
+  ): ChildType[];
+  findAllChildren(predicate: (child: BaseNode) => boolean): BaseNode[];
+  findAllChildren<ChildType extends BaseNode = BaseNode>(
+    predicate: (child: BaseNode) => child is ChildType
   ): ChildType[] {
     const results: ChildType[] = [];
     this.traverseChildren(node => {
       if (predicate(node)) {
-        results.push(node as ChildType);
+        results.push(node);
       }
     });
     return results;
@@ -488,9 +496,13 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
     this.traverseChildren(callback);
   }
 
-  findParent<ChildType extends BaseNode = BaseNode>(
-    predicate: (parent: BaseNode) => boolean
-  ): ChildType | null {
+  findParent<ParentType extends BaseNode = BaseNode>(
+    predicate: (parent: BaseNode) => parent is ParentType
+  ): ParentType | null;
+  findParent(predicate: (parent: BaseNode) => boolean): BaseNode | null;
+  findParent<ParentType extends BaseNode = BaseNode>(
+    predicate: (parent: BaseNode) => parent is ParentType
+  ): ParentType | null {
     const visited = new Set<BaseNode>();
     visited.add(this);
 
@@ -503,7 +515,7 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
       visited.add(current);
 
       if (predicate(current)) {
-        return current as ChildType;
+        return current;
       }
       current = current.parent;
     }
@@ -525,11 +537,13 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
   }
 
   findParentNodeStoreTransaction(): TransactionNode | null {
-    return this.findParent<TransactionNode>(p => isTransactionNode(p));
+    return this.findParent(p => isTransactionNode(p));
   }
 
   findParentEapTransaction(): EapSpanNode | null {
-    return this.findParent<EapSpanNode>(p => isEAPSpanNode(p) && p.value.is_transaction);
+    return this.findParent(
+      (p): p is EapSpanNode => isEAPSpanNode(p) && p.value.is_transaction
+    );
   }
 
   expand(expanding: boolean, tree: TraceTree): boolean {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer.tsx
@@ -24,10 +24,7 @@ export class TraceRowWidthMeasurer<T> {
     'row measure end': new Set(),
   };
 
-  once<K extends keyof TraceRowWidthMeasurerEvents<T>>(
-    event: K,
-    cb: (max: number) => void
-  ) {
+  once(event: keyof TraceRowWidthMeasurerEvents<T>, cb: (max: number) => void) {
     const listener = (...args: any[]) => {
       cb(...(args as ArgumentTypes<typeof cb>));
       this.off(event, listener);

--- a/static/app/views/settings/organizationRelay/modals/modalManager.tsx
+++ b/static/app/views/settings/organizationRelay/modals/modalManager.tsx
@@ -93,7 +93,7 @@ export class ModalManager<
     this.setValidForm(isFormValid);
   }
 
-  clearError<F extends keyof Values>(field: F) {
+  clearError(field: keyof Values) {
     this.setState(prevState => ({
       errors: omit(prevState.errors, field),
     }));
@@ -147,31 +147,29 @@ export class ModalManager<
     }
   };
 
-  handleValidate =
-    <F extends keyof Values>(field: F) =>
-    () => {
-      const isFieldValueEmpty = !this.state.values[field].replace(/\s/g, '');
+  handleValidate = (field: keyof Values) => () => {
+    const isFieldValueEmpty = !this.state.values[field].replace(/\s/g, '');
 
-      const fieldErrorAlreadyExist = this.state.errors[field];
+    const fieldErrorAlreadyExist = this.state.errors[field];
 
-      if (isFieldValueEmpty && fieldErrorAlreadyExist) {
-        return;
-      }
+    if (isFieldValueEmpty && fieldErrorAlreadyExist) {
+      return;
+    }
 
-      if (isFieldValueEmpty && !fieldErrorAlreadyExist) {
-        this.setState(prevState => ({
-          errors: {
-            ...prevState.errors,
-            [field]: t('Field Required'),
-          },
-        }));
-        return;
-      }
+    if (isFieldValueEmpty && !fieldErrorAlreadyExist) {
+      this.setState(prevState => ({
+        errors: {
+          ...prevState.errors,
+          [field]: t('Field Required'),
+        },
+      }));
+      return;
+    }
 
-      if (!isFieldValueEmpty && fieldErrorAlreadyExist) {
-        this.clearError(field);
-      }
-    };
+    if (!isFieldValueEmpty && fieldErrorAlreadyExist) {
+      this.clearError(field);
+    }
+  };
 
   handleValidateKey = () => {
     const {savedRelays} = this.props;

--- a/static/gsAdmin/schemas/broadcasts.tsx
+++ b/static/gsAdmin/schemas/broadcasts.tsx
@@ -10,7 +10,7 @@ import {
   TRIALCHOICES,
 } from 'getsentry/utils/broadcasts';
 
-const mapChoices = <T extends readonly [string, string]>(choices: readonly T[]) =>
+const mapChoices = (choices: ReadonlyArray<readonly [string, string]>) =>
   choices.map(([value, label]) => ({value, label}));
 
 export function getBroadcastSchema(): Field[] {

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
@@ -74,7 +74,7 @@ const getCustomReferrer = () => {
     // pull the referrer from the query parameter of the page
     const {referrer} = qs.parse(window.location.search) || {};
     // pull the referrer from session storage.
-    const storedReferrer = readStorageValue<string | null>(CUSTOM_REFERRER_KEY, null);
+    const storedReferrer = readStorageValue(CUSTOM_REFERRER_KEY, null) as string | null;
     // ?referrer takes precedence, but still unset session stored referrer.
     if (storedReferrer) {
       sessionStorageWrapper.removeItem(CUSTOM_REFERRER_KEY);

--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -1,5 +1,6 @@
 import type {FieldValue} from 'sentry/components/forms/model';
 import type {DataCategory} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
 import {makeAnalyticsFunction} from 'sentry/utils/analytics/makeAnalyticsFunction';
 
 import type {EventType} from 'getsentry/components/addEventsCTA';
@@ -397,5 +398,7 @@ const GETSENTRY_EVENT_MAP: Record<GetsentryEventKey, string> = {
     'Subscription Page: Usage Overview Add On Toggled',
 };
 
-export const trackGetsentryAnalytics =
-  makeAnalyticsFunction<GetsentryEventParameters>(GETSENTRY_EVENT_MAP);
+export const trackGetsentryAnalytics = makeAnalyticsFunction<
+  GetsentryEventParameters,
+  {organization: Organization}
+>(GETSENTRY_EVENT_MAP);

--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -1,6 +1,5 @@
 import type {FieldValue} from 'sentry/components/forms/model';
 import type {DataCategory} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
 import {makeAnalyticsFunction} from 'sentry/utils/analytics/makeAnalyticsFunction';
 
 import type {EventType} from 'getsentry/components/addEventsCTA';
@@ -398,7 +397,5 @@ const GETSENTRY_EVENT_MAP: Record<GetsentryEventKey, string> = {
     'Subscription Page: Usage Overview Add On Toggled',
 };
 
-export const trackGetsentryAnalytics = makeAnalyticsFunction<
-  GetsentryEventParameters,
-  {organization: Organization}
->(GETSENTRY_EVENT_MAP);
+export const trackGetsentryAnalytics =
+  makeAnalyticsFunction<GetsentryEventParameters>(GETSENTRY_EVENT_MAP);

--- a/static/gsApp/utils/trackSpendVisibilityAnalytics.tsx
+++ b/static/gsApp/utils/trackSpendVisibilityAnalytics.tsx
@@ -1,3 +1,4 @@
+import type {Organization} from 'sentry/types/organization';
 import {makeAnalyticsFunction} from 'sentry/utils/analytics/makeAnalyticsFunction';
 
 import type {Subscription} from 'getsentry/types';
@@ -39,5 +40,7 @@ const spendVisibilityEventMap: Record<SpendVisibilityEvents, string> = {
 };
 
 // The type-safe analytics function generated
-export const trackSpendVisibilityAnaltyics =
-  makeAnalyticsFunction<SpendVisibilityEventParameters>(spendVisibilityEventMap);
+export const trackSpendVisibilityAnaltyics = makeAnalyticsFunction<
+  SpendVisibilityEventParameters,
+  {organization: Organization}
+>(spendVisibilityEventMap);

--- a/static/gsApp/utils/trackSpendVisibilityAnalytics.tsx
+++ b/static/gsApp/utils/trackSpendVisibilityAnalytics.tsx
@@ -1,4 +1,3 @@
-import type {Organization} from 'sentry/types/organization';
 import {makeAnalyticsFunction} from 'sentry/utils/analytics/makeAnalyticsFunction';
 
 import type {Subscription} from 'getsentry/types';
@@ -40,7 +39,5 @@ const spendVisibilityEventMap: Record<SpendVisibilityEvents, string> = {
 };
 
 // The type-safe analytics function generated
-export const trackSpendVisibilityAnaltyics = makeAnalyticsFunction<
-  SpendVisibilityEventParameters,
-  {organization: Organization}
->(spendVisibilityEventMap);
+export const trackSpendVisibilityAnaltyics =
+  makeAnalyticsFunction<SpendVisibilityEventParameters>(spendVisibilityEventMap);

--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -55,8 +55,8 @@ export function PendingChanges({organization, subscription}: Props) {
     return pendingChange !== null && pendingChange !== currentValue;
   };
 
-  const getNestedValue = <T,>(object: Record<string, any>, keys: string): T | null => {
-    return keys.split('.').reduce((acc, key) => acc?.[key] ?? null, object) as T | null;
+  const getNestedValue = (object: Record<string, any>, keys: string) => {
+    return keys.split('.').reduce((acc, key) => acc?.[key] ?? null, object);
   };
 
   const getOnDemandChanges = () => {
@@ -66,10 +66,10 @@ export function PendingChanges({organization, subscription}: Props) {
       hasOnDemandBudgetsFeature(organization, subscription) ||
       (pendingChanges.onDemandBudgets && subscription.partner?.isActive)
     ) {
-      const nextOnDemandBudgets = getNestedValue<PendingOnDemandBudgets>(
+      const nextOnDemandBudgets = getNestedValue(
         pendingChanges,
         'onDemandBudgets'
-      );
+      ) as PendingOnDemandBudgets;
       if (nextOnDemandBudgets) {
         const pendingOnDemandBudgets = parseOnDemandBudgets(nextOnDemandBudgets);
         const currentOnDemandBudgets = parseOnDemandBudgetsFromSubscription(subscription);
@@ -99,9 +99,12 @@ export function PendingChanges({organization, subscription}: Props) {
       }
     } else if (hasChange('onDemandMaxSpend')) {
       const nextOnDemandMaxSpend =
-        getNestedValue<number>(pendingChanges, 'onDemandMaxSpend') ?? 0;
+        (getNestedValue(pendingChanges, 'onDemandMaxSpend') as unknown as
+          | number
+          | null) ?? 0;
       const currentOnDemandMaxSpend =
-        getNestedValue<number>(subscription, 'onDemandMaxSpend') ?? 0;
+        (getNestedValue(subscription, 'onDemandMaxSpend') as unknown as number | null) ??
+        0;
       results.push(
         tct('[budgetType] spend change from [currentAmount] to [newAmount]', {
           budgetType: displayBudgetName(subscription.planDetails, {title: true}),

--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -55,7 +55,10 @@ export function PendingChanges({organization, subscription}: Props) {
     return pendingChange !== null && pendingChange !== currentValue;
   };
 
-  const getNestedValue = (object: Record<string, any>, keys: string) => {
+  const getNestedValue = (
+    object: Record<string, any>,
+    keys: string
+  ): Record<string, any> | null => {
     return keys.split('.').reduce((acc, key) => acc?.[key] ?? null, object);
   };
 


### PR DESCRIPTION
Enables [`@typescript-eslint/no-unnecessary-type-parameters`](https://typescript-eslint.io/rules/no-unnecessary-type-parameters) internally. This enforces the ["Golden Rule of Generics"](https://effectivetypescript.com/2020/08/12/generics-golden-rule):

> **Rule: If a type parameter only appears in one location, strongly reconsider if you actually need it.**

Summarizing the rule's docs (would recommend reading, especially the FAQs) and that excellent blog post (definitely would recommend the read!): if a type parameter (commonly: `<T>`) is only used in one place, it's not actually useful. Single-use type parameters almost always either do nothing or mask an unsafe type assertion.

I added explainer comments inline in the PR.

Fixes ENG-7007