### PR TITLE
ref(scm): Raise exception in development environment on unknown event

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -13,6 +13,7 @@ from typing import Any, Protocol
 import orjson
 import sentry_sdk
 from dateutil.parser import parse as parse_date
+from django.conf import settings
 from django.db import IntegrityError, router, transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils.crypto import constant_time_compare
@@ -1158,6 +1159,7 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
                 "type": IntegrationProviderSlug.GITHUB.value,
             },
             silo="region" if SiloMode.get_current_mode() == SiloMode.CELL else "control",
+            is_dev=settings.IS_DEV,
         )
 
         return HttpResponse(status=204)

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -8,6 +8,7 @@ import time
 
 import orjson
 import sentry_sdk
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
@@ -333,6 +334,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
                 "type": IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
             },
             silo="region",
+            is_dev=settings.IS_DEV,
         )
 
         return HttpResponse(status=204)

--- a/src/sentry/scm/errors.py
+++ b/src/sentry/scm/errors.py
@@ -42,6 +42,12 @@ class SCMProviderException(SCMError):
     pass
 
 
+class SCMProviderEventNotSupported(SCMError):
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
 class SCMProviderNotSupported(SCMError):
     def __init__(self, message: str) -> None:
         self.message = message

--- a/src/sentry/scm/private/ipc.py
+++ b/src/sentry/scm/private/ipc.py
@@ -359,6 +359,8 @@ def produce_to_listeners(
     if parsed_event is None:
         raise SCMProviderEventNotSupported(f"Unsupported event type `{event['event_type_hint']}`.")
 
+    message = serialize_event(parsed_event)
+
     if isinstance(parsed_event, CheckRunEvent):
         event_type_hint = "check_run"
         listeners = list(stream.check_run_listeners.keys())
@@ -370,8 +372,6 @@ def produce_to_listeners(
         listeners = list(stream.pull_request_listeners.keys())
     else:
         assert_never(parsed_event)
-
-    message = serialize_event(parsed_event)
 
     for listener in listeners:
         produce_to_listener(message, cast(EventTypeHint, event_type_hint), listener, silo)

--- a/src/sentry/scm/private/ipc.py
+++ b/src/sentry/scm/private/ipc.py
@@ -16,7 +16,7 @@ from typing import assert_never, cast
 import msgspec
 import sentry_sdk
 
-from sentry.scm.errors import SCMProviderNotSupported
+from sentry.scm.errors import SCMProviderEventNotSupported, SCMProviderNotSupported
 from sentry.scm.private.event_stream import SourceCodeManagerEventStream, scm_event_stream
 from sentry.scm.private.webhooks.github import deserialize_github_event
 from sentry.scm.types import (
@@ -356,12 +356,8 @@ def produce_to_listeners(
     """
     parsed_event = deserialize_raw_event(event)
 
-    # Most events are not supported. We drop them. They could be processed elsewhere but they're
-    # not processed by the unified SCM platform.
     if parsed_event is None:
-        return None
-
-    message = serialize_event(parsed_event)
+        raise SCMProviderEventNotSupported(f"Unsupported event type `{event['event_type_hint']}`.")
 
     if isinstance(parsed_event, CheckRunEvent):
         event_type_hint = "check_run"
@@ -374,6 +370,8 @@ def produce_to_listeners(
         listeners = list(stream.pull_request_listeners.keys())
     else:
         assert_never(parsed_event)
+
+    message = serialize_event(parsed_event)
 
     for listener in listeners:
         produce_to_listener(message, cast(EventTypeHint, event_type_hint), listener, silo)

--- a/src/sentry/scm/private/stream_producer.py
+++ b/src/sentry/scm/private/stream_producer.py
@@ -12,7 +12,7 @@ from sentry.scm.private.ipc import (
 from sentry.scm.types import HybridCloudSilo, SubscriptionEvent
 from sentry.scm.utils import check_rollout_option
 
-logger = logging.getLogger()
+logger = logging.getLogger("sentry.scm")
 PREFIX = "sentry.scm.produce_event_to_scm_stream"
 
 

--- a/src/sentry/scm/private/stream_producer.py
+++ b/src/sentry/scm/private/stream_producer.py
@@ -47,18 +47,18 @@ def produce_event_to_scm_stream(
             f"{PREFIX}.failed", 1, {"reason": "provider-not-supported", "provider": event["type"]}
         )
         if is_dev:
-            logger.error("Failed to process SCM webhook event.")
+            logger.exception("Failed to process SCM webhook event.")
     except SCMProviderEventNotSupported:
         record_count(
             f"{PREFIX}.failed", 1, {"reason": "event-not-supported", "provider": event["type"]}
         )
         if is_dev:
-            logger.error("Failed to process SCM webhook event.")
+            logger.exception("Failed to process SCM webhook event.")
     except Exception as e:
         record_count(f"{PREFIX}.failed", 1, {"reason": "processing"})
         report_error(e)
         if is_dev:
-            logger.error("Failed to process SCM webhook event.")
+            logger.exception("Failed to process SCM webhook event.")
 
 
 __all__ = [

--- a/src/sentry/scm/private/stream_producer.py
+++ b/src/sentry/scm/private/stream_producer.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 
 from sentry.scm.errors import SCMProviderEventNotSupported, SCMProviderNotSupported
@@ -11,6 +12,7 @@ from sentry.scm.private.ipc import (
 from sentry.scm.types import HybridCloudSilo, SubscriptionEvent
 from sentry.scm.utils import check_rollout_option
 
+logger = logging.getLogger()
 PREFIX = "sentry.scm.produce_event_to_scm_stream"
 
 
@@ -38,19 +40,25 @@ def produce_event_to_scm_stream(
     try:
         produce_to_listeners(event, silo, produce_to_listener=produce_to_listener)
         record_count(f"{PREFIX}.success", 1, {})
+        if is_dev:
+            logger.info(f"Successfully processed SCM webhook event: {event['event_type_hint']}.")
     except SCMProviderNotSupported:
         record_count(
             f"{PREFIX}.failed", 1, {"reason": "provider-not-supported", "provider": event["type"]}
         )
+        if is_dev:
+            logger.error("Failed to process SCM webhook event.")
     except SCMProviderEventNotSupported:
         record_count(
             f"{PREFIX}.failed", 1, {"reason": "event-not-supported", "provider": event["type"]}
         )
         if is_dev:
-            raise
+            logger.error("Failed to process SCM webhook event.")
     except Exception as e:
         record_count(f"{PREFIX}.failed", 1, {"reason": "processing"})
         report_error(e)
+        if is_dev:
+            logger.error("Failed to process SCM webhook event.")
 
 
 __all__ = [

--- a/src/sentry/scm/private/stream_producer.py
+++ b/src/sentry/scm/private/stream_producer.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 
-from sentry.scm.errors import SCMProviderNotSupported
+from sentry.scm.errors import SCMProviderEventNotSupported, SCMProviderNotSupported
 from sentry.scm.private.ipc import (
     PRODUCE_TO_LISTENER,
     produce_to_listener,
@@ -18,6 +18,7 @@ def produce_event_to_scm_stream(
     event: SubscriptionEvent,
     silo: HybridCloudSilo,
     *,
+    is_dev: bool = False,
     produce_to_listener: PRODUCE_TO_LISTENER = produce_to_listener,
     record_count: Callable[[str, int, dict[str, str]], None] = record_count_metric,
     report_error: Callable[[Exception], None] = report_error_to_sentry,
@@ -38,7 +39,15 @@ def produce_event_to_scm_stream(
         produce_to_listeners(event, silo, produce_to_listener=produce_to_listener)
         record_count(f"{PREFIX}.success", 1, {})
     except SCMProviderNotSupported:
-        record_count(f"{PREFIX}.failed", 1, {"reason": "not-supported", "provider": event["type"]})
+        record_count(
+            f"{PREFIX}.failed", 1, {"reason": "provider-not-supported", "provider": event["type"]}
+        )
+    except SCMProviderEventNotSupported:
+        record_count(
+            f"{PREFIX}.failed", 1, {"reason": "event-not-supported", "provider": event["type"]}
+        )
+        if is_dev:
+            raise
     except Exception as e:
         record_count(f"{PREFIX}.failed", 1, {"reason": "processing"})
         report_error(e)

--- a/tests/sentry/scm/unit/private/test_ipc.py
+++ b/tests/sentry/scm/unit/private/test_ipc.py
@@ -3,6 +3,7 @@ from unittest import mock
 import msgspec
 import pytest
 
+from sentry.scm.errors import SCMProviderEventNotSupported
 from sentry.scm.private.event_stream import SourceCodeManagerEventStream
 from sentry.scm.private.ipc import (
     AuthorParser,
@@ -774,6 +775,7 @@ def test_produce_to_listeners_returns_none_for_unsupported_events() -> None:
         "type": "github",
     }
 
-    with mock.patch("sentry.scm.private.ipc.deserialize_raw_event", lambda e: None):
+    with pytest.raises(SCMProviderEventNotSupported):
         produce_to_listeners(subscription_event, "region", mock_produce)
-        assert len(produced_messages) == 0
+
+    assert len(produced_messages) == 0

--- a/tests/sentry/scm/unit/test_stream_producer.py
+++ b/tests/sentry/scm/unit/test_stream_producer.py
@@ -54,7 +54,7 @@ def test_produce_to_scm_stream_unsupported_provider() -> None:
         (
             "sentry.scm.produce_event_to_scm_stream.failed",
             1,
-            {"reason": "not-supported", "provider": event["type"]},
+            {"reason": "provider-not-supported", "provider": event["type"]},
         )
     ]
 


### PR DESCRIPTION
Unknown SCM events now fail loudly in dev (to catch bugs during development) and fail quietly but with better metrics in production.