### PR TITLE
feat(slack): Support unfurling Explore Logs URLs in Slack

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -276,6 +276,8 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/api/endpoints/organization_measurements_meta.py                 @getsentry/data-browsing
 src/sentry/api/endpoints/organization_attribute_mappings.py                 @getsentry/data-browsing
 
+/src/sentry/integrations/slack/unfurl/explore.py                           @getsentry/data-browsing
+
 /tests/snuba/api/endpoints/*                                                @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_tags.py                        @getsentry/data-browsing
 /tests/snuba/api/endpoints/test_organization_events_histogram.py            @getsentry/data-browsing

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -4,7 +4,7 @@ import html
 import logging
 import re
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TypedDict
 from urllib.parse import urlparse
 
 from django.http.request import QueryDict
@@ -25,6 +25,7 @@ from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.unfurl.types import Handler, UnfurlableUrl, UnfurledUrl
 from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
+from sentry.search.eap.types import SupportedTraceItemType
 from sentry.snuba.referrer import Referrer
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -33,8 +34,38 @@ from sentry.utils import json
 _logger = logging.getLogger(__name__)
 
 DEFAULT_PERIOD = "14d"
-DEFAULT_Y_AXIS = "count(span.duration)"
 TOP_N = 5
+
+
+class ExploreDatasetDefaults(TypedDict):
+    title: str
+    y_axis: str
+
+
+EXPLORE_DATASET_DEFAULTS: dict[SupportedTraceItemType, ExploreDatasetDefaults] = {
+    SupportedTraceItemType.SPANS: {
+        "title": "Explore Traces",
+        "y_axis": "count(span.duration)",
+    },
+    SupportedTraceItemType.LOGS: {
+        "title": "Explore Logs",
+        "y_axis": "count(message)",
+    },
+}
+
+
+def _get_explore_dataset_defaults(dataset: SupportedTraceItemType) -> ExploreDatasetDefaults:
+    """Returns the default title and y_axis for the given explore dataset."""
+    return EXPLORE_DATASET_DEFAULTS.get(
+        dataset, EXPLORE_DATASET_DEFAULTS[SupportedTraceItemType.SPANS]
+    )
+
+
+def _get_explore_dataset(url: str) -> SupportedTraceItemType:
+    """Returns the dataset based on the explore URL."""
+    if explore_logs_link_regex.match(url) or customer_domain_explore_logs_link_regex.match(url):
+        return SupportedTraceItemType.LOGS
+    return SupportedTraceItemType.SPANS
 
 
 def unfurl_explore(
@@ -83,9 +114,12 @@ def _unfurl_explore(
         params = link.args["query"]
         chart_type = link.args.get("chart_type")
 
+        explore_dataset = link.args.get("dataset", SupportedTraceItemType.SPANS)
+        defaults = _get_explore_dataset_defaults(explore_dataset)
+
         y_axes = params.getlist("yAxis")
         if not y_axes:
-            y_axes = [DEFAULT_Y_AXIS]
+            y_axes = [defaults["y_axis"]]
             params.setlist("yAxis", y_axes)
 
         group_bys = params.getlist("groupBy")
@@ -97,7 +131,7 @@ def _unfurl_explore(
         if not params.get("statsPeriod") and not params.get("start"):
             params["statsPeriod"] = DEFAULT_PERIOD
 
-        params["dataset"] = "spans"
+        params["dataset"] = explore_dataset.value
         params["referrer"] = Referrer.EXPLORE_SLACK_UNFURL.value
 
         try:
@@ -124,7 +158,7 @@ def _unfurl_explore(
             continue
 
         unfurls[link.url] = SlackDiscoverMessageBuilder(
-            title="Explore Traces",
+            title=defaults["title"],
             chart_url=url,
         ).build()
 
@@ -158,6 +192,8 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     parsed_url = urlparse(url)
     raw_query = QueryDict(parsed_url.query)
 
+    explore_dataset = _get_explore_dataset(url)
+
     # Parse visualize (spans explore) or aggregateField (logs explore) JSON params
     visualize_fields = raw_query.getlist("visualize") or raw_query.getlist("aggregateField")
     y_axes: list[str] = []
@@ -176,7 +212,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
             continue
 
     if not y_axes:
-        y_axes = [DEFAULT_Y_AXIS]
+        y_axes = [_get_explore_dataset_defaults(explore_dataset)["y_axis"]]
 
     # Build query params
     query = QueryDict(mutable=True)
@@ -191,7 +227,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
         if values:
             query.setlist(param, values)
 
-    return dict(**args, query=query, chart_type=chart_type)
+    return dict(**args, query=query, chart_type=chart_type, dataset=explore_dataset)
 
 
 explore_traces_link_regex = re.compile(
@@ -202,11 +238,21 @@ customer_domain_explore_traces_link_regex = re.compile(
     r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/traces/"
 )
 
+explore_logs_link_regex = re.compile(
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/logs/"
+)
+
+customer_domain_explore_logs_link_regex = re.compile(
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/logs/"
+)
+
 explore_handler = Handler(
     fn=unfurl_explore,
     matcher=[
         explore_traces_link_regex,
         customer_domain_explore_traces_link_regex,
+        explore_logs_link_regex,
+        customer_domain_explore_logs_link_regex,
     ],
     arg_mapper=map_explore_query_args,
 )

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -199,6 +199,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                     "org_slug": "org1",
                     "query": QueryDict("yAxis=avg(span.duration)&project=1&statsPeriod=24h"),
                     "chart_type": None,
+                    "dataset": "spans",
                 },
             ),
         ),
@@ -210,6 +211,31 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                     "org_slug": "org1",
                     "query": QueryDict("yAxis=count(span.duration)&statsPeriod=24h"),
                     "chart_type": None,
+                    "dataset": "spans",
+                },
+            ),
+        ),
+        (
+            "https://sentry.io/organizations/org1/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22sum(payload_size)%22%5D%7D&project=1&statsPeriod=24h",
+            (
+                LinkType.EXPLORE,
+                {
+                    "org_slug": "org1",
+                    "query": QueryDict("yAxis=sum(payload_size)&project=1&statsPeriod=24h"),
+                    "chart_type": None,
+                    "dataset": "logs",
+                },
+            ),
+        ),
+        (
+            "https://org1.sentry.io/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(payload_size)%22%5D%7D&statsPeriod=24h",
+            (
+                LinkType.EXPLORE,
+                {
+                    "org_slug": "org1",
+                    "query": QueryDict("yAxis=count(payload_size)&statsPeriod=24h"),
+                    "chart_type": None,
+                    "dataset": "logs",
                 },
             ),
         ),
@@ -1751,3 +1777,69 @@ class UnfurlTest(TestCase):
         call_kwargs = mock_client_get.call_args[1]
         api_params = call_kwargs["params"]
         assert api_params["interval"] == "1h"
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_logs(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        # aggregateField includes chartType:0 (bar) to verify chart_type is passed through
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22sum(payload_size)%22%5D%2C%22chartType%22%3A0%7D&project={self.project.id}&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        assert link_type == LinkType.EXPLORE
+        assert args["dataset"] == "logs"
+        assert args["chart_type"] == "bar"
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert (
+            unfurls[url]
+            == SlackDiscoverMessageBuilder(title="Explore Logs", chart_url="chart-url").build()
+        )
+        assert len(mock_generate_chart.mock_calls) == 1
+        chart_data = mock_generate_chart.call_args[0][1]
+        assert chart_data["type"] == "bar"
+        call_kwargs = mock_client_get.call_args[1]
+        api_params = call_kwargs["params"]
+        assert api_params["dataset"] == "logs"
+        assert api_params["yAxis"] == "sum(payload_size)"
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_logs_customer_domain(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        url = f"https://{self.organization.slug}.sentry.io/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(payload_size)%22%5D%7D&project={self.project.id}&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        assert link_type == LinkType.EXPLORE
+        assert args["dataset"] == "logs"
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert len(unfurls) == 1
+        call_kwargs = mock_client_get.call_args[1]
+        assert call_kwargs["params"]["dataset"] == "logs"


### PR DESCRIPTION
Add Slack unfurl support for Explore Logs URLs (`/explore/logs/`), alongside the
existing Explore Traces URL support.

The handler detects the URL path to determine logs vs traces, then sets the
correct dataset (`ourlogs` for logs, `spans` for traces) and title
(`Explore Logs` vs `Explore Traces`). The existing `map_explore_query_args`
already supported the `aggregateField` param format used by logs URLs, so only
the URL matching, dataset selection, and title needed to change.

Supports both `/organizations/{slug}/explore/logs/` and customer domain
`{slug}.sentry.io/explore/logs/` URL formats.

Fixes DAIN-1478