### PR TITLE
feat(onboarding): Pre-populate repo selector with full repo list

### DIFF
--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -11,6 +11,21 @@ import {
 
 import {ScmRepoSelector} from './scmRepoSelector';
 
+// Mock the virtualizer so all items render in JSDOM (no layout engine).
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: jest.fn(({count}) => ({
+    getVirtualItems: () =>
+      Array.from({length: count}, (_, i) => ({
+        key: i,
+        index: i,
+        start: i * 36,
+        size: 36,
+      })),
+    getTotalSize: () => count * 36,
+    measureElement: jest.fn(),
+  })),
+}));
+
 function makeOnboardingWrapper(initialState?: OnboardingSessionState) {
   return function OnboardingWrapper({children}: {children?: React.ReactNode}) {
     return (

--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -45,15 +45,6 @@ describe('ScmRepoSelector', () => {
   });
 
   it('renders search placeholder', () => {
-    render(<ScmRepoSelector integration={mockIntegration} />, {
-      organization,
-      wrapper: makeOnboardingWrapper(),
-    });
-
-    expect(screen.getByText('Search repositories')).toBeInTheDocument();
-  });
-
-  it('shows empty state message when search returns no results', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
       body: {repos: []},
@@ -64,7 +55,21 @@ describe('ScmRepoSelector', () => {
       wrapper: makeOnboardingWrapper(),
     });
 
-    await userEvent.type(screen.getByRole('textbox'), 'nonexistent');
+    expect(screen.getByText('Search repositories')).toBeInTheDocument();
+  });
+
+  it('shows empty state message when no repos are available', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
+      body: {repos: []},
+    });
+
+    render(<ScmRepoSelector integration={mockIntegration} />, {
+      organization,
+      wrapper: makeOnboardingWrapper(),
+    });
+
+    await userEvent.click(screen.getByRole('textbox'));
 
     expect(
       await screen.findByText(
@@ -85,14 +90,14 @@ describe('ScmRepoSelector', () => {
       wrapper: makeOnboardingWrapper(),
     });
 
-    await userEvent.type(screen.getByRole('textbox'), 'sentry');
+    await userEvent.click(screen.getByRole('textbox'));
 
     expect(
-      await screen.findByText('Failed to search repositories. Please try again.')
+      await screen.findByText('Failed to load repositories. Please try again.')
     ).toBeInTheDocument();
   });
 
-  it('displays repos returned by search', async () => {
+  it('displays repos fetched on mount', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
       body: {
@@ -108,7 +113,7 @@ describe('ScmRepoSelector', () => {
       wrapper: makeOnboardingWrapper(),
     });
 
-    await userEvent.type(screen.getByRole('textbox'), 'get');
+    await userEvent.click(screen.getByRole('textbox'));
 
     expect(
       await screen.findByRole('menuitemradio', {name: 'sentry'})
@@ -117,6 +122,11 @@ describe('ScmRepoSelector', () => {
   });
 
   it('shows selected repo value when one is in context', () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
+      body: {repos: []},
+    });
+
     const selectedRepo = RepositoryFixture({
       name: 'getsentry/old-repo',
       externalSlug: 'getsentry/old-repo',
@@ -130,7 +140,7 @@ describe('ScmRepoSelector', () => {
     expect(screen.getByText('getsentry/old-repo')).toBeInTheDocument();
   });
 
-  it('selects a repo from search results and triggers repo lookup', async () => {
+  it('selects a repo and triggers repo lookup', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
       body: {
@@ -153,13 +163,18 @@ describe('ScmRepoSelector', () => {
       wrapper: makeOnboardingWrapper(),
     });
 
-    await userEvent.type(screen.getByRole('textbox'), 'get');
+    await userEvent.click(screen.getByRole('textbox'));
     await userEvent.click(await screen.findByRole('menuitemradio', {name: 'sentry'}));
 
     await waitFor(() => expect(reposLookup).toHaveBeenCalled());
   });
 
   it('clears the selected repo', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
+      body: {repos: []},
+    });
+
     const selectedRepo = RepositoryFixture({
       name: 'getsentry/old-repo',
       externalSlug: 'getsentry/old-repo',
@@ -172,16 +187,14 @@ describe('ScmRepoSelector', () => {
 
     expect(screen.getByText('getsentry/old-repo')).toBeInTheDocument();
 
-    // The clear indicator uses Sentry's IconClose which renders with
-    // role="img" rather than aria-hidden, so use the test-id directly.
-    await userEvent.click(screen.getByTestId('icon-close'));
+    await userEvent.click(await screen.findByTestId('icon-close'));
 
     await waitFor(() => {
       expect(screen.queryByText('getsentry/old-repo')).not.toBeInTheDocument();
     });
   });
 
-  it('does not duplicate selected repo when it appears in search results', async () => {
+  it('does not duplicate selected repo when it appears in results', async () => {
     const selectedRepo = RepositoryFixture({
       name: 'getsentry/sentry',
       externalSlug: 'getsentry/sentry',
@@ -202,15 +215,14 @@ describe('ScmRepoSelector', () => {
       wrapper: makeOnboardingWrapper({selectedRepository: selectedRepo}),
     });
 
-    await userEvent.type(screen.getByRole('textbox'), 'get');
+    await userEvent.click(screen.getByRole('textbox'));
 
-    // Wait for search results to arrive
     expect(await screen.findByRole('menuitemradio', {name: 'relay'})).toBeInTheDocument();
     expect(screen.getByRole('menuitemradio', {name: 'sentry'})).toBeInTheDocument();
 
     // If the options-prepend logic fires incorrectly, it adds an extra option
     // with label 'getsentry/sentry' (selectedRepository.name) alongside the
-    // search result option with label 'sentry' (repo.name).
+    // result option with label 'sentry' (repo.name).
     expect(
       screen.queryByRole('menuitemradio', {name: 'getsentry/sentry'})
     ).not.toBeInTheDocument();

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -9,7 +9,8 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {ScmSearchControl} from './scmSearchControl';
-import {useScmRepoSearch} from './useScmRepoSearch';
+import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
+import {useScmRepos} from './useScmRepos';
 import {useScmRepoSelection} from './useScmRepoSelection';
 
 interface ScmRepoSelectorProps {
@@ -20,14 +21,10 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
   const organization = useOrganization();
   const {selectedRepository, setSelectedRepository, clearDerivedState} =
     useOnboardingContext();
-  const {
-    reposByIdentifier,
-    dropdownItems,
-    isFetching,
-    isError,
-    debouncedSearch,
-    setSearch,
-  } = useScmRepoSearch(integration.id, selectedRepository);
+  const {reposByIdentifier, dropdownItems, isFetching, isError} = useScmRepos(
+    integration.id,
+    selectedRepository
+  );
 
   const {busy, handleSelect, handleRemove} = useScmRepoSelection({
     integration,
@@ -58,7 +55,6 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
     clearDerivedState();
 
     if (option === null) {
-      setSearch('');
       handleRemove();
     } else {
       const repo = reposByIdentifier.get(option.value);
@@ -75,14 +71,11 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
 
   function noOptionsMessage() {
     if (isError) {
-      return t('Failed to search repositories. Please try again.');
+      return t('Failed to load repositories. Please try again.');
     }
-    if (debouncedSearch) {
-      return t(
-        'No repositories found. Check your installation permissions to ensure your integration has access.'
-      );
-    }
-    return t('Type to search repositories');
+    return t(
+      'No repositories found. Check your installation permissions to ensure your integration has access.'
+    );
   }
 
   return (
@@ -91,19 +84,12 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
       options={options}
       value={selectedRepository?.externalSlug ?? null}
       onChange={handleChange}
-      onInputChange={(value, actionMeta) => {
-        if (actionMeta.action === 'input-change') {
-          setSearch(value);
-        }
-      }}
-      // Disable client-side filtering; search is handled server-side.
-      filterOption={() => true}
       noOptionsMessage={noOptionsMessage}
       isLoading={isFetching}
       isDisabled={busy}
       clearable
       searchable
-      components={{Control: ScmSearchControl}}
+      components={{Control: ScmSearchControl, MenuList: ScmVirtualizedMenuList}}
     />
   );
 }

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -33,7 +33,7 @@ export function ScmRepoSelector({integration}: ScmRepoSelectorProps) {
   });
 
   // Prepend the selected repo so the Select can always resolve and display
-  // it, even when search results no longer include it.
+  // it, even when the fetched list does not include it.
   const options = useMemo(() => {
     const selectedSlug = selectedRepository?.externalSlug;
     if (!selectedSlug || dropdownItems.some(item => item.value === selectedSlug)) {

--- a/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
+++ b/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
@@ -55,6 +55,15 @@ export function ScmVirtualizedMenuList({
     );
   }
 
+  // Fallback when the virtualizer can't measure the container (e.g. jsdom)
+  if (virtualItems.length === 0 && items.length > 0) {
+    return (
+      <div ref={combinedRef} {...innerProps} style={{maxHeight, overflowY: 'auto'}}>
+        {children}
+      </div>
+    );
+  }
+
   return (
     <div ref={combinedRef} {...innerProps} style={{maxHeight, overflowY: 'auto'}}>
       <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>

--- a/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
+++ b/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
@@ -55,15 +55,6 @@ export function ScmVirtualizedMenuList({
     );
   }
 
-  // Fallback when the virtualizer can't measure the container (e.g. jsdom)
-  if (virtualItems.length === 0 && items.length > 0) {
-    return (
-      <div ref={combinedRef} {...innerProps} style={{maxHeight, overflowY: 'auto'}}>
-        {children}
-      </div>
-    );
-  }
-
   return (
     <div ref={combinedRef} {...innerProps} style={{maxHeight, overflowY: 'auto'}}>
       <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>

--- a/static/app/views/onboarding/components/useScmRepos.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepos.spec.tsx
@@ -1,30 +1,25 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {useScmRepoSearch} from './useScmRepoSearch';
+import {useScmRepos} from './useScmRepos';
 
-describe('useScmRepoSearch', () => {
+describe('useScmRepos', () => {
   const organization = OrganizationFixture();
   const integrationId = '1';
 
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
   afterEach(() => {
     MockApiClient.clearMockResponses();
-    jest.useRealTimers();
   });
 
-  function renderHook(selectedRepo?: Parameters<typeof useScmRepoSearch>[1]) {
-    return renderHookWithProviders(() => useScmRepoSearch(integrationId, selectedRepo), {
+  function renderHook(selectedRepo?: Parameters<typeof useScmRepos>[1]) {
+    return renderHookWithProviders(() => useScmRepos(integrationId, selectedRepo), {
       organization,
     });
   }
 
-  it('does not fetch when search is empty', () => {
+  it('fetches repos on mount', async () => {
     const request = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
       body: {repos: []},
@@ -32,46 +27,7 @@ describe('useScmRepoSearch', () => {
 
     renderHook();
 
-    expect(request).not.toHaveBeenCalled();
-  });
-
-  it('fetches repos after search is set', async () => {
-    const request = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
-      body: {repos: []},
-    });
-
-    const {result} = renderHook();
-
-    act(() => {
-      result.current.setSearch('sentry');
-      jest.advanceTimersByTime(200);
-    });
-
     await waitFor(() => expect(request).toHaveBeenCalled());
-  });
-
-  it('passes search query param to the API', async () => {
-    const request = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
-      body: {repos: []},
-    });
-
-    const {result} = renderHook();
-
-    act(() => {
-      result.current.setSearch('sentry');
-      jest.advanceTimersByTime(200);
-    });
-
-    await waitFor(() => expect(request).toHaveBeenCalled());
-
-    expect(request).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: expect.objectContaining({search: 'sentry', accessibleOnly: true}),
-      })
-    );
   });
 
   it('transforms API response into reposByIdentifier and dropdownItems', async () => {
@@ -86,11 +42,6 @@ describe('useScmRepoSearch', () => {
     });
 
     const {result} = renderHook();
-
-    act(() => {
-      result.current.setSearch('get');
-      jest.advanceTimersByTime(200);
-    });
 
     await waitFor(() => expect(result.current.reposByIdentifier.size).toBe(2));
 
@@ -120,11 +71,6 @@ describe('useScmRepoSearch', () => {
     const selectedRepo = RepositoryFixture({externalSlug: 'getsentry/sentry'});
     const {result} = renderHook(selectedRepo);
 
-    act(() => {
-      result.current.setSearch('get');
-      jest.advanceTimersByTime(200);
-    });
-
     await waitFor(() => expect(result.current.dropdownItems).toHaveLength(2));
 
     expect(result.current.dropdownItems[0]).toEqual(
@@ -144,40 +90,6 @@ describe('useScmRepoSearch', () => {
 
     const {result} = renderHook();
 
-    act(() => {
-      result.current.setSearch('sentry');
-      jest.advanceTimersByTime(200);
-    });
-
     await waitFor(() => expect(result.current.isError).toBe(true));
-  });
-
-  it('returns empty results when search is cleared after searching', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/${integrationId}/repos/`,
-      body: {
-        repos: [{identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false}],
-      },
-    });
-
-    const {result} = renderHook();
-
-    // Search and get results
-    act(() => {
-      result.current.setSearch('sentry');
-      jest.advanceTimersByTime(200);
-    });
-
-    await waitFor(() => expect(result.current.reposByIdentifier.size).toBe(1));
-
-    // Clear search
-    act(() => {
-      result.current.setSearch('');
-      jest.advanceTimersByTime(200);
-    });
-
-    // placeholderData returns undefined when debouncedSearch is empty
-    await waitFor(() => expect(result.current.reposByIdentifier.size).toBe(0));
-    expect(result.current.dropdownItems).toEqual([]);
   });
 });

--- a/static/app/views/onboarding/components/useScmRepos.ts
+++ b/static/app/views/onboarding/components/useScmRepos.ts
@@ -1,8 +1,8 @@
 import {useMemo} from 'react';
+import {useQuery} from '@tanstack/react-query';
 
 import type {IntegrationRepository, Repository} from 'sentry/types/integrations';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {fetchDataQuery, useQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface ScmReposResult {
@@ -12,31 +12,21 @@ interface ScmReposResult {
 export function useScmRepos(integrationId: string, selectedRepo?: Repository) {
   const organization = useOrganization();
 
-  const reposQuery = useQuery({
-    queryKey: [
-      getApiUrl(
-        '/organizations/$organizationIdOrSlug/integrations/$integrationId/repos/',
-        {
-          path: {
-            organizationIdOrSlug: organization.slug,
-            integrationId,
-          },
-        }
-      ),
-      {method: 'GET'},
-    ] as const,
-    queryFn: async context => {
-      return fetchDataQuery<ScmReposResult>(context);
-    },
-    retry: 0,
-    staleTime: 20_000,
-  });
+  const reposQuery = useQuery(
+    apiOptions.as<ScmReposResult>()(
+      '/organizations/$organizationIdOrSlug/integrations/$integrationId/repos/',
+      {
+        path: {organizationIdOrSlug: organization.slug, integrationId},
+        staleTime: 20_000,
+      }
+    )
+  );
 
   const selectedRepoSlug = selectedRepo?.externalSlug;
 
   const {reposByIdentifier, dropdownItems} = useMemo(
     () =>
-      (reposQuery.data?.[0]?.repos ?? []).reduce<{
+      (reposQuery.data?.repos ?? []).reduce<{
         dropdownItems: Array<{
           disabled: boolean;
           label: string;

--- a/static/app/views/onboarding/components/useScmRepos.ts
+++ b/static/app/views/onboarding/components/useScmRepos.ts
@@ -17,7 +17,7 @@ export function useScmRepos(integrationId: string, selectedRepo?: Repository) {
       '/organizations/$organizationIdOrSlug/integrations/$integrationId/repos/',
       {
         path: {organizationIdOrSlug: organization.slug, integrationId},
-        staleTime: 20_000,
+        staleTime: 60_000,
       }
     )
   );

--- a/static/app/views/onboarding/components/useScmRepos.ts
+++ b/static/app/views/onboarding/components/useScmRepos.ts
@@ -1,21 +1,18 @@
-import {useMemo, useState} from 'react';
+import {useMemo} from 'react';
 
 import type {IntegrationRepository, Repository} from 'sentry/types/integrations';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchDataQuery, useQuery} from 'sentry/utils/queryClient';
-import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-interface ScmRepoSearchResult {
+interface ScmReposResult {
   repos: IntegrationRepository[];
 }
 
-export function useScmRepoSearch(integrationId: string, selectedRepo?: Repository) {
+export function useScmRepos(integrationId: string, selectedRepo?: Repository) {
   const organization = useOrganization();
-  const [search, setSearch] = useState('');
-  const debouncedSearch = useDebouncedValue(search, 200);
 
-  const searchQuery = useQuery({
+  const reposQuery = useQuery({
     queryKey: [
       getApiUrl(
         '/organizations/$organizationIdOrSlug/integrations/$integrationId/repos/',
@@ -26,22 +23,20 @@ export function useScmRepoSearch(integrationId: string, selectedRepo?: Repositor
           },
         }
       ),
-      {method: 'GET', query: {search: debouncedSearch, accessibleOnly: true}},
+      {method: 'GET'},
     ] as const,
     queryFn: async context => {
-      return fetchDataQuery<ScmRepoSearchResult>(context);
+      return fetchDataQuery<ScmReposResult>(context);
     },
     retry: 0,
     staleTime: 20_000,
-    placeholderData: previousData => (debouncedSearch ? previousData : undefined),
-    enabled: !!debouncedSearch,
   });
 
   const selectedRepoSlug = selectedRepo?.externalSlug;
 
   const {reposByIdentifier, dropdownItems} = useMemo(
     () =>
-      (searchQuery.data?.[0]?.repos ?? []).reduce<{
+      (reposQuery.data?.[0]?.repos ?? []).reduce<{
         dropdownItems: Array<{
           disabled: boolean;
           label: string;
@@ -63,15 +58,13 @@ export function useScmRepoSearch(integrationId: string, selectedRepo?: Repositor
           dropdownItems: [],
         }
       ),
-    [searchQuery.data, selectedRepoSlug]
+    [reposQuery.data, selectedRepoSlug]
   );
 
   return {
     reposByIdentifier,
     dropdownItems,
-    isFetching: searchQuery.isFetching,
-    isError: searchQuery.isError,
-    debouncedSearch,
-    setSearch,
+    isFetching: reposQuery.isFetching,
+    isError: reposQuery.isError,
   };
 }

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -724,6 +724,10 @@ describe('Onboarding', () => {
         url: `/organizations/${scmOrganization.slug}/repos/`,
         body: [],
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${scmOrganization.slug}/integrations/1/repos/`,
+        body: {repos: []},
+      });
 
       renderOnboarding('scm-connect');
 


### PR DESCRIPTION
Fetch the complete list of repositories on mount so users can browse and select without typing first. The Select component handles filtering client-side when the user types, so there is no server-side search round-trip.

Previously the dropdown was empty until a search query was entered, requiring users to already know the repo name. Adds the virtualized menu list component to keep the dropdown performant with large repo lists.

Refs VDY-46