### PR TITLE
fix(aci): Fix issue with manual cron monitor selected project

### DIFF
--- a/static/app/views/detectors/components/forms/cron/index.spec.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.spec.tsx
@@ -57,8 +57,7 @@ describe('NewCronDetectorForm', () => {
     renderForm();
 
     // Form sections should be visible
-    expect(await screen.findByText(/Detect/)).toBeInTheDocument();
-    expect(screen.getByText(/Issue Ownership/)).toBeInTheDocument();
+    expect(await screen.findByTestId('form-sections')).toBeVisible();
 
     // Create Monitor button should be present and enabled
     const createButton = screen.getByRole('button', {name: 'Create Monitor'});
@@ -78,8 +77,7 @@ describe('NewCronDetectorForm', () => {
     await screen.findByText('Step 2 of 2');
 
     // Form sections should be hidden
-    expect(screen.queryByText(/Detect/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Issue Ownership/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('form-sections')).not.toBeVisible();
 
     // Create Monitor button should be present but disabled
     const createButton = screen.getByRole('button', {name: 'Create Monitor'});

--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -45,7 +45,11 @@ function CronDetectorForm({detector}: {detector?: CronDetector}) {
   return (
     <Stack gap="2xl" maxWidth={theme.breakpoints.xl}>
       {!detector && <InstrumentationGuide />}
-      <Stack display={showingPlatformGuide ? 'none' : 'flex'} gap="2xl">
+      <Stack
+        data-test-id="form-sections"
+        style={showingPlatformGuide ? {display: 'none'} : undefined}
+        gap="2xl"
+      >
         {dataSource?.queryObj.isUpserting && (
           <Alert variant="warning">
             {t(

--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -43,26 +42,22 @@ function CronDetectorForm({detector}: {detector?: CronDetector}) {
   const theme = useTheme();
   const showingPlatformGuide = useIsShowingPlatformGuide();
 
-  const formSections = (
-    <Fragment>
-      {dataSource?.queryObj.isUpserting && (
-        <Alert variant="warning">
-          {t(
-            'This monitor is managed in code and updates automatically with each check-in. Changes made here may be overwritten!'
-          )}
-        </Alert>
-      )}
-      <PreviewSection />
-      {FORM_SECTIONS.map((FormSection, index) => (
-        <FormSection key={index} step={index + 1} />
-      ))}
-    </Fragment>
-  );
-
   return (
     <Stack gap="2xl" maxWidth={theme.breakpoints.xl}>
       {!detector && <InstrumentationGuide />}
-      {!showingPlatformGuide && formSections}
+      <Stack display={showingPlatformGuide ? 'none' : 'flex'} gap="2xl">
+        {dataSource?.queryObj.isUpserting && (
+          <Alert variant="warning">
+            {t(
+              'This monitor is managed in code and updates automatically with each check-in. Changes made here may be overwritten!'
+            )}
+          </Alert>
+        )}
+        <PreviewSection />
+        {FORM_SECTIONS.map((FormSection, index) => (
+          <FormSection key={index} step={index + 1} />
+        ))}
+      </Stack>
     </Stack>
   );
 }


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/112484 caused a bug when creating cron monitors manually. The selected project will throw because the projectId is reset when the ProjectField gets rendered. 

This is a quirk with the old form system, but all form fields need to be available on first render, otherwise they will reset form state when they come back in. This change makes sure that the form fields are rendered but hidden until you click "manually create monitor"

This does fix a hidden existing bug, which is that the `initialData` passed to the form was not actually being set for cron monitors.