### PR TITLE
feat(tracemetrics): Bypass metric field validation for equations

### DIFF
--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -225,12 +225,13 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
                     )
 
                 # the metrics field is only required for non-equation queries
-                has_equations = all(
-                    is_equation(y_axis)
+                y_axes = [
+                    y_axis
                     for aggregate_field in q.get("aggregateField") or []
                     for y_axis in aggregate_field.get("yAxes") or []
-                )
-                if data["dataset"] == "metrics" and not has_equations and "metric" not in q:
+                ]
+                is_equations = len(y_axes) > 0 and all(is_equation(y_axis) for y_axis in y_axes)
+                if data["dataset"] == "metrics" and not is_equations and "metric" not in q:
                     raise serializers.ValidationError(
                         "Metric field is required for non-equation queries on the metrics dataset"
                     )

--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -227,8 +227,8 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
                 # the metrics field is only required for non-equation queries
                 has_equations = any(
                     is_equation(y_axis)
-                    for aggregate_field in q.get("aggregateField", [])
-                    for y_axis in aggregate_field.get("yAxes", [])
+                    for aggregate_field in q.get("aggregateField") or []
+                    for y_axis in aggregate_field.get("yAxes") or []
                 )
                 if data["dataset"] == "metrics" and not has_equations and "metric" not in q:
                     raise serializers.ValidationError(

--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -4,6 +4,7 @@ from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.serializers import ListField
 
 from sentry.constants import ALL_ACCESS_PROJECTS
+from sentry.discover.arithmetic import is_equation
 from sentry.explore.models import ExploreSavedQueryDataset
 from sentry.utils.dates import parse_stats_period, validate_interval
 
@@ -222,9 +223,16 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
                     raise serializers.ValidationError(
                         "Metric field is only allowed for metrics dataset"
                     )
-                if data["dataset"] == "metrics" and "metric" not in q:
+
+                # the metrics field is only required for non-equation queries
+                has_equations = any(
+                    is_equation(y_axis)
+                    for aggregate_field in q.get("aggregateField", [])
+                    for y_axis in aggregate_field.get("yAxes", [])
+                )
+                if data["dataset"] == "metrics" and not has_equations and "metric" not in q:
                     raise serializers.ValidationError(
-                        "Metric field is required for metrics dataset"
+                        "Metric field is required for non-equation queries on the metrics dataset"
                     )
                 inner_query = {}
                 for key in inner_query_keys:

--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -225,7 +225,7 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
                     )
 
                 # the metrics field is only required for non-equation queries
-                has_equations = any(
+                has_equations = all(
                     is_equation(y_axis)
                     for aggregate_field in q.get("aggregateField") or []
                     for y_axis in aggregate_field.get("yAxes") or []

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1273,7 +1273,9 @@ class ExploreSavedQueriesTest(APITestCase):
                 },
             )
         assert response.status_code == 400, response.content
-        assert "Metric field is required for metrics dataset" in str(response.data)
+        assert "Metric field is required for non-equation queries on the metrics dataset" in str(
+            response.data
+        )
 
     def test_save_with_start_and_end_time(self) -> None:
         with self.feature(self.features):

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1391,3 +1391,25 @@ class ExploreSavedQueriesTest(APITestCase):
                 },
             )
         assert response.status_code == 400
+
+    def test_post_with_equation_is_accepted(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Equation query",
+                    "projects": self.project_ids,
+                    "dataset": "metrics",
+                    "query": [
+                        {
+                            "aggregateField": [{"yAxes": ["equation|A + B"], "chartType": 1}],
+                            "mode": "samples",
+                            "fields": ["A", "B"],
+                            "orderby": "-timestamp",
+                        },
+                    ],
+                },
+            )
+        assert response.status_code == 201, response.content
+        data = response.data
+        assert data["query"][0].get("metric") is None


### PR DESCRIPTION
We enforce that there's a `metric` payload for saved queries, but when a user is plotting an equation, there can be multiple `metric`s involved, so this field no longer makes sense.

This PR relaxes the constraint so `metric` can be skipped if the user is querying an equation (i.e. we check if there's the `equation|` prefix)