### PR TITLE
ref(admin): Remove `browserHistory` usages in some views

### DIFF
--- a/static/gsAdmin/views/instanceLevelOAuth/components/confirmClientDeleteModal.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/components/confirmClientDeleteModal.tsx
@@ -5,10 +5,10 @@ import {Button} from '@sentry/scraps/button';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 type Props = ModalRenderProps & {
   clientID: string | null;
@@ -17,6 +17,7 @@ type Props = ModalRenderProps & {
 
 export function ConfirmClientDeleteModal({Body, Header, clientID, name}: Props) {
   const api = useApi();
+  const navigate = useNavigate();
 
   const deleteClientAndCloseModal = async () => {
     try {
@@ -24,7 +25,7 @@ export function ConfirmClientDeleteModal({Body, Header, clientID, name}: Props) 
         method: 'DELETE',
       });
       addSuccessMessage(`Client "${name}" deleted successfully`);
-      browserHistory.push('/_admin/instance-level-oauth/');
+      navigate('/_admin/instance-level-oauth/');
     } catch (err) {
       const message = 'Unable to load client data';
       handleXhrErrorResponse(message, err as RequestError);

--- a/static/gsAdmin/views/relocationCreate.tsx
+++ b/static/gsAdmin/views/relocationCreate.tsx
@@ -9,8 +9,8 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
 import {ConfigStore} from 'sentry/stores/configStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {useApi} from 'sentry/utils/useApi';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {PageHeader} from 'admin/components/pageHeader';
 
@@ -20,6 +20,7 @@ const PROMO_CODE_ERROR_MSG =
   'That promotional code has already been claimed, does not have enough remaining uses, is no longer valid, or never existed.';
 
 function RelocationForm() {
+  const navigate = useNavigate();
   // Use our own api client to initialize, since we need to be careful with the headers when using multipart/form-data
   const api = useApi({
     api: new Client({headers: {Accept: 'application/json; charset=utf-8'}}),
@@ -67,7 +68,7 @@ function RelocationForm() {
       });
 
       addSuccessMessage('The relocation job has started!');
-      browserHistory.push(`/_admin/relocations/${region.name}/${response.uuid}/`);
+      navigate(`/_admin/relocations/${region.name}/${response.uuid}/`);
     } catch (error: any) {
       if (error.responseJSON) {
         addErrorMessage(error.responseJSON.detail);

--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -10,9 +10,9 @@ import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {getDaysSinceDate} from 'sentry/utils/getDaysSinceDate';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
 import AddEventsCTA, {type EventType} from 'getsentry/components/addEventsCTA';
@@ -50,6 +50,7 @@ interface ProductTrialAlertProps {
 
 export function ProductTrialAlert(props: ProductTrialAlertProps) {
   const {trial, subscription, organization, onDismiss, product, api} = props;
+  const navigate = useNavigate();
   const [isStartingTrial, setIsStartingTrial] = useState(false);
   const [isUpgradeSent, setIsUpgradeSent] = useState(false);
 
@@ -166,7 +167,7 @@ export function ProductTrialAlert(props: ProductTrialAlertProps) {
           <Button
             priority="primary"
             onClick={() => {
-              browserHistory.push(normalizeUrl(`/checkout/${organization.slug}/`));
+              navigate(normalizeUrl(`/checkout/${organization.slug}/`));
             }}
           >
             {t('Update Plan')}
@@ -209,7 +210,7 @@ export function ProductTrialAlert(props: ProductTrialAlertProps) {
         <Button
           priority="primary"
           onClick={() => {
-            browserHistory.push(normalizeUrl(`/checkout/${organization.slug}/`));
+            navigate(normalizeUrl(`/checkout/${organization.slug}/`));
           }}
         >
           {t('Update Plan')}

--- a/static/gsApp/components/upsellProvider.tsx
+++ b/static/gsApp/components/upsellProvider.tsx
@@ -7,8 +7,8 @@ import type {Client} from 'sentry/api';
 import {Confirm} from 'sentry/components/confirm';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {withApi} from 'sentry/utils/withApi';
 import {withOrganization} from 'sentry/utils/withOrganization';
 
@@ -87,6 +87,7 @@ function UpsellProvider({
   showConfirmation,
   children,
 }: Props) {
+  const navigate = useNavigate();
   // if the org or subscription isn't loaded yet, don't render anything
   if (!organization || !subscription) {
     return null;
@@ -215,7 +216,7 @@ function UpsellProvider({
                 const baseUrl = subscription.canSelfServe
                   ? `/checkout/${organization.slug}/`
                   : `/settings/${organization.slug}/billing/overview/`;
-                browserHistory.push(`${normalizeUrl(baseUrl)}?referrer=upsell-${source}`);
+                navigate(`${normalizeUrl(baseUrl)}?referrer=upsell-${source}`);
               }
             } else {
               if (triggerMemberRequests) {

--- a/static/gsApp/views/cancelSubscription.tsx
+++ b/static/gsApp/views/cancelSubscription.tsx
@@ -18,7 +18,6 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
@@ -273,9 +272,7 @@ function CancelSubscriptionForm() {
               </Button>
               <Button
                 onClick={() => {
-                  browserHistory.push(
-                    normalizeUrl(`/settings/${organization.slug}/billing/`)
-                  );
+                  navigate(normalizeUrl(`/settings/${organization.slug}/billing/`));
                 }}
               >
                 {t('Never Mind')}


### PR DESCRIPTION
https://github.com/getsentry/frontend-tsc/issues/78

Removes `browserHistory` usages from some views.