### PR TITLE
fix(docs): Replace generic_metrics dataset with events_analytics_platform

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -1036,12 +1036,12 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         ```
 
         ### [Transaction Duration](/product/alerts/alert-types/#transaction-duration)
-        -  `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `generic_metrics`.
+        -  `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `events_analytics_platform`.
         -  `aggregate`: Valid values are `avg(transaction.duration)`, `p50(transaction.duration)`, `p75(transaction.duration)`, `p95(transaction.duration)`, `p99(transaction.duration)`, `p100(transaction.duration)`, and `percentile(transaction.duration,x)`, where `x` is your custom percentile.
         ```json
         {
             "queryType": 1,
-            "dataset": "generic_metrics",
+            "dataset": "events_analytics_platform",
             "aggregate": "avg(transaction.duration)"
         }
         ```
@@ -1066,29 +1066,29 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         ```
 
         ### [Largest Contentful Paint](/product/alerts/alert-types/#largest-contentful-display)
-        - `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `generic_metrics`.
+        - `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `events_analytics_platform`.
         - `aggregate`: Valid values are `avg(measurements.lcp)`, `p50(measurements.lcp)`, `p75(measurements.lcp)`, `p95(measurements.lcp)`, `p99(measurements.lcp)`, `p100(measurements.lcp)`, and `percentile(measurements.lcp,x)`, where `x` is your custom percentile.
         ```json
         {
             "queryType": 1,
-            "dataset": "generic_metrics",
+            "dataset": "events_analytics_platform",
             "aggregate": "p50(measurements.lcp)"
         }
         ```
 
         ### [First Input Delay](/product/alerts/alert-types/#first-input-delay)
-        - `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `generic_metrics`.
+        - `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `events_analytics_platform`.
         - `aggregate`: Valid values are `avg(measurements.fid)`, `p50(measurements.fid)`, `p75(measurements.fid)`, `p95(measurements.fid)`, `p99(measurements.fid)`, `p100(measurements.fid)`, and `percentile(measurements.fid,x)`, where `x` is your custom percentile.
         ```json
         {
             "queryType": 1,
-            "dataset": "generic_metrics",
+            "dataset": "events_analytics_platform",
             "aggregate": "p100(measurements.fid)"
         }
         ```
 
         ### [Cumulative Layout Shift](/product/alerts/alert-types/#cumulative-layout-shift)
-        - `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `generic_metrics`.
+        - `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `events_analytics_platform`.
         - `aggregate`: Valid values are `avg(measurements.cls)`, `p50(measurements.cls)`, `p75(measurements.cls)`, `p95(measurements.cls)`, `p99(measurements.cls)`, `p100(measurements.cls)`, and `percentile(measurements.cls,x)`, where `x` is your custom percentile.
         ```json
         {
@@ -1099,7 +1099,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         ```
 
         ### [Custom Metric](/product/alerts/alert-types/#custom-metric)
-        - `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `generic_metrics`.
+        - `dataset`: If a custom percentile is used, `dataset` is `transactions`. Otherwise, `dataset` is `events_analytics_platform`.
         - `aggregate`: Valid values are:
             - `avg(x)`, where `x` is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
             - `p50(x)`, where `x` is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
@@ -1114,7 +1114,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         ```json
         {
             "queryType": 1,
-            "dataset": "generic_metrics",
+            "dataset": "events_analytics_platform",
             "aggregate": "p75(measurements.ttfb)"
         }
         ```

--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -711,7 +711,7 @@ DATA_SOURCES_HELP_TEXT = """
             ```
 
             **Largest Contentful Paint Metric Monitor**
-            - `dataset`: If a custom percentile is used, dataset is `transactions`. Otherwise, dataset is `generic_metrics`.
+            - `dataset`: If a custom percentile is used, dataset is `transactions`. Otherwise, dataset is `events_analytics_platform`.
             - `aggregate`: Valid values are `avg(measurements.lcp)`, `p50(measurements.lcp)`, `p75(measurements.lcp)`, `p95(measurements.lcp)`, `p99(measurements.lcp)`, `p100(measurements.lcp)`, and `percentile(measurements.lcp,x)`, where `x` is your custom percentile.
 
             ```json
@@ -730,7 +730,7 @@ DATA_SOURCES_HELP_TEXT = """
             ```
 
             **Custom Metric Monitor**
-            - `dataset`: If a custom percentile is used, dataset is `transactions`. Otherwise, dataset is `generic_metrics`.
+            - `dataset`: If a custom percentile is used, dataset is `transactions`. Otherwise, dataset is `events_analytics_platform`.
             - `aggregate`: Valid values are:
             `avg(x)`, where `x` is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
             `p50(x)`, where `x` is `transaction.duration`, `measurements.cls`, `measurements.fcp`, `measurements.fid`, `measurements.fp`, `measurements.lcp`, `measurements.ttfb`, or `measurements.ttfb.requesttime`.
@@ -747,7 +747,7 @@ DATA_SOURCES_HELP_TEXT = """
             [
                 {
                     "aggregate": "p75(measurements.ttfb)"
-                    "dataset": "generic_metrics",
+                    "dataset": "events_analytics_platform",
                     "queryType": 1,
                 },
             ],


### PR DESCRIPTION
The generic metrics dataset is effectively deprecated (save for some am1 plans) so we don't want to encourage usage of it. Replace the mentions of it in the API docs with EAP. 