### PR TITLE
feat(chartcuterie): Add explore line chart render descriptor

### DIFF
--- a/static/app/chartcuterie/config.tsx
+++ b/static/app/chartcuterie/config.tsx
@@ -12,6 +12,7 @@
 import {lightTheme} from 'sentry/utils/theme/theme';
 
 import {makeDiscoverCharts} from './discover';
+import {makeExploreCharts} from './explore';
 import {makeMetricAlertCharts} from './metricAlert';
 import {makeMetricDetectorCharts} from './metricDetector';
 import {makePerformanceCharts} from './performance';
@@ -42,6 +43,7 @@ const register = (renderDescriptor: RenderDescriptor<ChartType>) =>
   renderConfig.set(renderDescriptor.key, renderDescriptor);
 
 makeDiscoverCharts(lightTheme).forEach(register);
+makeExploreCharts(lightTheme).forEach(register);
 makeMetricAlertCharts(lightTheme).forEach(register);
 makeMetricDetectorCharts(lightTheme).forEach(register);
 makePerformanceCharts(lightTheme).forEach(register);

--- a/static/app/chartcuterie/explore.tsx
+++ b/static/app/chartcuterie/explore.tsx
@@ -1,0 +1,96 @@
+import type {Theme} from '@emotion/react';
+
+import {XAxis} from 'sentry/components/charts/components/xAxis';
+import {LineSeries} from 'sentry/components/charts/series/lineSeries';
+import {timeSeriesItemToEChartsDataPoint} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {formatTimeSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName';
+
+import {DEFAULT_FONT_FAMILY, makeSlackChartDefaults, slackChartSize} from './slack';
+import type {RenderDescriptor} from './types';
+import {ChartType} from './types';
+
+type ExploreChartData = {
+  seriesName: string;
+  timeSeries: TimeSeries[];
+};
+
+export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartType>> => {
+  const exploreXAxis = XAxis({
+    theme,
+    splitNumber: 3,
+    isGroupedByDate: true,
+    axisLabel: {fontSize: 11, fontFamily: DEFAULT_FONT_FAMILY},
+  });
+
+  const slackChartDefaults = makeSlackChartDefaults(theme);
+  const exploreCharts: Array<RenderDescriptor<ChartType>> = [];
+
+  exploreCharts.push({
+    key: ChartType.SLACK_EXPLORE_LINE,
+    getOption: (data: ExploreChartData) => {
+      const matching = data.timeSeries.filter(ts => ts.yAxis === data.seriesName);
+
+      if (matching.length === 0) {
+        return {
+          ...slackChartDefaults,
+          xAxis: exploreXAxis,
+          useUTC: true,
+          series: [],
+        };
+      }
+
+      const hasGroups = matching.some(ts => ts.groupBy && ts.groupBy.length > 0);
+
+      if (!hasGroups) {
+        const ts = matching[0]!;
+        const color = theme.chart.getColorPalette(0);
+        const lineSeries = LineSeries({
+          name: data.seriesName,
+          data: ts.values.map(timeSeriesItemToEChartsDataPoint),
+          lineStyle: {color: color?.[0], opacity: 1},
+          itemStyle: {color: color?.[0]},
+        });
+
+        return {
+          ...slackChartDefaults,
+          xAxis: exploreXAxis,
+          useUTC: true,
+          color,
+          series: [lineSeries],
+        };
+      }
+
+      const sorted = matching
+        .slice()
+        .sort((a, b) => (a.meta?.order ?? 0) - (b.meta?.order ?? 0));
+      const hasOther = sorted.some(ts => ts.meta?.isOther);
+      const color = theme.chart
+        .getColorPalette(sorted.length - 1 - (hasOther ? 1 : 0))
+        ?.slice() as string[];
+      if (hasOther) {
+        color.push(theme.tokens.content.secondary);
+      }
+
+      const series = sorted.map((ts, i) => {
+        return LineSeries({
+          name: formatTimeSeriesName(ts),
+          data: ts.values.map(timeSeriesItemToEChartsDataPoint),
+          lineStyle: {color: color?.[i], opacity: 1},
+          itemStyle: {color: color?.[i]},
+        });
+      });
+
+      return {
+        ...slackChartDefaults,
+        xAxis: exploreXAxis,
+        useUTC: true,
+        color,
+        series,
+      };
+    },
+    ...slackChartSize,
+  });
+
+  return exploreCharts;
+};

--- a/static/app/chartcuterie/explore.tsx
+++ b/static/app/chartcuterie/explore.tsx
@@ -4,7 +4,7 @@ import {XAxis} from 'sentry/components/charts/components/xAxis';
 import {LineSeries} from 'sentry/components/charts/series/lineSeries';
 import {timeSeriesItemToEChartsDataPoint} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
-import {formatTimeSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName';
+import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 
 import {DEFAULT_FONT_FAMILY, makeSlackChartDefaults, slackChartSize} from './slack';
 import type {RenderDescriptor} from './types';
@@ -74,7 +74,7 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
 
       const series = sorted.map((ts, i) => {
         return LineSeries({
-          name: formatTimeSeriesName(ts),
+          name: formatTimeSeriesLabel(ts),
           data: ts.values.map(timeSeriesItemToEChartsDataPoint),
           lineStyle: {color: color?.[i], opacity: 1},
           itemStyle: {color: color?.[i]},

--- a/static/app/chartcuterie/explore.tsx
+++ b/static/app/chartcuterie/explore.tsx
@@ -11,7 +11,6 @@ import type {RenderDescriptor} from './types';
 import {ChartType} from './types';
 
 type ExploreChartData = {
-  seriesName: string;
   timeSeries: TimeSeries[];
 };
 
@@ -29,9 +28,9 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
   exploreCharts.push({
     key: ChartType.SLACK_EXPLORE_LINE,
     getOption: (data: ExploreChartData) => {
-      const matching = data.timeSeries.filter(ts => ts.yAxis === data.seriesName);
+      const {timeSeries} = data;
 
-      if (matching.length === 0) {
+      if (timeSeries.length === 0) {
         return {
           ...slackChartDefaults,
           xAxis: exploreXAxis,
@@ -40,13 +39,13 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
         };
       }
 
-      const hasGroups = matching.some(ts => ts.groupBy && ts.groupBy.length > 0);
+      const hasGroups = timeSeries.some(ts => ts.groupBy && ts.groupBy.length > 0);
 
       if (!hasGroups) {
-        const ts = matching[0]!;
+        const ts = timeSeries[0]!;
         const color = theme.chart.getColorPalette(0);
         const lineSeries = LineSeries({
-          name: data.seriesName,
+          name: ts.yAxis,
           data: ts.values.map(timeSeriesItemToEChartsDataPoint),
           lineStyle: {color: color?.[0], opacity: 1},
           itemStyle: {color: color?.[0]},
@@ -61,7 +60,7 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
         };
       }
 
-      const sorted = matching
+      const sorted = timeSeries
         .slice()
         .sort((a, b) => (a.meta?.order ?? 0) - (b.meta?.order ?? 0));
       const hasOther = sorted.some(ts => ts.meta?.isOther);

--- a/static/app/chartcuterie/types.tsx
+++ b/static/app/chartcuterie/types.tsx
@@ -20,6 +20,7 @@ export enum ChartType {
   SLACK_METRIC_DETECTOR_SESSIONS = 'slack:metricDetector.sessions',
   SLACK_PERFORMANCE_ENDPOINT_REGRESSION = 'slack:performance.endpointRegression',
   SLACK_PERFORMANCE_FUNCTION_REGRESSION = 'slack:performance.functionRegression',
+  SLACK_EXPLORE_LINE = 'slack:explore.line',
 }
 
 /**


### PR DESCRIPTION
Add `SLACK_EXPLORE_LINE` chartcuterie render descriptor that accepts
timeseries data directly from the `/events-timeseries/` endpoint. This
avoids the unnecessary conversion to EventsStats format (ms → seconds → ms)
currently done in the explore unfurl code.

Uses shared utilities:
- `TimeSeries` type from `dashboards/widgets/common/types`
- `timeSeriesItemToEChartsDataPoint` for data point conversion
- `formatTimeSeriesName` for series legend labels

Supports both single series and grouped (top N) data.

This needs to be deployed before the backend PR that switches the explore
unfurl to pass timeseries data directly.

Refs DAIN-1483