### PR TITLE
fix(explore): Fix attribute breakdowns tooltip caching stale params and losing values

### DIFF
--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -83,7 +83,7 @@ export function useAttributeBreakdownsTooltip({
 }: Params): TooltipOption {
   const [frozenPosition, setFrozenPosition] = useState<[number, number] | null>(null);
   const tooltipContentRef = useRef<string | null>(null);
-  const tooltipValueRef = useRef<string>('');
+  const tooltipValueRef = useRef<string | null>(null);
 
   // This effect runs on load and when the frozen position changes.
   // - If frozen position is set, trigger a re-render of the tooltip with frozen position to show the
@@ -111,7 +111,7 @@ export function useAttributeBreakdownsTooltip({
       if (frozenPosition) {
         setFrozenPosition(null);
         tooltipContentRef.current = null;
-        tooltipValueRef.current = '';
+        tooltipValueRef.current = null;
       } else {
         // If the tooltip is not frozen, set the frozen position to the current pixel point.
         setFrozenPosition(pixelPoint);

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -130,7 +130,7 @@ export function useAttributeBreakdownsTooltip({
       }
 
       tooltipContentRef.current = null;
-      tooltipValueRef.current = '';
+      tooltipValueRef.current = null;
       setFrozenPosition(null);
     };
 

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -129,7 +129,7 @@ export function useAttributeBreakdownsTooltip({
         el = el.parentElement;
       }
 
-      tooltipParamsRef.current = null;
+      tooltipContentRef.current = null;
       tooltipValueRef.current = '';
       setFrozenPosition(null);
     };

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -83,6 +83,7 @@ export function useAttributeBreakdownsTooltip({
 }: Params): TooltipOption {
   const [frozenPosition, setFrozenPosition] = useState<[number, number] | null>(null);
   const tooltipParamsRef = useRef<TooltipComponentFormatterCallbackParams | null>(null);
+  const tooltipValueRef = useRef<string>('');
 
   // This effect runs on load and when the frozen position changes.
   // - If frozen position is set, trigger a re-render of the tooltip with frozen position to show the
@@ -110,6 +111,7 @@ export function useAttributeBreakdownsTooltip({
       if (frozenPosition) {
         setFrozenPosition(null);
         tooltipParamsRef.current = null;
+        tooltipValueRef.current = '';
       } else {
         // If the tooltip is not frozen, set the frozen position to the current pixel point.
         setFrozenPosition(pixelPoint);
@@ -128,6 +130,7 @@ export function useAttributeBreakdownsTooltip({
       }
 
       tooltipParamsRef.current = null;
+      tooltipValueRef.current = '';
       setFrozenPosition(null);
     };
 
@@ -206,6 +209,8 @@ export function useAttributeBreakdownsTooltip({
         // including the tooltip actions placeholder.
         if (!frozenPosition) {
           tooltipParamsRef.current = params;
+          tooltipValueRef.current =
+            (Array.isArray(params) ? params[0]?.name : params.name) ?? '';
 
           const actionsPlaceholder = actions?.htmlRenderer
             ? `
@@ -233,8 +238,9 @@ export function useAttributeBreakdownsTooltip({
         // If the tooltip is frozen, use the cached tooltip params and
         // return the formatted content, including the tooltip actions.
         const p = tooltipParamsRef.current;
-        const value = (Array.isArray(p) ? p[0]?.name : p.name) ?? '';
-        return wrapContent(formatter(p) + (actions?.htmlRenderer(value) ?? ''));
+        return wrapContent(
+          formatter(p) + (actions?.htmlRenderer(tooltipValueRef.current) ?? '')
+        );
       },
       position(
         point: [number, number],
@@ -256,7 +262,7 @@ export function useAttributeBreakdownsTooltip({
         return [x, y];
       },
     }),
-    [frozenPosition, chartWidth, formatter, actions, tooltipParamsRef]
+    [frozenPosition, chartWidth, formatter, actions, tooltipParamsRef, tooltipValueRef]
   );
 
   return tooltipConfig;

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -82,7 +82,7 @@ export function useAttributeBreakdownsTooltip({
   actions,
 }: Params): TooltipOption {
   const [frozenPosition, setFrozenPosition] = useState<[number, number] | null>(null);
-  const tooltipParamsRef = useRef<TooltipComponentFormatterCallbackParams | null>(null);
+  const tooltipContentRef = useRef<string | null>(null);
   const tooltipValueRef = useRef<string>('');
 
   // This effect runs on load and when the frozen position changes.
@@ -110,7 +110,7 @@ export function useAttributeBreakdownsTooltip({
       // If the tooltip is frozen, toggle the frozen state and reset the tooltip params.
       if (frozenPosition) {
         setFrozenPosition(null);
-        tooltipParamsRef.current = null;
+        tooltipContentRef.current = null;
         tooltipValueRef.current = '';
       } else {
         // If the tooltip is not frozen, set the frozen position to the current pixel point.
@@ -208,9 +208,12 @@ export function useAttributeBreakdownsTooltip({
         // If the tooltip is NOT frozen, set the tooltip params and return the formatted content,
         // including the tooltip actions placeholder.
         if (!frozenPosition) {
-          tooltipParamsRef.current = params;
-          tooltipValueRef.current =
+          const formattedContent = formatter(params);
+          const tooltipValue =
             (Array.isArray(params) ? params[0]?.name : params.name) ?? '';
+
+          tooltipContentRef.current = formattedContent;
+          tooltipValueRef.current = tooltipValue;
 
           const actionsPlaceholder = actions?.htmlRenderer
             ? `
@@ -228,18 +231,23 @@ export function useAttributeBreakdownsTooltip({
         `.trim()
             : '';
 
-          return wrapContent(formatter(params) + actionsPlaceholder);
+          return wrapContent(formattedContent + actionsPlaceholder);
         }
 
-        if (!tooltipParamsRef.current) {
+        const frozenTooltipContent = tooltipContentRef.current ?? formatter(params);
+        const frozenTooltipValue =
+          tooltipValueRef.current ??
+          (Array.isArray(params) ? params[0]?.name : params.name) ??
+          '';
+
+        if (!frozenTooltipContent) {
           return wrapContent('\u2014');
         }
 
-        // If the tooltip is frozen, use the cached tooltip params and
-        // return the formatted content, including the tooltip actions.
-        const p = tooltipParamsRef.current;
+        // If the tooltip is frozen, use the cached tooltip content and
+        // append the tooltip actions based on the cached value.
         return wrapContent(
-          formatter(p) + (actions?.htmlRenderer(tooltipValueRef.current) ?? '')
+          frozenTooltipContent + (actions?.htmlRenderer(frozenTooltipValue) ?? '')
         );
       },
       position(
@@ -262,7 +270,7 @@ export function useAttributeBreakdownsTooltip({
         return [x, y];
       },
     }),
-    [frozenPosition, chartWidth, formatter, actions, tooltipParamsRef, tooltipValueRef]
+    [frozenPosition, chartWidth, formatter, actions, tooltipContentRef, tooltipValueRef]
   );
 
   return tooltipConfig;


### PR DESCRIPTION
Cache the rendered tooltip HTML and extracted value at hover time instead of storing raw echarts params and re-deriving them when frozen. This fixes the frozen tooltip showing stale or mismatched data when echarts re-invokes the formatter.

Closes [EXP-869](https://linear.app/getsentry/issue/EXP-869/attr-name-and-percentage-disappear-on-click)

<!-- linear:table-colwidths:200,200 -->
<table>
<thead>
<tr>
<th></th>
<th></th>
</tr>
</thead>
<tbody>
<tr>
<td>Before</td>
<td><img src="https://github.com/user-attachments/assets/6be109c6-5774-433c-9fd8-dbcdcd1fd637 " alt="Screenshot 2026-04-09 at 14 11 51" width="259" data-linear-height="210" /></td>
</tr>
<tr>
<td>After</td>
<td><img src="https://github.com/user-attachments/assets/aec62ecc-fcb9-4df4-b587-59db793e8689 " alt="Screenshot 2026-04-09 at 14 12 09" width="247" data-linear-height="204" /></td>
</tr>
</tbody>
</table>
