### PR TITLE
ref(ai-agents): Separate cached from net-new input tokens in span details

### DIFF
--- a/static/app/views/insights/pages/agents/utils/tokenBreakdown.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/tokenBreakdown.spec.ts
@@ -1,0 +1,160 @@
+import {getTokenBreakdown} from './tokenBreakdown';
+
+describe('getTokenBreakdown', () => {
+  it('returns input as netNewInput when there are no cached tokens', () => {
+    const result = getTokenBreakdown({
+      inputTokens: 100,
+      cachedTokens: 0,
+      outputTokens: 50,
+      reasoningTokens: 0,
+      totalTokens: 150,
+    });
+
+    expect(result).toEqual({
+      netNewInput: 100,
+      cached: 0,
+      output: 50,
+      total: 150,
+    });
+  });
+
+  it('separates cached from input when cached is included (OTel convention)', () => {
+    // OTel: inputTokens=100 includes 80 cached, output=50, total=150
+    const result = getTokenBreakdown({
+      inputTokens: 100,
+      cachedTokens: 80,
+      outputTokens: 50,
+      reasoningTokens: 0,
+      totalTokens: 150,
+    });
+
+    expect(result).toEqual({
+      netNewInput: 20,
+      cached: 80,
+      output: 50,
+      total: 150,
+    });
+  });
+
+  it('handles providers that report input exclusive of cached', () => {
+    // Some providers: inputTokens=30 (net new only), cached=80, output=90, total=200
+    // getAdjustedInput detects that 30+90+80=200 matches total, so adjusts input to 110
+    const result = getTokenBreakdown({
+      inputTokens: 30,
+      cachedTokens: 80,
+      outputTokens: 90,
+      reasoningTokens: 0,
+      totalTokens: 200,
+    });
+
+    expect(result).toEqual({
+      netNewInput: 30,
+      cached: 80,
+      output: 90,
+      total: 200,
+    });
+  });
+
+  it('clamps netNewInput to 0 when cached exceeds input (inconsistent data)', () => {
+    // Bad data: provider says cached=80 but input=50, and heuristic decides cached is included
+    // input+output=100 is closer to total=100 than input+output+cached=180
+    const result = getTokenBreakdown({
+      inputTokens: 50,
+      cachedTokens: 80,
+      outputTokens: 50,
+      reasoningTokens: 0,
+      totalTokens: 100,
+    });
+
+    expect(result.netNewInput).toBeGreaterThanOrEqual(0);
+  });
+
+  it('folds reasoning into output tokens (OTel convention)', () => {
+    // OTel: outputTokens=100 includes 30 reasoning, total=200
+    const result = getTokenBreakdown({
+      inputTokens: 100,
+      cachedTokens: 0,
+      outputTokens: 100,
+      reasoningTokens: 30,
+      totalTokens: 200,
+    });
+
+    expect(result).toEqual({
+      netNewInput: 100,
+      cached: 0,
+      output: 100,
+      total: 200,
+    });
+  });
+
+  it('adjusts output when reasoning is reported separately', () => {
+    // Provider reports output=70 exclusive of reasoning=30, total=200
+    // getAdjustedOutput detects that 100+70+30=200 matches total
+    const result = getTokenBreakdown({
+      inputTokens: 100,
+      cachedTokens: 0,
+      outputTokens: 70,
+      reasoningTokens: 30,
+      totalTokens: 200,
+    });
+
+    expect(result).toEqual({
+      netNewInput: 100,
+      cached: 0,
+      output: 100,
+      total: 200,
+    });
+  });
+
+  it('handles both cached and reasoning adjustments together', () => {
+    // input=20 (net new), cached=80 (exclusive), output=50 (exclusive of reasoning=30), total=180
+    const result = getTokenBreakdown({
+      inputTokens: 20,
+      cachedTokens: 80,
+      outputTokens: 50,
+      reasoningTokens: 30,
+      totalTokens: 180,
+    });
+
+    expect(result).toEqual({
+      netNewInput: 20,
+      cached: 80,
+      output: 80,
+      total: 180,
+    });
+  });
+
+  it('treats NaN cached as 0', () => {
+    const result = getTokenBreakdown({
+      inputTokens: 100,
+      cachedTokens: NaN,
+      outputTokens: 50,
+      reasoningTokens: 0,
+      totalTokens: 150,
+    });
+
+    expect(result).toEqual({
+      netNewInput: 100,
+      cached: 0,
+      output: 50,
+      total: 150,
+    });
+  });
+
+  it('treats NaN reasoning as 0', () => {
+    const result = getTokenBreakdown({
+      inputTokens: 100,
+      cachedTokens: 0,
+      outputTokens: 50,
+      reasoningTokens: NaN,
+      totalTokens: 150,
+    });
+
+    expect(result).toEqual({
+      netNewInput: 100,
+      cached: 0,
+      output: 50,
+      total: 150,
+    });
+  });
+});

