### PR TITLE
feat(api): Make InvalidParams a ParseError

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -25,7 +25,6 @@ from sentry.apidocs.examples.discover_performance_examples import DiscoverAndPer
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams, VisibilityParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
-from sentry.exceptions import InvalidParams
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
@@ -194,8 +193,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                     },
                 }
             )
-        except InvalidParams as err:
-            raise ParseError(detail=str(err))
 
         batch_features = self.get_features(organization, request)
 

--- a/src/sentry/exceptions.py
+++ b/src/sentry/exceptions.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import SuspiciousOperation
+from rest_framework.exceptions import ParseError
 
 
 class InvalidData(Exception):
@@ -89,5 +90,8 @@ class HashDiscarded(Exception):
         self.tombstone_id = tombstone_id
 
 
-class InvalidParams(Exception):
+class InvalidParams(ParseError):
+    """Inherits from ParseError so DRF automatically returns a 400 response
+    when this exception is unhandled in a view."""
+
     pass

--- a/src/sentry/issues/endpoints/group_attachments.py
+++ b/src/sentry/issues/endpoints/group_attachments.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 from django.utils import timezone
-from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -16,7 +15,6 @@ from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import EventAttachmentSerializer, serialize
 from sentry.api.utils import get_date_range_from_params, handle_query_errors
 from sentry.constants import CELL_API_DEPRECATION_DATE
-from sentry.exceptions import InvalidParams
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.eventattachment import EventAttachment, event_attachment_screenshot_filter
 from sentry.models.group import Group
@@ -103,10 +101,7 @@ class GroupAttachmentsEndpoint(GroupEndpoint):
         event_ids = request.GET.getlist("event_id") or None
         screenshot = "screenshot" in request.GET
 
-        try:
-            start, end = get_date_range_from_params(request.GET, optional=True)
-        except InvalidParams as e:
-            raise ParseError(detail=str(e))
+        start, end = get_date_range_from_params(request.GET, optional=True)
 
         if start:
             attachments = attachments.filter(date_added__gte=start)

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -31,7 +31,7 @@ from sentry.apidocs.examples.event_examples import EventExamples
 from sentry.apidocs.parameters import CursorQueryParam, EventParams, GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
-from sentry.exceptions import InvalidParams, InvalidSearchQuery
+from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.search.events.types import SnubaParams
 from sentry.search.utils import InvalidQuery, parse_query
@@ -99,10 +99,7 @@ class GroupEventsEndpoint(GroupEndpoint):
         except (NoResults, ResourceDoesNotExist):
             return Response([])
 
-        try:
-            start, end = get_date_range_from_params(request.GET, optional=True)
-        except InvalidParams as e:
-            raise ParseError(detail=str(e))
+        start, end = get_date_range_from_params(request.GET, optional=True)
 
         try:
             with handle_query_errors():

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -7,7 +7,7 @@ from typing import Any
 import sentry_sdk
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema
-from rest_framework.exceptions import ParseError, PermissionDenied
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import start_span
@@ -54,7 +54,7 @@ from sentry.apidocs.parameters import (
 )
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ALLOWED_FUTURE_DELTA
-from sentry.exceptions import InvalidParams, InvalidSearchQuery
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models.environment import Environment
 from sentry.models.group import QUERY_STATUS_LOOKUP, Group, GroupStatus
 from sentry.models.groupenvironment import GroupEnvironment
@@ -242,10 +242,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
     @track_slo_response("workflow")
     def get(self, request: Request, organization: Organization) -> Response:
         stats_period = request.GET.get("groupStatsPeriod")
-        try:
-            start, end = get_date_range_from_stats_period(request.GET)
-        except InvalidParams as e:
-            raise ParseError(detail=str(e))
+        start, end = get_date_range_from_stats_period(request.GET)
 
         expand = request.GET.getlist("expand", [])
         collapse = request.GET.getlist("collapse", [])

--- a/src/sentry/issues/endpoints/organization_group_index_stats.py
+++ b/src/sentry/issues/endpoints/organization_group_index_stats.py
@@ -11,7 +11,6 @@ from sentry.api.helpers.group_index import build_query_params_from_request, calc
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnuba
 from sentry.api.utils import get_date_range_from_stats_period
