### PR TITLE
fix(dashboards): Improve wrapping of global filter triggers

### DIFF
--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -10,7 +10,7 @@ import {
   MenuComponents,
   type SelectOption,
 } from '@sentry/scraps/compactSelect';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -42,10 +42,7 @@ import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {type SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
 import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
-import {
-  FilterSelectorTrigger,
-  FilterValueTruncated,
-} from 'sentry/views/dashboards/globalFilter/filterSelectorTrigger';
+import {FilterSelectorTrigger} from 'sentry/views/dashboards/globalFilter/filterSelectorTrigger';
 import {
   getFieldDefinitionForDataset,
   getFilterToken,
@@ -376,11 +373,9 @@ export function FilterSelector({
           </Flex>
         )}
         trigger={triggerProps => (
-          <Container maxWidth={FILTER_SELECTOR_MAX_WIDTH}>
-            <OverlayTrigger.Button {...triggerProps}>
-              {renderFilterSelectorTrigger(activeFilterValues)}
-            </OverlayTrigger.Button>
-          </Container>
+          <OverlayTrigger.Button {...triggerProps}>
+            {renderFilterSelectorTrigger(activeFilterValues)}
+          </OverlayTrigger.Button>
         )}
       />
     );
@@ -470,11 +465,9 @@ export function FilterSelector({
         </Flex>
       )}
       trigger={triggerProps => (
-        <Container maxWidth={FILTER_SELECTOR_MAX_WIDTH}>
-          <OverlayTrigger.Button {...triggerProps}>
-            {renderFilterSelectorTrigger(activeFilterValues)}
-          </OverlayTrigger.Button>
-        </Container>
+        <OverlayTrigger.Button {...triggerProps}>
+          {renderFilterSelectorTrigger(activeFilterValues)}
+        </OverlayTrigger.Button>
       )}
     />
   );
@@ -496,8 +489,6 @@ const translateKnownFilterOptions = (
   return options;
 };
 
-export const FILTER_SELECTOR_MAX_WIDTH = '300px';
-
 export const MenuTitleWrapper = styled('span')`
   display: inline-block;
   padding-top: ${p => p.theme.space.xs};
@@ -515,4 +506,13 @@ const WildcardButton = styled(Flex)`
 const SubText = styled('span')`
   color: ${p => p.theme.tokens.content.secondary};
   font-size: ${p => p.theme.font.size.sm};
+`;
+
+const FilterValueTruncated = styled('div')`
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+  width: min-content;
 `;

--- a/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelectorTrigger.tsx
@@ -2,7 +2,8 @@ import styled from '@emotion/styled';
 
 import {Badge} from '@sentry/scraps/badge';
 import type {SelectOption} from '@sentry/scraps/compactSelect';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
@@ -11,6 +12,8 @@ import {t} from 'sentry/locale';
 import {prettifyTagKey} from 'sentry/utils/fields';
 import type {UseQueryResult} from 'sentry/utils/queryClient';
 import type {GlobalFilter} from 'sentry/views/dashboards/types';
