### PR TITLE
feat(feature-showcase): Redesign and rewrite FeatureTourModal as FeatureShowcase

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -439,6 +439,9 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/loading/                @getsentry/app-frontend
 /static/app/components/events/interfaces/      @getsentry/app-frontend
 /static/app/components/forms/                  @getsentry/app-frontend
+/static/app/components/featureShowcase.mdx     @getsentry/app-frontend
+/static/app/components/featureShowcase.spec.tsx @getsentry/app-frontend
+/static/app/components/featureShowcase.tsx     @getsentry/app-frontend
 /static/app/components/markdownTextArea.tsx    @getsentry/app-frontend
 /static/app/locale.tsx                         @getsentry/app-frontend
 ## End of Frontend

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -25,6 +25,8 @@ const productionEntryPoints = [
   'static/app/components/pipeline/**/*.{js,ts,tsx}',
   // TODO: Remove when used
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
+  // TODO: Remove when used
+  'static/app/components/featureShowcase.tsx',
 ];
 
 const testingEntryPoints = [

--- a/static/app/components/featureShowcase.mdx
+++ b/static/app/components/featureShowcase.mdx
@@ -1,0 +1,196 @@
+---
+title: FeatureShowcase
+description: A multi-step modal tour for showcasing features.
+category: overlay
+source: sentry/components/featureShowcase
+---
+
+import {Fragment} from 'react';
+
+import tourAlertImage from 'sentry-images/spot/performance-tour-alert.svg';
+import tourCorrelateImage from 'sentry-images/spot/performance-tour-correlate.svg';
+import tourTraceImage from 'sentry-images/spot/performance-tour-trace.svg';
+
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import {FeatureShowcase, useShowcaseContext} from 'sentry/components/featureShowcase';
+import {GlobalModal} from 'sentry/components/globalModal';
+import * as Storybook from 'sentry/stories';
+
+export function ReadTheDocsFooter() {
+  const {close} = useShowcaseContext();
+  return (
+    <Flex justify="end">
+      <LinkButton
+        external
+        href="https://docs.sentry.io"
+        onClick={close}
+        priority="primary"
+      >
+        Read the Docs
+      </LinkButton>
+    </Flex>
+  );
+}
+
+Render `<FeatureShowcase>` inside `openModal` with `<FeatureShowcase.Step>` children to create a multi-step modal tour.
+
+```jsx
+openModal(deps => (
+  <FeatureShowcase {...deps}>
+    <FeatureShowcase.Step>
+      <FeatureShowcase.Image src={image} alt="Step title" />
+      <FeatureShowcase.StepTitle>Step title</FeatureShowcase.StepTitle>
+      <FeatureShowcase.StepContent>Step description</FeatureShowcase.StepContent>
+      <FeatureShowcase.StepActions />
+    </FeatureShowcase.Step>
+  </FeatureShowcase>
+));
+```
+
+## Basic
+
+Each step can include an image, title, content, and navigation actions. The default `<FeatureShowcase.StepActions />` renders Back/Next/Done buttons automatically.
+
+<Storybook.Demo>
+  <Fragment>
+    <GlobalModal />
+    <Button
+      priority="primary"
+      onClick={() => {
+        openModal(deps => (
+          <FeatureShowcase {...deps}>
+            <FeatureShowcase.Step>
+              <FeatureShowcase.Image src={tourTraceImage} alt="Trace Errors" />
+              <FeatureShowcase.StepTitle>Trace Errors</FeatureShowcase.StepTitle>
+              <FeatureShowcase.StepContent>
+                Trace errors across your services to find the root cause.
+              </FeatureShowcase.StepContent>
+              <FeatureShowcase.StepActions />
+            </FeatureShowcase.Step>
+            <FeatureShowcase.Step>
+              <FeatureShowcase.Image src={tourAlertImage} alt="Set Alerts" />
+              <FeatureShowcase.StepTitle>Set Alerts</FeatureShowcase.StepTitle>
+              <FeatureShowcase.StepContent>
+                Get notified when things break before your users do.
+              </FeatureShowcase.StepContent>
+              <FeatureShowcase.StepActions />
+            </FeatureShowcase.Step>
+            <FeatureShowcase.Step>
+              <FeatureShowcase.Image src={tourCorrelateImage} alt="Correlate Data" />
+              <FeatureShowcase.StepTitle>Correlate Data</FeatureShowcase.StepTitle>
+              <FeatureShowcase.StepContent>
+                Correlate errors, transactions, and releases to find patterns.
+              </FeatureShowcase.StepContent>
+              <FeatureShowcase.StepActions />
+            </FeatureShowcase.Step>
+          </FeatureShowcase>
+        ));
+      }}
+    >
+      Open Tour
+    </Button>
+  </Fragment>
+</Storybook.Demo>
+```jsx
+openModal(deps => (
+  <FeatureShowcase {...deps}>
+    <FeatureShowcase.Step>
+      <FeatureShowcase.Image src={tourTraceImage} alt="Trace Errors" />
+      <FeatureShowcase.StepTitle>Trace Errors</FeatureShowcase.StepTitle>
+      <FeatureShowcase.StepContent>
+        Trace errors across your services to find the root cause.
+      </FeatureShowcase.StepContent>
+      <FeatureShowcase.StepActions />
+    </FeatureShowcase.Step>
+    <FeatureShowcase.Step>
+      <FeatureShowcase.Image src={tourAlertImage} alt="Set Alerts" />
+      <FeatureShowcase.StepTitle>Set Alerts</FeatureShowcase.StepTitle>
+      <FeatureShowcase.StepContent>
+        Get notified when things break before your users do.
+      </FeatureShowcase.StepContent>
+      <FeatureShowcase.StepActions />
+    </FeatureShowcase.Step>
+    <FeatureShowcase.Step>
+      <FeatureShowcase.Image src={tourCorrelateImage} alt="Correlate Data" />
+      <FeatureShowcase.StepTitle>Correlate Data</FeatureShowcase.StepTitle>
+      <FeatureShowcase.StepContent>
+        Correlate errors, transactions, and releases to find patterns.
+      </FeatureShowcase.StepContent>
+      <FeatureShowcase.StepActions />
+    </FeatureShowcase.Step>
+  </FeatureShowcase>
+));
+```
+
+## Custom Footer Buttons
+
+Pass custom children alongside `<FeatureShowcase.StepActions />`, or replace it entirely with your own footer. Use `useShowcaseContext()` to access `close` and `advance` from custom components.
+
+<Storybook.Demo>
+  <Fragment>
+    <GlobalModal />
+    <Button
+      priority="primary"
+      onClick={() => {
+        openModal(deps => (
+          <FeatureShowcase {...deps}>
+            <FeatureShowcase.Step>
+              <FeatureShowcase.Image src={tourTraceImage} alt="Trace Errors" />
+              <FeatureShowcase.StepTitle>Trace Errors</FeatureShowcase.StepTitle>
+              <FeatureShowcase.StepContent>
+                Trace errors across your services to find the root cause.
+              </FeatureShowcase.StepContent>
+              <FeatureShowcase.StepActions />
+            </FeatureShowcase.Step>
+            <FeatureShowcase.Step>
+              <FeatureShowcase.Image src={tourCorrelateImage} alt="Correlate Data" />
+              <FeatureShowcase.StepTitle>Correlate Data</FeatureShowcase.StepTitle>
+              <FeatureShowcase.StepContent>
+                Correlate errors, transactions, and releases to find patterns.
+              </FeatureShowcase.StepContent>
+              <ReadTheDocsFooter />
+            </FeatureShowcase.Step>
+          </FeatureShowcase>
+        ));
+      }}
+    >
+      Open Tour
+    </Button>
+  </Fragment>
+</Storybook.Demo>
+```jsx
+function ReadTheDocsFooter() {
+  const {close} = useShowcaseContext();
+  return (
+    <Flex justify="end">
+      <LinkButton external href="https://docs.sentry.io" onClick={close} priority="primary">
+        Read the Docs
+      </LinkButton>
+    </Flex>
+  );
+}
+
+openModal(deps => (
+
+<FeatureShowcase {...deps}>
+  <FeatureShowcase.Step>
+    <FeatureShowcase.Image src={tourTraceImage} alt="Trace Errors" />
+    <FeatureShowcase.StepTitle>Trace Errors</FeatureShowcase.StepTitle>
+    <FeatureShowcase.StepContent>
+      Trace errors across your services to find the root cause.
+    </FeatureShowcase.StepContent>
+    <FeatureShowcase.StepActions />
+  </FeatureShowcase.Step>
+  <FeatureShowcase.Step>
+    <FeatureShowcase.Image src={tourCorrelateImage} alt="Correlate Data" />
+    <FeatureShowcase.StepTitle>Correlate Data</FeatureShowcase.StepTitle>
+    <FeatureShowcase.StepContent>
+      Correlate errors, transactions, and releases to find patterns.
+    </FeatureShowcase.StepContent>
+    <ReadTheDocsFooter />
+  </FeatureShowcase.Step>
+</FeatureShowcase>
+)); ```

--- a/static/app/components/featureShowcase.spec.tsx
+++ b/static/app/components/featureShowcase.spec.tsx
@@ -28,11 +28,10 @@ function CustomFooter() {
 
 describe('FeatureShowcase', () => {
   let onStepChange!: jest.Mock;
-  let onClose!: jest.Mock;
 
   function openTestShowcase() {
     openModal(deps => (
-      <FeatureShowcase {...deps} onStepChange={onStepChange} onClose={onClose}>
+      <FeatureShowcase {...deps} onStepChange={onStepChange}>
         <FeatureShowcase.Step>
           <FeatureShowcase.Image
             src="step-image.svg"
@@ -58,7 +57,6 @@ describe('FeatureShowcase', () => {
 
   beforeEach(() => {
     onStepChange = jest.fn();
-    onClose = jest.fn();
   });
 
   it('shows the modal', async () => {
@@ -168,7 +166,6 @@ describe('FeatureShowcase', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Complete tour'}));
 
     expect(onStepChange).toHaveBeenCalledTimes(1);
-    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('supports custom footer on last step', async () => {
@@ -179,7 +176,7 @@ describe('FeatureShowcase', () => {
           data-test-id="reveal"
           onClick={() => {
             openModal(deps => (
-              <FeatureShowcase {...deps} onStepChange={onStepChange} onClose={onClose}>
+              <FeatureShowcase {...deps} onStepChange={onStepChange}>
                 <FeatureShowcase.Step>
                   <FeatureShowcase.StepTitle>First</FeatureShowcase.StepTitle>
                   <FeatureShowcase.StepContent>First step</FeatureShowcase.StepContent>
@@ -208,7 +205,6 @@ describe('FeatureShowcase', () => {
     expect(button).toHaveAttribute('href', 'http://example.org');
 
     await userEvent.click(button);
-    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('close button dismisses modal', async () => {
@@ -224,7 +220,5 @@ describe('FeatureShowcase', () => {
     await userEvent.click(screen.getByTestId('reveal'));
 
     await userEvent.click(screen.getByRole('button', {name: 'Close tour'}));
-
-    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/static/app/components/featureShowcase.spec.tsx
+++ b/static/app/components/featureShowcase.spec.tsx
@@ -1,0 +1,230 @@
+import {Fragment} from 'react';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import {FeatureShowcase, useShowcaseContext} from 'sentry/components/featureShowcase';
+import {GlobalModal} from 'sentry/components/globalModal';
+
+function CustomFooter() {
+  const {close} = useShowcaseContext();
+  return (
+    <Flex justify="end">
+      <LinkButton
+        external
+        href="http://example.org"
+        onClick={close}
+        priority="primary"
+        aria-label="Complete tour"
+      >
+        Finished
+      </LinkButton>
+    </Flex>
+  );
+}
+
+describe('FeatureShowcase', () => {
+  let onStepChange!: jest.Mock;
+  let onClose!: jest.Mock;
+
+  function openTestShowcase() {
+    openModal(deps => (
+      <FeatureShowcase {...deps} onStepChange={onStepChange} onClose={onClose}>
+        <FeatureShowcase.Step>
+          <FeatureShowcase.Image
+            src="step-image.svg"
+            alt="Step image"
+            data-test-id="step-image"
+          />
+          <FeatureShowcase.StepTitle>First</FeatureShowcase.StepTitle>
+          <FeatureShowcase.StepContent>First step</FeatureShowcase.StepContent>
+          <FeatureShowcase.StepActions>
+            <a href="#" data-test-id="step-action">
+              additional action
+            </a>
+          </FeatureShowcase.StepActions>
+        </FeatureShowcase.Step>
+        <FeatureShowcase.Step>
+          <FeatureShowcase.StepTitle>Second</FeatureShowcase.StepTitle>
+          <FeatureShowcase.StepContent>Second step</FeatureShowcase.StepContent>
+          <FeatureShowcase.StepActions />
+        </FeatureShowcase.Step>
+      </FeatureShowcase>
+    ));
+  }
+
+  beforeEach(() => {
+    onStepChange = jest.fn();
+    onClose = jest.fn();
+  });
+
+  it('shows the modal', async () => {
+    render(
+      <Fragment>
+        <GlobalModal />
+        <button data-test-id="reveal" onClick={openTestShowcase}>
+          Open
+        </button>
+      </Fragment>
+    );
+
+    expect(screen.queryByTestId('feature-showcase')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('reveal'));
+
+    expect(screen.getByTestId('feature-showcase')).toBeInTheDocument();
+  });
+
+  it('advances on click', async () => {
+    render(
+      <Fragment>
+        <GlobalModal />
+        <button data-test-id="reveal" onClick={openTestShowcase}>
+          Open
+        </button>
+      </Fragment>
+    );
+
+    await userEvent.click(screen.getByTestId('reveal'));
+
+    expect(screen.getByRole('heading')).toHaveTextContent('First');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+    expect(screen.getByRole('heading')).toHaveTextContent('Second');
+    expect(onStepChange).toHaveBeenCalled();
+  });
+
+  it('does not show back button on first step', async () => {
+    render(
+      <Fragment>
+        <GlobalModal />
+        <button data-test-id="reveal" onClick={openTestShowcase}>
+          Open
+        </button>
+      </Fragment>
+    );
+
+    await userEvent.click(screen.getByTestId('reveal'));
+
+    expect(screen.queryByRole('button', {name: 'Back'})).not.toBeInTheDocument();
+  });
+
+  it('goes back on click', async () => {
+    render(
+      <Fragment>
+        <GlobalModal />
+        <button data-test-id="reveal" onClick={openTestShowcase}>
+          Open
+        </button>
+      </Fragment>
+    );
+
+    await userEvent.click(screen.getByTestId('reveal'));
+
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+    expect(screen.getByRole('heading')).toHaveTextContent('Second');
+    expect(screen.getByRole('button', {name: 'Back'})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Back'}));
+    expect(screen.getByRole('heading')).toHaveTextContent('First');
+    expect(screen.queryByRole('button', {name: 'Back'})).not.toBeInTheDocument();
+  });
+
+  it('shows step content', async () => {
+    render(
+      <Fragment>
+        <GlobalModal />
+        <button data-test-id="reveal" onClick={openTestShowcase}>
+          Open
+        </button>
+      </Fragment>
+    );
+
+    await userEvent.click(screen.getByTestId('reveal'));
+
+    expect(screen.getByRole('heading')).toHaveTextContent('First');
+    expect(screen.getByTestId('step-image')).toBeInTheDocument();
+    expect(screen.getByTestId('step-action')).toBeInTheDocument();
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+  });
+
+  it('last step shows done', async () => {
+    render(
+      <Fragment>
+        <GlobalModal />
+        <button data-test-id="reveal" onClick={openTestShowcase}>
+          Open
+        </button>
+      </Fragment>
+    );
+
+    await userEvent.click(screen.getByTestId('reveal'));
+
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+    await userEvent.click(screen.getByRole('button', {name: 'Complete tour'}));
+
+    expect(onStepChange).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports custom footer on last step', async () => {
+    render(
+      <Fragment>
+        <GlobalModal />
+        <button
+          data-test-id="reveal"
+          onClick={() => {
+            openModal(deps => (
+              <FeatureShowcase {...deps} onStepChange={onStepChange} onClose={onClose}>
+                <FeatureShowcase.Step>
+                  <FeatureShowcase.StepTitle>First</FeatureShowcase.StepTitle>
+                  <FeatureShowcase.StepContent>First step</FeatureShowcase.StepContent>
+                  <FeatureShowcase.StepActions />
+                </FeatureShowcase.Step>
+                <FeatureShowcase.Step>
+                  <FeatureShowcase.StepTitle>Second</FeatureShowcase.StepTitle>
+                  <FeatureShowcase.StepContent>Second step</FeatureShowcase.StepContent>
+                  <CustomFooter />
+                </FeatureShowcase.Step>
+              </FeatureShowcase>
+            ));
+          }}
+        >
+          Open
+        </button>
+      </Fragment>
+    );
+
+    await userEvent.click(screen.getByTestId('reveal'));
+
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+    const button = screen.getByRole('button', {name: 'Complete tour'});
+    expect(button).toHaveTextContent('Finished');
+    expect(button).toHaveAttribute('href', 'http://example.org');
+
+    await userEvent.click(button);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('close button dismisses modal', async () => {
+    render(
+      <Fragment>
+        <GlobalModal />
+        <button data-test-id="reveal" onClick={openTestShowcase}>
+          Open
+        </button>
+      </Fragment>
+    );
+
+    await userEvent.click(screen.getByTestId('reveal'));
+
+    await userEvent.click(screen.getByRole('button', {name: 'Close tour'}));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/static/app/components/featureShowcase.tsx
+++ b/static/app/components/featureShowcase.tsx
@@ -94,10 +94,6 @@ function StepActions({children}: {children?: ReactNode}) {
 type FeatureShowcaseProps = ModalRenderProps & {
   children: ReactNode;
   /**
-   * Called when the showcase modal is closed (via dismiss or completion).
-   */
-  onClose?: (step: number) => void;
-  /**
    * Called when the showcase advances to a new step.
    */
   onStepChange?: (step: number) => void;

--- a/static/app/components/featureShowcase.tsx
+++ b/static/app/components/featureShowcase.tsx
@@ -1,0 +1,199 @@
+import {
+  Children,
+  createContext,
+  isValidElement,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Image, type ImageProps} from '@sentry/scraps/image';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+type ShowcaseContextValue = {
+  advance: () => void;
+  back: () => void;
+  close: () => void;
+  current: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+  stepCount: number;
+};
+
+const ShowcaseContext = createContext<ShowcaseContextValue | null>(null);
+
+function useShowcaseContext(): ShowcaseContextValue {
+  const ctx = useContext(ShowcaseContext);
+  if (!ctx) {
+    throw new Error(
+      'FeatureShowcase compound components must be used within FeatureShowcase'
+    );
+  }
+  return ctx;
+}
+
+function Step({children}: {children: ReactNode}) {
+  return <Stack gap="md">{children}</Stack>;
+}
+
+function StepImage(props: ImageProps) {
+  return <Image height="200px" objectFit="contain" {...props} />;
+}
+
+function StepTitle({children}: {children: ReactNode}) {
+  const {current, stepCount} = useShowcaseContext();
+  return (
+    <Stack gap="md">
+      <Text size="sm" variant="muted">
+        {`${current + 1} / ${stepCount}`}
+      </Text>
+      <Heading as="h4" size="lg">
+        {children}
+      </Heading>
+    </Stack>
+  );
+}
+
+function StepContent({children}: {children: ReactNode}) {
+  return <Text as="p">{children}</Text>;
+}
+
+/**
+ * Renders the navigation footer for a step.
+ *
+ * - No children: renders default Back/Next/Done buttons.
+ * - With children: rendered alongside the default navigation buttons.
+ */
+function StepActions({children}: {children?: ReactNode}) {
+  const {advance, back, close, hasNext, hasPrevious} = useShowcaseContext();
+
+  return (
+    <Flex justify="end" gap="md">
+      {children}
+      {hasPrevious && <Button onClick={back}>{t('Back')}</Button>}
+      {hasNext ? (
+        <Button priority="primary" onClick={advance}>
+          {t('Next')}
+        </Button>
+      ) : (
+        <Button priority="primary" onClick={close} aria-label={t('Complete tour')}>
+          {t('Done')}
+        </Button>
+      )}
+    </Flex>
+  );
+}
+
+type FeatureShowcaseProps = ModalRenderProps & {
+  children: ReactNode;
+  /**
+   * Called when the showcase modal is closed (via dismiss or completion).
+   */
+  onClose?: (step: number) => void;
+  /**
+   * Called when the showcase advances to a new step.
+   */
+  onStepChange?: (step: number) => void;
+};
+
+/**
+ * A multi-step feature showcase modal. Render inside `openModal`.
+ *
+ * @example
+ * ```tsx
+ * openModal(deps => (
+ *   <FeatureShowcase {...deps} onStepChange={handleStep} onClose={handleClose}>
+ *     <FeatureShowcase.Step>
+ *       <FeatureShowcase.Image src={heroImage} alt="Step 1" />
+ *       <FeatureShowcase.StepTitle>Step 1</FeatureShowcase.StepTitle>
+ *       <FeatureShowcase.StepContent>Content here</FeatureShowcase.StepContent>
+ *       <FeatureShowcase.StepActions />
+ *     </FeatureShowcase.Step>
+ *     <FeatureShowcase.Step>
+ *       <FeatureShowcase.StepTitle>Step 2</FeatureShowcase.StepTitle>
+ *       <FeatureShowcase.StepContent>More content</FeatureShowcase.StepContent>
+ *       <FeatureShowcase.StepActions>
+ *         <Button onClick={...}>Extra</Button>
+ *       </FeatureShowcase.StepActions>
+ *     </FeatureShowcase.Step>
+ *   </FeatureShowcase>
+ * ));
+ * ```
+ */
+function FeatureShowcase({
+  closeModal,
+  children,
+  onStepChange,
+  onClose,
+}: FeatureShowcaseProps) {
+  const [current, setCurrent] = useState(0);
+  const stateRef = useRef({current: 0, onClose});
+  stateRef.current = {current, onClose};
+
+  useEffect(() => {
+    return () => {
+      stateRef.current.onClose?.(stateRef.current.current);
+    };
+  }, []);
+
+  const steps = Children.toArray(children).filter(
+    (child): child is ReactElement => isValidElement(child) && child.type === Step
+  );
+
+  const handleAdvance = () => {
+    const nextStep = current + 1;
+    if (nextStep !== current) {
+      setCurrent(nextStep);
+      onStepChange?.(nextStep);
+    }
+  };
+
+  const handleBack = () => {
+    if (current > 0) {
+      setCurrent(current - 1);
+    }
+  };
+
+  const stepCount = steps.length;
+  const hasNext = current < stepCount - 1;
+  const hasPrevious = current > 0;
+  const activeStep = steps[current] ?? steps[stepCount - 1];
+
+  const ctx: ShowcaseContextValue = {
+    current,
+    stepCount,
+    hasNext,
+    hasPrevious,
+    advance: handleAdvance,
+    back: handleBack,
+    close: closeModal,
+  };
+
+  return (
+    <Container data-test-id="feature-showcase">
+      <Flex justify="end">
+        <Button priority="transparent" onClick={closeModal} aria-label={t('Close tour')}>
+          <IconClose size="xs" />
+        </Button>
+      </Flex>
+      <ShowcaseContext.Provider value={ctx}>{activeStep}</ShowcaseContext.Provider>
+    </Container>
+  );
+}
+
+FeatureShowcase.Step = Step;
+FeatureShowcase.Image = StepImage;
+FeatureShowcase.StepTitle = StepTitle;
+FeatureShowcase.StepContent = StepContent;
+FeatureShowcase.StepActions = StepActions;
+
+export {FeatureShowcase, useShowcaseContext};

--- a/static/app/components/featureShowcase.tsx
+++ b/static/app/components/featureShowcase.tsx
@@ -3,8 +3,6 @@ import {
   createContext,
   isValidElement,
   useContext,
-  useEffect,
-  useRef,
   useState,
   type ReactElement,
   type ReactNode,
@@ -129,28 +127,20 @@ type FeatureShowcaseProps = ModalRenderProps & {
  * ));
  * ```
  */
-function FeatureShowcase({
-  closeModal,
-  children,
-  onStepChange,
-  onClose,
-}: FeatureShowcaseProps) {
+function FeatureShowcase({closeModal, children, onStepChange}: FeatureShowcaseProps) {
   const [current, setCurrent] = useState(0);
-  const stateRef = useRef({current: 0, onClose});
-  stateRef.current = {current, onClose};
-
-  useEffect(() => {
-    return () => {
-      stateRef.current.onClose?.(stateRef.current.current);
-    };
-  }, []);
 
   const steps = Children.toArray(children).filter(
     (child): child is ReactElement => isValidElement(child) && child.type === Step
   );
 
+  const stepCount = steps.length;
+  const hasNext = current < stepCount - 1;
+  const hasPrevious = current > 0;
+  const activeStep = steps[current] ?? steps[stepCount - 1];
+
   const handleAdvance = () => {
-    const nextStep = current + 1;
+    const nextStep = Math.min(current + 1, stepCount - 1);
     if (nextStep !== current) {
       setCurrent(nextStep);
       onStepChange?.(nextStep);
@@ -158,17 +148,14 @@ function FeatureShowcase({
   };
 
   const handleBack = () => {
-    if (current > 0) {
-      setCurrent(current - 1);
+    const prevStep = Math.max(current - 1, 0);
+    if (prevStep !== current) {
+      setCurrent(prevStep);
+      onStepChange?.(prevStep);
     }
   };
 
-  const stepCount = steps.length;
-  const hasNext = current < stepCount - 1;
-  const hasPrevious = current > 0;
-  const activeStep = steps[current] ?? steps[stepCount - 1];
-
-  const ctx: ShowcaseContextValue = {
+  const contextValue: ShowcaseContextValue = {
     current,
     stepCount,
     hasNext,
@@ -185,7 +172,9 @@ function FeatureShowcase({
           <IconClose size="xs" />
         </Button>
       </Flex>
-      <ShowcaseContext.Provider value={ctx}>{activeStep}</ShowcaseContext.Provider>
+      <ShowcaseContext.Provider value={contextValue}>
+        {activeStep}
+      </ShowcaseContext.Provider>
     </Container>
   );
 }


### PR DESCRIPTION
Ref ISWF-2160

We need to use a multi-step modal to demo the new Monitors/Alerts product, and we do already have `FeatureTourModal` which does that and is used in a few hard-to-find places. However, that modal is a bit outdated design-wise and doesn't have the most flexible API (and is a class component).

I decided to rewrite it, and to rename it `FeatureShowcase` (so that it will not be confused with the existing `Tour` compoent).

FeatureShowcase is a compound component, and the usage is like so (you can also see this in the story file):

```tsx
openModal(deps => (
  <FeatureShowcase {...deps}>
    <FeatureShowcase.Step>
      <FeatureShowcase.Image src={image} alt="Step title" />
      <FeatureShowcase.StepTitle>Step title</FeatureShowcase.StepTitle>
      <FeatureShowcase.StepContent>Step description</FeatureShowcase.StepContent>
      <FeatureShowcase.StepActions />
    </FeatureShowcase.Step>
  </FeatureShowcase>
));
```

See [Figma designs here](https://www.figma.com/design/99EtM4v3UYfGCN0QJU1QfI/Alerts-Create-Issues---ACI?node-id=10429-3219&t=37xCMRhfnf6YWwcf-0) (though I could not match precisely due to the default modal padding being quite large).

Before:

<img width="400"  alt="CleanShot 2026-04-08 at 14 04 02@2x" src="https://github.com/user-attachments/assets/2c3c4139-8d59-4136-9525-f7311f2bed95" />

After:

<img width="400"  alt="CleanShot 2026-04-08 at 14 04 13@2x" src="https://github.com/user-attachments/assets/19981f16-4e94-420e-9a10-8ffaaa8c1ce8" />
