### PR TITLE
ref(seer): Move get_github_username_for_user to shared utils

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -15,15 +15,12 @@ from sentry import features, quotas, tagstore
 from sentry.api.endpoints.organization_trace import OrganizationTraceEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory, ObjectStatus
-from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.integrations.types import ExternalProviders
 from sentry.issues.auto_source_code_config.code_mapping import (
     convert_stacktrace_frame_path_to_source_path,
     get_sorted_code_mapping_configs,
 )
 from sentry.issues.grouptype import WebVitalsGroup
-from sentry.models.commitauthor import CommitAuthor
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -49,6 +46,7 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree, fetch_profile_data
 from sentry.seer.models import SeerProjectPreference
 from sentry.seer.signed_seer_api import SeerViewerContext
+from sentry.seer.utils import get_github_username_for_user
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.ourlogs import OurLogs
@@ -458,66 +456,6 @@ def _respond_with_error(reason: str, status: int):
     )
 
 
-def _get_github_username_for_user(user: User | RpcUser, organization_id: int) -> str | None:
-    """
-    Get GitHub username for a user by checking multiple sources.
-
-    This function attempts to resolve a Sentry user to their GitHub username by:
-    1. Checking ExternalActor for explicit user→GitHub mappings
-    2. Falling back to CommitAuthor records matched by email (like suspect commits)
-    3. Extracting the GitHub username from the CommitAuthor external_id
-    """
-    # Method 1: Check ExternalActor for direct user→GitHub mapping
-    external_actor: ExternalActor | None = (
-        ExternalActor.objects.filter(
-            user_id=user.id,
-            organization_id=organization_id,
-            provider__in=[
-                ExternalProviders.GITHUB.value,
-                ExternalProviders.GITHUB_ENTERPRISE.value,
-            ],
-        )
-        .order_by("-date_added")
-        .first()
-    )
-
-    if external_actor and external_actor.external_name:
-        username = external_actor.external_name
-        return username[1:] if username.startswith("@") else username
-
-    # Method 2: Check CommitAuthor by email matching (like suspect commits does)
-    # Get all verified emails for this user
-    user_emails: list[str] = []
-    try:
-        # Both User and RpcUser models have a get_verified_emails method
-        if hasattr(user, "get_verified_emails"):
-            verified_emails = user.get_verified_emails()
-            user_emails.extend([e.email for e in verified_emails])
-    except Exception:
-        # If we can't get verified emails, don't use any
-        pass
-
-    if user_emails:
-        # Find CommitAuthors with matching emails that have GitHub external_id
-        commit_author = (
-            CommitAuthor.objects.filter(
-                organization_id=organization_id,
-                email__in=[email.lower() for email in user_emails],
-                external_id__isnull=False,
-            )
-            .exclude(external_id="")
-            .order_by("-id")
-            .first()
-        )
-
-        if commit_author:
-            commit_username = commit_author.get_username_from_external_id()
-            if commit_username:
-                return commit_username
-
-    return None
-
-
 def _call_autofix(
     *,
     user: User | AnonymousUser | RpcUser,
@@ -836,7 +774,7 @@ def trigger_autofix(
     # get github username for user
     github_username = None
     if not isinstance(user, AnonymousUser):
-        github_username = _get_github_username_for_user(user, group.organization.id)
+        github_username = get_github_username_for_user(user, group.organization.id)
 
     try:
         run_id = _call_autofix(

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
 from django.db.models import Q, QuerySet
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import ExternalProviders
+from sentry.models.commitauthor import CommitAuthor
 from sentry.models.repository import Repository
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
 
 
 def filter_repo_by_provider(
@@ -21,3 +28,63 @@ def filter_repo_by_provider(
         name=f"{owner}/{name}",
         status=ObjectStatus.ACTIVE,
     )
+
+
+def get_github_username_for_user(user: User | RpcUser, organization_id: int) -> str | None:
+    """
+    Get GitHub username for a user by checking multiple sources.
+
+    This function attempts to resolve a Sentry user to their GitHub username by:
+    1. Checking ExternalActor for explicit user->GitHub mappings
+    2. Falling back to CommitAuthor records matched by email (like suspect commits)
+    3. Extracting the GitHub username from the CommitAuthor external_id
+    """
+    # Method 1: Check ExternalActor for direct user->GitHub mapping
+    external_actor: ExternalActor | None = (
+        ExternalActor.objects.filter(
+            user_id=user.id,
+            organization_id=organization_id,
+            provider__in=[
+                ExternalProviders.GITHUB.value,
+                ExternalProviders.GITHUB_ENTERPRISE.value,
+            ],
+        )
+        .order_by("-date_added")
+        .first()
+    )
+
+    if external_actor and external_actor.external_name:
+        username = external_actor.external_name
+        return username[1:] if username.startswith("@") else username
+
+    # Method 2: Check CommitAuthor by email matching (like suspect commits does)
+    # Get all verified emails for this user
+    user_emails: list[str] = []
+    try:
+        # Both User and RpcUser models have a get_verified_emails method
+        if hasattr(user, "get_verified_emails"):
+            verified_emails = user.get_verified_emails()
+            user_emails.extend([e.email for e in verified_emails])
+    except Exception:
+        # If we can't get verified emails, don't use any
+        pass
+
+    if user_emails:
+        # Find CommitAuthors with matching emails that have GitHub external_id
+        commit_author = (
+            CommitAuthor.objects.filter(
+                organization_id=organization_id,
+                email__in=[email.lower() for email in user_emails],
+                external_id__isnull=False,
+            )
+            .exclude(external_id="")
+            .order_by("-id")
+            .first()
+        )
+
+        if commit_author:
+            commit_username = commit_author.get_username_from_external_id()
+            if commit_username:
+                return commit_username
+
+    return None

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -12,7 +12,6 @@ from sentry.issues.ingest import save_issue_occurrence
 from sentry.seer.autofix.autofix import (
     TIMEOUT_SECONDS,
     _call_autofix,
-    _get_github_username_for_user,
     _get_logs_for_event,
     _get_profile_from_trace_tree,
     _get_trace_tree_for_event,
@@ -26,6 +25,7 @@ from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.types import AutofixSelectRootCausePayload
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
 from sentry.seer.models import SeerApiError, SeerProjectPreference, SeerRawPreferenceResponse
+from sentry.seer.utils import get_github_username_for_user
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
@@ -1239,7 +1239,7 @@ class TestResolveProjectPreference(TestCase):
 
 
 class TestCallAutofix(TestCase):
-    @patch("sentry.seer.autofix.autofix._get_github_username_for_user")
+    @patch("sentry.seer.autofix.autofix.get_github_username_for_user")
     @patch("sentry.seer.autofix.autofix.make_autofix_start_request")
     def test_call_autofix(self, mock_request, mock_get_username) -> None:
         """Tests the _call_autofix function makes the correct API call."""
@@ -1340,7 +1340,7 @@ class TestGetGithubUsernameForUser(TestCase):
             integration_id=1,
         )
 
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username == "testuser"
 
     def test_get_github_username_for_user_with_github_enterprise(self) -> None:
@@ -1361,7 +1361,7 @@ class TestGetGithubUsernameForUser(TestCase):
             integration_id=2,
         )
 
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username == "gheuser"
 
     def test_get_github_username_for_user_without_at_prefix(self) -> None:
@@ -1382,7 +1382,7 @@ class TestGetGithubUsernameForUser(TestCase):
             integration_id=3,
         )
 
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username == "noprefixuser"
 
     def test_get_github_username_for_user_no_mapping(self) -> None:
@@ -1390,7 +1390,7 @@ class TestGetGithubUsernameForUser(TestCase):
         user = self.create_user()
         organization = self.create_organization()
 
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username is None
 
     def test_get_github_username_for_user_non_github_provider(self) -> None:
@@ -1411,7 +1411,7 @@ class TestGetGithubUsernameForUser(TestCase):
             integration_id=4,
         )
 
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username is None
 
     def test_get_github_username_for_user_multiple_mappings(self) -> None:
@@ -1444,7 +1444,7 @@ class TestGetGithubUsernameForUser(TestCase):
             date_added=before_now(days=1),
         )
 
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username == "newuser"
 
     def test_get_github_username_for_user_from_commit_author(self) -> None:
