### PR TITLE
feat(prompts): Register android tombstones onboarding prompt

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -15,6 +15,7 @@ DEFAULT_PROMPTS: dict[str, _PromptConfig] = {
     "data_consent_banner": {"required_fields": ["organization_id"]},
     "data_consent_priority": {"required_fields": ["organization_id"]},
     "github_missing_members": {"required_fields": ["organization_id"]},
+    "issue_android_tombstones_onboarding": {"required_fields": ["organization_id", "project_id"]},
     "issue_feedback_hidden": {"required_fields": ["organization_id", "project_id"]},
     "issue_priority": {"required_fields": ["organization_id"]},
     "issue_replay_inline_onboarding": {"required_fields": ["organization_id", "project_id"]},


### PR DESCRIPTION
Register `issue_android_tombstones_onboarding` in the prompts config so the
frontend can use the `/prompts-activity/` API to persist dismiss and snooze
state for the upcoming Android native tombstones onboarding banner.

Scoped per organization and project so that dismissing the banner for one
project doesn't hide it in others (different projects may have different SDK
configurations).

<img width="1130" height="1149" alt="Slack 2026-04-08 18 23 17" src="https://github.com/user-attachments/assets/2dc13088-3abe-4853-a621-eecaa024106f" />
