### PR TITLE
feat(issue-details): Add analytics for similar and merged issues drawers

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -121,6 +121,10 @@ export type IssueEventParameters = {
   };
   'issue_details.issue_status_docs_clicked': Record<string, unknown>;
   'issue_details.issue_tags_click': Record<string, unknown>;
+  'issue_details.merged_issues.drawer_opened': {
+    group_id: string;
+    project_id: string;
+  };
   'issue_details.related_trace_issue.trace_issue_clicked': {
     group_id: number;
   };
@@ -136,6 +140,10 @@ export type IssueEventParameters = {
     parent_group_id?: string;
     project_id?: string;
     shouldBeGrouped?: string;
+  };
+  'issue_details.similar_issues.drawer_opened': {
+    group_id: string;
+    project_id: string;
   };
   'issue_details.similar_issues.similarity_embeddings_feedback_recieved': {
     groupId: string;
@@ -323,6 +331,10 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_details.issue_content_selected': 'Issue Details: Issue Content Selected',
   'issue_details.issue_tags_click': 'Issue Details: Issue Tags Clicked',
   'issue.engaged_view': 'Issue: Engaged View',
+  'issue_details.similar_issues.drawer_opened':
+    'Issue Details: Similar Issues Drawer Opened',
+  'issue_details.merged_issues.drawer_opened':
+    'Issue Details: Merged Issues Drawer Opened',
   'issue_details.similar_issues.diff_clicked':
     'Issue Details: Similar Issues: Diff Clicked',
   'issue_details.similar_issues.similarity_embeddings_feedback_recieved':

--- a/static/app/views/issueDetails/streamline/hooks/useMergedIssuesDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useMergedIssuesDrawer.tsx
@@ -4,8 +4,10 @@ import {useDrawer} from 'sentry/components/globalDrawer';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {MergedIssuesDrawer} from 'sentry/views/issueDetails/groupMerged/mergedIssuesDrawer';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 
@@ -20,8 +22,14 @@ export function useMergedIssuesDrawer({
   const {baseUrl} = useGroupDetailsRoute();
   const navigate = useNavigate();
   const location = useLocation();
+  const organization = useOrganization();
 
   const openMergedIssuesDrawer = useCallback(() => {
+    trackAnalytics('issue_details.merged_issues.drawer_opened', {
+      organization,
+      group_id: group.id,
+      project_id: project.id,
+    });
     openDrawer(() => <MergedIssuesDrawer group={group} project={project} />, {
       ariaLabel: t('Merged Issues'),
       shouldCloseOnInteractOutside: () => false,
@@ -39,7 +47,7 @@ export function useMergedIssuesDrawer({
         );
       },
     });
-  }, [openDrawer, group, project, baseUrl, navigate, location.query]);
+  }, [openDrawer, group, project, baseUrl, navigate, location.query, organization]);
 
   return {openMergedIssuesDrawer};
 }

--- a/static/app/views/issueDetails/streamline/hooks/useSimilarIssuesDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useSimilarIssuesDrawer.tsx
@@ -4,8 +4,10 @@ import {useDrawer} from 'sentry/components/globalDrawer';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {SimilarIssuesDrawer} from 'sentry/views/issueDetails/groupSimilarIssues/similarIssuesDrawer';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 
@@ -20,8 +22,14 @@ export function useSimilarIssuesDrawer({
   const {baseUrl} = useGroupDetailsRoute();
   const navigate = useNavigate();
   const location = useLocation();
+  const organization = useOrganization();
 
   const openSimilarIssuesDrawer = useCallback(() => {
+    trackAnalytics('issue_details.similar_issues.drawer_opened', {
+      organization,
+      group_id: group.id,
+      project_id: project.id,
+    });
     openDrawer(() => <SimilarIssuesDrawer group={group} project={project} />, {
       ariaLabel: t('Similar Issues'),
       shouldCloseOnInteractOutside: () => false,
@@ -39,7 +47,7 @@ export function useSimilarIssuesDrawer({
         );
       },
     });
-  }, [openDrawer, group, project, baseUrl, navigate, location.query]);
+  }, [openDrawer, group, project, baseUrl, navigate, location.query, organization]);
 
   return {openSimilarIssuesDrawer};
 }


### PR DESCRIPTION
We currently have analytics for actual merging / unmerging issues, but we want to find out how often this drawer gets opened at all.