### PR TITLE
feat(intercom): separate chat per org

### DIFF
--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -90,7 +90,7 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
             created_at = int(user.last_active.timestamp())
 
         user_data = {
-            "userId": str(user.id),
+            "userId": f"{user.id}-{organization.id}",
             "email": user.email,
             "name": user.get_display_name(),
             "createdAt": created_at,

--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -16,7 +16,6 @@ from sentry.organizations.services.organization.model import (
     RpcUserOrganizationContext,
 )
 from sentry.utils import jwt
-from sentry.utils.hashlib import md5_text
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +70,7 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
         now = int(datetime.datetime.now(datetime.UTC).timestamp())
         exp = now + JWT_VALIDITY_WINDOW_SECONDS
         # intercom creates chat history based on this ID so we need one per (org, user) pair
-        intercom_user_id = md5_text(f"{user.id}-{organization.id}").hexdigest()
+        intercom_user_id = f"{user.id}-{organization.id}"
 
         # Build JWT claims - user_id is required by Intercom
         claims = {

--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -16,6 +16,7 @@ from sentry.organizations.services.organization.model import (
     RpcUserOrganizationContext,
 )
 from sentry.utils import jwt
+from sentry.utils.hashlib import md5_text
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,7 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
         now = int(datetime.datetime.now(datetime.UTC).timestamp())
         exp = now + JWT_VALIDITY_WINDOW_SECONDS
         # intercom creates chat history based on this ID so we need one per (org, user) pair
-        intercom_user_id = f"{user.id}-{organization.id}"
+        intercom_user_id = md5_text(f"{user.id}-{organization.id}").hexdigest()
 
         # Build JWT claims - user_id is required by Intercom
         claims = {

--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -69,10 +69,12 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
         user = request.user
         now = int(datetime.datetime.now(datetime.UTC).timestamp())
         exp = now + JWT_VALIDITY_WINDOW_SECONDS
+        # intercom creates chat history based on this ID so we need one per (org, user) pair
+        intercom_user_id = f"{user.id}-{organization.id}"
 
         # Build JWT claims - user_id is required by Intercom
         claims = {
-            "user_id": str(user.id),
+            "user_id": intercom_user_id,
             "email": user.email,
             "iat": now,
             "exp": exp,
@@ -90,7 +92,7 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
             created_at = int(user.last_active.timestamp())
 
         user_data = {
-            "userId": f"{user.id}-{organization.id}",
+            "userId": intercom_user_id,
             "email": user.email,
             "name": user.get_display_name(),
             "createdAt": created_at,

--- a/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
+++ b/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
@@ -27,6 +27,7 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
     def test_get_jwt_success(self) -> None:
         """With feature flag and secret configured, should return JWT and user data."""
         test_secret = "test-intercom-secret-key"
+        intercom_user_id = f"{self.user.id}-{self.organization.id}"
 
         with (
             self.feature("organizations:intercom-support"),
@@ -39,7 +40,7 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
 
         # Verify user data
         user_data = response.data["userData"]
-        assert user_data["userId"] == str(self.user.id)
+        assert user_data["userId"] == intercom_user_id
         assert user_data["email"] == self.user.email
         assert user_data["organizationId"] == str(self.organization.id)
         assert user_data["organizationName"] == self.organization.name
@@ -49,7 +50,7 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
         token = response.data["jwt"]
         decoded = jwt.decode(token, test_secret, algorithms=["HS256"], audience=False)
 
-        assert decoded["user_id"] == str(self.user.id)
+        assert decoded["user_id"] == intercom_user_id
         assert decoded["email"] == self.user.email
         assert "iat" in decoded
         assert "exp" in decoded

--- a/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
+++ b/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
@@ -1,7 +1,6 @@
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import jwt
-from sentry.utils.hashlib import md5_text
 
 
 @control_silo_test
@@ -28,7 +27,7 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
     def test_get_jwt_success(self) -> None:
         """With feature flag and secret configured, should return JWT and user data."""
         test_secret = "test-intercom-secret-key"
-        intercom_user_id = md5_text(f"{self.user.id}-{self.organization.id}").hexdigest()
+        intercom_user_id = f"{self.user.id}-{self.organization.id}"
 
         with (
             self.feature("organizations:intercom-support"),

--- a/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
+++ b/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
@@ -1,6 +1,7 @@
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import jwt
+from sentry.utils.hashlib import md5_text
 
 
 @control_silo_test
@@ -27,7 +28,7 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
     def test_get_jwt_success(self) -> None:
         """With feature flag and secret configured, should return JWT and user data."""
         test_secret = "test-intercom-secret-key"
-        intercom_user_id = f"{self.user.id}-{self.organization.id}"
+        intercom_user_id = md5_text(f"{self.user.id}-{self.organization.id}").hexdigest()
 
         with (
             self.feature("organizations:intercom-support"),


### PR DESCRIPTION
Intercom creates a chat group per user. A user can access history of all their chats.
By defining user id that is user_id-org_id, we make intercom create a chat group per user<>org pair. That way a user only has access to their chat history from org A on org A and not their other orgs.
