### PR TITLE
feat(chartcuterie): Add total period line chart type

### DIFF
--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -85,6 +85,65 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
   });
 
   discoverCharts.push({
+    key: ChartType.SLACK_DISCOVER_TOTAL_PERIOD_LINE,
+    getOption: (
+      data:
+        | {seriesName: string; stats: EventsStats}
+        | {stats: Record<string, EventsStats>; seriesName?: string}
+    ) => {
+      if (Array.isArray(data.stats.data)) {
+        const color = theme.chart.getColorPalette(data.stats.data.length - 1);
+        const lineSeries = LineSeries({
+          name: data.seriesName,
+          data: data.stats.data.map(([timestamp, countsForTimestamp]) => [
+            timestamp * 1000,
+            countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
+          ]),
+          lineStyle: {color: color?.[0], opacity: 1},
+          itemStyle: {color: color?.[0]},
+        });
+
+        return {
+          ...slackChartDefaults,
+          useUTC: true,
+          color,
+          series: [lineSeries],
+        };
+      }
+
+      const stats = Object.keys(data.stats).map(key =>
+        Object.assign({}, {key}, (data.stats as any)[key])
+      );
+      const color = theme.chart.getColorPalette(stats.length - 1);
+
+      const series = stats
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+        .map((s, i) =>
+          LineSeries({
+            name: s.key,
+            data: s.data.map(
+              ([timestamp, countsForTimestamp]: [number, Array<{count: number}>]) => [
+                timestamp * 1000,
+                countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
+              ]
+            ),
+            lineStyle: {color: color?.[i], opacity: 1},
+            itemStyle: {color: color?.[i]},
+          })
+        );
+
+      return {
+        ...slackChartDefaults,
+        xAxis: discoverxAxis,
+        useUTC: true,
+        color,
+        series,
+      };
+    },
+    ...slackChartSize,
+  });
+
+  discoverCharts.push({
     key: ChartType.SLACK_DISCOVER_TOTAL_DAILY,
     getOption: (
       data:

--- a/static/app/chartcuterie/types.tsx
+++ b/static/app/chartcuterie/types.tsx
@@ -9,6 +9,7 @@ import type {EChartsOption} from 'echarts';
  */
 export enum ChartType {
   SLACK_DISCOVER_TOTAL_PERIOD = 'slack:discover.totalPeriod',
+  SLACK_DISCOVER_TOTAL_PERIOD_LINE = 'slack:discover.totalPeriodLine',
   SLACK_DISCOVER_TOTAL_DAILY = 'slack:discover.totalDaily',
   SLACK_DISCOVER_TOP5_PERIOD = 'slack:discover.top5Period',
   SLACK_DISCOVER_TOP5_PERIOD_LINE = 'slack:discover.top5PeriodLine',


### PR DESCRIPTION
Add `SLACK_DISCOVER_TOTAL_PERIOD_LINE` chartcuterie render descriptor for
single-series line charts. This complements the existing area (`TOTAL_PERIOD`)
and bar (`TOTAL_DAILY`) chart types so Explore Slack unfurls can render the
correct chart style based on the user's selection.

This needs to be deployed before the backend PR that uses it for Explore
unfurls (which reads `chartType` from the URL and selects the appropriate
chart style).

Refs DAIN-1481