### PR TITLE
feat(tracemetrics): Allocate stable labels for metric queries

### DIFF
--- a/static/app/views/explore/metrics/hooks/useMetricReferences.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricReferences.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
-import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 export function useMetricReferences() {
   const metricQueries = useMultiMetricsQueryParams();
@@ -13,7 +12,8 @@ export function useMetricReferences() {
         .filter(metricQuery =>
           metricQuery.queryParams.visualizes.some(isVisualizeFunction)
         )
-        .map((metricQuery, index) => getFunctionLabel(metricQuery.labelIndex ?? index))
+        .map(metricQuery => metricQuery.label!)
+        .filter(Boolean)
     );
   }, [metricQueries]);
 }

--- a/static/app/views/explore/metrics/hooks/useMetricReferences.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricReferences.tsx
@@ -2,21 +2,18 @@ import {useMemo} from 'react';
 
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
-import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
+import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 export function useMetricReferences() {
   const metricQueries = useMultiMetricsQueryParams();
 
-  // TODO: This is only correct since all queries are listed before equations. If
-  // this changes we need to update this to persist the labels of the queries so
-  // references are still valid.
   return useMemo(() => {
     return new Set(
       metricQueries
         .filter(metricQuery =>
           metricQuery.queryParams.visualizes.some(isVisualizeFunction)
         )
-        .map((_metricQuery, index) => getVisualizeLabel(index))
+        .map((metricQuery, index) => getFunctionLabel(metricQuery.labelIndex ?? index))
     );
   }, [metricQueries]);
 }

--- a/static/app/views/explore/metrics/hooks/useMetricReferences.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricReferences.tsx
@@ -2,6 +2,7 @@ import {useMemo} from 'react';
 
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 export function useMetricReferences() {
   const metricQueries = useMultiMetricsQueryParams();
@@ -12,8 +13,7 @@ export function useMetricReferences() {
         .filter(metricQuery =>
           metricQuery.queryParams.visualizes.some(isVisualizeFunction)
         )
-        .map(metricQuery => metricQuery.label!)
-        .filter(Boolean)
+        .map((metricQuery, index) => metricQuery.label ?? getVisualizeLabel(index, false))
     );
   }, [metricQueries]);
 }

--- a/static/app/views/explore/metrics/hooks/useStableLabelIndices.tsx
+++ b/static/app/views/explore/metrics/hooks/useStableLabelIndices.tsx
@@ -1,0 +1,71 @@
+import {useMemo, useRef} from 'react';
+
+import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {
+  isVisualizeEquation,
+  isVisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
+
+/**
+ * Assigns sequential label indices to queries based on their type.
+ * Metrics get 0-based indices (A, B, C...), equations get 1-based (f1, f2...).
+ */
+function assignSequentialLabels(queries: BaseMetricQuery[]): number[] {
+  let nextMetricIndex = 0;
+  let nextEquationIndex = 1;
+  return queries.map(query => {
+    const isEquation = isVisualizeEquation(query.queryParams.visualizes[0]!);
+    return isEquation ? nextEquationIndex++ : nextMetricIndex++;
+  });
+}
+
+/**
+ * Returns the next available label index for the given query type.
+ * Metrics are 0-based (A=0, B=1...), equations are 1-based (f1=1, f2=2...).
+ */
+export function getNextLabelIndex(
+  metricQueries: BaseMetricQuery[],
+  type: 'aggregate' | 'equation'
+): number {
+  const queryFilter = type === 'equation' ? isVisualizeEquation : isVisualizeFunction;
+  const relevant = metricQueries.filter(q => queryFilter(q.queryParams.visualizes[0]!));
+  if (relevant.length === 0) {
+    return type === 'equation' ? 1 : 0;
+  }
+  return Math.max(...relevant.map((q, i) => q.labelIndex ?? i)) + 1;
+}
+
+/**
+ * Maintains stable label indices across query mutations within a session.
+ *
+ * Labels are compacted sequentially (A, B, C...) on fresh page loads, but
+ * preserved with gaps during a session (e.g. deleting B keeps A, C rather
+ * than reassigning to A, B).
+ *
+ * The ref tracks label assignments across URL navigations. Mutations (insert/remove)
+ * update the ref before navigating so the next render preserves the labels.
+ * When the ref length doesn't match the query count (fresh load or external
+ * navigation), labels are reassigned sequentially.
+ */
+export function useStableLabelIndices(queries: BaseMetricQuery[]) {
+  const indicesRef = useRef<number[]>([]);
+
+  if (indicesRef.current.length !== queries.length) {
+    indicesRef.current = assignSequentialLabels(queries);
+  }
+
+  return useMemo(
+    () => ({
+      getLabel(i: number): number {
+        return indicesRef.current[i] ?? i;
+      },
+      insert(position: number, labelIndex: number) {
+        indicesRef.current = indicesRef.current.toSpliced(position, 0, labelIndex);
+      },
+      remove(position: number) {
+        indicesRef.current = indicesRef.current.filter((_, j) => j !== position);
+      },
+    }),
+    []
+  );
+}

--- a/static/app/views/explore/metrics/hooks/useStableLabelIndices.tsx
+++ b/static/app/views/explore/metrics/hooks/useStableLabelIndices.tsx
@@ -96,6 +96,6 @@ export function useStableLabelIndices(queries: BaseMetricQuery[]) {
         labelsRef.current = labelsRef.current.filter((_, j) => j !== position);
       },
     }),
-    [] // stable — all methods close over labelsRef which is a stable ref
+    []
   );
 }

