### PR TITLE
fix(grouping): Fix ip parameterization tests

### DIFF
--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -61,8 +61,9 @@ standard_cases = [
         "traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
         "traceparent: <traceparent>",
     ),
-    ("ip - too many initial characters", "12345:6:789", "<int>:<int>:<int>"),
-    ("ip - too many final characters", "123:4:56789", "<int>:<int>:<int>"),
+    ("ip - too few segments", "12:31:99", "<int>:<int>:<int>"),
+    ("ip - too many initial characters", "12345::6:789", "<int>::<int>:<int>"),
+    ("ip - too many final characters", "123:4::56789", "<int>:<int>::<int>"),
     ("traceparent - aws", "1-67891233-abcdef012345678912345678", "<traceparent>"),
     (
         "traceparent - aws, but not word boundary",


### PR DESCRIPTION
Two of our test cases for IP address parameterization were designed to show that if there were too many leading or trailing digits, we both didn't erroneously mark the whole as an IP and didn't ignore the extra digit and mark the rest as an IP (even though without the extra digit, it would be valid). For example, given `12345:6:789`, the goal was to show that it neither became `<ip>` nor `1<ip>`. The problem with that second part is, these weren't valid IP addresses even without the extra digits, since they contained neither the full complement of 8 segments nor a double colon indicating the elision of segments with all zeros.

This PR fixes the test cases in question (by adding an extra colon to each), and adds another test case showing that even without extra digits, a three-segment IP address doesn't match our pattern.