### PR TITLE
ref(grouping): Remove false positive IP logging

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -469,10 +469,6 @@ class Parameterizer:
                     metrics.incr(
                         "grouping.parameterization_false_positive", tags={"key": matched_key}
                     )
-                    # TODO: Remove this once we have enough sample data
-                    _log_example_data(
-                        "ip_false_positive", extra={"input_str": input_str, "value": orig_value}
-                    )
 
             return replacement_string
 


### PR DESCRIPTION
Now that we've gathered a sufficient number of examples of non-IP values triggering the IP-like regex and getting rejected by the replacement callback, this removes the log.