### PR TITLE
fix(seer): Populate referrer field in agent_handoff analytics from launch path

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -154,6 +154,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
             instruction=instruction,
             user_id=request.user.id,
             initiator="user",
+            referrer="api.organization_coding_agents",
         )
 
         successes = results["successes"]

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -421,6 +421,7 @@ def launch_coding_agents_for_run(
     instruction: str | None = None,
     user_id: int | None = None,
     initiator: str | None = None,
+    referrer: str | None = None,
 ) -> dict[str, list]:
     """
     Launch coding agents for an autofix run.
@@ -521,7 +522,7 @@ def launch_coding_agents_for_run(
             organization_id=organization.id,
             project_id=autofix_state.request.project_id,
             group_id=autofix_state.request.issue["id"],
-            referrer=None,
+            referrer=referrer,
             coding_agent=coding_agent_name,
             initiator=initiator,
         )

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -602,6 +602,7 @@ def trigger_coding_agent_launch(
             run_id=run_id,
             trigger_source=AutofixTriggerSource(trigger_source),
             initiator="seer_agent",
+            referrer="seer_rpc.trigger_coding_agent_launch",
         )
         return {"success": True}
     except IntegrationNotFound:


### PR DESCRIPTION
## Summary
- The `ai.autofix.agent_handoff` event added in #112516 hardcoded `referrer=None` in `launch_coding_agents_for_run`, causing BigQuery queries filtering on `referrer` to miss these events
- Adds a `referrer` parameter and passes meaningful values from each caller: `api.organization_coding_agents` (UI) and `seer_rpc.trigger_coding_agent_launch` (Seer RPC)

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm `referrer` is populated in BigQuery after deploy


Agent transcript: https://claudescope.sentry.dev/share/UfJcQt8YPjsSgB02byVDpbig1RWMFUY4oBpF9MbQjRI