### PR TITLE
feat(releases): Cache calls to compare-commits 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -677,6 +677,7 @@ module = [
   "sentry.tasks.beacon",
   "sentry.tasks.codeowners.*",
   "sentry.tasks.commit_context",
+  "sentry.tasks.commits",
   "sentry.tasks.on_demand_metrics",
   "sentry.tasks.reprocessing2",
   "sentry.tasks.seer.delete_seer_grouping_records",

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -133,6 +133,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-claude-code", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-cursor", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-copilot-agent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:integrations-github-fetch-commits-compare-cache", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:integrations-github-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-perforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Project Management Integrations Feature Parity Flags

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -78,6 +78,15 @@ def generate_fetch_commits_error_email(
 # we're future proofing this function a bit so it could be used with other code
 
 
+def handle_invalid_identity(identity: Any, commit_failure: bool = False) -> None:
+    # email the user
+    msg = generate_invalid_identity_email(identity, commit_failure)
+    msg.send_async(to=[identity.user.email])
+
+    # now remove the identity, as its invalid
+    identity.delete()
+
+
 def get_github_compare_commits_cache_key(
     organization_id: int,
     repository_id: int,
@@ -129,15 +138,6 @@ def fetch_compare_commits(
             GITHUB_FETCH_COMMITS_COMPARE_CACHE_TTL_SECONDS,
         )
     return repo_commits
-
-
-def handle_invalid_identity(identity: Any, commit_failure: bool = False) -> None:
-    # email the user
-    msg = generate_invalid_identity_email(identity, commit_failure)
-    msg.send_async(to=[identity.user.email])
-
-    # now remove the identity, as its invalid
-    identity.delete()
 
 
 def get_repo_and_provider_for_ref(
@@ -198,7 +198,6 @@ def fetch_commits(
     prev_release_id: int | None = None,
     **kwargs: Any,
 ) -> None:
-    # TODO(dcramer): this function could use some cleanup/refactoring as it's a bit unwieldy
     commit_list: list[dict[str, Any]] = []
 
     release = Release.objects.get(id=release_id)

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -215,6 +215,9 @@ def fetch_commits(
             pass
 
     organization = release.organization
+    github_compare_commits_cache_feature_enabled = features.has(
+        GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE, organization, actor=user
+    )
 
     for ref in refs:
         resolved = get_repo_and_provider_for_ref(release=release, ref=ref, user_id=user_id)
@@ -259,9 +262,7 @@ def fetch_commits(
             try:
                 provider_name = repo.provider
                 compare_commits_cache_enabled = (
-                    features.has(
-                        GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE, organization, actor=user
-                    )
+                    github_compare_commits_cache_feature_enabled
                     and isinstance(provider_name, str)
                     and provider_name in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
                     and start_sha is not None

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import sentry_sdk
 from django.urls import reverse
@@ -45,7 +47,7 @@ GITHUB_CACHEABLE_REPOSITORY_PROVIDERS = frozenset(
 )
 
 
-def generate_invalid_identity_email(identity, commit_failure=False):
+def generate_invalid_identity_email(identity: Any, commit_failure: bool = False) -> MessageBuilder:
     new_context = {
         "identity": identity,
         "auth_url": absolute_uri(reverse("socialauth_associate", args=[identity.provider])),
@@ -60,7 +62,9 @@ def generate_invalid_identity_email(identity, commit_failure=False):
     )
 
 
-def generate_fetch_commits_error_email(release, repo, error_message):
+def generate_fetch_commits_error_email(
+    release: Release, repo: Repository, error_message: str
+) -> MessageBuilder:
     new_context = {"release": release, "error_message": error_message, "repo": repo}
 
     return MessageBuilder(
@@ -75,10 +79,14 @@ def generate_fetch_commits_error_email(release, repo, error_message):
 
 
 def get_github_compare_commits_cache_key(
-    organization_id: int, repository_id: int, provider: str, start_sha: str | None, end_sha: str
+    organization_id: int,
+    repository_id: int,
+    provider: str | None,
+    start_sha: str | None,
+    end_sha: str,
 ) -> str:
     digest = md5_text(
-        organization_id, repository_id, provider, start_sha or "", end_sha
+        organization_id, repository_id, provider or "", start_sha or "", end_sha
     ).hexdigest()
     return f"fetch-commits:compare-commits:v1:{digest}"
 
@@ -87,26 +95,17 @@ def fetch_compare_commits(
     *,
     cache_enabled: bool,
     repo: Repository,
-    provider,
+    provider: Any,
     is_integration_repo_provider: bool,
     start_sha: str | None,
     end_sha: str,
     user: RpcUser | None,
-    lifecycle,
-):
-    cache_key = None
-    provider = repo.provider
-    if (
-        cache_enabled
-        and isinstance(provider, str)
-        and provider in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
-        and start_sha is not None
-    ):
+    lifecycle: Any,
+) -> list[dict[str, Any]]:
+    if cache_enabled:
         cache_key = get_github_compare_commits_cache_key(
-            repo.organization_id, repo.id, provider, start_sha, end_sha
+            repo.organization_id, repo.id, repo.provider, start_sha, end_sha
         )
-
-    if cache_key is not None:
         cached_repo_commits = cache.get(cache_key)
         lifecycle.add_extra("compare_commits_cache_enabled", True)
         if cached_repo_commits is not None:
@@ -120,9 +119,10 @@ def fetch_compare_commits(
     if is_integration_repo_provider:
         repo_commits = provider.compare_commits(repo, start_sha, end_sha)
     else:
+        # XXX: This only works for plugins that support actor context
         repo_commits = provider.compare_commits(repo, start_sha, end_sha, actor=user)
 
-    if cache_key is not None:
+    if cache_enabled:
         cache.set(
             cache_key,
             repo_commits,
@@ -131,13 +131,56 @@ def fetch_compare_commits(
     return repo_commits
 
 
-def handle_invalid_identity(identity, commit_failure=False):
+def handle_invalid_identity(identity: Any, commit_failure: bool = False) -> None:
     # email the user
     msg = generate_invalid_identity_email(identity, commit_failure)
     msg.send_async(to=[identity.user.email])
 
     # now remove the identity, as its invalid
     identity.delete()
+
+
+def get_repo_and_provider_for_ref(
+    *,
+    release: Release,
+    ref: Mapping[str, str],
+    user_id: int,
+) -> tuple[Repository, Any, bool, str] | None:
+    repo = (
+        Repository.objects.filter(
+            organization_id=release.organization_id,
+            name=ref["repository"],
+            status=ObjectStatus.ACTIVE,
+        )
+        .order_by("-pk")
+        .first()
+    )
+    if not repo:
+        logger.info(
+            "repository.missing",
+            extra={
+                "organization_id": release.organization_id,
+                "user_id": user_id,
+                "repository": ref["repository"],
+            },
+        )
+        return None
+
+    is_integration_repo_provider = is_integration_provider(repo.provider)
+    binding_key = (
+        "integration-repository.provider" if is_integration_repo_provider else "repository.provider"
+    )
+    try:
+        provider_cls = bindings.get(binding_key).get(repo.provider)
+    except KeyError:
+        return None
+
+    provider = provider_cls(id=repo.provider)
+    provider_key = (
+        provider_cls.repo_provider if is_integration_repo_provider else provider_cls.auth_provider
+    )
+
+    return repo, provider, is_integration_repo_provider, provider_key
 
 
 @instrumented_task(
@@ -148,9 +191,15 @@ def handle_invalid_identity(identity, commit_failure=False):
     silo_mode=SiloMode.CELL,
 )
 @retry(exclude=(Release.DoesNotExist, User.DoesNotExist))
-def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **kwargs):
+def fetch_commits(
+    release_id: int,
+    user_id: int,
+    refs: Sequence[Mapping[str, str]],
+    prev_release_id: int | None = None,
+    **kwargs: Any,
+) -> None:
     # TODO(dcramer): this function could use some cleanup/refactoring as it's a bit unwieldy
-    commit_list = []
+    commit_list: list[dict[str, Any]] = []
 
     release = Release.objects.get(id=release_id)
     set_tag("organization.slug", release.organization.slug)
@@ -166,41 +215,12 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
             pass
 
     organization = release.organization
-    github_compare_commits_cache_enabled = features.has(
-        GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE, organization, actor=user
-    )
 
     for ref in refs:
-        repo = (
-            Repository.objects.filter(
-                organization_id=release.organization_id,
-                name=ref["repository"],
-                status=ObjectStatus.ACTIVE,
-            )
-            .order_by("-pk")
-            .first()
-        )
-        if not repo:
-            logger.info(
-                "repository.missing",
-                extra={
-                    "organization_id": release.organization_id,
-                    "user_id": user_id,
-                    "repository": ref["repository"],
-                },
-            )
+        resolved = get_repo_and_provider_for_ref(release=release, ref=ref, user_id=user_id)
+        if resolved is None:
             continue
-
-        is_integration_repo_provider = is_integration_provider(repo.provider)
-        binding_key = (
-            "integration-repository.provider"
-            if is_integration_repo_provider
-            else "repository.provider"
-        )
-        try:
-            provider_cls = bindings.get(binding_key).get(repo.provider)
-        except KeyError:
-            continue
+        repo, provider, is_integration_repo_provider, provider_key = resolved
 
         # if previous commit isn't provided, try to get from
         # previous release otherwise, try to get
@@ -219,13 +239,6 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
                 pass
 
         end_sha = ref["commit"]
-        provider = provider_cls(id=repo.provider)
-
-        provider_key = (
-            provider_cls.repo_provider
-            if is_integration_repo_provider
-            else provider_cls.auth_provider
-        )
 
         with SCMIntegrationInteractionEvent(
             SCMIntegrationInteractionType.COMPARE_COMMITS,
@@ -244,8 +257,17 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
                 }
             )
             try:
+                provider_name = repo.provider
+                compare_commits_cache_enabled = (
+                    features.has(
+                        GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE, organization, actor=user
+                    )
+                    and isinstance(provider_name, str)
+                    and provider_name in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
+                    and start_sha is not None
+                )
                 repo_commits = fetch_compare_commits(
-                    cache_enabled=github_compare_commits_cache_enabled,
+                    cache_enabled=compare_commits_cache_enabled,
                     repo=repo,
                     provider=provider,
                     is_integration_repo_provider=is_integration_repo_provider,
@@ -356,11 +378,11 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
         Deploy.notify_if_ready(deploy_id, fetch_complete=True)
 
 
-def is_integration_provider(provider):
-    return provider and provider.startswith("integrations:")
+def is_integration_provider(provider: str | None) -> bool:
+    return bool(provider and provider.startswith("integrations:"))
 
 
-def get_emails_for_user_or_org(user: RpcUser | None, orgId: int):
+def get_emails_for_user_or_org(user: RpcUser | None, orgId: int) -> list[str]:
     emails: list[str] = []
     if not user:
         return []

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from sentry_sdk import set_tag
 from taskbroker_client.retry import Retry
 
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity, PluginError
 from sentry.integrations.source_code_management.metrics import (
@@ -28,10 +29,20 @@ from sentry.taskworker.namespaces import issues_tasks
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
+from sentry.utils.cache import cache
 from sentry.utils.email import MessageBuilder
+from sentry.utils.hashlib import md5_text
 from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger(__name__)
+
+GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE = (
+    "organizations:integrations-github-fetch-commits-compare-cache"
+)
+GITHUB_FETCH_COMMITS_COMPARE_CACHE_TTL_SECONDS = 120
+GITHUB_CACHEABLE_REPOSITORY_PROVIDERS = frozenset(
+    ("integrations:github", "integrations:github_enterprise")
+)
 
 
 def generate_invalid_identity_email(identity, commit_failure=False):
@@ -61,6 +72,63 @@ def generate_fetch_commits_error_email(release, repo, error_message):
 
 
 # we're future proofing this function a bit so it could be used with other code
+
+
+def get_github_compare_commits_cache_key(
+    organization_id: int, repository_id: int, provider: str, start_sha: str | None, end_sha: str
+) -> str:
+    digest = md5_text(
+        organization_id, repository_id, provider, start_sha or "", end_sha
+    ).hexdigest()
+    return f"fetch-commits:compare-commits:v1:{digest}"
+
+
+def fetch_compare_commits(
+    *,
+    cache_enabled: bool,
+    repo: Repository,
+    provider,
+    is_integration_repo_provider: bool,
+    start_sha: str | None,
+    end_sha: str,
+    user: RpcUser | None,
+    lifecycle,
+):
+    cache_key = None
+    provider = repo.provider
+    if (
+        cache_enabled
+        and isinstance(provider, str)
+        and provider in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
+        and start_sha is not None
+    ):
+        cache_key = get_github_compare_commits_cache_key(
+            repo.organization_id, repo.id, provider, start_sha, end_sha
+        )
+
+    if cache_key is not None:
+        cached_repo_commits = cache.get(cache_key)
+        lifecycle.add_extra("compare_commits_cache_enabled", True)
+        if cached_repo_commits is not None:
+            lifecycle.add_extra("compare_commits_cache_hit", True)
+            return cached_repo_commits
+
+        lifecycle.add_extra("compare_commits_cache_hit", False)
+    else:
+        lifecycle.add_extra("compare_commits_cache_enabled", False)
+
+    if is_integration_repo_provider:
+        repo_commits = provider.compare_commits(repo, start_sha, end_sha)
+    else:
+        repo_commits = provider.compare_commits(repo, start_sha, end_sha, actor=user)
+
+    if cache_key is not None:
+        cache.set(
+            cache_key,
+            repo_commits,
+            GITHUB_FETCH_COMMITS_COMPARE_CACHE_TTL_SECONDS,
+        )
+    return repo_commits
 
 
 def handle_invalid_identity(identity, commit_failure=False):
@@ -96,6 +164,11 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
             prev_release = Release.objects.get(id=prev_release_id)
         except Release.DoesNotExist:
             pass
+
+    organization = release.organization
+    github_compare_commits_cache_enabled = features.has(
+        GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE, organization, actor=user
+    )
 
     for ref in refs:
         repo = (
@@ -171,10 +244,16 @@ def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **k
                 }
             )
             try:
-                if is_integration_repo_provider:
-                    repo_commits = provider.compare_commits(repo, start_sha, end_sha)
-                else:
-                    repo_commits = provider.compare_commits(repo, start_sha, end_sha, actor=user)
+                repo_commits = fetch_compare_commits(
+                    cache_enabled=github_compare_commits_cache_enabled,
+                    repo=repo,
+                    provider=provider,
+                    is_integration_repo_provider=is_integration_repo_provider,
+                    start_sha=start_sha,
+                    end_sha=end_sha,
+                    user=user,
+                    lifecycle=lifecycle,
+                )
             except NotImplementedError:
                 pass
             except IntegrationResourceNotFoundError:

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -33,7 +33,7 @@ from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.utils.cache import cache
 from sentry.utils.email import MessageBuilder
-from sentry.utils.hashlib import md5_text
+from sentry.utils.hashlib import hash_values
 from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger(__name__)
@@ -94,9 +94,10 @@ def get_github_compare_commits_cache_key(
     start_sha: str | None,
     end_sha: str,
 ) -> str:
-    digest = md5_text(
-        organization_id, repository_id, provider or "", start_sha or "", end_sha
-    ).hexdigest()
+    digest = hash_values(
+        [organization_id, repository_id, provider or "", start_sha or "", end_sha],
+        seed="fetch-commits:compare-commits",
+    )
     return f"fetch-commits:compare-commits:v1:{digest}"
 
 

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -206,6 +206,33 @@ class GitHubAppsProviderTest(TestCase):
         # Now that patchset was cached, github shouldn't have been called again
         assert len(responses.calls) == 1
 
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_compare_commits_reuses_cached_patchset_across_calls(
+        self, get_jwt: mock.MagicMock
+    ) -> None:
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
+            json=orjson.loads(COMPARE_COMMITS_EXAMPLE),
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
+            json=orjson.loads(COMPARE_COMMITS_EXAMPLE),
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            json=orjson.loads(GET_COMMIT_EXAMPLE),
+        )
+
+        first = self.provider.compare_commits(self.repository, "xyz123", "abcdef")
+        second = self.provider.compare_commits(self.repository, "xyz123", "abcdef")
+
+        assert first == second
+        assert len(responses.calls) == 3
+
     @responses.activate
     def test_compare_commits_failure(self) -> None:
         responses.add(

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -17,11 +17,19 @@ from sentry.tasks.commits import fetch_commits, handle_invalid_identity
 from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.utils.cache import cache
 from social_auth.models import UserSocialAuth
 
 
 @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
 class FetchCommitsTest(TestCase):
+    def _github_compare_commits_result(self, repo_name: str, end_sha: str) -> list[dict[str, str]]:
+        return [
+            {"id": "62de626b7c7cfb8e77efb4273b1a3df4123e6216", "repository": repo_name},
+            {"id": "58de626b7c7cfb8e77efb4273b1a3df4123e6345", "repository": repo_name},
+            {"id": end_sha, "repository": repo_name},
+        ]
+
     def _test_simple_action(self, user, org):
         repo = Repository.objects.create(name="example", provider="dummy", organization_id=org.id)
         release = Release.objects.create(organization_id=org.id, version="abcabcabc")
@@ -85,6 +93,154 @@ class FetchCommitsTest(TestCase):
         )
         Repository.objects.create(name="example", provider="dummy", organization_id=org.id)
         self._test_simple_action(user=self.user, org=org)
+
+    @patch("sentry.integrations.github.repository.GitHubRepositoryProvider.compare_commits")
+    def test_github_compare_commits_cache_flag_disabled(
+        self, mock_compare_commits: MagicMock, mock_record: MagicMock
+    ) -> None:
+        self.login_as(user=self.user)
+        cache.clear()
+
+        org = self.create_organization(owner=self.user, name="baz")
+        repo = Repository.objects.create(
+            name="example",
+            provider="integrations:github",
+            organization_id=org.id,
+        )
+        previous_release = Release.objects.create(organization_id=org.id, version="old-release")
+        previous_commit = Commit.objects.create(
+            organization_id=org.id, repository_id=repo.id, key="a" * 40
+        )
+        ReleaseHeadCommit.objects.create(
+            organization_id=org.id,
+            repository_id=repo.id,
+            release=previous_release,
+            commit=previous_commit,
+        )
+
+        refs = [{"repository": repo.name, "commit": "b" * 40}]
+        mock_compare_commits.return_value = self._github_compare_commits_result(repo.name, "b" * 40)
+
+        first_release = Release.objects.create(organization_id=org.id, version="new-release-1")
+        second_release = Release.objects.create(organization_id=org.id, version="new-release-2")
+
+        with self.tasks():
+            fetch_commits(
+                release_id=first_release.id,
+                user_id=self.user.id,
+                refs=refs,
+                previous_release_id=previous_release.id,
+            )
+            fetch_commits(
+                release_id=second_release.id,
+                user_id=self.user.id,
+                refs=refs,
+                previous_release_id=previous_release.id,
+            )
+
+        assert mock_compare_commits.call_count == 2
+
+    @patch("sentry.integrations.github.repository.GitHubRepositoryProvider.compare_commits")
+    def test_github_compare_commits_cache_flag_enabled(
+        self, mock_compare_commits: MagicMock, mock_record: MagicMock
+    ) -> None:
+        self.login_as(user=self.user)
+        cache.clear()
+
+        org = self.create_organization(owner=self.user, name="baz")
+        repo = Repository.objects.create(
+            name="example",
+            provider="integrations:github",
+            organization_id=org.id,
+        )
+        previous_release = Release.objects.create(organization_id=org.id, version="old-release")
+        previous_commit = Commit.objects.create(
+            organization_id=org.id, repository_id=repo.id, key="a" * 40
+        )
+        ReleaseHeadCommit.objects.create(
+            organization_id=org.id,
+            repository_id=repo.id,
+            release=previous_release,
+            commit=previous_commit,
+        )
+
+        refs = [{"repository": repo.name, "commit": "b" * 40}]
+        mock_compare_commits.return_value = self._github_compare_commits_result(repo.name, "b" * 40)
+
+        first_release = Release.objects.create(organization_id=org.id, version="new-release-1")
+        second_release = Release.objects.create(organization_id=org.id, version="new-release-2")
+
+        with self.feature(
+            {"organizations:integrations-github-fetch-commits-compare-cache": [org.slug]}
+        ):
+            with self.tasks():
+                fetch_commits(
+                    release_id=first_release.id,
+                    user_id=self.user.id,
+                    refs=refs,
+                    previous_release_id=previous_release.id,
+                )
+                fetch_commits(
+                    release_id=second_release.id,
+                    user_id=self.user.id,
+                    refs=refs,
+                    previous_release_id=previous_release.id,
+                )
+
+        assert mock_compare_commits.call_count == 1
+
+    @patch("sentry.integrations.github.repository.GitHubRepositoryProvider.compare_commits")
+    def test_github_compare_commits_cache_key_variance_on_end_sha(
+        self, mock_compare_commits: MagicMock, mock_record: MagicMock
+    ) -> None:
+        self.login_as(user=self.user)
+        cache.clear()
+
+        org = self.create_organization(owner=self.user, name="baz")
+        repo = Repository.objects.create(
+            name="example",
+            provider="integrations:github",
+            organization_id=org.id,
+        )
+        previous_release = Release.objects.create(organization_id=org.id, version="old-release")
+        previous_commit = Commit.objects.create(
+            organization_id=org.id, repository_id=repo.id, key="a" * 40
+        )
+        ReleaseHeadCommit.objects.create(
+            organization_id=org.id,
+            repository_id=repo.id,
+            release=previous_release,
+            commit=previous_commit,
+        )
+
+        refs_first = [{"repository": repo.name, "commit": "b" * 40}]
+        refs_second = [{"repository": repo.name, "commit": "c" * 40}]
+        mock_compare_commits.side_effect = [
+            self._github_compare_commits_result(repo.name, "b" * 40),
+            self._github_compare_commits_result(repo.name, "c" * 40),
+        ]
+
+        first_release = Release.objects.create(organization_id=org.id, version="new-release-1")
+        second_release = Release.objects.create(organization_id=org.id, version="new-release-2")
+
+        with self.feature(
+            {"organizations:integrations-github-fetch-commits-compare-cache": [org.slug]}
+        ):
+            with self.tasks():
+                fetch_commits(
+                    release_id=first_release.id,
+                    user_id=self.user.id,
+                    refs=refs_first,
+                    previous_release_id=previous_release.id,
+                )
+                fetch_commits(
+                    release_id=second_release.id,
+                    user_id=self.user.id,
+                    refs=refs_second,
+                    previous_release_id=previous_release.id,
+                )
+
+        assert mock_compare_commits.call_count == 2
 
     def test_release_locked(self, mock_record_event: MagicMock) -> None:
         self.login_as(user=self.user)

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -13,7 +13,11 @@ from sentry.models.release import Release
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
-from sentry.tasks.commits import fetch_commits, handle_invalid_identity
+from sentry.tasks.commits import (
+    fetch_commits,
+    get_github_compare_commits_cache_key,
+    handle_invalid_identity,
+)
 from sentry.testutils.asserts import assert_slo_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -29,6 +33,14 @@ class FetchCommitsTest(TestCase):
             {"id": "58de626b7c7cfb8e77efb4273b1a3df4123e6345", "repository": repo_name},
             {"id": end_sha, "repository": repo_name},
         ]
+
+    def test_github_compare_commits_cache_key_avoids_ambiguous_id_collisions(
+        self, mock_record: MagicMock
+    ) -> None:
+        key_one = get_github_compare_commits_cache_key(1, 23, "integrations:github", "a", "b")
+        key_two = get_github_compare_commits_cache_key(12, 3, "integrations:github", "a", "b")
+
+        assert key_one != key_two
 
     def _test_simple_action(self, user, org):
         repo = Repository.objects.create(name="example", provider="dummy", organization_id=org.id)

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -52,7 +52,7 @@ class FetchCommitsTest(TestCase):
                     release_id=release2.id,
                     user_id=user.id,
                     refs=refs,
-                    previous_release_id=release.id,
+                    prev_release_id=release.id,
                 )
 
         commit_list = list(
@@ -129,13 +129,13 @@ class FetchCommitsTest(TestCase):
                 release_id=first_release.id,
                 user_id=self.user.id,
                 refs=refs,
-                previous_release_id=previous_release.id,
+                prev_release_id=previous_release.id,
             )
             fetch_commits(
                 release_id=second_release.id,
                 user_id=self.user.id,
                 refs=refs,
-                previous_release_id=previous_release.id,
+                prev_release_id=previous_release.id,
             )
 
         assert mock_compare_commits.call_count == 2
@@ -178,13 +178,13 @@ class FetchCommitsTest(TestCase):
                     release_id=first_release.id,
                     user_id=self.user.id,
                     refs=refs,
-                    previous_release_id=previous_release.id,
+                    prev_release_id=previous_release.id,
                 )
                 fetch_commits(
                     release_id=second_release.id,
                     user_id=self.user.id,
                     refs=refs,
-                    previous_release_id=previous_release.id,
+                    prev_release_id=previous_release.id,
                 )
 
         assert mock_compare_commits.call_count == 1
@@ -231,13 +231,13 @@ class FetchCommitsTest(TestCase):
                     release_id=first_release.id,
                     user_id=self.user.id,
                     refs=refs_first,
-                    previous_release_id=previous_release.id,
+                    prev_release_id=previous_release.id,
                 )
                 fetch_commits(
                     release_id=second_release.id,
                     user_id=self.user.id,
                     refs=refs_second,
-                    previous_release_id=previous_release.id,
+                    prev_release_id=previous_release.id,
                 )
 
         assert mock_compare_commits.call_count == 2
@@ -264,7 +264,7 @@ class FetchCommitsTest(TestCase):
                 release_id=new_release.id,
                 user_id=self.user.id,
                 refs=refs,
-                previous_release_id=old_release.id,
+                prev_release_id=old_release.id,
             )
         count_query = ReleaseHeadCommit.objects.filter(release=new_release)
         # No release commits should be made as the task should return early.
@@ -297,7 +297,7 @@ class FetchCommitsTest(TestCase):
         mock_compare_commits.side_effect = InvalidIdentity(identity=usa)
 
         fetch_commits(
-            release_id=release2.id, user_id=self.user.id, refs=refs, previous_release_id=release.id
+            release_id=release2.id, user_id=self.user.id, refs=refs, prev_release_id=release.id
         )
 
         mock_handle_invalid_identity.assert_called_once_with(identity=usa, commit_failure=True)
@@ -334,7 +334,7 @@ class FetchCommitsTest(TestCase):
                 release_id=release2.id,
                 user_id=self.user.id,
                 refs=refs,
-                previous_release_id=release.id,
+                prev_release_id=release.id,
             )
 
         msg = mail.outbox[-1]
@@ -375,7 +375,7 @@ class FetchCommitsTest(TestCase):
                 release_id=release2.id,
                 user_id=sentry_app.proxy_user_id,
                 refs=refs,
-                previous_release_id=release.id,
+                prev_release_id=release.id,
             )
 
         msg = mail.outbox[-1]
@@ -415,7 +415,7 @@ class FetchCommitsTest(TestCase):
                 release_id=release2.id,
                 user_id=self.user.id,
                 refs=refs,
-                previous_release_id=release.id,
+                prev_release_id=release.id,
             )
 
         msg = mail.outbox[-1]
