### PR TITLE
feat(seer): Add rca_source to supergroup queries with feature flag gating

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -571,6 +571,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:supergroup-embeddings-explorer", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable lightweight Explorer RCA runs for supergroup quality evaluation
     manager.add("projects:supergroup-lightweight-rca", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use lightweight RCA source for supergroup clustering and queries
+    manager.add("organizations:supergroups-lightweight-rca-clustering", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     manager.add("projects:workflow-engine-performance-detectors", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -571,8 +571,10 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:supergroup-embeddings-explorer", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable lightweight Explorer RCA runs for supergroup quality evaluation
     manager.add("projects:supergroup-lightweight-rca", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use lightweight RCA source for supergroup clustering and queries
-    manager.add("organizations:supergroups-lightweight-rca-clustering", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable lightweight RCA clustering write path (generate embeddings on new issues)
+    manager.add("organizations:supergroups-lightweight-rca-clustering-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable lightweight RCA clustering read path (query lightweight embeddings in supergroup APIs)
+    manager.add("organizations:supergroups-lightweight-rca-clustering-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     manager.add("projects:workflow-engine-performance-detectors", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1385,14 +1385,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Supergroups / Lightweight RCA
-register(
-    "supergroups.lightweight-enabled-orgs",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # ## sentry.killswitches
 #
 # The following options are documented in sentry.killswitches in more detail

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import logging
+from enum import StrEnum
 from typing import Any, NotRequired, TypedDict
 from urllib.parse import urlparse
 
@@ -369,6 +370,11 @@ class SummarizeIssueRequest(TypedDict):
     experiment_variant: NotRequired[str | None]
 
 
+class RCASource(StrEnum):
+    EXPLORER = "explorer"
+    LIGHTWEIGHT = "lightweight"
+
+
 class SupergroupsEmbeddingRequest(TypedDict):
     organization_id: int
     group_id: int
@@ -387,11 +393,13 @@ class LightweightRCAClusterRequest(TypedDict):
 class SupergroupsGetRequest(TypedDict):
     organization_id: int
     supergroup_id: int
+    rca_source: str
 
 
 class SupergroupsGetByGroupIdsRequest(TypedDict):
     organization_id: int
     group_ids: list[int]
+    rca_source: str
 
 
 class SupergroupDetailData(TypedDict):

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -371,8 +371,8 @@ class SummarizeIssueRequest(TypedDict):
 
 
 class RCASource(StrEnum):
-    EXPLORER = "explorer"
-    LIGHTWEIGHT = "lightweight"
+    EXPLORER = "EXPLORER"
+    LIGHTWEIGHT = "LIGHTWEIGHT"
 
 
 class SupergroupsEmbeddingRequest(TypedDict):

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
@@ -12,7 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.signed_seer_api import SeerViewerContext, make_supergroups_get_request
+from sentry.seer.signed_seer_api import RCASource, SeerViewerContext, make_supergroups_get_request
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +35,18 @@ class OrganizationSupergroupDetailsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:top-issues-ui", organization, actor=request.user):
             return Response({"detail": "Feature not available"}, status=403)
 
+        rca_source = (
+            RCASource.LIGHTWEIGHT
+            if features.has("organizations:supergroups-lightweight-rca-clustering", organization)
+            else RCASource.EXPLORER
+        )
+
         response = make_supergroups_get_request(
-            {"organization_id": organization.id, "supergroup_id": supergroup_id},
+            {
+                "organization_id": organization.id,
+                "supergroup_id": supergroup_id,
+                "rca_source": rca_source,
+            },
             SeerViewerContext(organization_id=organization.id, user_id=request.user.id),
             timeout=10,
         )

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
@@ -37,7 +37,9 @@ class OrganizationSupergroupDetailsEndpoint(OrganizationEndpoint):
 
         rca_source = (
             RCASource.LIGHTWEIGHT
-            if features.has("organizations:supergroups-lightweight-rca-clustering", organization)
+            if features.has(
+                "organizations:supergroups-lightweight-rca-clustering-read", organization
+            )
             else RCASource.EXPLORER
         )
 

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
@@ -80,7 +80,9 @@ class OrganizationSupergroupsByGroupEndpoint(OrganizationEndpoint):
 
         rca_source = (
             RCASource.LIGHTWEIGHT
-            if features.has("organizations:supergroups-lightweight-rca-clustering", organization)
+            if features.has(
+                "organizations:supergroups-lightweight-rca-clustering-read", organization
+            )
             else RCASource.EXPLORER
         )
 

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
@@ -15,6 +15,7 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.models.group import STATUS_QUERY_CHOICES, Group
 from sentry.models.organization import Organization
 from sentry.seer.signed_seer_api import (
+    RCASource,
     SeerViewerContext,
     SupergroupsByGroupIdsResponse,
     make_supergroups_get_by_group_ids_request,
@@ -77,8 +78,14 @@ class OrganizationSupergroupsByGroupEndpoint(OrganizationEndpoint):
                 status=status_codes.HTTP_404_NOT_FOUND,
             )
 
+        rca_source = (
+            RCASource.LIGHTWEIGHT
+            if features.has("organizations:supergroups-lightweight-rca-clustering", organization)
+            else RCASource.EXPLORER
+        )
+
         response = make_supergroups_get_by_group_ids_request(
-            {"organization_id": organization.id, "group_ids": group_ids},
+            {"organization_id": organization.id, "group_ids": group_ids, "rca_source": rca_source},
             SeerViewerContext(organization_id=organization.id, user_id=request.user.id),
             timeout=10,
         )

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1593,8 +1593,7 @@ def kick_off_lightweight_rca_cluster(job: PostProcessJob) -> None:
     event = job["event"]
     group = event.group
 
-    enabled_orgs: list[int] = options.get("supergroups.lightweight-enabled-orgs")
-    if group.organization.id not in enabled_orgs:
+    if not features.has("organizations:supergroups-lightweight-rca-clustering", group.organization):
         return
 
     trigger_lightweight_rca_cluster_task.delay(group.id)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1593,7 +1593,9 @@ def kick_off_lightweight_rca_cluster(job: PostProcessJob) -> None:
     event = job["event"]
     group = event.group
 
-    if not features.has("organizations:supergroups-lightweight-rca-clustering", group.organization):
+    if not features.has(
+        "organizations:supergroups-lightweight-rca-clustering-write", group.organization
+    ):
         return
 
     trigger_lightweight_rca_cluster_task.delay(group.id)

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import orjson
+
+from sentry.testutils.cases import APITestCase
+
+
+def mock_seer_response(data: dict[str, Any]) -> MagicMock:
+    response = MagicMock()
+    response.status = 200
+    response.data = orjson.dumps(data)
+    return response
+
+
+class OrganizationSupergroupDetailsEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-supergroup-details"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroup_details.make_supergroups_get_request"
+    )
+    def test_get_supergroup_details(self, mock_seer):
+        mock_seer.return_value = mock_seer_response(
+            {"id": 1, "title": "NullPointerException in auth", "group_ids": [10, 20]}
+        )
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(self.organization.slug, "1")
+
+        assert response.data["id"] == 1
+        assert response.data["title"] == "NullPointerException in auth"
+        assert response.data["group_ids"] == [10, 20]
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroup_details.make_supergroups_get_request"
+    )
+    def test_rca_source_defaults_to_explorer(self, mock_seer):
+        mock_seer.return_value = mock_seer_response({"id": 1, "title": "test"})
+
+        with self.feature("organizations:top-issues-ui"):
+            self.get_success_response(self.organization.slug, "1")
+
+        body = mock_seer.call_args.args[0]
+        assert body["rca_source"] == "explorer"
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroup_details.make_supergroups_get_request"
+    )
+    def test_rca_source_lightweight_when_flag_enabled(self, mock_seer):
+        mock_seer.return_value = mock_seer_response({"id": 1, "title": "test"})
+
+        with self.feature(
+            {
+                "organizations:top-issues-ui": True,
+                "organizations:supergroups-lightweight-rca-clustering": True,
+            }
+        ):
+            self.get_success_response(self.organization.slug, "1")
+
+        body = mock_seer.call_args.args[0]
+        assert body["rca_source"] == "lightweight"

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
@@ -47,7 +47,7 @@ class OrganizationSupergroupDetailsEndpointTest(APITestCase):
             self.get_success_response(self.organization.slug, "1")
 
         body = mock_seer.call_args.args[0]
-        assert body["rca_source"] == "explorer"
+        assert body["rca_source"] == "EXPLORER"
 
     @patch(
         "sentry.seer.supergroups.endpoints.organization_supergroup_details.make_supergroups_get_request"
@@ -64,4 +64,4 @@ class OrganizationSupergroupDetailsEndpointTest(APITestCase):
             self.get_success_response(self.organization.slug, "1")
 
         body = mock_seer.call_args.args[0]
-        assert body["rca_source"] == "lightweight"
+        assert body["rca_source"] == "LIGHTWEIGHT"

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
@@ -58,7 +58,7 @@ class OrganizationSupergroupDetailsEndpointTest(APITestCase):
         with self.feature(
             {
                 "organizations:top-issues-ui": True,
-                "organizations:supergroups-lightweight-rca-clustering": True,
+                "organizations:supergroups-lightweight-rca-clustering-read": True,
             }
         ):
             self.get_success_response(self.organization.slug, "1")

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -74,3 +74,38 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
                 status="bogus",
                 status_code=400,
             )
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroups_by_group.make_supergroups_get_by_group_ids_request"
+    )
+    def test_rca_source_defaults_to_explorer(self, mock_seer):
+        mock_seer.return_value = mock_seer_response({"data": []})
+
+        with self.feature("organizations:top-issues-ui"):
+            self.get_success_response(
+                self.organization.slug,
+                group_id=[self.unresolved_group.id],
+            )
+
+        body = mock_seer.call_args.args[0]
+        assert body["rca_source"] == "explorer"
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroups_by_group.make_supergroups_get_by_group_ids_request"
+    )
+    def test_rca_source_lightweight_when_flag_enabled(self, mock_seer):
+        mock_seer.return_value = mock_seer_response({"data": []})
+
+        with self.feature(
+            {
+                "organizations:top-issues-ui": True,
+                "organizations:supergroups-lightweight-rca-clustering": True,
+            }
+        ):
+            self.get_success_response(
+                self.organization.slug,
+                group_id=[self.unresolved_group.id],
+            )
+
+        body = mock_seer.call_args.args[0]
+        assert body["rca_source"] == "lightweight"

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -99,7 +99,7 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
         with self.feature(
             {
                 "organizations:top-issues-ui": True,
-                "organizations:supergroups-lightweight-rca-clustering": True,
+                "organizations:supergroups-lightweight-rca-clustering-read": True,
             }
         ):
             self.get_success_response(

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -88,7 +88,7 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
             )
 
         body = mock_seer.call_args.args[0]
-        assert body["rca_source"] == "explorer"
+        assert body["rca_source"] == "EXPLORER"
 
     @patch(
         "sentry.seer.supergroups.endpoints.organization_supergroups_by_group.make_supergroups_get_by_group_ids_request"
@@ -108,4 +108,4 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
             )
 
         body = mock_seer.call_args.args[0]
-        assert body["rca_source"] == "lightweight"
+        assert body["rca_source"] == "LIGHTWEIGHT"

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3078,7 +3078,7 @@ class KickOffLightweightRCAClusterTestMixin(BasePostProcessGroupMixin):
             project_id=self.project.id,
         )
 
-        with self.feature("organizations:supergroups-lightweight-rca-clustering"):
+        with self.feature("organizations:supergroups-lightweight-rca-clustering-write"):
             self.call_post_process_group(
                 is_new=True,
                 is_regression=False,
@@ -3111,7 +3111,7 @@ class KickOffLightweightRCAClusterTestMixin(BasePostProcessGroupMixin):
             project_id=self.project.id,
         )
 
-        with self.feature("organizations:supergroups-lightweight-rca-clustering"):
+        with self.feature("organizations:supergroups-lightweight-rca-clustering-write"):
             self.call_post_process_group(
                 is_new=False,
                 is_regression=False,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3078,7 +3078,7 @@ class KickOffLightweightRCAClusterTestMixin(BasePostProcessGroupMixin):
             project_id=self.project.id,
         )
 
-        with self.options({"supergroups.lightweight-enabled-orgs": [self.project.organization.id]}):
+        with self.feature("organizations:supergroups-lightweight-rca-clustering"):
             self.call_post_process_group(
                 is_new=True,
                 is_regression=False,
@@ -3095,13 +3095,12 @@ class KickOffLightweightRCAClusterTestMixin(BasePostProcessGroupMixin):
             project_id=self.project.id,
         )
 
-        with self.options({"supergroups.lightweight-enabled-orgs": []}):
-            self.call_post_process_group(
-                is_new=True,
-                is_regression=False,
-                is_new_group_environment=True,
-                event=event,
-            )
+        self.call_post_process_group(
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            event=event,
+        )
 
         mock_task.assert_not_called()
 
@@ -3112,7 +3111,7 @@ class KickOffLightweightRCAClusterTestMixin(BasePostProcessGroupMixin):
             project_id=self.project.id,
         )
 
-        with self.options({"supergroups.lightweight-enabled-orgs": [self.project.organization.id]}):
+        with self.feature("organizations:supergroups-lightweight-rca-clustering"):
             self.call_post_process_group(
                 is_new=False,
                 is_regression=False,


### PR DESCRIPTION
Add `rca_source` parameter to supergroup query APIs so Seer knows which embedding space (explorer vs lightweight) to query from. The source is determined by the `organizations:supergroups-lightweight-rca-clustering` feature flag.

Also replaces the `supergroups.lightweight-enabled-orgs` sentry-option with this feature flag for both:
- **Write path**: post_process task dispatch for lightweight RCA clustering
- **Read path**: supergroup query endpoints (details + by-group)

This is consistent with how all other supergroup features are gated (via feature flags, not options).

Depends on #112229 (merged).