### PR TITLE
feat(integrations): Propagate ViewerContext in Jira Server webhook

### DIFF
--- a/src/sentry/integrations/jira_server/utils/api.py
+++ b/src/sentry/integrations/jira_server/utils/api.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.utils.sync import sync_group_assignee_inbound
+from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
 
 if TYPE_CHECKING:
     from sentry.integrations.models.integration import Integration
@@ -76,9 +77,10 @@ def handle_status_change(
         providers=[integration.provider],
     )
     for oi in org_integrations:
-        installation = integration.get_installation(oi.organization_id)
+        with webhook_viewer_context(oi.organization_id):
+            installation = integration.get_installation(oi.organization_id)
 
-        if hasattr(installation, "sync_status_inbound"):
-            installation.sync_status_inbound(
-                issue_key, {"changelog": changelog, "issue": data["issue"]}
-            )
+            if hasattr(installation, "sync_status_inbound"):
+                installation.sync_status_inbound(
+                    issue_key, {"changelog": changelog, "issue": data["issue"]}
+                )

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -9,7 +9,9 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode
+from sentry.viewer_context import ActorType, get_viewer_context
 
 from . import EXAMPLE_PAYLOAD, get_integration, link_group
 
@@ -93,6 +95,27 @@ class JiraServerWebhookEndpointTest(APITestCase):
                 "issue": EXAMPLE_PAYLOAD["issue"],
             },
         )
+
+    @override_options({"viewer-context.enabled": True})
+    @patch.object(JiraServerIntegration, "sync_status_inbound")
+    def test_post_update_status_sets_viewer_context(self, mock_sync: MagicMock) -> None:
+        captured_contexts: list = []
+
+        def capture_context(*args: object, **kwargs: object) -> None:
+            captured_contexts.append(get_viewer_context())
+
+        mock_sync.side_effect = capture_context
+
+        project = self.create_project()
+        self.create_group(project=project)
+
+        self.get_success_response(self.jwt_token, **EXAMPLE_PAYLOAD)
+
+        assert len(captured_contexts) == 1
+        vc = captured_contexts[0]
+        assert vc is not None
+        assert vc.organization_id == self.organization.id
+        assert vc.actor_type == ActorType.INTEGRATION
 
     @responses.activate
     def test_post_update_status_token_error(self) -> None:


### PR DESCRIPTION
## Summary
- Wraps the per-org iteration in `handle_status_change` with `webhook_viewer_context` so downstream code has access to the current organization identity via the ViewerContext contextvar.
- Gated behind the `viewer-context.enabled` option (no-op when disabled).
- Part of the ViewerContext RFC rollout for webhook handlers.