-from sentry.exceptions import InvalidParams
 from sentry.issues.endpoints.organization_group_index import ERR_INVALID_STATS_PERIOD
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -68,10 +67,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEndpoint):
         """
 
         stats_period = request.GET.get("groupStatsPeriod")
-        try:
-            start, end = get_date_range_from_stats_period(request.GET)
-        except InvalidParams as e:
-            raise ParseError(detail=str(e))
+        start, end = get_date_range_from_stats_period(request.GET)
 
         expand = request.GET.getlist("expand", [])
         collapse = request.GET.getlist("collapse", ["base"])

--- a/src/sentry/issues/endpoints/organization_issues_count.py
+++ b/src/sentry/issues/endpoints/organization_issues_count.py
@@ -1,4 +1,3 @@
-from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import start_span
@@ -11,7 +10,6 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.group_index import validate_search_filter_permissions
 from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.utils import get_date_range_from_params
-from sentry.exceptions import InvalidParams
 from sentry.issues.issue_search import convert_query_values, parse_search_query
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization.model import RpcOrganization
@@ -76,10 +74,7 @@ class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization: Organization | RpcOrganization) -> Response:
         stats_period = request.GET.get("groupStatsPeriod")
-        try:
-            start, end = get_date_range_from_params(request.GET)
-        except InvalidParams as e:
-            raise ParseError(detail=str(e))
+        start, end = get_date_range_from_params(request.GET)
 
         if stats_period not in (None, "", "24h", "14d", "auto"):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)

--- a/src/sentry/releases/endpoints/organization_release_health_data.py
+++ b/src/sentry/releases/endpoints/organization_release_health_data.py
@@ -71,19 +71,16 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
         """
         fields = request.GET.getlist("field", [])
         for field in fields:
-            try:
-                metric_field = parse_field(field, allow_mri=True)
-                if (
-                    metric_field.op is None
-                    and not metric_field.metric_mri.startswith("e:")
-                    and metric_field.metric_mri
-                    != "d:sessions/duration.exited@second"  # this is special case, derived metric without 'e' as entity
-                ):
-                    raise ParseError(
-                        detail="You can not use generic metric public field without operation"
-                    )
-            except InvalidParams as exc:
-                raise ParseError(detail=str(exc))
+            metric_field = parse_field(field, allow_mri=True)
+            if (
+                metric_field.op is None
+                and not metric_field.metric_mri.startswith("e:")
+                and metric_field.metric_mri
+                != "d:sessions/duration.exited@second"  # this is special case, derived metric without 'e' as entity
+            ):
+                raise ParseError(
+                    detail="You can not use generic metric public field without operation"
+                )
 
     def get(self, request: Request, organization: Organization) -> Response:
         projects = self.get_projects(request, organization)

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 from drf_spectacular.utils import extend_schema
-from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -16,7 +15,6 @@ from sentry.api.serializers import Serializer, serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.parameters import GlobalParams, IssueAlertParams
-from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.rules.history import fetch_rule_hourly_stats
@@ -67,9 +65,6 @@ class ProjectRuleStatsIndexEndpoint(WorkflowEngineRuleEndpoint):
         """
         Note that results are returned in hourly buckets.
         """
-        try:
-            start, end = get_date_range_from_params(request.GET)
-        except InvalidParams as e:
-            raise ParseError(detail=str(e))
+        start, end = get_date_range_from_params(request.GET)
         results = fetch_rule_hourly_stats(rule, start, end)
         return Response(serialize(results, request.user, TimeSeriesValueSerializer()))

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -583,7 +583,7 @@ class DerivedOp(DerivedOpDefinition, MetricOperation):
         try:
             return self.snql_func(**kwargs)
         except TypeError as e:
-            raise InvalidParams(e)
+            raise InvalidParams(str(e))
 
     def get_default_null_values(self) -> int | list[tuple[float]] | None:
         return self.default_null_value


### PR DESCRIPTION
InvalidParam is raised in API parsing contexts; we have 20+ cases already catching it and turning it into a 400, another 15 or so cases where we _should_ be (prior to this change).
Rather than continuing to add that boilerplate, we can make InvalidParam a ParseError, so that the default behavior when parameters don't seem correct is a 400 response.
The existing uses that don't convert to a 400 still work as they did previously.

