### PR TITLE
feat(slack): Respect chart type in Explore Slack unfurls

### DIFF
--- a/src/sentry/charts/types.py
+++ b/src/sentry/charts/types.py
@@ -13,6 +13,7 @@ class ChartType(Enum):
     """
 
     SLACK_DISCOVER_TOTAL_PERIOD = "slack:discover.totalPeriod"
+    SLACK_DISCOVER_TOTAL_PERIOD_LINE = "slack:discover.totalPeriodLine"
     SLACK_DISCOVER_TOTAL_DAILY = "slack:discover.totalDaily"
     SLACK_DISCOVER_TOP5_PERIOD = "slack:discover.top5Period"
     SLACK_DISCOVER_TOP5_PERIOD_LINE = "slack:discover.top5PeriodLine"

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -52,6 +52,10 @@ LINE_PLOT_FIELDS = {
 
 TOP_N = 5
 
+# Frontend ChartType enum values from static/app/views/insights/common/components/chart.tsx
+FRONTEND_CHART_TYPE_BAR = 0
+FRONTEND_CHART_TYPE_LINE = 1
+
 
 def _serialize_single_series(series: dict[str, Any]) -> dict[str, Any]:
     """Convert a single TimeSeries into events-stats format."""
@@ -157,17 +161,27 @@ def _unfurl_explore(
             params.setlist("yAxis", y_axes)
 
         group_bys = params.getlist("groupBy")
+        chart_type_str = params.get("chartType")
+        is_bar = chart_type_str == str(FRONTEND_CHART_TYPE_BAR)
+        is_line = chart_type_str == str(FRONTEND_CHART_TYPE_LINE)
 
         # Only one yAxis is charted; multiple charts per unfurl not yet supported.
         if group_bys:
             aggregate_fn = y_axes[-1].split("(")[0]
-            if aggregate_fn in LINE_PLOT_FIELDS:
+            if is_bar:
+                style = ChartType.SLACK_DISCOVER_TOP5_DAILY
+            elif is_line or aggregate_fn in LINE_PLOT_FIELDS:
                 style = ChartType.SLACK_DISCOVER_TOP5_PERIOD_LINE
             else:
                 style = ChartType.SLACK_DISCOVER_TOP5_PERIOD
             params.setlist("topEvents", [str(TOP_N)])
         else:
-            style = ChartType.SLACK_DISCOVER_TOTAL_PERIOD
+            if is_bar:
+                style = ChartType.SLACK_DISCOVER_TOTAL_DAILY
+            elif is_line:
+                style = ChartType.SLACK_DISCOVER_TOTAL_PERIOD_LINE
+            else:
+                style = ChartType.SLACK_DISCOVER_TOTAL_PERIOD
 
         if not params.get("statsPeriod") and not params.get("start"):
             params["statsPeriod"] = DEFAULT_PERIOD
@@ -230,11 +244,14 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     aggregate_fields = raw_query.getlist("aggregateField")
     y_axes: list[str] = []
     group_bys: list[str] = []
+    chart_type: int | None = None
     for field_json in aggregate_fields:
         try:
             parsed = json.loads(field_json)
             if "yAxes" in parsed and isinstance(parsed["yAxes"], list):
                 y_axes.extend(parsed["yAxes"])
+                if "chartType" in parsed and isinstance(parsed["chartType"], int):
+                    chart_type = parsed["chartType"]
             if "groupBy" in parsed and parsed["groupBy"]:
                 group_bys.append(parsed["groupBy"])
         except (json.JSONDecodeError, TypeError):
@@ -246,6 +263,9 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     # Build query params
     query = QueryDict(mutable=True)
     query.setlist("yAxis", y_axes)
+
+    if chart_type is not None:
+        query["chartType"] = str(chart_type)
 
     if group_bys:
         query.setlist("groupBy", group_bys)

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1527,6 +1527,88 @@ class UnfurlTest(TestCase):
         "sentry.integrations.slack.unfurl.explore.client.get",
     )
     @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_bar_chart(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(
+            data=self._build_mock_timeseries_response(y_axis="count(span.duration)")
+        )
+        # chartType 0 = BAR
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%2C%22chartType%22%3A0%7D&project={self.project.id}&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert len(unfurls) == 1
+        assert len(mock_generate_chart.mock_calls) == 1
+        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_DISCOVER_TOTAL_DAILY
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_bar_chart_with_groupby(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        # chartType 0 = BAR with groupBy
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22span.op%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%2C%22chartType%22%3A0%7D&project={self.project.id}&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert len(unfurls) == 1
+        assert len(mock_generate_chart.mock_calls) == 1
+        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_DISCOVER_TOP5_DAILY
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_line_chart(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(
+            data=self._build_mock_timeseries_response(y_axis="count(span.duration)")
+        )
+        # chartType 1 = LINE
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%2C%22chartType%22%3A1%7D&project={self.project.id}&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert len(unfurls) == 1
+        assert len(mock_generate_chart.mock_calls) == 1
+        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_DISCOVER_TOTAL_PERIOD_LINE
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
     def test_unfurl_explore_with_groupby(
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:


### PR DESCRIPTION
Parse `chartType` from the `aggregateField` JSON in Explore URLs and
select the matching chartcuterie style for Slack unfurls. Previously all
Explore unfurls rendered as area charts regardless of the user's selection.

| chartType | Without groupBy | With groupBy |
|-----------|----------------|--------------|
| 0 (BAR)   | `TOTAL_DAILY`  | `TOP5_DAILY` |
| 1 (LINE)  | `TOTAL_PERIOD_LINE` | `TOP5_PERIOD_LINE` |
| 2 (AREA)  | `TOTAL_PERIOD` | `TOP5_PERIOD` |

Depends on #112580 for the `TOTAL_PERIOD_LINE` render descriptor.

Refs DAIN-1481