### PR TITLE
ref(preprod): Add endpoint to decide whether to reveal mobile builds or snapshot tabs in releases

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_has_data.py
+++ b/src/sentry/preprod/api/endpoints/preprod_has_data.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import NoProjects, OrganizationEndpoint
+from sentry.models.organization import Organization
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+
+VALID_TYPES = {"size", "snapshots"}
+
+
+@cell_silo_endpoint
+class OrganizationPreprodHasDataEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has(
+            "organizations:preprod-frontend-routes", organization, actor=request.user
+        ):
+            return Response(
+                {"detail": "Feature organizations:preprod-frontend-routes is not enabled."},
+                status=403,
+            )
+
+        requested_types = set(request.GET.getlist("type"))
+        valid_requested = requested_types & VALID_TYPES
+        if not valid_requested:
+            return Response(
+                {"detail": f"type must include at least one of: {', '.join(sorted(VALID_TYPES))}"},
+                status=400,
+            )
+
+        try:
+            params = self.get_filter_params(request, organization, date_filter_optional=True)
+        except NoProjects:
+            return Response({t: False for t in valid_requested})
+
+        artifact_qs = PreprodArtifact.objects.filter(
+            project_id__in=params["project_id"],
+        )
+
+        if params.get("start"):
+            artifact_qs = artifact_qs.filter(date_added__gte=params["start"])
+        if params.get("end"):
+            artifact_qs = artifact_qs.filter(date_added__lte=params["end"])
+
+        result = {}
+
+        if "size" in valid_requested:
+            result["size"] = PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact__in=artifact_qs
+            ).exists()
+
+        if "snapshots" in valid_requested:
+            result["snapshots"] = PreprodSnapshotMetrics.objects.filter(
+                preprod_artifact__in=artifact_qs
+            ).exists()
+
+        return Response(result)

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -32,6 +32,7 @@ from .preprod_artifact_snapshot import (
     OrganizationPreprodSnapshotEndpoint,
     ProjectPreprodSnapshotEndpoint,
 )
+from .preprod_has_data import OrganizationPreprodHasDataEndpoint
 from .preprod_snapshot_recompare import PreprodSnapshotRecompareEndpoint
 from .project_installable_preprod_artifact_download import (
     ProjectInstallablePreprodArtifactDownloadEndpoint,
@@ -211,6 +212,11 @@ preprod_organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/(?P<head_artifact_id>[^/]+)/distribution/$",
         ProjectPreprodDistributionEndpoint.as_view(),
         name="sentry-api-0-organization-preprod-artifact-distribution",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/preprod/has-data/$",
+        OrganizationPreprodHasDataEndpoint.as_view(),
+        name="sentry-api-0-organization-preprod-has-data",
     ),
 ]
 

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -475,6 +475,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/pr-comments/$repoName/$prNumber/'
   | '/organizations/$organizationIdOrSlug/preprod-artifact/rerun-analysis/$headArtifactId/'
   | '/organizations/$organizationIdOrSlug/preprod-artifact/rerun-status-checks/$headArtifactId/'
+  | '/organizations/$organizationIdOrSlug/preprod/has-data/'
   | '/organizations/$organizationIdOrSlug/preprod/quota/'
   | '/organizations/$organizationIdOrSlug/preprod/retention/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/approve/'

--- a/tests/sentry/preprod/api/endpoints/test_preprod_has_data.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_has_data.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationPreprodHasDataEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-preprod-has-data"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def test_returns_400_when_no_type_param(self) -> None:
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_response(self.organization.slug)
+        assert response.status_code == 400
+
+    def test_returns_400_when_invalid_type_param(self) -> None:
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_response(self.organization.slug, type="invalid")
+        assert response.status_code == 400
+
+    def test_returns_403_when_feature_flag_off(self) -> None:
+        response = self.get_response(self.organization.slug, type="size")
+        assert response.status_code == 403
+
+    def test_size_false_when_no_artifacts(self) -> None:
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_success_response(self.organization.slug, type="size")
+        assert response.data == {"size": False}
+
+    def test_snapshots_false_when_no_artifacts(self) -> None:
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_success_response(self.organization.slug, type="snapshots")
+        assert response.data == {"snapshots": False}
+
+    def test_size_true_when_size_metrics_exist(self) -> None:
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        self.create_preprod_artifact_size_metrics(artifact)
+
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_success_response(self.organization.slug, type="size")
+        assert response.data == {"size": True}
+
+    def test_snapshots_true_when_snapshot_metrics_exist(self) -> None:
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        PreprodSnapshotMetrics.objects.create(preprod_artifact=artifact, image_count=5)
+
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_success_response(self.organization.slug, type="snapshots")
+        assert response.data == {"snapshots": True}
+
+    def test_both_types_returned_together(self) -> None:
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        self.create_preprod_artifact_size_metrics(artifact)
+        PreprodSnapshotMetrics.objects.create(preprod_artifact=artifact, image_count=5)
+
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_success_response(self.organization.slug, type=["size", "snapshots"])
+        assert response.data == {"size": True, "snapshots": True}
+
+    def test_respects_time_range(self) -> None:
+        now = timezone.now()
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            date_added=now - timedelta(days=30),
+        )
+        self.create_preprod_artifact_size_metrics(artifact)
+
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_success_response(
+                self.organization.slug,
+                type="size",
+                start=(now - timedelta(days=1)).isoformat(),
+                end=now.isoformat(),
+            )
+        assert response.data == {"size": False}
+
+    def test_respects_project_filter(self) -> None:
+        other_project = self.create_project(organization=self.organization)
+        artifact = self.create_preprod_artifact(
+            project=other_project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        self.create_preprod_artifact_size_metrics(artifact)
+
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_success_response(
+                self.organization.slug,
+                type="size",
+                project=[self.project.id],
+            )
+        assert response.data == {"size": False}
+
+    def test_no_cross_org_data_leak(self) -> None:
+        other_org = self.create_organization(owner=self.create_user())
+        other_project = self.create_project(organization=other_org)
+        artifact = self.create_preprod_artifact(
+            project=other_project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        self.create_preprod_artifact_size_metrics(artifact)
+
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.get_success_response(self.organization.slug, type="size")
+        assert response.data == {"size": False}


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
