### PR TITLE
fix(dashboards): Send current dashboard state on Seer follow-up messages

### DIFF
--- a/static/app/views/dashboards/useSeerDashboardSession.spec.tsx
+++ b/static/app/views/dashboards/useSeerDashboardSession.spec.tsx
@@ -121,6 +121,68 @@ describe('useSeerDashboardSession', () => {
     );
   });
 
+  it('sends current dashboard state as on_page_context with follow-up messages', async () => {
+    const dashboard = {
+      title: 'My Dashboard',
+      widgets: [
+        {
+          title: 'Count',
+          displayType: DisplayType.LINE,
+          interval: '1h',
+          queries: [
+            {
+              name: '',
+              conditions: '',
+              fields: ['count()'],
+              columns: [],
+              aggregates: ['count()'],
+              orderby: '',
+            },
+          ],
+        },
+      ],
+    };
+
+    MockApiClient.addMockResponse({
+      url: apiUrl,
+      body: COMPLETED_SESSION,
+    });
+
+    const postMock = MockApiClient.addMockResponse({
+      url: apiUrl,
+      method: 'POST',
+      body: {},
+    });
+
+    const onDashboardUpdate = jest.fn();
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useSeerDashboardSession({
+          seerRunId: SEER_RUN_ID,
+          dashboard,
+          onDashboardUpdate,
+        }),
+      {organization}
+    );
+
+    await act(async () => {
+      await result.current.sendFollowUpMessage('Add an error rate widget');
+    });
+
+    expect(postMock).toHaveBeenCalledWith(
+      apiUrl,
+      expect.objectContaining({
+        method: 'POST',
+        data: expect.objectContaining({
+          query: 'Add an error rate widget',
+          on_page_context:
+            'The user is editing an existing dashboard. The current dashboard state is:\n\n{"title":"My Dashboard","widgets":[{"title":"Count","displayType":"line","interval":"1h","queries":[{"name":"","conditions":"","fields":["count()"],"columns":[],"aggregates":["count()"],"orderby":""}]}]}\n\nThis session must ONLY modify the dashboard artifact. Produce a COMPLETE dashboard artifact that incorporates the requested changes while preserving widgets the user did not ask to change.',
+        }),
+      })
+    );
+  });
+
   it('starts a new session via the generate endpoint when dashboard is provided without seerRunId', async () => {
     const dashboard = {
       title: 'My Dashboard',

--- a/static/app/views/dashboards/useSeerDashboardSession.tsx
+++ b/static/app/views/dashboards/useSeerDashboardSession.tsx
@@ -15,6 +15,12 @@ import type {DashboardDetails, Widget} from './types';
 const POLL_INTERVAL_MS = 500;
 const POST_COMPLETE_POLL_MS = 5000;
 
+function buildEditOnPageContext(
+  dashboard: Pick<DashboardDetails, 'title' | 'widgets'>
+): string {
+  return `The user is editing an existing dashboard. The current dashboard state is:\n\n${JSON.stringify({title: dashboard.title, widgets: dashboard.widgets})}\n\nThis session must ONLY modify the dashboard artifact. Produce a COMPLETE dashboard artifact that incorporates the requested changes while preserving widgets the user did not ask to change.`;
+}
+
 async function startDashboardEditSession(
   orgSlug: string,
   message: string,
@@ -159,7 +165,10 @@ export function useSeerDashboardSession({
           await fetchMutation({
             url,
             method: 'POST',
-            data: {query: message},
+            data: {
+              query: message,
+              ...(dashboard ? {on_page_context: buildEditOnPageContext(dashboard)} : {}),
+            },
           });
           queryClient.invalidateQueries({queryKey});
         }


### PR DESCRIPTION
## Summary
- Fixes a bug where manual dashboard edits (add/move/edit widgets) made during an edit session get overwritten when Seer responds to a follow-up message
- The root cause is that follow-up messages to the Seer chat endpoint only sent `{query: message}` without including the current dashboard state, so Seer generated a complete dashboard based on stale context
- Now sends the current `modifiedDashboard` as `on_page_context` on follow-up messages, matching how initial session creation already sends `current_dashboard`