### PR TITLE
fix(aci): Change response from 404 to 400 when there's an issue with billing metric alerts

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_project_detector_index.py
@@ -9,7 +9,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -73,7 +72,10 @@ class OrganizationProjectDetectorIndexEndpoint(ProjectEndpoint):
         if detector_type == MetricIssue.slug and not features.has(
             "organizations:incidents", organization, actor=request.user
         ):
-            raise ResourceDoesNotExist
+            return Response(
+                serialize({"detail": "Unable to process request, confirm payment options."}),
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         validator = get_detector_validator(request, project, detector_type)
         if not validator.is_valid():

--- a/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_project_detector_index.py
@@ -155,10 +155,12 @@ class OrganizationProjectDetectorIndexPostTest(OrganizationProjectDetectorIndexB
                 self.organization.slug,
                 self.project.slug,
                 **self.valid_data,
-                status_code=404,
+                status_code=400,
             )
         assert response.data == {
-            "detail": ErrorDetail(string="The requested resource does not exist", code="error")
+            "detail": ErrorDetail(
+                string="Unable to process request, confirm payment options.", code="error"
+            )
         }
 
     def test_project_not_found(self) -> None:


### PR DESCRIPTION
# Description
Currently, we return a 404 when there's a billing issue. This leads to a confusing user experience and there aren't clear next steps.

This PR changes the 404 response to 400; to greater illustrate that it's an issue with the request data / state. The detail information also includes the recommendation to checkout your organization billing settings to give users next steps.