@@ -1463,7 +1463,7 @@ class TestGetGithubUsernameForUser(TestCase):
             external_id="github:githubuser",
         )
 
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username == "githubuser"
 
     def test_get_github_username_for_user_from_commit_author_github_enterprise(self) -> None:
@@ -1482,7 +1482,7 @@ class TestGetGithubUsernameForUser(TestCase):
             external_id="github_enterprise:ghuser",
         )
 
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username == "ghuser"
 
     def test_get_github_username_for_user_external_actor_priority(self) -> None:
@@ -1513,7 +1513,7 @@ class TestGetGithubUsernameForUser(TestCase):
         )
 
         # Should use ExternalActor (higher priority)
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username == "externaluser"
 
     def test_get_github_username_for_user_commit_author_no_external_id(self) -> None:
@@ -1532,7 +1532,7 @@ class TestGetGithubUsernameForUser(TestCase):
             external_id=None,
         )
 
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username is None
 
     def test_get_github_username_for_user_wrong_organization(self) -> None:
@@ -1552,7 +1552,7 @@ class TestGetGithubUsernameForUser(TestCase):
             external_id="github:wrongorguser",
         )
 
-        username = _get_github_username_for_user(user, organization1.id)
+        username = get_github_username_for_user(user, organization1.id)
         assert username is None
 
     def test_get_github_username_for_user_unverified_email_not_matched(self) -> None:
@@ -1575,7 +1575,7 @@ class TestGetGithubUsernameForUser(TestCase):
         )
 
         # Should NOT match the unverified email (security fix)
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username is None
 
     def test_get_github_username_for_user_verified_secondary_email_matched(self) -> None:
@@ -1598,7 +1598,7 @@ class TestGetGithubUsernameForUser(TestCase):
         )
 
         # Should match the verified secondary email
-        username = _get_github_username_for_user(user, organization.id)
+        username = get_github_username_for_user(user, organization.id)
         assert username == "developeruser"
 
 


### PR DESCRIPTION
## Summary

Extract `get_github_username_for_user` from `autofix.py` to `seer/utils.py` so it can be reused by the explorer flow.

No behavior change.

## Stack

- **This PR** (1/2)
- [feat(seer): Pass PR assignment flag and GitHub username to Seer](https://github.com/getsentry/sentry/pull/NEW) (2/2)

## Test plan

- [x] All 13 `TestGetGithubUsernameForUser` tests pass
- [x] `TestCallAutofix` passes


Agent transcript: https://claudescope.sentry.dev/share/gQE_FjdkKYG_ni3m7GJV0vvaMby0_VYjfOfMHJCpAbA