### PR TITLE
fix(tests): Fix flaky AI conversations tests exceeding Snuba retention

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -1128,7 +1128,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_tool_errors_counted(self) -> None:
         """Test that toolErrors counts only failed tool spans"""
-        now = before_now(days=22).replace(microsecond=0)
+        now = before_now(days=35).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -637,7 +637,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_first_input_last_output(self) -> None:
         """Test firstInput and lastOutput are correctly populated from ai_client spans"""
-        now = before_now(days=90).replace(microsecond=0)
+        now = before_now(days=11).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -699,7 +699,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_no_ai_client_spans_filtered_out(self) -> None:
         """Test conversations without input/output are filtered out"""
-        now = before_now(days=91).replace(microsecond=0)
+        now = before_now(days=12).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -732,7 +732,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_query_filter(self) -> None:
         """Test that query parameter filters conversations"""
-        now = before_now(days=30).replace(microsecond=0)
+        now = before_now(days=25).replace(microsecond=0)
         conversation_id_1 = uuid4().hex
         conversation_id_2 = uuid4().hex
 
@@ -770,7 +770,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_conversation_with_user_data(self) -> None:
         """Test that user data is extracted from spans and returned in the response"""
-        now = before_now(days=100).replace(microsecond=0)
+        now = before_now(days=13).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -822,7 +822,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_conversation_with_partial_user_data(self) -> None:
         """Test that user is returned even with partial user data"""
-        now = before_now(days=101).replace(microsecond=0)
+        now = before_now(days=14).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -857,7 +857,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_new_format_input_output_messages(self) -> None:
         """Test that new format gen_ai.input.messages and gen_ai.output.messages are parsed correctly"""
-        now = before_now(days=102).replace(microsecond=0)
+        now = before_now(days=16).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -904,7 +904,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_new_format_with_multiple_text_parts(self) -> None:
         """Test that multiple text parts are concatenated correctly"""
-        now = before_now(days=103).replace(microsecond=0)
+        now = before_now(days=17).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -955,7 +955,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_new_format_priority_over_old_format(self) -> None:
         """Test that new format attributes take priority over old format when both exist"""
-        now = before_now(days=104).replace(microsecond=0)
+        now = before_now(days=18).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -1010,7 +1010,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_new_format_parts_structure(self) -> None:
         """Test that new format with parts structure works correctly"""
-        now = before_now(days=105).replace(microsecond=0)
+        now = before_now(days=19).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -1055,7 +1055,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_tool_names_populated(self) -> None:
         """Test that toolNames is populated with distinct tool names from tool spans"""
-        now = before_now(days=106).replace(microsecond=0)
+        now = before_now(days=21).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -1128,7 +1128,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_tool_errors_counted(self) -> None:
         """Test that toolErrors counts only failed tool spans"""
-        now = before_now(days=107).replace(microsecond=0)
+        now = before_now(days=22).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -1212,7 +1212,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_empty_tool_names_when_no_tool_calls(self) -> None:
         """Test that toolNames is empty when there are no tool calls"""
-        now = before_now(days=108).replace(microsecond=0)
+        now = before_now(days=23).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -1257,7 +1257,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         This prevents double counting when both agent spans (invoke_agent) and their
         child ai_client spans have token/cost data.
         """
-        now = before_now(days=109).replace(microsecond=0)
+        now = before_now(days=24).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 


### PR DESCRIPTION
<img width="1035" height="455" alt="Screenshot 2026-04-09 at 12 44 50 PM" src="https://github.com/user-attachments/assets/4bbb8b35-9014-4070-845a-1cd1db587b19" />
https://github.com/getsentry/sentry/actions/runs/24205379487/job/70659792593

This flake has been showing frequently and being covered by retries.

The test stores spans into Snuba, then immediately queries them. Sometimes the query returns nothing: `assert len(response.data) == 1` fails with 0.

`span_to_trace_item()` hardcodes `retention_days=90` for all test spans. But these tests use `before_now(days=107)` and similar, so the span timestamps are already past their own retention period at insertion time.

Original tests, days=10..80: https://github.com/getsentry/sentry/commit/ec760c4d8f4
Following tests added days 90..109:
- https://github.com/getsentry/sentry/commit/a0f021e947f
- https://github.com/getsentry/sentry/commit/5cad1d93b65
- https://github.com/getsentry/sentry/commit/6c679902c92
- https://github.com/getsentry/sentry/commit/2afaa854852

Most likely the reason this flakes is that ClickHouse doesn't reject expired data on insert, and relies on a background process to clean up rows past their TTL. Assuming that the test is able to pass when the query runs before that process is able to clean these rows.

https://clickhouse.com/blog/using-ttl-to-manage-data-lifecycles-in-clickhouse
<img width="819" height="156" alt="Screenshot 2026-04-09 at 1 01 53 PM" src="https://github.com/user-attachments/assets/0c0fe536-7dc3-42a2-b58d-8331359ec149" />

Fixed all 13 tests in this file that had `days` values >= 90 to within the retention window. Also fixed a duplicate `days=30` between two tests.
