### PR TITLE
fix(ai-conversations): Escape conversation IDs in query strings

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -12,6 +12,7 @@ from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
+from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
@@ -125,7 +126,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
     ):
         result = Spans.run_table_query(
             params=snuba_params,
-            query_string=f"gen_ai.conversation.id:{conversation_id}",
+            query_string=build_escaped_term_filter("gen_ai.conversation.id", [conversation_id]),
             selected_columns=selected_columns,
             orderby=["precise.start_ts"],
             offset=offset,

--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -17,6 +17,7 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers.rest_framework import OrganizationAIConversationsSerializer
 from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
+from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.events.constants import NON_FAILURE_STATUS
@@ -341,7 +342,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     ) -> TableQuery:
         return TableQuery(
             name="aggregations",
-            query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}]",
+            query_string=build_escaped_term_filter("gen_ai.conversation.id", conversation_ids),
             selected_columns=[
                 "gen_ai.conversation.id",
                 "failure_count()",
@@ -365,7 +366,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     ) -> TableQuery:
         return TableQuery(
             name="enrichment",
-            query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}] has:gen_ai.operation.type",
+            query_string=f"{build_escaped_term_filter('gen_ai.conversation.id', conversation_ids)} has:gen_ai.operation.type",
             selected_columns=[
                 "gen_ai.conversation.id",
                 "gen_ai.operation.type",
@@ -392,7 +393,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     ) -> TableQuery:
         return TableQuery(
             name="first_last_io",
-            query_string=f"gen_ai.conversation.id:[{','.join(conversation_ids)}] gen_ai.operation.type:ai_client",
+            query_string=f"{build_escaped_term_filter('gen_ai.conversation.id', conversation_ids)} gen_ai.operation.type:ai_client",
             selected_columns=[
                 "gen_ai.conversation.id",
                 "gen_ai.input.messages",


### PR DESCRIPTION
Conversation IDs were interpolated directly into search query strings
without escaping in both the AI conversations list and details endpoints.
Values containing special characters like parentheses (e.g. `UUID(xxx)`)
would be misinterpreted by the search parser, breaking queries entirely.

More critically, this was a stored injection vector: conversation IDs
returned from Snuba results were used unescaped in subsequent queries
(aggregations, enrichment, first/last IO). A malicious conversation ID
value like `foo OR user.email:*` stored in ClickHouse could modify the
query logic and potentially leak data across conversations.

Uses the existing `build_escaped_term_filter` utility from
`sentry.search.eap.occurrences.query_utils` which properly double-quotes
values and escapes backslashes and quotes within them.