### PR TITLE
feat(preprod): Add per-app summary and sort to snapshot PR comments

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections import Counter
+from enum import IntEnum
+
 from django.utils.translation import gettext_lazy as _
 
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
@@ -14,6 +17,85 @@ COMPARISON_TABLE_HEADER = (
 )
 
 
+class _ArtifactStatus(IntEnum):
+    """Per-artifact status, ordered by display priority (failures first)."""
+
+    FAILED = 0
+    NEEDS_APPROVAL = 1
+    PROCESSING = 2
+    UPLOADED_NO_BASE = 3
+    UNCHANGED = 4
+    APPROVED = 5
+
+
+_STATUS_DISPLAY: dict[_ArtifactStatus, str] = {
+    _ArtifactStatus.FAILED: "❌ Comparison failed",
+    _ArtifactStatus.NEEDS_APPROVAL: "⏳ Needs approval",
+    _ArtifactStatus.PROCESSING: PROCESSING_STATUS,
+    _ArtifactStatus.UNCHANGED: "✅ Unchanged",
+    _ArtifactStatus.APPROVED: "✅ Approved",
+    # UPLOADED_NO_BASE is special-cased with the image count
+}
+
+_SUMMARY_LABELS: dict[_ArtifactStatus, str] = {
+    _ArtifactStatus.FAILED: "❌ {count} failed",
+    _ArtifactStatus.NEEDS_APPROVAL: "⏳ {count} needs approval",
+    _ArtifactStatus.PROCESSING: "⏳ {count} processing",
+    _ArtifactStatus.UPLOADED_NO_BASE: "✅ {count} uploaded",
+    _ArtifactStatus.UNCHANGED: "✅ {count} unchanged",
+    _ArtifactStatus.APPROVED: "✅ {count} approved",
+}
+
+
+def _compute_artifact_status(
+    artifact: PreprodArtifact,
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
+    comparisons_map: dict[int, PreprodSnapshotComparison],
+    base_artifact_map: dict[int, PreprodArtifact],
+    changes_map: dict[int, bool],
+    approvals_map: dict[int, PreprodComparisonApproval] | None = None,
+) -> _ArtifactStatus:
+    metrics = snapshot_metrics_map.get(artifact.id)
+    if not metrics:
+        return _ArtifactStatus.PROCESSING
+
+    comparison = comparisons_map.get(metrics.id)
+    has_base = artifact.id in base_artifact_map
+
+    if not comparison and not has_base:
+        return _ArtifactStatus.UPLOADED_NO_BASE
+
+    if not comparison:
+        return _ArtifactStatus.PROCESSING
+
+    if comparison.state in (
+        PreprodSnapshotComparison.State.PENDING,
+        PreprodSnapshotComparison.State.PROCESSING,
+    ):
+        return _ArtifactStatus.PROCESSING
+
+    if comparison.state == PreprodSnapshotComparison.State.FAILED:
+        return _ArtifactStatus.FAILED
+
+    has_changes = changes_map.get(artifact.id, False)
+    is_approved = approvals_map is not None and artifact.id in approvals_map
+    if has_changes and is_approved:
+        return _ArtifactStatus.APPROVED
+    elif has_changes:
+        return _ArtifactStatus.NEEDS_APPROVAL
+
+    return _ArtifactStatus.UNCHANGED
+
+
+def _format_summary_line(status_counts: Counter[_ArtifactStatus]) -> str:
+    parts = []
+    for status in _ArtifactStatus:
+        count = status_counts.get(status, 0)
+        if count > 0:
+            parts.append(_SUMMARY_LABELS[status].format(count=count))
+    return " · ".join(parts)
+
+
 def format_snapshot_pr_comment(
     artifacts: list[PreprodArtifact],
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
@@ -26,39 +108,43 @@ def format_snapshot_pr_comment(
     if not artifacts:
         raise ValueError("Cannot format PR comment for empty artifact list")
 
-    table_rows = []
+    # Compute status for each artifact and sort by priority (failures first)
+    artifact_statuses = [
+        (
+            artifact,
+            _compute_artifact_status(
+                artifact,
+                snapshot_metrics_map,
+                comparisons_map,
+                base_artifact_map,
+                changes_map,
+                approvals_map,
+            ),
+        )
+        for artifact in artifacts
+    ]
+    artifact_statuses.sort(key=lambda pair: (pair[1].value, _app_display_info(pair[0])[0]))
 
-    for artifact in artifacts:
+    status_counts: Counter[_ArtifactStatus] = Counter(s for _, s in artifact_statuses)
+    summary_line = _format_summary_line(status_counts)
+
+    table_rows = []
+    for artifact, status in artifact_statuses:
         name_cell = _name_cell(artifact, snapshot_metrics_map, base_artifact_map)
         metrics = snapshot_metrics_map.get(artifact.id)
 
-        if not metrics:
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | {PROCESSING_STATUS} |")
-            continue
-
-        comparison = comparisons_map.get(metrics.id)
-        has_base = artifact.id in base_artifact_map
-
-        if not comparison and not has_base:
-            # No base to compare against — show snapshot count only
-            table_rows.append(
-                f"| {name_cell} | - | - | - | - | - | ✅ {metrics.image_count} uploaded |"
-            )
-            continue
-
-        if not comparison:
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | {PROCESSING_STATUS} |")
-            continue
-
-        if comparison.state in (
-            PreprodSnapshotComparison.State.PENDING,
-            PreprodSnapshotComparison.State.PROCESSING,
+        if status == _ArtifactStatus.UPLOADED_NO_BASE:
+            image_count = metrics.image_count if metrics else 0
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | ✅ {image_count} uploaded |")
+        elif status in (
+            _ArtifactStatus.PROCESSING,
+            _ArtifactStatus.FAILED,
         ):
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | {PROCESSING_STATUS} |")
-        elif comparison.state == PreprodSnapshotComparison.State.FAILED:
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | ❌ Comparison failed |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | {_STATUS_DISPLAY[status]} |")
         else:
+            # SUCCESS states: UNCHANGED, NEEDS_APPROVAL, APPROVED
             base_artifact = base_artifact_map.get(artifact.id)
+            comparison = comparisons_map.get(metrics.id) if metrics else None
             artifact_url = (
                 get_preprod_artifact_comparison_url(
                     artifact, base_artifact, comparison_type="snapshots"
@@ -67,26 +153,17 @@ def format_snapshot_pr_comment(
                 else get_preprod_artifact_url(artifact, view_type="snapshots")
             )
 
-            has_changes = changes_map.get(artifact.id, False)
-            is_approved = approvals_map is not None and artifact.id in approvals_map
-            if has_changes and is_approved:
-                status = "✅ Approved"
-            elif has_changes:
-                status = "⏳ Needs approval"
-            else:
-                status = "✅ Unchanged"
-
             table_rows.append(
                 f"| {name_cell}"
-                f" | {_section_cell(comparison.images_added, 'added', artifact_url)}"
-                f" | {_section_cell(comparison.images_removed, 'removed', artifact_url)}"
-                f" | {_section_cell(comparison.images_changed, 'changed', artifact_url)}"
-                f" | {_section_cell(comparison.images_renamed, 'renamed', artifact_url)}"
-                f" | {_section_cell(comparison.images_unchanged, 'unchanged', artifact_url)}"
-                f" | {status} |"
+                f" | {_section_cell(comparison.images_added, 'added', artifact_url) if comparison else '0'}"
+                f" | {_section_cell(comparison.images_removed, 'removed', artifact_url) if comparison else '0'}"
+                f" | {_section_cell(comparison.images_changed, 'changed', artifact_url) if comparison else '0'}"
+                f" | {_section_cell(comparison.images_renamed, 'renamed', artifact_url) if comparison else '0'}"
+                f" | {_section_cell(comparison.images_unchanged, 'unchanged', artifact_url) if comparison else '0'}"
+                f" | {_STATUS_DISPLAY[status]} |"
             )
 
-    return f"{_HEADER}\n\n{COMPARISON_TABLE_HEADER}" + "\n".join(table_rows)
+    return f"{_HEADER}\n\n{summary_line}\n\n{COMPARISON_TABLE_HEADER}" + "\n".join(table_rows)
 
 
 def _name_cell(

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -8,10 +8,14 @@ from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.url_utils import get_preprod_artifact_comparison_url, get_preprod_artifact_url
 from sentry.preprod.vcs.pr_comments.snapshot_templates import (
+    _STATUS_DISPLAY,
     COMPARISON_TABLE_HEADER,
     PROCESSING_STATUS,
     _app_display_info,
+    _ArtifactStatus,
+    _compute_artifact_status,
     _format_name_cell,
+    _format_summary_line,
     _name_cell,
     _section_cell,
 )
@@ -224,28 +228,40 @@ def _format_snapshot_summary(
     changes_map: dict[int, bool],
     approvals_map: dict[int, PreprodComparisonApproval] | None = None,
 ) -> str:
+    from collections import Counter
+
+    artifact_statuses = [
+        (
+            artifact,
+            _compute_artifact_status(
+                artifact,
+                snapshot_metrics_map,
+                comparisons_map,
+                base_artifact_map,
+                changes_map,
+                approvals_map,
+            ),
+        )
+        for artifact in artifacts
+    ]
+    artifact_statuses.sort(key=lambda pair: (pair[1].value, _app_display_info(pair[0])[0]))
+
+    status_counts: Counter[_ArtifactStatus] = Counter(s for _, s in artifact_statuses)
+    summary_line = _format_summary_line(status_counts)
+
     table_rows = []
-
-    for artifact in artifacts:
+    for artifact, status in artifact_statuses:
         name = _name_cell(artifact, snapshot_metrics_map, base_artifact_map)
-
         metrics = snapshot_metrics_map.get(artifact.id)
-        if not metrics:
-            table_rows.append(f"| {name} | - | - | - | - | - | {PROCESSING_STATUS} |")
-            continue
 
-        comparison = comparisons_map.get(metrics.id)
-        if not comparison:
-            table_rows.append(f"| {name} | - | - | - | - | - | {PROCESSING_STATUS} |")
-            continue
-
-        if comparison.state in (
-            PreprodSnapshotComparison.State.PENDING,
-            PreprodSnapshotComparison.State.PROCESSING,
-        ):
-            table_rows.append(f"| {name} | - | - | - | - | - | {PROCESSING_STATUS} |")
+        if status == _ArtifactStatus.UPLOADED_NO_BASE:
+            image_count = metrics.image_count if metrics else 0
+            table_rows.append(f"| {name} | - | - | - | - | - | ✅ {image_count} uploaded |")
+        elif status in (_ArtifactStatus.PROCESSING, _ArtifactStatus.FAILED):
+            table_rows.append(f"| {name} | - | - | - | - | - | {_STATUS_DISPLAY[status]} |")
         else:
             base_artifact = base_artifact_map.get(artifact.id)
+            comparison = comparisons_map.get(metrics.id) if metrics else None
             artifact_url = (
                 get_preprod_artifact_comparison_url(
                     artifact, base_artifact, comparison_type="snapshots"
@@ -254,23 +270,14 @@ def _format_snapshot_summary(
                 else get_preprod_artifact_url(artifact, view_type="snapshots")
             )
 
-            has_changes = changes_map.get(artifact.id, False)
-            is_approved = approvals_map is not None and artifact.id in approvals_map
-            if has_changes and is_approved:
-                status = "✅ Approved"
-            elif has_changes:
-                status = "⏳ Needs approval"
-            else:
-                status = "✅ Unchanged"
-
             table_rows.append(
                 f"| {name}"
-                f" | {_section_cell(comparison.images_added, 'added', artifact_url)}"
-                f" | {_section_cell(comparison.images_removed, 'removed', artifact_url)}"
-                f" | {_section_cell(comparison.images_changed, 'changed', artifact_url)}"
-                f" | {_section_cell(comparison.images_renamed, 'renamed', artifact_url)}"
-                f" | {_section_cell(comparison.images_unchanged, 'unchanged', artifact_url)}"
-                f" | {status} |"
+                f" | {_section_cell(comparison.images_added, 'added', artifact_url) if comparison else '0'}"
+                f" | {_section_cell(comparison.images_removed, 'removed', artifact_url) if comparison else '0'}"
+                f" | {_section_cell(comparison.images_changed, 'changed', artifact_url) if comparison else '0'}"
+                f" | {_section_cell(comparison.images_renamed, 'renamed', artifact_url) if comparison else '0'}"
+                f" | {_section_cell(comparison.images_unchanged, 'unchanged', artifact_url) if comparison else '0'}"
+                f" | {_STATUS_DISPLAY[status]} |"
             )
 
-    return COMPARISON_TABLE_HEADER + "\n".join(table_rows)
+    return f"{summary_line}\n\n{COMPARISON_TABLE_HEADER}" + "\n".join(table_rows)

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
@@ -387,3 +387,136 @@ class FormatSnapshotPrCommentNoBaseTest(SnapshotPrCommentTestBase):
         result = format_snapshot_pr_comment([artifact], {artifact.id: metrics}, {}, {}, {})
 
         assert "`com.example.myapp`" in result
+
+
+@cell_silo_test
+class FormatSnapshotPrCommentSummaryLineTest(SnapshotPrCommentTestBase):
+    def test_single_unchanged_app_shows_summary(self) -> None:
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+        self._create_comparison(head_metrics, base_metrics)
+
+        result = format_snapshot_pr_comment(
+            [head_artifact],
+            {head_artifact.id: head_metrics},
+            {
+                head_metrics.id: PreprodSnapshotComparison.objects.get(
+                    head_snapshot_metrics=head_metrics
+                )
+            },
+            {head_artifact.id: base_artifact},
+            {},
+        )
+
+        assert "✅ 1 unchanged" in result
+
+    def test_mixed_statuses_shows_all_in_summary(self) -> None:
+        # Failed artifact
+        failed_artifact, failed_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.failed", build_number=1
+        )
+        failed_base, failed_base_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.fbase", build_number=10
+        )
+        failed_comparison = self._create_comparison(
+            failed_metrics, failed_base_metrics, state=PreprodSnapshotComparison.State.FAILED
+        )
+
+        # Unchanged artifact
+        ok_artifact, ok_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.ok", build_number=2
+        )
+        ok_base, ok_base_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.obase", build_number=11
+        )
+        ok_comparison = self._create_comparison(ok_metrics, ok_base_metrics)
+
+        result = format_snapshot_pr_comment(
+            [failed_artifact, ok_artifact],
+            {failed_artifact.id: failed_metrics, ok_artifact.id: ok_metrics},
+            {failed_metrics.id: failed_comparison, ok_metrics.id: ok_comparison},
+            {failed_artifact.id: failed_base, ok_artifact.id: ok_base},
+            {},
+        )
+
+        assert "❌ 1 failed" in result
+        assert "✅ 1 unchanged" in result
+
+    def test_summary_line_omits_zero_count_statuses(self) -> None:
+        artifact, metrics = self._create_artifact_with_metrics()
+
+        result = format_snapshot_pr_comment([artifact], {artifact.id: metrics}, {}, {}, {})
+
+        # Only "uploaded" should appear, not "failed" or "unchanged"
+        summary_line = result.split("\n")[2]  # Line after header and blank line
+        assert "uploaded" in summary_line
+        assert "failed" not in summary_line
+        assert "unchanged" not in summary_line
+
+
+@cell_silo_test
+class FormatSnapshotPrCommentSortOrderTest(SnapshotPrCommentTestBase):
+    def test_failed_appears_before_unchanged(self) -> None:
+        # Create unchanged first
+        ok_artifact, ok_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.aaa_ok", build_number=1
+        )
+        ok_base, ok_base_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.obase", build_number=10
+        )
+        ok_comparison = self._create_comparison(ok_metrics, ok_base_metrics)
+
+        # Create failed second
+        failed_artifact, failed_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.zzz_failed", build_number=2
+        )
+        failed_base, failed_base_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.fbase", build_number=11
+        )
+        failed_comparison = self._create_comparison(
+            failed_metrics, failed_base_metrics, state=PreprodSnapshotComparison.State.FAILED
+        )
+
+        # Pass unchanged first in list — should still render failed first
+        result = format_snapshot_pr_comment(
+            [ok_artifact, failed_artifact],
+            {ok_artifact.id: ok_metrics, failed_artifact.id: failed_metrics},
+            {ok_metrics.id: ok_comparison, failed_metrics.id: failed_comparison},
+            {ok_artifact.id: ok_base, failed_artifact.id: failed_base},
+            {},
+        )
+
+        failed_pos = result.index("com.example.zzz_failed")
+        ok_pos = result.index("com.example.aaa_ok")
+        assert failed_pos < ok_pos
+
+    def test_needs_approval_appears_before_unchanged(self) -> None:
+        ok_artifact, ok_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.ok", build_number=1
+        )
+        ok_base, ok_base_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.obase1", build_number=10
+        )
+        ok_comparison = self._create_comparison(ok_metrics, ok_base_metrics)
+
+        pending_artifact, pending_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.pending", build_number=2
+        )
+        pending_base, pending_base_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.obase2", build_number=11
+        )
+        pending_comparison = self._create_comparison(
+            pending_metrics, pending_base_metrics, images_changed=5
+        )
+
+        result = format_snapshot_pr_comment(
+            [ok_artifact, pending_artifact],
+            {ok_artifact.id: ok_metrics, pending_artifact.id: pending_metrics},
+            {ok_metrics.id: ok_comparison, pending_metrics.id: pending_comparison},
+            {ok_artifact.id: ok_base, pending_artifact.id: pending_base},
+            {pending_artifact.id: True},
+        )
+
+        pending_pos = result.index("com.example.pending")
+        ok_pos = result.index("com.example.ok")
+        assert pending_pos < ok_pos

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -118,7 +118,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
 
         assert title == "Snapshot Testing"
         assert subtitle == "Comparing snapshots..."
-        assert "Processing" in summary
+        assert "uploaded" in summary
 
     def test_comparison_in_pending_state_shows_comparing(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics(app_id="com.example.head")
@@ -640,6 +640,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "No changes detected"
 
         expected = (
+            "✅ 1 unchanged\n\n"
             "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"
@@ -682,6 +683,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 4 unchanged"
 
         expected = (
+            "⏳ 1 needs approval\n\n"
             "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"
@@ -1035,6 +1037,7 @@ class SnapshotApprovalFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 4 unchanged"
 
         expected = (
+            "✅ 1 approved\n\n"
             "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"


### PR DESCRIPTION
## Summary
- Adds a summary line above the snapshot PR comment table showing per-status counts (e.g. `❌ 1 failed · ✅ 5 unchanged`)
- Sorts artifacts by status priority so failures and actionable items surface first
- Extracts shared `_ArtifactStatus` enum and `_compute_artifact_status()` helper, eliminating duplicated status logic between PR comment and status check templates

Fixes EME-906