### PR TITLE
ref(grouping): remove dead background grouping code

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -65,7 +65,6 @@ from sentry.grouping.ingest.config import is_in_transition, update_or_set_groupi
 from sentry.grouping.ingest.hashing import (
     find_grouphash_with_group,
     get_or_create_grouphashes,
-    maybe_run_background_grouping,
     maybe_run_secondary_grouping,
     run_primary_grouping,
 )
@@ -1357,11 +1356,6 @@ def assign_event_to_group(
             result = "no_match"
 
     # From here on out, we're just doing housekeeping
-
-    # Background grouping is a way for us to get performance metrics for a new
-    # config without having it actually affect on how events are grouped. It runs
-    # either before or after the main grouping logic, depending on the option value.
-    maybe_run_background_grouping(project, job)
 
     record_hash_calculation_metrics(
         project, primary.config, primary.hashes, secondary.config, secondary.hashes, result

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 import sentry_sdk
 
-from sentry import options
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.grouping.component import ContributingComponent, RootGroupingComponent
 from sentry.grouping.context import GroupingContext
@@ -147,15 +146,6 @@ class SecondaryGroupingConfigLoader(ProjectGroupingConfigLoader):
 
     option_name = "sentry:secondary_grouping_config"
     cache_prefix = "secondary-grouping-enhancements:"
-
-
-class BackgroundGroupingConfigLoader(GroupingConfigLoader):
-    """Does not affect grouping, runs in addition to measure performance impact"""
-
-    cache_prefix = "background-grouping-enhancements:"
-
-    def _get_config_id(self, _project: Project) -> str:
-        return options.get("store.background-grouping-config-id")
 
 
 @sentry_sdk.tracing.trace

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -12,7 +12,6 @@ from sentry import options
 from sentry.exceptions import HashDiscarded
 from sentry.grouping.api import (
     NULL_GROUPING_CONFIG,
-    BackgroundGroupingConfigLoader,
     GroupingConfig,
     SecondaryGroupingConfigLoader,
     apply_server_side_fingerprinting,
@@ -32,7 +31,6 @@ from sentry.grouping.ingest.grouphash_metadata import (
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
-from sentry.options.rollout import in_random_rollout
 from sentry.utils import metrics
 from sentry.utils.metrics import MutableTags
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
@@ -78,35 +76,6 @@ def _calculate_event_grouping(
             hashes, variants = event.get_hashes_and_variants(loaded_grouping_config)
 
         return (hashes, variants)
-
-
-def maybe_run_background_grouping(project: Project, job: Job) -> None:
-    """
-    Optionally run a fraction of events with an experimental grouping config.
-
-    This does not affect actual grouping, but can be helpful to measure the new config's performance
-    impact.
-    """
-    try:
-        if in_random_rollout("store.background-grouping-sample-rate"):
-            config = BackgroundGroupingConfigLoader().get_config_dict(project)
-            if config["id"]:
-                copied_event = copy.deepcopy(job["event"])
-                _calculate_background_grouping(project, copied_event, config)
-    except Exception as err:
-        sentry_sdk.capture_exception(err)
-
-
-def _calculate_background_grouping(
-    project: Project, event: Event, config: GroupingConfig
-) -> list[str]:
-    metric_tags: MutableTags = {
-        "grouping_config": config["id"],
-        "platform": event.platform or "unknown",
-        "sdk": normalized_sdk_tag_from_event(event.data),
-    }
-    with metrics.timer("event_manager.background_grouping", tags=metric_tags):
-        return _calculate_event_grouping(project, event, config)[0]
 
 
 def maybe_run_secondary_grouping(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1460,16 +1460,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Run an experimental grouping config in background for performance analysis
-register("store.background-grouping-config-id", default=None, flags=FLAG_AUTOMATOR_MODIFIABLE)
-
-# Fraction of events that will pass through background grouping
-register(
-    "store.background-grouping-sample-rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Minimum number of files in an archive. Archives with fewer files are extracted and have their
 # contents stored as separate release files.
 register("processing.release-archive-min-files", default=10, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/sentry/grouping/test_hashing.py
+++ b/tests/sentry/grouping/test_hashing.py
@@ -18,44 +18,10 @@ from sentry.models.project import Project
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.grouping import NO_MSG_PARAM_CONFIG
 
 pytestmark = [requires_snuba]
-
-
-class BackgroundGroupingTest(TestCase):
-    @override_options({"store.background-grouping-config-id": NO_MSG_PARAM_CONFIG})
-    @patch("sentry.grouping.ingest.hashing._calculate_background_grouping")
-    def test_background_grouping_sample_rate(
-        self, mock_calc_background_grouping: MagicMock
-    ) -> None:
-        with override_options({"store.background-grouping-sample-rate": 0.0}):
-            save_new_event({"message": "Dogs are great! 1231"}, self.project)
-            assert mock_calc_background_grouping.call_count == 0
-
-        with override_options({"store.background-grouping-sample-rate": 1.0}):
-            save_new_event({"message": "Dogs are great! 1121"}, self.project)
-            assert mock_calc_background_grouping.call_count == 1
-
-    @override_options({"store.background-grouping-config-id": NO_MSG_PARAM_CONFIG})
-    @override_options({"store.background-grouping-sample-rate": 1.0})
-    @patch("sentry_sdk.capture_exception")
-    def test_handles_errors_with_background_grouping(
-        self, mock_capture_exception: MagicMock
-    ) -> None:
-        background_grouping_error = Exception("nope")
-
-        with patch(
-            "sentry.grouping.ingest.hashing._calculate_background_grouping",
-            side_effect=background_grouping_error,
-        ):
-            event = save_new_event({"message": "Dogs are great! 1231"}, self.project)
-
-            mock_capture_exception.assert_called_with(background_grouping_error)
-            # This proves the background grouping crash didn't crash the overall grouping process
-            assert event.group
 
 
 class SecondaryGroupingTest(TestCase):


### PR DESCRIPTION
The `store.background-grouping-sample-rate` option has been 0 for a long time, making all background grouping code dead. Remove the functions, config loader, option registrations, call site in `event_manager`, and associated tests.