### PR TITLE
feat(tracemetrics): Add column sorting to samples table

### DIFF
--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -43,6 +43,7 @@ type ReadableQuery = {
   // - `aggregateField` which contains a list of group bys and visualizes merged together
   // - `groupby` and `visualize` which contains the group bys and visualizes separately
   aggregateField?: Array<RawGroupBy | RawVisualize>;
+  aggregateOrderby?: string;
   caseInsensitive?: CaseInsensitive;
 
   groupby?: string[];
@@ -59,6 +60,7 @@ class SavedQueryQuery {
   query: string;
   caseInsensitive?: CaseInsensitive;
   aggregateField: Array<RawGroupBy | RawVisualize>;
+  aggregateOrderby?: string;
   groupby: string[];
   visualize: RawVisualize[];
 
@@ -71,6 +73,7 @@ class SavedQueryQuery {
     this.orderby = query.orderby;
     this.query = query.query;
     this.caseInsensitive = query.caseInsensitive;
+    this.aggregateOrderby = query.aggregateOrderby;
     // for compatibility, we ensure that aggregate fields, group bys and visualizes are all populated
     // we ensure that group bys + visualizes = aggregate fields
     this.groupby =

--- a/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
+++ b/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
@@ -75,6 +75,9 @@ export function useSaveMetricsMultiQuery() {
             orderby: metricQuery.queryParams.sortBys[0]
               ? encodeSort(metricQuery.queryParams.sortBys[0])
               : undefined,
+            aggregateOrderby: metricQuery.queryParams.aggregateSortBys[0]
+              ? encodeSort(metricQuery.queryParams.aggregateSortBys[0])
+              : undefined,
             query: metricQuery.queryParams.query ?? '',
             mode: metricQuery.queryParams.mode,
           };

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
@@ -9,6 +9,7 @@ import {
   StyledSimpleTableHeaderCell,
 } from 'sentry/views/explore/metrics/metricInfoTabs/metricInfoTabStyles';
 import {
+  SORTABLE_SAMPLE_COLUMNS,
   TraceMetricKnownFieldKey,
   VirtualTableSampleColumnKey,
   type SampleTableColumnKey,
@@ -18,11 +19,6 @@ import {
   useQueryParamsSortBys,
   useSetQueryParamsSortBys,
 } from 'sentry/views/explore/queryParams/context';
-
-const SORTABLE_COLUMNS = new Set<SampleTableColumnKey>([
-  TraceMetricKnownFieldKey.METRIC_VALUE,
-  TraceMetricKnownFieldKey.TIMESTAMP,
-]);
 
 interface MetricsSamplesTableHeaderProps {
   columns: SampleTableColumnKey[];
@@ -76,7 +72,7 @@ function FieldHeaderCellWrapper({
   const columnType = getMetricTableColumnType(field);
   const label = getFieldLabel(field);
   const hasPadding = field !== VirtualTableSampleColumnKey.EXPAND_ROW;
-  const canSort = SORTABLE_COLUMNS.has(field);
+  const canSort = SORTABLE_SAMPLE_COLUMNS.has(field);
 
   function handleSortClick() {
     const kind = sort === 'desc' ? 'asc' : 'desc';

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
@@ -19,9 +19,9 @@ import {
   useSetQueryParamsSortBys,
 } from 'sentry/views/explore/queryParams/context';
 
-const NON_SORTABLE_COLUMNS = new Set<SampleTableColumnKey>([
-  VirtualTableSampleColumnKey.EXPAND_ROW,
-  VirtualTableSampleColumnKey.PROJECT_BADGE,
+const SORTABLE_COLUMNS = new Set<SampleTableColumnKey>([
+  TraceMetricKnownFieldKey.METRIC_VALUE,
+  TraceMetricKnownFieldKey.TIMESTAMP,
 ]);
 
 interface MetricsSamplesTableHeaderProps {
@@ -76,7 +76,7 @@ function FieldHeaderCellWrapper({
   const columnType = getMetricTableColumnType(field);
   const label = getFieldLabel(field);
   const hasPadding = field !== VirtualTableSampleColumnKey.EXPAND_ROW;
-  const canSort = !NON_SORTABLE_COLUMNS.has(field);
+  const canSort = SORTABLE_COLUMNS.has(field);
 
   function handleSortClick() {
     const kind = sort === 'desc' ? 'asc' : 'desc';

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
@@ -3,6 +3,7 @@ import type {ReactNode} from 'react';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {t} from 'sentry/locale';
+import type {Sort} from 'sentry/utils/discover/fields';
 import {
   StyledSimpleTableHeader,
   StyledSimpleTableHeaderCell,
@@ -13,7 +14,15 @@ import {
   type SampleTableColumnKey,
 } from 'sentry/views/explore/metrics/types';
 import {getMetricTableColumnType} from 'sentry/views/explore/metrics/utils';
-import {useQueryParamsSortBys} from 'sentry/views/explore/queryParams/context';
+import {
+  useQueryParamsSortBys,
+  useSetQueryParamsSortBys,
+} from 'sentry/views/explore/queryParams/context';
+
+const NON_SORTABLE_COLUMNS = new Set<SampleTableColumnKey>([
+  VirtualTableSampleColumnKey.EXPAND_ROW,
+  VirtualTableSampleColumnKey.PROJECT_BADGE,
+]);
 
 interface MetricsSamplesTableHeaderProps {
   columns: SampleTableColumnKey[];
@@ -25,6 +34,7 @@ export function MetricsSamplesTableHeader({
   embedded,
 }: MetricsSamplesTableHeaderProps) {
   const sorts = useQueryParamsSortBys();
+  const setSorts = useSetQueryParamsSortBys();
 
   return (
     <StyledSimpleTableHeader>
@@ -37,6 +47,7 @@ export function MetricsSamplesTableHeader({
             field={field}
             index={i}
             sort={sorts.find(s => s.field === field)?.kind}
+            setSorts={setSorts}
             embedded={embedded}
           >
             {label}
@@ -52,23 +63,32 @@ function FieldHeaderCellWrapper({
   children,
   index,
   sort,
+  setSorts,
   embedded = false,
 }: {
   children: ReactNode;
   field: SampleTableColumnKey;
   index: number;
+  setSorts: (sorts: Sort[]) => void;
   embedded?: boolean;
   sort?: 'asc' | 'desc';
 }) {
   const columnType = getMetricTableColumnType(field);
   const label = getFieldLabel(field);
   const hasPadding = field !== VirtualTableSampleColumnKey.EXPAND_ROW;
+  const canSort = !NON_SORTABLE_COLUMNS.has(field);
+
+  function handleSortClick() {
+    const kind = sort === 'desc' ? 'asc' : 'desc';
+    setSorts([{field, kind}]);
+  }
 
   if (columnType === 'metric_value') {
     return (
       <StyledSimpleTableHeaderCell
         key={index}
         sort={sort}
+        handleSortClick={canSort ? handleSortClick : undefined}
         style={{
           justifyContent: 'flex-end',
           paddingRight: 'calc(12px + 15px)', // 12px is the padding of the cell, 15px is the width of the scrollbar.
@@ -86,6 +106,7 @@ function FieldHeaderCellWrapper({
     <StyledSimpleTableHeaderCell
       key={index}
       sort={sort}
+      handleSortClick={canSort ? handleSortClick : undefined}
       noPadding={!hasPadding}
       embedded={embedded}
     >

--- a/static/app/views/explore/metrics/metricQuery.spec.tsx
+++ b/static/app/views/explore/metrics/metricQuery.spec.tsx
@@ -22,7 +22,6 @@ describe('decodeMetricsQueryParams', () => {
 
     const result = decodeMetricsQueryParams(json);
 
-    expect(result).not.toBeNull();
     expect(result?.queryParams.aggregateFields).toEqual([
       new VisualizeFunction('p50(value,test_metric,distribution,-)'),
       new VisualizeFunction('p75(value,test_metric,distribution,-)'),
@@ -75,7 +74,6 @@ describe('decodeMetricsQueryParams', () => {
 
     const result = decodeMetricsQueryParams(json);
 
-    expect(result).not.toBeNull();
     expect(result?.queryParams.aggregateFields).toEqual([
       new VisualizeFunction('p50(value,test_metric,distribution,-)'),
       new VisualizeFunction('p75(value,test_metric,distribution,-)'),
@@ -107,7 +105,6 @@ describe('decodeMetricsQueryParams', () => {
     const encoded = encodeMetricQueryParams(original);
     const decoded = decodeMetricsQueryParams(encoded);
 
-    expect(decoded).not.toBeNull();
     expect(decoded?.metric).toEqual(original.metric);
     expect(decoded?.queryParams.aggregateFields).toEqual(
       original.queryParams.aggregateFields
@@ -136,7 +133,6 @@ describe('decodeMetricsQueryParams', () => {
     const encoded = encodeMetricQueryParams(original);
     const decoded = decodeMetricsQueryParams(encoded);
 
-    expect(decoded).not.toBeNull();
     expect(decoded?.queryParams.sortBys).toEqual([{field: 'value', kind: 'asc'}]);
   });
 
@@ -151,7 +147,6 @@ describe('decodeMetricsQueryParams', () => {
 
     const result = decodeMetricsQueryParams(json);
 
-    expect(result).not.toBeNull();
     expect(result?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
   });
 
@@ -167,7 +162,6 @@ describe('decodeMetricsQueryParams', () => {
 
     const result = decodeMetricsQueryParams(json);
 
-    expect(result).not.toBeNull();
     expect(result?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
   });
 
@@ -183,7 +177,6 @@ describe('decodeMetricsQueryParams', () => {
 
     const result = decodeMetricsQueryParams(json);
 
-    expect(result).not.toBeNull();
     expect(result?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
   });
 });

--- a/static/app/views/explore/metrics/metricQuery.spec.tsx
+++ b/static/app/views/explore/metrics/metricQuery.spec.tsx
@@ -155,6 +155,22 @@ describe('decodeMetricsQueryParams', () => {
     expect(result?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
   });
 
+  it('falls back to default sortBys when field is not sortable', () => {
+    const json = JSON.stringify({
+      metric: {name: 'test_metric', type: 'counter'},
+      query: '',
+      aggregateFields: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+      aggregateSortBys: [],
+      sortBys: [{field: 'arbitrary_field', kind: 'desc'}],
+      mode: 'samples',
+    });
+
+    const result = decodeMetricsQueryParams(json);
+
+    expect(result).not.toBeNull();
+    expect(result?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
+  });
+
   it('falls back to default sortBys when format is invalid', () => {
     const json = JSON.stringify({
       metric: {name: 'test_metric', type: 'counter'},

--- a/static/app/views/explore/metrics/metricQuery.spec.tsx
+++ b/static/app/views/explore/metrics/metricQuery.spec.tsx
@@ -112,5 +112,62 @@ describe('decodeMetricsQueryParams', () => {
     expect(decoded?.queryParams.aggregateFields).toEqual(
       original.queryParams.aggregateFields
     );
+    expect(decoded?.queryParams.sortBys).toEqual(original.queryParams.sortBys);
+  });
+
+  it('round-trips custom sortBys through encode/decode', () => {
+    const original = {
+      metric: {name: 'test_metric', type: 'counter'},
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.SAMPLES,
+        query: '',
+        cursor: '',
+        fields: ['id', 'timestamp'],
+        sortBys: [{field: 'value', kind: 'asc' as const}],
+        aggregateCursor: '',
+        aggregateFields: [new VisualizeFunction('sum(value,test_metric,counter,-)')],
+        aggregateSortBys: [
+          {field: 'sum(value,test_metric,counter,-)', kind: 'desc' as const},
+        ],
+      }),
+    };
+
+    const encoded = encodeMetricQueryParams(original);
+    const decoded = decodeMetricsQueryParams(encoded);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded?.queryParams.sortBys).toEqual([{field: 'value', kind: 'asc'}]);
+  });
+
+  it('falls back to default sortBys when missing from JSON', () => {
+    const json = JSON.stringify({
+      metric: {name: 'test_metric', type: 'counter'},
+      query: '',
+      aggregateFields: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+      aggregateSortBys: [],
+      mode: 'samples',
+    });
+
+    const result = decodeMetricsQueryParams(json);
+
+    expect(result).not.toBeNull();
+    expect(result?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
+  });
+
+  it('falls back to default sortBys when format is invalid', () => {
+    const json = JSON.stringify({
+      metric: {name: 'test_metric', type: 'counter'},
+      query: '',
+      aggregateFields: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+      aggregateSortBys: [],
+      sortBys: [{field: 'value', kind: 'invalid'}],
+      mode: 'samples',
+    });
+
+    const result = decodeMetricsQueryParams(json);
+
+    expect(result).not.toBeNull();
+    expect(result?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
   });
 });

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -3,6 +3,7 @@ import type {Location} from 'history';
 import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {SORTABLE_SAMPLE_COLUMNS} from 'sentry/views/explore/metrics/types';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {validateAggregateSort} from 'sentry/views/explore/queryParams/aggregateSortBy';
 import {isGroupBy, type GroupBy} from 'sentry/views/explore/queryParams/groupBy';
@@ -234,6 +235,7 @@ function parseSortBys(value: unknown, fields: string[]): Sort[] {
       typeof v === 'object' &&
       'field' in v &&
       typeof v.field === 'string' &&
+      SORTABLE_SAMPLE_COLUMNS.has(v.field) &&
       'kind' in v &&
       (v.kind === 'asc' || v.kind === 'desc')
   );

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -67,6 +67,8 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
   const groupBys = parseGroupBys(json.aggregateFields);
   const aggregateFields = [...visualizes, ...groupBys];
   const aggregateSortBys = parseAggregateSortBys(json.aggregateSortBys, aggregateFields);
+  const fields = defaultFields();
+  const sortBys = parseSortBys(json.sortBys, fields);
 
   return {
     metric,
@@ -76,8 +78,8 @@ export function decodeMetricsQueryParams(value: string): BaseMetricQuery | null 
       query,
 
       cursor: '',
-      fields: defaultFields(),
-      sortBys: defaultSortBys(defaultFields()),
+      fields,
+      sortBys,
 
       aggregateCursor: '',
       aggregateFields,
@@ -99,6 +101,7 @@ export function encodeMetricQueryParams(metricQuery: BaseMetricQuery): string {
       return field;
     }),
     aggregateSortBys: metricQuery.queryParams.aggregateSortBys,
+    sortBys: metricQuery.queryParams.sortBys,
     mode: metricQuery.queryParams.mode,
   });
 }
@@ -218,4 +221,26 @@ function parseAggregateSortBys(
   }
 
   return value;
+}
+
+function parseSortBys(value: unknown, fields: string[]): Sort[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    return defaultSortBys(fields);
+  }
+
+  const isValid = value.every(
+    (v: unknown) =>
+      v !== null &&
+      typeof v === 'object' &&
+      'field' in v &&
+      typeof v.field === 'string' &&
+      'kind' in v &&
+      (v.kind === 'asc' || v.kind === 'desc')
+  );
+
+  if (!isValid) {
+    return defaultSortBys(fields);
+  }
+
+  return value as Sort[];
 }

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -62,6 +62,7 @@ export function MetricsQueryParamsProvider({
         query: getUpdatedValue(writableQueryParams.query, defaultQuery),
         aggregateFields: writableQueryParams.aggregateFields,
         aggregateSortBys: writableQueryParams.aggregateSortBys,
+        sortBys: writableQueryParams.sortBys,
         mode: writableQueryParams.mode,
       });
 

--- a/static/app/views/explore/metrics/types.tsx
+++ b/static/app/views/explore/metrics/types.tsx
@@ -106,3 +106,8 @@ export enum VirtualTableSampleColumnKey {
 }
 
 export type SampleTableColumnKey = TraceMetricFieldKey | VirtualTableSampleColumnKey;
+
+export const SORTABLE_SAMPLE_COLUMNS = new Set<SampleTableColumnKey>([
+  TraceMetricKnownFieldKey.METRIC_VALUE,
+  TraceMetricKnownFieldKey.TIMESTAMP,
+]);

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -103,7 +103,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
     ]);
   });
 
-  it('falls back to defaults when aggregateOrderby is missing (backwards compat)', () => {
+  it('falls back to legacy orderby when aggregateOrderby is missing (backwards compat)', () => {
     const url = getMetricsUrlFromSavedQueryUrl({
       organization,
       savedQuery: new SavedQuery({
@@ -122,7 +122,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
             mode: Mode.SAMPLES,
             query: '',
             fields: ['id', 'timestamp'],
-            orderby: '-timestamp',
+            orderby: '-sum(value,test_metric,counter,-)',
             aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
             metric: {name: 'test_metric', type: 'counter'},
           },

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -37,7 +37,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
     return decodeMetricsQueryParams(metricParam!);
   }
 
-  it('decodes orderby into sortBys', () => {
+  it('decodes orderby into sortBys for new-format queries', () => {
     const url = getMetricsUrlFromSavedQueryUrl({
       organization,
       savedQuery: new SavedQuery({
@@ -57,6 +57,7 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
             query: '',
             fields: ['id', 'timestamp'],
             orderby: '-value',
+            aggregateOrderby: '-sum(value,test_metric,counter,-)',
             aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
             metric: {name: 'test_metric', type: 'counter'},
           },
@@ -132,6 +133,78 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
 
     const decoded = decodeMetricFromUrl(url);
     expect(decoded?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
+    expect(decoded?.queryParams.aggregateSortBys).toEqual([
+      {field: 'sum(value,test_metric,counter,-)', kind: 'desc'},
+    ]);
+  });
+
+  it('does not reuse legacy aggregate timestamp orderby as sample sort', () => {
+    const url = getMetricsUrlFromSavedQueryUrl({
+      organization,
+      savedQuery: new SavedQuery({
+        id: 1,
+        interval: '5m',
+        name: 'test query',
+        projects: [],
+        dataset: 'metrics',
+        dateAdded: '2025-01-01T00:00:00.000000Z',
+        dateUpdated: '2025-01-01T00:00:00.000000Z',
+        lastVisited: '2025-01-01T00:00:00.000000Z',
+        starred: false,
+        position: null,
+        query: [
+          {
+            mode: Mode.SAMPLES,
+            query: '',
+            fields: ['id', 'timestamp'],
+            orderby: 'timestamp',
+            aggregateField: [
+              {yAxes: ['sum(value,test_metric,counter,-)']},
+              {groupBy: 'timestamp'},
+            ],
+            metric: {name: 'test_metric', type: 'counter'},
+          },
+        ],
+      }),
+    });
+
+    const decoded = decodeMetricFromUrl(url);
+    expect(decoded?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
+    expect(decoded?.queryParams.aggregateSortBys).toEqual([
+      {field: 'timestamp', kind: 'asc'},
+    ]);
+  });
+
+  it('treats empty aggregateOrderby as new-format and preserves sample sort', () => {
+    const url = getMetricsUrlFromSavedQueryUrl({
+      organization,
+      savedQuery: new SavedQuery({
+        id: 1,
+        interval: '5m',
+        name: 'test query',
+        projects: [],
+        dataset: 'metrics',
+        dateAdded: '2025-01-01T00:00:00.000000Z',
+        dateUpdated: '2025-01-01T00:00:00.000000Z',
+        lastVisited: '2025-01-01T00:00:00.000000Z',
+        starred: false,
+        position: null,
+        query: [
+          {
+            mode: Mode.SAMPLES,
+            query: '',
+            fields: ['id', 'timestamp'],
+            orderby: '-value',
+            aggregateOrderby: '',
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            metric: {name: 'test_metric', type: 'counter'},
+          },
+        ],
+      }),
+    });
+
+    const decoded = decodeMetricFromUrl(url);
+    expect(decoded?.queryParams.sortBys).toEqual([{field: 'value', kind: 'desc'}]);
     expect(decoded?.queryParams.aggregateSortBys).toEqual([
       {field: 'sum(value,test_metric,counter,-)', kind: 'desc'},
     ]);

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -1,4 +1,13 @@
-import {mapMetricUnitToFieldType} from 'sentry/views/explore/metrics/utils';
+import qs from 'query-string';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {decodeMetricsQueryParams} from 'sentry/views/explore/metrics/metricQuery';
+import {
+  getMetricsUrlFromSavedQueryUrl,
+  mapMetricUnitToFieldType,
+} from 'sentry/views/explore/metrics/utils';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
 
 describe('mapMetricUnitToFieldType', () => {
   it.each([
@@ -16,5 +25,146 @@ describe('mapMetricUnitToFieldType', () => {
     ['custom_unit', {fieldType: 'number', unit: undefined}],
   ])('maps %s to the correct field type', (unit, expected) => {
     expect(mapMetricUnitToFieldType(unit)).toEqual(expected);
+  });
+});
+
+describe('getMetricsUrlFromSavedQueryUrl', () => {
+  const organization = OrganizationFixture();
+
+  function decodeMetricFromUrl(url: string) {
+    const query = qs.parseUrl(url).query;
+    const metricParam = Array.isArray(query.metric) ? query.metric[0] : query.metric;
+    return decodeMetricsQueryParams(metricParam!);
+  }
+
+  it('decodes orderby into sortBys', () => {
+    const url = getMetricsUrlFromSavedQueryUrl({
+      organization,
+      savedQuery: new SavedQuery({
+        id: 1,
+        interval: '5m',
+        name: 'test query',
+        projects: [],
+        dataset: 'metrics',
+        dateAdded: '2025-01-01T00:00:00.000000Z',
+        dateUpdated: '2025-01-01T00:00:00.000000Z',
+        lastVisited: '2025-01-01T00:00:00.000000Z',
+        starred: false,
+        position: null,
+        query: [
+          {
+            mode: Mode.SAMPLES,
+            query: '',
+            fields: ['id', 'timestamp'],
+            orderby: '-value',
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            metric: {name: 'test_metric', type: 'counter'},
+          },
+        ],
+      }),
+    });
+
+    const decoded = decodeMetricFromUrl(url);
+    expect(decoded?.queryParams.sortBys).toEqual([{field: 'value', kind: 'desc'}]);
+  });
+
+  it('decodes aggregateOrderby into aggregateSortBys', () => {
+    const url = getMetricsUrlFromSavedQueryUrl({
+      organization,
+      savedQuery: new SavedQuery({
+        id: 1,
+        interval: '5m',
+        name: 'test query',
+        projects: [],
+        dataset: 'metrics',
+        dateAdded: '2025-01-01T00:00:00.000000Z',
+        dateUpdated: '2025-01-01T00:00:00.000000Z',
+        lastVisited: '2025-01-01T00:00:00.000000Z',
+        starred: false,
+        position: null,
+        query: [
+          {
+            mode: Mode.SAMPLES,
+            query: '',
+            fields: ['id', 'timestamp'],
+            orderby: '-timestamp',
+            aggregateOrderby: '-sum(value,test_metric,counter,-)',
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            metric: {name: 'test_metric', type: 'counter'},
+          },
+        ],
+      }),
+    });
+
+    const decoded = decodeMetricFromUrl(url);
+    expect(decoded?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
+    expect(decoded?.queryParams.aggregateSortBys).toEqual([
+      {field: 'sum(value,test_metric,counter,-)', kind: 'desc'},
+    ]);
+  });
+
+  it('falls back to defaults when aggregateOrderby is missing (backwards compat)', () => {
+    const url = getMetricsUrlFromSavedQueryUrl({
+      organization,
+      savedQuery: new SavedQuery({
+        id: 1,
+        interval: '5m',
+        name: 'test query',
+        projects: [],
+        dataset: 'metrics',
+        dateAdded: '2025-01-01T00:00:00.000000Z',
+        dateUpdated: '2025-01-01T00:00:00.000000Z',
+        lastVisited: '2025-01-01T00:00:00.000000Z',
+        starred: false,
+        position: null,
+        query: [
+          {
+            mode: Mode.SAMPLES,
+            query: '',
+            fields: ['id', 'timestamp'],
+            orderby: '-timestamp',
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            metric: {name: 'test_metric', type: 'counter'},
+          },
+        ],
+      }),
+    });
+
+    const decoded = decodeMetricFromUrl(url);
+    expect(decoded?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
+    expect(decoded?.queryParams.aggregateSortBys).toEqual([
+      {field: 'sum(value,test_metric,counter,-)', kind: 'desc'},
+    ]);
+  });
+
+  it('falls back to defaults when orderby is missing', () => {
+    const url = getMetricsUrlFromSavedQueryUrl({
+      organization,
+      savedQuery: new SavedQuery({
+        id: 1,
+        interval: '5m',
+        name: 'test query',
+        projects: [],
+        dataset: 'metrics',
+        dateAdded: '2025-01-01T00:00:00.000000Z',
+        dateUpdated: '2025-01-01T00:00:00.000000Z',
+        lastVisited: '2025-01-01T00:00:00.000000Z',
+        starred: false,
+        position: null,
+        query: [
+          {
+            mode: Mode.SAMPLES,
+            query: '',
+            fields: ['id', 'timestamp'],
+            orderby: '',
+            aggregateField: [{yAxes: ['sum(value,test_metric,counter,-)']}],
+            metric: {name: 'test_metric', type: 'counter'},
+          },
+        ],
+      }),
+    });
+
+    const decoded = decodeMetricFromUrl(url);
+    expect(decoded?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
   });
 });

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -145,7 +145,10 @@ export function getMetricsUrlFromSavedQueryUrl({
         mode: queryItem.mode,
         query: queryItem.query,
         aggregateFields,
-        aggregateSortBys: decodeSorts(queryItem.orderby) || [],
+        aggregateSortBys: queryItem.aggregateOrderby
+          ? decodeSorts(queryItem.aggregateOrderby)
+          : undefined,
+        sortBys: queryItem.orderby ? decodeSorts(queryItem.orderby) : undefined,
       }),
     };
   });

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -138,6 +138,13 @@ export function getMetricsUrlFromSavedQueryUrl({
 
     const aggregateFields = [...visualizes, ...groupBys];
 
+    let aggregateSortBys = undefined;
+    if (queryItem.aggregateOrderby) {
+      aggregateSortBys = decodeSorts(queryItem.aggregateOrderby);
+    } else if (queryItem.orderby) {
+      aggregateSortBys = decodeSorts(queryItem.orderby);
+    }
+
     return {
       ...defaultQuery,
       metric: queryItem.metric ?? defaultQuery.metric,
@@ -145,9 +152,7 @@ export function getMetricsUrlFromSavedQueryUrl({
         mode: queryItem.mode,
         query: queryItem.query,
         aggregateFields,
-        aggregateSortBys: queryItem.aggregateOrderby
-          ? decodeSorts(queryItem.aggregateOrderby)
-          : undefined,
+        aggregateSortBys,
         sortBys: queryItem.orderby ? decodeSorts(queryItem.orderby) : undefined,
       }),
     };

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -3,6 +3,7 @@ import qs from 'query-string';
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import type {EventsMetaType, MetaType} from 'sentry/utils/discover/eventView';
 import {
   DurationUnit,
@@ -138,12 +139,20 @@ export function getMetricsUrlFromSavedQueryUrl({
 
     const aggregateFields = [...visualizes, ...groupBys];
 
+    const hasAggregateOrderby = defined(queryItem.aggregateOrderby);
     let aggregateSortBys = undefined;
-    if (queryItem.aggregateOrderby) {
-      aggregateSortBys = decodeSorts(queryItem.aggregateOrderby);
+    if (hasAggregateOrderby) {
+      aggregateSortBys = queryItem.aggregateOrderby
+        ? decodeSorts(queryItem.aggregateOrderby)
+        : undefined;
     } else if (queryItem.orderby) {
       aggregateSortBys = decodeSorts(queryItem.orderby);
     }
+
+    const sortBys =
+      hasAggregateOrderby && queryItem.orderby
+        ? decodeSorts(queryItem.orderby)
+        : undefined;
 
     return {
       ...defaultQuery,
@@ -153,7 +162,7 @@ export function getMetricsUrlFromSavedQueryUrl({
         query: queryItem.query,
         aggregateFields,
         aggregateSortBys,
-        sortBys: queryItem.orderby ? decodeSorts(queryItem.orderby) : undefined,
+        sortBys,
       }),
     };
   });


### PR DESCRIPTION
Add click-to-sort on the metrics samples table for `value` and `timestamp` columns, bringing it to parity with the aggregates table which already had sorting.

Sort state is persisted in the URL so it survives page reloads. The samples sort and aggregate sort are stored independently — a new `aggregateOrderby` field is added to saved queries so each table retains its own sort order when saving and restoring queries.

Sort field names are validated against a shared `SORTABLE_SAMPLE_COLUMNS` set on decode, falling back to the default (`timestamp desc`) for unknown or malformed values. Backwards compatibility is maintained: saved queries without `aggregateOrderby` fall back to deriving the aggregate sort from `orderby` as before.

Closes LOGS-633

Example:

https://github.com/user-attachments/assets/4eec9754-36fe-498f-b495-29b605dc9f59