### PR TITLE
feat(slack): Pass timeseries data directly to chartcuterie for Explore unfurls

### DIFF
--- a/src/sentry/charts/types.py
+++ b/src/sentry/charts/types.py
@@ -24,6 +24,7 @@ class ChartType(Enum):
     SLACK_PERFORMANCE_FUNCTION_REGRESSION = "slack:performance.functionRegression"
     SLACK_METRIC_DETECTOR_EVENTS = "slack:metricDetector.events"
     SLACK_METRIC_DETECTOR_SESSIONS = "slack:metricDetector.sessions"
+    SLACK_EXPLORE_LINE = "slack:explore.line"
 
 
 class ChartSize(TypedDict):

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -34,76 +34,7 @@ _logger = logging.getLogger(__name__)
 
 DEFAULT_PERIOD = "14d"
 DEFAULT_Y_AXIS = "count(span.duration)"
-
-# All `multiPlotType: line` fields in /static/app/utils/discover/fields.tsx
-LINE_PLOT_FIELDS = {
-    "count_unique",
-    "min",
-    "max",
-    "p50",
-    "p75",
-    "p90",
-    "p95",
-    "p99",
-    "p100",
-    "percentile",
-    "avg",
-}
-
 TOP_N = 5
-
-
-def _serialize_single_series(series: dict[str, Any]) -> dict[str, Any]:
-    """Convert a single TimeSeries into events-stats format."""
-    values = series.get("values", [])
-    data = []
-    for row in values:
-        # events-timeseries uses milliseconds, events-stats uses seconds
-        timestamp = int(row["timestamp"] / 1000)
-        data.append((timestamp, [{"count": row.get("value", 0)}]))
-
-    start = int(values[0]["timestamp"] / 1000) if values else 0
-    end = int(values[-1]["timestamp"] / 1000) if values else 0
-
-    return {
-        "data": data,
-        "start": start,
-        "end": end,
-        "isMetricsData": False,
-    }
-
-
-def timeseries_to_chart_data(
-    resp_data: dict[str, Any], y_axis: str, has_groups: bool = False
-) -> dict[str, Any]:
-    """
-    Converts an events-timeseries StatsResponse into the events-stats format
-    that Chartcuterie expects.
-
-    For single series:
-        {"data": [(timestamp_sec, [{"count": N}]), ...], "start": sec, "end": sec}
-
-    For top events (grouped):
-        {"group_label": {"data": [...], "order": N, ...}, ...}
-    """
-    time_series = resp_data.get("timeSeries", [])
-    matching = [ts for ts in time_series if ts.get("yAxis") == y_axis]
-
-    if not matching:
-        return {"data": [], "start": 0, "end": 0, "isMetricsData": False}
-
-    if has_groups:
-        # Top events: return dict keyed by group label
-        result = {}
-        for i, ts in enumerate(matching):
-            group_by = ts.get("groupBy", [])
-            label = ",".join(str(g.get("value", "")) for g in group_by) if group_by else str(i)
-            series_data = _serialize_single_series(ts)
-            series_data["order"] = ts.get("meta", {}).get("order", i)
-            result[label] = series_data
-        return result
-
-    return _serialize_single_series(matching[0])
 
 
 def unfurl_explore(
@@ -158,16 +89,9 @@ def _unfurl_explore(
 
         group_bys = params.getlist("groupBy")
 
-        # Only one yAxis is charted; multiple charts per unfurl not yet supported.
+        style = ChartType.SLACK_EXPLORE_LINE
         if group_bys:
-            aggregate_fn = y_axes[-1].split("(")[0]
-            if aggregate_fn in LINE_PLOT_FIELDS:
-                style = ChartType.SLACK_DISCOVER_TOP5_PERIOD_LINE
-            else:
-                style = ChartType.SLACK_DISCOVER_TOP5_PERIOD
             params.setlist("topEvents", [str(TOP_N)])
-        else:
-            style = ChartType.SLACK_DISCOVER_TOTAL_PERIOD
 
         if not params.get("statsPeriod") and not params.get("start"):
             params["statsPeriod"] = DEFAULT_PERIOD
@@ -186,11 +110,11 @@ def _unfurl_explore(
             _logger.warning("Failed to load events-timeseries for explore unfurl")
             continue
 
-        # QueryDict.items() sends only the last value per key to the API,
-        # so we must match that by charting the last yAxis
         y_axis = y_axes[-1]
-        stats = timeseries_to_chart_data(resp.data, y_axis, has_groups=bool(group_bys))
-        chart_data = {"seriesName": y_axis, "stats": stats}
+        chart_data = {
+            "seriesName": y_axis,
+            "timeSeries": resp.data.get("timeSeries", []),
+        }
 
         try:
             url = charts.generate_chart(style, chart_data)

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -110,9 +110,7 @@ def _unfurl_explore(
             _logger.warning("Failed to load events-timeseries for explore unfurl")
             continue
 
-        y_axis = y_axes[-1]
         chart_data = {
-            "seriesName": y_axis,
             "timeSeries": resp.data.get("timeSeries", []),
         }
 

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1497,9 +1497,10 @@ class UnfurlTest(TestCase):
             == SlackDiscoverMessageBuilder(title="Explore Traces", chart_url="chart-url").build()
         )
         assert len(mock_generate_chart.mock_calls) == 1
-        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_DISCOVER_TOTAL_PERIOD
+        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_EXPLORE_LINE
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["seriesName"] == "avg(span.duration)"
+        assert "timeSeries" in chart_data
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",
@@ -1546,8 +1547,7 @@ class UnfurlTest(TestCase):
 
         assert len(unfurls) == 1
         assert len(mock_generate_chart.mock_calls) == 1
-        # avg is a line plot field, so top5line display mode
-        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_DISCOVER_TOP5_PERIOD_LINE
+        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_EXPLORE_LINE
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",
@@ -1651,19 +1651,19 @@ class UnfurlTest(TestCase):
         chart_type = mock_generate_chart.call_args[0][0]
         chart_data = mock_generate_chart.call_args[0][1]
 
-        assert chart_type == ChartType.SLACK_DISCOVER_TOTAL_PERIOD
+        assert chart_type == ChartType.SLACK_EXPLORE_LINE
         assert chart_data["seriesName"] == "avg(span.duration)"
-        # Stats should be in events-stats format: {data: [(ts, [{count: N}]), ...], start, end}
-        stats = chart_data["stats"]
-        assert "data" in stats
-        assert "start" in stats
-        assert "end" in stats
-        assert len(stats["data"]) == INTERVALS_PER_DAY
-        # Each data point is (timestamp, [{count: value}])
-        first_point = stats["data"][0]
-        assert isinstance(first_point[0], int)
-        assert isinstance(first_point[1], list)
-        assert "count" in first_point[1][0]
+        # timeSeries should be passed through directly from the API response
+        time_series = chart_data["timeSeries"]
+        assert isinstance(time_series, list)
+        assert len(time_series) > 0
+        first_series = time_series[0]
+        assert first_series["yAxis"] == "avg(span.duration)"
+        assert len(first_series["values"]) == INTERVALS_PER_DAY
+        # Each data point has timestamp (ms) and value directly
+        first_point = first_series["values"][0]
+        assert "timestamp" in first_point
+        assert "value" in first_point
 
         # Step 5: Verify the unfurl result
         assert len(unfurls) == 1

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1499,7 +1499,6 @@ class UnfurlTest(TestCase):
         assert len(mock_generate_chart.mock_calls) == 1
         assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_EXPLORE_LINE
         chart_data = mock_generate_chart.call_args[0][1]
-        assert chart_data["seriesName"] == "avg(span.duration)"
         assert "timeSeries" in chart_data
 
     @patch(
@@ -1575,7 +1574,7 @@ class UnfurlTest(TestCase):
         assert len(unfurls) == 1
         assert len(mock_generate_chart.mock_calls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
-        assert chart_data["seriesName"] == "count(span.duration)"
+        assert "timeSeries" in chart_data
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",
@@ -1603,7 +1602,7 @@ class UnfurlTest(TestCase):
         # Should still unfurl with default yAxis
         assert len(unfurls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
-        assert chart_data["seriesName"] == "count(span.duration)"
+        assert "timeSeries" in chart_data
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",
@@ -1652,7 +1651,6 @@ class UnfurlTest(TestCase):
         chart_data = mock_generate_chart.call_args[0][1]
 
         assert chart_type == ChartType.SLACK_EXPLORE_LINE
-        assert chart_data["seriesName"] == "avg(span.duration)"
         # timeSeries should be passed through directly from the API response
         time_series = chart_data["timeSeries"]
         assert isinstance(time_series, list)


### PR DESCRIPTION
Switch Explore Slack unfurls from converting timeseries data to EventsStats
format to passing the `/events-timeseries/` response directly to the new
`SLACK_EXPLORE_LINE` chartcuterie render descriptor.

Previously the flow was:
```
API response (ms timestamps, {value})
  → timeseries_to_chart_data() converts to EventsStats (seconds, [{count}])
  → discover.tsx getOption() multiplies timestamps × 1000 back to ms
```

Now:
```
API response (ms timestamps, {value})
  → explore.tsx getOption() reads timestamps and values directly
```

This removes `_serialize_single_series()`, `timeseries_to_chart_data()`, and
the `LINE_PLOT_FIELDS` constant which are no longer needed.

Depends on #112584 for the `SLACK_EXPLORE_LINE` render descriptor.

Refs DAIN-1483