### PR TITLE
fix(chartcuterie): Avoid plottable imports that break Node VM sandbox

### DIFF
--- a/static/app/chartcuterie/explore.tsx
+++ b/static/app/chartcuterie/explore.tsx
@@ -1,11 +1,14 @@
 import type {Theme} from '@emotion/react';
+import type {BarSeriesOption, LineSeriesOption} from 'echarts';
 
 import {XAxis} from 'sentry/components/charts/components/xAxis';
+import {AreaSeries} from 'sentry/components/charts/series/areaSeries';
+import {BarSeries} from 'sentry/components/charts/series/barSeries';
+import {LineSeries} from 'sentry/components/charts/series/lineSeries';
+import {timeSeriesItemToEChartsDataPoint} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
-import type {ContinuousTimeSeriesPlottingOptions} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries';
-import {createPlottableFromTimeSeries} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries';
 
 import {DEFAULT_FONT_FAMILY, makeSlackChartDefaults, slackChartSize} from './slack';
 import type {RenderDescriptor} from './types';
@@ -15,6 +18,29 @@ type ExploreChartData = {
   timeSeries: TimeSeries[];
   type?: DisplayType;
 };
+
+/**
+ * Creates an ECharts series based on the display type.
+ *
+ * NOTE: We intentionally avoid importing the plottable classes (Line, Area,
+ * Bars) here because they pull in `@sentry/react` which requires browser
+ * globals that are unavailable in chartcuterie's Node.js VM sandbox. Using
+ * the series constructors directly keeps this bundle compatible.
+ */
+function createSeries(
+  displayType: DisplayType,
+  props: LineSeriesOption & BarSeriesOption
+) {
+  switch (displayType) {
+    case DisplayType.BAR:
+      return BarSeries(props);
+    case DisplayType.AREA:
+      return AreaSeries({...props, areaStyle: {opacity: 0.4}});
+    case DisplayType.LINE:
+    default:
+      return LineSeries(props);
+  }
+}
 
 export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartType>> => {
   const exploreXAxis = XAxis({
@@ -46,13 +72,11 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
       if (!hasGroups) {
         const ts = timeSeries[0]!;
         const color = theme.chart.getColorPalette(0);
-        const plottingOptions: ContinuousTimeSeriesPlottingOptions = {
-          color: color?.[0] ?? '',
-          unit: ts.meta.valueUnit,
-          yAxisPosition: 'left',
-        };
-        const plottable = createPlottableFromTimeSeries(displayType, ts, {
-          color: color?.[0],
+        const singleSeries = createSeries(displayType, {
+          name: ts.yAxis,
+          data: ts.values.map(timeSeriesItemToEChartsDataPoint),
+          lineStyle: {color: color?.[0], opacity: 1},
+          itemStyle: {color: color?.[0]},
         });
 
         return {
@@ -60,7 +84,7 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
           xAxis: exploreXAxis,
           useUTC: true,
           color,
-          series: plottable?.toSeries(plottingOptions) ?? [],
+          series: [singleSeries],
         };
       }
 
@@ -75,17 +99,13 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
         color.push(theme.tokens.content.secondary);
       }
 
-      const series = sorted.flatMap((ts, i) => {
-        const plottingOptions: ContinuousTimeSeriesPlottingOptions = {
-          color: color?.[i] ?? '',
-          unit: ts.meta.valueUnit,
-          yAxisPosition: 'left',
-        };
-        const plottable = createPlottableFromTimeSeries(displayType, ts, {
+      const series = sorted.map((ts, i) => {
+        return createSeries(displayType, {
           name: formatTimeSeriesLabel(ts),
-          color: color?.[i],
+          data: ts.values.map(timeSeriesItemToEChartsDataPoint),
+          lineStyle: {color: color?.[i], opacity: 1},
+          itemStyle: {color: color?.[i]},
         });
-        return plottable?.toSeries(plottingOptions) ?? [];
       });
 
       return {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries.tsx
@@ -13,7 +13,7 @@ type PlottableConfig = {
   stack?: string;
 };
 
-export function createPlottableFromTimeSeries(
+function createPlottableFromTimeSeries(
   displayType: DisplayType,
   timeSeries: TimeSeries,
   config?: PlottableConfig


### PR DESCRIPTION
The plottable classes (`Line`, `Area`, `Bars`) import `@sentry/react` which requires browser globals (`window`, `document`, etc.) unavailable in chartcuterie's Node.js VM sandbox. When the config bundle includes these imports, `runInNewContext` fails during eval, causing chartcuterie to silently fall back to its previous config — which doesn't include `slack:explore.line`. This broke all Explore Slack unfurls.

Replaces the plottable `toSeries()` approach with direct `LineSeries`/`BarSeries`/`AreaSeries` constructors, which are lightweight wrappers that are safe for the chartcuterie bundle. Keeps the `DisplayType` support for rendering different chart types.

Fixes https://linear.app/getsentry/issue/DAIN-1486/unfurl-fails