### PR TITLE
ref(compactSelect): Auto-select single option on Enter when searching

### DIFF
--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -447,6 +447,60 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
 
+    it('selects the single remaining option when Enter is pressed', async () => {
+      const onChange = jest.fn();
+      render(
+        <CompactSelect
+          search={{placeholder: 'Search here…'}}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={onChange}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // type 'Two' to narrow the list to exactly one option
+      await userEvent.keyboard('Two');
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // pressing Enter should select the single visible option
+      await userEvent.keyboard('{Enter}');
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({value: 'opt_two'}));
+    });
+
+    it('does not auto-select when multiple options are visible and Enter is pressed', async () => {
+      const onChange = jest.fn();
+      render(
+        <CompactSelect
+          search={{placeholder: 'Search here…'}}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={onChange}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // type 'Option' — both options are still visible
+      await userEvent.keyboard('Option');
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+
+      // pressing Enter should not select anything
+      await userEvent.keyboard('{Enter}');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('restores full list when search query is cleared', async () => {
       render(
         <CompactSelect

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -501,6 +501,33 @@ describe('CompactSelect', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    it('does not auto-select when one enabled and one disabled option are visible', async () => {
+      const onChange = jest.fn();
+      render(
+        <CompactSelect
+          search={{placeholder: 'Search here…'}}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two', disabled: true},
+          ]}
+          value={undefined}
+          onChange={onChange}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // type 'Option' — both options are visible (one enabled, one disabled)
+      await userEvent.keyboard('Option');
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+
+      // pressing Enter must not auto-select even though only one option is enabled
+      await userEvent.keyboard('{Enter}');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('restores full list when search query is cleared', async () => {
       render(
         <CompactSelect

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -284,11 +284,13 @@ export function Control({
           ...(overlayRef.current?.querySelectorAll<HTMLLIElement>(`li[role="${role}"]`) ??
             []),
         ];
+        const firstOption = allVisibleOptions[0];
         if (
           allVisibleOptions.length === 1 &&
-          allVisibleOptions[0]?.getAttribute('aria-disabled') !== 'true'
+          firstOption &&
+          firstOption.getAttribute('aria-disabled') !== 'true'
         ) {
-          allVisibleOptions[0].click();
+          firstOption.click();
         }
       }
 

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -272,9 +272,18 @@ export function Control({
           ?.focus();
       }
 
-      // Prevent form submissions on Enter key press in search box
+      // Prevent form submissions on Enter key press in search box.
+      // If there is exactly one enabled option visible, select it automatically.
       if (e.key === 'Enter') {
         e.preventDefault();
+        const role = grid ? 'row' : 'option';
+        const enabledOptions = [
+          ...(overlayRef.current?.querySelectorAll<HTMLLIElement>(`li[role="${role}"]`) ??
+            []),
+        ].filter(opt => opt.getAttribute('aria-disabled') !== 'true');
+        if (enabledOptions.length === 1) {
+          enabledOptions[0]?.click();
+        }
       }
 
       // Continue propagation, otherwise the overlay won't close on Esc key press

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -273,16 +273,22 @@ export function Control({
       }
 
       // Prevent form submissions on Enter key press in search box.
-      // If there is exactly one enabled option visible, select it automatically.
+      // If there is exactly one visible option (enabled or disabled), and it is
+      // enabled, select it automatically. We count all visible options so that a
+      // disabled-but-visible option does not trick us into auto-selecting when
+      // the user still sees multiple items in the list.
       if (e.key === 'Enter') {
         e.preventDefault();
         const role = grid ? 'row' : 'option';
-        const enabledOptions = [
+        const allVisibleOptions = [
           ...(overlayRef.current?.querySelectorAll<HTMLLIElement>(`li[role="${role}"]`) ??
             []),
-        ].filter(opt => opt.getAttribute('aria-disabled') !== 'true');
-        if (enabledOptions.length === 1) {
-          enabledOptions[0]?.click();
+        ];
+        if (
+          allVisibleOptions.length === 1 &&
+          allVisibleOptions[0]?.getAttribute('aria-disabled') !== 'true'
+        ) {
+          allVisibleOptions[0].click();
         }
       }
 


### PR DESCRIPTION
When a user types in the search box and narrows the list down to exactly one visible option, pressing Enter now automatically selects that option. Previously Enter was a no-op in the search input (it only prevented form submission).

The implementation queries enabled (non-hidden, non-disabled) list items in the overlay on Enter. Hidden options are already marked `aria-disabled` by the list state, so filtering on that attribute cleanly identifies what's actually selectable. If exactly one item is left, it receives a programmatic click, going through the normal React Aria selection path including `onChange` and the menu closing logic.

When multiple options are still visible, Enter continues to do nothing, avoiding accidental selections.