### PR TITLE
feat(insights): Remove Projects from Insights navigation

### DIFF
--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -353,7 +353,6 @@ describe('desktop navigation', () => {
           [`${ORG}/insights/ai-agents/`, 'Insights', 'Agents'],
           [`${ORG}/insights/mcp/`, 'Insights', 'MCP'],
           [`${ORG}/monitors/crons/?insightsRedirect=true`, 'Monitors', 'Crons'],
-          [`${ORG}/insights/projects/`, 'Insights', 'All Projects'],
           // Monitors
           [`${ORG}/monitors/`, 'Monitors', 'All Monitors'],
           [`${ORG}/monitors/my-monitors/`, 'Monitors', 'My Monitors'],

--- a/static/app/views/navigation/primaryNavigationContext.tsx
+++ b/static/app/views/navigation/primaryNavigationContext.tsx
@@ -13,6 +13,7 @@ const PRIMARY_NAVIGATION_GROUP_CONFIG = {
   explore: ['explore'],
   dashboards: ['dashboards', 'dashboard'],
   insights: ['insights'],
+  projects: ['projects'], // No primary nav button — accessed via logo nav. Needed for secondary nav routing.
   monitors: ['monitors'],
   settings: ['settings'],
   prevent: ['prevent'],

--- a/static/app/views/navigation/secondary/content.tsx
+++ b/static/app/views/navigation/secondary/content.tsx
@@ -8,6 +8,7 @@ import {ExploreSecondaryNavigation} from 'sentry/views/navigation/secondary/sect
 import {InsightsSecondaryNavigation} from 'sentry/views/navigation/secondary/sections/insights/insightsSecondaryNavigation';
 import {IssuesSecondaryNavigation} from 'sentry/views/navigation/secondary/sections/issues/issuesSecondaryNavigation';
 import {MonitorsSecondaryNavigation} from 'sentry/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation';
+import {ProjectsSecondaryNavigation} from 'sentry/views/navigation/secondary/sections/projects/projectsSecondaryNavigation';
 import {SettingsSecondaryNavigation} from 'sentry/views/navigation/secondary/sections/settings/settingsSecondaryNavigation';
 
 export function SecondaryNavigationContent(): ReactNode {
@@ -21,6 +22,8 @@ export function SecondaryNavigationContent(): ReactNode {
       return <DashboardsSecondaryNavigation />;
     case 'explore':
       return <ExploreSecondaryNavigation />;
+    case 'projects':
+      return <ProjectsSecondaryNavigation />;
     case 'monitors':
       return <MonitorsSecondaryNavigation />;
     case 'prevent':

--- a/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
@@ -1,10 +1,8 @@
-import {Fragment, useMemo} from 'react';
-import partition from 'lodash/partition';
+import {Fragment} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 import {
@@ -29,22 +27,12 @@ import {
 } from 'sentry/views/insights/pages/mobile/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
+import {ProjectsNavigationItems} from 'sentry/views/navigation/secondary/sections/projects/starredProjectsList';
 
 export function InsightsSecondaryNavigation() {
   const user = useUser();
   const organization = useOrganization();
   const baseUrl = `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}`;
-
-  const {projects} = useProjects();
-
-  const [starredProjects, nonStarredProjects] = useMemo(() => {
-    return partition(projects, project => project.isBookmarked);
-  }, [projects]);
-
-  const displayStarredProjects = starredProjects.length > 0;
-  const projectsToDisplay = displayStarredProjects
-    ? starredProjects.slice(0, 8)
-    : nonStarredProjects.filter(project => project.isMember).slice(0, 8);
 
   const shouldRedirectToMonitors =
     organization.features.includes('workflow-engine-ui') && !user?.isStaff;
@@ -133,49 +121,15 @@ export function InsightsSecondaryNavigation() {
             </Feature>
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
-        <SecondaryNavigation.Separator />
-        <SecondaryNavigation.Section id="insights-projects-all">
-          <SecondaryNavigation.List>
-            <SecondaryNavigation.ListItem>
-              <SecondaryNavigation.Link
-                to={`${baseUrl}/projects/`}
-                end
-                analyticsItemName="insights_projects_all"
-              >
-                {t('All Projects')}
-              </SecondaryNavigation.Link>
-            </SecondaryNavigation.ListItem>
-          </SecondaryNavigation.List>
-        </SecondaryNavigation.Section>
-        {projectsToDisplay.length > 0 ? (
+        {!organization.features.includes('workflow-engine-ui') && (
           <Fragment>
             <SecondaryNavigation.Separator />
-            <SecondaryNavigation.Section
-              id="insights-starred-projects"
-              title={displayStarredProjects ? t('Starred Projects') : t('Projects')}
-            >
-              <SecondaryNavigation.List>
-                {projectsToDisplay.map(project => (
-                  <SecondaryNavigation.ListItem key={project.id}>
-                    <SecondaryNavigation.Link
-                      to={`${baseUrl}/projects/${project.slug}/`}
-                      leadingItems={
-                        <SecondaryNavigation.ProjectIcon
-                          projectPlatforms={
-                            project.platform ? [project.platform] : ['default']
-                          }
-                        />
-                      }
-                      analyticsItemName="insights_project_starred"
-                    >
-                      {project.slug}
-                    </SecondaryNavigation.Link>
-                  </SecondaryNavigation.ListItem>
-                ))}
-              </SecondaryNavigation.List>
-            </SecondaryNavigation.Section>
+            <ProjectsNavigationItems
+              allProjectsAnalyticsItemName="insights_projects_all"
+              starredAnalyticsItemName="insights_project_starred"
+            />
           </Fragment>
-        ) : null}
+        )}
       </SecondaryNavigation.Body>
     </Fragment>
   );

--- a/static/app/views/navigation/secondary/sections/projects/projectsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/projects/projectsSecondaryNavigation.tsx
@@ -1,0 +1,16 @@
+import {Fragment} from 'react';
+
+import {t} from 'sentry/locale';
+import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
+import {ProjectsNavigationItems} from 'sentry/views/navigation/secondary/sections/projects/starredProjectsList';
+
+export function ProjectsSecondaryNavigation() {
+  return (
+    <Fragment>
+      <SecondaryNavigation.Header>{t('Projects')}</SecondaryNavigation.Header>
+      <SecondaryNavigation.Body>
+        <ProjectsNavigationItems />
+      </SecondaryNavigation.Body>
+    </Fragment>
+  );
+}

--- a/static/app/views/navigation/secondary/sections/projects/starredProjectsList.tsx
+++ b/static/app/views/navigation/secondary/sections/projects/starredProjectsList.tsx
@@ -1,0 +1,80 @@
+import {Fragment, useMemo} from 'react';
+import partition from 'lodash/partition';
+
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
+import {makeProjectsPathname} from 'sentry/views/projects/pathname';
+
+interface ProjectsNavigationItemsProps {
+  allProjectsAnalyticsItemName?: string;
+  starredAnalyticsItemName?: string;
+}
+
+export function ProjectsNavigationItems({
+  allProjectsAnalyticsItemName = 'projects_all',
+  starredAnalyticsItemName = 'project_starred',
+}: ProjectsNavigationItemsProps) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
+
+  const [starredProjects, nonStarredProjects] = useMemo(() => {
+    return partition(projects, project => project.isBookmarked);
+  }, [projects]);
+
+  const displayStarredProjects = starredProjects.length > 0;
+  const projectsToDisplay = displayStarredProjects
+    ? starredProjects.slice(0, 8)
+    : nonStarredProjects.filter(project => project.isMember).slice(0, 8);
+
+  return (
+    <Fragment>
+      <SecondaryNavigation.Section id="projects-all">
+        <SecondaryNavigation.List>
+          <SecondaryNavigation.ListItem>
+            <SecondaryNavigation.Link
+              to={makeProjectsPathname({path: '/', organization})}
+              end
+              analyticsItemName={allProjectsAnalyticsItemName}
+            >
+              {t('All Projects')}
+            </SecondaryNavigation.Link>
+          </SecondaryNavigation.ListItem>
+        </SecondaryNavigation.List>
+      </SecondaryNavigation.Section>
+      {projectsToDisplay.length > 0 ? (
+        <Fragment>
+          <SecondaryNavigation.Separator />
+          <SecondaryNavigation.Section
+            id="starred-projects"
+            title={displayStarredProjects ? t('Starred Projects') : t('Projects')}
+          >
+            <SecondaryNavigation.List>
+              {projectsToDisplay.map(project => (
+                <SecondaryNavigation.ListItem key={project.id}>
+                  <SecondaryNavigation.Link
+                    to={makeProjectsPathname({
+                      path: `/${project.slug}/`,
+                      organization,
+                    })}
+                    leadingItems={
+                      <SecondaryNavigation.ProjectIcon
+                        projectPlatforms={
+                          project.platform ? [project.platform] : ['default']
+                        }
+                      />
+                    }
+                    analyticsItemName={starredAnalyticsItemName}
+                  >
+                    {project.slug}
+                  </SecondaryNavigation.Link>
+                </SecondaryNavigation.ListItem>
+              ))}
+            </SecondaryNavigation.List>
+          </SecondaryNavigation.Section>
+        </Fragment>
+      ) : null}
+    </Fragment>
+  );
+}

--- a/static/app/views/projects/index.tsx
+++ b/static/app/views/projects/index.tsx
@@ -1,13 +1,26 @@
 import {Outlet} from 'react-router-dom';
 
 import {Redirect} from 'sentry/components/redirect';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useRedirectNavigationV2Routes} from 'sentry/views/navigation/useRedirectNavigationV2Routes';
 
 export default function Projects() {
-  const redirectPath = useRedirectNavigationV2Routes({
+  const organization = useOrganization();
+  // Both hooks are called unconditionally (React rules of hooks), but only one
+  // can match at a time since the current URL can't start with both prefixes.
+  // We select which result to act on based on the feature flag.
+  const forwardRedirect = useRedirectNavigationV2Routes({
     oldPathPrefix: '/projects/',
     newPathPrefix: '/insights/projects/',
   });
+  const reverseRedirect = useRedirectNavigationV2Routes({
+    oldPathPrefix: '/insights/projects/',
+    newPathPrefix: '/projects/',
+  });
+
+  const redirectPath = organization.features.includes('workflow-engine-ui')
+    ? reverseRedirect
+    : forwardRedirect;
 
   if (redirectPath) {
     return <Redirect to={redirectPath} />;

--- a/static/app/views/projects/pathname.tsx
+++ b/static/app/views/projects/pathname.tsx
@@ -1,8 +1,6 @@
 import type {Organization} from 'sentry/types/organization';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 
-const PROJECTS_BASE_PATHNAME = 'insights/projects';
-
 export function makeProjectsPathname({
   path,
   organization,
@@ -10,7 +8,8 @@ export function makeProjectsPathname({
   organization: Organization;
   path: '/' | `/${string}/`;
 }) {
-  return normalizeUrl(
-    `/organizations/${organization.slug}/${PROJECTS_BASE_PATHNAME}${path}`
-  );
+  const base = organization.features.includes('workflow-engine-ui')
+    ? 'projects'
+    : 'insights/projects';
+  return normalizeUrl(`/organizations/${organization.slug}/${base}${path}`);
 }


### PR DESCRIPTION
The much beleaguered "Projects" page is being slowly shuffled out. Here's the current (strange) state:

- "Projects" is (mysteriously) available from the logo dropdown, even though everything else in there goes to settings pages, and there is such a thing as project settings!
- "Projects" _also_ shows up in the Insights secondary navigation. Why? Got dumped there during the last sidebar re-shuffle, I think
- Project pages live on the path `/insights/projects`, we moved them there from their old home at `/projects`

The Product™ has decided that the "Projects" page and the actual per-project pages are not wanted anymore. The use-case for them is better covered with Dashboards and/or Project Settings in the sidebar, we even added some analytics about it.

Since the sidebar is getting a big shuffle in the near future when "Monitors" appears, we'll also take that opportunity to remove "Projects" from the Insights secondary menu. (We're actually going to remove "Insights" menu completely, but one things at a time). Things are still a bit weird, but it's an intermediate state we're okay with for now. Soon, we will delete these pages altogether, but for now:

1. "Projects" are available as a link in the logo menu item, that link goes to `/projects/`. `/insights/projects/` now redirects to `/projects/`
2. "Projects" is removed from the Insights secondary sidebar completely! Sorry y'all
3. Projects now has its _own_ secondary menu. Otherwise, if someone has their secondary menu pinned and they land on `/projects/` what would show up there? Now it has the list of pinned projects, which is helpful
4. There's no primary menu item associated with projects, which is a bit weird, but there it is

This is all gated behind the Workflow UI flag since we're going to roll out with them!

**e.g.,**

<img width="477" height="454" alt="Screenshot 2026-04-08 at 4 07 30 PM" src="https://github.com/user-attachments/assets/f8dadcc6-11f9-4a5a-8dcd-a82fe5886407" />
<img width="423" height="488" alt="Screenshot 2026-04-08 at 4 06 40 PM" src="https://github.com/user-attachments/assets/c63dba52-06b4-48dc-a14b-dc3a13bc2fd7" />

