### PR TITLE
perf(issues): Fix N+1 queries in starred views endpoint

### DIFF
--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -1,6 +1,8 @@
 from collections.abc import MutableMapping
 from typing import Any, TypedDict
 
+from django.db.models import prefetch_related_objects
+
 from sentry.api.serializers import Serializer, register
 from sentry.models.groupsearchview import GroupSearchView
 from sentry.models.groupsearchviewlastvisited import GroupSearchViewLastVisited
@@ -33,6 +35,7 @@ class GroupSearchViewSerializer(Serializer):
         super().__init__(*args, **kwargs)
 
     def get_attrs(self, item_list, user, **kwargs) -> MutableMapping[Any, Any]:
+        prefetch_related_objects(item_list, "projects")
         attrs: MutableMapping[Any, Any] = {}
 
         last_visited_views = GroupSearchViewLastVisited.objects.filter(

--- a/src/sentry/api/serializers/models/groupsearchview.py
+++ b/src/sentry/api/serializers/models/groupsearchview.py
@@ -68,7 +68,7 @@ class GroupSearchViewSerializer(Serializer):
         return attrs
 
     def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewSerializerResponse:
-        projects = [-1] if obj.is_all_projects else list(obj.projects.values_list("id", flat=True))
+        projects = [-1] if obj.is_all_projects else [p.id for p in obj.projects.all()]
 
         return {
             "id": str(obj.id),

--- a/src/sentry/api/serializers/models/groupsearchviewstarred.py
+++ b/src/sentry/api/serializers/models/groupsearchviewstarred.py
@@ -3,7 +3,6 @@ from typing import TypedDict
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.groupsearchview import (
     GroupSearchViewSerializer,
-    GroupSearchViewSerializerResponse,
 )
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.savedsearch import SORT_LITERALS
@@ -28,13 +27,14 @@ class GroupSearchViewStarredSerializer(Serializer):
         self.organization = kwargs.pop("organization", None)
         super().__init__(*args, **kwargs)
 
-    def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewStarredSerializerResponse:
-        serialized_view: GroupSearchViewSerializerResponse = serialize(
-            obj.group_search_view,
+    def get_attrs(self, item_list, user, **kwargs):
+        views = [item.group_search_view for item in item_list]
+        serialized_views = serialize(
+            views,
             user,
-            serializer=GroupSearchViewSerializer(
-                organization=self.organization,
-            ),
+            serializer=GroupSearchViewSerializer(organization=self.organization),
         )
+        return dict(zip(item_list, serialized_views))
 
-        return serialized_view
+    def serialize(self, obj, attrs, user, **kwargs) -> GroupSearchViewStarredSerializerResponse:
+        return attrs

--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -31,13 +31,9 @@ class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
         """
 
         assert request.user.id is not None
-        starred_views = (
-            GroupSearchViewStarred.objects.filter(
-                organization=organization, user_id=request.user.id
-            )
-            .select_related("group_search_view")
-            .prefetch_related("group_search_view__projects")
-        )
+        starred_views = GroupSearchViewStarred.objects.filter(
+            organization=organization, user_id=request.user.id
+        ).select_related("group_search_view")
 
         return self.paginate(
             request=request,

--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -31,9 +31,13 @@ class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
         """
 
         assert request.user.id is not None
-        starred_views = GroupSearchViewStarred.objects.filter(
-            organization=organization, user_id=request.user.id
-        ).select_related("group_search_view")
+        starred_views = (
+            GroupSearchViewStarred.objects.filter(
+                organization=organization, user_id=request.user.id
+            )
+            .select_related("group_search_view")
+            .prefetch_related("group_search_view__projects")
+        )
 
         return self.paginate(
             request=request,


### PR DESCRIPTION
The starred views serializer was calling `serialize()` individually per item, triggering separate `get_attrs()` calls for each view - roughly 4N+1 queries for N starred views. Saw this endpoint taking 1.3s in production.

Batch-serialize all views in a single `get_attrs()` call instead. Also adds `prefetch_related` for the projects M2M and switches `values_list()` to `.all()` so Django's prefetch cache is actually used.

[example trace w/ n+1](https://sentry.sentry.io/insights/summary/trace/8ca7fa1241cb4f28b317ddd079eb01ae/?node=span-acdf0e34aeb1edd2&project=1&query=organization.slug%3Asentry&referrer=performance-transaction-summary&segmentSpansCursor=0%3A5%3A0&showTransactions=slow&source=performance_transaction_summary&statsPeriod=14d&timestamp=1774981357&transaction=%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fgroup-search-views%2Fstarred%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)
[transaction summary](https://sentry.sentry.io/insights/summary/?project=1&referrer=performance-transaction-summary&statsPeriod=14d&transaction=%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fgroup-search-views%2Fstarred%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)