### PR TITLE
ref(issue-list): Simplify monitors dropdown labels and item behavior

### DIFF
--- a/static/app/views/issueList/monitorsDropdown.spec.tsx
+++ b/static/app/views/issueList/monitorsDropdown.spec.tsx
@@ -27,10 +27,10 @@ describe('MonitorsDropdown', () => {
     await userEvent.click(dropdown);
 
     expect(
-      await screen.findByRole('menuitemradio', {name: /2 Active Cron Monitors/})
+      await screen.findByRole('menuitemradio', {name: /View Cron Monitors/})
     ).toHaveAttribute('href', '/organizations/org-slug/insights/crons/');
     expect(
-      await screen.findByRole('menuitemradio', {name: /1 Active Uptime Monitor/})
+      await screen.findByRole('menuitemradio', {name: /View Uptime Monitors/})
     ).toHaveAttribute('href', '/organizations/org-slug/insights/uptime/');
   });
 });

--- a/static/app/views/issueList/monitorsDropdown.spec.tsx
+++ b/static/app/views/issueList/monitorsDropdown.spec.tsx
@@ -27,10 +27,10 @@ describe('MonitorsDropdown', () => {
     await userEvent.click(dropdown);
 
     expect(
-      await screen.findByRole('menuitemradio', {name: /View Cron Monitors/})
+      await screen.findByRole('menuitemradio', {name: /View Active Cron Monitors/})
     ).toHaveAttribute('href', '/organizations/org-slug/insights/crons/');
     expect(
-      await screen.findByRole('menuitemradio', {name: /View Uptime Monitors/})
+      await screen.findByRole('menuitemradio', {name: /View Active Uptime Monitors/})
     ).toHaveAttribute('href', '/organizations/org-slug/insights/uptime/');
   });
 });

--- a/static/app/views/issueList/monitorsDropdown.tsx
+++ b/static/app/views/issueList/monitorsDropdown.tsx
@@ -1,7 +1,6 @@
 import {DropdownButton} from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {IconArrow} from 'sentry/icons';
-import {tn} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {keepPreviousData, useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -66,39 +65,29 @@ export function MonitorsDropdown() {
       items={[
         {
           key: 'crons',
-          label: tn(
-            '%s Active Cron Monitor',
-            '%s Active Cron Monitors',
-            cronsData?.counts.active
-          ),
+          label: t('View Cron Monitors (%s)', cronsData.counts.active),
           to: `/organizations/${organization.slug}/insights/crons/`,
           details:
-            cronsData?.counts.disabled > 0
+            cronsData.counts.disabled > 0
               ? tn(
                   '%s disabled monitor',
                   '%s disabled monitors',
-                  cronsData?.counts.disabled
+                  cronsData.counts.disabled
                 )
               : undefined,
-          trailingItems: <IconArrow direction="right" />,
         },
         {
           key: 'uptime',
-          label: tn(
-            '%s Active Uptime Monitor',
-            '%s Active Uptime Monitors',
-            uptimeData?.counts.active
-          ),
+          label: t('View Uptime Monitors (%s)', uptimeData.counts.active),
           to: `/organizations/${organization.slug}/insights/uptime/`,
           details:
-            uptimeData?.counts.disabled > 0
+            uptimeData.counts.disabled > 0
               ? tn(
                   '%s disabled monitor',
                   '%s disabled monitors',
-                  uptimeData?.counts.disabled
+                  uptimeData.counts.disabled
                 )
               : undefined,
-          trailingItems: <IconArrow direction="right" />,
         },
       ]}
       trigger={(props, isOpen) => (

--- a/static/app/views/issueList/monitorsDropdown.tsx
+++ b/static/app/views/issueList/monitorsDropdown.tsx
@@ -65,7 +65,7 @@ export function MonitorsDropdown() {
       items={[
         {
           key: 'crons',
-          label: t('View Cron Monitors (%s)', cronsData.counts.active),
+          label: t('View Active Cron Monitors (%s)', cronsData.counts.active),
           to: `/organizations/${organization.slug}/insights/crons/`,
           details:
             cronsData.counts.disabled > 0
@@ -78,7 +78,7 @@ export function MonitorsDropdown() {
         },
         {
           key: 'uptime',
-          label: t('View Uptime Monitors (%s)', uptimeData.counts.active),
+          label: t('View Active Uptime Monitors (%s)', uptimeData.counts.active),
           to: `/organizations/${organization.slug}/insights/uptime/`,
           details:
             uptimeData.counts.disabled > 0


### PR DESCRIPTION
Simplify the monitors dropdown in the issue list by updating item labels to a cleaner "View Cron/Uptime Monitors (N)" format indicating the link behavior.

I initially thought that the arrows were indicating sub-menus, which was quite confusing given that they are links...

Note for the design system here that we should probably not allow trailing items in dropdown menus - those should be reserved for the chevron sub-menu indicator and consumers should only use leading icons to indicate entries