### PR TITLE
feat(issue-details): Add android native tombstones onboarding banner

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
@@ -12,8 +12,6 @@ import type {EntryException, Event} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
-import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
 const ANDROID_NATIVE_SDK_PREFIX = 'sentry.native.android';
 const TOMBSTONES_DOCS_URL =
@@ -76,78 +74,76 @@ export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
   }
 
   return (
-    <InterimSection type={SectionKey.EXCEPTION} title={t('Improve Native Crash Reports')}>
-      <BannerWrapper>
-        <div>
-          <BannerTitle>{t('Enable Tombstone Collection')}</BannerTitle>
-          <BannerDescription>
-            {t(
-              'This native crash was captured via the Android NDK integration only. Enable Tombstone collection in your application to get richer crash reports with more context, including additional thread information, better stack traces and more.'
-            )}
-          </BannerDescription>
-          <CodeBlock
-            tabs={[
-              {label: 'AndroidManifest.xml', value: 'manifest'},
-              {label: 'Kotlin', value: 'kotlin'},
-              {label: 'Java', value: 'java'},
-            ]}
-            selectedTab={codeTab}
-            onTabClick={setCodeTab}
-            language={codeTab === 'manifest' ? 'xml' : codeTab}
-          >
-            {CODE_SNIPPETS[codeTab]}
-          </CodeBlock>
-          <LinkButton
-            style={{marginTop: '12px'}}
-            href={TOMBSTONES_DOCS_URL}
-            external
-            priority="primary"
-            size="sm"
-            analyticsEventName="Clicked Android Tombstones Onboarding CTA"
-            analyticsEventKey="issue-details.android-tombstones-onboarding-cta-clicked"
-            analyticsParams={{
-              organization,
-              sdk_name: event.sdk?.name ?? '',
-            }}
-          >
-            {t('Learn More')}
-          </LinkButton>
-        </div>
-        <CloseDropdownMenu
-          position="bottom-end"
-          triggerProps={{
-            showChevron: false,
-            priority: 'transparent',
-            icon: <IconClose variant="muted" />,
-          }}
-          size="xs"
-          items={[
-            {
-              key: 'dismiss',
-              label: t('Dismiss'),
-              onAction: () => {
-                dismissPrompt();
-                trackAnalytics('issue-details.android-tombstones-cta-dismiss', {
-                  organization,
-                  type: 'dismiss',
-                });
-              },
-            },
-            {
-              key: 'snooze',
-              label: t('Snooze'),
-              onAction: () => {
-                snoozePrompt();
-                trackAnalytics('issue-details.android-tombstones-cta-dismiss', {
-                  organization,
-                  type: 'snooze',
-                });
-              },
-            },
+    <BannerWrapper>
+      <div>
+        <BannerTitle>{t('Enable Tombstone Collection')}</BannerTitle>
+        <BannerDescription>
+          {t(
+            'This native crash was captured via the Android NDK integration only. Enable Tombstone collection in your application to get richer crash reports with more context, including additional thread information, better stack traces and more.'
+          )}
+        </BannerDescription>
+        <CodeBlock
+          tabs={[
+            {label: 'AndroidManifest.xml', value: 'manifest'},
+            {label: 'Kotlin', value: 'kotlin'},
+            {label: 'Java', value: 'java'},
           ]}
-        />
-      </BannerWrapper>
-    </InterimSection>
+          selectedTab={codeTab}
+          onTabClick={setCodeTab}
+          language={codeTab === 'manifest' ? 'xml' : codeTab}
+        >
+          {CODE_SNIPPETS[codeTab]}
+        </CodeBlock>
+        <LinkButton
+          style={{marginTop: '12px'}}
+          href={TOMBSTONES_DOCS_URL}
+          external
+          priority="primary"
+          size="sm"
+          analyticsEventName="Clicked Android Tombstones Onboarding CTA"
+          analyticsEventKey="issue-details.android-tombstones-onboarding-cta-clicked"
+          analyticsParams={{
+            organization,
+            sdk_name: event.sdk?.name ?? '',
+          }}
+        >
+          {t('Learn More')}
+        </LinkButton>
+      </div>
+      <CloseDropdownMenu
+        position="bottom-end"
+        triggerProps={{
+          showChevron: false,
+          priority: 'transparent',
+          icon: <IconClose variant="muted" />,
+        }}
+        size="xs"
+        items={[
+          {
+            key: 'dismiss',
+            label: t('Dismiss'),
+            onAction: () => {
+              dismissPrompt();
+              trackAnalytics('issue-details.android-tombstones-cta-dismiss', {
+                organization,
+                type: 'dismiss',
+              });
+            },
+          },
+          {
+            key: 'snooze',
+            label: t('Snooze'),
+            onAction: () => {
+              snoozePrompt();
+              trackAnalytics('issue-details.android-tombstones-cta-dismiss', {
+                organization,
+                type: 'snooze',
+              });
+            },
+          },
+        ]}
+      />
+    </BannerWrapper>
   );
 }
 

--- a/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
@@ -8,7 +8,7 @@ import {usePrompt} from 'sentry/actionCreators/prompts';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {EntryException, Event} from 'sentry/types/event';
+import type {EntryException, Event, ExceptionValue} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -40,7 +40,7 @@ function hasSignalHandlerMechanism(event: Event): boolean {
   }
   return (
     exceptionEntry.data.values?.some(
-      value => value.mechanism?.type === 'signalhandler'
+      (value: ExceptionValue) => value.mechanism?.type === 'signalhandler'
     ) ?? false
   );
 }
