### PR TITLE
feat(aci): Add ability to create new environments in the API

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 import logging
 import operator
 from datetime import timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sentry.models.environment import Environment
 
 import sentry_sdk
 from django import forms
@@ -54,7 +60,7 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
      - `user`: The user from `request.user`
     """
 
-    environment = EnvironmentField(required=False, allow_null=True)
+    environment = serializers.CharField(required=False, allow_null=True)
     projects = serializers.ListField(
         child=ProjectField(scope="project:read"),
         required=False,
@@ -119,6 +125,11 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
         AlertRuleThresholdType.ABOVE: lambda threshold: threshold + 100,
         AlertRuleThresholdType.BELOW: lambda threshold: 100 - threshold,
     }
+
+    def validate_environment(self, value: str | None) -> Environment | None:
+        field = EnvironmentField()
+        field.bind("environment", self)
+        return field.to_internal_value(value)
 
     def validate_threshold_type(self, threshold_type):
         try:

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -9,7 +9,6 @@ from rest_framework import serializers
 from snuba_sdk import Column, Condition, Entity, Limit, Op
 
 from sentry import features
-from sentry.api.serializers.rest_framework import EnvironmentField
 from sentry.exceptions import (
     IncompatibleMetricsQuery,
     InvalidSearchQuery,
@@ -23,6 +22,7 @@ from sentry.incidents.logic import (
     translate_aggregate_field,
 )
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
+from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.search.eap.constants import VALID_GRANULARITIES
 from sentry.search.eap.trace_metrics.validator import validate_trace_metrics_aggregate
@@ -90,7 +90,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
     query = serializers.CharField(required=True, allow_blank=True)
     aggregate = serializers.CharField(required=True)
     time_window = serializers.IntegerField(required=True)
-    environment = EnvironmentField(required=True, allow_null=True)
+    environment = serializers.CharField(required=True, allow_null=True)
     event_types = serializers.ListField(
         child=serializers.CharField(),
     )
@@ -123,6 +123,23 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
         # if false, time_window is interpreted as minutes.
         # TODO: only accept time_window in seconds once AlertRuleSerializer is removed
         self.time_window_seconds = timeWindowSeconds
+
+    def validate_environment(self, value: str | None) -> Environment | None:
+        """
+        This is not using the `EnvironmentField` so we can inline create new envs
+        inline when creating alerts. The use case is when a new environment is needed
+        for an alert, but there haven't been any events ingested yet.
+        """
+        if value is None:
+            return None
+
+        try:
+            return Environment.get_or_create(
+                project=self.context["project"],
+                name=value,
+            )
+        except Exception:
+            raise serializers.ValidationError("Failed to retrieve or create environment.")
 
     def validate_aggregate(self, aggregate: str) -> str:
         """

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -90,7 +90,11 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
     query = serializers.CharField(required=True, allow_blank=True)
     aggregate = serializers.CharField(required=True)
     time_window = serializers.IntegerField(required=True)
-    environment = serializers.CharField(required=True, allow_null=True)
+    environment = serializers.CharField(
+        required=True,
+        allow_null=True,
+        max_length=64,
+    )
     event_types = serializers.ListField(
         child=serializers.CharField(),
     )

--- a/tests/sentry/snuba/test_validators.py
+++ b/tests/sentry/snuba/test_validators.py
@@ -2,6 +2,7 @@ import pytest
 from rest_framework import serializers
 from rest_framework.exceptions import ErrorDetail
 
+from sentry.models.environment import Environment
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
@@ -38,6 +39,21 @@ class SnubaQueryValidatorTest(TestCase):
         assert validator.validated_data["environment"] == self.environment
         assert validator.validated_data["event_types"] == [SnubaQueryEventType.EventType.ERROR]
         assert isinstance(validator.validated_data["_creator"], DataSourceCreator)
+
+    def test_environment_get_or_create(self) -> None:
+        new_env_name = "new-test-environment"
+        assert not Environment.objects.filter(
+            name=new_env_name, organization_id=self.project.organization_id
+        ).exists()
+
+        self.valid_data["environment"] = new_env_name
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid()
+
+        env = validator.validated_data["environment"]
+        assert isinstance(env, Environment)
+        assert env.name == new_env_name
+        assert env.organization_id == self.project.organization_id
 
     def test_invalid_query(self) -> None:
         unsupported_query = "release:latest"


### PR DESCRIPTION
# Description
This allows us to send a new environment through the API; (first step for [ISWF-2363](https://linear.app/getsentry/issue/ISWF-2363/uptime-monitor-environment-selector-should-allow-you-to-create-a-new)).