### PR TITLE
feat(preprod): Check for actual build data when showing mobile builds tab

### DIFF
--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -100,6 +100,10 @@ describe('ReleasesList', () => {
       method: 'POST',
       body: {attributes: {}},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/builds/`,
+      body: [],
+    });
   });
 
   afterEach(() => {

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import {forceCheck} from 'react-lazyload';
 import styled from '@emotion/styled';
-import {useQuery} from '@tanstack/react-query';
+import {keepPreviousData, useQuery} from '@tanstack/react-query';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -251,6 +251,7 @@ export default function ReleasesList() {
     }),
     staleTime: 60_000,
     enabled: !!hasPreprodFeature,
+    placeholderData: keepPreviousData,
   });
 
   // When "All Projects" is selected (represented by [-1]), check all accessible projects

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import {forceCheck} from 'react-lazyload';
 import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -41,6 +42,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {buildDetailsApiOptions} from 'sentry/views/preprod/utils/buildDetailsApiOptions';
 import {ReleaseArchivedNotice} from 'sentry/views/releases/detail/overview/releaseArchivedNotice';
 import {MobileBuilds} from 'sentry/views/releases/list/mobileBuilds';
 import {ReleaseHealthCTA} from 'sentry/views/releases/list/releaseHealthCTA';
@@ -232,13 +234,28 @@ export default function ReleasesList() {
       : selectedIds.map(id => `${id}`);
   }, [selection.projects]);
 
-  const shouldShowMobileBuildsTab = useMemo(() => {
-    if (!organization.features?.includes('preprod-frontend-routes')) {
-      return false;
-    }
+  const hasPreprodFeature = organization.features?.includes('preprod-frontend-routes');
 
-    // When "All Projects" is selected (represented by [-1]), check all accessible projects
-    // When specific projects are selected, check only those projects
+  const {statsPeriod, start, end, utc} = normalizeDateTimeParams(location.query);
+  const buildsProbeQuery = useQuery({
+    ...buildDetailsApiOptions({
+      organization,
+      queryParams: {
+        per_page: 1,
+        project: selectedProjectIds,
+        ...(statsPeriod && {statsPeriod}),
+        ...(start && {start}),
+        ...(end && {end}),
+        ...(utc && {utc}),
+      },
+    }),
+    staleTime: 60_000,
+    enabled: !!hasPreprodFeature,
+  });
+
+  // When "All Projects" is selected (represented by [-1]), check all accessible projects
+  // When specific projects are selected, check only those projects
+  const hasAnyStrictlyMobileProject = useMemo(() => {
     const isAllProjects =
       selectedProjectIds.length === 1 &&
       selectedProjectIds[0] === `${ALL_ACCESS_PROJECTS}`;
@@ -247,13 +264,17 @@ export default function ReleasesList() {
       : selectedProjectIds;
 
     // Check if at least one project has a mobile platform
-    const hasAnyStrictlyMobileProject = projectIdsToCheck
+    return projectIdsToCheck
       .map(id => ProjectsStore.getById(id))
       .filter(Boolean)
       .some(project => project?.platform && isMobileRelease(project.platform, false));
+  }, [selectedProjectIds, projects]);
 
-    return hasAnyStrictlyMobileProject;
-  }, [organization.features, selectedProjectIds, projects]);
+  const hasBuildsData =
+    !buildsProbeQuery.isPending && (buildsProbeQuery.data?.length ?? 0) > 0;
+
+  const shouldShowMobileBuildsTab =
+    hasPreprodFeature && (hasBuildsData || hasAnyStrictlyMobileProject);
 
   const selectedTab = useMemo(() => {
     if (!shouldShowMobileBuildsTab) {


### PR DESCRIPTION
Adjust the Mobile Builds tab visibility on the Releases page to also check
for actual build data, not just whether the project has a mobile platform.

Previously, the tab showed purely based on `isMobileRelease()` — a client-side
platform check. Now we also probe the existing `/builds/` endpoint with
`per_page=1` to see if any preprod builds exist for the selected projects
and time range. The tab shows if either condition is true:

1. The builds endpoint returns at least one result
2. At least one selected project has a mobile platform (existing fallback)

The probe query is gated behind the `preprod-frontend-routes` feature flag
and uses a 60s stale time. Only date-related params are passed to avoid
spurious refetches from unrelated URL query changes.

Refs EME-706