### PR TITLE
perf(hybridcloud): Skip correlated subqueries in user.serialize_many

### DIFF
--- a/src/sentry/hybridcloud/rpc/filter_query.py
+++ b/src/sentry/hybridcloud/rpc/filter_query.py
@@ -121,7 +121,7 @@ class FilterQueryDatabaseImpl(
         if as_user is None and auth_context:
             as_user = auth_context.user
 
-        result = self.query_many(filter=filter)
+        result = self.query_many(filter=filter, select_related=False)
         return serialize(
             list(result),
             user=as_user,

--- a/src/sentry/hybridcloud/rpc/filter_query.py
+++ b/src/sentry/hybridcloud/rpc/filter_query.py
@@ -109,6 +109,7 @@ class FilterQueryDatabaseImpl(
         as_user: RpcUser | None = None,
         auth_context: AuthenticationContext | None = None,
         serializer: SERIALIZER_ENUM | None = None,
+        select_related: bool = True,
     ) -> list[OpaqueSerializedResponse]:
         from sentry.api.serializers import serialize
         from sentry.users.services.user import RpcUser
@@ -121,7 +122,7 @@ class FilterQueryDatabaseImpl(
         if as_user is None and auth_context:
             as_user = auth_context.user
 
-        result = self.query_many(filter=filter, select_related=False)
+        result = self.query_many(filter=filter, select_related=select_related)
         return serialize(
             list(result),
             user=as_user,

--- a/src/sentry/users/services/user/impl.py
+++ b/src/sentry/users/services/user/impl.py
@@ -62,7 +62,12 @@ class DatabaseBackedUserService(UserService):
         auth_context: AuthenticationContext | None = None,
         serializer: UserSerializeType | None = None,
     ) -> list[OpaqueSerializedResponse]:
-        return self._FQ.serialize_many(filter, as_user, auth_context, serializer)
+        # Pass select_related=False to skip the correlated subqueries in
+        # base_query() - they are only used by the get_many/serialize_rpc path.
+        # The API serializer fetches what it needs in get_attrs().
+        return self._FQ.serialize_many(
+            filter, as_user, auth_context, serializer, select_related=False
+        )
 
     def get_many(self, *, filter: UserFilterArgs) -> list[RpcUser]:
         return self._FQ.get_many(filter)

--- a/src/sentry/users/services/user/impl.py
+++ b/src/sentry/users/services/user/impl.py
@@ -62,9 +62,6 @@ class DatabaseBackedUserService(UserService):
         auth_context: AuthenticationContext | None = None,
         serializer: UserSerializeType | None = None,
     ) -> list[OpaqueSerializedResponse]:
-        # Pass select_related=False to skip the correlated subqueries in
-        # base_query() - they are only used by the get_many/serialize_rpc path.
-        # The API serializer fetches what it needs in get_attrs().
         return self._FQ.serialize_many(
             filter, as_user, auth_context, serializer, select_related=False
         )

--- a/tests/sentry/users/services/test_user.py
+++ b/tests/sentry/users/services/test_user.py
@@ -77,13 +77,11 @@ class UserServiceTest(TestCase):
         created = user_service.add_permission(user_id=self.user.id, permission="superuser.write")
         assert created is False
 
-    def test_serialize_many_does_not_use_extra_subqueries(self) -> None:
-        """serialize_many goes through the API serializer path which does its own
-        queries in get_attrs(). The correlated subqueries from base_query()
-        (permissions, roles, useremails, authenticators, useravatar) should not
-        be included since they are only needed for the get_many/serialize_rpc path."""
+    def test_serialize_many_avoids_correlated_subqueries(self) -> None:
+        """base_query() eagerly loads data via correlated subqueries for the
+        get_many/serialize_rpc path. serialize_many should not pay for these
+        since the API serializer re-fetches what it needs in get_attrs()."""
         with assume_test_silo_mode(SiloMode.CONTROL):
-            # Warm up any caches
             user_service.serialize_many(filter={"user_ids": [self.user.id]})
 
             with CaptureQueriesContext(connections["control"]) as ctx:

--- a/tests/sentry/users/services/test_user.py
+++ b/tests/sentry/users/services/test_user.py
@@ -1,3 +1,6 @@
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
+
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
@@ -73,6 +76,21 @@ class UserServiceTest(TestCase):
         # Test adding the same permission again returns False
         created = user_service.add_permission(user_id=self.user.id, permission="superuser.write")
         assert created is False
+
+    def test_serialize_many_does_not_use_extra_subqueries(self) -> None:
+        """serialize_many goes through the API serializer path which does its own
+        queries in get_attrs(). The correlated subqueries from base_query()
+        (permissions, roles, useremails, authenticators, useravatar) should not
+        be included since they are only needed for the get_many/serialize_rpc path."""
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            # Warm up any caches
+            user_service.serialize_many(filter={"user_ids": [self.user.id]})
+
+            with CaptureQueriesContext(connections["control"]) as ctx:
+                user_service.serialize_many(filter={"user_ids": [self.user.id]})
+
+            all_sql = " ".join(q["sql"] for q in ctx.captured_queries)
+            assert "array_agg" not in all_sql
 
     def test_remove_permission(self) -> None:
         # Create a permission first


### PR DESCRIPTION
https://github.com/getsentry/sentry/blob/a8fcbce0cc94e981c42ef26c033fb9eb56b1b03d/src/sentry/users/services/user/impl.py#L358-L375

`base_query()` adds 5 correlated subqueries via `.extra()` (permissions, roles, useremails, authenticators, useravatar) that are only consumed by `serialize_rpc_user()` in the `get_many` path. `serialize_many` goes through the API serializer which re-queries the same data in `get_attrs()`, so the extra subqueries were pure overhead - the data was fetched, attached to the User objects, and then ignored.

Threads `select_related` through `FilterQueryDatabaseImpl.serialize_many` as an opt-in parameter and has the user service pass `False`. The `select_related=False` escape hatch already exists (added after #48088) and is used by `get_many_ids` and `get_many_profiles`, but `serialize_many` wasn't using it.

Context: #45564 moved `base_query` into `FilterQueryDatabaseImpl`, #48088 added the eager-loaded subqueries to fix N+1s in the `serialize_rpc` path.