@@ -92,7 +92,7 @@ export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
           onTabClick={setCodeTab}
           language={codeTab === 'manifest' ? 'xml' : codeTab}
         >
-          {CODE_SNIPPETS[codeTab]}
+          {CODE_SNIPPETS[codeTab] ?? ''}
         </CodeBlock>
         <LinkButton
           style={{marginTop: '12px'}}

--- a/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
@@ -1,0 +1,187 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {CodeBlock} from '@sentry/scraps/code';
+
+import {usePrompt} from 'sentry/actionCreators/prompts';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {EntryException, Event} from 'sentry/types/event';
+import {EntryType} from 'sentry/types/event';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+
+const ANDROID_NATIVE_SDK_PREFIX = 'sentry.native.android';
+const TOMBSTONES_DOCS_URL =
+  'https://docs.sentry.io/platforms/android/configuration/tombstones/';
+
+const CODE_SNIPPETS: Record<string, string> = {
+  manifest: `<application>
+  <meta-data
+    android:name="io.sentry.tombstone.enable"
+    android:value="true" />
+</application>`,
+  kotlin: `SentryAndroid.init(context) { options ->
+  options.isReportHistoricalTombstones = true
+}`,
+  java: `SentryAndroid.init(context, options -> {
+  options.setReportHistoricalTombstones(true);
+});`,
+};
+
+function hasSignalHandlerMechanism(event: Event): boolean {
+  const exceptionEntry = event.entries?.find(
+    (entry): entry is EntryException => entry.type === EntryType.EXCEPTION
+  );
+  if (!exceptionEntry) {
+    return false;
+  }
+  return (
+    exceptionEntry.data.values?.some(
+      value => value.mechanism?.type === 'signalhandler'
+    ) ?? false
+  );
+}
+
+function isAndroidNativeSdk(event: Event): boolean {
+  return event.sdk?.name?.startsWith(ANDROID_NATIVE_SDK_PREFIX) ?? false;
+}
+
+export function shouldShowTombstonesBanner(event: Event): boolean {
+  return isAndroidNativeSdk(event) && hasSignalHandlerMechanism(event);
+}
+
+interface Props {
+  event: Event;
+  projectId: string;
+}
+
+export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
+  const organization = useOrganization();
+  const [codeTab, setCodeTab] = useState('manifest');
+
+  const {isLoading, isError, isPromptDismissed, dismissPrompt, snoozePrompt} = usePrompt({
+    feature: 'issue_android_tombstones_onboarding',
+    organization,
+    projectId,
+    daysToSnooze: 7,
+  });
+
+  if (isLoading || isError || isPromptDismissed) {
+    return null;
+  }
+
+  return (
+    <InterimSection type={SectionKey.EXCEPTION} title={t('Improve Native Crash Reports')}>
+      <BannerWrapper>
+        <div>
+          <BannerTitle>{t('Enable Tombstone Collection')}</BannerTitle>
+          <BannerDescription>
+            {t(
+              'This native crash was captured via the Android NDK integration only. Enable Tombstone collection in your application to get richer crash reports with more context, including additional thread information, better stack traces and more.'
+            )}
+          </BannerDescription>
+          <CodeBlock
+            tabs={[
+              {label: 'AndroidManifest.xml', value: 'manifest'},
+              {label: 'Kotlin', value: 'kotlin'},
+              {label: 'Java', value: 'java'},
+            ]}
+            selectedTab={codeTab}
+            onTabClick={setCodeTab}
+            language={codeTab === 'manifest' ? 'xml' : codeTab}
+          >
+            {CODE_SNIPPETS[codeTab]}
+          </CodeBlock>
+          <LinkButton
+            style={{marginTop: '12px'}}
+            href={TOMBSTONES_DOCS_URL}
+            external
+            priority="primary"
+            size="sm"
+            analyticsEventName="Clicked Android Tombstones Onboarding CTA"
+            analyticsEventKey="issue-details.android-tombstones-onboarding-cta-clicked"
+            analyticsParams={{
+              organization,
+              sdk_name: event.sdk?.name ?? '',
+            }}
+          >
+            {t('Learn More')}
+          </LinkButton>
+        </div>
+        <CloseDropdownMenu
+          position="bottom-end"
+          triggerProps={{
+            showChevron: false,
+            priority: 'transparent',
+            icon: <IconClose variant="muted" />,
+          }}
+          size="xs"
+          items={[
+            {
+              key: 'dismiss',
+              label: t('Dismiss'),
+              onAction: () => {
+                dismissPrompt();
+                trackAnalytics('issue-details.android-tombstones-cta-dismiss', {
+                  organization,
+                  type: 'dismiss',
+                });
+              },
+            },
+            {
+              key: 'snooze',
+              label: t('Snooze'),
+              onAction: () => {
+                snoozePrompt();
+                trackAnalytics('issue-details.android-tombstones-cta-dismiss', {
+                  organization,
+                  type: 'snooze',
+                });
+              },
+            },
+          ]}
+        />
+      </BannerWrapper>
+    </InterimSection>
+  );
+}
+
+const BannerWrapper = styled('div')`
+  position: relative;
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  padding: ${p => p.theme.space.xl};
+  margin: ${p => p.theme.space.md} 0;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, ${p => p.theme.tokens.background.secondary} 0%, transparent) 0%,
+    ${p => p.theme.tokens.background.secondary} 70%,
+    ${p => p.theme.tokens.background.secondary} 100%
+  );
+`;
+
+const BannerTitle = styled('div')`
+  font-size: ${p => p.theme.font.size.xl};
+  margin-bottom: ${p => p.theme.space.md};
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+`;
+
+const BannerDescription = styled('div')`
+  margin-bottom: ${p => p.theme.space.lg};
+  max-width: 460px;
+`;
+
+const CloseDropdownMenu = styled(DropdownMenu)`
+  position: absolute;
+  display: block;
+  top: ${p => p.theme.space.md};
+  right: ${p => p.theme.space.md};
+  color: ${p => p.theme.colors.white};
+  cursor: pointer;
+  z-index: 1;
+`;

