### PR TITLE
feat(seer): Show the Seer settings link even when hideAiFeatures is enabled

### DIFF
--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -175,7 +175,6 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           description: t(
             "Manage settings for Seer's automated analysis across your organization"
           ),
-          show: ({organization}) => !!organization && !organization.hideAiFeatures,
           id: 'seer',
         },
         {

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -60,7 +60,6 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/seer/`,
           title: t('Seer'),
-          show: () => !organization?.hideAiFeatures,
         },
         {
           path: `${pathPrefix}/user-feedback/`,


### PR DESCRIPTION
When `hideAiFeatures` is enabled Seer is disabled, that's always the way. `hideAiFeatures` can be quickly toggled from the Settings > General page. 

What's confusing though is that we also hide the button to Seer in the sidenav. This gave me a freight because i didn't see the Seer button and didn't know why. One of the tenets we've had for a long time is [Disable and Explain](https://develop.sentry.dev/frontend/design-tenets/#disable-and-explain-dont-hide), and we already had a message to explain things. 

Now we keep the sidebar button, and show the explaination.

<img width="1256" height="388" alt="SCR-20260408-kpjo" src="https://github.com/user-attachments/assets/d53557bf-d2e2-453c-a506-ebfdfaf2b608" />
