### PR TITLE
fix(autofix): Dual-delete Seer preferences for disabled repositories

### DIFF
--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -132,11 +132,23 @@ class DatabaseBackedRepositoryService(RepositoryService):
         self, *, organization_id: int, integration_id: int, provider: str
     ) -> None:
         with transaction.atomic(router.db_for_write(Repository)):
-            Repository.objects.filter(
-                organization_id=organization_id,
-                integration_id=integration_id,
-                provider=provider,
-            ).update(status=ObjectStatus.DISABLED)
+            repo_ids = list(
+                Repository.objects.filter(
+                    organization_id=organization_id,
+                    integration_id=integration_id,
+                    provider=provider,
+                ).values_list("id", flat=True)
+            )
+
+            if repo_ids:
+                Repository.objects.filter(id__in=repo_ids).update(status=ObjectStatus.DISABLED)
+
+                try:
+                    organization = Organization.objects.get_from_cache(id=organization_id)
+                    if features.has("organizations:seer-project-settings-dual-write", organization):
+                        SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
+                except Organization.DoesNotExist:
+                    pass
 
     def disable_repositories_by_external_ids(
         self,
@@ -147,13 +159,25 @@ class DatabaseBackedRepositoryService(RepositoryService):
         external_ids: list[str],
     ) -> None:
         with transaction.atomic(router.db_for_write(Repository)):
-            Repository.objects.filter(
-                organization_id=organization_id,
-                integration_id=integration_id,
-                provider=provider,
-                external_id__in=external_ids,
-                status=ObjectStatus.ACTIVE,
-            ).update(status=ObjectStatus.DISABLED)
+            repo_ids = list(
+                Repository.objects.filter(
+                    organization_id=organization_id,
+                    integration_id=integration_id,
+                    provider=provider,
+                    external_id__in=external_ids,
+                    status=ObjectStatus.ACTIVE,
+                ).values_list("id", flat=True)
+            )
+
+            if repo_ids:
+                Repository.objects.filter(id__in=repo_ids).update(status=ObjectStatus.DISABLED)
+
+                try:
+                    organization = Organization.objects.get_from_cache(id=organization_id)
+                    if features.has("organizations:seer-project-settings-dual-write", organization):
+                        SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
+                except Organization.DoesNotExist:
+                    pass
 
     def disassociate_organization_integration(
         self,

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -132,13 +132,14 @@ class DatabaseBackedRepositoryService(RepositoryService):
         self, *, organization_id: int, integration_id: int, provider: str
     ) -> None:
         with transaction.atomic(router.db_for_write(Repository)):
-            repo_ids = list(
+            repos = list(
                 Repository.objects.filter(
                     organization_id=organization_id,
                     integration_id=integration_id,
                     provider=provider,
-                ).values_list("id", flat=True)
+                ).values_list("id", "external_id", "provider")
             )
+            repo_ids = [repo_id for repo_id, _, _ in repos]
 
             if repo_ids:
                 Repository.objects.filter(id__in=repo_ids).update(status=ObjectStatus.DISABLED)
@@ -149,6 +150,19 @@ class DatabaseBackedRepositoryService(RepositoryService):
                         SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
                 except Organization.DoesNotExist:
                     pass
+
+        repos_to_clean = [
+            {"repo_external_id": external_id, "repo_provider": repo_provider}
+            for _, external_id, repo_provider in repos
+            if external_id and repo_provider
+        ]
+        if repos_to_clean:
+            bulk_cleanup_seer_repository_preferences.apply_async(
+                kwargs={
+                    "organization_id": organization_id,
+                    "repos": repos_to_clean,
+                }
+            )
 
     def disable_repositories_by_external_ids(
         self,
@@ -159,15 +173,16 @@ class DatabaseBackedRepositoryService(RepositoryService):
         external_ids: list[str],
     ) -> None:
         with transaction.atomic(router.db_for_write(Repository)):
-            repo_ids = list(
+            repos = list(
                 Repository.objects.filter(
                     organization_id=organization_id,
                     integration_id=integration_id,
                     provider=provider,
                     external_id__in=external_ids,
                     status=ObjectStatus.ACTIVE,
-                ).values_list("id", flat=True)
+                ).values_list("id", "external_id", "provider")
             )