--- a/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
@@ -242,7 +242,6 @@ const CloseDropdownMenu = styled(DropdownMenu)`
   display: block;
   top: ${p => p.theme.space.md};
   right: ${p => p.theme.space.md};
-  color: ${p => p.theme.colors.white};
   cursor: pointer;
   z-index: 1;
 `;

--- a/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
+import {Flex} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import {usePrompt} from 'sentry/actionCreators/prompts';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -13,7 +15,7 @@ import {EntryType} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-const ANDROID_NATIVE_SDK_PREFIX = 'sentry.native.android';
+const ANDROID_NATIVE_SDK_NAME = 'sentry.native.android';
 const TOMBSTONES_DOCS_URL =
   'https://docs.sentry.io/platforms/android/configuration/tombstones/';
 
@@ -46,7 +48,7 @@ function hasSignalHandlerMechanism(event: Event): boolean {
 }
 
 function isAndroidNativeSdk(event: Event): boolean {
-  return event.sdk?.name?.startsWith(ANDROID_NATIVE_SDK_PREFIX) ?? false;
+  return event.sdk?.name === ANDROID_NATIVE_SDK_NAME;
 }
 
 export function shouldShowTombstonesBanner(event: Event): boolean {
@@ -75,13 +77,13 @@ export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
 
   return (
     <BannerWrapper>
-      <div>
-        <BannerTitle>{t('Enable Tombstone Collection')}</BannerTitle>
-        <BannerDescription>
+      <Flex direction="column" gap="md">
+        <Heading as="h4">{t('Enable Tombstone Collection')}</Heading>
+        <Text as="p" style={{maxWidth: 460}}>
           {t(
             'This native crash was captured via the Android NDK integration only. Enable Tombstone collection in your application to get richer crash reports with more context, including additional thread information, better stack traces and more.'
           )}
-        </BannerDescription>
+        </Text>
         <CodeBlock
           tabs={[
             {label: 'AndroidManifest.xml', value: 'manifest'},
@@ -109,7 +111,7 @@ export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
         >
           {t('Learn More')}
         </LinkButton>
-      </div>
+      </Flex>
       <CloseDropdownMenu
         position="bottom-end"
         triggerProps={{
@@ -159,17 +161,6 @@ const BannerWrapper = styled('div')`
     ${p => p.theme.tokens.background.secondary} 70%,
     ${p => p.theme.tokens.background.secondary} 100%
   );
-`;
-
-const BannerTitle = styled('div')`
-  font-size: ${p => p.theme.font.size.xl};
-  margin-bottom: ${p => p.theme.space.md};
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-`;
-
-const BannerDescription = styled('div')`
-  margin-bottom: ${p => p.theme.space.lg};
-  max-width: 460px;
 `;
 
 const CloseDropdownMenu = styled(DropdownMenu)`

--- a/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
@@ -15,22 +15,92 @@ import {EntryType} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-const ANDROID_NATIVE_SDK_NAME = 'sentry.native.android';
 const TOMBSTONES_DOCS_URL =
   'https://docs.sentry.io/platforms/android/configuration/tombstones/';
 
-const CODE_SNIPPETS: Record<string, string> = {
-  manifest: `<application>
+type TabConfig = {
+  code: string;
+  label: string;
+  language: string;
+  value: string;
+};
+
+type SdkConfig = {
+  defaultTab: string;
+  tabs: TabConfig[];
+};
+
+const ANDROID_SDK_CONFIG: SdkConfig = {
+  defaultTab: 'manifest',
+  tabs: [
+    {
+      label: 'AndroidManifest.xml',
+      value: 'manifest',
+      language: 'xml',
+      code: `<!-- Requires sentry-android 8.35.0+ -->
+<application>
   <meta-data
     android:name="io.sentry.tombstone.enable"
     android:value="true" />
 </application>`,
-  kotlin: `SentryAndroid.init(context) { options ->
-  options.isReportHistoricalTombstones = true
+    },
+    {
+      label: 'Kotlin',
+      value: 'kotlin',
+      language: 'kotlin',
+      code: `// Requires sentry-android 8.35.0+
+SentryAndroid.init(context) { options ->
+  options.isTombstoneEnabled = true
 }`,
-  java: `SentryAndroid.init(context, options -> {
-  options.setReportHistoricalTombstones(true);
+    },
+    {
+      label: 'Java',
+      value: 'java',
+      language: 'java',
+      code: `// Requires sentry-android 8.35.0+
+SentryAndroid.init(context, options -> {
+  options.setTombstoneEnabled(true);
 });`,
+    },
+  ],
+};
+
+const REACT_NATIVE_SDK_CONFIG: SdkConfig = {
+  defaultTab: 'javascript',
+  tabs: [
+    {
+      label: 'JavaScript',
+      value: 'javascript',
+      language: 'javascript',
+      code: `// Requires @sentry/react-native 8.5.0+
+Sentry.init({
+  enableTombstone: true,
+});`,
+    },
+  ],
+};
+
+const FLUTTER_SDK_CONFIG: SdkConfig = {
+  defaultTab: 'dart',
+  tabs: [
+    {
+      label: 'Dart',
+      value: 'dart',
+      language: 'dart',
+      code: `// Requires sentry_flutter 9.15.0+
+await SentryFlutter.init(
+  (options) {
+    options.enableTombstone = true;
+  },
+);`,
+    },
+  ],
+};
+
+const SDK_CONFIGS: Record<string, SdkConfig> = {
+  'sentry.native.android': ANDROID_SDK_CONFIG,
+  'sentry.native.android.react-native': REACT_NATIVE_SDK_CONFIG,
+  'sentry.native.android.flutter': FLUTTER_SDK_CONFIG,
 };
 
 function hasSignalHandlerMechanism(event: Event): boolean {
@@ -47,12 +117,16 @@ function hasSignalHandlerMechanism(event: Event): boolean {
   );
 }
 
-function isAndroidNativeSdk(event: Event): boolean {
-  return event.sdk?.name === ANDROID_NATIVE_SDK_NAME;
+function getSdkConfig(event: Event): SdkConfig | undefined {
+  const sdkName = event.sdk?.name;
+  if (!sdkName) {
+    return undefined;
+  }
+  return SDK_CONFIGS[sdkName];
 }
 
 export function shouldShowTombstonesBanner(event: Event): boolean {
-  return isAndroidNativeSdk(event) && hasSignalHandlerMechanism(event);
+  return getSdkConfig(event) !== undefined && hasSignalHandlerMechanism(event);
 }
 
 interface Props {
@@ -62,7 +136,8 @@ interface Props {
 
 export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
   const organization = useOrganization();
-  const [codeTab, setCodeTab] = useState('manifest');
+  const sdkConfig = getSdkConfig(event);
+  const [codeTab, setCodeTab] = useState(sdkConfig?.defaultTab ?? 'manifest');
 
   const {isLoading, isError, isPromptDismissed, dismissPrompt, snoozePrompt} = usePrompt({
     feature: 'issue_android_tombstones_onboarding',
@@ -71,9 +146,12 @@ export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
     daysToSnooze: 7,
   });
 
-  if (isLoading || isError || isPromptDismissed) {
+  if (isLoading || isError || isPromptDismissed || !sdkConfig) {
     return null;
   }
+
+  const activeTab =
+    sdkConfig.tabs.find(tab => tab.value === codeTab) ?? sdkConfig.tabs[0];
 
   return (
     <BannerWrapper>
@@ -85,19 +163,15 @@ export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
           )}
         </Text>
         <CodeBlock
-          tabs={[
-            {label: 'AndroidManifest.xml', value: 'manifest'},
-            {label: 'Kotlin', value: 'kotlin'},
-            {label: 'Java', value: 'java'},
-          ]}
+          tabs={sdkConfig.tabs.map(tab => ({label: tab.label, value: tab.value}))}
           selectedTab={codeTab}
           onTabClick={setCodeTab}
-          language={codeTab === 'manifest' ? 'xml' : codeTab}
+          language={activeTab.language}
         >
-          {CODE_SNIPPETS[codeTab] ?? ''}
+          {activeTab.code}
         </CodeBlock>
         <LinkButton
-          style={{marginTop: '12px'}}
+          style={{alignSelf: 'flex-start'}}
           href={TOMBSTONES_DOCS_URL}
           external
           priority="primary"

--- a/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
@@ -151,7 +151,7 @@ export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
   }
 
   const activeTab =
-    sdkConfig.tabs.find(tab => tab.value === codeTab) ?? sdkConfig.tabs[0];
+    sdkConfig.tabs.find(tab => tab.value === codeTab) ?? sdkConfig.tabs[0]!;
 
   return (
     <BannerWrapper>

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -72,6 +72,7 @@ export type IssueEventParameters = {
   'integrations.integration_reinstall_clicked': {
     provider: string;
   };
+  'issue-details.android-tombstones-cta-dismiss': {type: string};
   'issue-details.replay-cta-dismiss': {type: string};
   'issue.engaged_view': {
     group_id: number;
@@ -400,6 +401,8 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_details.event_dropdown_option_selected':
     'Issue Details: Event Dropdown Option Selected',
   'issue_details.header_view_replay_clicked': 'Issue Details: Header View Replay Clicked',
+  'issue-details.android-tombstones-cta-dismiss':
+    'Issue Details Android Tombstones CTA Dismissed',
   'issue-details.replay-cta-dismiss': 'Issue Details Replay CTA Dismissed',
   'issue_group_details.anr_root_cause_detected': 'Detected ANR Root Cause',
   'issue_details.copy_issue_details_as_markdown':

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -30,6 +30,10 @@ import {EventFeatureFlagSection} from 'sentry/components/events/featureFlags/eve
 import {EventGroupingInfoSection} from 'sentry/components/events/groupingInfo/groupingInfoSection';
 import {HighlightsDataSection} from 'sentry/components/events/highlights/highlightsDataSection';
 import {HighlightsIconSummary} from 'sentry/components/events/highlights/highlightsIconSummary';
+import {
+  AndroidNativeTombstonesBanner,
+  shouldShowTombstonesBanner,
+} from 'sentry/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner';
 import {Csp} from 'sentry/components/events/interfaces/csp';
 import {DebugMeta} from 'sentry/components/events/interfaces/debugMeta';
 import {Exception} from 'sentry/components/events/interfaces/exception';
@@ -79,6 +83,7 @@ import {InstrumentationFixSection} from 'sentry/views/issueDetails/streamline/in
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {MetricDetectorTriggeredSection} from 'sentry/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection';
 import {SizeAnalysisTriggeredSection} from 'sentry/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection';
+import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 
@@ -118,6 +123,7 @@ export function EventDetailsContent({
       : null;
   const isMetricKitHang = hangProfileData !== null;
   const groupingCurrentLevel = group?.metadata?.current_level;
+  const isSampleError = useIsSampleEvent();
 
   useCopyIssueDetails(group, event);
 
@@ -184,6 +190,14 @@ export function EventDetailsContent({
                 display: block !important;
               `}
             >
+              {shouldShowTombstonesBanner(event) && !isSampleError && (
+                <ErrorBoundary mini>
+                  <AndroidNativeTombstonesBanner
+                    event={event}
+                    projectId={group?.project.id ?? event.projectID ?? ''}
+                  />
+                </ErrorBoundary>
+              )}
               {defined(eventEntries[EntryType.EXCEPTION]) && (
                 <EntryErrorBoundary type={EntryType.EXCEPTION}>
                   {shouldUseNewStackTrace ? (


### PR DESCRIPTION
Show an onboarding banner on the issue details page when a native crash was
captured via the Android NDK integration with only a signalhandler mechanism.
The banner encourages users to enable [tombstone collection](https://docs.sentry.io/platforms/android/configuration/tombstones/) for richer crash
reports.

Includes:
- Tabbed code snippets (AndroidManifest.xml, Kotlin, Java) inline in the banner
- Dismiss/snooze support via the prompts-activity API (scoped per project)
- Suppressed on sample/demo events
- Analytics for CTA click and dismiss/snooze

Depends on #112477 (backend prompt registration) — land that first.

<img width="1130" height="1065" alt="image" src="https://github.com/user-attachments/assets/cf826134-78df-4856-945c-748719e8cbd5" />
