### PR TITLE
Remove deprecated fields from CustomerUsage type

### DIFF
--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -571,8 +571,6 @@ export type BillingStatTotal = {
 };
 
 export type CustomerUsage = {
-  onDemandEventsAllowed: number;
-  onDemandMaxSpend: number;
   periodEnd: string;
   periodStart: string;
   stats: Record<string, BillingStats>;

--- a/tests/js/getsentry-test/fixtures/customerUsage.ts
+++ b/tests/js/getsentry-test/fixtures/customerUsage.ts
@@ -8,8 +8,6 @@ export function CustomerUsageFixture(
   return {
     periodStart: '2022-06-01',
     periodEnd: '2022-06-30',
-    onDemandMaxSpend: 0,
-    onDemandEventsAllowed: 0,
     totals: {
       errors: UsageTotalFixture(),
       transactions: UsageTotalFixture(),


### PR DESCRIPTION
The onDemandMaxSpend and onDemandEventsAllowed fields on the customer usage endpoint response have been deprecated since 2022 and are not read by any frontend consumer.
