### PR TITLE
fix(slack): Cast user id to string in set_user call

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -281,7 +281,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
         if identity_user:
             sentry_sdk.set_user(
                 {
-                    "id": identity_user.id,
+                    "id": str(identity_user.id),
                     "email": identity_user.email,
                     "username": identity_user.username,
                 }


### PR DESCRIPTION
Follow-up to #112530. `sentry_sdk.set_user` expects a string for the `id` field. The previous PR passed `identity_user.id` as an int, which can prevent `user.id` from being indexed correctly in EAP spans.