### PR TITLE
feat(seer): Add Night Shift nightly autofix cron scaffolding

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -991,6 +991,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tasks.seer.explorer_index",
     "sentry.tasks.seer.context_engine_index",
     "sentry.tasks.seer.lightweight_rca_cluster",
+    "sentry.tasks.seer.night_shift",
     # Used for tests
     "sentry.taskworker.tasks.examples",
 )

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1173,6 +1173,11 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         # Run once a month at midnight
         "schedule": crontab("0", "0", "*", "1", "*"),
     },
+    "seer-night-shift": {
+        "task": "seer:sentry.tasks.seer.night_shift.schedule_night_shift",
+        # Run daily at 10:00 AM UTC (2/3 AM Pacific)
+        "schedule": crontab("0", "10", "*", "*", "*"),
+    },
     "refresh-artifact-bundles-in-use": {
         "task": "attachments:sentry.debug_files.tasks.refresh_artifact_bundles_in_use",
         "schedule": crontab("*/1", "*", "*", "*", "*"),

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -300,6 +300,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer Index job
     manager.add("organizations:seer-explorer-index", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable Seer Night Shift nightly autofix cron
+    manager.add("organizations:seer-night-shift", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable streaming responses for Seer Explorer
     manager.add("organizations:seer-explorer-streaming", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable context engine for Seer Explorer

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1373,6 +1373,17 @@ register(
     default=0.0,
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "seer.night_shift.enable",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "seer.night_shift.issues_per_org",
+    default=5,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Supergroups / Lightweight RCA
 register(

--- a/src/sentry/seer/autofix/constants.py
+++ b/src/sentry/seer/autofix/constants.py
@@ -54,6 +54,7 @@ class AutofixReferrer(enum.StrEnum):
     ISSUE_SUMMARY_POST_PROCESS_FIXABILITY = "issue_summary.post_process_fixability"
     SLACK = "slack"
     ON_COMPLETION_HOOK = "autofix.on_completion_hook"
+    NIGHT_SHIFT = "night_shift"
     UNKNOWN = "unknown"
 
 
@@ -61,3 +62,4 @@ class SeerAutomationSource(enum.Enum):
     ISSUE_DETAILS = "issue_details"
     ALERT = "alert"
     POST_PROCESS = "post_process"
+    NIGHT_SHIFT = "night_shift"

--- a/src/sentry/tasks/seer/night_shift.py
+++ b/src/sentry/tasks/seer/night_shift.py
@@ -8,7 +8,6 @@ import sentry_sdk
 
 from sentry import features, options
 from sentry.models.organization import Organization, OrganizationStatus
-from sentry.seer.autofix.constants import SeerAutomationSource
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.iterators import chunked
@@ -23,8 +22,6 @@ FEATURE_NAMES = [
     "organizations:seer-night-shift",
     "organizations:gen-ai-features",
 ]
-
-NIGHT_SHIFT_AUTO_RUN_SOURCE = SeerAutomationSource.NIGHT_SHIFT.value
 
 
 @instrumented_task(
@@ -50,7 +47,7 @@ def schedule_night_shift() -> None:
         ),
         100,
     ):
-        eligible_ids = _get_eligible_org_ids_from_batch_d7(org_batch)
+        eligible_ids = _get_eligible_org_ids_from_batch(org_batch)
 
         org_map = {org.id: org for org in org_batch}
         for org_id in eligible_ids:
@@ -102,7 +99,7 @@ def run_night_shift_for_org(organization_id: int) -> None:
     )
 
 
-def _get_eligible_org_ids_from_batch_d7(
+def _get_eligible_org_ids_from_batch(
     orgs: Sequence[Organization],
 ) -> list[int]:
     """

--- a/src/sentry/tasks/seer/night_shift.py
+++ b/src/sentry/tasks/seer/night_shift.py
@@ -47,19 +47,14 @@ def schedule_night_shift() -> None:
         ),
         100,
     ):
-        eligible_ids = _get_eligible_org_ids_from_batch(org_batch)
-
-        org_map = {org.id: org for org in org_batch}
-        for org_id in eligible_ids:
-            org = org_map[org_id]
-
+        for org in _get_eligible_orgs_from_batch(org_batch):
             if bool(org.get_option("sentry:hide_ai_features")):
                 continue
 
             delay = (batch_index * NIGHT_SHIFT_DISPATCH_STEP_SECONDS) % spread_seconds
 
             run_night_shift_for_org.apply_async(
-                args=[org_id],
+                args=[org.id],
                 countdown=delay,
             )
             batch_index += 1
@@ -99,24 +94,23 @@ def run_night_shift_for_org(organization_id: int) -> None:
     )
 
 
-def _get_eligible_org_ids_from_batch(
+def _get_eligible_orgs_from_batch(
     orgs: Sequence[Organization],
-) -> list[int]:
+) -> list[Organization]:
     """
     Check feature flags for a batch of orgs using batch_has_for_organizations.
-    Returns org IDs that have all required feature flags enabled.
+    Returns orgs that have all required feature flags enabled.
     """
-    eligible = {org.id for org in orgs}
+    eligible = list(orgs)
 
     for feature_name in FEATURE_NAMES:
-        batch_result = features.batch_has_for_organizations(feature_name, orgs)
+        batch_result = features.batch_has_for_organizations(feature_name, eligible)
         if batch_result is None:
             raise RuntimeError(f"batch_has_for_organizations returned None for {feature_name}")
 
-        passing = {org.id for org in orgs if batch_result.get(f"organization:{org.id}", False)}
-        eligible &= passing
+        eligible = [org for org in eligible if batch_result.get(f"organization:{org.id}", False)]
 
         if not eligible:
             return []
 
-    return list(eligible)
+    return eligible

--- a/src/sentry/tasks/seer/night_shift.py
+++ b/src/sentry/tasks/seer/night_shift.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import timedelta
+
+import sentry_sdk
+
+from sentry import features, options
+from sentry.models.organization import Organization, OrganizationStatus
+from sentry.seer.autofix.constants import SeerAutomationSource
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import seer_tasks
+from sentry.utils.iterators import chunked
+from sentry.utils.query import RangeQuerySetWrapper
+
+logger = logging.getLogger("sentry.tasks.seer.night_shift")
+
+NIGHT_SHIFT_DISPATCH_STEP_SECONDS = 37
+NIGHT_SHIFT_SPREAD_DURATION = timedelta(hours=4)
+
+FEATURE_NAMES = [
+    "organizations:seer-night-shift",
+    "organizations:gen-ai-features",
+]
+
+NIGHT_SHIFT_AUTO_RUN_SOURCE = SeerAutomationSource.NIGHT_SHIFT.value
+
+
+@instrumented_task(
+    name="sentry.tasks.seer.night_shift.schedule_night_shift",
+    namespace=seer_tasks,
+    processing_deadline_duration=15 * 60,
+)
+def schedule_night_shift() -> None:
+    """
+    Nightly scheduler: iterates active orgs in batches, checks feature flags
+    in bulk, and dispatches per-org worker tasks with jitter.
+    """
+    if not options.get("seer.night_shift.enable"):
+        return
+
+    spread_seconds = int(NIGHT_SHIFT_SPREAD_DURATION.total_seconds())
+    batch_index = 0
+
+    for org_batch in chunked(
+        RangeQuerySetWrapper[Organization](
+            Organization.objects.filter(status=OrganizationStatus.ACTIVE),
+            step=1000,
+        ),
+        100,
+    ):
+        eligible_ids = _get_eligible_org_ids_from_batch_d7(org_batch)
+
+        org_map = {org.id: org for org in org_batch}
+        for org_id in eligible_ids:
+            org = org_map[org_id]
+
+            if bool(org.get_option("sentry:hide_ai_features")):
+                continue
+
+            delay = (batch_index * NIGHT_SHIFT_DISPATCH_STEP_SECONDS) % spread_seconds
+
+            run_night_shift_for_org.apply_async(
+                args=[org_id],
+                countdown=delay,
+            )
+            batch_index += 1
+
+    logger.info(
+        "night_shift.schedule_complete",
+        extra={"orgs_dispatched": batch_index},
+    )
+
+
+@instrumented_task(
+    name="sentry.tasks.seer.night_shift.run_night_shift_for_org",
+    namespace=seer_tasks,
+    processing_deadline_duration=5 * 60,
+)
+def run_night_shift_for_org(organization_id: int) -> None:
+    try:
+        organization = Organization.objects.get(
+            id=organization_id, status=OrganizationStatus.ACTIVE
+        )
+    except Organization.DoesNotExist:
+        return
+
+    sentry_sdk.set_tags(
+        {
+            "organization_id": organization.id,
+            "organization_slug": organization.slug,
+        }
+    )
+
+    logger.info(
+        "night_shift.org_dispatched",
+        extra={
+            "organization_id": organization_id,
+            "organization_slug": organization.slug,
+        },
+    )
+
+
+def _get_eligible_org_ids_from_batch_d7(
+    orgs: Sequence[Organization],
+) -> list[int]:
+    """
+    Check feature flags for a batch of orgs using batch_has_for_organizations.
+    Returns org IDs that have all required feature flags enabled.
+    """
+    eligible = {org.id for org in orgs}
+
+    for feature_name in FEATURE_NAMES:
+        batch_result = features.batch_has_for_organizations(feature_name, orgs)
+        if batch_result is None:
+            batch_result = {
+                f"organization:{org.id}": features.has(feature_name, org) for org in orgs
+            }
+
+        passing = {org.id for org in orgs if batch_result.get(f"organization:{org.id}", False)}
+        eligible &= passing
+
+        if not eligible:
+            return []
+
+    return list(eligible)

--- a/src/sentry/tasks/seer/night_shift.py
+++ b/src/sentry/tasks/seer/night_shift.py
@@ -111,9 +111,7 @@ def _get_eligible_org_ids_from_batch(
     for feature_name in FEATURE_NAMES:
         batch_result = features.batch_has_for_organizations(feature_name, orgs)
         if batch_result is None:
-            batch_result = {
-                f"organization:{org.id}": features.has(feature_name, org) for org in orgs
-            }
+            raise RuntimeError(f"batch_has_for_organizations returned None for {feature_name}")
 
         passing = {org.id for org in orgs if batch_result.get(f"organization:{org.id}", False)}
         eligible &= passing

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -1,0 +1,79 @@
+from unittest.mock import patch
+
+from sentry.tasks.seer.night_shift import (
+    run_night_shift_for_org,
+    schedule_night_shift,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@django_db_all
+class TestScheduleNightShift(TestCase):
+    def test_disabled_by_option(self) -> None:
+        with (
+            self.options({"seer.night_shift.enable": False}),
+            patch("sentry.tasks.seer.night_shift.run_night_shift_for_org") as mock_worker,
+        ):
+            schedule_night_shift()
+            mock_worker.apply_async.assert_not_called()
+
+    def test_dispatches_eligible_orgs(self) -> None:
+        org = self.create_organization()
+
+        with (
+            self.options({"seer.night_shift.enable": True}),
+            self.feature(
+                {
+                    "organizations:seer-night-shift": [org.slug],
+                    "organizations:gen-ai-features": [org.slug],
+                }
+            ),
+            patch("sentry.tasks.seer.night_shift.run_night_shift_for_org") as mock_worker,
+        ):
+            schedule_night_shift()
+            mock_worker.apply_async.assert_called_once()
+            assert mock_worker.apply_async.call_args.kwargs["args"] == [org.id]
+
+    def test_skips_ineligible_orgs(self) -> None:
+        self.create_organization()
+
+        with (
+            self.options({"seer.night_shift.enable": True}),
+            patch("sentry.tasks.seer.night_shift.run_night_shift_for_org") as mock_worker,
+        ):
+            schedule_night_shift()
+            mock_worker.apply_async.assert_not_called()
+
+    def test_skips_orgs_with_hidden_ai(self) -> None:
+        org = self.create_organization()
+        org.update_option("sentry:hide_ai_features", True)
+
+        with (
+            self.options({"seer.night_shift.enable": True}),
+            self.feature(
+                {
+                    "organizations:seer-night-shift": [org.slug],
+                    "organizations:gen-ai-features": [org.slug],
+                }
+            ),
+            patch("sentry.tasks.seer.night_shift.run_night_shift_for_org") as mock_worker,
+        ):
+            schedule_night_shift()
+            mock_worker.apply_async.assert_not_called()
+
+
+@django_db_all
+class TestRunNightShiftForOrg(TestCase):
+    def test_logs_for_valid_org(self) -> None:
+        org = self.create_organization()
+
+        with patch("sentry.tasks.seer.night_shift.logger") as mock_logger:
+            run_night_shift_for_org(org.id)
+            mock_logger.info.assert_called_once()
+            assert mock_logger.info.call_args.args[0] == "night_shift.org_dispatched"
+
+    def test_nonexistent_org(self) -> None:
+        with patch("sentry.tasks.seer.night_shift.logger") as mock_logger:
+            run_night_shift_for_org(999999999)
+            mock_logger.info.assert_not_called()


### PR DESCRIPTION
Add the scaffolding for a nightly cron job ("Night Shift") that fans out per-org to trigger Seer Autofix on top issues. This decouples automation from the hot `post_process` pipeline, enabling better issue selection and serving lower-volume orgs.

The scheduler iterates active orgs using batched feature flag checks (`batch_has_for_organizations`) to avoid N+1, applies deterministic jitter to spread load, and dispatches per-org worker tasks. The worker task is currently a stub that just logs — the issue selection and autofix triggering logic will be added in a follow-up once we've decided on the approach.

**What's included:**
- `schedule_night_shift()` — cron scheduler task (daily at 10:00 AM UTC / ~2-3 AM PT)
- `run_night_shift_for_org()` — per-org worker task (stub for now)
- Feature flag: `organizations:seer-night-shift` (flagpole, disabled by default)
- Options: `seer.night_shift.enable` (global killswitch), `seer.night_shift.issues_per_org`
- `NIGHT_SHIFT` referrer and automation source enums
- Cron schedule entry in `TASKWORKER_REGION_SCHEDULES`

**Not included (follow-ups):**
- Issue selection logic in the worker task
- Options-automator config (must deploy this PR first)

Refs https://www.notion.so/sentry/Seer-Night-Shift-3338b10e4b5d807e80a6fbd6d70b3f60