+            repo_ids = [repo_id for repo_id, _, _ in repos]
 
             if repo_ids:
                 Repository.objects.filter(id__in=repo_ids).update(status=ObjectStatus.DISABLED)
@@ -178,6 +193,19 @@ class DatabaseBackedRepositoryService(RepositoryService):
                         SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
                 except Organization.DoesNotExist:
                     pass
+
+        repos_to_clean = [
+            {"repo_external_id": external_id, "repo_provider": repo_provider}
+            for _, external_id, repo_provider in repos
+            if external_id and repo_provider
+        ]
+        if repos_to_clean:
+            bulk_cleanup_seer_repository_preferences.apply_async(
+                kwargs={
+                    "organization_id": organization_id,
+                    "repos": repos_to_clean,
+                }
+            )
 
     def disassociate_organization_integration(
         self,

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -128,6 +128,37 @@ class DatabaseBackedRepositoryService(RepositoryService):
 
             Repository.objects.bulk_update(repositories, fields=list(fields_to_update))
 
+    def _cleanup_seer_project_repositories(
+        self,
+        organization_id: int,
+        repo_tuples: list[tuple[int, str, str]],
+    ) -> None:
+        """Delete SeerProjectRepository rows and call Seer API cleanup.
+
+        repo_tuples: list of (repo_id, external_id, provider).
+        """
+        try:
+            organization = Organization.objects.get_from_cache(id=organization_id)
+            if features.has("organizations:seer-project-settings-dual-write", organization):
+                SeerProjectRepository.objects.filter(
+                    repository_id__in=[repo_id for repo_id, _, _ in repo_tuples]
+                ).delete()
+        except Organization.DoesNotExist:
+            pass
+
+        repos_to_clean = [
+            {"repo_external_id": external_id, "repo_provider": repo_provider}
+            for _, external_id, repo_provider in repo_tuples
+            if external_id and repo_provider
+        ]
+        if repos_to_clean:
+            bulk_cleanup_seer_repository_preferences.apply_async(
+                kwargs={
+                    "organization_id": organization_id,
+                    "repos": repos_to_clean,
+                }
+            )
+
     def disable_repositories_for_integration(
         self, *, organization_id: int, integration_id: int, provider: str
     ) -> None:
@@ -143,26 +174,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
 
             if repo_ids:
                 Repository.objects.filter(id__in=repo_ids).update(status=ObjectStatus.DISABLED)
-
-                try:
-                    organization = Organization.objects.get_from_cache(id=organization_id)
-                    if features.has("organizations:seer-project-settings-dual-write", organization):
-                        SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
-                except Organization.DoesNotExist:
-                    pass
-
-        repos_to_clean = [
-            {"repo_external_id": external_id, "repo_provider": repo_provider}
-            for _, external_id, repo_provider in repos
-            if external_id and repo_provider
-        ]
-        if repos_to_clean:
-            bulk_cleanup_seer_repository_preferences.apply_async(
-                kwargs={
-                    "organization_id": organization_id,
-                    "repos": repos_to_clean,
-                }
-            )
+                self._cleanup_seer_project_repositories(organization_id, repos)
 
     def disable_repositories_by_external_ids(
         self,
@@ -186,26 +198,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
 
             if repo_ids:
                 Repository.objects.filter(id__in=repo_ids).update(status=ObjectStatus.DISABLED)
-
-                try:
-                    organization = Organization.objects.get_from_cache(id=organization_id)
-                    if features.has("organizations:seer-project-settings-dual-write", organization):
-                        SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
-                except Organization.DoesNotExist:
-                    pass
-
-        repos_to_clean = [
-            {"repo_external_id": external_id, "repo_provider": repo_provider}
-            for _, external_id, repo_provider in repos
-            if external_id and repo_provider
-        ]
-        if repos_to_clean:
-            bulk_cleanup_seer_repository_preferences.apply_async(
-                kwargs={
-                    "organization_id": organization_id,
-                    "repos": repos_to_clean,
-                }
-            )
+                self._cleanup_seer_project_repositories(organization_id, repos)
 
     def disassociate_organization_integration(
         self,
@@ -223,19 +216,8 @@ class DatabaseBackedRepositoryService(RepositoryService):
             repo_ids = [repo_id for repo_id, _, _ in repos]
 
             if repo_ids:
-                # Disassociate repos from the organization integration being deleted
                 Repository.objects.filter(id__in=repo_ids).update(integration_id=None)
-
-                # Delete Seer project preferences for the affected repos.
-                # Organization may already be deleted if org deletion and integration
-                # uninstall overlap; skip SeerProjectRepository cleanup in that case
-                # since cascades will handle it.
-                try:
-                    organization = Organization.objects.get_from_cache(id=organization_id)
-                    if features.has("organizations:seer-project-settings-dual-write", organization):
-                        SeerProjectRepository.objects.filter(repository_id__in=repo_ids).delete()
-                except Organization.DoesNotExist:
-                    pass
+                self._cleanup_seer_project_repositories(organization_id, repos)
 
             # Delete Code Owners with a Code Mapping using the OrganizationIntegration
             ProjectCodeOwners.objects.filter(
@@ -248,17 +230,3 @@ class DatabaseBackedRepositoryService(RepositoryService):
             RepositoryProjectPathConfig.objects.filter(
                 organization_integration_id=organization_integration_id
             ).delete()
-
-        # Delete Seer project preferences for the affected repos via Seer API
-        repos_to_clean = [
-            {"repo_external_id": external_id, "repo_provider": provider}
-            for _, external_id, provider in repos
-            if external_id and provider
-        ]
-        if repos_to_clean:
-            bulk_cleanup_seer_repository_preferences.apply_async(
-                kwargs={
-                    "organization_id": organization_id,
-                    "repos": repos_to_clean,
-                }
-            )

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -215,7 +215,6 @@ class DatabaseBackedRepositoryService(RepositoryService):
         integration_id: int,
     ) -> None:
         with transaction.atomic(router.db_for_write(Repository)):
-            # Disassociate repos from the organization integration being deleted
             repos = list(
                 Repository.objects.filter(
                     organization_id=organization_id, integration_id=integration_id
@@ -223,6 +222,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
             )
             repo_ids = [repo_id for repo_id, _, _ in repos]
             if repo_ids:
+                # Disassociate repos from the organization integration being deleted
                 Repository.objects.filter(id__in=repo_ids).update(integration_id=None)
                 self._cleanup_seer_project_repositories(organization_id, repos)
 

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -133,9 +133,13 @@ class DatabaseBackedRepositoryService(RepositoryService):
         organization_id: int,
         repo_tuples: list[tuple[int, str | None, str | None]],
     ) -> None:
-        """Delete SeerProjectRepository rows and call Seer API cleanup.
+        """Delete SeerProjectRepository rows and schedule Seer API cleanup.
 
-        repo_tuples: list of (repo_id, external_id, provider).
+        Must be called inside a transaction.atomic() block. The SeerProjectRepository
+        delete participates in the transaction, while the Seer API task is dispatched
+        via on_commit so it only fires if the transaction succeeds.
+
+        repo_tuples: list of (repo_id, external_id, provider) from Repository.values_list().
         """
         try:
             organization = Organization.objects.get_from_cache(id=organization_id)
@@ -152,11 +156,14 @@ class DatabaseBackedRepositoryService(RepositoryService):
             if external_id and repo_provider
         ]
         if repos_to_clean:
-            bulk_cleanup_seer_repository_preferences.apply_async(
-                kwargs={
-                    "organization_id": organization_id,
-                    "repos": repos_to_clean,
-                }
+            transaction.on_commit(
+                lambda: bulk_cleanup_seer_repository_preferences.apply_async(
+                    kwargs={
+                        "organization_id": organization_id,
+                        "repos": repos_to_clean,
+                    }
+                ),
+                using=router.db_for_write(Repository),
             )
 
     def disable_repositories_for_integration(

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -131,7 +131,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
     def _cleanup_seer_project_repositories(
         self,
         organization_id: int,
-        repo_tuples: list[tuple[int, str, str]],
+        repo_tuples: list[tuple[int, str | None, str | None]],
     ) -> None:
         """Delete SeerProjectRepository rows and call Seer API cleanup.
 

--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -215,13 +215,13 @@ class DatabaseBackedRepositoryService(RepositoryService):
         integration_id: int,
     ) -> None:
         with transaction.atomic(router.db_for_write(Repository)):
+            # Disassociate repos from the organization integration being deleted
             repos = list(
                 Repository.objects.filter(
                     organization_id=organization_id, integration_id=integration_id
                 ).values_list("id", "external_id", "provider")
             )
             repo_ids = [repo_id for repo_id, _, _ in repos]
-
             if repo_ids:
                 Repository.objects.filter(id__in=repo_ids).update(integration_id=None)
                 self._cleanup_seer_project_repositories(organization_id, repos)

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -455,7 +455,8 @@ class InstallationRepositoriesEventWebhookTest(APITestCase):
         assert repos[0].provider == "integrations:github"
         assert repos[1].name == "getsentry/snuba"
 
-    def test_end_to_end_repos_removed(self) -> None:
+    @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
+    def test_end_to_end_repos_removed(self, mock_seer_cleanup: MagicMock) -> None:
         """Full end-to-end: webhook URL → handler → task → Repository disabled."""
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
         integration = self.create_integration(

--- a/tests/sentry/integrations/services/repository/test_impl.py
+++ b/tests/sentry/integrations/services/repository/test_impl.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.repository.service import repository_service
 from sentry.models.repository import Repository
@@ -164,7 +166,8 @@ class DisableRepositoriesByExternalIdsTest(TestCase):
         assert repo.status == ObjectStatus.ACTIVE
 
     @with_feature("organizations:seer-project-settings-dual-write")
-    def test_deletes_seer_project_repository_rows(self) -> None:
+    @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
+    def test_cleans_up_seer_preferences(self, mock_cleanup) -> None:
         project = self.create_project(organization=self.organization)
         repo = Repository.objects.create(
             organization_id=self.organization.id,
@@ -183,9 +186,13 @@ class DisableRepositoriesByExternalIdsTest(TestCase):
             external_ids=["100"],
         )
 
-        repo.refresh_from_db()
-        assert repo.status == ObjectStatus.DISABLED
         assert not SeerProjectRepository.objects.filter(repository_id=repo.id).exists()
+        mock_cleanup.apply_async.assert_called_once_with(
+            kwargs={
+                "organization_id": self.organization.id,
+                "repos": [{"repo_external_id": "100", "repo_provider": self.provider}],
+            }
+        )
 
 
 @cell_silo_test
@@ -198,7 +205,7 @@ class DisableRepositoriesForIntegrationTest(TestCase):
         )
         self.provider = "integrations:github"
 
-    def test_disables_all_repos_for_integration(self) -> None:
+    def test_disables_matching_active_repos(self) -> None:
         repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="getsentry/sentry",
@@ -218,7 +225,8 @@ class DisableRepositoriesForIntegrationTest(TestCase):
         assert repo.status == ObjectStatus.DISABLED
 
     @with_feature("organizations:seer-project-settings-dual-write")
-    def test_deletes_seer_project_repository_rows(self) -> None:
+    @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
+    def test_cleans_up_seer_preferences(self, mock_cleanup) -> None:
         project = self.create_project(organization=self.organization)
         repo = Repository.objects.create(
             organization_id=self.organization.id,
@@ -236,6 +244,10 @@ class DisableRepositoriesForIntegrationTest(TestCase):
             provider=self.provider,
         )
 
-        repo.refresh_from_db()
-        assert repo.status == ObjectStatus.DISABLED
         assert not SeerProjectRepository.objects.filter(repository_id=repo.id).exists()
+        mock_cleanup.apply_async.assert_called_once_with(
+            kwargs={
+                "organization_id": self.organization.id,
+                "repos": [{"repo_external_id": "100", "repo_provider": self.provider}],
+            }
+        )

--- a/tests/sentry/integrations/services/repository/test_impl.py
+++ b/tests/sentry/integrations/services/repository/test_impl.py
@@ -19,7 +19,8 @@ class DisableRepositoriesByExternalIdsTest(TestCase):
         )
         self.provider = "integrations:github"
 
-    def test_disables_matching_active_repos(self) -> None:
+    @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
+    def test_disables_matching_active_repos(self, mock_seer_cleanup: MagicMock) -> None:
         repo1 = Repository.objects.create(
             organization_id=self.organization.id,
             name="getsentry/sentry",
@@ -115,7 +116,8 @@ class DisableRepositoriesByExternalIdsTest(TestCase):
         repo.refresh_from_db()
         assert repo.status == ObjectStatus.ACTIVE
 
-    def test_only_disables_specified_external_ids(self) -> None:
+    @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
+    def test_only_disables_specified_external_ids(self, mock_seer_cleanup: MagicMock) -> None:
         repo_to_disable = Repository.objects.create(
             organization_id=self.organization.id,
             name="getsentry/sentry",
@@ -205,7 +207,8 @@ class DisableRepositoriesForIntegrationTest(TestCase):
         )
         self.provider = "integrations:github"
 
-    def test_disables_matching_active_repos(self) -> None:
+    @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
+    def test_disables_matching_active_repos(self, mock_seer_cleanup: MagicMock) -> None:
         repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="getsentry/sentry",

--- a/tests/sentry/integrations/services/repository/test_impl.py
+++ b/tests/sentry/integrations/services/repository/test_impl.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.repository.service import repository_service
@@ -167,7 +167,7 @@ class DisableRepositoriesByExternalIdsTest(TestCase):
 
     @with_feature("organizations:seer-project-settings-dual-write")
     @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
-    def test_cleans_up_seer_preferences(self, mock_cleanup) -> None:
+    def test_cleans_up_seer_preferences(self, mock_cleanup: MagicMock) -> None:
         project = self.create_project(organization=self.organization)
         repo = Repository.objects.create(
             organization_id=self.organization.id,
@@ -226,7 +226,7 @@ class DisableRepositoriesForIntegrationTest(TestCase):
 
     @with_feature("organizations:seer-project-settings-dual-write")
     @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
-    def test_cleans_up_seer_preferences(self, mock_cleanup) -> None:
+    def test_cleans_up_seer_preferences(self, mock_cleanup: MagicMock) -> None:
         project = self.create_project(organization=self.organization)
         repo = Repository.objects.create(
             organization_id=self.organization.id,

--- a/tests/sentry/integrations/services/repository/test_impl.py
+++ b/tests/sentry/integrations/services/repository/test_impl.py
@@ -1,7 +1,9 @@
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.repository.service import repository_service
 from sentry.models.repository import Repository
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import cell_silo_test
 
 
@@ -160,3 +162,80 @@ class DisableRepositoriesByExternalIdsTest(TestCase):
 
         repo.refresh_from_db()
         assert repo.status == ObjectStatus.ACTIVE
+
+    @with_feature("organizations:seer-project-settings-dual-write")
+    def test_deletes_seer_project_repository_rows(self) -> None:
+        project = self.create_project(organization=self.organization)
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/sentry",
+            external_id="100",
+            provider=self.provider,
+            integration_id=self.integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        SeerProjectRepository.objects.create(project=project, repository_id=repo.id)
+
+        repository_service.disable_repositories_by_external_ids(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            provider=self.provider,
+            external_ids=["100"],
+        )
+
+        repo.refresh_from_db()
+        assert repo.status == ObjectStatus.DISABLED
+        assert not SeerProjectRepository.objects.filter(repository_id=repo.id).exists()
+
+
+@cell_silo_test
+class DisableRepositoriesForIntegrationTest(TestCase):
+    def setUp(self) -> None:
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="1",
+            provider="github",
+        )
+        self.provider = "integrations:github"
+
+    def test_disables_all_repos_for_integration(self) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/sentry",
+            external_id="100",
+            provider=self.provider,
+            integration_id=self.integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+
+        repository_service.disable_repositories_for_integration(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            provider=self.provider,
+        )
+
+        repo.refresh_from_db()
+        assert repo.status == ObjectStatus.DISABLED
+
+    @with_feature("organizations:seer-project-settings-dual-write")
+    def test_deletes_seer_project_repository_rows(self) -> None:
+        project = self.create_project(organization=self.organization)
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/sentry",
+            external_id="100",
+            provider=self.provider,
+            integration_id=self.integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        SeerProjectRepository.objects.create(project=project, repository_id=repo.id)
+
+        repository_service.disable_repositories_for_integration(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            provider=self.provider,
+        )
+
+        repo.refresh_from_db()
+        assert repo.status == ObjectStatus.DISABLED
+        assert not SeerProjectRepository.objects.filter(repository_id=repo.id).exists()

--- a/tests/sentry/integrations/services/repository/test_impl.py
+++ b/tests/sentry/integrations/services/repository/test_impl.py
@@ -1,6 +1,9 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from sentry.constants import ObjectStatus
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.repository.service import repository_service
 from sentry.models.repository import Repository
 from sentry.seer.models.project_repository import SeerProjectRepository
@@ -188,6 +191,9 @@ class DisableRepositoriesByExternalIdsTest(TestCase):
             external_ids=["100"],
         )
 
+        repo.refresh_from_db()
+        assert repo.status == ObjectStatus.DISABLED
+
         assert not SeerProjectRepository.objects.filter(repository_id=repo.id).exists()
         mock_cleanup.apply_async.assert_called_once_with(
             kwargs={
@@ -247,6 +253,9 @@ class DisableRepositoriesForIntegrationTest(TestCase):
             provider=self.provider,
         )
 
+        repo.refresh_from_db()
+        assert repo.status == ObjectStatus.DISABLED
+
         assert not SeerProjectRepository.objects.filter(repository_id=repo.id).exists()
         mock_cleanup.apply_async.assert_called_once_with(
             kwargs={
@@ -254,3 +263,98 @@ class DisableRepositoriesForIntegrationTest(TestCase):
                 "repos": [{"repo_external_id": "100", "repo_provider": self.provider}],
             }
         )
+
+
+@cell_silo_test
+class DisassociateOrganizationIntegrationTest(TestCase):
+    def setUp(self) -> None:
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="1",
+            provider="github",
+        )
+        self.provider = "integrations:github"
+        self.org_integration = self.integration.organizationintegration_set.first()
+
+    @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
+    def test_disassociates_repos(self, mock_cleanup: MagicMock) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/sentry",
+            external_id="100",
+            provider=self.provider,
+            integration_id=self.integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+
+        repository_service.disassociate_organization_integration(
+            organization_id=self.organization.id,
+            organization_integration_id=self.org_integration.id,
+            integration_id=self.integration.id,
+        )
+
+        repo.refresh_from_db()
+        assert repo.integration_id is None
+        mock_cleanup.apply_async.assert_called_once()
+
+    @with_feature("organizations:seer-project-settings-dual-write")
+    @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
+    def test_cleans_up_seer_preferences(self, mock_cleanup: MagicMock) -> None:
+        project = self.create_project(organization=self.organization)
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/sentry",
+            external_id="100",
+            provider=self.provider,
+            integration_id=self.integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        SeerProjectRepository.objects.create(project=project, repository_id=repo.id)
+
+        repository_service.disassociate_organization_integration(
+            organization_id=self.organization.id,
+            organization_integration_id=self.org_integration.id,
+            integration_id=self.integration.id,
+        )
+
+        repo.refresh_from_db()
+        assert repo.integration_id is None
+        assert not SeerProjectRepository.objects.filter(repository_id=repo.id).exists()
+        mock_cleanup.apply_async.assert_called_once_with(
+            kwargs={
+                "organization_id": self.organization.id,
+                "repos": [{"repo_external_id": "100", "repo_provider": self.provider}],
+            }
+        )
+
+    @patch("sentry.integrations.services.repository.impl.bulk_cleanup_seer_repository_preferences")
+    def test_transaction_rollback_does_not_dispatch_seer_cleanup(
+        self, mock_cleanup: MagicMock
+    ) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/sentry",
+            external_id="100",
+            provider=self.provider,
+            integration_id=self.integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+
+        with patch.object(
+            RepositoryProjectPathConfig.objects,
+            "filter",
+            side_effect=RuntimeError("simulated failure"),
+        ):
+            with pytest.raises(RuntimeError):
+                repository_service.disassociate_organization_integration(
+                    organization_id=self.organization.id,
+                    organization_integration_id=self.org_integration.id,
+                    integration_id=self.integration.id,
+                )
+
+        # Transaction rolled back: repo should still have its integration
+        repo.refresh_from_db()
+        assert repo.integration_id == self.integration.id
+
+        # Task should not have been dispatched
+        mock_cleanup.apply_async.assert_not_called()


### PR DESCRIPTION
Remove SeerProjectRepository rows and call `/v1/project-preference/bulk-remove-repositories` Seer endpoint for disabled repositories. This covers more of Seer's deletion task `cleanup_stale_seer_preferences_task`, as part of the migration of Seer settings from Seer to Sentry ([spec](https://www.notion.so/sentry/Tech-Spec-Migrate-Seer-Settings-to-Sentry-Database-3208b10e4b5d80f58ea0d7b77a301e2a)).