### PR TITLE
ref(gitlab): Wrap status sync delete+create in transaction.atomic()

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, MutableMapping
 from typing import Any
 from urllib.parse import urlparse
 
+from django.db import router, transaction
 from django.http.request import HttpRequest
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -371,29 +372,33 @@ class GitlabIntegration(
 
             data["sync_status_forward"] = bool(project_mappings)
 
-            IntegrationExternalProject.objects.filter(
-                organization_integration_id=self.org_integration.id
-            ).delete()
+            with transaction.atomic(router.db_for_write(IntegrationExternalProject)):
+                IntegrationExternalProject.objects.filter(
+                    organization_integration_id=self.org_integration.id
+                ).delete()
 
-            for project_path, statuses in project_mappings.items():
-                # Validate status values
-                valid_statuses = {GitLabIssueStatus.OPENED.value, GitLabIssueStatus.CLOSED.value}
-                if statuses["on_resolve"] not in valid_statuses:
-                    raise IntegrationError(
-                        f"Invalid resolve status: {statuses['on_resolve']}. Must be 'opened' or 'closed'."
-                    )
-                if statuses["on_unresolve"] not in valid_statuses:
-                    raise IntegrationError(
-                        f"Invalid unresolve status: {statuses['on_unresolve']}. Must be 'opened' or 'closed'."
-                    )
+                for project_path, statuses in project_mappings.items():
+                    # Validate status values
+                    valid_statuses = {
+                        GitLabIssueStatus.OPENED.value,
+                        GitLabIssueStatus.CLOSED.value,
+                    }
+                    if statuses["on_resolve"] not in valid_statuses:
+                        raise IntegrationError(
+                            f"Invalid resolve status: {statuses['on_resolve']}. Must be 'opened' or 'closed'."
+                        )
+                    if statuses["on_unresolve"] not in valid_statuses:
+                        raise IntegrationError(
+                            f"Invalid unresolve status: {statuses['on_unresolve']}. Must be 'opened' or 'closed'."
+                        )
 
-                IntegrationExternalProject.objects.create(
-                    organization_integration_id=self.org_integration.id,
-                    external_id=project_path,
-                    name=project_path,
-                    resolved_status=statuses["on_resolve"],
-                    unresolved_status=statuses["on_unresolve"],
-                )
+                    IntegrationExternalProject.objects.create(
+                        organization_integration_id=self.org_integration.id,
+                        external_id=project_path,
+                        name=project_path,
+                        resolved_status=statuses["on_resolve"],
+                        unresolved_status=statuses["on_unresolve"],
+                    )
 
         # Check webhook version BEFORE updating config to determine if migration is needed
         current_webhook_version = config.get(GITLAB_WEBHOOK_VERSION_KEY, 0)

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -20,7 +20,6 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import ExternalProviders
-from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import (
     ApiForbiddenError,
     IntegrationConfigurationError,

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -20,6 +20,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import ExternalProviders
+from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import (
     ApiForbiddenError,
     IntegrationConfigurationError,


### PR DESCRIPTION
## Summary

- Wraps the `IntegrationExternalProject` delete-then-recreate sequence in `update_organization_config` with `transaction.atomic()` to prevent data loss if a `create()` fails mid-loop
- Without this, a partial failure leaves the org with no external project records and status sync silently broken

Followup to #107216 per @GabeVillalobos's review.

## Test plan

- [ ] Existing `test_update_organization_config_status_sync`, `test_update_organization_config_invalid_status`, and `test_update_organization_config_missing_status` tests cover the happy path and error cases