### PR TITLE
feat(eslint): enable @typescript-eslint/no-redeclare

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -607,6 +607,7 @@ export default typescript.config([
           '@typescript-eslint/no-base-to-string': 'error',
           '@typescript-eslint/no-duplicate-type-constituents': 'error',
           '@typescript-eslint/no-for-in-array': 'error',
+          '@typescript-eslint/no-redeclare': 'error',
           '@typescript-eslint/no-unnecessary-template-expression': 'error',
           '@typescript-eslint/no-unnecessary-type-assertion': 'error',
           '@typescript-eslint/no-unnecessary-type-parameters': 'error',


### PR DESCRIPTION
```plaintext
static/app/components/core/input/numberDragInput.tsx
  39:17  error  'NumberDragInput' is already defined  @typescript-eslint/no-redeclare

static/app/components/events/autofix/v1/body.tsx
  16:17  error  'SeerDrawerBody' is already defined  @typescript-eslint/no-redeclare

static/app/components/events/autofix/v3/body.tsx
  10:17  error  'SeerDrawerBody' is already defined  @typescript-eslint/no-redeclare

static/app/components/profiling/continuousProfileHeader.tsx
  23:17  error  'ContinuousProfileHeader' is already defined  @typescript-eslint/no-redeclare

static/app/components/sentryDocumentTitle/documentTitleManager.tsx
  25:17  error  'DocumentTitleManager' is already defined  @typescript-eslint/no-redeclare

static/app/stories/props.tsx
  17:17  error  'PropMatrix' is already defined  @typescript-eslint/no-redeclare

static/app/views/alerts/rules/uptime/assertions/assertionFailure/assertionFailureTree.tsx
  34:10  error  'Connector' is already defined  @typescript-eslint/no-redeclare

static/app/views/app/asyncSDKIntegrationProvider.tsx
  13:7  error  'Context' is already defined  @typescript-eslint/no-redeclare

static/app/views/dashboards/contexts/widgetSyncContext.tsx
  17:52  error  'WidgetSyncContext' is already defined  @typescript-eslint/no-redeclare

static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
  44:17  error  'AttributeDistribution' is already defined  @typescript-eslint/no-redeclare

static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
  307:17  error  'AttributesTree' is already defined  @typescript-eslint/no-redeclare

static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
  59:17  error  'AutofixSection' is already defined  @typescript-eslint/no-redeclare

static/app/views/navigation/navigationTour.tsx
  239:7  error  'NavigationTourReminderContext' is already defined  @typescript-eslint/no-redeclare

static/app/views/navigation/primaryNavigationContext.tsx
  36:7  error  'PrimaryNavigationContext' is already defined  @typescript-eslint/no-redeclare

static/app/views/navigation/secondaryNavigationContext.tsx
  19:14  error  'SecondaryNavigationContext' is already defined  @typescript-eslint/no-redeclare

static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
  15:7  error  'TraceStateContext' is already defined  @typescript-eslint/no-redeclare

static/app/views/performance/transactionSummary/transactionSummaryContext.tsx
  20:14  error  'TransactionSummaryContext' is already defined  @typescript-eslint/no-redeclare

static/app/views/preprod/components/visualizations/treemapControlButtons.tsx
  48:7  error  'TreemapControlButton' is already defined  @typescript-eslint/no-redeclare

static/app/views/seerExplorer/blockComponents.tsx
  527:7  error  'Block' is already defined  @typescript-eslint/no-redeclare

static/gsAdmin/components/createBroadcastModal.tsx
  19:17  error  'CreateBroadcastModal' is already defined  @typescript-eslint/no-redeclare

static/gsApp/components/profiling/alerts.tsx
  324:17  error  'ContinuousProfilingBillingRequirementBanner' is already defined  @typescript-eslint/no-redeclare

tests/js/fixtures/autofixRootCauseData.ts
  3:17  error  'AutofixRootCauseData' is already defined  @typescript-eslint/no-redeclare

✖ 22 problems (22 errors, 0 warnings)
```