--- a/static/app/views/explore/metrics/hooks/useStableLabelIndices.tsx
+++ b/static/app/views/explore/metrics/hooks/useStableLabelIndices.tsx
@@ -5,38 +5,68 @@ import {
   isVisualizeEquation,
   isVisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+import {
+  getFunctionLabel,
+  getVisualizeLabel,
+} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 /**
- * Assigns sequential label indices to queries based on their type.
- * Metrics get 0-based indices (A, B, C...), equations get 1-based (f1, f2...).
+ * Assigns sequential labels to queries based on their type.
+ * Metrics get letter labels (A, B, C...), equations get function labels (ƒ1, ƒ2...).
  */
-function assignSequentialLabels(queries: BaseMetricQuery[]): number[] {
+function assignSequentialLabels(queries: BaseMetricQuery[]): string[] {
   let nextMetricIndex = 0;
   let nextEquationIndex = 1;
   return queries.map(query => {
     const isEquation = isVisualizeEquation(query.queryParams.visualizes[0]!);
-    return isEquation ? nextEquationIndex++ : nextMetricIndex++;
+    return getVisualizeLabel(
+      isEquation ? nextEquationIndex++ : nextMetricIndex++,
+      isEquation
+    );
   });
 }
 
 /**
- * Returns the next available label index for the given query type.
- * Metrics are 0-based (A=0, B=1...), equations are 1-based (f1=1, f2=2...).
+ * Returns the next available label for the given query type.
  */
-export function getNextLabelIndex(
+export function getNextLabel(
   metricQueries: BaseMetricQuery[],
   type: 'aggregate' | 'equation'
-): number {
-  const queryFilter = type === 'equation' ? isVisualizeEquation : isVisualizeFunction;
+): string {
+  const isEquation = type === 'equation';
+  const queryFilter = isEquation ? isVisualizeEquation : isVisualizeFunction;
   const relevant = metricQueries.filter(q => queryFilter(q.queryParams.visualizes[0]!));
   if (relevant.length === 0) {
-    return type === 'equation' ? 1 : 0;
+    return getVisualizeLabel(0, isEquation);
   }
-  return Math.max(...relevant.map((q, i) => q.labelIndex ?? i)) + 1;
+  const maxIndex = Math.max(
+    ...relevant.map((q, i) => {
+      const label = q.label;
+      if (!label) {
+        return i;
+      }
+      return isEquation ? parseEquationIndex(label) : parseFunctionIndex(label);
+    })
+  );
+  return getVisualizeLabel(maxIndex + 1, isEquation);
 }
 
 /**
- * Maintains stable label indices across query mutations within a session.
+ * Parses "A" → 0, "B" → 1, etc.
+ */
+function parseFunctionIndex(label: string): number {
+  return label.charCodeAt(0) - 'A'.charCodeAt(0);
+}
+
+/**
+ * Parses "ƒ1" → 1, "ƒ2" → 2, etc.
+ */
+function parseEquationIndex(label: string): number {
+  return parseInt(label.slice(1), 10) || 0;
+}
+
+/**
+ * Maintains stable labels across query mutations within a session.
  *
  * Labels are compacted sequentially (A, B, C...) on fresh page loads, but
  * preserved with gaps during a session (e.g. deleting B keeps A, C rather
@@ -48,24 +78,24 @@ export function getNextLabelIndex(
  * navigation), labels are reassigned sequentially.
  */
 export function useStableLabelIndices(queries: BaseMetricQuery[]) {
-  const indicesRef = useRef<number[]>([]);
+  const labelsRef = useRef<string[]>([]);
 
-  if (indicesRef.current.length !== queries.length) {
-    indicesRef.current = assignSequentialLabels(queries);
+  if (labelsRef.current.length !== queries.length) {
+    labelsRef.current = assignSequentialLabels(queries);
   }
 
   return useMemo(
     () => ({
-      getLabel(i: number): number {
-        return indicesRef.current[i] ?? i;
+      getLabel(i: number): string {
+        return labelsRef.current[i] ?? getFunctionLabel(i);
       },
-      insert(position: number, labelIndex: number) {
-        indicesRef.current = indicesRef.current.toSpliced(position, 0, labelIndex);
+      insert(position: number, label: string) {
+        labelsRef.current = labelsRef.current.toSpliced(position, 0, label);
       },
       remove(position: number) {
-        indicesRef.current = indicesRef.current.filter((_, j) => j !== position);
+        labelsRef.current = labelsRef.current.filter((_, j) => j !== position);
       },
     }),
-    []
+    [] // stable — all methods close over labelsRef which is a stable ref
   );
 }

--- a/static/app/views/explore/metrics/hooks/useStableLabels.tsx
+++ b/static/app/views/explore/metrics/hooks/useStableLabels.tsx
@@ -37,7 +37,7 @@ export function getNextLabel(
   const queryFilter = isEquation ? isVisualizeEquation : isVisualizeFunction;
   const relevant = metricQueries.filter(q => queryFilter(q.queryParams.visualizes[0]!));
   if (relevant.length === 0) {
-    return getVisualizeLabel(0, isEquation);
+    return getVisualizeLabel(isEquation ? 1 : 0, isEquation);
   }
   const maxIndex = Math.max(
     ...relevant.map((q, i) => {

--- a/static/app/views/explore/metrics/hooks/useStableLabels.tsx
+++ b/static/app/views/explore/metrics/hooks/useStableLabels.tsx
@@ -77,7 +77,7 @@ function parseEquationIndex(label: string): number {
  * When the ref length doesn't match the query count (fresh load or external
  * navigation), labels are reassigned sequentially.
  */
-export function useStableLabelIndices(queries: BaseMetricQuery[]) {
+export function useStableLabels(queries: BaseMetricQuery[]) {
   const labelsRef = useRef<string[]>([]);
 
   if (labelsRef.current.length !== queries.length) {

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -143,7 +143,7 @@ describe('MetricPanel', () => {
     });
 
     it('renders the metric panel', async () => {
-      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
         organization,
         additionalWrapper: createWrapper({queryParams, traceMetric}),
       });
@@ -152,7 +152,7 @@ describe('MetricPanel', () => {
     });
 
     it('does not render the visualize label badge', async () => {
-      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
         organization,
         additionalWrapper: createWrapper({queryParams, traceMetric}),
       });
@@ -237,7 +237,7 @@ describe('MetricPanel', () => {
     });
 
     it('renders the metric panel', async () => {
-      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
         organization,
         additionalWrapper: createWrapper({queryParams, traceMetric}),
       });
@@ -246,17 +246,17 @@ describe('MetricPanel', () => {
     });
 
     it('renders the visualize label badge', async () => {
-      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
         organization,
         additionalWrapper: createWrapper({queryParams, traceMetric}),
       });
 
-      // The visualize label badge "A" (from getFunctionLabel(0)) should be present
+      // The visualize label badge "A" should be present
       expect(await screen.findByText('A')).toBeInTheDocument();
     });
 
     it('does not render orientation controls', async () => {
-      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} />, {
+      render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
         organization,
         additionalWrapper: createWrapper({queryParams, traceMetric}),
       });

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -251,7 +251,7 @@ describe('MetricPanel', () => {
         additionalWrapper: createWrapper({queryParams, traceMetric}),
       });
 
-      // The visualize label badge "A" (from getVisualizeLabel(0)) should be present
+      // The visualize label badge "A" (from getFunctionLabel(0)) should be present
       expect(await screen.findByText('A')).toBeInTheDocument();
     });
 

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -34,11 +34,17 @@ const TWO_MINUTE_DELAY = 120;
 
 interface MetricPanelProps {
   queryIndex: number;
+  queryLabel: string;
   traceMetric: TraceMetric;
   references?: Set<string>;
 }
 
-export function MetricPanel({traceMetric, queryIndex, references}: MetricPanelProps) {
+export function MetricPanel({
+  traceMetric,
+  queryIndex,
+  queryLabel,
+  references,
+}: MetricPanelProps) {
   const organization = useOrganization();
   const {
     orientation,
@@ -97,7 +103,7 @@ export function MetricPanel({traceMetric, queryIndex, references}: MetricPanelPr
             <Container paddingBottom={visualize.visible ? undefined : 'sm'}>
               <MetricToolbar
                 traceMetric={traceMetric}
-                queryIndex={queryIndex}
+                queryLabel={queryLabel}
                 references={references}
               />
             </Container>

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -37,6 +37,7 @@ function isTraceMetric(value: unknown): value is TraceMetric {
 export interface BaseMetricQuery {
   metric: TraceMetric;
   queryParams: ReadableQueryParams;
+  labelIndex?: number;
 }
 
 export interface MetricQuery extends BaseMetricQuery {

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -37,7 +37,7 @@ function isTraceMetric(value: unknown): value is TraceMetric {
 export interface BaseMetricQuery {
   metric: TraceMetric;
   queryParams: ReadableQueryParams;
-  labelIndex?: number;
+  label?: string;
 }
 
 export interface MetricQuery extends BaseMetricQuery {

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -40,7 +40,12 @@ export function MetricToolbar({traceMetric, queryIndex, references}: MetricToolb
     setVisualize(visualize.replace({visible: !visualize.visible}));
   }, [setVisualize, visualize]);
   const setTraceMetric = useSetTraceMetric();
-  const canRemoveMetric = metricQueries.length > 1;
+
+  // We need at least one metric visualized, but equations should always
+  // be removable
+  const canRemoveMetric =
+    metricQueries.filter(q => isVisualizeFunction(q.queryParams.visualizes[0]!)).length >
+      1 || isVisualizeEquation(visualize);
 
   const handleExpressionChange = useCallback(
     (newExpression: Expression) => {

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -26,12 +26,12 @@ import {
 } from 'sentry/views/explore/queryParams/visualize';
 
 interface MetricToolbarProps {
-  queryIndex: number;
+  queryLabel: string;
   traceMetric: TraceMetric;
   references?: Set<string>;
 }
 
-export function MetricToolbar({traceMetric, queryIndex, references}: MetricToolbarProps) {
+export function MetricToolbar({traceMetric, queryLabel, references}: MetricToolbarProps) {
   const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const visualize = useMetricVisualize();
@@ -75,7 +75,7 @@ export function MetricToolbar({traceMetric, queryIndex, references}: MetricToolb
         paddingTop="md"
       >
         <VisualizeLabel
-          index={queryIndex}
+          label={queryLabel}
           visualize={visualize}
           onClick={toggleVisibility}
         />
@@ -124,7 +124,7 @@ export function MetricToolbar({traceMetric, queryIndex, references}: MetricToolb
       data-test-id="metric-toolbar"
     >
       <VisualizeLabel
-        index={queryIndex}
+        label={queryLabel}
         visualize={visualize}
         onClick={toggleVisibility}
       />

--- a/static/app/views/explore/metrics/metricToolbar/visualizeLabel.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/visualizeLabel.tsx
@@ -8,22 +8,16 @@ import {IconChevron, IconShow} from 'sentry/icons';
 import {IconHide} from 'sentry/icons/iconHide';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
-import {
-  isVisualizeEquation,
-  type Visualize,
-} from 'sentry/views/explore/queryParams/visualize';
-import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 
 interface VisualizeLabelProps {
-  index: number;
+  label: string;
   onClick: MouseEventHandler<HTMLDivElement>;
   visualize: Visualize;
 }
 
-export function VisualizeLabel({index, onClick, visualize}: VisualizeLabelProps) {
+export function VisualizeLabel({label, onClick, visualize}: VisualizeLabelProps) {
   const organization = useOrganization();
-  const isEquation = isVisualizeEquation(visualize);
-  const label = getVisualizeLabel(index, isEquation);
 
   if (canUseMetricsUIRefresh(organization)) {
     return (

--- a/static/app/views/explore/metrics/metricToolbar/visualizeLabel.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/visualizeLabel.tsx
@@ -8,7 +8,10 @@ import {IconChevron, IconShow} from 'sentry/icons';
 import {IconHide} from 'sentry/icons/iconHide';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {canUseMetricsUIRefresh} from 'sentry/views/explore/metrics/metricsFlags';
-import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {
+  isVisualizeEquation,
+  type Visualize,
+} from 'sentry/views/explore/queryParams/visualize';
 import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 interface VisualizeLabelProps {
@@ -19,6 +22,8 @@ interface VisualizeLabelProps {
 
 export function VisualizeLabel({index, onClick, visualize}: VisualizeLabelProps) {
   const organization = useOrganization();
+  const isEquation = isVisualizeEquation(visualize);
+  const label = getVisualizeLabel(index, isEquation);
 
   if (canUseMetricsUIRefresh(organization)) {
     return (
@@ -32,7 +37,7 @@ export function VisualizeLabel({index, onClick, visualize}: VisualizeLabelProps)
           <IconChevron size="md" direction={visualize.visible ? 'down' : 'right'} />
           <RefreshLabel justify="center" align="center">
             <Text as="span" bold variant="accent">
-              {getVisualizeLabel(index)}
+              {label}
             </Text>
           </RefreshLabel>
         </Flex>
@@ -40,7 +45,6 @@ export function VisualizeLabel({index, onClick, visualize}: VisualizeLabelProps)
     );
   }
 
-  const label = getVisualizeLabel(index);
   const icon = visualize.visible ? <IconShow /> : <IconHide />;
 
   return (

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -612,4 +612,59 @@ describe('MetricsTabContent', () => {
     expect(await screen.findByText('Add Metric')).toBeInTheDocument();
     expect(screen.getByText('Add Equation')).toBeInTheDocument();
   });
+
+  it('disables both Add Metric and Add Equation buttons when the maximum number of metric queries is reached', async () => {
+    const metricQueryWithGroupBy = JSON.stringify({
+      metric: {name: 'bar', type: 'distribution'},
+      query: '',
+      aggregateFields: [
+        {groupBy: 'environment'},
+        {yAxes: ['per_second(bar)'], displayType: 'line'},
+      ],
+      aggregateSortBys: [],
+      mode: 'aggregate',
+    });
+    const orgWithFeature = OrganizationFixture({
+      features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+    });
+    render(
+      <ProviderWrapper>
+        <MetricsTabContent datePageFilterProps={datePageFilterProps} />
+      </ProviderWrapper>,
+      {
+        organization: orgWithFeature,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/:orgId/explore/metrics/',
+            query: {
+              start: '2025-04-10T14%3A37%3A55',
+              end: '2025-04-10T20%3A04%3A51',
+              metric: [
+                metricQueryWithGroupBy,
+                metricQueryWithGroupBy,
+                metricQueryWithGroupBy,
+                metricQueryWithGroupBy,
+                metricQueryWithGroupBy,
+                metricQueryWithGroupBy,
+                metricQueryWithGroupBy,
+              ],
+              title: 'Test Title',
+            },
+          },
+          route: '/organizations/:orgId/explore/metrics/',
+        },
+      }
+    );
+    expect(await screen.findByText('Add Metric')).toBeInTheDocument();
+    expect(screen.getByText('Add Equation')).toBeInTheDocument();
+
+    // Only 7 entries -> both buttons are enabled
+    expect(screen.getByRole('button', {name: 'Add Metric'})).toBeEnabled();
+    expect(screen.getByRole('button', {name: 'Add Equation'})).toBeEnabled();
+
+    // Add an entry, 8 entries -> both buttons are disabled
+    await userEvent.click(screen.getByRole('button', {name: 'Add Metric'}));
+    expect(screen.getByRole('button', {name: 'Add Metric'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Add Equation'})).toBeDisabled();
+  });
 });

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -43,6 +43,7 @@ import {
   isVisualizeEquation,
   isVisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 export const METRICS_CHART_GROUP = 'metrics-charts-group';
 
 type MetricsTabProps = {
@@ -91,6 +92,11 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
     isVisualizeEquation(q.queryParams.visualizes[0]!)
   ).length;
 
+  // Cannot add metric queries beyond Z
+  const isAddMetricDisabled =
+    metricCount >= MAX_METRIC_QUERIES ||
+    getFunctionLabel(Math.max(...metricQueries.map(q => q.labelIndex ?? 0))) === 'Z';
+
   if (canUseMetricsUIRefresh(organization)) {
     return (
       <ExploreBodySearch>
@@ -107,7 +113,7 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
             <Flex gap="sm" align="center">
               <ToolbarVisualizeAddChart
                 add={addMetricQuery}
-                disabled={metricCount >= MAX_METRIC_QUERIES}
+                disabled={isAddMetricDisabled}
                 label={t('Add Metric')}
                 display="button"
               />
@@ -166,6 +172,11 @@ function MetricsQueryBuilderSection() {
     return null;
   }
 
+  // Cannot add metric queries beyond Z
+  const isAddMetricDisabled =
+    metricCount >= MAX_METRIC_QUERIES ||
+    getFunctionLabel(Math.max(...metricQueries.map(q => q.labelIndex ?? 0))) === 'Z';
+
   return (
     <MetricsQueryBuilderContainer borderTop="primary" padding="md" style={{flexGrow: 0}}>
       <Flex direction="column" gap="lg" align="start">
@@ -193,7 +204,7 @@ function MetricsQueryBuilderSection() {
         <Flex direction="row" gap="sm" align="center" minWidth={0} width="100%">
           <ToolbarVisualizeAddChart
             add={addMetricQuery}
-            disabled={metricCount >= MAX_METRIC_QUERIES}
+            disabled={isAddMetricDisabled}
             label={t('Add Metric')}
           />
           {hasEquations && (
@@ -234,6 +245,11 @@ function MetricsTabBodySection() {
     isVisualizeEquation(q.queryParams.visualizes[0]!)
   ).length;
 
+  // Cannot add metric queries beyond Z
+  const isAddMetricDisabled =
+    metricCount >= MAX_METRIC_QUERIES ||
+    getFunctionLabel(Math.max(...metricQueries.map(q => q.labelIndex ?? 0))) === 'Z';
+
   if (canUseMetricsUIRefresh(organization)) {
     return (
       <ExploreContentSection>
@@ -263,7 +279,7 @@ function MetricsTabBodySection() {
             <Flex gap="sm" direction="row">
               <ToolbarVisualizeAddChart
                 add={addMetricQuery}
-                disabled={metricCount >= MAX_METRIC_QUERIES}
+                disabled={isAddMetricDisabled}
                 label={t('Add Metric')}
                 display="button"
               />

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -29,6 +29,8 @@ import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQu
 import {MetricToolbar} from 'sentry/views/explore/metrics/metricToolbar';
 import {MetricSaveAs} from 'sentry/views/explore/metrics/metricToolbar/metricSaveAs';
 import {
+  MAX_EQUATION_QUERIES,
+  MAX_METRIC_QUERIES,
   MultiMetricsQueryParamsProvider,
   useAddMetricQuery,
   useMultiMetricsQueryParams,
@@ -37,8 +39,10 @@ import {
   FilterBarWithSaveAsContainer,
   StyledPageFilterBar,
 } from 'sentry/views/explore/metrics/styles';
-
-const MAX_METRICS_ALLOWED = 8;
+import {
+  isVisualizeEquation,
+  isVisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
 export const METRICS_CHART_GROUP = 'metrics-charts-group';
 
 type MetricsTabProps = {
@@ -80,6 +84,13 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
   const addEquationQuery = useAddMetricQuery({type: 'equation'});
   const hasEquations = canUseMetricsEquations(organization);
 
+  const metricCount = metricQueries.filter(
+    q => !isVisualizeEquation(q.queryParams.visualizes[0]!)
+  ).length;
+  const equationCount = metricQueries.filter(q =>
+    isVisualizeEquation(q.queryParams.visualizes[0]!)
+  ).length;
+
   if (canUseMetricsUIRefresh(organization)) {
     return (
       <ExploreBodySearch>
@@ -96,7 +107,7 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
             <Flex gap="sm" align="center">
               <ToolbarVisualizeAddChart
                 add={addMetricQuery}
-                disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+                disabled={metricCount >= MAX_METRIC_QUERIES}
                 label={t('Add Metric')}
                 display="button"
               />
@@ -105,7 +116,7 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
                 <ToolbarVisualizeAddChart
                   display="button"
                   add={addEquationQuery}
-                  disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+                  disabled={equationCount >= MAX_EQUATION_QUERIES}
                   label={t('Add Equation')}
                 />
               )}
@@ -144,6 +155,13 @@ function MetricsQueryBuilderSection() {
   const hasEquations = canUseMetricsEquations(organization);
   const references = useMetricReferences();
 
+  const metricCount = metricQueries.filter(
+    q => !isVisualizeEquation(q.queryParams.visualizes[0]!)
+  ).length;
+  const equationCount = metricQueries.filter(q =>
+    isVisualizeEquation(q.queryParams.visualizes[0]!)
+  ).length;
+
   if (canUseMetricsUIRefresh(organization)) {
     return null;
   }
@@ -152,9 +170,12 @@ function MetricsQueryBuilderSection() {
     <MetricsQueryBuilderContainer borderTop="primary" padding="md" style={{flexGrow: 0}}>
       <Flex direction="column" gap="lg" align="start">
         {metricQueries.map((metricQuery, index) => {
+          // The key needs to differentiate between equations and functions to
+          // avoid key collisions since the label indices can overlap
+          const key = `queryBuilder-${isVisualizeEquation(metricQuery.queryParams.visualizes[0]!) ? 'eq' : 'm'}-${metricQuery.labelIndex ?? index}`;
           return (
             <MetricsQueryParamsProvider
-              key={`queryBuilder-${index}`}
+              key={key}
               queryParams={metricQuery.queryParams}
               setQueryParams={metricQuery.setQueryParams}
               traceMetric={metricQuery.metric}
@@ -163,7 +184,7 @@ function MetricsQueryBuilderSection() {
             >
               <MetricToolbar
                 traceMetric={metricQuery.metric}
-                queryIndex={index}
+                queryIndex={metricQuery.labelIndex ?? index}
                 references={references}
               />
             </MetricsQueryParamsProvider>
@@ -172,13 +193,13 @@ function MetricsQueryBuilderSection() {
         <Flex direction="row" gap="sm" align="center" minWidth={0} width="100%">
           <ToolbarVisualizeAddChart
             add={addMetricQuery}
-            disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+            disabled={metricCount >= MAX_METRIC_QUERIES}
             label={t('Add Metric')}
           />
           {hasEquations && (
             <ToolbarVisualizeAddChart
               add={addEquationQuery}
-              disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+              disabled={equationCount >= MAX_EQUATION_QUERIES}
               label={t('Add Equation')}
             />
           )}
@@ -206,15 +227,25 @@ function MetricsTabBodySection() {
   });
   const references = useMetricReferences();
 
+  const metricCount = metricQueries.filter(q =>
+    isVisualizeFunction(q.queryParams.visualizes[0]!)
+  ).length;
+  const equationCount = metricQueries.filter(q =>
+    isVisualizeEquation(q.queryParams.visualizes[0]!)
+  ).length;
+
   if (canUseMetricsUIRefresh(organization)) {
     return (
       <ExploreContentSection>
         <Stack>
           <WidgetSyncContextProvider groupName={METRICS_CHART_GROUP}>
             {metricQueries.map((metricQuery, index) => {
+              // The key needs to differentiate between equations and functions to
+              // avoid key collisions since the label indices can overlap
+              const key = `queryPanel-${isVisualizeEquation(metricQuery.queryParams.visualizes[0]!) ? 'eq' : 'm'}-${metricQuery.labelIndex ?? index}`;
               return (
                 <MetricsQueryParamsProvider
-                  key={`queryPanel-${index}`}
+                  key={key}
                   queryParams={metricQuery.queryParams}
                   setQueryParams={metricQuery.setQueryParams}
                   traceMetric={metricQuery.metric}
@@ -223,7 +254,7 @@ function MetricsTabBodySection() {
                 >
                   <MetricPanel
                     traceMetric={metricQuery.metric}
-                    queryIndex={index}
+                    queryIndex={metricQuery.labelIndex ?? index}
                     references={references}
                   />
                 </MetricsQueryParamsProvider>
@@ -232,7 +263,7 @@ function MetricsTabBodySection() {
             <Flex gap="sm" direction="row">
               <ToolbarVisualizeAddChart
                 add={addMetricQuery}
-                disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+                disabled={metricCount >= MAX_METRIC_QUERIES}
                 label={t('Add Metric')}
                 display="button"
               />
@@ -240,7 +271,7 @@ function MetricsTabBodySection() {
                 <ToolbarVisualizeAddChart
                   display="button"
                   add={addEquationQuery}
-                  disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+                  disabled={equationCount >= MAX_EQUATION_QUERIES}
                   label={t('Add Equation')}
                 />
               )}
@@ -257,9 +288,12 @@ function MetricsTabBodySection() {
         <Stack>
           <WidgetSyncContextProvider groupName={METRICS_CHART_GROUP}>
             {metricQueries.map((metricQuery, index) => {
+              // The key needs to differentiate between equations and functions to
+              // avoid key collisions since the label indices can overlap
+              const key = `queryPanel-${isVisualizeEquation(metricQuery.queryParams.visualizes[0]!) ? 'eq' : 'm'}-${metricQuery.labelIndex ?? index}`;
               return (
                 <MetricsQueryParamsProvider
-                  key={`queryPanel-${index}`}
+                  key={key}
                   queryParams={metricQuery.queryParams}
                   setQueryParams={metricQuery.setQueryParams}
                   traceMetric={metricQuery.metric}
@@ -268,7 +302,7 @@ function MetricsTabBodySection() {
                 >
                   <MetricPanel
                     traceMetric={metricQuery.metric}
-                    queryIndex={index}
+                    queryIndex={metricQuery.labelIndex ?? index}
                     references={references}
                   />
                 </MetricsQueryParamsProvider>

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -29,8 +29,7 @@ import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQu
 import {MetricToolbar} from 'sentry/views/explore/metrics/metricToolbar';
 import {MetricSaveAs} from 'sentry/views/explore/metrics/metricToolbar/metricSaveAs';
 import {
-  MAX_EQUATION_QUERIES,
-  MAX_METRIC_QUERIES,
+  MAX_METRICS_ALLOWED,
   MultiMetricsQueryParamsProvider,
   useAddMetricQuery,
   useMultiMetricsQueryParams,
@@ -39,10 +38,6 @@ import {
   FilterBarWithSaveAsContainer,
   StyledPageFilterBar,
 } from 'sentry/views/explore/metrics/styles';
-import {
-  isVisualizeEquation,
-  isVisualizeFunction,
-} from 'sentry/views/explore/queryParams/visualize';
 export const METRICS_CHART_GROUP = 'metrics-charts-group';
 
 type MetricsTabProps = {
@@ -84,16 +79,10 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
   const addEquationQuery = useAddMetricQuery({type: 'equation'});
   const hasEquations = canUseMetricsEquations(organization);
 
-  const metricCount = metricQueries.filter(
-    q => !isVisualizeEquation(q.queryParams.visualizes[0]!)
-  ).length;
-  const equationCount = metricQueries.filter(q =>
-    isVisualizeEquation(q.queryParams.visualizes[0]!)
-  ).length;
-
   // Cannot add metric queries beyond Z
   const isAddMetricDisabled =
-    metricCount >= MAX_METRIC_QUERIES || metricQueries.some(q => q.label === 'Z');
+    metricQueries.length >= MAX_METRICS_ALLOWED ||
+    metricQueries.some(q => q.label === 'Z');
 
   if (canUseMetricsUIRefresh(organization)) {
     return (
@@ -120,7 +109,7 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
                 <ToolbarVisualizeAddChart
                   display="button"
                   add={addEquationQuery}
-                  disabled={equationCount >= MAX_EQUATION_QUERIES}
+                  disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
                   label={t('Add Equation')}
                 />
               )}
@@ -159,20 +148,14 @@ function MetricsQueryBuilderSection() {
   const hasEquations = canUseMetricsEquations(organization);
   const references = useMetricReferences();
 
-  const metricCount = metricQueries.filter(
-    q => !isVisualizeEquation(q.queryParams.visualizes[0]!)
-  ).length;
-  const equationCount = metricQueries.filter(q =>
-    isVisualizeEquation(q.queryParams.visualizes[0]!)
-  ).length;
-
   if (canUseMetricsUIRefresh(organization)) {
     return null;
   }
 
   // Cannot add metric queries beyond Z
   const isAddMetricDisabled =
-    metricCount >= MAX_METRIC_QUERIES || metricQueries.some(q => q.label === 'Z');
+    metricQueries.length >= MAX_METRICS_ALLOWED ||
+    metricQueries.some(q => q.label === 'Z');
 
   return (
     <MetricsQueryBuilderContainer borderTop="primary" padding="md" style={{flexGrow: 0}}>
@@ -204,7 +187,7 @@ function MetricsQueryBuilderSection() {
           {hasEquations && (
             <ToolbarVisualizeAddChart
               add={addEquationQuery}
-              disabled={equationCount >= MAX_EQUATION_QUERIES}
+              disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
               label={t('Add Equation')}
             />
           )}
@@ -232,16 +215,10 @@ function MetricsTabBodySection() {
   });
   const references = useMetricReferences();
 
-  const metricCount = metricQueries.filter(q =>
-    isVisualizeFunction(q.queryParams.visualizes[0]!)
-  ).length;
-  const equationCount = metricQueries.filter(q =>
-    isVisualizeEquation(q.queryParams.visualizes[0]!)
-  ).length;
-
   // Cannot add metric queries beyond Z
   const isAddMetricDisabled =
-    metricCount >= MAX_METRIC_QUERIES || metricQueries.some(q => q.label === 'Z');
+    metricQueries.length >= MAX_METRICS_ALLOWED ||
+    metricQueries.some(q => q.label === 'Z');
 
   if (canUseMetricsUIRefresh(organization)) {
     return (
@@ -278,7 +255,7 @@ function MetricsTabBodySection() {
                 <ToolbarVisualizeAddChart
                   display="button"
                   add={addEquationQuery}
-                  disabled={equationCount >= MAX_EQUATION_QUERIES}
+                  disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
                   label={t('Add Equation')}
                 />
               )}

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -43,7 +43,6 @@ import {
   isVisualizeEquation,
   isVisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
-import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 export const METRICS_CHART_GROUP = 'metrics-charts-group';
 
 type MetricsTabProps = {
@@ -94,8 +93,7 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
 
   // Cannot add metric queries beyond Z
   const isAddMetricDisabled =
-    metricCount >= MAX_METRIC_QUERIES ||
-    getFunctionLabel(Math.max(...metricQueries.map(q => q.labelIndex ?? 0))) === 'Z';
+    metricCount >= MAX_METRIC_QUERIES || metricQueries.some(q => q.label === 'Z');
 
   if (canUseMetricsUIRefresh(organization)) {
     return (
@@ -174,16 +172,13 @@ function MetricsQueryBuilderSection() {
 
   // Cannot add metric queries beyond Z
   const isAddMetricDisabled =
-    metricCount >= MAX_METRIC_QUERIES ||
-    getFunctionLabel(Math.max(...metricQueries.map(q => q.labelIndex ?? 0))) === 'Z';
+    metricCount >= MAX_METRIC_QUERIES || metricQueries.some(q => q.label === 'Z');
 
   return (
     <MetricsQueryBuilderContainer borderTop="primary" padding="md" style={{flexGrow: 0}}>
       <Flex direction="column" gap="lg" align="start">
         {metricQueries.map((metricQuery, index) => {
-          // The key needs to differentiate between equations and functions to
-          // avoid key collisions since the label indices can overlap
-          const key = `queryBuilder-${isVisualizeEquation(metricQuery.queryParams.visualizes[0]!) ? 'eq' : 'm'}-${metricQuery.labelIndex ?? index}`;
+          const key = `queryBuilder-${metricQuery.label ?? index}`;
           return (
             <MetricsQueryParamsProvider
               key={key}
@@ -195,7 +190,7 @@ function MetricsQueryBuilderSection() {
             >
               <MetricToolbar
                 traceMetric={metricQuery.metric}
-                queryIndex={metricQuery.labelIndex ?? index}
+                queryLabel={metricQuery.label ?? ''}
                 references={references}
               />
             </MetricsQueryParamsProvider>
@@ -247,8 +242,7 @@ function MetricsTabBodySection() {
 
   // Cannot add metric queries beyond Z
   const isAddMetricDisabled =
-    metricCount >= MAX_METRIC_QUERIES ||
-    getFunctionLabel(Math.max(...metricQueries.map(q => q.labelIndex ?? 0))) === 'Z';
+    metricCount >= MAX_METRIC_QUERIES || metricQueries.some(q => q.label === 'Z');
 
   if (canUseMetricsUIRefresh(organization)) {
     return (
@@ -256,9 +250,7 @@ function MetricsTabBodySection() {
         <Stack>
           <WidgetSyncContextProvider groupName={METRICS_CHART_GROUP}>
             {metricQueries.map((metricQuery, index) => {
-              // The key needs to differentiate between equations and functions to
-              // avoid key collisions since the label indices can overlap
-              const key = `queryPanel-${isVisualizeEquation(metricQuery.queryParams.visualizes[0]!) ? 'eq' : 'm'}-${metricQuery.labelIndex ?? index}`;
+              const key = `queryPanel-${metricQuery.label ?? index}`;
               return (
                 <MetricsQueryParamsProvider
                   key={key}
@@ -270,7 +262,8 @@ function MetricsTabBodySection() {
                 >
                   <MetricPanel
                     traceMetric={metricQuery.metric}
-                    queryIndex={metricQuery.labelIndex ?? index}
+                    queryIndex={index}
+                    queryLabel={metricQuery.label ?? ''}
                     references={references}
                   />
                 </MetricsQueryParamsProvider>
@@ -304,9 +297,7 @@ function MetricsTabBodySection() {
         <Stack>
           <WidgetSyncContextProvider groupName={METRICS_CHART_GROUP}>
             {metricQueries.map((metricQuery, index) => {
-              // The key needs to differentiate between equations and functions to
-              // avoid key collisions since the label indices can overlap
-              const key = `queryPanel-${isVisualizeEquation(metricQuery.queryParams.visualizes[0]!) ? 'eq' : 'm'}-${metricQuery.labelIndex ?? index}`;
+              const key = `queryPanel-${metricQuery.label ?? index}`;
               return (
                 <MetricsQueryParamsProvider
                   key={key}
@@ -318,7 +309,8 @@ function MetricsTabBodySection() {
                 >
                   <MetricPanel
                     traceMetric={metricQuery.metric}
-                    queryIndex={metricQuery.labelIndex ?? index}
+                    queryIndex={index}
+                    queryLabel={metricQuery.label ?? ''}
                     references={references}
                   />
                 </MetricsQueryParamsProvider>

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -178,10 +178,9 @@ function MetricsQueryBuilderSection() {
     <MetricsQueryBuilderContainer borderTop="primary" padding="md" style={{flexGrow: 0}}>
       <Flex direction="column" gap="lg" align="start">
         {metricQueries.map((metricQuery, index) => {
-          const key = `queryBuilder-${metricQuery.label ?? index}`;
           return (
             <MetricsQueryParamsProvider
-              key={key}
+              key={`queryBuilder-${metricQuery.label ?? index}`}
               queryParams={metricQuery.queryParams}
               setQueryParams={metricQuery.setQueryParams}
               traceMetric={metricQuery.metric}
@@ -250,10 +249,9 @@ function MetricsTabBodySection() {
         <Stack>
           <WidgetSyncContextProvider groupName={METRICS_CHART_GROUP}>
             {metricQueries.map((metricQuery, index) => {
-              const key = `queryPanel-${metricQuery.label ?? index}`;
               return (
                 <MetricsQueryParamsProvider
-                  key={key}
+                  key={`queryPanel-${metricQuery.label ?? index}`}
                   queryParams={metricQuery.queryParams}
                   setQueryParams={metricQuery.setQueryParams}
                   traceMetric={metricQuery.metric}
@@ -297,10 +295,9 @@ function MetricsTabBodySection() {
         <Stack>
           <WidgetSyncContextProvider groupName={METRICS_CHART_GROUP}>
             {metricQueries.map((metricQuery, index) => {
-              const key = `queryPanel-${metricQuery.label ?? index}`;
               return (
                 <MetricsQueryParamsProvider
-                  key={key}
+                  key={`queryPanel-${metricQuery.label ?? index}`}
                   queryParams={metricQuery.queryParams}
                   setQueryParams={metricQuery.setQueryParams}
                   traceMetric={metricQuery.metric}

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -28,6 +28,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
 
     expect(result.current).toEqual([
       {
+        labelIndex: 0,
         metric: {name: '', type: ''},
         queryParams: new ReadableQueryParams({
           extrapolate: true,

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -28,7 +28,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
 
     expect(result.current).toEqual([
       {
-        labelIndex: 0,
+        label: 'A',
         metric: {name: '', type: ''},
         queryParams: new ReadableQueryParams({
           extrapolate: true,

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -1,7 +1,7 @@
 import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders, screen} from 'sentry-test/reactTestingLibrary';
 
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -16,8 +16,25 @@ import {
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
 
+function TestableMetricComponent() {
+  const metricQueries = useMultiMetricsQueryParams();
+
+  return (
+    <div>
+      {metricQueries.map((metricQuery, index) => (
+        <div key={index}>{metricQuery.label}</div>
+      ))}
+    </div>
+  );
+}
+
 function Wrapper({children}: {children: ReactNode}) {
-  return <MultiMetricsQueryParamsProvider>{children}</MultiMetricsQueryParamsProvider>;
+  return (
+    <MultiMetricsQueryParamsProvider>
+      <TestableMetricComponent />
+      {children}
+    </MultiMetricsQueryParamsProvider>
+  );
 }
 
 describe('MultiMetricsQueryParamsProvider', () => {
@@ -267,6 +284,86 @@ describe('MultiMetricsQueryParamsProvider', () => {
     ]);
   });
 
+  describe('stable labels', () => {
+    it('preserves label B when A is deleted from [A, B]', () => {
+      const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/metrics/',
+            query: {
+              metric: [
+                JSON.stringify({
+                  metric: {name: 'foo', type: 'counter'},
+                  query: '',
+                  aggregateFields: [
+                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                  ],
+                  aggregateSortBys: [],
+                  mode: 'samples',
+                }),
+                JSON.stringify({
+                  metric: {name: 'bar', type: 'counter'},
+                  query: '',
+                  aggregateFields: [
+                    new VisualizeFunction('sum(value,bar,counter,-)').serialize(),
+                  ],
+                  aggregateSortBys: [],
+                  mode: 'samples',
+                }),
+              ],
+            },
+          },
+        },
+      });
+
+      expect(result.current).toHaveLength(2);
+      expect(result.current[0]).toEqual(expect.objectContaining({label: 'A'}));
+      expect(result.current[1]).toEqual(expect.objectContaining({label: 'B'}));
+
+      // Delete A
+      act(() => result.current[0]!.removeMetric());
+
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0]).toEqual(expect.objectContaining({label: 'B'}));
+    });
+
+    it('assigns correct labels for metrics and equations', () => {
+      const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/metrics/',
+            query: {
+              metric: [
+                JSON.stringify({
+                  metric: {name: 'foo', type: 'counter'},
+                  query: '',
+                  aggregateFields: [
+                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                  ],
+                  aggregateSortBys: [],
+                  mode: 'samples',
+                }),
+                JSON.stringify({
+                  metric: {name: '', type: ''},
+                  query: '',
+                  aggregateFields: [new VisualizeEquation(EQUATION_PREFIX).serialize()],
+                  aggregateSortBys: [],
+                  mode: 'samples',
+                }),
+              ],
+            },
+          },
+        },
+      });
+
+      expect(result.current).toHaveLength(2);
+      expect(result.current[0]).toEqual(expect.objectContaining({label: 'A'}));
+      expect(result.current[1]).toEqual(expect.objectContaining({label: 'ƒ1'}));
+    });
+  });
+
   describe('useAddMetricQuery', () => {
     it('adds new metric at the end of the list when adding without equations', () => {
       const {result, router} = renderHookWithProviders(useAddMetricQuery, {
@@ -458,6 +555,90 @@ describe('MultiMetricsQueryParamsProvider', () => {
           aggregateFields: [new VisualizeEquation(EQUATION_PREFIX).serialize()],
         })
       );
+    });
+
+    it('adds metric before equation with independent label sequences', () => {
+      const {result} = renderHookWithProviders(useAddMetricQuery, {
+        additionalWrapper: Wrapper,
+        organization: OrganizationFixture({
+          features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+        }),
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/metrics/',
+            query: {
+              metric: [
+                JSON.stringify({
+                  metric: {name: 'foo', type: 'counter'},
+                  query: '',
+                  aggregateFields: [
+                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                  ],
+                  aggregateSortBys: [],
+                  mode: 'samples',
+                }),
+                JSON.stringify({
+                  metric: {name: '', type: ''},
+                  query: '',
+                  aggregateFields: [new VisualizeEquation(EQUATION_PREFIX).serialize()],
+                  aggregateSortBys: [],
+                  mode: 'samples',
+                }),
+              ],
+            },
+          },
+        },
+      });
+
+      // Add a new metric — should be inserted before the equation
+      act(() => result.current());
+
+      expect(screen.getByText('A')).toBeInTheDocument();
+      expect(screen.getByText('B')).toBeInTheDocument();
+      expect(screen.getByText('ƒ1')).toBeInTheDocument();
+    });
+
+    it('increments the equation label from the last equation label counter', () => {
+      const {result} = renderHookWithProviders(useAddMetricQuery, {
+        additionalWrapper: Wrapper,
+        organization: OrganizationFixture({
+          features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+        }),
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/metrics/',
+            query: {
+              metric: [
+                JSON.stringify({
+                  metric: {name: 'foo', type: 'counter'},
+                  query: '',
+                  aggregateFields: [
+                    new VisualizeFunction('sum(value,foo,counter,-)').serialize(),
+                  ],
+                  aggregateSortBys: [],
+                  mode: 'samples',
+                }),
+                JSON.stringify({
+                  metric: {name: '', type: ''},
+                  query: '',
+                  aggregateFields: [new VisualizeEquation(EQUATION_PREFIX).serialize()],
+                  aggregateSortBys: [],
+                  mode: 'samples',
+                }),
+              ],
+            },
+          },
+        },
+        initialProps: {
+          type: 'equation',
+        },
+      });
+
+      act(() => result.current());
+
+      expect(screen.getByText('A')).toBeInTheDocument();
+      expect(screen.getByText('ƒ1')).toBeInTheDocument();
+      expect(screen.getByText('ƒ2')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -12,6 +12,10 @@ import {
   OPTIONS_BY_TYPE,
 } from 'sentry/views/explore/metrics/constants';
 import {
+  getNextLabelIndex,
+  useStableLabelIndices,
+} from 'sentry/views/explore/metrics/hooks/useStableLabelIndices';
+import {
   decodeMetricsQueryParams,
   defaultMetricQuery,
   encodeMetricQueryParams,
@@ -28,7 +32,11 @@ import {
   isVisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
 
+export const MAX_METRIC_QUERIES = 8;
+export const MAX_EQUATION_QUERIES = 8;
+
 interface MultiMetricsQueryParamsContextValue {
+  insertLabelAtIndex: (position: number, labelIndex: number) => void;
   metricQueries: MetricQuery[];
 }
 
@@ -51,9 +59,16 @@ export function MultiMetricsQueryParamsProvider({
 }: MultiMetricsQueryParamsProviderProps) {
   const location = useLocation();
   const navigate = useNavigate();
+  const rawQueries = getMultiMetricsQueryParamsFromLocation(location, allowUpTo);
+  const labels = useStableLabelIndices(rawQueries);
 
   const value = useMemo(() => {
-    const metricQueries = getMultiMetricsQueryParamsFromLocation(location, allowUpTo);
+    const metricQueries = rawQueries.map((query, i) => ({
+      ...query,
+      // Labels are injected adhoc so each session maintains a label for each query
+      // but the labels will compact sequentially on fresh page loads.
+      labelIndex: labels.getLabel(i),
+    }));
 
     function setQueryParamsForIndex(i: number) {
       return function (newQueryParams: ReadableQueryParams) {
@@ -67,6 +82,7 @@ export function MultiMetricsQueryParamsProvider({
             return {
               metric: metricQuery.metric,
               queryParams: newQueryParams,
+              labelIndex: metricQuery.labelIndex,
             };
           })
           .map((metricQuery: BaseMetricQuery) => encodeMetricQueryParams(metricQuery))
@@ -118,6 +134,7 @@ export function MultiMetricsQueryParamsProvider({
             return {
               queryParams: metricQuery.queryParams.replace({aggregateFields}),
               metric: newTraceMetric,
+              labelIndex: metricQuery.labelIndex,
             };
           })
           .map((metric: BaseMetricQuery) => encodeMetricQueryParams(metric))
@@ -135,6 +152,9 @@ export function MultiMetricsQueryParamsProvider({
           return;
         }
 
+        // Update labels before navigating so they stay stable
+        labels.remove(i);
+
         const target = {...location, query: {...location.query}};
 
         const newMetricQueries = metricQueries
@@ -149,6 +169,7 @@ export function MultiMetricsQueryParamsProvider({
     }
 
     return {
+      insertLabelAtIndex: labels.insert,
       metricQueries: metricQueries.map((metric: BaseMetricQuery, index: number) => {
         return {
           ...metric,
@@ -158,7 +179,7 @@ export function MultiMetricsQueryParamsProvider({
         };
       }),
     };
-  }, [allowUpTo, location, navigate]);
+  }, [labels, location, navigate, rawQueries]);
 
   return (
     <MultiMetricsQueryParamsContext value={value}>
@@ -193,11 +214,20 @@ export function useAddMetricQuery({
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
-  const {metricQueries}: {metricQueries: BaseMetricQuery[]} =
+  const {metricQueries, insertLabelAtIndex}: MultiMetricsQueryParamsContextValue =
     useMultiMetricsQueryParamsContext();
   const hasEquations = canUseMetricsEquations(organization);
 
   return function () {
+    const nextLabel = getNextLabelIndex(metricQueries, type);
+
+    if (type === 'aggregate' && nextLabel >= MAX_METRIC_QUERIES) {
+      return;
+    }
+    if (type === 'equation' && nextLabel > MAX_EQUATION_QUERIES) {
+      return;
+    }
+
     const target = {...location, query: {...location.query}};
     const equationStart = metricQueries.findIndex(metricQuery =>
       isVisualizeEquation(metricQuery.queryParams.visualizes[0]!)
@@ -210,8 +240,15 @@ export function useAddMetricQuery({
     const canDuplicate =
       type === 'aggregate' &&
       lastAggregate?.queryParams.visualizes.some(isVisualizeFunction);
-    const newQuery = canDuplicate ? lastAggregate : defaultMetricQuery({type});
-    const newMetricQueries = metricQueries.toSpliced(insertAt, 0, newQuery);
+    const newQuery = canDuplicate
+      ? {...lastAggregate, labelIndex: nextLabel}
+      : defaultMetricQuery({type});
+
+    // Update label ref before navigating so labels stay stable
+    insertLabelAtIndex(insertAt, nextLabel);
+
+    const baseQueries: BaseMetricQuery[] = metricQueries;
+    const newMetricQueries = baseQueries.toSpliced(insertAt, 0, newQuery);
     target.query.metric = newMetricQueries
       .map((metricQuery: BaseMetricQuery) => encodeMetricQueryParams(metricQuery))
       .filter(defined)

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -32,8 +32,7 @@ import {
   isVisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
 
-export const MAX_METRIC_QUERIES = 8;
-export const MAX_EQUATION_QUERIES = 8;
+export const MAX_METRICS_ALLOWED = 8;
 
 interface MultiMetricsQueryParamsContextValue {
   insertLabelAtIndex: (position: number, label: string) => void;
@@ -224,20 +223,6 @@ export function useAddMetricQuery({
 
   return function () {
     const nextLabel = getNextLabel(metricQueries, type);
-
-    const aggregateCount = metricQueries.filter(q =>
-      isVisualizeFunction(q.queryParams.visualizes[0]!)
-    ).length;
-    const equationCount = metricQueries.filter(q =>
-      isVisualizeEquation(q.queryParams.visualizes[0]!)
-    ).length;
-
-    if (type === 'aggregate' && aggregateCount >= MAX_METRIC_QUERIES) {
-      return;
-    }
-    if (type === 'equation' && equationCount >= MAX_EQUATION_QUERIES) {
-      return;
-    }
 
     const target = {...location, query: {...location.query}};
     const equationStart = metricQueries.findIndex(metricQuery =>

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -12,7 +12,7 @@ import {
   OPTIONS_BY_TYPE,
 } from 'sentry/views/explore/metrics/constants';
 import {
-  getNextLabelIndex,
+  getNextLabel,
   useStableLabelIndices,
 } from 'sentry/views/explore/metrics/hooks/useStableLabelIndices';
 import {
@@ -36,7 +36,7 @@ export const MAX_METRIC_QUERIES = 8;
 export const MAX_EQUATION_QUERIES = 8;
 
 interface MultiMetricsQueryParamsContextValue {
-  insertLabelAtIndex: (position: number, labelIndex: number) => void;
+  insertLabelAtIndex: (position: number, label: string) => void;
   metricQueries: MetricQuery[];
 }
 
@@ -67,7 +67,7 @@ export function MultiMetricsQueryParamsProvider({
       ...query,
       // Labels are injected adhoc so each session maintains a label for each query
       // but the labels will compact sequentially on fresh page loads.
-      labelIndex: labels.getLabel(i),
+      label: labels.getLabel(i),
     }));
 
     function setQueryParamsForIndex(i: number) {
@@ -82,7 +82,7 @@ export function MultiMetricsQueryParamsProvider({
             return {
               metric: metricQuery.metric,
               queryParams: newQueryParams,
-              labelIndex: metricQuery.labelIndex,
+              label: metricQuery.label,
             };
           })
           .map((metricQuery: BaseMetricQuery) => encodeMetricQueryParams(metricQuery))
@@ -134,7 +134,7 @@ export function MultiMetricsQueryParamsProvider({
             return {
               queryParams: metricQuery.queryParams.replace({aggregateFields}),
               metric: newTraceMetric,
-              labelIndex: metricQuery.labelIndex,
+              label: metricQuery.label,
             };
           })
           .map((metric: BaseMetricQuery) => encodeMetricQueryParams(metric))
@@ -219,12 +219,19 @@ export function useAddMetricQuery({
   const hasEquations = canUseMetricsEquations(organization);
 
   return function () {
-    const nextLabel = getNextLabelIndex(metricQueries, type);
+    const nextLabel = getNextLabel(metricQueries, type);
 
-    if (type === 'aggregate' && nextLabel >= MAX_METRIC_QUERIES) {
+    const aggregateCount = metricQueries.filter(q =>
+      isVisualizeFunction(q.queryParams.visualizes[0]!)
+    ).length;
+    const equationCount = metricQueries.filter(q =>
+      isVisualizeEquation(q.queryParams.visualizes[0]!)
+    ).length;
+
+    if (type === 'aggregate' && aggregateCount >= MAX_METRIC_QUERIES) {
       return;
     }
-    if (type === 'equation' && nextLabel > MAX_EQUATION_QUERIES) {
+    if (type === 'equation' && equationCount >= MAX_EQUATION_QUERIES) {
       return;
     }
 
@@ -241,7 +248,7 @@ export function useAddMetricQuery({
       type === 'aggregate' &&
       lastAggregate?.queryParams.visualizes.some(isVisualizeFunction);
     const newQuery = canDuplicate
-      ? {...lastAggregate, labelIndex: nextLabel}
+      ? {...lastAggregate, label: nextLabel}
       : defaultMetricQuery({type});
 
     // Update label ref before navigating so labels stay stable

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -13,8 +13,8 @@ import {
 } from 'sentry/views/explore/metrics/constants';
 import {
   getNextLabel,
-  useStableLabelIndices,
-} from 'sentry/views/explore/metrics/hooks/useStableLabelIndices';
+  useStableLabels,
+} from 'sentry/views/explore/metrics/hooks/useStableLabels';
 import {
   decodeMetricsQueryParams,
   defaultMetricQuery,
@@ -60,7 +60,7 @@ export function MultiMetricsQueryParamsProvider({
   const location = useLocation();
   const navigate = useNavigate();
   const rawQueries = getMultiMetricsQueryParamsFromLocation(location, allowUpTo);
-  const labels = useStableLabelIndices(rawQueries);
+  const labels = useStableLabels(rawQueries);
 
   const value = useMemo(() => {
     const metricQueries = rawQueries.map((query, i) => ({

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -59,7 +59,11 @@ export function MultiMetricsQueryParamsProvider({
 }: MultiMetricsQueryParamsProviderProps) {
   const location = useLocation();
   const navigate = useNavigate();
-  const rawQueries = getMultiMetricsQueryParamsFromLocation(location, allowUpTo);
+  const rawQueries = useMemo(
+    () => getMultiMetricsQueryParamsFromLocation(location, allowUpTo),
+    [location, allowUpTo]
+  );
+
   const labels = useStableLabels(rawQueries);
 
   const value = useMemo(() => {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -18,7 +18,10 @@ import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useAddMetricToDashboard} from 'sentry/views/explore/metrics/hooks/useAddMetricToDashboard';
 import {useSaveMetricsMultiQuery} from 'sentry/views/explore/metrics/hooks/useSaveMetricsMultiQuery';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
-import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
+import {
+  isVisualize,
+  isVisualizeEquation,
+} from 'sentry/views/explore/queryParams/visualize';
 import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -114,9 +117,10 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
               ]
             : []),
           ...metricQueries.map((metricQuery, index) => {
+            const isEq = isVisualizeEquation(metricQuery.queryParams.visualizes[0]!);
             return {
               key: `add-to-dashboard-${index}`,
-              label: `${getVisualizeLabel(index)}: ${
+              label: `${getVisualizeLabel(metricQuery.labelIndex ?? index, isEq)}: ${
                 formatTraceMetricsFunction(
                   metricQuery.queryParams.aggregateFields
                     .filter(isVisualize)

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -18,11 +18,7 @@ import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useAddMetricToDashboard} from 'sentry/views/explore/metrics/hooks/useAddMetricToDashboard';
 import {useSaveMetricsMultiQuery} from 'sentry/views/explore/metrics/hooks/useSaveMetricsMultiQuery';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
-import {
-  isVisualize,
-  isVisualizeEquation,
-} from 'sentry/views/explore/queryParams/visualize';
-import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
+import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 import {canUseMetricsSavedQueriesUI} from './metricsFlags';
@@ -117,10 +113,9 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
               ]
             : []),
           ...metricQueries.map((metricQuery, index) => {
-            const isEq = isVisualizeEquation(metricQuery.queryParams.visualizes[0]!);
             return {
               key: `add-to-dashboard-${index}`,
-              label: `${getVisualizeLabel(metricQuery.labelIndex ?? index, isEq)}: ${
+              label: `${metricQuery.label ?? ''}: ${
                 formatTraceMetricsFunction(
                   metricQuery.queryParams.aggregateFields
                     .filter(isVisualize)

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -18,7 +18,11 @@ import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useAddMetricToDashboard} from 'sentry/views/explore/metrics/hooks/useAddMetricToDashboard';
 import {useSaveMetricsMultiQuery} from 'sentry/views/explore/metrics/hooks/useSaveMetricsMultiQuery';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
-import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
+import {
+  isVisualize,
+  isVisualizeEquation,
+} from 'sentry/views/explore/queryParams/visualize';
+import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 import {canUseMetricsSavedQueriesUI} from './metricsFlags';
@@ -115,7 +119,7 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
           ...metricQueries.map((metricQuery, index) => {
             return {
               key: `add-to-dashboard-${index}`,
-              label: `${metricQuery.label ?? ''}: ${
+              label: `${metricQuery.label ?? getVisualizeLabel(index, isVisualizeEquation(metricQuery.queryParams.visualizes[0]!))}: ${
                 formatTraceMetricsFunction(
                   metricQuery.queryParams.aggregateFields
                     .filter(isVisualize)

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -272,12 +272,20 @@ interface VisualizeLabelProps {
   visualize: Visualize;
 }
 
-export function getVisualizeLabel(index: number) {
+export function getFunctionLabel(index: number) {
   return String.fromCharCode('A'.charCodeAt(0) + index);
 }
 
+function getEquationLabel(index: number) {
+  return `ƒ${index}`;
+}
+
+export function getVisualizeLabel(labelIndex: number, isEquation: boolean): string {
+  return isEquation ? getEquationLabel(labelIndex) : getFunctionLabel(labelIndex);
+}
+
 function VisualizeLabel({index, onClick, visualize}: VisualizeLabelProps) {
-  const label = visualize.visible ? getVisualizeLabel(index) : <IconHide />;
+  const label = visualize.visible ? getFunctionLabel(index) : <IconHide />;
 
   return <Label onClick={onClick}>{label}</Label>;
 }

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -285,7 +285,11 @@ export function getVisualizeLabel(labelIndex: number, isEquation: boolean): stri
 }
 
 function VisualizeLabel({index, onClick, visualize}: VisualizeLabelProps) {
-  const label = visualize.visible ? getFunctionLabel(index) : <IconHide />;
+  const label = visualize.visible ? (
+    getVisualizeLabel(index, isVisualizeEquation(visualize))
+  ) : (
+    <IconHide />
+  );
 
   return <Label onClick={onClick}>{label}</Label>;
 }

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -285,11 +285,7 @@ export function getVisualizeLabel(labelIndex: number, isEquation: boolean): stri
 }
 
 function VisualizeLabel({index, onClick, visualize}: VisualizeLabelProps) {
-  const label = visualize.visible ? (
-    getVisualizeLabel(index, isVisualizeEquation(visualize))
-  ) : (
-    <IconHide />
-  );
+  const label = visualize.visible ? getFunctionLabel(index) : <IconHide />;
 
   return <Label onClick={onClick}>{label}</Label>;
 }


### PR DESCRIPTION
Since equations use label references, I want to have to avoid re-adjusting the labels in an equation if things are added/deleted. e.g. imagine the case where a user has A, B, C as metrics, and their equation is `A + C`, when B is deleted, I don't want the UI to change the label from C -> B and change the equation to `A + B`

To maintain this stability I'm assigning a `label` property to the queries on load. Regular function queries will get `A..Z` whereas equations will have `ƒ1...ƒn` to differentiate them and avoid key collisions. Also keeps the references disjoint. Any deletions will keep the label around, and additions will look at the max label to determine what the next one is.

The flow of this PR is:
- in the provider, assign labels to the metric queries
  - the labels are generated from iterating through the metric queries and calling `getVisualizeLabel` with the index to use in the getter, as well as whether or not to use an equation label or function label
- apply different labels to functions vs equations
- propagate labels down to keys/wherever we rendered labels using the index previously

The way we assign labels is the more complicated part of this PR. Since we don't have stable IDs for metrics, and I want to auto-compact on refresh (i.e. A, C turn into A, B when you refresh the page), I don't want to store any of the label state in the URL. Instead, I've added a hook that initializes the labels by index and type and stores it in an array that parallels the visualizations, then whenever we add or remove a visualization we update this array and the subsequent `navigate` call picks up on the new label to assign it on the next render. 

⚠️ I did rely on Claude to validate my ideas and build out the boilerplate for the stable label hook, but I've reviewed it and iterated a number of times to be satisfied with its current implementation


https://github.com/user-attachments/assets/7fce054a-af19-4597-81b9-02b4a526a86f