@@ -456,7 +456,7 @@ class FetchCommitsTest(TestCase):
                 release_id=release2.id,
                 user_id=self.user.id,
                 refs=refs,
-                previous_release_id=release.id,
+                prev_release_id=release.id,
             )
 
         msg = mail.outbox[-1]

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -34,6 +34,29 @@ class FetchCommitsTest(TestCase):
             {"id": end_sha, "repository": repo_name},
         ]
 
+    def _setup_github_compare_commits_cache_context(self):
+        org = self.create_organization(owner=self.user, name="baz")
+        repo = Repository.objects.create(
+            name="example",
+            provider="integrations:github",
+            organization_id=org.id,
+        )
+        previous_release = Release.objects.create(organization_id=org.id, version="old-release")
+        previous_commit = Commit.objects.create(
+            organization_id=org.id, repository_id=repo.id, key="a" * 40
+        )
+        ReleaseHeadCommit.objects.create(
+            organization_id=org.id,
+            repository_id=repo.id,
+            release=previous_release,
+            commit=previous_commit,
+        )
+
+        refs = [{"repository": repo.name, "commit": "b" * 40}]
+        first_release = Release.objects.create(organization_id=org.id, version="new-release-1")
+        second_release = Release.objects.create(organization_id=org.id, version="new-release-2")
+        return org, repo, previous_release, first_release, second_release, refs
+
     def test_github_compare_commits_cache_key_avoids_ambiguous_id_collisions(
         self, mock_record: MagicMock
     ) -> None:
