### PR TITLE
fix(preprod): Add organization_slug to snapshot log statements

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -534,7 +534,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 "preprod_artifact_id": artifact.id,
                 "snapshot_metrics_id": snapshot_metrics.id,
                 "project_id": project.id,
-                "organization_id": project.organization_id,
+                "organization_slug": project.organization.slug,
                 "head_sha": head_sha,
                 "manifest_key": manifest_key,
                 "image_count": len(images),

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -232,6 +232,7 @@ def _try_auto_approve_snapshot(
         extra={
             "head_artifact_id": head_artifact.id,
             "prev_approved_artifact_id": approved_sibling.id,
+            "organization_slug": head_artifact.project.organization.slug,
         },
     )
 
@@ -722,6 +723,7 @@ def compare_snapshots(
             extra={
                 "head_artifact_id": head_artifact_id,
                 "base_artifact_id": base_artifact_id,
+                "organization_slug": head_artifact.project.organization.slug,
                 "changed": changed_count,
                 "unchanged": unchanged_count,
                 "added": len(added),
@@ -737,6 +739,7 @@ def compare_snapshots(
             extra={
                 "head_artifact_id": head_artifact_id,
                 "base_artifact_id": base_artifact_id,
+                "organization_slug": head_artifact.project.organization.slug,
             },
         )
         if comparison is not None:

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -260,7 +260,7 @@ def compare_snapshots(
     )
 
     try:
-        head_artifact = PreprodArtifact.objects.get(
+        head_artifact = PreprodArtifact.objects.select_related("project__organization").get(
             id=head_artifact_id,
             project__organization_id=org_id,
             project_id=project_id,


### PR DESCRIPTION
## Summary
- Adds `organization_slug` to 4 preprod snapshot log statements for easier filtering by organization in logging dashboards
- Replaces `organization_id` with `organization_slug` in the snapshot creation log
- Adds `organization_slug` to auto-approve, comparison complete, and comparison failed logs


doing this for our sentry dashboard usage