### PR TITLE
perf(github): Cache accessible repos for accessibleOnly search

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_repos.py
@@ -71,7 +71,9 @@ class OrganizationIntegrationReposEndpoint(CellOrganizationIntegrationBaseEndpoi
             accessible_only = request.GET.get("accessibleOnly", "false").lower() == "true"
 
             try:
-                repositories = install.get_repositories(search, accessible_only=accessible_only)
+                repositories = install.get_repositories(
+                    search, accessible_only=accessible_only, use_cache=accessible_only
+                )
             except (IntegrationError, IdentityNotValid) as e:
                 return self.respond({"detail": str(e)}, status=400)
 

--- a/src/sentry/integrations/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_repos.py
@@ -72,7 +72,9 @@ class OrganizationIntegrationReposEndpoint(CellOrganizationIntegrationBaseEndpoi
 
             try:
                 repositories = install.get_repositories(
-                    search, accessible_only=accessible_only, use_cache=accessible_only
+                    search,
+                    accessible_only=accessible_only,
+                    use_cache=accessible_only and bool(search),
                 )
             except (IntegrationError, IdentityNotValid) as e:
                 return self.respond({"detail": str(e)}, status=400)

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -137,6 +137,7 @@ class BitbucketIntegration(RepositoryIntegration[BitbucketApiClient], BitbucketI
         query: str | None = None,
         page_number_limit: int | None = None,
         accessible_only: bool = False,
+        use_cache: bool = False,
     ) -> list[RepositoryInfo]:
         username = self.model.metadata.get("uuid", self.username)
         if not query:

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -288,6 +288,7 @@ class BitbucketServerIntegration(RepositoryIntegration[BitbucketServerClient]):
         query: str | None = None,
         page_number_limit: int | None = None,
         accessible_only: bool = False,
+        use_cache: bool = False,
     ) -> list[RepositoryInfo]:
         if not query:
             resp = self.get_client().get_repos()

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -154,6 +154,7 @@ class ExampleIntegration(RepositoryIntegration, SourceCodeIssueIntegration, Issu
         query: str | None = None,
         page_number_limit: int | None = None,
         accessible_only: bool = False,
+        use_cache: bool = False,
     ) -> list[RepositoryInfo]:
         return [{"name": "repo", "identifier": "user/repo", "external_id": "1"}]
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -8,9 +8,9 @@ from typing import Any, TypedDict
 
 import orjson
 import sentry_sdk
-from django.core.cache import cache
 from requests import PreparedRequest
 
+from sentry.cache import default_cache
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import (
     create_blame_query,
@@ -550,21 +550,33 @@ class GitHubBaseClient(
                 page_number_limit=page_number_limit,
             )
 
-    def get_accessible_repo_ids(self, ttl: int = 300) -> set[int]:
+    def get_accessible_repos_cached(self, ttl: int = 300) -> list[dict[str, Any]]:
         """
-        Return the set of GitHub repo IDs accessible to this installation.
-        Cached in Django cache (Redis) for ``ttl`` seconds to avoid
-        re-fetching all pages on every keystroke.
+        Return all non-archived repos accessible to this installation.
+        Cached in Django cache for ``ttl`` seconds so that debounced
+        search keystrokes don't re-fetch all pages from GitHub.
         """
-        cache_key = f"github:accessible_repo_ids:{self.integration.id}"
-        cached = cache.get(cache_key)
+        cache_key = f"github:accessible_repos:{self.integration.id}"
+        cached = default_cache.get(cache_key)
         if cached is not None:
-            return set(cached)
+            logger.info(
+                "get_accessible_repos_cached.cache_hit",
+                extra={"integration_id": self.integration.id, "count": len(cached)},
+            )
+            return cached
 
+        logger.info(
+            "get_accessible_repos_cached.cache_miss",
+            extra={"integration_id": self.integration.id},
+        )
         all_repos = self.get_repos()
-        repo_ids = {r["id"] for r in all_repos if not r.get("archived")}
-        cache.set(cache_key, list(repo_ids), ttl)
-        return repo_ids
+        repos = [r for r in all_repos if not r.get("archived")]
+        default_cache.set(cache_key, repos, ttl)
+        logger.info(
+            "get_accessible_repos_cached.cached",
+            extra={"integration_id": self.integration.id, "count": len(repos)},
+        )
+        return repos
 
     def search_repositories(self, query: bytes) -> Mapping[str, Sequence[Any]]:
         """

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -550,18 +550,25 @@ class GitHubBaseClient(
                 page_number_limit=page_number_limit,
             )
 
+    # Fields from the GitHub API response needed by get_repositories().
+    _CACHED_REPO_FIELDS = ("id", "name", "full_name", "default_branch", "archived")
+
     def get_accessible_repos_cached(self, ttl: int = 300) -> list[dict[str, Any]]:
         """
         Return all repos accessible to this installation.
         Cached in Django cache for ``ttl`` seconds so that debounced
         search keystrokes don't re-fetch all pages from GitHub.
+
+        Only the fields used by get_repositories() are stored to keep
+        the cache payload small.
         """
         cache_key = f"github:accessible_repos:{self.integration.id}"
         cached = default_cache.get(cache_key)
         if cached is not None:
             return cached
 
-        repos = self.get_repos()
+        all_repos = self.get_repos()
+        repos = [{k: r.get(k) for k in self._CACHED_REPO_FIELDS} for r in all_repos]
         default_cache.set(cache_key, repos, ttl)
         return repos
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -550,10 +550,17 @@ class GitHubBaseClient(
                 page_number_limit=page_number_limit,
             )
 
+    class CachedRepo(TypedDict):
+        id: int
+        name: str
+        full_name: str
+        default_branch: str | None
+        archived: bool | None
+
     # Fields from the GitHub API response needed by get_repositories().
     _CACHED_REPO_FIELDS = ("id", "name", "full_name", "default_branch", "archived")
 
-    def get_accessible_repos_cached(self, ttl: int = 300) -> list[dict[str, Any]]:
+    def get_accessible_repos_cached(self, ttl: int = 300) -> list[CachedRepo]:
         """
         Return all repos accessible to this installation.
         Cached in Django cache for ``ttl`` seconds so that debounced

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -557,9 +557,6 @@ class GitHubBaseClient(
         default_branch: str | None
         archived: bool | None
 
-    # Fields from the GitHub API response needed by get_repositories().
-    _CACHED_REPO_FIELDS = ("id", "name", "full_name", "default_branch", "archived")
-
     def get_accessible_repos_cached(self, ttl: int = 300) -> list[CachedRepo]:
         """
         Return all repos accessible to this installation.
@@ -575,7 +572,16 @@ class GitHubBaseClient(
             return cached
 
         all_repos = self.get_repos()
-        repos = [{k: r.get(k) for k in self._CACHED_REPO_FIELDS} for r in all_repos]
+        repos: list[GitHubBaseClient.CachedRepo] = [
+            {
+                "id": r["id"],
+                "name": r["name"],
+                "full_name": r["full_name"],
+                "default_branch": r.get("default_branch"),
+                "archived": r.get("archived"),
+            }
+            for r in all_repos
+        ]
         cache.set(cache_key, repos, ttl)
         return repos
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -552,7 +552,7 @@ class GitHubBaseClient(
 
     def get_accessible_repos_cached(self, ttl: int = 300) -> list[dict[str, Any]]:
         """
-        Return all non-archived repos accessible to this installation.
+        Return all repos accessible to this installation.
         Cached in Django cache for ``ttl`` seconds so that debounced
         search keystrokes don't re-fetch all pages from GitHub.
         """
@@ -569,8 +569,7 @@ class GitHubBaseClient(
             "get_accessible_repos_cached.cache_miss",
             extra={"integration_id": self.integration.id},
         )
-        all_repos = self.get_repos()
-        repos = [r for r in all_repos if not r.get("archived")]
+        repos = self.get_repos()
         default_cache.set(cache_key, repos, ttl)
         logger.info(
             "get_accessible_repos_cached.cached",

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -558,16 +558,15 @@ class GitHubBaseClient(
                 page_number_limit=page_number_limit,
             )
 
-    def get_accessible_repos_cached(self, ttl: int = 300) -> list[CachedRepo]:
+    def get_repos_cached(self, ttl: int = 300) -> list[CachedRepo]:
         """
-        Return all repos accessible to this installation.
-        Cached in Django cache for ``ttl`` seconds so that debounced
-        search keystrokes don't re-fetch all pages from GitHub.
+        Return all repos accessible to this installation, cached in
+        Django cache for ``ttl`` seconds.
 
         Only the fields used by get_repositories() are stored to keep
         the cache payload small.
         """
-        cache_key = f"github:accessible_repos:{self.integration.id}"
+        cache_key = f"github:repos:{self.integration.id}"
         cached = cache.get(cache_key)
         if cached is not None:
             return cached

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -57,6 +57,14 @@ MINIMUM_REQUESTS = 200
 JWT_AUTH_ROUTES = ("/app/installations", "access_tokens")
 
 
+class CachedRepo(TypedDict):
+    id: int
+    name: str
+    full_name: str
+    default_branch: str | None
+    archived: bool | None
+
+
 class GithubRateLimitInfo:
     def __init__(self, info: dict[str, int]) -> None:
         self.limit = info["limit"]
@@ -550,13 +558,6 @@ class GitHubBaseClient(
                 page_number_limit=page_number_limit,
             )
 
-    class CachedRepo(TypedDict):
-        id: int
-        name: str
-        full_name: str
-        default_branch: str | None
-        archived: bool | None
-
     def get_accessible_repos_cached(self, ttl: int = 300) -> list[CachedRepo]:
         """
         Return all repos accessible to this installation.
@@ -572,7 +573,7 @@ class GitHubBaseClient(
             return cached
 
         all_repos = self.get_repos()
-        repos: list[GitHubBaseClient.CachedRepo] = [
+        repos: list[CachedRepo] = [
             {
                 "id": r["id"],
                 "name": r["name"],

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -8,9 +8,9 @@ from typing import Any, TypedDict
 
 import orjson
 import sentry_sdk
+from django.core.cache import cache
 from requests import PreparedRequest
 
-from sentry.cache import default_cache
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import (
     create_blame_query,
@@ -570,13 +570,13 @@ class GitHubBaseClient(
         the cache payload small.
         """
         cache_key = f"github:accessible_repos:{self.integration.id}"
-        cached = default_cache.get(cache_key)
+        cached = cache.get(cache_key)
         if cached is not None:
             return cached
 
         all_repos = self.get_repos()
         repos = [{k: r.get(k) for k in self._CACHED_REPO_FIELDS} for r in all_repos]
-        default_cache.set(cache_key, repos, ttl)
+        cache.set(cache_key, repos, ttl)
         return repos
 
     def search_repositories(self, query: bytes) -> Mapping[str, Sequence[Any]]:

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -559,22 +559,10 @@ class GitHubBaseClient(
         cache_key = f"github:accessible_repos:{self.integration.id}"
         cached = default_cache.get(cache_key)
         if cached is not None:
-            logger.info(
-                "get_accessible_repos_cached.cache_hit",
-                extra={"integration_id": self.integration.id, "count": len(cached)},
-            )
             return cached
 
-        logger.info(
-            "get_accessible_repos_cached.cache_miss",
-            extra={"integration_id": self.integration.id},
-        )
         repos = self.get_repos()
         default_cache.set(cache_key, repos, ttl)
-        logger.info(
-            "get_accessible_repos_cached.cached",
-            extra={"integration_id": self.integration.id, "count": len(repos)},
-        )
         return repos
 
     def search_repositories(self, query: bytes) -> Mapping[str, Sequence[Any]]:

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -8,6 +8,7 @@ from typing import Any, TypedDict
 
 import orjson
 import sentry_sdk
+from django.core.cache import cache
 from requests import PreparedRequest
 
 from sentry.constants import ObjectStatus
@@ -548,6 +549,22 @@ class GitHubBaseClient(
                 response_key="repositories",
                 page_number_limit=page_number_limit,
             )
+
+    def get_accessible_repo_ids(self, ttl: int = 300) -> set[int]:
+        """
+        Return the set of GitHub repo IDs accessible to this installation.
+        Cached in Django cache (Redis) for ``ttl`` seconds to avoid
+        re-fetching all pages on every keystroke.
+        """
+        cache_key = f"github:accessible_repo_ids:{self.integration.id}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return set(cached)
+
+        all_repos = self.get_repos()
+        repo_ids = {r["id"] for r in all_repos if not r.get("archived")}
+        cache.set(cache_key, list(repo_ids), ttl)
+        return repo_ids
 
     def search_repositories(self, query: bytes) -> Mapping[str, Sequence[Any]]:
         """

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -347,14 +347,14 @@ class GitHubIntegration(
                     "default_branch": i.get("default_branch"),
                 }
                 for i in raw_repos
-                if not i.get("archived")
             ]
 
         # accessible_only: filter cached repo list locally.
         # Avoids re-fetching all pages on every debounced keystroke and
         # avoids the Search API's 30 req/min shared rate limit.
         if accessible_only:
-            repos = to_repo_info(client.get_accessible_repos_cached())
+            all_repos = client.get_accessible_repos_cached()
+            repos = to_repo_info(r for r in all_repos if not r.get("archived"))
             if not query:
                 return repos
             query_lower = query.lower()
@@ -362,7 +362,8 @@ class GitHubIntegration(
 
         # No query: fetch all accessible repos
         if not query:
-            return to_repo_info(client.get_repos(page_number_limit=page_number_limit))
+            all_repos = client.get_repos(page_number_limit=page_number_limit)
+            return to_repo_info(r for r in all_repos if not r.get("archived"))
 
         # Query without accessible_only: existing search behavior
         full_query = build_repository_query(self.model.metadata, self.model.name, query)

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -349,21 +349,22 @@ class GitHubIntegration(
                 for i in raw_repos
             ]
 
-        # accessible_only: fetch all accessible repos (cached) for listing and querying
-        # avoids re-fetching all pages on every debounced keystroke and
-        # avoids the Search API's 30 req/min shared rate limit.
-        if accessible_only:
-            all_repos = client.get_accessible_repos_cached()
-            repos = to_repo_info(r for r in all_repos if not r.get("archived"))
-            if not query:
-                return repos
-            query_lower = query.lower()
-            return [r for r in repos if query_lower in r["identifier"].lower()]
-
         # No query: fetch all accessible repos (without cache)
         if not query:
             all_repos = client.get_repos(page_number_limit=page_number_limit)
             return to_repo_info(r for r in all_repos if not r.get("archived"))
+
+        # accessible_only: fetch and filter accessible repos (cached)
+        # avoids re-fetching all pages on every debounced keystroke and
+        # avoids the Search API's 30 req/min shared rate limit.
+        if accessible_only:
+            all_repos_cached = client.get_accessible_repos_cached()
+            query_lower = query.lower()
+            return to_repo_info(
+                r
+                for r in all_repos_cached
+                if not r.get("archived") and query_lower in r["full_name"].lower()
+            )
 
         # Query without accessible_only: existing search behavior
         full_query = build_repository_query(self.model.metadata, self.model.name, query)

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -325,6 +325,7 @@ class GitHubIntegration(
         query: str | None = None,
         page_number_limit: int | None = None,
         accessible_only: bool = False,
+        use_cache: bool = False,
     ) -> list[RepositoryInfo]:
         """
         args:
@@ -332,6 +333,8 @@ class GitHubIntegration(
         * accessible_only - when True with a query, fetch only installation-
           accessible repos and filter locally instead of using the Search API
           (which may return repos outside the installation's scope)
+        * use_cache - when True, serve repos from a short-lived cache instead
+          of re-fetching all pages from GitHub on every call
 
         This fetches all repositories accessible to the Github App
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
@@ -349,24 +352,29 @@ class GitHubIntegration(
                 for i in raw_repos
             ]
 
-        # No query: fetch all accessible repos (without cache)
+        def _get_all_repos():
+            if use_cache:
+                return client.get_accessible_repos_cached()
+            return client.get_repos(page_number_limit=page_number_limit)
+
+        # No query: return all non-archived repos
         if not query:
-            all_repos = client.get_repos(page_number_limit=page_number_limit)
+            all_repos = _get_all_repos()
             return to_repo_info(r for r in all_repos if not r.get("archived"))
 
-        # accessible_only: fetch and filter accessible repos (cached)
-        # avoids re-fetching all pages on every debounced keystroke and
-        # avoids the Search API's 30 req/min shared rate limit.
+        # accessible_only: fetch accessible repos and filter locally
+        # avoids the Search API's 30 req/min shared rate limit
         if accessible_only:
-            all_repos_cached = client.get_accessible_repos_cached()
+            all_repos = _get_all_repos()
             query_lower = query.lower()
             return to_repo_info(
                 r
-                for r in all_repos_cached
+                for r in all_repos
                 if not r.get("archived") and query_lower in r["full_name"].lower()
             )
 
-        # Query without accessible_only: existing search behavior
+        # Query without accessible_only: use the Search API
+        assert not use_cache, "use_cache is not supported with the Search API path"
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
         response = client.search_repositories(full_query)
         return to_repo_info(response.get("items", []))

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -349,8 +349,8 @@ class GitHubIntegration(
                 for i in raw_repos
             ]
 
-        # accessible_only: filter cached repo list locally.
-        # Avoids re-fetching all pages on every debounced keystroke and
+        # accessible_only: fetch all accessible repos (cached) for listing and querying
+        # avoids re-fetching all pages on every debounced keystroke and
         # avoids the Search API's 30 req/min shared rate limit.
         if accessible_only:
             all_repos = client.get_accessible_repos_cached()
@@ -360,7 +360,7 @@ class GitHubIntegration(
             query_lower = query.lower()
             return [r for r in repos if query_lower in r["identifier"].lower()]
 
-        # No query: fetch all accessible repos
+        # No query: fetch all accessible repos (without cache)
         if not query:
             all_repos = client.get_repos(page_number_limit=page_number_limit)
             return to_repo_info(r for r in all_repos if not r.get("archived"))

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -354,16 +354,13 @@ class GitHubIntegration(
 
         def _get_all_repos():
             if use_cache:
-                return client.get_accessible_repos_cached()
+                return client.get_repos_cached()
             return client.get_repos(page_number_limit=page_number_limit)
 
-        # No query: return all non-archived repos
         if not query:
             all_repos = _get_all_repos()
             return to_repo_info(r for r in all_repos if not r.get("archived"))
 
-        # accessible_only: fetch accessible repos and filter locally
-        # avoids the Search API's 30 req/min shared rate limit
         if accessible_only:
             all_repos = _get_all_repos()
             query_lower = query.lower()
@@ -373,7 +370,6 @@ class GitHubIntegration(
                 if not r.get("archived") and query_lower in r["full_name"].lower()
             )
 
-        # Query without accessible_only: use the Search API
         assert not use_cache, "use_cache is not supported with the Search API path"
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
         response = client.search_repositories(full_query)

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, NotRequired, TypedDict
@@ -338,7 +338,7 @@ class GitHubIntegration(
         """
         client = self.get_client()
 
-        def to_repo_info(raw_repos: Sequence[Mapping[str, Any]]) -> list[RepositoryInfo]:
+        def to_repo_info(raw_repos: Iterable[Mapping[str, Any]]) -> list[RepositoryInfo]:
             return [
                 {
                     "name": i["name"],

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -338,29 +338,7 @@ class GitHubIntegration(
         """
         client = self.get_client()
 
-        # accessible_only: filter cached repo list locally.
-        # Avoids re-fetching all pages on every debounced keystroke and
-        # avoids the Search API's 30 req/min shared rate limit.
-        if accessible_only:
-            all_repos = client.get_accessible_repos_cached()
-            repos: list[RepositoryInfo] = [
-                {
-                    "name": i["name"],
-                    "identifier": i["full_name"],
-                    "external_id": self.get_repo_external_id(i),
-                    "default_branch": i.get("default_branch"),
-                }
-                for i in all_repos
-                if not i.get("archived")
-            ]
-            if not query:
-                return repos
-            query_lower = query.lower()
-            return [r for r in repos if query_lower in r["identifier"].lower()]
-
-        # No query: fetch all accessible repos
-        if not query:
-            all_repos = client.get_repos(page_number_limit=page_number_limit)
+        def to_repo_info(raw_repos: Sequence[Mapping[str, Any]]) -> list[RepositoryInfo]:
             return [
                 {
                     "name": i["name"],
@@ -368,22 +346,28 @@ class GitHubIntegration(
                     "external_id": self.get_repo_external_id(i),
                     "default_branch": i.get("default_branch"),
                 }
-                for i in all_repos
+                for i in raw_repos
                 if not i.get("archived")
             ]
+
+        # accessible_only: filter cached repo list locally.
+        # Avoids re-fetching all pages on every debounced keystroke and
+        # avoids the Search API's 30 req/min shared rate limit.
+        if accessible_only:
+            repos = to_repo_info(client.get_accessible_repos_cached())
+            if not query:
+                return repos
+            query_lower = query.lower()
+            return [r for r in repos if query_lower in r["identifier"].lower()]
+
+        # No query: fetch all accessible repos
+        if not query:
+            return to_repo_info(client.get_repos(page_number_limit=page_number_limit))
 
         # Query without accessible_only: existing search behavior
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
         response = client.search_repositories(full_query)
-        return [
-            {
-                "name": i["name"],
-                "identifier": i["full_name"],
-                "external_id": self.get_repo_external_id(i),
-                "default_branch": i.get("default_branch"),
-            }
-            for i in response.get("items", [])
-        ]
+        return to_repo_info(response.get("items", []))
 
     def get_unmigratable_repositories(self) -> list[RpcRepository]:
         accessible_repos = self.get_repositories()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -352,11 +352,12 @@ class GitHubIntegration(
                 if not i.get("archived")
             ]
 
-        # Query + accessible_only: use Search API + cached ID set
+        # Query + accessible_only: filter cached repo list locally.
+        # Avoids re-fetching all pages on every debounced keystroke and
+        # avoids the Search API's 30 req/min shared rate limit.
         if accessible_only:
-            accessible_ids = client.get_accessible_repo_ids()
-            full_query = build_repository_query(self.model.metadata, self.model.name, query)
-            response = client.search_repositories(full_query)
+            all_repos = client.get_accessible_repos_cached()
+            query_lower = query.lower()
             return [
                 {
                     "name": i["name"],
@@ -364,8 +365,8 @@ class GitHubIntegration(
                     "external_id": self.get_repo_external_id(i),
                     "default_branch": i.get("default_branch"),
                 }
-                for i in response.get("items", [])
-                if i["id"] in accessible_ids
+                for i in all_repos
+                if query_lower in i["full_name"].lower()
             ]
 
         # Query without accessible_only: existing search behavior

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -336,9 +336,12 @@ class GitHubIntegration(
         This fetches all repositories accessible to the Github App
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
         """
-        if not query or accessible_only:
-            all_repos = self.get_client().get_repos(page_number_limit=page_number_limit)
-            repos: list[RepositoryInfo] = [
+        client = self.get_client()
+
+        # No query: fetch all accessible repos (existing behavior)
+        if not query:
+            all_repos = client.get_repos(page_number_limit=page_number_limit)
+            return [
                 {
                     "name": i["name"],
                     "identifier": i["full_name"],
@@ -348,14 +351,27 @@ class GitHubIntegration(
                 for i in all_repos
                 if not i.get("archived")
             ]
-            if query:
-                query_lower = query.lower()
-                repos = [r for r in repos if query_lower in str(r["identifier"]).lower()]
-            return repos
 
+        # Query + accessible_only: use Search API + cached ID set
+        if accessible_only:
+            accessible_ids = client.get_accessible_repo_ids()
+            full_query = build_repository_query(self.model.metadata, self.model.name, query)
+            response = client.search_repositories(full_query)
+            return [
+                {
+                    "name": i["name"],
+                    "identifier": i["full_name"],
+                    "external_id": self.get_repo_external_id(i),
+                    "default_branch": i.get("default_branch"),
+                }
+                for i in response.get("items", [])
+                if i["id"] in accessible_ids
+            ]
+
+        # Query without accessible_only: existing search behavior
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
-        response = self.get_client().search_repositories(full_query)
-        search_repos: list[RepositoryInfo] = [
+        response = client.search_repositories(full_query)
+        return [
             {
                 "name": i["name"],
                 "identifier": i["full_name"],
@@ -364,7 +380,6 @@ class GitHubIntegration(
             }
             for i in response.get("items", [])
         ]
-        return search_repos
 
     def get_unmigratable_repositories(self) -> list[RpcRepository]:
         accessible_repos = self.get_repositories()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -338,7 +338,27 @@ class GitHubIntegration(
         """
         client = self.get_client()
 
-        # No query: fetch all accessible repos (existing behavior)
+        # accessible_only: filter cached repo list locally.
+        # Avoids re-fetching all pages on every debounced keystroke and
+        # avoids the Search API's 30 req/min shared rate limit.
+        if accessible_only:
+            all_repos = client.get_accessible_repos_cached()
+            repos: list[RepositoryInfo] = [
+                {
+                    "name": i["name"],
+                    "identifier": i["full_name"],
+                    "external_id": self.get_repo_external_id(i),
+                    "default_branch": i.get("default_branch"),
+                }
+                for i in all_repos
+                if not i.get("archived")
+            ]
+            if not query:
+                return repos
+            query_lower = query.lower()
+            return [r for r in repos if query_lower in r["identifier"].lower()]
+
+        # No query: fetch all accessible repos
         if not query:
             all_repos = client.get_repos(page_number_limit=page_number_limit)
             return [
@@ -350,23 +370,6 @@ class GitHubIntegration(
                 }
                 for i in all_repos
                 if not i.get("archived")
-            ]
-
-        # Query + accessible_only: filter cached repo list locally.
-        # Avoids re-fetching all pages on every debounced keystroke and
-        # avoids the Search API's 30 req/min shared rate limit.
-        if accessible_only:
-            all_repos = client.get_accessible_repos_cached()
-            query_lower = query.lower()
-            return [
-                {
-                    "name": i["name"],
-                    "identifier": i["full_name"],
-                    "external_id": self.get_repo_external_id(i),
-                    "default_branch": i.get("default_branch"),
-                }
-                for i in all_repos
-                if query_lower in i["full_name"].lower()
             ]
 
         # Query without accessible_only: existing search behavior

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -226,6 +226,7 @@ class GitHubEnterpriseIntegration(
         query: str | None = None,
         page_number_limit: int | None = None,
         accessible_only: bool = False,
+        use_cache: bool = False,
     ) -> list[RepositoryInfo]:
         if not query:
             all_repos = self.get_client().get_repos(page_number_limit=page_number_limit)

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -179,6 +179,7 @@ class GitlabIntegration(
         query: str | None = None,
         page_number_limit: int | None = None,
         accessible_only: bool = False,
+        use_cache: bool = False,
     ) -> list[RepositoryInfo]:
         try:
             # Note: gitlab projects are the same things as repos everywhere else

--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -361,6 +361,7 @@ class PerforceIntegration(RepositoryIntegration[PerforceClient], CommitContextIn
         query: str | None = None,
         page_number_limit: int | None = None,
         accessible_only: bool = False,
+        use_cache: bool = False,
     ) -> list[RepositoryInfo]:
         """
         Get list of depots/streams from Perforce server.

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -59,6 +59,7 @@ class BaseRepositoryIntegration(ABC):
         query: str | None = None,
         page_number_limit: int | None = None,
         accessible_only: bool = False,
+        use_cache: bool = False,
     ) -> list[RepositoryInfo]:
         """
         Get a list of available repositories for an installation

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -315,6 +315,7 @@ class VstsIntegration(RepositoryIntegration[VstsApiClient], VstsIssuesSpec):
         query: str | None = None,
         page_number_limit: int | None = None,
         accessible_only: bool = False,
+        use_cache: bool = False,
     ) -> list[RepositoryInfo]:
         try:
             repos = self.get_client().get_repos()

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -200,7 +200,7 @@ class OrganizationIntegrationReposTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with("rad", accessible_only=True)
+        get_repositories.assert_called_once_with("rad", accessible_only=True, use_cache=True)
         assert response.data == {
             "repos": [
                 {
@@ -224,7 +224,7 @@ class OrganizationIntegrationReposTest(APITestCase):
         response = self.client.get(self.path, format="json", data={"accessibleOnly": "true"})
 
         assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with(None, accessible_only=True)
+        get_repositories.assert_called_once_with(None, accessible_only=True, use_cache=True)
 
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
@@ -249,7 +249,7 @@ class OrganizationIntegrationReposTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with("Example", accessible_only=True)
+        get_repositories.assert_called_once_with("Example", accessible_only=True, use_cache=True)
         assert response.data == {
             "repos": [
                 {

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -224,7 +224,7 @@ class OrganizationIntegrationReposTest(APITestCase):
         response = self.client.get(self.path, format="json", data={"accessibleOnly": "true"})
 
         assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with(None, accessible_only=True, use_cache=True)
+        get_repositories.assert_called_once_with(None, accessible_only=True, use_cache=False)
 
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -679,9 +679,31 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_get_repositories_accessible_only(self) -> None:
-        """When accessible_only=True, fetches installation repos and filters locally."""
+        """accessible_only+query uses Search API filtered by cached accessible IDs."""
         with self.tasks():
             self.assert_setup_flow()
+
+        querystring = urlencode({"q": "fork:true org:Test Organization foo"})
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/search/repositories?{querystring}",
+            json={
+                "items": [
+                    {
+                        "id": 1296269,
+                        "name": "foo",
+                        "full_name": "Test-Organization/foo",
+                        "default_branch": "master",
+                    },
+                    {
+                        "id": 9999999,
+                        "name": "foo-external",
+                        "full_name": "Other-Org/foo-external",
+                        "default_branch": "main",
+                    },
+                ]
+            },
+        )
 
         integration = Integration.objects.get(provider=self.provider.key)
         installation = get_installation_of_type(
@@ -689,6 +711,8 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         result = installation.get_repositories("foo", accessible_only=True)
+        # foo-external is filtered out: its id (9999999) is the archived repo's id,
+        # which is excluded from the accessible set
         assert result == [
             {
                 "name": "foo",
@@ -700,9 +724,16 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_get_repositories_accessible_only_no_match(self) -> None:
-        """When accessible_only=True and nothing matches, returns empty list."""
+        """When accessible_only=True and search returns no accessible repos, returns empty list."""
         with self.tasks():
             self.assert_setup_flow()
+
+        querystring = urlencode({"q": "fork:true org:Test Organization nonexistent"})
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/search/repositories?{querystring}",
+            json={"items": []},
+        )
 
         integration = Integration.objects.get(provider=self.provider.key)
         installation = get_installation_of_type(
@@ -711,6 +742,49 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
         result = installation.get_repositories("nonexistent", accessible_only=True)
         assert result == []
+
+    @responses.activate
+    def test_get_repositories_accessible_only_caches_ids(self) -> None:
+        """Second accessible_only call uses cached IDs instead of re-fetching all repos."""
+        with self.tasks():
+            self.assert_setup_flow()
+
+        querystring = urlencode({"q": "fork:true org:Test Organization foo"})
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/search/repositories?{querystring}",
+            json={
+                "items": [
+                    {
+                        "id": 1296269,
+                        "name": "foo",
+                        "full_name": "Test-Organization/foo",
+                        "default_branch": "master",
+                    },
+                ]
+            },
+        )
+
+        integration = Integration.objects.get(provider=self.provider.key)
+        installation = get_installation_of_type(
+            GitHubIntegration, integration, self.organization.id
+        )
+
+        # First call: cache miss, fetches /installation/repositories + search
+        result1 = installation.get_repositories("foo", accessible_only=True)
+        install_repo_calls = [
+            c for c in responses.calls if "/installation/repositories" in c.request.url
+        ]
+        first_fetch_count = len(install_repo_calls)
+        assert first_fetch_count > 0
+
+        # Second call: cache hit, only search is called (no new /installation/repositories)
+        result2 = installation.get_repositories("foo", accessible_only=True)
+        install_repo_calls = [
+            c for c in responses.calls if "/installation/repositories" in c.request.url
+        ]
+        assert len(install_repo_calls) == first_fetch_count
+        assert result1 == result2
 
     @responses.activate
     def test_get_repositories_all_and_pagination(self) -> None:

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -724,7 +724,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         # First call: cache miss, fetches /installation/repositories
-        result1 = installation.get_repositories("foo", accessible_only=True)
+        result1 = installation.get_repositories("foo", accessible_only=True, use_cache=True)
         install_repo_calls = [
             c for c in responses.calls if "/installation/repositories" in c.request.url
         ]
@@ -732,7 +732,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert first_fetch_count > 0
 
         # Second call: cache hit, no new /installation/repositories calls
-        result2 = installation.get_repositories("foo", accessible_only=True)
+        result2 = installation.get_repositories("foo", accessible_only=True, use_cache=True)
         install_repo_calls = [
             c for c in responses.calls if "/installation/repositories" in c.request.url
         ]

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -679,31 +679,9 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_get_repositories_accessible_only(self) -> None:
-        """accessible_only+query uses Search API filtered by cached accessible IDs."""
+        """accessible_only+query filters cached repo list locally."""
         with self.tasks():
             self.assert_setup_flow()
-
-        querystring = urlencode({"q": "fork:true org:Test Organization foo"})
-        responses.add(
-            responses.GET,
-            f"{self.base_url}/search/repositories?{querystring}",
-            json={
-                "items": [
-                    {
-                        "id": 1296269,
-                        "name": "foo",
-                        "full_name": "Test-Organization/foo",
-                        "default_branch": "master",
-                    },
-                    {
-                        "id": 9999999,
-                        "name": "foo-external",
-                        "full_name": "Other-Org/foo-external",
-                        "default_branch": "main",
-                    },
-                ]
-            },
-        )
 
         integration = Integration.objects.get(provider=self.provider.key)
         installation = get_installation_of_type(
@@ -711,8 +689,6 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         result = installation.get_repositories("foo", accessible_only=True)
-        # foo-external is filtered out: its id (9999999) is the archived repo's id,
-        # which is excluded from the accessible set
         assert result == [
             {
                 "name": "foo",
@@ -724,16 +700,9 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_get_repositories_accessible_only_no_match(self) -> None:
-        """When accessible_only=True and search returns no accessible repos, returns empty list."""
+        """accessible_only+query with no matching repos returns empty list."""
         with self.tasks():
             self.assert_setup_flow()
-
-        querystring = urlencode({"q": "fork:true org:Test Organization nonexistent"})
-        responses.add(
-            responses.GET,
-            f"{self.base_url}/search/repositories?{querystring}",
-            json={"items": []},
-        )
 
         integration = Integration.objects.get(provider=self.provider.key)
         installation = get_installation_of_type(
@@ -744,33 +713,17 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert result == []
 
     @responses.activate
-    def test_get_repositories_accessible_only_caches_ids(self) -> None:
-        """Second accessible_only call uses cached IDs instead of re-fetching all repos."""
+    def test_get_repositories_accessible_only_caches_repos(self) -> None:
+        """Second accessible_only call uses cached repos instead of re-fetching from GitHub."""
         with self.tasks():
             self.assert_setup_flow()
-
-        querystring = urlencode({"q": "fork:true org:Test Organization foo"})
-        responses.add(
-            responses.GET,
-            f"{self.base_url}/search/repositories?{querystring}",
-            json={
-                "items": [
-                    {
-                        "id": 1296269,
-                        "name": "foo",
-                        "full_name": "Test-Organization/foo",
-                        "default_branch": "master",
-                    },
-                ]
-            },
-        )
 
         integration = Integration.objects.get(provider=self.provider.key)
         installation = get_installation_of_type(
             GitHubIntegration, integration, self.organization.id
         )
 
-        # First call: cache miss, fetches /installation/repositories + search
+        # First call: cache miss, fetches /installation/repositories
         result1 = installation.get_repositories("foo", accessible_only=True)
         install_repo_calls = [
             c for c in responses.calls if "/installation/repositories" in c.request.url
@@ -778,7 +731,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         first_fetch_count = len(install_repo_calls)
         assert first_fetch_count > 0
 
-        # Second call: cache hit, only search is called (no new /installation/repositories)
+        # Second call: cache hit, no new /installation/repositories calls
         result2 = installation.get_repositories("foo", accessible_only=True)
         install_repo_calls = [
             c for c in responses.calls if "/installation/repositories" in c.request.url


### PR DESCRIPTION
## Summary

- The `OrganizationIntegrationReposEndpoint` (`/integrations/{id}/repos/`) lets the frontend search for GitHub repos available to a GitHub App installation. When called with `accessibleOnly=true` and a search query (as the SCM onboarding repo selector does on each debounced keystroke), the previous implementation fetched all installation-accessible repos from the GitHub API (up to 50 pages of 100 = 5,000 repos) on every request, then filtered with a Python list comprehension
- Cache the full repo list in `sentry.cache.default_cache` (Redis) for 5 minutes, and filter locally on subsequent requests — reducing each typed query from O(pages) GitHub API calls to zero

## Test plan

- [ ] Existing `get_repositories` tests pass (6/6)
- [ ] New `test_get_repositories_accessible_only_caches_repos` verifies cache hit path skips `/installation/repositories` calls
- [ ] Manual testing: second `accessibleOnly` search returns instantly from cache

Refs VDY-68