### PR TITLE
feat(seer): Distinguish legacy vs explorer autofix in agent_handoff initiator

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -576,7 +576,7 @@ def trigger_coding_agent_handoff(
             group_id=group.id,
             referrer=referrer.value,
             coding_agent=coding_agent_name,
-            initiator="automation",
+            initiator="automation.explorer",
         )
     )
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -601,7 +601,7 @@ def trigger_coding_agent_launch(
             integration_id=integration_id,
             run_id=run_id,
             trigger_source=AutofixTriggerSource(trigger_source),
-            initiator="seer_agent",
+            initiator="automation.legacy",
             referrer="seer_rpc.trigger_coding_agent_launch",
         )
         return {"success": True}


### PR DESCRIPTION
## Summary
- Renames `initiator` values on the `ai.autofix.agent_handoff` analytics event to distinguish which autofix version triggered the coding agent handoff:
  - `"seer_agent"` → `"automation.legacy"` — old pipeline-based autofix (Seer's `RootCauseStep` calls `trigger_coding_agent_launch` RPC)
  - `"automation"` → `"automation.explorer"` — new Explorer-based autofix (Sentry's `AutofixOnCompletionHook` calls `trigger_coding_agent_handoff`)
  - `"user"` — unchanged, user-initiated from UI

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm new initiator values appear in BigQuery after deploy


Agent transcript: https://claudescope.sentry.dev/share/mt_IR7vrLGu7E0d4X-V3aRgufEXZBTeXGYU6o-tFPqc