### PR TITLE
fix(billing): Prevent crash on invalid data category for plan

### DIFF
--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -185,7 +185,23 @@ export function getBucket({
       return buckets[slot]!;
     }
   }
-  throw new Error('Invalid data category for plan');
+
+  // Report to Sentry but don't crash the page
+  Sentry.withScope(scope => {
+    scope.setExtras({
+      buckets,
+      events,
+      price,
+      shouldMinimize,
+    });
+    Sentry.captureException(new Error('Invalid data category for plan'));
+  });
+
+  // Return a fallback bucket with zero price to prevent crashes
+  return {
+    price: 0,
+    quantity: events ?? 0,
+  };
 }
 
 type ReservedTotalProps = {


### PR DESCRIPTION
The billing overview page (`/settings/billing/overview/`) was crashing when the `getBucket` function encountered a data category that didn't have a corresponding bucket in the plan's configuration.

This could happen when:
- A plan has an unexpected or newly added data category (e.g., `seer_user`)
- The plan's bucket configuration is incomplete or mismatched

**Changes:**
- Modified `getBucket` to report errors to Sentry with full context (buckets, events, price, shouldMinimize)
- Returns a fallback bucket with zero price instead of throwing an error
- The page now continues to render instead of crashing

**Impact:**
- Users no longer experience crashes on the billing page
- We still get error reports in Sentry to investigate which data categories are causing issues
- The affected product row displays with $0 additional spend (a safe fallback)

This maintains observability while providing a better user experience.