### PR TITLE
fix(traces): align log table contents to start, regardless of height

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -153,6 +153,7 @@ export const LogTableBody = styled(TableBody)<{
     padding-top: ${p.theme.space.md};
     padding-bottom: ${p.theme.space.md};
     `}
+  align-content: start;
   overflow-x: hidden;
   overflow-anchor: none;
 

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -87,6 +87,7 @@ const TableContainer = styled('div')`
   margin-top: ${p => p.theme.space.xl};
   display: flex;
   flex-direction: column;
+  flex: 1;
   min-height: 0;
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -87,7 +87,6 @@ const TableContainer = styled('div')`
   margin-top: ${p => p.theme.space.xl};
   display: flex;
   flex-direction: column;
-  flex: 1;
   min-height: 0;
 `;
 


### PR DESCRIPTION
The existing `flex: 1` on `TableContainer` makes the table contents grow to fill their vertical space. When there aren't enough logs to fill the screen, by default flex-expand vertically. This adds `align-contents: start` so they're shoved into the beginning instead.

Example traces:

* One log: sentry > `f4ce570538e746b4b3ea9a745c51bdce`
* Three logs: sentry > `5eedb0ca1a5b43c18aaaeb9ad926f8ba`
* Ten logs: sentry > `f8764c2c9c594eb6b47e4ee35b397277`
* Hundreds of logs: sentry > `64dbb2f1952742a0941ece5188ae07d5`
* Thousands of logs (thanks @k-fish!): sentry > `a7988807ac5d496bafb9611c5626538b`

Fixes LOGS-677