### PR TITLE
fix(slack): Use set_user for user context in Slack event webhook

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -279,7 +279,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
             sentry_sdk.set_tag("organization.slug", organization.slug)
         identity_user = slack_request.get_identity_user()
         if identity_user:
-            sentry_sdk.set_tag("user.email", identity_user.email)
+            sentry_sdk.set_user({"email": identity_user.email})
 
         logger_params = {
             "integration_id": slack_request.integration.id,

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -279,7 +279,13 @@ class SlackEventEndpoint(SlackDMEndpoint):
             sentry_sdk.set_tag("organization.slug", organization.slug)
         identity_user = slack_request.get_identity_user()
         if identity_user:
-            sentry_sdk.set_user({"email": identity_user.email})
+            sentry_sdk.set_user(
+                {
+                    "id": identity_user.id,
+                    "email": identity_user.email,
+                    "username": identity_user.username,
+                }
+            )
 
         logger_params = {
             "integration_id": slack_request.integration.id,


### PR DESCRIPTION
Replace `set_tag("user.email", ...)` with `set_user({"id", "email", "username"})` in the Slack event webhook's `on_link_shared` handler.

Previously, `user.email` was set via `set_tag("user.email", ...)` which stored it under the wrong attribute key, causing `user.email` to never appear in EAP span queries for spans with `slack.event_type`. Using `set_user()` stores the values under the correct `sentry.user.*` attributes that match the EAP search definitions. Also adds `user.id` (as string) and `user.username` to enrich the user context.