### PR TITLE
fix(tracemetrics): Prevent header text wrapping in samples table during loading

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -74,6 +74,7 @@ export const StyledSimpleTableHeaderCell = styled(SimpleTable.HeaderCell)<{
   noPadding?: boolean;
 }>`
   font-size: ${p => p.theme.font.size.sm};
+  white-space: nowrap;
   padding: ${p => (p.noPadding ? 0 : p.embedded ? p.theme.space.xl : p.theme.space.lg)};
   padding-top: ${p =>
     p.noPadding ? 0 : p.embedded ? p.theme.space.sm : p.theme.space.xs};


### PR DESCRIPTION
Fix styling issue where `Trace ID` column, was being line wrapped on load.

Before:
<img width="815" height="368" alt="Screenshot 2026-04-09 at 09 35 37" src="https://github.com/user-attachments/assets/af335581-42d2-4fa4-a5d6-ef924753b031" />

After:
<img width="815" height="368" alt="Screenshot 2026-04-09 at 09 56 11" src="https://github.com/user-attachments/assets/f50453aa-f425-4f31-a6ff-08ee3db1fb4e" />