### PR TITLE
feat(preprod): Sort insight diff by total potential savings

### DIFF
--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -150,8 +150,12 @@ export function InsightComparisonSection({
       }
     }
 
-    for (const insights of Object.values(byTab)) {
-      insights.sort((a, b) => b.total_savings_change - a.total_savings_change);
+    for (const [tab, insights] of Object.entries(byTab)) {
+      insights.sort((a, b) =>
+        tab === 'resolved'
+          ? a.total_savings_change - b.total_savings_change
+          : b.total_savings_change - a.total_savings_change
+      );
     }
 
     return {

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -150,6 +150,10 @@ export function InsightComparisonSection({
       }
     }
 
+    for (const insights of Object.values(byTab)) {
+      insights.sort((a, b) => b.total_savings_change - a.total_savings_change);
+    }
+
     return {
       byTab,
       counts: {


### PR DESCRIPTION
## Summary
- Sort insights by `total_savings_change` descending within each tab of the insight diff, so the biggest opportunities surface first
- Applies per-tab, meaning "unresolved" and "resolved" tabs sort by their recalculated values
- Affects both the build comparison page and the issue details insight diff section

Fixes EME-997

## Test plan
- [ ] Open a build comparison page with multiple insights and verify they are sorted by savings descending
- [ ] Switch between tabs (All, New, Unresolved, Resolved) and confirm each tab is independently sorted
- [ ] Verify the issue details insight diff section also shows sorted insights