### PR TITLE
feat(integrations): Log as warning when failed http.response

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -114,7 +114,8 @@ class BaseApiClient:
                 log_params["retry_after"] = retry_after
 
         log_params.update(getattr(self, "logging_context", None) or {})
-        self.logger.info("%s.http_response", self.integration_type, extra=log_params)
+        log_level = self.logger.warning if error else self.logger.info
+        log_level("%s.http_response", self.integration_type, extra=log_params)
 
     def get_cache_prefix(self) -> str:
         return f"{self.integration_type}.{self.name}.client:"

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -381,7 +381,7 @@ class ApiClientTest(TestCase):
         with mock.patch.object(client, "logger") as mock_logger:
             with pytest.raises(ApiError):
                 client.get("http://example.com")
-            extra = mock_logger.info.call_args.kwargs["extra"]
+            extra = mock_logger.warning.call_args.kwargs["extra"]
             assert extra["retry_after"] == "60"
 
     @responses.activate
@@ -431,7 +431,7 @@ class ApiClientTest(TestCase):
         with mock.patch.object(client, "logger") as mock_logger:
             with pytest.raises(ApiError):
                 client.get("http://example.com")
-            extra = mock_logger.info.call_args.kwargs["extra"]
+            extra = mock_logger.warning.call_args.kwargs["extra"]
             assert extra["github_request_id"] == "err-789"
 
     @responses.activate


### PR DESCRIPTION
Very minor change which makes looking to hundreds of logs a bit more obvious which ones did not get a 200 status code.