### PR TITLE
fix(api): Avoid double query in prompts-activity single-feature path

### DIFF
--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -79,8 +79,7 @@ class PromptsActivityEndpoint(OrganizationEndpoint):
         )
         featuredata = {k.feature: k.data for k in result_qs}
         if len(features) == 1:
-            result = result_qs.first()
-            data = None if result is None else result.data
+            data = featuredata.get(features[0])
             return Response({"data": data, "features": featuredata})
         else:
             return Response({"features": featuredata})


### PR DESCRIPTION
The single-feature GET path on prompts-activity evaluated the queryset twice - once to build the featuredata dict, then again via `.first()`. Just read from the dict we already have.

[example trace](https://sentry.sentry.io/explore/traces/trace/e786f5b9f75148c68eb58a5fb551d3c5/?fov=323.5058053135872%2C154.58315217494965&node=span-9a322e9eb96fce8f&project=1&query=span.description%3A%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fprompts-activity%2F&source=traces&statsPeriod=24h&targetId=8300d0ed2360b6f2&timestamp=1775754718)