### PR TITLE
ref(seer): Deduplicate widget query hints and shorten dashboard context

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -34,6 +34,7 @@ import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 import {WidgetSyncContextProvider} from './contexts/widgetSyncContext';
+import {getQueryHintLegend} from './widgetCard/widgetLLMContext';
 import {ADD_WIDGET_BUTTON_DRAG_ID, AddWidget} from './addWidget';
 import {
   assignDefaultLayout,
@@ -129,9 +130,10 @@ function DashboardInner({
   // Push dashboard metadata into the LLM context tree for Seer Explorer.
   useLLMContext({
     contextHint:
-      'This is a Sentry dashboard. The dateRange, environments, and projects below are global page filters that scope every widget query. Each child widget node contains its own query config that can be used with tools like telemetry_live_search and telemetry_index_list_nodes to fetch data for that widget and dig deeper. Based on the user question, data might be needed from multiple widgets.',
+      'Sentry dashboard. dateRange, environments, and projects are global filters applied to every widget. Each widget has its own query config. Use telemetry_live_search or telemetry_index_list_nodes to fetch data. Based on the user question, data might be needed from multiple widgets.',
     title: dashboard.title,
     widgetCount: dashboard.widgets.length,
+    queryHints: getQueryHintLegend(dashboard.widgets),
     filters: dashboard.filters,
     isEditingDashboard,
     dateRange: selection.datetime,

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -64,7 +64,7 @@ import {
   useTransactionsDeprecationWarning,
 } from './widgetCardContextMenu';
 import {WidgetFrame} from './widgetFrame';
-import {getWidgetQueryLLMHint, readableConditions} from './widgetLLMContext';
+import {readableConditions} from './widgetLLMContext';
 
 export type OnDataFetchedParams = {
   tableResults?: TableDataWithTitle[];
@@ -162,7 +162,6 @@ function WidgetCard(props: Props) {
     title: props.widget.title,
     displayType: resolvedDisplayType,
     widgetType: props.widget.widgetType,
-    queryHint: getWidgetQueryLLMHint(resolvedDisplayType),
     queries: props.widget.queries.map(q => ({
       name: q.name,
       conditions: readableConditions(q.conditions),

--- a/static/app/views/dashboards/widgetCard/widgetLLMContext.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetLLMContext.spec.tsx
@@ -1,6 +1,12 @@
+import {WidgetFixture} from 'sentry-fixture/widget';
+
 import {DisplayType} from 'sentry/views/dashboards/types';
 
-import {getWidgetQueryLLMHint, readableConditions} from './widgetLLMContext';
+import {
+  getQueryHintLegend,
+  getWidgetQueryLLMHint,
+  readableConditions,
+} from './widgetLLMContext';
 
 describe('getWidgetQueryLLMHint', () => {
   it.each([
@@ -18,12 +24,49 @@ describe('getWidgetQueryLLMHint', () => {
   it('returns single number hint for BIG_NUMBER', () => {
     expect(getWidgetQueryLLMHint(DisplayType.BIG_NUMBER)).toContain('single number');
     expect(getWidgetQueryLLMHint(DisplayType.BIG_NUMBER)).toContain(
-      'current value is included below'
+      'current value is included in each widget'
     );
   });
 
   it('returns generic hint for unknown types', () => {
     expect(getWidgetQueryLLMHint(DisplayType.WHEEL)).toContain('shows data');
+  });
+});
+
+describe('getQueryHintLegend', () => {
+  it('returns hints keyed by display type', () => {
+    const widgets = [
+      WidgetFixture({displayType: DisplayType.BAR}),
+      WidgetFixture({displayType: DisplayType.BIG_NUMBER}),
+    ];
+    const legend = getQueryHintLegend(widgets);
+    expect(Object.keys(legend)).toEqual(
+      expect.arrayContaining([DisplayType.BAR, DisplayType.BIG_NUMBER])
+    );
+    expect(Object.keys(legend)).toHaveLength(2);
+  });
+
+  it('only includes display types present in the widget list', () => {
+    const widgets = [WidgetFixture({displayType: DisplayType.TABLE})];
+    const legend = getQueryHintLegend(widgets);
+    expect(Object.keys(legend)).toEqual([DisplayType.TABLE]);
+  });
+
+  it('deduplicates multiple widgets of the same type', () => {
+    const widgets = [
+      WidgetFixture({displayType: DisplayType.BAR}),
+      WidgetFixture({displayType: DisplayType.BAR}),
+      WidgetFixture({displayType: DisplayType.BAR}),
+    ];
+    const legend = getQueryHintLegend(widgets);
+    expect(Object.keys(legend)).toEqual([DisplayType.BAR]);
+  });
+
+  it('resolves TOP_N to AREA', () => {
+    const widgets = [WidgetFixture({displayType: DisplayType.TOP_N})];
+    const legend = getQueryHintLegend(widgets);
+    expect(Object.keys(legend)).toEqual([DisplayType.AREA]);
+    expect(legend[DisplayType.AREA]).toContain('timeseries chart');
   });
 });
 

--- a/static/app/views/dashboards/widgetCard/widgetLLMContext.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetLLMContext.tsx
@@ -1,4 +1,5 @@
 import {OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 /**
@@ -23,12 +24,25 @@ export function getWidgetQueryLLMHint(displayType: DisplayType): string {
     case DisplayType.LINE:
     case DisplayType.AREA:
     case DisplayType.BAR:
-      return 'This widget shows a timeseries chart. The aggregates are the y-axis metrics, columns are the group-by breakdowns, and conditions filter the data. Understand the intent from the query config below.';
+      return 'This widget shows a timeseries chart. The aggregates are the y-axis metrics, columns are the group-by breakdowns, and conditions filter the data. Understand the intent from the query config in each widget. Use telemetry_live_search or telemetry_index_list_nodes to fetch data.';
     case DisplayType.TABLE:
-      return 'This widget shows a table. The aggregates and columns define the visible fields, orderby is the sort, and conditions filter the data. Understand the intent from the query config below.';
+      return 'This widget shows a table. The aggregates and columns define the visible fields, orderby is the sort, and conditions filter the data. Understand the intent from the query config in each widget. Use telemetry_live_search or telemetry_index_list_nodes to fetch data.';
     case DisplayType.BIG_NUMBER:
-      return 'This widget shows a single number. The aggregate is the metric, conditions filter the data, and the current value is included below. Understand the intent from the query config below.';
+      return 'This widget shows a single number. The aggregate is the metric, conditions filter the data, and the current value is included in each widget. Use telemetry_live_search or telemetry_index_list_nodes to fetch data.';
     default:
-      return 'This widget shows data. The aggregates, columns, and conditions define what is displayed. Understand the intent from the query config below.';
+      return 'This widget shows data. The aggregates, columns, and conditions define what is displayed. Understand the intent from the query config in each widget. Use telemetry_live_search or telemetry_index_list_nodes to fetch data.';
   }
+}
+
+/**
+ * Build a legend mapping each display type present in the dashboard to its
+ * query hint. This lives on the dashboard node so hints aren't repeated on
+ * every widget.
+ */
+export function getQueryHintLegend(widgets: Widget[]): Record<string, string> {
+  const resolved = widgets.map(w =>
+    w.displayType === DisplayType.TOP_N ? DisplayType.AREA : w.displayType
+  );
+  const uniqueTypes = new Set(resolved);
+  return Object.fromEntries([...uniqueTypes].map(dt => [dt, getWidgetQueryLLMHint(dt)]));
 }


### PR DESCRIPTION
+ Move per-widget queryHint to a dashboard-level legend keyed by displayType so hints are not repeated on every widget. 
+ Shorten the dashboard contextHint to reduce token overhead. Update hint text to reference tool names and say "in each widget" instead of "below".
