### PR TITLE
perf(sourcemaps): Flip debug-id EXISTS query to drive from project side

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -212,14 +212,14 @@ class SourceMapDebugBlueThunderEditionEndpoint(ProjectEndpoint):
         has_uploaded_some_artifact_with_a_debug_id = bool(
             debug_ids_with_uploaded_source_file or debug_ids_with_uploaded_source_map
         ) or (
-            DebugIdArtifactBundle.objects.filter(
-                organization_id=project.organization_id,
+            ProjectArtifactBundle.objects.filter(
+                project_id=project.id,
             )
             .filter(
                 Exists(
-                    ProjectArtifactBundle.objects.filter(
+                    DebugIdArtifactBundle.objects.filter(
                         artifact_bundle_id=OuterRef("artifact_bundle_id"),
-                        project_id=project.id,
+                        organization_id=project.organization_id,
                     )
                 )
             )


### PR DESCRIPTION
#112627 replaced the double join (DebugIdArtifactBundle -> ArtifactBundle -> ProjectArtifactBundle) with a correlated EXISTS subquery.

This flips the query to start from `ProjectArtifactBundle` (scoped by `project_id`, much smaller) as the outer table, with the EXISTS probing `DebugIdArtifactBundle` by the FK index on `artifact_bundle_id`. Same semantics, but Postgres starts from the small side.
