### PR TITLE
ref(snapshots): Remove unused org_id and project_id metric tags

### DIFF
--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -666,8 +666,6 @@ def compare_snapshots(
         time_now = timezone.now()
 
         metric_tags = {
-            "org_id_temp": str(org_id),
-            "project_id_temp": str(project_id),
             "app_id_temp": head_artifact.app_id or "",
         }
 


### PR DESCRIPTION
Remove `org_id_temp` and `project_id_temp` from the `compare_snapshots` metric tags — we no longer need them.