### PR TITLE
feat(aci): Register workflow engine onboarding banner prompt

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -24,6 +24,7 @@ DEFAULT_PROMPTS: dict[str, _PromptConfig] = {
     "seer_autofix_setup_acknowledged": {"required_fields": ["organization_id"]},
     "stacktrace_link": {"required_fields": ["organization_id", "project_id"]},
     "user_snooze_deprecation": {"required_fields": ["organization_id", "project_id"]},
+    "workflow_engine_onboarding_banner": {"required_fields": ["organization_id"]},
 }
 
 


### PR DESCRIPTION
Ref ISWF-2160

Register the `workflow_engine_onboarding_banner` prompt so we can track dismissals for the upcoming banner.