### PR TITLE
fix(dart): Safe field access

### DIFF
--- a/src/sentry/lang/dart/plugin.py
+++ b/src/sentry/lang/dart/plugin.py
@@ -17,7 +17,7 @@ class DartPlugin(Plugin2):
         return False
 
     def get_event_preprocessors(self, data: Mapping[str, Any]) -> Sequence[EventPreprocessor]:
-        sdk_name = data.get("sdk", {}).get("name", "")
+        sdk_name = (data.get("sdk") or {}).get("name", "")
         if sdk_name not in ("sentry.dart", "sentry.dart.flutter"):
             return []
 

--- a/tests/sentry/lang/dart/test_plugin_deobfuscation.py
+++ b/tests/sentry/lang/dart/test_plugin_deobfuscation.py
@@ -146,6 +146,9 @@ class DartPluginDeobfuscationTest(TestCase):
         assert exception_values[2]["type"] == "FileNotFoundException"
         assert exception_values[2]["value"] == "File error: def not found"
 
+    def test_missing_sdk(self) -> None:
+        self.plugin.get_event_preprocessors({"sdk": None})
+
     def test_dart_partial_deobfuscation_direct(self) -> None:
         """Test partial deobfuscation when some symbols are not in the map."""
         # Upload symbols that only contain xyz mapping, using a distinct debug_id


### PR DESCRIPTION
Events are `Annotated` so any field value can be `None`.

Fixes SENTRY-5K61.