### PR TITLE
fix(bitbucket): Fetch all repository pages from Bitbucket Cloud API

### DIFF
--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -56,6 +56,10 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
 
     integration_name = IntegrationProviderSlug.BITBUCKET.value
 
+    # Bitbucket Cloud defaults to pagelen=10 and caps at 100.
+    page_size = 100
+    page_number_limit = 50
+
     def __init__(self, integration: RpcIntegration | Integration):
         self.base_url = integration.metadata["base_url"]
         self.shared_secret = integration.metadata["shared_secret"]
@@ -108,10 +112,6 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
 
     def get_repo(self, repo):
         return self.get(BitbucketAPIPath.repository.format(repo=repo))
-
-    # Bitbucket Cloud defaults to pagelen=10 and caps at 100.
-    page_size = 100
-    page_number_limit = 50
 
     def _get_all_from_paginated(
         self,

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -125,7 +125,11 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
         Bitbucket uses a ``next`` URL in the response body (not headers)
         to link to the next page.
         """
-        if page_number_limit is None or page_number_limit > self.page_number_limit:
+        if (
+            page_number_limit is None
+            or page_number_limit < 1
+            or page_number_limit > self.page_number_limit
+        ):
             page_number_limit = self.page_number_limit
 
         if params is None:

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -109,8 +109,37 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
     def get_repo(self, repo):
         return self.get(BitbucketAPIPath.repository.format(repo=repo))
 
-    def get_repos(self, username):
-        return self.get(BitbucketAPIPath.repositories.format(username=username))
+    # Bitbucket Cloud defaults to pagelen=10 and caps at 100.
+    page_size = 100
+    page_number_limit = 50
+
+    def _get_all_from_paginated(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        """
+        Aggregate all pages from a Bitbucket Cloud paginated endpoint.
+
+        Bitbucket uses a ``next`` URL in the response body (not headers)
+        to link to the next page.
+        """
+        if params is None:
+            params = {}
+        params.setdefault("pagelen", self.page_size)
+
+        output: list[dict[str, Any]] = []
+        resp = self.get(path, params=params)
+        output.extend(resp.get("values", []))
+
+        page_number = 1
+        while "next" in resp and page_number < self.page_number_limit:
+            resp = self.get(resp["next"])
+            output.extend(resp.get("values", []))
+            page_number += 1
+
+        return output
+
+    def get_repos(self, username: str) -> list[dict[str, Any]]:
+        return self._get_all_from_paginated(BitbucketAPIPath.repositories.format(username=username))
 
     def search_repositories(self, username, query):
         return self.get(

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -114,7 +114,10 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
     page_number_limit = 50
 
     def _get_all_from_paginated(
-        self, path: str, params: dict[str, Any] | None = None
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        page_number_limit: int | None = None,
     ) -> list[dict[str, Any]]:
         """
         Aggregate all pages from a Bitbucket Cloud paginated endpoint.
@@ -122,6 +125,9 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
         Bitbucket uses a ``next`` URL in the response body (not headers)
         to link to the next page.
         """
+        if page_number_limit is None or page_number_limit > self.page_number_limit:
+            page_number_limit = self.page_number_limit
+
         if params is None:
             params = {}
         params.setdefault("pagelen", self.page_size)
@@ -131,15 +137,20 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
         output.extend(resp.get("values", []))
 
         page_number = 1
-        while "next" in resp and page_number < self.page_number_limit:
+        while "next" in resp and page_number < page_number_limit:
             resp = self.get(resp["next"])
             output.extend(resp.get("values", []))
             page_number += 1
 
         return output
 
-    def get_repos(self, username: str) -> list[dict[str, Any]]:
-        return self._get_all_from_paginated(BitbucketAPIPath.repositories.format(username=username))
+    def get_repos(
+        self, username: str, page_number_limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        return self._get_all_from_paginated(
+            BitbucketAPIPath.repositories.format(username=username),
+            page_number_limit=page_number_limit,
+        )
 
     def search_repositories(self, username, query):
         return self.get(

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -125,11 +125,7 @@ class BitbucketApiClient(ApiClient, RepositoryClient):
         Bitbucket uses a ``next`` URL in the response body (not headers)
         to link to the next page.
         """
-        if (
-            page_number_limit is None
-            or page_number_limit < 1
-            or page_number_limit > self.page_number_limit
-        ):
+        if page_number_limit is None or page_number_limit > self.page_number_limit:
             page_number_limit = self.page_number_limit
 
         if params is None:

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -140,14 +140,14 @@ class BitbucketIntegration(RepositoryIntegration[BitbucketApiClient], BitbucketI
     ) -> list[RepositoryInfo]:
         username = self.model.metadata.get("uuid", self.username)
         if not query:
-            repos = self.get_client().get_repos(username, page_number_limit=page_number_limit)
+            all_repos = self.get_client().get_repos(username, page_number_limit=page_number_limit)
             return [
                 {
                     "identifier": repo["full_name"],
                     "name": repo["full_name"],
                     "external_id": self.get_repo_external_id(repo),
                 }
-                for repo in repos
+                for repo in all_repos
             ]
 
         client = self.get_client()
@@ -215,7 +215,7 @@ class BitbucketIntegration(RepositoryIntegration[BitbucketApiClient], BitbucketI
     # Bitbucket only methods
 
     @property
-    def username(self):
+    def username(self) -> str:
         return self.model.name
 
 

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -140,7 +140,7 @@ class BitbucketIntegration(RepositoryIntegration[BitbucketApiClient], BitbucketI
     ) -> list[RepositoryInfo]:
         username = self.model.metadata.get("uuid", self.username)
         if not query:
-            repos = self.get_client().get_repos(username)
+            repos = self.get_client().get_repos(username, page_number_limit=page_number_limit)
             return [
                 {
                     "identifier": repo["full_name"],

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -140,14 +140,14 @@ class BitbucketIntegration(RepositoryIntegration[BitbucketApiClient], BitbucketI
     ) -> list[RepositoryInfo]:
         username = self.model.metadata.get("uuid", self.username)
         if not query:
-            resp = self.get_client().get_repos(username)
+            repos = self.get_client().get_repos(username)
             return [
                 {
                     "identifier": repo["full_name"],
                     "name": repo["full_name"],
                     "external_id": self.get_repo_external_id(repo),
                 }
-                for repo in resp.get("values", [])
+                for repo in repos
             ]
 
         client = self.get_client()

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -124,6 +124,49 @@ class BitbucketIntegrationTest(APITestCase):
         assert len(responses.calls) == 1
 
     @responses.activate
+    def test_get_repositories_zero_page_limit_returns_first_page(self) -> None:
+        """A page_number_limit of 0 still returns the first page but fetches no further."""
+        base_url = "https://api.bitbucket.org/2.0/repositories/sentryuser"
+        responses.add(
+            responses.GET,
+            base_url,
+            json={
+                "values": [{"full_name": "sentryuser/repo-1", "uuid": "{r1}"}],
+                "next": f"{base_url}?pagelen=100&page=2",
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{base_url}?pagelen=100&page=2",
+            json={"values": [{"full_name": "sentryuser/repo-2", "uuid": "{r2}"}]},
+        )
+
+        installation = self.integration.get_installation(self.organization.id)
+        result = installation.get_repositories(page_number_limit=0)
+        assert result == [
+            {"identifier": "sentryuser/repo-1", "name": "sentryuser/repo-1", "external_id": "{r1}"},
+        ]
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_get_repositories_clamps_excessive_page_limit(self) -> None:
+        """A page_number_limit above the class max is clamped to the default."""
+        base_url = "https://api.bitbucket.org/2.0/repositories/sentryuser"
+        responses.add(
+            responses.GET,
+            base_url,
+            json={"values": [{"full_name": "sentryuser/repo-1", "uuid": "{r1}"}]},
+        )
+
+        installation = self.integration.get_installation(self.organization.id)
+        client = installation.get_client()
+        result = installation.get_repositories(page_number_limit=client.page_number_limit + 100)
+        assert result == [
+            {"identifier": "sentryuser/repo-1", "name": "sentryuser/repo-1", "external_id": "{r1}"},
+        ]
+        assert len(responses.calls) == 1
+
+    @responses.activate
     def test_get_repositories_exact_match(self) -> None:
         querystring = urlencode({"q": 'name="stuf"'})
         responses.add(

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -70,7 +70,7 @@ class BitbucketIntegrationTest(APITestCase):
             responses.GET,
             base_url,
             json={
-                "values": [{"full_name": "sentryuser/repo-1"}],
+                "values": [{"full_name": "sentryuser/repo-1", "uuid": "{r1}"}],
                 "next": f"{base_url}?pagelen=100&page=2",
             },
         )
@@ -78,22 +78,22 @@ class BitbucketIntegrationTest(APITestCase):
             responses.GET,
             f"{base_url}?pagelen=100&page=2",
             json={
-                "values": [{"full_name": "sentryuser/repo-2"}],
+                "values": [{"full_name": "sentryuser/repo-2", "uuid": "{r2}"}],
                 "next": f"{base_url}?pagelen=100&page=3",
             },
         )
         responses.add(
             responses.GET,
             f"{base_url}?pagelen=100&page=3",
-            json={"values": [{"full_name": "sentryuser/repo-3"}]},
+            json={"values": [{"full_name": "sentryuser/repo-3", "uuid": "{r3}"}]},
         )
 
         installation = self.integration.get_installation(self.organization.id)
         result = installation.get_repositories()
         assert result == [
-            {"identifier": "sentryuser/repo-1", "name": "sentryuser/repo-1"},
-            {"identifier": "sentryuser/repo-2", "name": "sentryuser/repo-2"},
-            {"identifier": "sentryuser/repo-3", "name": "sentryuser/repo-3"},
+            {"identifier": "sentryuser/repo-1", "name": "sentryuser/repo-1", "external_id": "{r1}"},
+            {"identifier": "sentryuser/repo-2", "name": "sentryuser/repo-2", "external_id": "{r2}"},
+            {"identifier": "sentryuser/repo-3", "name": "sentryuser/repo-3", "external_id": "{r3}"},
         ]
 
     @responses.activate
@@ -105,7 +105,7 @@ class BitbucketIntegrationTest(APITestCase):
             responses.GET,
             base_url,
             json={
-                "values": [{"full_name": "sentryuser/repo-1"}],
+                "values": [{"full_name": "sentryuser/repo-1", "uuid": "{r1}"}],
                 "next": f"{base_url}?pagelen=100&page=2",
             },
         )
@@ -113,13 +113,13 @@ class BitbucketIntegrationTest(APITestCase):
         responses.add(
             responses.GET,
             f"{base_url}?pagelen=100&page=2",
-            json={"values": [{"full_name": "sentryuser/repo-2"}]},
+            json={"values": [{"full_name": "sentryuser/repo-2", "uuid": "{r2}"}]},
         )
 
         installation = self.integration.get_installation(self.organization.id)
         result = installation.get_repositories(page_number_limit=1)
         assert result == [
-            {"identifier": "sentryuser/repo-1", "name": "sentryuser/repo-1"},
+            {"identifier": "sentryuser/repo-1", "name": "sentryuser/repo-1", "external_id": "{r1}"},
         ]
         assert len(responses.calls) == 1
 

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -63,6 +63,67 @@ class BitbucketIntegrationTest(APITestCase):
         ]
 
     @responses.activate
+    def test_get_repositories_multiple_pages(self) -> None:
+        """get_repos aggregates all pages by following the 'next' URL."""
+        base_url = "https://api.bitbucket.org/2.0/repositories/sentryuser"
+        responses.add(
+            responses.GET,
+            base_url,
+            json={
+                "values": [{"full_name": "sentryuser/repo-1"}],
+                "next": f"{base_url}?pagelen=100&page=2",
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{base_url}?pagelen=100&page=2",
+            json={
+                "values": [{"full_name": "sentryuser/repo-2"}],
+                "next": f"{base_url}?pagelen=100&page=3",
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{base_url}?pagelen=100&page=3",
+            json={"values": [{"full_name": "sentryuser/repo-3"}]},
+        )
+
+        installation = self.integration.get_installation(self.organization.id)
+        result = installation.get_repositories()
+        assert result == [
+            {"identifier": "sentryuser/repo-1", "name": "sentryuser/repo-1"},
+            {"identifier": "sentryuser/repo-2", "name": "sentryuser/repo-2"},
+            {"identifier": "sentryuser/repo-3", "name": "sentryuser/repo-3"},
+        ]
+
+    @responses.activate
+    def test_get_repositories_respects_page_limit(self) -> None:
+        """Pagination stops at the page_number_limit."""
+        base_url = "https://api.bitbucket.org/2.0/repositories/sentryuser"
+        # Page 1 has a next link but we pass page_number_limit=1
+        responses.add(
+            responses.GET,
+            base_url,
+            json={
+                "values": [{"full_name": "sentryuser/repo-1"}],
+                "next": f"{base_url}?pagelen=100&page=2",
+            },
+        )
+        # Page 2 should not be fetched
+        responses.add(
+            responses.GET,
+            f"{base_url}?pagelen=100&page=2",
+            json={"values": [{"full_name": "sentryuser/repo-2"}]},
+        )
+
+        installation = self.integration.get_installation(self.organization.id)
+        result = installation.get_repositories(page_number_limit=1)
+        assert result == [
+            {"identifier": "sentryuser/repo-1", "name": "sentryuser/repo-1"},
+        ]
+        assert len(responses.calls) == 1
+
+    @responses.activate
     def test_get_repositories_exact_match(self) -> None:
         querystring = urlencode({"q": 'name="stuf"'})
         responses.add(


### PR DESCRIPTION
## Summary

- Bitbucket Cloud defaults to `pagelen=10` when no parameter is specified, so `get_repos()` was silently returning only the first 10 repositories for any workspace
- This affected repo selector dropdowns, stacktrace linking, code mappings, and unmigratable repo detection for any Bitbucket Cloud workspace with >10 repos
- Add `_get_all_from_paginated()` that follows the `next` URL in Bitbucket response bodies with `pagelen=100` (the API max), aggregating all pages
- Applied to `get_repos()` only; `search_repositories()` is left unchanged

## Test plan

- [x] Existing Bitbucket tests pass (65/65)
- [x] Manually test with a Bitbucket Cloud workspace that has >10 repos to confirm all repos are now returned

Refs VDY-67