### PR TITLE
feat(seer): Record agent_handoff analytics in launch_coding_agents_for_run

### DIFF
--- a/src/sentry/analytics/events/autofix_events.py
+++ b/src/sentry/analytics/events/autofix_events.py
@@ -72,6 +72,7 @@ class AiAutofixPrCreatedCompletedEvent(AiAutofixPhaseEvent):
 @analytics.eventclass("ai.autofix.agent_handoff")
 class AiAutofixAgentHandoffEvent(AiAutofixPhaseEvent):
     coding_agent: str | None
+    initiator: str | None = None
 
 
 analytics.register(AiAutofixRootCauseStartedEvent)

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -153,7 +153,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
             trigger_source=trigger_source,
             instruction=instruction,
             user_id=request.user.id,
-            referrer="api.organization_coding_agents",
+            initiator="user",
         )
 
         successes = results["successes"]

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -153,6 +153,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
             trigger_source=trigger_source,
             instruction=instruction,
             user_id=request.user.id,
+            referrer="api.organization_coding_agents",
         )
 
         successes = results["successes"]

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -576,6 +576,7 @@ def trigger_coding_agent_handoff(
             group_id=group.id,
             referrer=referrer.value,
             coding_agent=coding_agent_name,
+            initiator="automation",
         )
     )
 

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -11,7 +11,7 @@ from django.conf import settings as django_settings
 from requests import HTTPError
 from rest_framework.exceptions import APIException, NotFound, PermissionDenied, ValidationError
 
-from sentry import features
+from sentry import analytics, features
 
 
 class IntegrationNotFound(NotFound):
@@ -30,6 +30,7 @@ class StateReposNotFound(NotFound):
     pass
 
 
+from sentry.analytics.events.autofix_events import AiAutofixAgentHandoffEvent
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT, ObjectStatus
 from sentry.integrations.claude_code.integration import (
     ClaudeCodeIntegrationMetadata,
@@ -419,6 +420,7 @@ def launch_coding_agents_for_run(
     trigger_source: AutofixTriggerSource = AutofixTriggerSource.SOLUTION,
     instruction: str | None = None,
     user_id: int | None = None,
+    referrer: str | None = None,
 ) -> dict[str, list]:
     """
     Launch coding agents for an autofix run.
@@ -511,6 +513,17 @@ def launch_coding_agents_for_run(
             "repos_succeeded": len(results["successes"]),
             "repos_failed": len(results["failures"]),
         },
+    )
+
+    coding_agent_name = provider or (integration.provider if integration else None)
+    analytics.record(
+        AiAutofixAgentHandoffEvent(
+            organization_id=organization.id,
+            project_id=autofix_state.request.project_id,
+            group_id=autofix_state.request.issue["id"],
+            referrer=referrer,
+            coding_agent=coding_agent_name,
+        )
     )
 
     return results

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -420,7 +420,7 @@ def launch_coding_agents_for_run(
     trigger_source: AutofixTriggerSource = AutofixTriggerSource.SOLUTION,
     instruction: str | None = None,
     user_id: int | None = None,
-    referrer: str | None = None,
+    initiator: str | None = None,
 ) -> dict[str, list]:
     """
     Launch coding agents for an autofix run.
@@ -521,8 +521,9 @@ def launch_coding_agents_for_run(
             organization_id=organization.id,
             project_id=autofix_state.request.project_id,
             group_id=autofix_state.request.issue["id"],
-            referrer=referrer,
+            referrer=None,
             coding_agent=coding_agent_name,
+            initiator=initiator,
         )
     )
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -601,7 +601,7 @@ def trigger_coding_agent_launch(
             integration_id=integration_id,
             run_id=run_id,
             trigger_source=AutofixTriggerSource(trigger_source),
-            referrer="seer_rpc.trigger_coding_agent_launch",
+            initiator="seer_agent",
         )
         return {"success": True}
     except IntegrationNotFound:

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -601,6 +601,7 @@ def trigger_coding_agent_launch(
             integration_id=integration_id,
             run_id=run_id,
             trigger_source=AutofixTriggerSource(trigger_source),
+            referrer="seer_rpc.trigger_coding_agent_launch",
         )
         return {"success": True}
     except IntegrationNotFound:


### PR DESCRIPTION
## Summary
- Adds `ai.autofix.agent_handoff` analytics event to `launch_coding_agents_for_run`, which was previously only recorded in `trigger_coding_agent_handoff` (on-completion hook path)
- Adds a `referrer` parameter to distinguish the source: `api.organization_coding_agents` (user-initiated from UI), `seer_rpc.trigger_coding_agent_launch` (seer-initiated), or the existing `autofix.on_completion_hook` (automation)
- This ensures all coding agent launches (Cursor, Claude Code, GitHub Copilot) are tracked in BigQuery regardless of trigger path

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm `ai.autofix.agent_handoff` events appear in BigQuery with the new referrer values after deploy


Agent transcript: https://claudescope.sentry.dev/share/K0dXID_ySuOGsHj7b4N5JYUuP88VYoij1v1UHwMd8CA