### PR TITLE
fix(cells): Invalid invitation token or context always 404s

### DIFF
--- a/src/sentry/web/frontend/accept_organization_invite_redirect.py
+++ b/src/sentry/web/frontend/accept_organization_invite_redirect.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseNotFound, HttpResponseRedirect
 from django.urls import reverse
 
 from sentry.api.endpoints.accept_organization_invite import get_invite_state
@@ -29,11 +29,11 @@ class AcceptOrganizationInviteRedirectView(GenericReactPageView):
             request=request,
         )
         if invite_context is None:
-            return self.handle_react(request, **kwargs)
+            return HttpResponseNotFound()
 
         helper = ApiInviteHelper(request=request, token=token, invite_context=invite_context)
         if not helper.valid_token:
-            return self.handle_react(request, **kwargs)
+            return HttpResponseNotFound()
 
         redirect_url = reverse(
             "sentry-organization-accept-invite",

--- a/tests/sentry/web/frontend/test_accept_organization_invite_redirect.py
+++ b/tests/sentry/web/frontend/test_accept_organization_invite_redirect.py
@@ -37,11 +37,9 @@ class AcceptOrganizationInviteRedirectViewTest(TestCase):
             reverse("sentry-accept-invite", args=[member.id, "invalidtoken"])
         )
 
-        assert response.status_code == 200
-        self.assertTemplateUsed(response, "sentry/base-react.html")
+        assert response.status_code == 404
 
-    def test_unresolved_legacy_invite_falls_back_to_react_page(self) -> None:
+    def test_unresolved_legacy_invite_returns_404(self) -> None:
         response = self.client.get(reverse("sentry-accept-invite", args=[123456, "invalidtoken"]))
 
-        assert response.status_code == 200
-        self.assertTemplateUsed(response, "sentry/base-react.html")
+        assert response.status_code == 404


### PR DESCRIPTION
Invalid or expired invite links now return 404 rather than falling through to handle_react. Since the old React route is being removed, the fallback would have silently broken anyway — 404 is the semantically correct response for a link that doesn't resolve to a valid invite.

We never want to reveal the org if the token or invite context is not valid