--- a/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
+++ b/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
@@ -1,0 +1,89 @@
+export interface TokenBreakdown {
+  cached: number;
+  netNewInput: number;
+  output: number;
+  total: number;
+}
+
+/**
+ * Computes a display-ready token breakdown from raw span attributes.
+ *
+ * Per OTel conventions, `inputTokens` includes cached and `outputTokens`
+ * includes reasoning. Some providers don't follow this, so we detect the
+ * gap and adjust as a fallback (see `getAdjustedInput` / `getAdjustedOutput`).
+ *
+ * Returns net-new input (excluding cached), cached, output (including
+ * reasoning), and total.
+ */
+export function getTokenBreakdown({
+  inputTokens,
+  cachedTokens,
+  outputTokens,
+  reasoningTokens,
+  totalTokens,
+}: {
+  cachedTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  totalTokens: number;
+}): TokenBreakdown {
+  const cached = isNaN(cachedTokens) ? 0 : cachedTokens;
+  const reasoning = isNaN(reasoningTokens) ? 0 : reasoningTokens;
+
+  const adjustedInput = getAdjustedInput(inputTokens, cached, outputTokens, totalTokens);
+  const adjustedOutput = getAdjustedOutput(
+    adjustedInput,
+    outputTokens,
+    reasoning,
+    totalTokens
+  );
+
+  return {
+    netNewInput: cached > 0 ? adjustedInput - cached : adjustedInput,
+    cached,
+    output: adjustedOutput,
+    total: totalTokens,
+  };
+}
+
+/**
+ * Some providers report `inputTokens` exclusive of cached; others inclusive.
+ * We pick whichever interpretation makes `input + output` closest to `total`.
+ */
+function getAdjustedInput(
+  inputTokens: number,
+  cachedTokens: number,
+  outputTokens: number,
+  totalTokens: number
+): number {
+  if (cachedTokens <= 0) {
+    return inputTokens;
+  }
+  const without = inputTokens + outputTokens;
+  const withCached = without + cachedTokens;
+  if (Math.abs(withCached - totalTokens) < Math.abs(without - totalTokens)) {
+    return inputTokens + cachedTokens;
+  }
+  return inputTokens;
+}
+
+/**
+ * Same idea for reasoning tokens inside `outputTokens`.
+ */
+function getAdjustedOutput(
+  adjustedInput: number,
+  outputTokens: number,
+  reasoningTokens: number,
+  totalTokens: number
+): number {
+  if (reasoningTokens <= 0) {
+    return outputTokens;
+  }
+  const without = adjustedInput + outputTokens;
+  const withReasoning = without + reasoningTokens;
+  if (Math.abs(withReasoning - totalTokens) < Math.abs(without - totalTokens)) {
+    return outputTokens + reasoningTokens;
+  }
+  return outputTokens;
+}

