### PR TITLE
fix(seer): Convert Seer Repo Details form to new form system, clear onboarding-check cache

### DIFF
--- a/static/app/components/repositories/useBulkUpdateRepositorySettings.tsx
+++ b/static/app/components/repositories/useBulkUpdateRepositorySettings.tsx
@@ -8,7 +8,7 @@ import {
 } from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-export type RepositorySettings =
+type RepositorySettings =
   | {
       enabledCodeReview: boolean;
       repositoryIds: string[];

--- a/static/app/utils/getSeerOnboardingCheckQueryOptions.tsx
+++ b/static/app/utils/getSeerOnboardingCheckQueryOptions.tsx
@@ -1,0 +1,27 @@
+import type {Organization} from 'sentry/types/organization';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+
+interface SeerOnboardingCheckResponse {
+  hasSupportedScmIntegration: boolean;
+  isAutofixEnabled: boolean;
+  isCodeReviewEnabled: boolean;
+  isSeerConfigured: boolean;
+  needsConfigReminder: boolean;
+}
+
+interface Props {
+  organization: Organization;
+  staleTime?: number;
+}
+
+export function getSeerOnboardingCheckQueryOptions({organization, staleTime = 0}: Props) {
+  return apiOptions.as<SeerOnboardingCheckResponse>()(
+    '/organizations/$organizationIdOrSlug/seer/onboarding-check/',
+    {
+      path: {
+        organizationIdOrSlug: organization.slug,
+      },
+      staleTime,
+    }
+  );
+}

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -1,14 +1,23 @@
-import {Alert} from '@sentry/scraps/alert';
-import {Stack} from '@sentry/scraps/layout';
+import {mutationOptions} from '@tanstack/react-query';
+import {z} from 'zod';
 
-import {Form} from 'sentry/components/forms/form';
-import JsonForm from 'sentry/components/forms/jsonForm';
-import {type RepositorySettings} from 'sentry/components/repositories/useBulkUpdateRepositorySettings';
+import {Alert} from '@sentry/scraps/alert';
+import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
+import {Container, Stack} from '@sentry/scraps/layout';
+
+import {getRepositoryWithSettingsQueryKey} from 'sentry/components/repositories/useRepositoryWithSettings';
 import {t, tct} from 'sentry/locale';
-import {type RepositoryWithSettings} from 'sentry/types/integrations';
+import type {RepositoryWithSettings} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
+import {getSeerOnboardingCheckQueryOptions} from 'sentry/utils/getSeerOnboardingCheckQueryOptions';
+import {fetchMutation, useQueryClient} from 'sentry/utils/queryClient';
 
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
+
+const schema = z.object({
+  enabledCodeReview: z.boolean(),
+  codeReviewTriggers: z.array(z.string()),
+});
 
 interface Props {
   organization: Organization;
@@ -17,6 +26,57 @@ interface Props {
 
 export function RepoDetailsForm({organization, repoWithSettings}: Props) {
   const canWrite = useCanWriteSettings();
+  const queryClient = useQueryClient();
+
+  const repoQueryKey = getRepositoryWithSettingsQueryKey(
+    organization,
+    repoWithSettings.id
+  );
+
+  const repoMutationOpts = mutationOptions({
+    mutationFn: (data: {codeReviewTriggers?: string[]; enabledCodeReview?: boolean}) => {
+      return fetchMutation<RepositoryWithSettings[]>({
+        method: 'PUT',
+        url: `/organizations/${organization.slug}/repos/settings/`,
+        data: {...data, repositoryIds: [repoWithSettings.id]},
+      });
+    },
+    onMutate: (data: {codeReviewTriggers?: string[]; enabledCodeReview?: boolean}) => {
+      const previous =
+        queryClient.getQueryData<
+          [RepositoryWithSettings, string | undefined, Response | undefined]
+        >(repoQueryKey);
+      if (previous) {
+        const [repo, statusText, resp] = previous;
+        queryClient.setQueryData(repoQueryKey, [
+          {
+            ...repo,
+            settings: {
+              ...repo.settings,
+              ...data,
+            },
+          },
+          statusText,
+          resp,
+        ]);
+      }
+      return {previous};
+    },
+    onError: (_error, _data, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(repoQueryKey, context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: [`/organizations/${organization.slug}/repos/`],
+      });
+      queryClient.invalidateQueries({
+        queryKey: getSeerOnboardingCheckQueryOptions({organization}).queryKey,
+      });
+      queryClient.invalidateQueries({queryKey: repoQueryKey});
+    },
+  });
 
   return (
     <Stack gap="lg">
@@ -27,59 +87,58 @@ export function RepoDetailsForm({organization, repoWithSettings}: Props) {
           )}
         </Alert>
       )}
-      <Form
-        allowUndo
-        saveOnBlur
-        apiMethod="PUT"
-        apiEndpoint={`/organizations/${organization.slug}/repos/settings/`}
-        initialData={
-          {
-            enabledCodeReview: repoWithSettings?.settings?.enabledCodeReview ?? false,
-            codeReviewTriggers: repoWithSettings?.settings?.codeReviewTriggers ?? [],
-            repositoryIds: [repoWithSettings.id],
-          } satisfies RepositorySettings
-        }
-      >
-        <JsonForm
-          disabled={!canWrite}
-          forms={[
-            {
-              title: t('AI Code Review'),
-              fields: [
-                {
-                  name: 'enabledCodeReview',
-                  label: t('Enable Code Review'),
-                  help: t('Seer will review your PRs and flag potential bugs.'),
-                  type: 'boolean',
-                  getData: data => ({
-                    enabledCodeReview: data.enabledCodeReview,
-                    repositoryIds: [repoWithSettings.id],
-                  }),
-                },
-                {
-                  name: 'codeReviewTriggers',
-                  label: t('Code Review Triggers'),
-                  help: tct(
-                    'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
-                    {code: <code />}
-                  ),
-                  type: 'choice',
-                  multiple: true,
-                  choices: [
-                    ['on_ready_for_review', t('On Ready for Review')],
-                    ['on_new_commit', t('On New Commit')],
-                  ],
-                  formatMessageValue: false,
-                  getData: data => ({
-                    codeReviewTriggers: data.codeReviewTriggers,
-                    repositoryIds: [repoWithSettings.id],
-                  }),
-                },
-              ],
-            },
-          ]}
-        />
-      </Form>
+      <FieldGroup title={t('AI Code Review')}>
+        <AutoSaveForm
+          name="enabledCodeReview"
+          schema={schema}
+          initialValue={repoWithSettings?.settings?.enabledCodeReview ?? false}
+          mutationOptions={repoMutationOpts}
+        >
+          {field => (
+            <field.Layout.Row
+              label={t('Enable Code Review')}
+              hintText={t('Seer will review your PRs and flag potential bugs.')}
+            >
+              <Container flexGrow={1}>
+                <field.Switch
+                  checked={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={!canWrite}
+                />
+              </Container>
+            </field.Layout.Row>
+          )}
+        </AutoSaveForm>
+        <AutoSaveForm
+          name="codeReviewTriggers"
+          schema={schema}
+          initialValue={repoWithSettings?.settings?.codeReviewTriggers ?? []}
+          mutationOptions={repoMutationOpts}
+        >
+          {field => (
+            <field.Layout.Row
+              label={t('Code Review Triggers')}
+              hintText={tct(
+                'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
+                {code: <code />}
+              )}
+            >
+              <Container flexGrow={1}>
+                <field.Select
+                  multiple
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={!canWrite}
+                  options={[
+                    {value: 'on_ready_for_review', label: t('On Ready for Review')},
+                    {value: 'on_new_commit', label: t('On New Commit')},
+                  ]}
+                />
+              </Container>
+            </field.Layout.Row>
+          )}
+        </AutoSaveForm>
+      </FieldGroup>
     </Stack>
   );
 }


### PR DESCRIPTION
This converts the form to the new form system, does an optimistic update to the cache when a change is made, and clears the cache of `/seer/onboarding-check/` which could change based on if something is enabed/disabled for code-review.

The new file, static/app/utils/getSeerOnboardingCheckQueryOptions.tsx, is also added in #112643, but shouldn't conflict as it's the same content.