### PR TITLE
fix(rpc): fix seer RPC exception handling to default to 500 and preserve rest APIException

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -269,13 +269,15 @@ class SeerRpcServiceEndpoint(Endpoint):
         except SnubaRPCRateLimitExceeded as e:
             sentry_sdk.capture_exception()
             raise Throttled(detail="Rate limit exceeded") from e
+        except APIException:
+            raise
         except Exception as e:
             if in_test_environment():
                 raise
             if settings.DEBUG:
                 raise Exception(f"Problem processing seer rpc endpoint {method_name}") from e
             sentry_sdk.capture_exception()
-            raise ValidationError from e
+            raise APIException from e
         return Response(data=result)
 
 

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -84,6 +84,45 @@ class TestSeerRpc(APITestCase):
         assert response.status_code == 429
         assert "Rate limit exceeded" in response.data["detail"]
 
+    def test_rest_framework_exceptions_are_reraised(self) -> None:
+        """Test that REST framework exceptions preserve their status codes."""
+        from rest_framework.exceptions import APIException
+
+        class CustomAPIException(APIException):
+            status_code = 503
+            default_detail = "Service temporarily unavailable"
+
+        path = self._get_path("get_organization_slug")
+        data: dict[str, Any] = {"args": {"org_id": 1}, "meta": {}}
+
+        with patch(
+            "sentry.seer.endpoints.seer_rpc.SeerRpcServiceEndpoint._dispatch_to_local_method"
+        ) as mock_dispatch:
+            mock_dispatch.side_effect = CustomAPIException()
+
+            response = self.client.post(
+                path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
+            )
+
+        assert response.status_code == 503
+        assert "Service temporarily unavailable" in response.data["detail"]
+
+    def test_generic_exceptions_return_500(self) -> None:
+        """Test that generic exceptions return 500 instead of 400."""
+        path = self._get_path("get_organization_slug")
+        data: dict[str, Any] = {"args": {"org_id": 1}, "meta": {}}
+
+        with patch(
+            "sentry.seer.endpoints.seer_rpc.SeerRpcServiceEndpoint._dispatch_to_local_method"
+        ) as mock_dispatch:
+            mock_dispatch.side_effect = RuntimeError("Unexpected internal error")
+
+            response = self.client.post(
+                path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
+            )
+
+        assert response.status_code == 500
+
 
 class TestSeerRpcMethods(APITestCase):
     """Test individual RPC methods"""

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -112,16 +112,21 @@ class TestSeerRpc(APITestCase):
         path = self._get_path("get_organization_slug")
         data: dict[str, Any] = {"args": {"org_id": 1}, "meta": {}}
 
-        with patch(
-            "sentry.seer.endpoints.seer_rpc.SeerRpcServiceEndpoint._dispatch_to_local_method"
-        ) as mock_dispatch:
-            mock_dispatch.side_effect = RuntimeError("Unexpected internal error")
+        for is_test_environment in [True, False]:
+            with patch(
+                "sentry.seer.endpoints.seer_rpc.in_test_environment",
+                return_value=is_test_environment,
+            ):
+                with patch(
+                    "sentry.seer.endpoints.seer_rpc.SeerRpcServiceEndpoint._dispatch_to_local_method"
+                ) as mock_dispatch:
+                    mock_dispatch.side_effect = RuntimeError("Unexpected internal error")
 
-            response = self.client.post(
-                path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
-            )
+                    response = self.client.post(
+                        path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
+                    )
 
-        assert response.status_code == 500
+                assert response.status_code == 500
 
 
 class TestSeerRpcMethods(APITestCase):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When Seer makes RPC calls to Sentry and encounters downstream errors (like 429 rate limits or 500 errors from Snuba), the current code catches all exceptions and re-raises them as `ValidationError` (400). This misrepresents the actual issue, making it appear as if the client sent bad request parameters when the real cause is a downstream service error.

Example issue: https://sentry.dev.getsentry.net:7999/issues/7380803020/events/d3e6e1d5ddf44d7b94c86e6ce2435ea6/

## Solution

This PR fixes the exception handling in the seer RPC endpoint to raise a generic 500 APIException by default, implying an error happened on sentry server. Also re-raises APIException's (base class for rest framework excs) so developers can bubble their own status codes up to response for Seer.

1. **Added a handler to re-raise REST framework exceptions directly** - Any `APIException` (which includes `Throttled`, custom API exceptions, etc.) is now re-raised as-is, preserving its status code
2. **Changed generic exception handler to raise `APIException` (500) instead of `ValidationError` (400)** - Unknown errors now correctly return 500 Internal Server Error instead of 400 Bad Request

### Changes

- Modified `SeerRpcServiceEndpoint.post()` in `src/sentry/seer/endpoints/seer_rpc.py`:
  - Added `except APIException: raise` handler before the generic exception handler
  - Changed `raise ValidationError from e` to `raise APIException from e` for generic exceptions
- Added test cases in `tests/sentry/seer/endpoints/test_seer_rpc.py`:
  - `test_rest_framework_exceptions_are_reraised` - verifies custom API exceptions preserve their status codes
  - `test_generic_exceptions_return_500` - verifies generic exceptions return 500 instead of 400

## Testing

Pre-commit checks pass ✅

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0AAF0JD0GK/p1775600719171269?thread_ts=1775600719.171269&cid=C0AAF0JD0GK)

<div><a href="https://cursor.com/agents/bc-8bf9c0b1-d369-5efa-81a7-a650bb7e83cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bf9c0b1-d369-5efa-81a7-a650bb7e83cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