+
+import {FILTER_SELECTOR_TRIGGER_MAX_WIDTH} from './settings';
 
 type FilterSelectorTriggerProps = {
   activeFilterValues: string[];
@@ -31,6 +34,7 @@ export function FilterSelectorTrigger({
   const {tag} = globalFilter;
 
   const shouldShowBadge = !isFetching && activeFilterValues.length > 1;
+
   // "All" means no filter is applied (empty selection). We intentionally avoid
   // comparing against options.length because when tag values fail to load,
   // options only contains the already-selected values — making a length
@@ -45,53 +49,49 @@ export function FilterSelectorTrigger({
     options.find(option => option.value === filterValue)?.label || filterValue;
 
   return (
-    <ButtonLabelWrapper gap="xs">
-      <Flex align="center" gap={isDefaultOperator ? '0' : 'xs'}>
-        <FilterValueTruncated>{tagKey}</FilterValueTruncated>
-        <SubText>{opLabel}</SubText>
-      </Flex>
-      {!isFetching && (
-        <span style={{fontWeight: 'normal'}}>
-          {isAllSelected ? (
-            t('All')
-          ) : (
-            <FilterValueTruncated>{label}</FilterValueTruncated>
-          )}
-        </span>
-      )}
-      {isFetching && <StyledLoadingIndicator size={14} />}
+    <Flex
+      gap="xs"
+      align="center"
+      minWidth={0}
+      maxWidth={FILTER_SELECTOR_TRIGGER_MAX_WIDTH}
+    >
+      <Container minWidth={0} flexShrink={1} flexGrow={0} overflow="hidden">
+        <Text variant="primary" ellipsis>
+          {tagKey}
+        </Text>
+      </Container>
+
+      <Text variant="muted" bold={false}>
+        {opLabel}
+      </Text>
+
+      {!isFetching &&
+        (isAllSelected ? (
+          <Text variant="primary" bold={false}>
+            {t('All')}
+          </Text>
+        ) : (
+          <Container minWidth={0} flexShrink={1} flexGrow={0} overflow="hidden">
+            <Text variant="primary" bold={false} ellipsis>
+              {label}
+            </Text>
+          </Container>
+        ))}
+
+      {isFetching && <InlineLoadingIndicator size={14} />}
+
       {shouldShowBadge && (
-        <StyledBadge variant="muted">{`+${activeFilterValues.length - 1}`}</StyledBadge>
+        <Container>
+          <Badge variant="muted">{`+${activeFilterValues.length - 1}`}</Badge>
+        </Container>
       )}
-    </ButtonLabelWrapper>
+    </Flex>
   );
 }
 
-const StyledLoadingIndicator = styled(LoadingIndicator)`
+const InlineLoadingIndicator = styled(LoadingIndicator)`
   && {
     margin: 0;
     margin-left: ${p => p.theme.space.xs};
   }
-`;
-
-const StyledBadge = styled(Badge)`
-  flex-shrink: 0;
-`;
-
-const ButtonLabelWrapper = styled(Flex)`
-  align-items: center;
-`;
-
-export const FilterValueTruncated = styled('div')`
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 300px;
-  width: min-content;
-`;
-
-const SubText = styled('span')`
-  color: ${p => p.theme.colors.gray500};
-  font-weight: ${p => p.theme.font.weight.sans.regular};
 `;

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -22,10 +22,7 @@ import {
 } from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
 import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
-import {
-  FILTER_SELECTOR_MAX_WIDTH,
-  MenuTitleWrapper,
-} from 'sentry/views/dashboards/globalFilter/filterSelector';
+import {MenuTitleWrapper} from 'sentry/views/dashboards/globalFilter/filterSelector';
 import type {GenericFilterSelectorProps} from 'sentry/views/dashboards/globalFilter/genericFilterSelector';
 import {
   BetweenFilterSelectorTrigger,
@@ -38,6 +35,8 @@ import {
   parseFilterValue,
 } from 'sentry/views/dashboards/globalFilter/utils';
 import type {GlobalFilter} from 'sentry/views/dashboards/types';
+
+import {FILTER_SELECTOR_TRIGGER_MAX_WIDTH} from './settings';
 
 enum CustomOperator {
   BETWEEN = 'between',
@@ -331,7 +330,7 @@ export function NumericFilterSelector({
         </MenuBodyWrap>
       }
       trigger={triggerProps => (
-        <Container maxWidth={FILTER_SELECTOR_MAX_WIDTH}>
+        <Container maxWidth={FILTER_SELECTOR_TRIGGER_MAX_WIDTH}>
           <OverlayTrigger.Button {...triggerProps}>
             {filter.renderSelectorTrigger()}
           </OverlayTrigger.Button>

--- a/static/app/views/dashboards/globalFilter/settings.ts
+++ b/static/app/views/dashboards/globalFilter/settings.ts
@@ -1,0 +1,1 @@
+export const FILTER_SELECTOR_TRIGGER_MAX_WIDTH = '300px';


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/111238 we started capping the maximum width of global filter dropdowns, but if the filters are long (which is common) the truncation worked poorly, e.g.,

<img width="313" height="58" alt="Screenshot 2026-04-08 at 11 03 56 AM" src="https://github.com/user-attachments/assets/8338b02d-14c1-4903-aeaf-2a1162f45aa6" />

This PR fixes the situation by:

1. Moving the max width wrapping code _into the trigger_ so it doesn't have to be duplicated
2. Adding some fancier flexbox wrappers and ellipses around the tag name and value

The result is that truncation is handled more gracefully. The filter tag key and value both shrink to fit the maximum width, so the user can have an idea of both the key and the value they're filtering by.

**e.g.,**
<img width="188" height="54" alt="Screenshot 2026-04-08 at 11 12 38 AM" src="https://github.com/user-attachments/assets/d74affcb-57c4-4286-817e-36e11ec58a55" />
<img width="230" height="56" alt="Screenshot 2026-04-08 at 11 20 28 AM" src="https://github.com/user-attachments/assets/ed6f470f-46a8-46d6-bbf7-582221bbf680" />
<img width="372" height="53" alt="Screenshot 2026-04-08 at 11 12 01 AM" src="https://github.com/user-attachments/assets/49140d09-290d-46a0-ae15-6f5b03973a08" />
<img width="379" height="60" alt="Screenshot 2026-04-08 at 11 11 28 AM" src="https://github.com/user-attachments/assets/5f7c0de8-5235-4f86-bffc-9f7e263b08ae" />
<img width="367" height="51" alt="Screenshot 2026-04-08 at 11 11 14 AM" src="https://github.com/user-attachments/assets/824605fd-3dc8-4a77-983c-2e7e70f52a1b" />
<img width="365" height="52" alt="Screenshot 2026-04-08 at 11 10 50 AM" src="https://github.com/user-attachments/assets/eb5c877a-2d60-4ef5-92d7-412682a510ad" />
<img width="367" height="54" alt="Screenshot 2026-04-08 at 11 10 38 AM" src="https://github.com/user-attachments/assets/6917c444-a567-41f7-b0f6-0999b0cf7741" />
<img width="227" height="55" alt="Screenshot 2026-04-08 at 11 10 26 AM" src="https://github.com/user-attachments/assets/8e22dd3e-b4c5-4a8a-885b-2452e1ce701d" />


