### PR TITLE
fix(seer): Add links to manage your agent integrations, 

### DIFF
--- a/static/app/views/settings/seer/overview/autofixOverviewSection.tsx
+++ b/static/app/views/settings/seer/overview/autofixOverviewSection.tsx
@@ -182,9 +182,25 @@ function AgentNameForm({
         <Stack gap="md">
           <field.Layout.Row
             label={t('Default Preferred Coding Agent')}
-            hintText={t(
-              'For new projects, select which coding agent to use when proposing code changes.'
-            )}
+            hintText={
+              <Text>
+                {tct(
+                  'For new projects, select which coding agent to use when proposing code changes. [manageLink:Manage Coding Agent Integrations]',
+                  {
+                    manageLink: (
+                      <Link
+                        to={{
+                          pathname: `/settings/${organization.slug}/integrations/`,
+                          query: {category: 'coding agent'},
+                        }}
+                      >
+                        {t('Manage Coding Agent Integrations')}
+                      </Link>
+                    ),
+                  }
+                )}
+              </Text>
+            }
           >
             <Container flexGrow={1}>
               {preferredAgent.isPending || codingAgentSelectOptions.isPending ? (

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
+import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
@@ -78,7 +78,7 @@ export function AutofixAgent({canWrite, preference, project}: Props) {
 
   return (
     <PanelNoMargin>
-      <PanelHeader>{t('Autofix Handoff')}</PanelHeader>
+      <PanelHeader>{t('Autofix')}</PanelHeader>
       <PanelBody>
         {isPending ? (
           <Flex justify="center" align="center" padding="xl">
@@ -88,22 +88,29 @@ export function AutofixAgent({canWrite, preference, project}: Props) {
           <LoadingError />
         ) : (
           <Fragment>
-            {/* If the `agent` is undefined then we have a problem! Show an alert? */}
+            {/* If the `agent` is undefined then we default to Seer Agent */}
             <SelectField
               disabled={Boolean(disabledReason)}
               disabledReason={disabledReason}
               name="autofixAgent"
-              label={t('Autofix Handoff')}
+              label={t('Preferred Coding Agent')}
               help={tct(
-                'Seer will orchestrate the autofix process, and automatically hand off issue data to the coding agent for processing. You can choose to automatically process Issues, and which agent to use here. You can also manually trigger autofix with different agents from the Issue Details page. [docsLink:Read the docs] to learn more.',
+                'Select the coding agent to use when proposing code changes. [manageLink:Manage Coding Agent Integrations]',
                 {
-                  docsLink: (
-                    <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/" />
+                  manageLink: (
+                    <Link
+                      to={{
+                        pathname: `/settings/${organization.slug}/integrations/`,
+                        query: {category: 'coding agent'},
+                      }}
+                    >
+                      {t('Manage Coding Agent Integrations')}
+                    </Link>
                   ),
                 }
               )}
               options={options.data ?? []}
-              value={selected}
+              value={selected ?? 'seer'}
               onChange={(integration: 'seer' | CodingAgentIntegration) => {
                 mutateSelectedAgent(integration, {
                   onSuccess: () =>

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -5,16 +5,19 @@ import {Alert} from '@sentry/scraps/alert';
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import type {useUpdateBulkAutofixAutomationSettings} from 'sentry/components/events/autofix/preferences/hooks/useBulkAutofixAutomationSettings';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t, tct, tn} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   useBulkMutateSelectedAgent,
@@ -34,7 +37,34 @@ interface Props {
 
 const COLUMNS = [
   {title: t('Project'), key: 'project', sortKey: 'project'},
-  {title: t('Agent'), key: 'fixes', sortKey: 'agent'},
+  {
+    title: ({organization}: {organization: Organization}) => (
+      <Flex gap="sm" align="center">
+        {t('Preferred Coding Agent')}
+        <InfoTip
+          title={tct(
+            'Select the coding agent to use when proposing code changes. [manageLink:Manage Coding Agent Integrations]',
+            {
+              manageLink: (
+                <Link
+                  to={{
+                    pathname: normalizeUrl(
+                      `/settings/${organization.slug}/integrations/`
+                    ),
+                    query: {category: 'coding agent'},
+                  }}
+                >
+                  {t('Manage Coding Agent Integrations')}
+                </Link>
+              ),
+            }
+          )}
+        />
+      </Flex>
+    ),
+    key: 'fixes',
+    sortKey: 'agent',
+  },
   {
     title: (
       <Flex gap="sm" align="center">
@@ -126,7 +156,7 @@ export function ProjectTableHeader({
             }
             sort={sort?.field === sortKey ? sort.kind : undefined}
           >
-            {title}
+            {typeof title === 'function' ? title({organization}) : title}
           </SimpleTable.HeaderCell>
         ))}
       </TableHeader>

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -96,7 +96,7 @@ export function SeerProjectTableRow({
               disabled={!canWrite}
               name="autofixAgent"
               options={agentOptions.data ?? []}
-              value={autofixAgent}
+              value={autofixAgent ?? 'seer'}
               onChange={option => {
                 mutateSelectedAgent(option.value, {
                   onSuccess: () => {

--- a/static/gsApp/views/seerAutomation/projects.tsx
+++ b/static/gsApp/views/seerAutomation/projects.tsx
@@ -1,9 +1,8 @@
-import {ExternalLink, Link} from '@sentry/scraps/link';
+import {ExternalLink} from '@sentry/scraps/link';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
 import {SeerProjectTable} from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTable';
@@ -11,7 +10,6 @@ import {SeerSettingsPageContent} from 'getsentry/views/seerAutomation/components
 import {SeerSettingsPageWrapper} from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 
 export default function SeerAutomationProjects() {
-  const organization = useOrganization();
   return (
     <AnalyticsArea name="projects">
       <SeerSettingsPageWrapper>
@@ -26,17 +24,6 @@ export default function SeerAutomationProjects() {
               ),
               docs: (
                 <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities" />
-              ),
-
-              manageLink: (
-                <Link
-                  to={{
-                    pathname: `/settings/${organization.slug}/integrations/`,
-                    query: {category: 'coding agent'},
-                  }}
-                >
-                  {t('Manage Coding Agent Integrations')}
-                </Link>
               ),
             }
           )}

--- a/static/gsApp/views/seerAutomation/projects.tsx
+++ b/static/gsApp/views/seerAutomation/projects.tsx
@@ -1,8 +1,9 @@
-import {ExternalLink} from '@sentry/scraps/link';
+import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
 import {SeerProjectTable} from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTable';
@@ -10,6 +11,7 @@ import {SeerSettingsPageContent} from 'getsentry/views/seerAutomation/components
 import {SeerSettingsPageWrapper} from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 
 export default function SeerAutomationProjects() {
+  const organization = useOrganization();
   return (
     <AnalyticsArea name="projects">
       <SeerSettingsPageWrapper>
@@ -24,6 +26,17 @@ export default function SeerAutomationProjects() {
               ),
               docs: (
                 <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities" />
+              ),
+
+              manageLink: (
+                <Link
+                  to={{
+                    pathname: `/settings/${organization.slug}/integrations/`,
+                    query: {category: 'coding agent'},
+                  }}
+                >
+                  {t('Manage Coding Agent Integrations')}
+                </Link>
               ),
             }
           )}


### PR DESCRIPTION
We should have these links to manage agents whenever a user can choose an agent.

| Page | Img |
| --- | --- |
| Seer Overview | <img width="983" height="490" alt="SCR-20260409-qlla" src="https://github.com/user-attachments/assets/b830e6f5-75a2-4d5b-8557-d84b3d1add7d" />
| Autofix project list | <img width="977" height="435" alt="SCR-20260409-qlmb" src="https://github.com/user-attachments/assets/304ed25e-b9f1-45be-8759-c0607f8ee748" />
| Autofix Specific project | <img width="982" height="642" alt="SCR-20260409-qlnk" src="https://github.com/user-attachments/assets/dabc8363-0a1a-437b-a107-27164e1d5f6a" />
