### PR TITLE
ref(sdk): filter `asyncio.CancelledError` events

### DIFF
--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -12,7 +12,6 @@ from urllib.parse import urljoin, urlparse
 import httpx
 from asgiref.sync import sync_to_async
 from django.conf import settings
-from django.core.exceptions import RequestAborted
 from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 
@@ -199,7 +198,7 @@ async def proxy_cell_request(
                     return _adapt_response(resp, target_url)
             except asyncio.CancelledError:
                 metrics.incr("apigateway.proxy.request_aborted", tags=metric_tags)
-                raise RequestAborted()
+                raise
             except httpx.TimeoutException:
                 metrics.incr("apigateway.proxy.request_timeout", tags=metric_tags)
                 circuitbreaker.incr_failures()

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -255,7 +255,10 @@ def before_send(event: Event, hint: Hint) -> Event | None:
         if settings.SENTRY_LOCAL_CELL:
             event["tags"]["sentry_region"] = settings.SENTRY_LOCAL_CELL
 
-    if hint.get("exc_info", [None])[0] == OperationalError:
+    event_exc: type[BaseException] | None = hint.get("exc_info", [None])[0]
+    if event_exc == asyncio.CancelledError:
+        return None
+    if event_exc == OperationalError:
         event["level"] = "warning"
 
     return event


### PR DESCRIPTION
SSIA

The only source for this kind of errors is aborted requests in ASGI mode (currently in canary for control silo).