### PR TITLE
fix(autofix): Show Add Integration CTA when no coding agents installed

### DIFF
--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -213,6 +213,25 @@ describe('SeerDrawerNextStep', () => {
       expect(autofix.startStep).toHaveBeenCalledWith('solution', 1);
     });
 
+    it('shows coding agent dropdown with Add Integration CTA when no integrations exist', async () => {
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('root_cause')]}
+          autofix={autofix}
+        />
+      );
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'More code fix options'})
+      );
+      const addIntegrationLink = screen.getByRole('button', {name: 'Add Integration'});
+      expect(addIntegrationLink).toHaveAttribute(
+        'href',
+        '/settings/org-slug/integrations/?category=coding%20agent'
+      );
+    });
+
     it('shows coding agent dropdown when integrations exist', async () => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/coding-agents/',

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -345,7 +345,7 @@ function NextStepTemplate({
           {codingAgentIntegrations === undefined ? null : (
             <DropdownMenu
               items={codingAgentOptions}
-              isDisabled={isProcessing}
+              isDisabled={false}
               trigger={(triggerProps, isOpen) => (
                 <Button
                   {...triggerProps}

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -342,7 +342,7 @@ function NextStepTemplate({
           <Button priority="primary" disabled={isProcessing} onClick={onClickYes}>
             {labelYes}
           </Button>
-          {codingAgentOptions?.length ? (
+          {codingAgentIntegrations === undefined ? null : (
             <DropdownMenu
               items={codingAgentOptions}
               trigger={(triggerProps, isOpen) => (
@@ -367,7 +367,7 @@ function NextStepTemplate({
                 </DropdownMenuFooter>
               }
             />
-          ) : null}
+          )}
         </ButtonBar>
       </Flex>
     </Flex>

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -345,6 +345,7 @@ function NextStepTemplate({
           {codingAgentIntegrations === undefined ? null : (
             <DropdownMenu
               items={codingAgentOptions}
+              isDisabled={isProcessing}
               trigger={(triggerProps, isOpen) => (
                 <Button
                   {...triggerProps}


### PR DESCRIPTION
The coding agent dropdown in the autofix next-step UI was gated on
`codingAgentOptions.length > 0`, which meant the "Add Integration" CTA
link inside the dropdown footer was only visible to orgs that already had
at least one coding agent integration installed. Orgs with zero
integrations had no way to discover or install one from the autofix flow.

Changed the guard to render the dropdown whenever `codingAgentIntegrations`
is defined (i.e. the current step supports coding agents), regardless of
whether any are installed. The dropdown now shows the "Add Integration"
footer link even when empty, directing users to the integrations settings
page.


Agent transcript: https://claudescope.sentry.dev/share/PXwCZuS75XHaHSRH9gv580ohH3NWiDH8vmAajsJ010c