### PR TITLE
ref(preprod): [frontent] Use new endpoint for preprod tab show logic

### DIFF
--- a/static/app/views/preprod/utils/preprodHasDataApiOptions.ts
+++ b/static/app/views/preprod/utils/preprodHasDataApiOptions.ts
@@ -1,0 +1,24 @@
+import type {Organization} from 'sentry/types/organization';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+
+type PreprodHasDataResponse = {
+  size?: boolean;
+  snapshots?: boolean;
+};
+
+export function preprodHasDataApiOptions({
+  organization,
+  queryParams,
+}: {
+  organization: Organization;
+  queryParams?: Record<string, unknown>;
+}) {
+  return apiOptions.as<PreprodHasDataResponse>()(
+    '/organizations/$organizationIdOrSlug/preprod/has-data/',
+    {
+      path: {organizationIdOrSlug: organization.slug},
+      query: queryParams,
+      staleTime: 30_000,
+    }
+  );
+}


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
