### PR TITLE
fix(ui): Fix "Missing queryFn" error in useAggregatedQueryKeys

### DIFF
--- a/static/app/utils/api/useAggregatedQueryKeys.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.tsx
@@ -4,11 +4,9 @@ import type {ApiResult} from 'sentry/api';
 import {defined} from 'sentry/utils';
 import {uniq} from 'sentry/utils/array/uniq';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import {fetchDataQuery, QueryObserver, useQueryClient} from 'sentry/utils/queryClient';
+import {fetchDataQuery, useQueryClient} from 'sentry/utils/queryClient';
 
 const BUFFER_WAIT_MS = 20;
-
-type Subscription = () => void;
 
 interface Props<AggregatableQueryKey, Data> {
   /**
@@ -90,14 +88,6 @@ export function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
 
   const key = getQueryKey([]).at(0);
 
-  const subscriptions = useRef<Subscription[]>([]);
-  useEffect(() => {
-    const subs = subscriptions.current;
-    return () => {
-      subs.forEach(unsubscribe => unsubscribe());
-    };
-  }, []);
-
   // The query keys that this instance cares about
   const prevQueryKeys = useRef<AggregatableQueryKey[]>([]);
 
@@ -148,19 +138,17 @@ export function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
       });
 
       const queryKey = getQueryKey(queuedAggregatableBatch);
-      queryClient.fetchQuery({
-        queryKey,
-        queryFn: fetchDataQuery,
-      });
-
-      const observer = new QueryObserver(queryClient, {queryKey});
-      const unsubscribe = observer.subscribe(_result => {
-        queryClient.removeQueries({
-          queryKey: ['aggregate', cacheKey, key, 'inFlight'],
-          predicate: isQueryKeyInBatch,
+      queryClient
+        .fetchQuery({
+          queryKey,
+          queryFn: fetchDataQuery,
+        })
+        .finally(() => {
+          queryClient.removeQueries({
+            queryKey: ['aggregate', cacheKey, key, 'inFlight'],
+            predicate: isQueryKeyInBatch,
+          });
         });
-      });
-      subscriptions.current.push(unsubscribe);
 
       if (allQueuedQueries.length > queuedQueriesBatch.length) {
         fetchData();


### PR DESCRIPTION
`useAggregatedQueryKeys` created a `QueryObserver` without a `queryFn` just to listen for when `fetchQuery` resolved so it could clean up inFlight markers. In TanStack Query v5 this throws "Missing queryFn"

Replace the observer with `.finally()` on the promise `fetchQuery` already returns - simpler and doesn't need the subscription ref cleanup.

fixes JAVASCRIPT-38K4