### PR TITLE
ref(action creators): Replace `browserHistory` usage in organizations actionCreator

### DIFF
--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -11,18 +11,17 @@ import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 
 type RedirectRemainingOrganizationParams = {
   /**
+   * navigate function from useNavigate
+   */
+  navigate: NavigateFunction;
+  /**
    * The organization slug
    */
   orgId: string;
-  /**
-   * navigate function from useNavigate
-   */
-  navigate?: NavigateFunction;
   /**
    * Should remove org?
    */
@@ -45,12 +44,7 @@ export function redirectToRemainingOrganization({
     org => org.status.id === 'active' && org.slug !== orgId
   );
   if (!allOrgs.length) {
-    if (navigate) {
-      navigate('/organizations/new/');
-    } else {
-      browserHistory.push('/organizations/new/');
-    }
-
+    navigate('/organizations/new/');
     return;
   }
 
@@ -64,11 +58,7 @@ export function redirectToRemainingOrganization({
     return;
   }
 
-  if (navigate) {
-    navigate(route);
-  } else {
-    browserHistory.push(route);
-  }
+  navigate(route);
 
   // Remove org from SidebarDropdown
   if (removeOrg) {

--- a/static/gsApp/hooks/disabledMemberView.tsx
+++ b/static/gsApp/hooks/disabledMemberView.tsx
@@ -16,6 +16,7 @@ import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery, useMutation} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
 import {OrganizationDropdown} from 'sentry/views/navigation/primary/organizationDropdown';
 import {UserDropdown} from 'sentry/views/navigation/primary/userDropdown';
@@ -32,6 +33,7 @@ type Props = {
 
 function DisabledMemberView(props: Props) {
   const {orgId} = useParams<{orgId: string}>();
+  const navigate = useNavigate();
   const api = useApi({persistInFlight: true});
   const [requested, setRequested] = useState(false);
 
@@ -95,7 +97,7 @@ function DisabledMemberView(props: Props) {
         organization: organization!,
         subscription,
       });
-      redirectToRemainingOrganization({orgId, removeOrg: true});
+      redirectToRemainingOrganization({navigate, orgId, removeOrg: true});
     },
     onError: () => {
       addErrorMessage(t('Unable to leave organization'));


### PR DESCRIPTION
https://github.com/getsentry/frontend-tsc/issues/78

Replaces `browserHistory` usage in organizations actionCreator.