--- a/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
+++ b/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
@@ -40,7 +40,7 @@ export function getTokenBreakdown({
   );
 
   return {
-    netNewInput: cached > 0 ? adjustedInput - cached : adjustedInput,
+    netNewInput: cached > 0 ? Math.max(0, adjustedInput - cached) : adjustedInput,
     cached,
     output: adjustedOutput,
     total: totalTokens,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import type {CaptureContext} from '@sentry/core';
 import * as Sentry from '@sentry/react';
@@ -20,6 +21,7 @@ import {
   getToolSpansFilter,
 } from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
+import {getTokenBreakdown} from 'sentry/views/insights/pages/agents/utils/tokenBreakdown';
 import {SpanFields} from 'sentry/views/insights/types';
 import {tryParseJsonRecursive} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
@@ -356,42 +358,6 @@ function HighlightedTools({
   );
 }
 
-// Per our and OTel conventions, input_tokens includes cached and output_tokens includes
-// reasoning. Some providers don't do this, so we detect the gap and adjust as a fallback.
-function getDisplayInputTokens(
-  inputTokens: number,
-  cachedTokens: number,
-  outputTokens: number,
-  totalTokens: number
-): number {
-  if (cachedTokens <= 0) {
-    return inputTokens;
-  }
-  const without = inputTokens + outputTokens;
-  const withCached = without + cachedTokens;
-  if (Math.abs(withCached - totalTokens) < Math.abs(without - totalTokens)) {
-    return inputTokens + cachedTokens;
-  }
-  return inputTokens;
-}
-
-function getDisplayOutputTokens(
-  displayInput: number,
-  outputTokens: number,
-  reasoningTokens: number,
-  totalTokens: number
-): number {
-  if (reasoningTokens <= 0) {
-    return outputTokens;
-  }
-  const without = displayInput + outputTokens;
-  const withReasoning = without + reasoningTokens;
-  if (Math.abs(withReasoning - totalTokens) < Math.abs(without - totalTokens)) {
-    return outputTokens + reasoningTokens;
-  }
-  return outputTokens;
-}
-
 function HighlightedTokenAttributes({
   inputTokens,
   cachedTokens,
@@ -405,50 +371,54 @@ function HighlightedTokenAttributes({
   reasoningTokens: number;
   totalTokens: number;
 }) {
-  const effectiveCached = isNaN(cachedTokens) ? 0 : cachedTokens;
-  const effectiveReasoning = isNaN(reasoningTokens) ? 0 : reasoningTokens;
-
-  const displayInput = getDisplayInputTokens(
+  const breakdown = getTokenBreakdown({
     inputTokens,
-    effectiveCached,
+    cachedTokens,
     outputTokens,
-    totalTokens
-  );
-  const displayOutput = getDisplayOutputTokens(
-    displayInput,
-    outputTokens,
-    effectiveReasoning,
-    totalTokens
-  );
+    reasoningTokens,
+    totalTokens,
+  });
+
+  const hasCached = breakdown.cached > 0;
 
   return (
     <Tooltip
       title={
         <TokensTooltipTitle>
           <span>{t('Input')}</span>
-          <span>{inputTokens.toString()}</span>
-          <SubTextCell>{t('Cached')}</SubTextCell>
-          <SubTextCell>{effectiveCached.toString()}</SubTextCell>
+          <span>{breakdown.netNewInput.toLocaleString()}</span>
+          {hasCached && (
+            <Fragment>
+              <span>{t('Cached')}</span>
+              <span>{breakdown.cached.toLocaleString()}</span>
+            </Fragment>
+          )}
           <span>{t('Output')}</span>
-          <span>{outputTokens.toString()}</span>
-          <SubTextCell>{t('Reasoning')}</SubTextCell>
-          <SubTextCell>{effectiveReasoning.toString()}</SubTextCell>
+          <span>{breakdown.output.toLocaleString()}</span>
           <span>{t('Total')}</span>
-          <span>{totalTokens.toString()}</span>
+          <span>{breakdown.total.toLocaleString()}</span>
         </TokensTooltipTitle>
       }
     >
       <TokensSpan>
         <span>
-          <Count value={displayInput.toString()} /> {t('in')}
+          <Count value={breakdown.netNewInput} /> {t('in')}
         </span>
+        {hasCached && (
+          <Fragment>
+            <span>+</span>
+            <span>
+              <Count value={breakdown.cached} /> {t('cached')}
+            </span>
+          </Fragment>
+        )}
         <span>+</span>
         <span>
-          <Count value={displayOutput.toString()} /> {t('out')}
+          <Count value={breakdown.output} /> {t('out')}
         </span>
         <span>=</span>
         <span>
-          <Count value={totalTokens.toString()} /> {t('total')}
+          <Count value={breakdown.total} /> {t('total')}
         </span>
       </TokensSpan>
     </Tooltip>
@@ -465,11 +435,6 @@ const TokensTooltipTitle = styled('div')`
     text-align: right;
   }
   gap: ${p => p.theme.space.xs};
-`;
-
-const SubTextCell = styled('span')`
-  margin-left: ${p => p.theme.space.md};
-  color: ${p => p.theme.tokens.content.secondary};
 `;
 
 const TokensSpan = styled('span')`


### PR DESCRIPTION
Extract token breakdown logic to shared utility. 
Show cached tokens as a separate term in the equation (x in + y cached + z out = w total) instead of folding them into input. Cached only appears when > 0. Tooltip mirrors the equation.

<img width="418" height="175" alt="image" src="https://github.com/user-attachments/assets/e1e5b893-e433-4b31-a2e3-e72dd7982e98" />
