### PR TITLE
ref(preprod): post task deployment, remove no longer needed fallback

### DIFF
--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -54,7 +54,7 @@ def compare_preprod_artifact_size_analysis(
     project_id: int,
     org_id: int,
     artifact_id: int,
-    triggered_at: str | None = None,
+    triggered_at: str,
     **kwargs: Any,
 ) -> None:
     logger.info(
@@ -268,11 +268,9 @@ def compare_preprod_artifact_size_analysis(
             except (ValueError, AttributeError, TypeError):
                 artifact_type_name = "unknown"
 
-            # TODO: Remove artifact.date_added fallback once all producers pass triggered_at
-            start_time = (
-                datetime.fromisoformat(triggered_at) if triggered_at else artifact.date_added
+            e2e_size_analysis_compare_duration = timezone.now() - datetime.fromisoformat(
+                triggered_at
             )
-            e2e_size_analysis_compare_duration = timezone.now() - start_time
             metrics.distribution(
                 "preprod.size_analysis.compare.results_e2e",
                 e2e_size_analysis_compare_duration.total_seconds(),


### PR DESCRIPTION
Follow-up to #112527. Removes the `artifact.date_added` fallback and makes `triggered_at` a required parameter now that all producers pass it.