### PR TITLE
Check project access during groupId issue linking

### DIFF
--- a/src/sentry/sentry_apps/services/cell/impl.py
+++ b/src/sentry/sentry_apps/services/cell/impl.py
@@ -89,7 +89,7 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
         Matches: src/sentry/sentry_apps/api/endpoints/installation_external_issue_actions.py @ POST
         """
         try:
-            group = Group.objects.get(
+            group = Group.objects.select_related("project").get(
                 id=group_id,
                 project_id__in=Project.objects.filter(organization_id=organization_id),
             )
@@ -98,6 +98,29 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
                 error=RpcSentryAppError(
                     message="Could not find the corresponding issue for the given groupId",
                     status_code=404,
+                )
+            )
+
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            return RpcPlatformExternalIssueResult(
+                error=RpcSentryAppError(
+                    message="Could not find the corresponding issue for the given groupId",
+                    status_code=404,
+                )
+            )
+
+        access = self._access_for_installation_user(
+            organization=organization,
+            installation=installation,
+            user=user,
+        )
+        if not access.has_project_access(group.project):
+            return RpcPlatformExternalIssueResult(
+                error=RpcSentryAppError(
+                    message="You do not have permission to link this issue.",
+                    status_code=403,
                 )
             )
 
@@ -187,6 +210,21 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
 
         return RpcEmptyResult()
 
+    def _access_for_installation_user(
+        self,
+        *,
+        organization: Organization,
+        installation: RpcSentryAppInstallation,
+        user: RpcUser,
+    ) -> Access:
+        if user.is_sentry_app:
+            return OrganizationGlobalMembership(
+                organization=organization,
+                scopes=installation.sentry_app.scope_list,
+                sso_is_valid=True,
+            )
+        return from_user(user=user, organization=organization)
+
     def _determine_access(
         self,
         *,
@@ -200,13 +238,11 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
             raise SentryAppSentryError(message="Organization not found")
         if not (user := auth_context.user):
             raise SentryAppSentryError(message="User not found")
-        if user.is_sentry_app:
-            return OrganizationGlobalMembership(
-                organization=organization,
-                scopes=installation.sentry_app.scope_list,
-                sso_is_valid=True,
-            )
-        return from_user(user=user, organization=organization)
+        return self._access_for_installation_user(
+            organization=organization,
+            installation=installation,
+            user=user,
+        )
 
     def get_service_hook_projects(
         self,

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
@@ -1,6 +1,7 @@
 import responses
 from django.urls import reverse
 
+from sentry.models.organization import Organization
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
@@ -85,3 +86,42 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
         )
         with assume_test_silo_mode_of(PlatformExternalIssue):
             assert not PlatformExternalIssue.objects.all()
+
+    def test_rejects_group_from_inaccessible_project(self) -> None:
+        with assume_test_silo_mode_of(Organization):
+            self.org.flags.allow_joinleave = False
+            self.org.save()
+
+        user_team = self.create_team(organization=self.org, name="user-team")
+        other_team = self.create_team(organization=self.org, name="other-team")
+        self.create_project(organization=self.org, teams=[user_team], name="user-proj")
+        other_project = self.create_project(
+            organization=self.org, teams=[other_team], name="other-proj"
+        )
+        other_group = self.create_group(project=other_project)
+
+        limited_user = self.create_user()
+        self.create_member(
+            organization=self.org,
+            user=limited_user,
+            role="member",
+            teams=[user_team],
+            teamRole="admin",
+        )
+
+        self.login_as(user=limited_user)
+        response = self.client.post(
+            self.url,
+            data={
+                "groupId": other_group.id,
+                "action": "create",
+                "fields": {"title": "Hello"},
+                "uri": "/create-issues",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.data["detail"] == "You do not have permission to link this issue."
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert not PlatformExternalIssue.objects.filter(group_id=other_group.id).exists()

--- a/tests/sentry/sentry_apps/services/test_cell_service.py
+++ b/tests/sentry/sentry_apps/services/test_cell_service.py
@@ -148,6 +148,92 @@ class TestSentryAppCellService(TestCase):
         assert result.error.webhook_context["error_type"] == "external_issue.linked.bad_response"
         assert result.error.status_code == 500
 
+    def test_create_issue_link_denied_without_project_access(self) -> None:
+        with assume_test_silo_mode_of(Organization):
+            self.org.flags.allow_joinleave = False
+            self.org.save()
+
+        user_team = self.create_team(organization=self.org, name="user-team")
+        other_team = self.create_team(organization=self.org, name="other-team")
+        self.create_project(organization=self.org, teams=[user_team], name="user-proj")
+        other_project = self.create_project(
+            organization=self.org, teams=[other_team], name="other-proj"
+        )
+        other_group = self.create_group(project=other_project)
+
+        limited_user = self.create_user()
+        self.create_member(
+            organization=self.org,
+            user=limited_user,
+            role="member",
+            teams=[user_team],
+            teamRole="admin",
+        )
+
+        result = sentry_app_cell_service.create_issue_link(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            group_id=other_group.id,
+            action="create",
+            fields={"title": "nope"},
+            uri="/link-issue",
+            user=serialize_rpc_user(limited_user),
+        )
+
+        assert result.error is not None
+        assert result.error.status_code == 403
+        assert result.external_issue is None
+
+    @responses.activate
+    def test_create_issue_link_allowed_with_project_access(self) -> None:
+        with assume_test_silo_mode_of(Organization):
+            self.org.flags.allow_joinleave = False
+            self.org.save()
+
+        user_team = self.create_team(organization=self.org, name="allowed-team")
+        accessible_project = self.create_project(organization=self.org, teams=[user_team])
+        accessible_group = self.create_group(project=accessible_project)
+
+        limited_user = self.create_user()
+        self.create_member(
+            organization=self.org,
+            user=limited_user,
+            role="member",
+            teams=[user_team],
+            teamRole="admin",
+        )
+
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issue",
+            json={
+                "project": "Projectname",
+                "webUrl": "https://example.com/project/issue-id",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert (
+                PlatformExternalIssue.objects.filter(group_id=accessible_group.id).exists() is False
+            )
+
+        result = sentry_app_cell_service.create_issue_link(
+            organization_id=self.org.id,
+            installation=self.rpc_installation,
+            group_id=accessible_group.id,
+            action="create",
+            fields={"title": "An Issue"},
+            uri="/link-issue",
+            user=serialize_rpc_user(limited_user),
+        )
+
+        assert result.error is None
+        assert result.external_issue is not None
+        assert result.external_issue.group_id == accessible_group.id
+
     def test_create_external_issue(self) -> None:
         with assume_test_silo_mode_of(PlatformExternalIssue):
             assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists() is False


### PR DESCRIPTION
IDOR allowed linking to other projects in the same org as we lacked a auth check during external issue link creation. Initially spotted in the POST to /external-issue-actions/

There's some other areas to check after this too around this `create_external_issue, delete_external_issue, get_select_options`, but saving for the next PR