### PR TITLE
feat(cells): Remove the legacy org invite route

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -158,10 +158,6 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/acceptOrganizationInvite')),
     },
     {
-      path: '/accept/:memberId/:token/',
-      component: make(() => import('sentry/views/acceptOrganizationInvite')),
-    },
-    {
       path: '/accept-transfer/',
       component: make(() => import('sentry/views/acceptProjectTransfer')),
     },

--- a/static/app/views/acceptOrganizationInvite/index.spec.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.spec.tsx
@@ -106,7 +106,7 @@ describe('AcceptOrganizationInvite', () => {
 
   it('renders error message', async () => {
     MockApiClient.addMockResponse({
-      url: '/accept-invite/1/abc/',
+      url: '/accept-invite/org-slug/1/abc/',
       method: 'GET',
       statusCode: 400,
       body: {detail: 'uh oh'},
@@ -115,9 +115,9 @@ describe('AcceptOrganizationInvite', () => {
     render(<AcceptOrganizationInvite />, {
       initialRouterConfig: {
         location: {
-          pathname: '/accept-invite/1/abc/',
+          pathname: '/accept-invite/org-slug/1/abc/',
         },
-        route: '/accept-invite/:memberId/:token/',
+        route: '/accept-invite/:orgId/:memberId/:token/',
       },
     });
 

--- a/static/app/views/acceptOrganizationInvite/index.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.tsx
@@ -204,30 +204,22 @@ function AuthenticationActions({inviteDetails}: {inviteDetails: InviteDetails}) 
 
 function AcceptOrganizationInvite() {
   const api = useApi({persistInFlight: true});
-  const params = useParams<{memberId: string; token: string; orgId?: string}>();
-
-  const orgSlug = params.orgId || ConfigStore.get('customerDomain')?.subdomain || null;
+  const params = useParams<{memberId: string; token: string; orgId: string}>();
 
   const {
     data: inviteDetails,
     isPending,
     isError,
   } = useApiQuery<InviteDetails>(
-    orgSlug
-      ? [
-          getApiUrl('/accept-invite/$organizationIdOrSlug/$memberId/$token/', {
-            path: {
-              organizationIdOrSlug: orgSlug,
-              memberId: params.memberId,
-              token: params.token,
-            },
-          }),
-        ]
-      : [
-          getApiUrl('/accept-invite/$memberId/$token/', {
-            path: {memberId: params.memberId, token: params.token},
-          }),
-        ],
+    [
+      getApiUrl('/accept-invite/$organizationIdOrSlug/$memberId/$token/', {
+        path: {
+          organizationIdOrSlug: params.orgId,
+          memberId: params.memberId,
+          token: params.token,
+        },
+      }),
+    ],
     {
       staleTime: Infinity,
       retry: false,
@@ -241,9 +233,7 @@ function AcceptOrganizationInvite() {
   } = useMutation({
     mutationFn: () =>
       api.requestPromise(
-        orgSlug
-          ? `/accept-invite/${orgSlug}/${params.memberId}/${params.token}/`
-          : `/accept-invite/${params.memberId}/${params.token}/`,
+        `/accept-invite/${params.orgId}/${params.memberId}/${params.token}/`,
         {
           method: 'POST',
         }
@@ -273,7 +263,10 @@ function AcceptOrganizationInvite() {
                     data-test-id="existing-member-link"
                     onClick={e => {
                       e.preventDefault();
-                      logout(api, `/accept/${params.memberId}/${params.token}/`);
+                      logout(
+                        api,
+                        `/accept/${params.orgId}/${params.memberId}/${params.token}/`
+                      );
                     }}
                   />
                 ),

--- a/static/app/views/acceptOrganizationInvite/index.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.tsx
@@ -204,7 +204,7 @@ function AuthenticationActions({inviteDetails}: {inviteDetails: InviteDetails}) 
 
 function AcceptOrganizationInvite() {
   const api = useApi({persistInFlight: true});
-  const params = useParams<{memberId: string; token: string; orgId: string}>();
+  const params = useParams<{memberId: string; orgId: string; token: string}>();
 
   const {
     data: inviteDetails,


### PR DESCRIPTION
- removes the old /accept/:memberId/:token/ route. The component now only mounts via the org-scoped /accept/:orgId/:memberId/:token/ route
- this is safe now because https://github.com/getsentry/sentry/pull/112513 added a redirect that ensures the old route is never hit anymore
- the react component is also simplified as it no longer has to handle the case where an org is not present
