### PR TITLE
fix(issues): Exclude gen_ai ops from consecutive HTTP detector

### DIFF
--- a/src/sentry/issue_detection/detectors/consecutive_http_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_http_detector.py
@@ -42,10 +42,10 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
 
         self.consecutive_http_spans: list[Span] = []
         self.lcp = None
-        self.gen_ai_chat_spans: list[str] = [
+        self.gen_ai_spans: list[str] = [
             span.get("span_id")
             for span in event.get("spans", [])
-            if span.get("op") == "gen_ai.chat"
+            if (span.get("op") or "").startswith("gen_ai.")
         ]
 
         lcp_value = get_path(self.event(), "measurements", "lcp", "value")
@@ -179,7 +179,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         if not op.startswith("http.client"):
             return False
 
-        if span.get("parent_span_id") in self.gen_ai_chat_spans:
+        if span.get("parent_span_id") in self.gen_ai_spans:
             return False
 
         if (

--- a/tests/sentry/issue_detection/test_consecutive_http_detector.py
+++ b/tests/sentry/issue_detection/test_consecutive_http_detector.py
@@ -399,7 +399,7 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
         assert len(problems) == 0
 
     def test_ignores_http_spans_with_gen_ai_parent(self) -> None:
-        """Test that HTTP spans with gen_ai.chat parent spans are ignored."""
+        """Test that HTTP spans with gen_ai.* parent spans are ignored."""
         span_duration = 2000
 
         # Create a gen_ai.chat span first


### PR DESCRIPTION
The consecutive HTTP detector only excluded HTTP spans parented to gen_ai.chat spans. Agentic AI workflows use gen_ai.invoke_agent and other gen_ai.* ops, causing false positive detections on inherently sequential LLM call loops.

Broaden the filter from gen_ai.chat to any span with a gen_ai.* prefix.