### PR TITLE
fix(slack): Pass interval param through Explore unfurl URL parsing

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -186,7 +186,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
         query.setlist("groupBy", group_bys)
 
     # Copy standard params
-    for param in ("project", "statsPeriod", "start", "end", "query", "environment"):
+    for param in ("project", "statsPeriod", "start", "end", "query", "environment", "interval"):
         values = raw_query.getlist(param)
         if values:
             query.setlist(param, values)

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1725,3 +1725,29 @@ class UnfurlTest(TestCase):
         assert len(unfurls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
         assert "type" not in chart_data
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_with_interval(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D&project={self.project.id}&statsPeriod=24h&interval=1h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert len(unfurls) == 1
+        call_kwargs = mock_client_get.call_args[1]
+        api_params = call_kwargs["params"]
+        assert api_params["interval"] == "1h"


### PR DESCRIPTION
The `map_explore_query_args()` function explicitly whitelists URL params to
forward to the events-timeseries API, but `interval` was missing from that
list. This caused Explore unfurls to always use the auto-calculated interval
instead of respecting the user's chosen interval.

Unlike Discover unfurls which copy the entire query dict, Explore unfurls
selectively pick params — `interval` was simply omitted from the whitelist.

Fixes DAIN-1484