### PR TITLE
fix(dashboards): Apply filters correctly navigating between dashboards

### DIFF
--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -227,4 +227,58 @@ describe('OrgDashboards', () => {
 
     expect(router.location.query).toEqual({});
   });
+
+  it('applies saved filters after navigating back from a dashboard without filters', async () => {
+    const mockDashboardWithFilters = {
+      dateCreated: '2021-08-10T21:20:46.798237Z',
+      id: '1',
+      title: 'Test Dashboard',
+      widgets: [],
+      projects: [1],
+      filters: {},
+    };
+    const mockDashboardWithoutFilters = {
+      dateCreated: '2021-08-10T21:20:46.798237Z',
+      id: '2',
+      title: 'Test Dashboard',
+      widgets: [],
+      projects: [],
+      filters: {},
+    };
+    const dashboardWithoutFiltersPath = `/organizations/${organization.slug}/dashboard/2/`;
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/1/',
+      method: 'GET',
+      body: mockDashboardWithFilters,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/2/',
+      method: 'GET',
+      body: mockDashboardWithoutFilters,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [mockDashboardWithFilters, mockDashboardWithoutFilters],
+    });
+
+    const {router} = render(<OrgDashboards>{renderChildFn}</OrgDashboards>, {
+      initialRouterConfig,
+      organization,
+    });
+
+    await waitFor(() => expect(router.location.query.project).toBe('1'));
+
+    router.navigate(dashboardWithoutFiltersPath);
+
+    // Since we navigate to a URL without parameters, the empty query assertion
+    // trivially succeeds - wait on loading to be complete so that we know the
+    // dashboard filter hook has run, and _then_ make sure the query is (still)
+    // empty.
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+    await waitFor(() => expect(router.location.query).toEqual({}));
+
+    router.navigate(dashboardPath);
+
+    await waitFor(() => expect(router.location.query.project).toBe('1'));
+  });
 });

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -133,13 +133,21 @@ export function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) 
 
     // current filters based on location
     const locationFilters = getCurrentPageFilters(location);
+
+    if (!selectedDashboard) {
+      // Still loading.
+      return;
+    }
+
     if (
-      !selectedDashboard ||
       !hasSavedPageFilters(selectedDashboard) ||
       // Apply redirect once for each dashboard id
       dashboardRedirectRef.current === selectedDashboard.id ||
       hasSavedPageFilters(locationFilters)
     ) {
+      // Mark the redirect check complete even though we didn't redirect (so
+      // that switching to another dashboard reruns the check.)
+      dashboardRedirectRef.current = selectedDashboard.id;
       return;
     }
 


### PR DESCRIPTION
Repro steps:
1. Star a dashboard that has no saved filters, and a dashboard that does have saved filters (e.g. a single project)
2. Navigate to the dashboard with filters -> correctly loads with filters
3. Using the starred dashboards sidebar, navigate to the dashboard without filters -> correctly loads without filters
4. Using the starrred dashboards sidebar, navigate back to the dashboard with filters -> **bug**: does **not** apply saved filters

Dashboards without filters (step 3) failed to update `dashboardRedirectRef`, so the redirect state for the dashboard from step 2 was still considered valid in step 4 - causing the filter application check to short-circuit before applying the saved filters.

Update the ref whenever a filter application decision is made so that navigating between dashboards always triggers a new filter application check.