### PR TITLE
fix(aci): Add support for an empty conditionGroup in the API for the Error detector

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -222,7 +222,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
                     validated_data.pop("owner")
                 )
 
-            if "condition_group" in validated_data:
+            if "condition_group" in validated_data and validated_data.get("condition_group"):
                 condition_group = validated_data.pop("condition_group")
                 data_conditions: list[DataConditionType] = condition_group.get("conditions")
 

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -16,9 +16,11 @@ from sentry.workflow_engine.models.detector import Detector
 class ErrorDetectorValidator(BaseDetectorTypeValidator):
     data_source_required = False
 
+    # TODO - Update the Error Detector to store grouping rules in the DataCondition
     condition_group = serializers.DictField(
-        required=False
-    )  # This is only used to validate that it's empty
+        required=False,
+        allow_null=True,
+    )  # type: ignore[assignment]  # Intentionally overrides nested serializer to accept empty dicts
 
     fingerprinting_rules = serializers.CharField(required=False, allow_blank=True, allow_null=True)
 
@@ -41,11 +43,7 @@ class ErrorDetectorValidator(BaseDetectorTypeValidator):
                 "Condition group is not supported for error detectors"
             )
 
-        if value is not None:
-            # We want to allow an empty DataConditionGroup, but not create anything.
-            return None
-
-        return value
+        return None
 
     def validate_name(self, value: Any) -> str:
         # if name is different from existing, raise an error

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -16,7 +16,12 @@ from sentry.workflow_engine.models.detector import Detector
 class ErrorDetectorValidator(BaseDetectorTypeValidator):
     data_source_required = False
 
+    condition_group = serializers.DictField(
+        required=False
+    )  # This is only used to validate that it's empty
+
     fingerprinting_rules = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+
     resolve_age = EmptyIntegerField(
         required=False,
         allow_null=True,
@@ -31,10 +36,15 @@ class ErrorDetectorValidator(BaseDetectorTypeValidator):
         return type
 
     def validate_condition_group(self, value: Any) -> Any:
-        if value is not None:
+        if value:
             raise serializers.ValidationError(
                 "Condition group is not supported for error detectors"
             )
+
+        if value is not None:
+            # We want to allow an empty DataConditionGroup, but not create anything.
+            return None
+
         return value
 
     def validate_name(self, value: Any) -> str:

--- a/tests/sentry/workflow_engine/detectors/test_error_detector.py
+++ b/tests/sentry/workflow_engine/detectors/test_error_detector.py
@@ -82,6 +82,14 @@ class TestErrorDetectorValidator(TestCase):
             )
         ]
 
+    def test_valid_condition_group(self) -> None:
+        data = {
+            **self.valid_data,
+            "condition_group": {},
+        }
+        validator = ErrorDetectorValidator(data=data, context=self.context)
+        assert validator.is_valid()
+
     def test_update_existing_with_valid_data(self) -> None:
         user = self.create_user()
         self.create_member(organization=self.project.organization, user=user)


### PR DESCRIPTION
# Description
Fixes: https://linear.app/getsentry/issue/ISWF-2357/saving-error-monitor-after-creating-alert-fails

<img width="1080" height="394" alt="Screenshot 2026-04-09 at 4 18 21 PM" src="https://github.com/user-attachments/assets/6e5d899e-5aef-486c-ac19-da6bebfb620d" />

The issue seems like that the validator for ErrorDetectors was throwing because it has an empty data condition group; this should be okay and makes sense in our UI to provide as a default.

Rather than updating the UI to not send the field, this PR will allow the `{}` for the condition group.