### PR TITLE
fix(dashboards): Send null legendType when legend breakdown is disabled

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -166,7 +166,7 @@ export type Widget = {
   exploreUrls?: null | string[];
   id?: string;
   layout?: WidgetLayout | null;
-  legendType?: LegendType;
+  legendType?: LegendType | null;
   // Used to define 'topEvents' when fetching time-series data for a widget
   limit?: number;
   // Used for table widget column widths, currently is not saved

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -37,7 +37,9 @@ describe('convertBuilderStateToWidget', () => {
           selectedAggregate: undefined,
         },
       ],
+      legendType: null,
       thresholds: undefined,
+      axisRange: undefined,
     });
   });
 

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -300,4 +300,30 @@ describe('convertBuilderStateToWidget', () => {
       axisRange: undefined,
     });
   });
+
+  it('sends null legendType when legend breakdown is not set', () => {
+    const mockState: WidgetBuilderState = {
+      dataset: WidgetType.ERRORS,
+      displayType: DisplayType.LINE,
+      legendType: undefined,
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    // legendType must be null (not undefined) so it survives JSON serialization
+    // and the backend clears the previously saved value
+    expect(widget.legendType).toBeNull();
+  });
+
+  it('preserves breakdown legendType when set', () => {
+    const mockState: WidgetBuilderState = {
+      dataset: WidgetType.ERRORS,
+      displayType: DisplayType.LINE,
+      legendType: 'breakdown',
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.legendType).toBe('breakdown');
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -147,7 +147,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     queries: widgetQueries,
     widgetType: state.dataset,
     limit,
-    legendType: state.legendType,
+    legendType: state.legendType ?? null,
     thresholds: state.thresholds,
     axisRange: getAxisRange(state.axisRange) ?? datasetConfig.axisRange,
   };

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -69,7 +69,7 @@ export function convertWidgetToQueryParams(
     sort,
     legendAlias,
     selectedAggregate: firstWidgetQuery?.selectedAggregate,
-    legendType: widget.legendType,
+    legendType: widget.legendType ?? undefined,
     thresholds: widget.thresholds ? serializeThresholds(widget.thresholds) : undefined,
     axisRange: getAxisRange(widget.axisRange) ?? 'auto',
     linkedDashboards: firstWidgetQuery?.linkedDashboards


### PR DESCRIPTION
When a user disables "Show legend breakdown" in the widget builder and saves,
the `legendType` field is set to `undefined` in the widget state. Since
`JSON.stringify` strips `undefined` values, the field is omitted from the API
request payload entirely. The backend's `update_widget` then falls back to the
previous value via `data.get("legend_type", prev_legend_type)`, so the old
`'breakdown'` value is never cleared.

This changes `convertBuilderStateToWidget` to emit `null` instead of `undefined`
for `legendType`, ensuring the value survives JSON serialization and reaches the
backend to clear the stored legend type. Also updates the `Widget` type to allow
`null` and normalizes `null` back to `undefined` when loading widget state into
the builder.

Fixes DAIN-1444
Fixes GH-112087