### PR TITLE
feat(dashboards): Add thresholds support to generated dashboard widgets

### DIFF
--- a/src/sentry/dashboards/models/generate_dashboard_artifact.py
+++ b/src/sentry/dashboards/models/generate_dashboard_artifact.py
@@ -82,7 +82,7 @@ Polarity = Literal["+", "-"]
 
 
 class GeneratedWidgetThresholds(BaseModel):
-    """Color-coded thresholds for big_number widgets. max1 and max2 define thresholds for three zones whose color meaning depends on preferred_polarity."""
+    """Color-coded thresholds for big_number and timeseries widgets. max1 and max2 define thresholds for three zones whose color meaning depends on preferred_polarity."""
 
     max_values: dict[str, float] = Field(
         ...,

--- a/src/sentry/dashboards/models/generate_dashboard_artifact.py
+++ b/src/sentry/dashboards/models/generate_dashboard_artifact.py
@@ -78,6 +78,36 @@ class GeneratedWidgetQuery(BaseModel):
         return v
 
 
+Polarity = Literal["+", "-"]
+
+
+class GeneratedWidgetThresholds(BaseModel):
+    """Color-coded thresholds for big_number widgets. max1 and max2 define thresholds for three zones whose color meaning depends on preferred_polarity."""
+
+    max_values: dict[str, float] = Field(
+        ...,
+        description="Threshold boundaries. Must contain keys 'max1' and 'max2' where max1 < max2. Both values must be non-negative.",
+    )
+    unit: str | None = Field(
+        default=None,
+        description="Display unit for threshold values (e.g. 'millisecond', 'percent'). Null means use the widget's default unit.",
+    )
+    preferred_polarity: Polarity = Field(
+        description="Determines color meaning: '+' means higher is better (green above max2), '-' means lower is better (green below max1). Must be '+' or '-'.",
+    )
+
+    @validator("max_values")
+    def validate_max_values(cls, v: dict[str, float]) -> dict[str, float]:
+        allowed_keys = {"max1", "max2"}
+        if set(v.keys()) != allowed_keys:
+            raise ValueError("max_values must contain exactly 'max1' and 'max2'")
+        if v["max1"] < 0 or v["max2"] < 0:
+            raise ValueError("Threshold values must be non-negative")
+        if v["max1"] >= v["max2"]:
+            raise ValueError("max1 must be less than max2")
+        return v
+
+
 class GeneratedWidgetLayout(BaseModel):
     """Layout position and size on a 6-column grid. Widget widths in each row should sum to 6 to fill the grid completely."""
 
@@ -147,6 +177,10 @@ class GeneratedWidget(BaseModel):
         description="For charts with group by columns, the maximum number series that can be displayed. For table widgets, the maximum number of rows that can be displayed. Categorical bar charts have a maximum limit of 25. For any other chart type, the maximum limit is 10. Default value is 5.",
     )
     interval: Intervals = Field(default="1h")
+    thresholds: GeneratedWidgetThresholds | None = Field(
+        default=None,
+        description="Color-coded thresholds for big_number widgets. Defines two boundaries (max1 < max2) that split the value into three color zones. Only applicable to big_number, line, anad area chart display types.",
+    )
 
     @root_validator
     def check_text_widget_constraints(cls, values: dict[str, Any]) -> dict[str, Any]:

--- a/src/sentry/dashboards/models/generate_dashboard_artifact.py
+++ b/src/sentry/dashboards/models/generate_dashboard_artifact.py
@@ -82,7 +82,7 @@ Polarity = Literal["+", "-"]
 
 
 class GeneratedWidgetThresholds(BaseModel):
-    """Color-coded thresholds for big_number and timeseries widgets. max1 and max2 define thresholds for three zones whose color meaning depends on preferred_polarity."""
+    """Color-coded thresholds for big_number, line, and area chart widgets. max1 and max2 define thresholds for three zones whose color meaning depends on preferred_polarity."""
 
     max_values: dict[str, float] = Field(
         ...,
@@ -179,7 +179,7 @@ class GeneratedWidget(BaseModel):
     interval: Intervals = Field(default="1h")
     thresholds: GeneratedWidgetThresholds | None = Field(
         default=None,
-        description="Color-coded thresholds for big_number widgets. Defines two boundaries (max1 < max2) that split the value into three color zones. Only applicable to big_number, line, anad area chart display types.",
+        description="Color-coded thresholds for big_number, line, and area chart widgets. Defines two boundaries (max1 < max2) that split the value into three color zones.",
     )
 
     @root_validator


### PR DESCRIPTION
Add a `GeneratedWidgetThresholds` model to the dashboard artifact generation
schema, enabling color-coded threshold zones for AI-generated dashboard widgets.

The new model supports `max_values` (two boundaries defining three zones),
`unit` (optional display unit), and `preferred_polarity` (whether higher or
lower values are "good"). Thresholds are applicable to big_number, line, and
area chart display types.