### PR TITLE
ref(grouping): remove unused EventGroupingConfig type

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -29,13 +29,6 @@ export type EventGroupComponent = {
   name: string | null;
   values: EventGroupComponent[] | string[];
 };
-type EventGroupingConfig = {
-  base: string | null;
-  delegates: string[];
-  id: string;
-  strategies: string[];
-};
-
 type VariantEvidence = {
   desc: string;
   fingerprint: string;
@@ -78,7 +71,6 @@ interface ChecksumVariant extends BaseVariant {
 interface HasComponentGrouping {
   client_values?: string[];
   component?: EventGroupComponent;
-  config?: EventGroupingConfig;
   matched_rule?: string;
   values?: string[];
 }


### PR DESCRIPTION
While refactoring in https://github.com/getsentry/sentry/pull/112536, we stopped using `EventGroupingConfig` anywhere, so we can clean it up.