@@ -113,28 +136,10 @@ class FetchCommitsTest(TestCase):
         self.login_as(user=self.user)
         cache.clear()
 
-        org = self.create_organization(owner=self.user, name="baz")
-        repo = Repository.objects.create(
-            name="example",
-            provider="integrations:github",
-            organization_id=org.id,
+        _, repo, previous_release, first_release, second_release, refs = (
+            self._setup_github_compare_commits_cache_context()
         )
-        previous_release = Release.objects.create(organization_id=org.id, version="old-release")
-        previous_commit = Commit.objects.create(
-            organization_id=org.id, repository_id=repo.id, key="a" * 40
-        )
-        ReleaseHeadCommit.objects.create(
-            organization_id=org.id,
-            repository_id=repo.id,
-            release=previous_release,
-            commit=previous_commit,
-        )
-
-        refs = [{"repository": repo.name, "commit": "b" * 40}]
         mock_compare_commits.return_value = self._github_compare_commits_result(repo.name, "b" * 40)
-
-        first_release = Release.objects.create(organization_id=org.id, version="new-release-1")
-        second_release = Release.objects.create(organization_id=org.id, version="new-release-2")
 
         with self.tasks():
             fetch_commits(
@@ -159,28 +164,10 @@ class FetchCommitsTest(TestCase):
         self.login_as(user=self.user)
         cache.clear()
 
-        org = self.create_organization(owner=self.user, name="baz")
-        repo = Repository.objects.create(
-            name="example",
-            provider="integrations:github",
-            organization_id=org.id,
+        org, repo, previous_release, first_release, second_release, refs = (
+            self._setup_github_compare_commits_cache_context()
         )
-        previous_release = Release.objects.create(organization_id=org.id, version="old-release")
-        previous_commit = Commit.objects.create(
-            organization_id=org.id, repository_id=repo.id, key="a" * 40
-        )
-        ReleaseHeadCommit.objects.create(
-            organization_id=org.id,
-            repository_id=repo.id,
-            release=previous_release,
-            commit=previous_commit,
-        )
-
-        refs = [{"repository": repo.name, "commit": "b" * 40}]
         mock_compare_commits.return_value = self._github_compare_commits_result(repo.name, "b" * 40)
-
-        first_release = Release.objects.create(organization_id=org.id, version="new-release-1")
-        second_release = Release.objects.create(organization_id=org.id, version="new-release-2")
 
         with self.feature(
             {"organizations:integrations-github-fetch-commits-compare-cache": [org.slug]}
@@ -208,32 +195,14 @@ class FetchCommitsTest(TestCase):
         self.login_as(user=self.user)
         cache.clear()
 
-        org = self.create_organization(owner=self.user, name="baz")
-        repo = Repository.objects.create(
-            name="example",
-            provider="integrations:github",
-            organization_id=org.id,
+        org, repo, previous_release, first_release, second_release, refs_first = (
+            self._setup_github_compare_commits_cache_context()
         )
-        previous_release = Release.objects.create(organization_id=org.id, version="old-release")
-        previous_commit = Commit.objects.create(
-            organization_id=org.id, repository_id=repo.id, key="a" * 40
-        )
-        ReleaseHeadCommit.objects.create(
-            organization_id=org.id,
-            repository_id=repo.id,
-            release=previous_release,
-            commit=previous_commit,
-        )
-
-        refs_first = [{"repository": repo.name, "commit": "b" * 40}]
         refs_second = [{"repository": repo.name, "commit": "c" * 40}]
         mock_compare_commits.side_effect = [
             self._github_compare_commits_result(repo.name, "b" * 40),
             self._github_compare_commits_result(repo.name, "c" * 40),
         ]
-
-        first_release = Release.objects.create(organization_id=org.id, version="new-release-1")
-        second_release = Release.objects.create(organization_id=org.id, version="new-release-2")
 
         with self.feature(
             {"organizations:integrations-github-fetch-commits-compare-cache": [org.slug]}


### PR DESCRIPTION
A customer has a large number of GitHub API rate limit emails coming in and the highest referrer is compare-commits.

This branch aims to temporarily cache and protect from many incoming calls to compare-commits and see if it solves the problem.